### PR TITLE
Add RGB <-> HSV conversion functions for SKColor (#61)

### DIFF
--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -231,7 +231,7 @@ namespace SkiaSharp
 			return (int)(x * (1 << 16));
 		}
 
-        public override string ToString ()
+		public override string ToString ()
 		{
 			return string.Format (CultureInfo.InvariantCulture, "#{0:x2}{1:x2}{2:x2}{3:x2}",  Alpha, Red, Green, Blue);
 		}

--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -97,6 +97,30 @@ namespace SkiaSharp
 		public byte Green => (byte)((color >> 8) & 0xff);
 		public byte Blue => (byte)((color) & 0xff);
 
+		public float Hue {
+			get {
+				float hue, saturation, value;
+				ToHSV (out hue, out saturation, out value);
+				return hue;
+			}
+		}
+
+		public float Saturation {
+			get {
+				float hue, saturation, value;
+				ToHSV (out hue, out saturation, out value);
+				return saturation;
+			}
+		}
+
+		public float Value {
+			get {
+				float hue, saturation, value;
+				ToHSV (out hue, out saturation, out value);
+				return value;
+			}
+		}
+
 		public static SKColor FromHSV (float hue, float saturation, float value)
 		{
 			if (saturation < 0 || saturation > 1)
@@ -132,11 +156,10 @@ namespace SkiaSharp
 			return new SKColor ((byte)r, (byte)g, (byte)b);
 		}
 
-		public static void ToHSV(SKColor color, out float hue, out float saturation, out float value)
+		public void ToHSV(out float hue, out float saturation, out float value)
 		{
-			byte r = color.Red, g = color.Green, b = color.Blue;
-			byte min = Math.Min (r, Math.Min (g, b));
-			byte max = Math.Max (r, Math.Max (g, b));
+			byte min = Math.Min (Red, Math.Min (Green, Blue));
+			byte max = Math.Max (Red, Math.Max (Green, Blue));
 			byte delta = (byte)(max - min);
 
 			float v = ByteToScalar (max);
@@ -151,12 +174,12 @@ namespace SkiaSharp
 			float s = ByteDivToScalar (delta, max);
 
 			float h;
-			if (r == max) {
-				h = ByteDivToScalar (g - b, delta);
-			} else if (g == max) {
-				h = SkIntToScalar (2) + ByteDivToScalar (b - r, delta);
-			} else { // b == max
-				h = SkIntToScalar (4) + ByteDivToScalar (r - g, delta);
+			if (Red == max) {
+				h = ByteDivToScalar (Green - Blue, delta);
+			} else if (Green == max) {
+				h = SkIntToScalar (2) + ByteDivToScalar (Blue - Red, delta);
+			} else { // Blue == max
+				h = SkIntToScalar (4) + ByteDivToScalar (Red - Green, delta);
 			}
 
 			h *= 60;
@@ -167,11 +190,6 @@ namespace SkiaSharp
 			hue = h;
 			saturation = s;
 			value = v;
-		}
-
-		public void ToHSV(out float hue, out float saturation, out float value)
-		{
-			ToHSV (this, out hue, out saturation, out value);
 		}
 
 		private static float ByteDivToScalar (int numer, byte denom)

--- a/tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.csproj
+++ b/tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.csproj
@@ -81,6 +81,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Tests\SKColorTest.cs">
+      <Link>SKColorTest.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Tests\SKManagedStreamTest.cs">
       <Link>SKManagedStreamTest.cs</Link>

--- a/tests/Tests/SKColorTest.cs
+++ b/tests/Tests/SKColorTest.cs
@@ -8,7 +8,7 @@ namespace SkiaSharp.Tests
 	[TestFixture]
 	public class SKColorTest : SKTest
 	{
-        private void AssertEquivalent(byte r, byte g, byte b, float hue, float saturation, float value)
+		private void AssertEquivalent (byte r, byte g, byte b, float hue, float saturation, float value)
 		{
 			SKColor color = new SKColor (r, g, b);
 			float checkh, checks, checkv;
@@ -20,24 +20,24 @@ namespace SkiaSharp.Tests
 
 			color = SKColor.FromHSV (hue, saturation, value);
 			// Allow a small delta for rounding errors.
-            Assert.AreEqual (r, color.Red, 1);
-            Assert.AreEqual (g, color.Green, 1);
-            Assert.AreEqual (b, color.Blue, 1);
-        }
+			Assert.AreEqual (r, color.Red, 1);
+			Assert.AreEqual (g, color.Green, 1);
+			Assert.AreEqual (b, color.Blue, 1);
+		}
 
 		[Test]
-        public void TestRGBHSVConversions()
-        {
-            AssertEquivalent (0x00, 0x00, 0x00, 0, 0, 0);
-            AssertEquivalent (0xff, 0xff, 0xff, 0, 0, 1);
-            AssertEquivalent (0xff, 0x00, 0x00, 0, 1, 1);
-            AssertEquivalent (0x00, 0xff, 0x00, 120, 1, 1);
-            AssertEquivalent (0x00, 0x00, 0xff, 240, 1, 1);
-            AssertEquivalent (0x00, 0xff, 0xff, 180, 1, 1);
-            AssertEquivalent (0xff, 0xff, 0x00, 60, 1, 1);
-            AssertEquivalent (0x80, 0x80, 0x80, 0, 0, 0.5f);
-            AssertEquivalent (0xc0, 0xc0, 0xc0, 0, 0, 0.75f);
+		public void TestRGBHSVConversions ()
+		{
+			AssertEquivalent (0x00, 0x00, 0x00, 0, 0, 0);
+			AssertEquivalent (0xff, 0xff, 0xff, 0, 0, 1);
+			AssertEquivalent (0xff, 0x00, 0x00, 0, 1, 1);
+			AssertEquivalent (0x00, 0xff, 0x00, 120, 1, 1);
+			AssertEquivalent (0x00, 0x00, 0xff, 240, 1, 1);
+			AssertEquivalent (0x00, 0xff, 0xff, 180, 1, 1);
+			AssertEquivalent (0xff, 0xff, 0x00, 60, 1, 1);
+			AssertEquivalent (0x80, 0x80, 0x80, 0, 0, 0.5f);
+			AssertEquivalent (0xc0, 0xc0, 0xc0, 0, 0, 0.75f);
 			AssertEquivalent (0x40, 0x80, 0x40, 120, 0.5f, 0.5f);
-        }
+		}
 	}
 }

--- a/tests/Tests/SKColorTest.cs
+++ b/tests/Tests/SKColorTest.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using NUnit.Framework;
+
+namespace SkiaSharp.Tests
+{
+	[TestFixture]
+	public class SKColorTest : SKTest
+	{
+        private void AssertEquivalent(byte r, byte g, byte b, float hue, float saturation, float value)
+		{
+			SKColor color = new SKColor (r, g, b);
+			float checkh, checks, checkv;
+			SKColor.ToHSV (color, out checkh, out checks, out checkv);
+			// Allow a small delta for rounding errors.
+			Assert.AreEqual (hue, checkh, 0.01);
+			Assert.AreEqual (saturation, checks, 0.01);
+			Assert.AreEqual (value, checkv, 0.01);
+
+			color = SKColor.FromHSV (hue, saturation, value);
+			// Allow a small delta for rounding errors.
+            Assert.AreEqual (r, color.Red, 1);
+            Assert.AreEqual (g, color.Green, 1);
+            Assert.AreEqual (b, color.Blue, 1);
+        }
+
+		[Test]
+        public void TestRGBHSVConversions()
+        {
+            AssertEquivalent (0x00, 0x00, 0x00, 0, 0, 0);
+            AssertEquivalent (0xff, 0xff, 0xff, 0, 0, 1);
+            AssertEquivalent (0xff, 0x00, 0x00, 0, 1, 1);
+            AssertEquivalent (0x00, 0xff, 0x00, 120, 1, 1);
+            AssertEquivalent (0x00, 0x00, 0xff, 240, 1, 1);
+            AssertEquivalent (0x00, 0xff, 0xff, 180, 1, 1);
+            AssertEquivalent (0xff, 0xff, 0x00, 60, 1, 1);
+            AssertEquivalent (0x80, 0x80, 0x80, 0, 0, 0.5f);
+            AssertEquivalent (0xc0, 0xc0, 0xc0, 0, 0, 0.75f);
+			AssertEquivalent (0x40, 0x80, 0x40, 120, 0.5f, 0.5f);
+        }
+	}
+}

--- a/tests/Tests/SKColorTest.cs
+++ b/tests/Tests/SKColorTest.cs
@@ -12,17 +12,23 @@ namespace SkiaSharp.Tests
 		{
 			SKColor color = new SKColor (r, g, b);
 			float checkh, checks, checkv;
-			SKColor.ToHSV (color, out checkh, out checks, out checkv);
+			color.ToHSV (out checkh, out checks, out checkv);
 			// Allow a small delta for rounding errors.
 			Assert.AreEqual (hue, checkh, 0.01);
 			Assert.AreEqual (saturation, checks, 0.01);
 			Assert.AreEqual (value, checkv, 0.01);
+			Assert.AreEqual (color.Hue, checkh, 0.01);
+			Assert.AreEqual (color.Saturation, checks, 0.01);
+			Assert.AreEqual (color.Value, checkv, 0.01);
 
 			color = SKColor.FromHSV (hue, saturation, value);
 			// Allow a small delta for rounding errors.
 			Assert.AreEqual (r, color.Red, 1);
 			Assert.AreEqual (g, color.Green, 1);
 			Assert.AreEqual (b, color.Blue, 1);
+			Assert.AreEqual (color.Hue, checkh, 0.01);
+			Assert.AreEqual (color.Saturation, checks, 0.01);
+			Assert.AreEqual (color.Value, checkv, 0.01);
 		}
 
 		[Test]


### PR DESCRIPTION
Issue #61.

This is a direct translation from the Skia functions `SkRGBToHSV` and `SkHSVToColor`. Happy to make any changes.