### PR TITLE
Issue #333, corrected formula for total bitmap bytes

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/AndroidExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/AndroidExtensions.cs
@@ -165,7 +165,8 @@ namespace SkiaSharp.Views.Android
 			}
 			else
 			{
-				success = skiaBitmap.CopyPixelsTo(ptr, bmp.Width * bmp.RowBytes);
+				// must multiply HEIGHT * rowBytes to get total number of bytes
+				success = skiaBitmap.CopyPixelsTo(ptr, bmp.Height * bmp.RowBytes);
 			}
 
 			bmp.UnlockPixels();


### PR DESCRIPTION
To calculate the total number of bytes for the bitmap, you must multiply HEIGHT by the number of bytes per row, not the width. If multiplied by the width, this can caused the copy to fail if the bitmaps height is greater than its width since not enough bytes will be copied.