### PR TITLE
Don't link libGL, libGLU and libX11 at compile time

### DIFF
--- a/native-builds/libSkiaSharp_linux/Makefile
+++ b/native-builds/libSkiaSharp_linux/Makefile
@@ -82,7 +82,7 @@ cflags = \
 	-fPIC -fdata-sections -ffunction-sections
 cflags_c = 
 cflags_cc = -std=c++11 -fno-rtti -fno-threadsafe-statics -Wnon-virtual-dtor
-ldflags = $(library_dirs:%=-L%) -lpthread -ldl -lfontconfig -lGL -lGLU -lX11
+ldflags = $(LDFLAGS) $(library_dirs:%=-L%) -lpthread -ldl -lfontconfig
 includes = $(include_dirs:%=-I%)
 library_names = $(notdir ${library_paths})
 libraries = $(library_names:lib%.a=-l%)


### PR DESCRIPTION
To be used with https://github.com/mono/skia/pull/50

```
$ objdump -p bin/x64/libSkiaSharp.so.56.1.0 |grep NEEDED
  NEEDED               libpthread.so.0
  NEEDED               libdl.so.2
  NEEDED               libfontconfig.so.1
  NEEDED               libm.so.6
  NEEDED               libgcc_s.so.1
  NEEDED               libc.so.6
  NEEDED               ld-linux-x86-64.so.2

```