### PR TITLE
SKManagedStream Memory Fixes

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -358,7 +358,7 @@ namespace SkiaSharp
 			if (stream == null) {
 				throw new ArgumentNullException (nameof (stream));
 			}
-			return DecodeBounds (SKStream.WrapManagedStream (stream));
+			return DecodeBounds (WrapManagedStream (stream));
 		}
 
 		public static SKImageInfo DecodeBounds (SKStream stream)
@@ -441,7 +441,7 @@ namespace SkiaSharp
 			if (stream == null) {
 				throw new ArgumentNullException (nameof (stream));
 			}
-			return Decode (SKStream.WrapManagedStream (stream));
+			return Decode (WrapManagedStream (stream));
 		}
 
 		public static SKBitmap Decode (Stream stream, SKImageInfo bitmapInfo)
@@ -449,7 +449,7 @@ namespace SkiaSharp
 			if (stream == null) {
 				throw new ArgumentNullException (nameof (stream));
 			}
-			return Decode (SKStream.WrapManagedStream (stream), bitmapInfo);
+			return Decode (WrapManagedStream (stream), bitmapInfo);
 		}
 
 		public static SKBitmap Decode (SKStream stream)
@@ -645,6 +645,21 @@ namespace SkiaSharp
 			using (new SKAutoLockPixels (this))
 			using (var pixmap = new SKPixmap ()) {
 				return PeekPixels (pixmap) && pixmap.Encode (dst, format, quality);
+			}
+		}
+
+		private static SKStream WrapManagedStream (Stream stream)
+		{
+			if (stream == null) {
+				throw new ArgumentNullException (nameof (stream));
+			}
+
+			// we will need a seekable stream, so buffer it if need be
+			if (stream.CanSeek) {
+				return new SKManagedStream (stream, true);
+			} else {
+				var buffered = new SKFrontBufferedStream (stream, SKCodec.MinBufferedBytesNeeded, true);
+				return new SKManagedStream (buffered, true);
 			}
 		}
 

--- a/binding/Binding/SKCodec.cs
+++ b/binding/Binding/SKCodec.cs
@@ -256,7 +256,7 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 			var codec = GetObject<SKCodec> (SkiaApi.sk_codec_new_from_stream (stream.Handle));
-			stream.RevokeOwnership (codec);
+			stream.RevokeOwnership ();
 			return codec;
 		}
 

--- a/binding/Binding/SKData.cs
+++ b/binding/Binding/SKData.cs
@@ -142,7 +142,8 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 
-			return Create (SKStream.WrapManagedStream (stream), length);
+			using (var managed = new SKManagedStream (stream))
+				return Create (managed, length);
 		}
 
 		public static SKData Create (Stream stream, ulong length)
@@ -150,7 +151,8 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 
-			return Create (SKStream.WrapManagedStream (stream), length);
+			using (var managed = new SKManagedStream (stream))
+				return Create (managed, length);
 		}
 
 		public static SKData Create (Stream stream, long length)
@@ -158,7 +160,8 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 
-			return Create (SKStream.WrapManagedStream (stream), length);
+			using (var managed = new SKManagedStream (stream))
+				return Create (managed, length);
 		}
 
 		public static SKData Create (SKStream stream)

--- a/binding/Binding/SKDocument.cs
+++ b/binding/Binding/SKDocument.cs
@@ -58,7 +58,7 @@ namespace SkiaSharp
 		{
 			var stream = new SKFileWStream (path);
 			var doc = CreateXps (stream, dpi);
-			doc.TakeOwnership (stream);
+			stream.RevokeOwnership (doc);
 			return doc;
 		}
 

--- a/binding/Binding/SKDocument.cs
+++ b/binding/Binding/SKDocument.cs
@@ -58,7 +58,7 @@ namespace SkiaSharp
 		{
 			var stream = new SKFileWStream (path);
 			var doc = CreateXps (stream, dpi);
-			stream.RevokeOwnership (doc);
+			stream.RevokeOwnership ();
 			return doc;
 		}
 

--- a/binding/Binding/SKManagedStream.cs
+++ b/binding/Binding/SKManagedStream.cs
@@ -22,7 +22,7 @@ namespace SkiaSharp
 {
 	public class SKManagedStream : SKStreamAsset
 	{
-		public static readonly ConcurrentDictionary<IntPtr, SKManagedStream> managedStreams = new ConcurrentDictionary<IntPtr, SKManagedStream> ();
+		private static readonly ConcurrentDictionary<IntPtr, SKManagedStream> managedStreams = new ConcurrentDictionary<IntPtr, SKManagedStream> ();
 
 		// delegate declarations
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -251,7 +251,7 @@ namespace SkiaSharp
 		#endif
 		private static IntPtr CreateNewInternal (IntPtr managedStreamPtr)
 		{
-			var managedStream = AsManagedStream(managedStreamPtr);
+			var managedStream = AsManagedStream (managedStreamPtr);
 			var newStream = new SKManagedStream (managedStream.stream, false, false);
 			return newStream.Handle;
 		}

--- a/binding/Binding/SKManagedStream.cs
+++ b/binding/Binding/SKManagedStream.cs
@@ -18,6 +18,9 @@ using System.Threading;
 using ObjCRuntime;
 #endif
 
+//using Logger = System.Console;
+using Logger = System.Diagnostics.Debug;
+
 namespace SkiaSharp
 {
 	public class SKManagedStream : SKStreamAsset
@@ -89,7 +92,7 @@ namespace SkiaSharp
 
 		//~SKManagedStream()
 		//{
-		//	Debug.WriteLine($"~SKManagedStream {Handle}");
+		//	Logger.WriteLine($"~SKManagedStream {Handle}");
 		//}
 
 		public SKManagedStream (Stream managedStream)
@@ -108,7 +111,8 @@ namespace SkiaSharp
 			if (Handle == IntPtr.Zero) {
 				throw new InvalidOperationException ("Unable to create a new SKManagedStream instance.");
 			}
-			Console.WriteLine($"ctor {Handle}");
+			
+			Logger.WriteLine($"ctor {Handle}");
 
 			managedStreams.TryAdd (Handle, this);
 
@@ -118,7 +122,7 @@ namespace SkiaSharp
 
 		private void DisposeFromNative ()
 		{
-			//Debug.WriteLine($"DisposeFromNative {Handle}");
+			//Logger.WriteLine($"DisposeFromNative {Handle}");
 
 			//WeakReference<SKManagedStream> managedStream;
 			//managedStreams.TryRemove (Handle, out managedStream);
@@ -126,7 +130,7 @@ namespace SkiaSharp
 			//if (disposeStream && stream != null) {
 			//	stream.Dispose ();
 			//	stream = null;
-			//	Debug.WriteLine($"Disposing managed stream {Handle}");
+			//	Logger.WriteLine($"Disposing managed stream {Handle}");
 			//}
 
 			Interlocked.Exchange(ref fromNative, 1);
@@ -137,12 +141,12 @@ namespace SkiaSharp
 
 		protected override void Dispose (bool disposing)
 		{
-			//Debug.WriteLine($"Dispose {disposing} => {Handle}");
+			//Logger.WriteLine($"Dispose {disposing} => {Handle}");
 
 			//var st = new StackTrace();
 			//foreach (var t in st.GetFrames())
 			//{
-			//	Debug.WriteLine($"  {t.ToString()}");
+			//	Logger.WriteLine($"  {t.ToString()}");
 			//}
 			
 			if (disposing) {
@@ -152,12 +156,12 @@ namespace SkiaSharp
 				if (disposeStream && stream != null) {
 					stream.Dispose ();
 					stream = null;
-					//Debug.WriteLine($"Disposing managed stream {Handle}");
+					//Logger.WriteLine($"Disposing managed stream {Handle}");
 				}
 			}
 
 			if (Interlocked.CompareExchange(ref fromNative, 0, 0) == 0 && Handle != IntPtr.Zero && OwnsHandle) {
-				//Debug.WriteLine($"sk_managedstream_destroy {disposing} => {Handle}");
+				//Logger.WriteLine($"sk_managedstream_destroy {disposing} => {Handle}");
 				SkiaApi.sk_managedstream_destroy (Handle);
 			}
 
@@ -279,9 +283,11 @@ namespace SkiaSharp
 		#endif
 		private static IntPtr CreateNewInternal (IntPtr managedStreamPtr)
 		{
-			var managedStream = AsManagedStream (managedStreamPtr);
+			var managedStream = AsManagedStream(managedStreamPtr);
 			var newStream = new SKManagedStream (managedStream.stream, false, false);
-			//Debug.WriteLine($"CreateNewInternal {managedStreamPtr} => {newStream.Handle}");
+
+			Logger.WriteLine($"CreateNewInternal {managedStreamPtr} => {newStream.Handle}");
+
 			return newStream.Handle;
 		}
 		#if __IOS__
@@ -289,13 +295,13 @@ namespace SkiaSharp
 		#endif
 		private static void DestroyInternal (IntPtr managedStreamPtr)
 		{
-			Console.WriteLine($"DestroyInternal {managedStreamPtr}");
+			Logger.WriteLine($"DestroyInternal {managedStreamPtr}");
 
 			SKManagedStream managedStream;
 			if (AsManagedStream (managedStreamPtr, out managedStream)) {
 				managedStream.DisposeFromNative ();
 			} else {
-				Debug.WriteLine ("Destroying disposed SKManagedStream: " + managedStreamPtr);
+				Logger.WriteLine ("Destroying disposed SKManagedStream: " + managedStreamPtr);
 			}
 		}
 		private static SKManagedStream AsManagedStream(IntPtr ptr)

--- a/binding/Binding/SKManagedStream.cs
+++ b/binding/Binding/SKManagedStream.cs
@@ -10,7 +10,6 @@ using System;
 using System.Runtime.InteropServices;
 using System.IO;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Text;
 using System.Threading;
 
@@ -113,7 +112,7 @@ namespace SkiaSharp
 
 		private void DisposeFromNative ()
 		{
-			Interlocked.Exchange(ref fromNative, 1);
+			Interlocked.Exchange (ref fromNative, 1);
 			Dispose ();
 		}
 
@@ -129,7 +128,7 @@ namespace SkiaSharp
 				}
 			}
 
-			if (Interlocked.CompareExchange(ref fromNative, 0, 0) == 0 && Handle != IntPtr.Zero && OwnsHandle) {
+			if (Interlocked.CompareExchange (ref fromNative, 0, 0) == 0 && Handle != IntPtr.Zero && OwnsHandle) {
 				SkiaApi.sk_managedstream_destroy (Handle);
 			}
 

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -19,9 +19,9 @@ namespace SkiaSharp
 {
 	public abstract class SKObject : SKNativeObject
 	{
-		private static readonly Dictionary<IntPtr, WeakReference> instances = new Dictionary<IntPtr, WeakReference>();
+		public static readonly Dictionary<IntPtr, WeakReference> instances = new Dictionary<IntPtr, WeakReference>();
 
-		private readonly List<SKObject> ownedObjects = new List<SKObject>();
+		public readonly List<SKObject> ownedObjects = new List<SKObject>();
 		private int referenceCount = 0;
 		private bool ownsHandle = false;
 
@@ -170,7 +170,7 @@ namespace SkiaSharp
 		/// This object will take ownership of the specified object.
 		/// </summary>
 		/// <param name="obj">The object to own.</param>
-		internal void TakeOwnership(SKObject obj)
+		private void TakeOwnership(SKObject obj)
 		{
 			lock (ownedObjects)
 			{
@@ -180,23 +180,15 @@ namespace SkiaSharp
 		}
 
 		/// <summary>
-		/// This object will no longer own it's handle.
-		/// </summary>
-		internal void RevokeOwnership()
-		{
-			OwnsHandle = false;
-		}
-
-		/// <summary>
 		/// This object will hand ownership over to the specified object.
 		/// </summary>
 		/// <param name="owner">The object to give ownership to.</param>
-		internal void RevokeOwnership(SKObject owner)
+		internal void RevokeOwnership(SKObject owner = null)
 		{
 			if (owner != null) {
 				owner.TakeOwnership (this);
 			} else {
-				this.RevokeOwnership ();
+				OwnsHandle = false;
 			}
 		}
 

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -19,9 +19,9 @@ namespace SkiaSharp
 {
 	public abstract class SKObject : SKNativeObject
 	{
-		public static readonly Dictionary<IntPtr, WeakReference> instances = new Dictionary<IntPtr, WeakReference>();
+		private static readonly Dictionary<IntPtr, WeakReference> instances = new Dictionary<IntPtr, WeakReference>();
 
-		public readonly List<SKObject> ownedObjects = new List<SKObject>();
+		private readonly List<SKObject> ownedObjects = new List<SKObject>();
 		private int referenceCount = 0;
 		private bool ownsHandle = false;
 

--- a/binding/Binding/SKStream.cs
+++ b/binding/Binding/SKStream.cs
@@ -119,21 +119,6 @@ namespace SkiaSharp
 				return (int)SkiaApi.sk_stream_get_length (Handle);
 			}
 		}
-
-		internal static SKStream WrapManagedStream (Stream stream)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
-
-			// we will need a seekable stream, so buffer it if need be
-			if (stream.CanSeek) {
-				return new SKManagedStream (stream, true);
-			} else {
-				var buffered = new SKFrontBufferedStream (stream, SKCodec.MinBufferedBytesNeeded, true);
-				return new SKManagedStream (buffered, true);
-			}
-		}
 	}
 
 	public abstract class SKStreamRewindable : SKStream

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -7,7 +7,6 @@
 // Copyright 2016 Xamarin Inc
 //
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -24,7 +23,6 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing)
 		{
 			if (Handle != IntPtr.Zero && OwnsHandle) {
-				Debug.WriteLine($"sk_typeface_unref {disposing} => {Handle}");
 				SkiaApi.sk_typeface_unref (Handle);
 			}
 

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -7,6 +7,7 @@
 // Copyright 2016 Xamarin Inc
 //
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -23,6 +24,7 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing)
 		{
 			if (Handle != IntPtr.Zero && OwnsHandle) {
+				Debug.WriteLine($"sk_typeface_unref {disposing} => {Handle}");
 				SkiaApi.sk_typeface_unref (Handle);
 			}
 
@@ -85,7 +87,7 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 			var typeface = GetObject<SKTypeface> (SkiaApi.sk_typeface_create_from_stream (stream.Handle, index));
-			stream.RevokeOwnership (typeface);
+			stream.RevokeOwnership ();
 			return typeface;
 		}
 

--- a/source/SkiaSharpSource.Mac.sln
+++ b/source/SkiaSharpSource.Mac.sln
@@ -3,6 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.iOS", "..\Binding\SkiaSharp.iOS\SkiaSharp.iOS.csproj", "{6A678CFB-21A7-4E81-8909-FD72ABBFD408}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.tvOS", "..\Binding\SkiaSharp.tvOS\SkiaSharp.tvOS.csproj", "{5180E370-A455-42BB-99F9-97BD269B8A52}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.OSX", "..\Binding\SkiaSharp.OSX\SkiaSharp.OSX.csproj", "{4588A759-3853-49B8-8A68-6C7917BE9220}"
+EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SkiaSharp.Views.Forms.Shared", "SkiaSharp.Views.Forms\SkiaSharp.Views.Forms.Shared\SkiaSharp.Views.Forms.Shared.shproj", "{314FB505-9858-4E03-B799-91B0BA627D05}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.Views.Forms.Android", "SkiaSharp.Views.Forms\SkiaSharp.Views.Forms.Android\SkiaSharp.Views.Forms.Android.csproj", "{2F94F024-1841-47E8-B521-74AA4E3EBA54}"
@@ -28,12 +34,6 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Binding", "..\Binding\Binding\Binding.shproj", "{9C502B9A-25D4-473F-89BD-5A13DDE16354}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.Android", "..\Binding\SkiaSharp.Android\SkiaSharp.Android.csproj", "{C737DC80-5B71-4B26-A2DC-DA30421788B0}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.iOS", "..\Binding\SkiaSharp.iOS\SkiaSharp.iOS.csproj", "{6A678CFB-21A7-4E81-8909-FD72ABBFD408}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.tvOS", "..\Binding\SkiaSharp.tvOS\SkiaSharp.tvOS.csproj", "{5180E370-A455-42BB-99F9-97BD269B8A52}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.OSX", "..\Binding\SkiaSharp.OSX\SkiaSharp.OSX.csproj", "{4588A759-3853-49B8-8A68-6C7917BE9220}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharp.Portable", "..\Binding\SkiaSharp.Portable\SkiaSharp.Portable.csproj", "{7AA90628-2FDD-4585-AF2F-CC51CFA8B52A}"
 EndProject

--- a/tests/Tests/SKManagedStreamTest.cs
+++ b/tests/Tests/SKManagedStreamTest.cs
@@ -88,7 +88,7 @@ namespace SkiaSharp.Tests
 		}
 
 		[Test]
-		public void teast()
+		public void ManagedStreamIsNotCollectedPrematurely()
 		{
 			using (var stream = new SKDynamicMemoryWStream())
 			using (SKDocument document = SKDocument.CreatePdf(stream, new SKDocumentPdfMetadata()))

--- a/tests/Tests/SKManagedStreamTest.cs
+++ b/tests/Tests/SKManagedStreamTest.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace SkiaSharp.Tests
 {
@@ -84,6 +85,42 @@ namespace SkiaSharp.Tests
 			var resultData = data.Skip(offset).Take(buffer.Length).ToArray();
 			resultData = resultData.Concat(Enumerable.Repeat<byte>(0, offset)).ToArray();
 			Assert.AreEqual(resultData, buffer);
+		}
+
+		[Test]
+		public void teast()
+		{
+			using (var stream = new SKDynamicMemoryWStream())
+			using (SKDocument document = SKDocument.CreatePdf(stream, new SKDocumentPdfMetadata()))
+			{
+				var paintList = new List<SKPaint>();
+
+				for (int index = 0; index < 10; index++)
+				{
+					Stream fontStream = File.OpenRead(Path.Combine(PathToFonts, "Roboto2-Regular_NoEmbed.ttf"));
+					SKTypeface typeface = SKTypeface.FromStream(fontStream);
+
+					SKPaint paint = new SKPaint
+					{
+						Typeface = typeface
+					};
+					paintList.Add(paint);
+				}
+
+				using (SKCanvas pageCanvas = document.BeginPage(792, 842))
+				{
+					foreach (var paint in paintList)
+					{
+						for (int i = 0; i < 100; i++)
+							pageCanvas.DrawText("Text", 0, 5 * i, paint);
+					}
+
+					document.EndPage();
+				}
+
+				GC.Collect();
+				document.Close();
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses #83 and #376

I believe there is a bug in the native skia that does not dispose properly of the streams passed to `SKTypeface`. As this was where I started working with streams (the loading of fonts) I had written code, that was flawed, to get around the issue. A problem arose when memory was tight or bitmaps were used - sometimes the GC would dispose the stream, when it should have waited for the native side to let it know when to destroy.

`SKManagedStream` is a special case in that it's lifetime is directly managed by the native, and the managed side needs to wait for the dispose event to be triggered from the native destructor. As a result, I keep a strong reference to the managed type to prevent them inadvertently disposing the native side when the GC kicks in.

As a result of the bug with `SKTypeface`, managed streams opened sometimes do not get closed and will live forever. This is not a simple case of disposing the streams as internally, the native side will make a copy of the stream reference (a new stream, but the same data). Some of these are the streams that never get disposed.

The only suggestion to avoid this is to reduce the number of `SKTypeface` instances that are created, rather keep a reference around and reuse that. This should not be a big issue as most apps do not use an extraneous amount of fonts - and even if it does, the actual managed data stream only has a single copy, just the native wrappers are copied (and they are quite small).

Other types, such as `SKBitmap`, `SKCodec` and others all properly dispose they streams.

In addition, the GC will never pick up a `SKManagedStream` since they are designed to live until they are disposed from the NATVE side. As a result, always make sure to dispose the stream when no longer in use.

