### PR TITLE
IntPtr text manipulation overloads and encoding support

### DIFF
--- a/binding/Binding/Binding.projitems
+++ b/binding/Binding/Binding.projitems
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -32,5 +32,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)SKImageDecoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PreserveAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\SkiaSharp\Properties\SkiaSharpAssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Util.cs" />
   </ItemGroup>
 </Project>

--- a/binding/Binding/SKCanvas.cs
+++ b/binding/Binding/SKCanvas.cs
@@ -240,7 +240,7 @@ namespace SkiaSharp
 			if (paint == null)
 				throw new ArgumentNullException ("paint");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes (text);
+			var bytes = Util.GetEncodedText(text, paint.TextEncoding);
 			SkiaApi.sk_canvas_draw_text (Handle, bytes, bytes.Length, x, y, paint.Handle);
 		}
 
@@ -253,22 +253,57 @@ namespace SkiaSharp
 			if (points == null)
 				throw new ArgumentNullException ("points");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes (text);
-			SkiaApi.sk_canvas_draw_pos_text (Handle, bytes, bytes.Length, points, paint.Handle);
+			var bytes = Util.GetEncodedText(text, paint.TextEncoding);
+			SkiaApi.sk_canvas_draw_pos_text(Handle, bytes, bytes.Length, points, paint.Handle);
 		}
 
-		public void DrawText (string text, SKPath path, float hOffset, float vOffset, SKPaint paint)
+		public void DrawText (IntPtr buffer, int length, SKPath path, float hOffset, float vOffset, SKPaint paint)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException("buffer");
+			if (paint == null)
+				throw new ArgumentNullException ("paint");
+			if (paint == null)
+				throw new ArgumentNullException ("paint");
+			
+			SkiaApi.sk_canvas_draw_text_on_path(Handle, buffer, length, path.Handle, hOffset, vOffset, paint.Handle);
+		}
+
+		public void DrawText(IntPtr buffer, int length, float x, float y, SKPaint paint)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException("buffer");
+			if (paint == null)
+				throw new ArgumentNullException("paint");
+			
+			SkiaApi.sk_canvas_draw_text(Handle, buffer, length, x, y, paint.Handle);
+		}
+
+		public void DrawText(IntPtr buffer, int length, SKPoint[] points, SKPaint paint)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException("buffer");
+			if (paint == null)
+				throw new ArgumentNullException("paint");
+			if (points == null)
+				throw new ArgumentNullException("points");
+			
+			SkiaApi.sk_canvas_draw_pos_text(Handle, buffer, length, points, paint.Handle);
+		}
+
+		public void DrawText(string text, SKPath path, float hOffset, float vOffset, SKPaint paint)
 		{
 			if (text == null)
-				throw new ArgumentNullException ("text");
+				throw new ArgumentNullException("text");
 			if (paint == null)
-				throw new ArgumentNullException ("paint");
+				throw new ArgumentNullException("paint");
 			if (paint == null)
-				throw new ArgumentNullException ("paint");
+				throw new ArgumentNullException("paint");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes (text);
-			SkiaApi.sk_canvas_draw_text_on_path (Handle, bytes, bytes.Length, path.Handle, hOffset, vOffset, paint.Handle);
+			var bytes = Util.GetEncodedText(text, paint.TextEncoding);
+			SkiaApi.sk_canvas_draw_text_on_path(Handle, bytes, bytes.Length, path.Handle, hOffset, vOffset, paint.Handle);
 		}
+
 
 		public void ResetMatrix ()
 		{

--- a/binding/Binding/SKCanvas.cs
+++ b/binding/Binding/SKCanvas.cs
@@ -240,7 +240,7 @@ namespace SkiaSharp
 			if (paint == null)
 				throw new ArgumentNullException ("paint");
 
-			var bytes = Util.GetEncodedText(text, paint.TextEncoding);
+			var bytes = Util.GetEncodedText (text, paint.TextEncoding);
 			SkiaApi.sk_canvas_draw_text (Handle, bytes, bytes.Length, x, y, paint.Handle);
 		}
 
@@ -253,55 +253,55 @@ namespace SkiaSharp
 			if (points == null)
 				throw new ArgumentNullException ("points");
 
-			var bytes = Util.GetEncodedText(text, paint.TextEncoding);
-			SkiaApi.sk_canvas_draw_pos_text(Handle, bytes, bytes.Length, points, paint.Handle);
+			var bytes = Util.GetEncodedText (text, paint.TextEncoding);
+			SkiaApi.sk_canvas_draw_pos_text (Handle, bytes, bytes.Length, points, paint.Handle);
 		}
 
 		public void DrawText (IntPtr buffer, int length, SKPath path, float hOffset, float vOffset, SKPaint paint)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException("buffer");
+				throw new ArgumentNullException ("buffer");
 			if (paint == null)
 				throw new ArgumentNullException ("paint");
 			if (paint == null)
 				throw new ArgumentNullException ("paint");
 			
-			SkiaApi.sk_canvas_draw_text_on_path(Handle, buffer, length, path.Handle, hOffset, vOffset, paint.Handle);
+			SkiaApi.sk_canvas_draw_text_on_path (Handle, buffer, length, path.Handle, hOffset, vOffset, paint.Handle);
 		}
 
-		public void DrawText(IntPtr buffer, int length, float x, float y, SKPaint paint)
+		public void DrawText (IntPtr buffer, int length, float x, float y, SKPaint paint)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException("buffer");
+				throw new ArgumentNullException ("buffer");
 			if (paint == null)
-				throw new ArgumentNullException("paint");
+				throw new ArgumentNullException ("paint");
 			
-			SkiaApi.sk_canvas_draw_text(Handle, buffer, length, x, y, paint.Handle);
+			SkiaApi.sk_canvas_draw_text (Handle, buffer, length, x, y, paint.Handle);
 		}
 
-		public void DrawText(IntPtr buffer, int length, SKPoint[] points, SKPaint paint)
+		public void DrawText (IntPtr buffer, int length, SKPoint[] points, SKPaint paint)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException("buffer");
+				throw new ArgumentNullException ("buffer");
 			if (paint == null)
-				throw new ArgumentNullException("paint");
+				throw new ArgumentNullException ("paint");
 			if (points == null)
-				throw new ArgumentNullException("points");
+				throw new ArgumentNullException ("points");
 			
-			SkiaApi.sk_canvas_draw_pos_text(Handle, buffer, length, points, paint.Handle);
+			SkiaApi.sk_canvas_draw_pos_text (Handle, buffer, length, points, paint.Handle);
 		}
 
-		public void DrawText(string text, SKPath path, float hOffset, float vOffset, SKPaint paint)
+		public void DrawText (string text, SKPath path, float hOffset, float vOffset, SKPaint paint)
 		{
 			if (text == null)
-				throw new ArgumentNullException("text");
+				throw new ArgumentNullException ("text");
 			if (paint == null)
-				throw new ArgumentNullException("paint");
+				throw new ArgumentNullException ("paint");
 			if (paint == null)
-				throw new ArgumentNullException("paint");
+				throw new ArgumentNullException ("paint");
 
-			var bytes = Util.GetEncodedText(text, paint.TextEncoding);
-			SkiaApi.sk_canvas_draw_text_on_path(Handle, bytes, bytes.Length, path.Handle, hOffset, vOffset, paint.Handle);
+			var bytes = Util.GetEncodedText (text, paint.TextEncoding);
+			SkiaApi.sk_canvas_draw_text_on_path (Handle, bytes, bytes.Length, path.Handle, hOffset, vOffset, paint.Handle);
 		}
 
 

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -194,40 +194,40 @@ namespace SkiaSharp
 			}
 		}
 
-		public float MeasureText(string text)
+		public float MeasureText (string text)
 		{
 			if (text == null)
-				throw new ArgumentNullException("text");
+				throw new ArgumentNullException ("text");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+			var bytes = Util.GetEncodedText (text, TextEncoding);
 
-			return SkiaApi.sk_paint_measure_text(Handle, bytes, (IntPtr) bytes.Length, IntPtr.Zero);
+			return SkiaApi.sk_paint_measure_text (Handle, bytes, (IntPtr) bytes.Length, IntPtr.Zero);
 		}
 
-		public float MeasureText(IntPtr buffer, IntPtr length)
+		public float MeasureText (IntPtr buffer, IntPtr length)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException("buffer");
+				throw new ArgumentNullException ("buffer");
 
-			return SkiaApi.sk_paint_measure_text(Handle, buffer, length, IntPtr.Zero);
+			return SkiaApi.sk_paint_measure_text (Handle, buffer, length, IntPtr.Zero);
 		}
 
-		public float MeasureText(string text, ref SKRect bounds)
+		public float MeasureText (string text, ref SKRect bounds)
 		{
 			if (text == null)
-				throw new ArgumentNullException("text");
+				throw new ArgumentNullException ("text");
 
-			var bytes = Util.GetEncodedText(text, TextEncoding);
+			var bytes = Util.GetEncodedText (text, TextEncoding);
 
-			return SkiaApi.sk_paint_measure_text(Handle, bytes, (IntPtr) bytes.Length, ref bounds);
+			return SkiaApi.sk_paint_measure_text (Handle, bytes, (IntPtr) bytes.Length, ref bounds);
 		}
 
-		public float MeasureText(IntPtr buffer, IntPtr length, ref SKRect bounds)
+		public float MeasureText (IntPtr buffer, IntPtr length, ref SKRect bounds)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException("buffer");
+				throw new ArgumentNullException ("buffer");
 
-			return SkiaApi.sk_paint_measure_text(Handle, buffer, length, ref bounds);
+			return SkiaApi.sk_paint_measure_text (Handle, buffer, length, ref bounds);
 		}
 
 		public long BreakText (string text, float maxWidth)
@@ -241,18 +241,18 @@ namespace SkiaSharp
 			if (text == null)
 				throw new ArgumentNullException ("text");
 
-			var bytes = Util.GetEncodedText(text, TextEncoding);
+			var bytes = Util.GetEncodedText (text, TextEncoding);
 
-			return (long) SkiaApi.sk_paint_break_text(Handle, bytes, (IntPtr) bytes.Length, maxWidth, out measuredWidth);
+			return (long) SkiaApi.sk_paint_break_text (Handle, bytes, (IntPtr) bytes.Length, maxWidth, out measuredWidth);
 		}
 
 
-		public long BreakText(IntPtr buffer, IntPtr length, float maxWidth, out float measuredWidth)
+		public long BreakText (IntPtr buffer, IntPtr length, float maxWidth, out float measuredWidth)
 		{
 			if (buffer == IntPtr.Zero)
-				throw new ArgumentNullException("buffer");
+				throw new ArgumentNullException ("buffer");
 
-			return (long)SkiaApi.sk_paint_break_text(Handle, buffer, length, maxWidth, out measuredWidth);
+			return (long)SkiaApi.sk_paint_break_text (Handle, buffer, length, maxWidth, out measuredWidth);
 		}
 	}
 }

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -194,24 +194,40 @@ namespace SkiaSharp
 			}
 		}
 
-		public float MeasureText (string text)
+		public float MeasureText(string text)
 		{
 			if (text == null)
-				throw new ArgumentNullException ("text");
+				throw new ArgumentNullException("text");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes (text);
+			var bytes = System.Text.Encoding.UTF8.GetBytes(text);
 
-			return SkiaApi.sk_paint_measure_text (Handle, bytes, (IntPtr)bytes.Length, IntPtr.Zero);
+			return SkiaApi.sk_paint_measure_text(Handle, bytes, (IntPtr) bytes.Length, IntPtr.Zero);
 		}
 
-		public float MeasureText (string text, ref SKRect bounds)
+		public float MeasureText(IntPtr buffer, IntPtr length)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException("buffer");
+
+			return SkiaApi.sk_paint_measure_text(Handle, buffer, length, IntPtr.Zero);
+		}
+
+		public float MeasureText(string text, ref SKRect bounds)
 		{
 			if (text == null)
-				throw new ArgumentNullException ("text");
+				throw new ArgumentNullException("text");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes (text);
+			var bytes = Util.GetEncodedText(text, TextEncoding);
 
-			return SkiaApi.sk_paint_measure_text (Handle, bytes, (IntPtr)bytes.Length, ref bounds);
+			return SkiaApi.sk_paint_measure_text(Handle, bytes, (IntPtr) bytes.Length, ref bounds);
+		}
+
+		public float MeasureText(IntPtr buffer, IntPtr length, ref SKRect bounds)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException("buffer");
+
+			return SkiaApi.sk_paint_measure_text(Handle, buffer, length, ref bounds);
 		}
 
 		public long BreakText (string text, float maxWidth)
@@ -225,9 +241,18 @@ namespace SkiaSharp
 			if (text == null)
 				throw new ArgumentNullException ("text");
 
-			var bytes = System.Text.Encoding.UTF8.GetBytes (text);
+			var bytes = Util.GetEncodedText(text, TextEncoding);
 
-			return (long)SkiaApi.sk_paint_break_text (Handle, bytes, (IntPtr)bytes.Length, maxWidth, out measuredWidth);
+			return (long) SkiaApi.sk_paint_break_text(Handle, bytes, (IntPtr) bytes.Length, maxWidth, out measuredWidth);
+		}
+
+
+		public long BreakText(IntPtr buffer, IntPtr length, float maxWidth, out float measuredWidth)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException("buffer");
+
+			return (long)SkiaApi.sk_paint_break_text(Handle, buffer, length, maxWidth, out measuredWidth);
 		}
 	}
 }

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -235,7 +235,7 @@ namespace SkiaSharp
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static IntPtr sk_paint_break_text(sk_paint_t t, IntPtr text, IntPtr length, float maxWidth, out float measuredWidth);
 
-        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_image_t sk_image_new_raster_copy(ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_image_t sk_image_new_from_encoded(sk_data_t encoded, ref SKRectI subset);

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -120,13 +120,19 @@ namespace SkiaSharp
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_line(sk_canvas_t t, float x0, float y0, float x1, float y1, sk_paint_t paint);
 
-		// These can be overloaded to take an IntPtr which points to some utf8 text.
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_text(sk_canvas_t t, byte[] text, int len, float x, float y, sk_paint_t paint);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_pos_text(sk_canvas_t t, byte[] text, int len, [In] SKPoint[] points, sk_paint_t paint);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_text_on_path(sk_canvas_t t, byte[] text, int len, sk_path_t path, float hOffset, float vOffset, sk_paint_t paint);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_canvas_draw_text(sk_canvas_t t, IntPtr text, int len, float x, float y, sk_paint_t paint);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_canvas_draw_pos_text(sk_canvas_t t, IntPtr text, int len, [In] SKPoint[] points, sk_paint_t paint);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_canvas_draw_text_on_path(sk_canvas_t t, IntPtr text, int len, sk_path_t path, float hOffset, float vOffset, sk_paint_t paint);
+
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_bitmap(sk_canvas_t t, sk_bitmap_t bitmap, float x, float y, sk_paint_t paint);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -223,9 +229,13 @@ namespace SkiaSharp
 		public extern static float sk_paint_measure_text (sk_paint_t t, byte [] text, IntPtr length, IntPtr boundsZero);
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static IntPtr sk_paint_break_text (sk_paint_t t, byte [] text, IntPtr length, float maxWidth, out float measuredWidth);
-
-
+		public extern static float sk_paint_measure_text(sk_paint_t t, IntPtr text, IntPtr length, ref SKRect bounds);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static float sk_paint_measure_text(sk_paint_t t, IntPtr text, IntPtr length, IntPtr boundsZero);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static IntPtr sk_paint_break_text(sk_paint_t t, IntPtr text, IntPtr length, float maxWidth, out float measuredWidth);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_image_t sk_image_new_raster_copy(ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_image_t sk_image_new_from_encoded(sk_data_t encoded, ref SKRectI subset);

--- a/binding/Binding/Util.cs
+++ b/binding/Binding/Util.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SkiaSharp
+{
+	static class Util
+	{
+		public static byte[] GetEncodedText(string text, SKTextEncoding encoding)
+		{
+			switch (encoding)
+			{
+				case SKTextEncoding.Utf8:
+					return Encoding.UTF8.GetBytes(text);
+				case SKTextEncoding.Utf16:
+					return Encoding.Unicode.GetBytes(text);
+				case SKTextEncoding.Utf32:
+					return Encoding.UTF32.GetBytes(text);
+				default:
+					throw new ArgumentException($"Encoding {encoding} is not supported");
+			}
+		}
+
+	}
+}

--- a/binding/SkiaSharp.Windows.sln.DotSettings
+++ b/binding/SkiaSharp.Windows.sln.DotSettings
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_ARRAY_ACCESS_BRACKETS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_EMPTY_METHOD_CALL_PARENTHESES/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_EMPTY_METHOD_PARENTHESES/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_METHOD_CALL_PARENTHESES/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_METHOD_PARENTHESES/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Your current implementation ignores SkPaint's encoding, I've fixed that. I've also added IntPtr-based overloads, so optimizations like passing a pointer to the part of pinned `string` can be used.