### PR TITLE
Update SKBitmap docs for removal of Lock/UnlockPixels

### DIFF
--- a/docs/en/SkiaSharp/SKBitmap.xml
+++ b/docs/en/SkiaSharp/SKBitmap.xml
@@ -25,6 +25,7 @@
     <remarks>
       <para>A bitmap has an integer width and height, and a format (colortype), and a pointer to the actual pixels. Bitmaps can be drawn into a <see cref="T:SkiaSharp.SKCanvas" />, but they are also used to specify the target of a <see cref="T:SkiaSharp.SKCanvas" />' drawing operations.</para>
       <para>A <see cref="T:SkiaSharp.SKBitmap" /> exposes <see cref="M:SkiaSharp.SKBitmap.GetPixels" />, which lets a caller write its pixels. To retrieve a pointer to the raw image data of the bitmap, call the <see cref="M:SkiaSharp.SKBitmap.LockPixels" /> method, and then call the <see cref="M:SkiaSharp.SKBitmap.GetPixels" /> method to get a pointer to the image data.  Once you no longer need to use the raw data pointer, call the <see cref="M:SkiaSharp.SKBitmap.UnlockPixels" /> method. The raw data is laid out in the format configured at the time that the bitmap was created.</para>
+      <para>(Note: As of SkiaSharp 1.60.0, calls to <see cref="M:SkiaSharp.SKBitmap.LockPixels" /> and <see cref="M:SkiaSharp.SKBitmap.UnlockPixels" /> are no longer required, and they no longer exist as part of the API.)</para>
     </remarks>
   </Docs>
   <Members>

--- a/docs/en/SkiaSharp/SKSurface.xml
+++ b/docs/en/SkiaSharp/SKSurface.xml
@@ -48,8 +48,10 @@
         canvas.DrawRect (new SKRect (i, i, 256-i, 256-i), (i % 16 == 0) ? redBrush : blueBrush);
 
     // Save the artwork
-    var pngEncodedFile = surface.Snapshot().Encode();
-    File.WriteAllBytes ("demo.png", pngEncodedFile);
+    using (var output = File.OpenWrite ("demo.png"))
+    {
+        surface.Snapshot().Encode().SaveTo(output);
+    }
 }
 ]]></code>
       </example>


### PR DESCRIPTION
LockPixels() and UnlockPixels() have been removed in the latest SkiaSharp, but nearly all documentation about SKBitmap on the Internet still refers to them (as does the official SKBitmap.xml document itself). After wasting an hour this morning wondering what was going on (since I've never used Skia before), and researching why even simple examples wouldn't compile, I added a note to the SKBitmap documentation that explains that these are no longer required operations, per discussion at https://bugs.chromium.org/p/skia/issues/detail?id=6481&desc=2 .  I don't know if the "note" I added is really the *correct* update for the documentation, but I sure would've saved me a lot of time today if it had been included.  Feel free to alter its wording.