### PR TITLE
Fixed "Could not AOT the assembly" issue for Xamarin

### DIFF
--- a/binding/Binding/SKStream.cs
+++ b/binding/Binding/SKStream.cs
@@ -219,7 +219,7 @@ namespace SkiaSharp
 		}
 
 		public SKMemoryStream (SKData data)
-			: this(SkiaApi.sk_memorystream_new_with_skdata (data), true)
+			: this(SkiaApi.sk_memorystream_new_with_skdata (data.Handle), true)
 		{
 			if (Handle == IntPtr.Zero) {
 				throw new InvalidOperationException ("Unable to create a new SKMemoryStream instance.");

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -1030,7 +1030,7 @@ namespace SkiaSharp
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static sk_stream_memorystream_t sk_memorystream_new_with_data(byte[] data, IntPtr length, bool copyData);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
-		public extern static sk_stream_memorystream_t sk_memorystream_new_with_skdata(SKData data);
+		public extern static sk_stream_memorystream_t sk_memorystream_new_with_skdata(IntPtr data);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_memorystream_set_memory(sk_stream_memorystream_t s, IntPtr data, IntPtr length, bool copyData);
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Fixed issue #134, it looks like it is SkiaSharp bug after all.
This is a major issue now that [Telerik uses SkiaSharp](http://www.telerik.com/forums/could-not-aot-the-assembly-skiasharp-dll) for their Xamarin controls.

No quarantee the fix is 100% correct but passing SKData object directly to imported method seems wrong. Fixed version survives AOT just fine.