### PR TITLE
fixed typo in SKMatrix.xml

### DIFF
--- a/docs/en/SkiaSharp/SKMatrix.xml
+++ b/docs/en/SkiaSharp/SKMatrix.xml
@@ -1017,7 +1017,7 @@
       <Docs>
         <param name="matrix">The target matrix.</param>
         <param name="degrees">The angle for the rotation, in degrees.</param>
-        <summary>Rotates the spefixied matrix by the specified degrees.</summary>
+        <summary>Rotates the specified matrix by the specified degrees.</summary>
         <remarks>
           <para></para>
         </remarks>
@@ -1053,7 +1053,7 @@
         <param name="degrees">The angle for the rotation, in degrees.</param>
         <param name="pivotx">The x-coordiate for the rotation pivot.</param>
         <param name="pivoty">The y-coordiate for the rotation pivot.</param>
-        <summary>Rotates the spefixied matrix by the specified degrees.</summary>
+        <summary>Rotates the specified matrix by the specified degrees.</summary>
         <remarks>
           <para></para>
         </remarks>


### PR DESCRIPTION
I saw a typo in the documentation shown by intellisense. 
I guess this is the correct place to fix it?

Take care,
-Martin