### PR TITLE
Revert "SKSvg - Fixed SVG not loaded when viewport / viewbox not specified"

### DIFF
--- a/source/SkiaSharp.Svg/SkiaSharp.Svg.Shared/SKSvg.cs
+++ b/source/SkiaSharp.Svg/SkiaSharp.Svg.Shared/SKSvg.cs
@@ -93,15 +93,6 @@ namespace SkiaSharp
 			{
 				ViewBox = ReadRectangle(viewBoxA.Value);
 			}
-			else
-			{
-				var widthA = svg.Attribute("width");
-				var heightA = svg.Attribute("height");
-				var width = ReadNumber(widthA);
-				var height = ReadNumber(heightA);
-				var size = new SKSize(width, height);
-				ViewBox = SKRect.Create(size);
-			}
 
 			if (CanvasSize.IsEmpty)
 			{


### PR DESCRIPTION
Reverts mono/SkiaSharp#239

Reverting as this does not really follow the SVG spec: http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute

See the original issue for more info:  #239