### PR TITLE
Add setting/getting fill type to SKPath.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "skia"]
 	path = skia
-	url = git@github.com:mono/skia.git
+url=git@github.com:petergolde/skia.git
 [submodule "depot_tools"]
 	path = depot_tools
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -133,6 +133,14 @@ namespace SkiaSharp
 		CounterClockwise
 	}
 
+    public enum SKPathFillType
+    {
+        Winding,
+        EvenOdd,
+        InverseWinding,
+        InverseEvenOdd
+    }
+
 	public enum SKColorType {
 		Unknown,
 		Rgba_8888,

--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -133,13 +133,13 @@ namespace SkiaSharp
 		CounterClockwise
 	}
 
-    public enum SKPathFillType
-    {
-        Winding,
-        EvenOdd,
-        InverseWinding,
-        InverseEvenOdd
-    }
+	public enum SKPathFillType
+	{
+		Winding,
+		EvenOdd,
+		InverseWinding,
+		InverseEvenOdd
+	}
 
 	public enum SKColorType {
 		Unknown,

--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -31,7 +31,16 @@ namespace SkiaSharp
 
 			base.Dispose (disposing);
 		}
-		
+
+		public SKPathFillType FillType {
+			get {
+				return SkiaApi.sk_path_get_filltype (Handle);
+			}
+			set {
+				SkiaApi.sk_path_set_filltype (Handle, value);
+			}
+		}
+
 		public void MoveTo (float x, float y)
 		{
 			SkiaApi.sk_path_move_to (Handle, x, y);

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -288,9 +288,13 @@ namespace SkiaSharp
 		public extern static void sk_path_add_oval(sk_path_t t, ref SKRect rect, SKPathDirection direction);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static bool sk_path_get_bounds(sk_path_t t, out SKRect rect);
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static SKPathFillType sk_path_get_filltype (sk_path_t t);
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_path_set_filltype (sk_path_t t, SKPathFillType filltype);
 
 		// SkMaskFilter
-		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_maskfilter_unref(sk_maskfilter_t t);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_maskfilter_t sk_maskfilter_new_blur(SKBlurStyle style, float sigma);


### PR DESCRIPTION
Allows setting and getting the fill type in an SKPath. This is necessary, for example, to use the EvenOdd fill type. 

Note that changes to the skia C API were necessary also. You can see these changes in the petergolde/skia repo under the path-fill-type branch.

Edit:  Skia changes now in [PR 1][1] of mono/Skia

[1]: https://github.com/mono/skia/pull/1