### PR TITLE
CharsToGlyphs(SKEncoding) does not use the specified encoding.

### DIFF
--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -107,7 +107,7 @@ namespace SkiaSharp
 				glyphs = new ushort[n];
 
 				fixed (ushort *gp = &glyphs [0]){
-					return SkiaApi.sk_typeface_chars_to_glyphs (Handle, str, SKEncoding.Utf16, (IntPtr) gp, n);
+					return SkiaApi.sk_typeface_chars_to_glyphs (Handle, str, encoding, (IntPtr) gp, n);
 				}
 			}
 		}


### PR DESCRIPTION
I believe this is just a mistake on copy-n-paste the code. But CharsToGlyphs variant that accepts SKEncoding should use encoding instead of SKEncoding.Utf16.