### PR TITLE
Add SKPaint.GetTextPath to convert text into a path.

### DIFF
--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -248,6 +248,35 @@ namespace SkiaSharp
 			return (long)SkiaApi.sk_paint_break_text (Handle, buffer, length, maxWidth, out measuredWidth);
 		}
 
+		public SKPath GetTextPath(string text, float x, float y)
+		{
+			if (text == null)
+				throw new ArgumentNullException(nameof(text));
+			return new SKPath(SkiaApi.sk_paint_get_utf16_text_path(Handle, text, (IntPtr)text.Length, x, y));
+		}
+
+		public SKPath GetTextPath(IntPtr buffer, IntPtr length, float x, float y)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException(nameof(buffer));
+			return new SKPath(SkiaApi.sk_paint_get_text_path(Handle, buffer, length, x, y));
+
+		}
+
+		public SKPath GetTextPath(string text, SKPoint[] points)
+		{
+			if (text == null)
+				throw new ArgumentNullException(nameof(text));
+			return new SKPath(SkiaApi.sk_paint_get_pos_utf16_text_path(Handle, text, (IntPtr)text.Length, points));
+		}
+
+		public SKPath GetTextPath(IntPtr buffer, IntPtr length, SKPoint[] points)
+		{
+			if (buffer == IntPtr.Zero)
+				throw new ArgumentNullException(nameof(buffer));
+			return new SKPath(SkiaApi.sk_paint_get_pos_text_path(Handle, buffer, length, points));
+		}
+
 		public SKFontMetrics FontMetrics
 		{
 			get

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -244,6 +244,16 @@ namespace SkiaSharp
 		public extern static IntPtr sk_paint_break_utf16_text(sk_paint_t t, [MarshalAs(UnmanagedType.LPWStr)] string text, IntPtr length, float maxWidth, out float measuredWidth);
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static IntPtr sk_paint_break_text (sk_paint_t t, byte [] text, IntPtr length, float maxWidth, out float measuredWidth);
+
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static sk_path_t sk_paint_get_text_path(sk_paint_t t, IntPtr text, IntPtr length, float x, float y);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static sk_path_t sk_paint_get_utf16_text_path(sk_paint_t t, [MarshalAs(UnmanagedType.LPWStr)] string text, IntPtr lengthInChars, float x, float y);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static sk_path_t sk_paint_get_pos_text_path(sk_paint_t t, IntPtr text, IntPtr length, [In] SKPoint[] points);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static sk_path_t sk_paint_get_pos_utf16_text_path(sk_paint_t t, [MarshalAs(UnmanagedType.LPWStr)] string text, IntPtr lengthInChars, [In] SKPoint[] points);
+
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static float sk_paint_get_fontmetrics(sk_paint_t t, out SKFontMetrics fontMetrics, float scale);
 


### PR DESCRIPTION
Requires mono/skia PR #5.