### PR TITLE
Add colortable setter support

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -28,6 +28,7 @@ namespace SkiaSharp
 		{
 			releaseDelegate = new SKBitmapReleaseDelegateInternal (SKBitmapReleaseInternal);
 		}
+		const string UNSUPPORTED_CLR_TYPE_MSG = "Setting the ColorTable is only supported for bitmaps with ColorTypes of Index8";
 
 		[Preserve]
 		internal SKBitmap (IntPtr handle, bool owns)
@@ -223,10 +224,18 @@ namespace SkiaSharp
 		}
 
 		public void SetPixels(IntPtr pixels, SKColorTable ct = null) {
+			if (ct != null && ColorType != SKColorType.Index8)
+			{
+				throw new NotSupportedException(UNSUPPORTED_CLR_TYPE_MSG);
+			}
 			SkiaApi.sk_bitmap_set_pixels(Handle, pixels, ct != null ? ct.Handle : IntPtr.Zero);
 		}
 
 		public void SetColorTable(SKColorTable ct) {
+			if (ColorType != SKColorType.Index8)
+			{
+				throw new NotSupportedException(UNSUPPORTED_CLR_TYPE_MSG);
+			}
 			IntPtr length;
 			SetPixels(this.GetPixels(out length), ct);
 		}

--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -217,6 +217,19 @@ namespace SkiaSharp
 		{
 			return SkiaApi.sk_bitmap_get_pixels (Handle, out length);
 		}
+
+		public void SetPixels(IntPtr pixels) {
+			SetPixels(pixels, this.ColorTable);
+		}
+
+		public void SetPixels(IntPtr pixels, SKColorTable ct = null) {
+			SkiaApi.sk_bitmap_set_pixels(Handle, pixels, ct != null ? ct.Handle : IntPtr.Zero);
+		}
+
+		public void SetColorTable(SKColorTable ct) {
+			IntPtr length;
+			SetPixels(this.GetPixels(out length), ct);
+		}
 		
 		public byte[] Bytes {
 			get { 
@@ -268,11 +281,6 @@ namespace SkiaSharp
 
 		public SKColorTable ColorTable {
 			get { return GetObject<SKColorTable> (SkiaApi.sk_bitmap_get_colortable (Handle)); }
-			set
-			{
-				if (value != null)
-					SkiaApi.sk_bitmap_set_colortable(Handle, value.Handle);
-			}
 		}
 
 		public static SKImageInfo DecodeBounds (SKStream stream)

--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -227,8 +227,8 @@ namespace SkiaSharp
 			SetPixels(pixels, this.ColorTable);
 		}
 
-		public void SetPixels(IntPtr pixels, SKColorTable ct = null) {
-			if (ct != null && ColorType != SKColorType.Index8)
+		public void SetPixels(IntPtr pixels, SKColorTable ct) {
+			if (ColorType != SKColorType.Index8)
 			{
 				throw new NotSupportedException(UNSUPPORTED_CLR_TYPE_MSG);
 			}
@@ -236,10 +236,6 @@ namespace SkiaSharp
 		}
 
 		public void SetColorTable(SKColorTable ct) {
-			if (ColorType != SKColorType.Index8)
-			{
-				throw new NotSupportedException(UNSUPPORTED_CLR_TYPE_MSG);
-			}
 			IntPtr length;
 			SetPixels(this.GetPixels(out length), ct);
 		}

--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -28,7 +28,7 @@ namespace SkiaSharp
 		{
 			releaseDelegate = new SKBitmapReleaseDelegateInternal (SKBitmapReleaseInternal);
 		}
-		const string UNSUPPORTED_CLR_TYPE_MSG = "Setting the ColorTable is only supported for bitmaps with ColorTypes of Index8";
+		const string UNSUPPORTED_CLR_TYPE_MSG = "Setting the ColorTable is only supported for bitmaps with ColorTypes of Index8.";
 
 		[Preserve]
 		internal SKBitmap (IntPtr handle, bool owns)
@@ -116,6 +116,10 @@ namespace SkiaSharp
 
 		public void SetPixel (int x, int y, SKColor color)
 		{
+			if (ColorType == SKColorType.Index8)
+			{
+				throw new NotSupportedException("This method is not supported for bitmaps with ColorTypes of Index8.");
+			}
 			SkiaApi.sk_bitmap_set_pixel_color (Handle, x, y, color);
 		}
 

--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -268,6 +268,11 @@ namespace SkiaSharp
 
 		public SKColorTable ColorTable {
 			get { return GetObject<SKColorTable> (SkiaApi.sk_bitmap_get_colortable (Handle)); }
+			set
+			{
+				if (value != null)
+					SkiaApi.sk_bitmap_set_colortable(Handle, value.Handle);
+			}
 		}
 
 		public static SKImageInfo DecodeBounds (SKStream stream)

--- a/binding/Binding/SKCanvas.cs
+++ b/binding/Binding/SKCanvas.cs
@@ -36,6 +36,18 @@ namespace SkiaSharp
 			base.Dispose (disposing);
 		}
 
+		public bool QuickReject (SKRect rect)
+		{
+			return SkiaApi.sk_canvas_quick_reject (Handle, ref rect);
+		}
+
+		public bool QuickReject (SKPath path)
+		{
+			if (path == null)
+				throw new ArgumentNullException (nameof (path));
+			return path.IsEmpty || QuickReject (path.Bounds);
+		}
+
 		public int Save ()
 		{
 			if (Handle == IntPtr.Zero)
@@ -234,6 +246,15 @@ namespace SkiaSharp
 			SkiaApi.sk_canvas_draw_paint (Handle, paint.Handle);
 		}
 
+		public void DrawRegion (SKRegion region, SKPaint paint)
+		{
+			if (region == null)
+				throw new ArgumentNullException (nameof (region));
+			if (paint == null)
+				throw new ArgumentNullException (nameof (paint));
+			SkiaApi.sk_canvas_draw_region (Handle, region.Handle, paint.Handle);
+		}
+
 		public void DrawRect (SKRect rect, SKPaint paint)
 		{
 			if (paint == null)
@@ -364,7 +385,13 @@ namespace SkiaSharp
 			SkiaApi.sk_canvas_draw_text (Handle, bytes, bytes.Length, x, y, paint.Handle);
 		}
 
+		[Obsolete ("Use DrawPositionedText instead.")]
 		public void DrawText (string text, SKPoint [] points, SKPaint paint)
+		{
+			DrawPositionedText (text, points, paint);
+		}
+
+		public void DrawPositionedText (string text, SKPoint [] points, SKPaint paint)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -399,7 +426,13 @@ namespace SkiaSharp
 			SkiaApi.sk_canvas_draw_text (Handle, buffer, length, x, y, paint.Handle);
 		}
 
+		[Obsolete ("Use DrawPositionedText instead.")]
 		public void DrawText (IntPtr buffer, int length, SKPoint[] points, SKPaint paint)
+		{
+			DrawPositionedText (buffer, length, points, paint);
+		}
+
+		public void DrawPositionedText (IntPtr buffer, int length, SKPoint[] points, SKPaint paint)
 		{
 			if (buffer == IntPtr.Zero)
 				throw new ArgumentNullException (nameof (buffer));
@@ -558,6 +591,11 @@ namespace SkiaSharp
 	{
 		private SKCanvas canvas;
 		private readonly int saveCount;
+
+		public SKAutoCanvasRestore (SKCanvas canvas)
+			: this (canvas, true)
+		{
+		}
 
 		public SKAutoCanvasRestore (SKCanvas canvas, bool doSave)
 		{

--- a/binding/Binding/SKCodec.cs
+++ b/binding/Binding/SKCodec.cs
@@ -146,6 +146,49 @@ namespace SkiaSharp
 			return GetPixels (info, pixels, info.RowBytes, SKCodecOptions.Default, colorTable, ref colorTableCount);
 		}
 
+		public unsafe SKCodecResult StartIncrementalDecode(SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options, IntPtr colorTable, ref int colorTableCount)
+		{
+			if (pixels == IntPtr.Zero)
+				throw new ArgumentNullException (nameof (pixels));
+
+			var nativeOptions = new SKCodecOptionsInternal {
+				fZeroInitialized = options.ZeroInitialized,
+				fSubset = null
+			};
+			if (options.HasSubset) {
+				var subset = options.Subset.Value;
+				nativeOptions.fSubset = &subset;
+			}
+			return SkiaApi.sk_codec_start_incremental_decode (Handle, ref info, pixels, (IntPtr)rowBytes, ref nativeOptions, colorTable, ref colorTableCount);
+		}
+
+		public SKCodecResult StartIncrementalDecode (SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options)
+		{
+			int colorTableCount = 0;
+			return StartIncrementalDecode (info, pixels, rowBytes, options, IntPtr.Zero, ref colorTableCount);
+		}
+
+		public SKCodecResult StartIncrementalDecode (SKImageInfo info, IntPtr pixels, int rowBytes)
+		{
+			return SkiaApi.sk_codec_start_incremental_decode (Handle, ref info, pixels, (IntPtr)rowBytes, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+		}
+
+		public unsafe SKCodecResult StartIncrementalDecode(SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options, SKColorTable colorTable, ref int colorTableCount)
+		{
+			return StartIncrementalDecode (info, pixels, rowBytes, options, colorTable == null ? IntPtr.Zero : colorTable.ReadColors (), ref colorTableCount);
+		}
+
+		public SKCodecResult IncrementalDecode (out int rowsDecoded)
+		{
+			return SkiaApi.sk_codec_incremental_decode (Handle, out rowsDecoded);
+		}
+
+		public SKCodecResult IncrementalDecode ()
+		{
+			int rowsDecoded;
+			return SkiaApi.sk_codec_incremental_decode (Handle, out rowsDecoded);
+		}
+
 		public static SKCodec Create (SKStream stream)
 		{
 			if (stream == null)

--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -75,6 +75,14 @@ namespace SkiaSharp
 		
 		public bool IsConcave => Convexity == SKPathConvexity.Concave;
 
+		public bool IsEmpty => VerbCount == 0;
+
+		public int VerbCount {
+			get {
+				return SkiaApi.sk_path_count_verbs (Handle);
+			}
+		}
+
 		public int PointCount {
 			get {
 				return SkiaApi.sk_path_count_points (Handle);

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -131,11 +131,16 @@ namespace SkiaSharp
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_concat(sk_canvas_t t, ref SKMatrix m);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public extern static bool sk_canvas_quick_reject(sk_canvas_t t, ref SKRect rect);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_clip_rect(sk_canvas_t t, ref SKRect rect);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_clip_path(sk_canvas_t t, sk_path_t p);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_paint(sk_canvas_t t, sk_paint_t p);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_canvas_draw_region(sk_canvas_t t, sk_region_t region, sk_paint_t paint);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_canvas_draw_rect(sk_canvas_t t, ref SKRect rect, sk_paint_t paint);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -500,6 +505,8 @@ namespace SkiaSharp
 		public extern static void sk_path_add_rounded_rect (sk_path_t t, ref SKRect rect, float rx, float ry, SKPathDirection dir);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_path_add_circle (sk_path_t t, float x, float y, float radius, SKPathDirection dir);
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static int sk_path_count_verbs (sk_path_t path);
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static int sk_path_count_points (sk_path_t path);
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1093,6 +1100,12 @@ namespace SkiaSharp
 		public extern static void sk_bitmap_set_pixel_color(sk_bitmap_t cbitmap, int x, int y, SKColor color);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs(UnmanagedType.I1)]
+		public extern static bool sk_bitmap_ready_to_draw(sk_bitmap_t b);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public extern static bool sk_bitmap_copy_pixels_to(sk_bitmap_t cbitmap, IntPtr dst, IntPtr dstSize, IntPtr dstRowBytes, bool preserveDstPad);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
 		public extern static bool sk_bitmap_copy(sk_bitmap_t cbitmap, sk_bitmap_t dst, SKColorType ct);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs(UnmanagedType.I1)]
@@ -1101,6 +1114,9 @@ namespace SkiaSharp
 		public extern static void sk_bitmap_lock_pixels(sk_bitmap_t b);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_bitmap_unlock_pixels(sk_bitmap_t b);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public extern static bool sk_bitmap_install_pixels(sk_bitmap_t cbitmap, ref SKImageInfo cinfo, IntPtr pixels, IntPtr rowBytes, sk_colortable_t ctable, IntPtr releaseProc, IntPtr context);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs(UnmanagedType.I1)]
 		public extern static bool sk_bitmap_try_alloc_pixels(sk_bitmap_t cbitmap, ref SKImageInfo requestedInfo, IntPtr rowBytes);

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -1040,6 +1040,14 @@ namespace SkiaSharp
 		public extern static SKCodecResult sk_codec_get_pixels(sk_codec_t codec, ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes, ref SKCodecOptionsInternal options, IntPtr ctable, ref int ctableCount);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static SKCodecResult sk_codec_get_pixels_using_defaults(sk_codec_t codec, ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static SKCodecResult sk_codec_start_incremental_decode(sk_codec_t codec, ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes, ref SKCodecOptionsInternal options, IntPtr ctable, ref int ctableCount);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static SKCodecResult sk_codec_start_incremental_decode(sk_codec_t codec, ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes, ref SKCodecOptionsInternal options, IntPtr ctableZero, IntPtr ctableCountZero);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static SKCodecResult sk_codec_start_incremental_decode(sk_codec_t codec, ref SKImageInfo info, IntPtr pixels, IntPtr rowBytes, IntPtr optionsZero, IntPtr ctableZero, IntPtr ctableCountZero);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static SKCodecResult sk_codec_incremental_decode(sk_codec_t codec, out int rowsDecoded);
 
 		// Bitmap
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -1126,7 +1126,7 @@ namespace SkiaSharp
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_colortable_t sk_bitmap_get_colortable(sk_bitmap_t cbitmap);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
-		public extern static void sk_bitmap_set_colortable(sk_bitmap_t cbitmap, sk_colortable_t ctable);
+		public extern static void sk_bitmap_set_pixels(sk_bitmap_t cbitmap, IntPtr pixels, sk_colortable_t ctable);
 
 		// Matrix
 

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -1125,6 +1125,8 @@ namespace SkiaSharp
 		public extern static bool sk_bitmap_try_alloc_pixels_with_color_table(sk_bitmap_t cbitmap, ref SKImageInfo requestedInfo, sk_pixelref_factory_t factory, sk_colortable_t ctable);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_colortable_t sk_bitmap_get_colortable(sk_bitmap_t cbitmap);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_bitmap_set_colortable(sk_bitmap_t cbitmap, sk_colortable_t ctable);
 
 		// Matrix
 

--- a/docs/en/SkiaSharp/SKBitmap.xml
+++ b/docs/en/SkiaSharp/SKBitmap.xml
@@ -1221,9 +1221,29 @@
       <Docs>
         <summary>The number of bytes per row.</summary>
         <value>
-          <para></para>
+          <para>
+          </para>
         </value>
         <remarks>The same as <see cref="P:SkiaSharp.SKImageInfo.RowBytes" />.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetColorTable">
+      <MemberSignature Language="C#" Value="public void SetColorTable (SkiaSharp.SKColorTable ct);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetColorTable(class SkiaSharp.SKColorTable ct) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.55.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="ct" Type="SkiaSharp.SKColorTable" />
+      </Parameters>
+      <Docs>
+        <param name="ct">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetImmutable">
@@ -1275,6 +1295,46 @@
         <param name="color">The color to set.</param>
         <summary>Sets the color of the pixel at a specified location.</summary>
         <remarks>This method will set the color of the pixel on the bitmap to the specified <paramref name="color" /> performing any necessary color conversions to the format of the bitmap.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetPixels">
+      <MemberSignature Language="C#" Value="public void SetPixels (IntPtr pixels);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetPixels(native int pixels) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.55.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="pixels" Type="System.IntPtr" />
+      </Parameters>
+      <Docs>
+        <param name="pixels">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetPixels">
+      <MemberSignature Language="C#" Value="public void SetPixels (IntPtr pixels, SkiaSharp.SKColorTable ct = null);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SetPixels(native int pixels, class SkiaSharp.SKColorTable ct) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.55.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="pixels" Type="System.IntPtr" />
+        <Parameter Name="ct" Type="SkiaSharp.SKColorTable" />
+      </Parameters>
+      <Docs>
+        <param name="pixels">To be added.</param>
+        <param name="ct">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnlockPixels">

--- a/tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.csproj
+++ b/tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.csproj
@@ -113,6 +113,9 @@
     <Compile Include="..\Tests\SKBasicTypesTest.cs" >
       <Link>SKBasicTypesTest.cs</Link>
     </Compile>
+    <Compile Include="..\Tests\SKBitmapTest.cs" >
+      <Link>SKBitmapTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\samples\SkiaSharpSample.Shared\Media\content-font.ttf">

--- a/tests/Tests/SKBitmapTest.cs
+++ b/tests/Tests/SKBitmapTest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+
+namespace SkiaSharp.Tests
+{
+	[TestFixture]
+	public class SKBitmapTest : SKTest
+	{
+		[Test]
+		public void ReleaseBitmapPixelsWasInvoked()
+		{
+			bool released = false;
+
+			var onRelease = new SKBitmapReleaseDelegate((addr, ctx) => {
+				Marshal.FreeCoTaskMem(addr);
+				released = true;
+			});
+
+			using (var bitmap = new SKBitmap()) {
+				var info = new SKImageInfo(1, 1);
+				var pixels = Marshal.AllocCoTaskMem(info.BytesSize);
+
+				bitmap.InstallPixels(info, pixels, info.RowBytes, null, onRelease, "RELEASING!");
+			}
+
+			Assert.IsTrue(released, "The SKBitmapReleaseDelegate was not called.");
+		}
+
+		[Test]
+		public void ReleaseBitmapPixelsWithNullDelegate()
+		{
+			var info = new SKImageInfo(1, 1);
+			var pixels = Marshal.AllocCoTaskMem(info.BytesSize);
+
+			using (var bitmap = new SKBitmap()) {
+				bitmap.InstallPixels(info, pixels, info.RowBytes);
+			}
+
+			Marshal.FreeCoTaskMem(pixels);
+		}
+	}
+}

--- a/tests/Tests/SKCodecTest.cs
+++ b/tests/Tests/SKCodecTest.cs
@@ -42,6 +42,59 @@ namespace SkiaSharp.Tests
 		}
 
 		[Test]
+		public void DecodePartialImage ()
+		{
+			// read the data here, so we can fake a throttle/download
+			var path = Path.Combine (PathToImages, "baboon.png");
+			var fileData = File.ReadAllBytes (path);
+			SKColor[] correctBytes;
+			using (var bitmap = SKBitmap.Decode (path)) {
+				correctBytes = bitmap.Pixels;
+			}
+
+			int offset = 0;
+			int maxCount = 1024 * 4;
+
+			// the "download" stream needs some data
+			var downloadStream = new MemoryStream ();
+			downloadStream.Write (fileData, offset, maxCount);
+			downloadStream.Position -= maxCount;
+			offset += maxCount;
+
+			using (var codec = SKCodec.Create (new SKManagedStream (downloadStream))) {
+				var info = new SKImageInfo (codec.Info.Width, codec.Info.Height);
+
+				// the bitmap to be decoded
+				using (var incremental = new SKBitmap (info)) {
+
+					// start decoding
+					IntPtr length;
+					var pixels = incremental.GetPixels (out length);
+					var result = codec.StartIncrementalDecode (info, pixels, info.RowBytes);
+
+					// make sure the start was successful
+					Assert.AreEqual (SKCodecResult.Success, result);
+					result = SKCodecResult.IncompleteInput;
+
+					while (result == SKCodecResult.IncompleteInput) {
+						// decode the rest
+						int rowsDecoded = 0;
+						result = codec.IncrementalDecode (out rowsDecoded);
+
+						// write some more data to the stream
+						maxCount = Math.Min (maxCount, fileData.Length - offset);
+						downloadStream.Write (fileData, offset, maxCount);
+						downloadStream.Position -= maxCount;
+						offset += maxCount;
+					}
+
+					// compare to original
+					CollectionAssert.AreEqual (correctBytes, incremental.Pixels);
+				}
+			}
+		}
+
+		[Test]
 		public void BitmapDecodesCorrectly ()
 		{
 			byte[] codecPixels;


### PR DESCRIPTION
Adds a support for setting the ColorTable of a bitmap. Technically this is for index8 bitmaps, but I've left in the logic to check that to the actual Skia library.

Addresses #186.
Requires https://github.com/mono/skia/pull/36.