### PR TITLE
Added missing functions for SKPath

### DIFF
--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -103,16 +103,16 @@ namespace SkiaSharp
 		}
 
 		public void Rewind()
-        {
-            SkiaApi.sk_path_rewind(Handle);
-        }
+		{
+			SkiaApi.sk_path_rewind(Handle);
+		}
 
-        public void Reset()
-        {
-            SkiaApi.sk_path_reset(Handle);
-        }
+		public void Reset()
+		{
+			SkiaApi.sk_path_reset(Handle);
+		}
 
-        public void AddRect (SKRect rect, SKPathDirection direction)
+		public void AddRect (SKRect rect, SKPathDirection direction)
 		{
 			SkiaApi.sk_path_add_rect (Handle, ref rect, direction);
 		}

--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -102,7 +102,17 @@ namespace SkiaSharp
 			SkiaApi.sk_path_close (Handle);
 		}
 
-		public void AddRect (SKRect rect, SKPathDirection direction)
+        public void Rewind()
+        {
+            SkiaApi.sk_path_rewind(Handle);
+        }
+
+        public void Reset()
+        {
+            SkiaApi.sk_path_reset(Handle);
+        }
+
+        public void AddRect (SKRect rect, SKPathDirection direction)
 		{
 			SkiaApi.sk_path_add_rect (Handle, ref rect, direction);
 		}

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -318,7 +318,11 @@ namespace SkiaSharp
 		public extern static void sk_path_rcubic_to(sk_path_t t, float dx0, float dy0, float dx1, float dy1, float dx2, float dy2);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_path_close(sk_path_t t);
-		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        public extern static void sk_path_rewind(sk_path_t t);
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        public extern static void sk_path_reset(sk_path_t t);
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_path_add_rect(sk_path_t t, ref SKRect rect, SKPathDirection direction);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_path_add_rect_start(sk_path_t t, ref SKRect rect, SKPathDirection direction, uint startIndex);


### PR DESCRIPTION
Added missing functions for SKPath:
- Reset()
- Rewind()
Added to SKPath.cs and SkiaAPI.cs in same style as SKPath.Close()