### PR TITLE
Always decode images with premultiplied alpha

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -404,7 +404,11 @@ namespace SkiaSharp
 			if (codec == null) {
 				throw new ArgumentNullException (nameof (codec));
 			}
-			return Decode (codec, codec.Info);
+			var info = codec.Info;
+			if (info.AlphaType == SKAlphaType.Unpremul) {
+				info.AlphaType = SKAlphaType.Premul;
+			}
+			return Decode (codec, info);
 		}
 
 		public static SKBitmap Decode (Stream stream)


### PR DESCRIPTION
Decoded images will always be unpremul, but skia draws in premul.

This is a "fix" for #282. Not really a bug since we are preserving image data, but we will probably always have to use premul when drawing. So this change is rather an enhancement that a fix.