### PR TITLE
fixed bug in Utils.cake that failed parsing the version number if the…

### DIFF
--- a/cake/Utils.cake
+++ b/cake/Utils.cake
@@ -68,7 +68,7 @@ FilePath GetSNToolPath (string possible)
             var dirPath = progFiles.Combine ("Microsoft SDKs/Windows").FullPath + "/v*A";
             var dirs = GetDirectories (dirPath).OrderBy (d => {
                 var version = d.GetDirectoryName ();
-                return double.Parse (version.Substring (1, version.Length - 2));
+                return double.Parse (version.Substring (1, version.Length - 2), System.Globalization.CultureInfo.InvariantCulture);
             });
             foreach (var dir in dirs) {
                 var path = dir.FullPath + "/bin/*/" + arch + "/sn.exe";


### PR DESCRIPTION
… system's decimal symbol is set to something different than '.', e.g. ','.

Without this fix the following error occurs on an affected system when trying to build SkiaSharp:

```
PS C:\Projects\SkiaSharp> .\bootstrapper.ps1 -Target everything
Preparing to run build script...
Running build script...
Analyzing build script...
Processing build script...
Installing addins...
Compiling build script...
Error: One or more errors occurred.
        Input string was not in a correct format.
```