### PR TITLE
Add bitmap resize support

### DIFF
--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -536,7 +536,17 @@ namespace SkiaSharp
 		RgbaF16
 	}
 
-	[Obsolete ("May be removed in the next version.")]
+	public enum SKResizeMode {
+		Box,
+		Triangle,
+		Lanczos3,
+		Hamming,
+		Mitchell,
+ 		FirstMethod = Box,
+ 		LastMethod = Mitchell
+	}
+
+	[Obsolete("May be removed in the next version.")]
 	public enum SKColorProfileType {
 		Linear,
 		SRGB

--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -460,6 +460,11 @@ namespace SkiaSharp
 			}
 		}
 
+		public bool Resize(SKBitmap destination, SKResizeMode mode)
+		{
+			return SkiaApi.sk_bitmap_resize(destination.Handle, Handle, mode);
+		}
+
 		// internal proxy
 		#if __IOS__
 		[ObjCRuntime.MonoPInvokeCallback (typeof (SKBitmapReleaseDelegateInternal))]

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -1137,6 +1137,9 @@ namespace SkiaSharp
 		public extern static sk_colortable_t sk_bitmap_get_colortable(sk_bitmap_t cbitmap);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_bitmap_set_pixels(sk_bitmap_t cbitmap, IntPtr pixels, sk_colortable_t ctable);
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public extern static bool sk_bitmap_resize(sk_bitmap_t cbitmap_dst, sk_bitmap_t cbitmap_src, SKResizeMode mode);
 
 		// Matrix
 


### PR DESCRIPTION
This commit adds support for leveraging Skia's methods for resizing bitmaps. Skia provides the use convolution matrices to resize images, which has a noticeable quality gain over using canvas scaling when downsampling bitmaps.

Depends on https://github.com/mono/skia/pull/38.