### PR TITLE
Fix for memory leak in UWP SKXamlCanvas 

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
@@ -152,6 +152,7 @@ namespace SkiaSharp.Views.UWP
 
 		private void FreeBitmap(bool freeArray)
 		{
+		    Background = null;
 			if (bitmap != null)
 			{
 				bitmap = null;


### PR DESCRIPTION
The ImageBrush used as background holds a reference to the WriteableBitmap