### PR TITLE
Make the iOS Forms views non-opaque

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKCanvasViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKCanvasViewRenderer.cs
@@ -86,6 +86,9 @@ namespace SkiaSharp.Views.Forms
 				UserInteractionEnabled = false;
 
 				this.controller = controller;
+
+				// Force the opacity to false for consistency with the other platforms
+				Opaque = false;
 			}
 
 			public override void DrawInSurface(SKSurface surface, SKImageInfo info)

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKGLViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKGLViewRenderer.cs
@@ -132,6 +132,9 @@ namespace SkiaSharp.Views.Forms
 				UserInteractionEnabled = false;
 
 				this.controller = controller;
+
+				// Force the opacity to false for consistency with the other platforms
+				Opaque = false;
 			}
 
 			public override void DrawInSurface(SKSurface surface, GRBackendRenderTargetDesc renderTarget)


### PR DESCRIPTION
By default, the UWP and Android views are not opaque. These patches explicitly change the iOS renderers to copy this behavior.

I split the patches in two because I think the GL one could have some performance impacts.

This would fix #198 