### PR TITLE
Fixed issue when exception would be thrown when property was null

### DIFF
--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -113,7 +113,7 @@ namespace SkiaSharp
 				{
 					var shouldReplace =
 						reference == null ||
-						reference.Target != null ||
+						reference.Target == null ||
 						((SKObject)reference.Target).Handle == IntPtr.Zero;
 
 					Debug.WriteLineIf(!shouldReplace, "Not replacing existing, living, managed instance with new object.");


### PR DESCRIPTION
Fix for random `NullReferenceException` described in issue #39