### PR TITLE
Use static libfreetype for Linux

### DIFF
--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -439,7 +439,7 @@ Task ("externals-linux")
         SetEnvironmentVariable ("SKIA_OUT", outPath);
 
         // build skia_lib
-        RunGyp ("skia_os='linux' skia_arch_type='" + arch + "' skia_gpu=1 skia_pic=1 skia_pdf_use_sfntly=0", "ninja");
+        RunGyp ("skia_os='linux' skia_arch_type='" + arch + "' skia_gpu=1 skia_pic=1 skia_pdf_use_sfntly=0 freetype_static=1 skia_freetype_static=1", "ninja");
         RunProcess (ninja, new ProcessSettings {
             Arguments = "-C out/" + folder + "/Release " + targets,
             WorkingDirectory = SKIA_PATH.FullPath,

--- a/native-builds/libSkiaSharp_linux/Makefile
+++ b/native-builds/libSkiaSharp_linux/Makefile
@@ -66,7 +66,8 @@ library_paths = \
 	../../externals/skia/out/${ARCH}/Release/obj/gyp/libSkKTX.a                 \
 	../../externals/skia/out/${ARCH}/Release/obj/gyp/libdng_sdk.a               \
 	../../externals/skia/out/${ARCH}/Release/obj/gyp/libpiex.a                  \
-	../../externals/skia/out/${ARCH}/Release/obj/gyp/libexpat_static.a
+	../../externals/skia/out/${ARCH}/Release/obj/gyp/libexpat_static.a          \
+        ../../externals/skia/out/${ARCH}/Release/libfreetype_static.a
 defines = \
 	-DSK_INTERNAL -DSK_GAMMA_APPLY_TO_A8 -DQT_NO_KEYWORDS             \
 	-DSK_ALLOW_STATIC_GLOBAL_INITIALIZERS=1 -DSK_SUPPORT_GPU=1        \
@@ -81,7 +82,7 @@ cflags = \
 	-fPIC -fdata-sections -ffunction-sections
 cflags_c = 
 cflags_cc = -std=c++11 -fno-rtti -fno-threadsafe-statics -Wnon-virtual-dtor
-ldflags = $(library_dirs:%=-L%) -lpthread -ldl -lfontconfig -lfreetype -lGL -lGLU -lX11
+ldflags = $(library_dirs:%=-L%) -lpthread -ldl -lfontconfig -lGL -lGLU -lX11
 includes = $(include_dirs:%=-I%)
 library_names = $(notdir ${library_paths})
 libraries = $(library_names:lib%.a=-l%)


### PR DESCRIPTION
I've managed to produce a portable Linux binary using Holy Build Box.

However, I had to use static version of libfreetype.

https://files.gitter.im/AvaloniaUI/Avalonia/xFjI/libSkiaSharp.so - portable binary file.


I'll upload my docker container and instructions soon. That should allow to produce a single build of libSkiaSharp for most of modern Linux distributions based on glibc. It should work on

-    Debian >= 7
-    Ubuntu >= 12.04
-    Red Hat Enterprise Linux >= 6
-    CentOS >= 6

And their derivatives. I had to use more recent fontconfig, so library won't work on CentOS 5 and Debian 6, but I'm not sure that Skia# needs to target those ancient distros.
