### PR TITLE
remove index8 check for adding pixels

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -232,9 +232,6 @@ namespace SkiaSharp
 
 		public void SetPixels(IntPtr pixels, SKColorTable ct)
 		{
-			if (ColorType != SKColorType.Index8) {
-				throw new NotSupportedException (UnsupportedColorTypeMessage);
-			}
 			SkiaApi.sk_bitmap_set_pixels (Handle, pixels, ct != null ? ct.Handle : IntPtr.Zero);
 		}
 


### PR DESCRIPTION
After looking at this there really isn't any reason that this check needs to be here.