### PR TITLE
GH-460 : Make sure to re-create the SkiaSharp context

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/GLTextureView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/GLTextureView.cs
@@ -728,11 +728,6 @@ namespace SkiaSharp.Views.Android
 				{
 					GuardedRun();
 				}
-				catch (Exception e)
-				{
-					// fall thru and exit normally
-					throw e;
-				}
 				finally
 				{
 					threadManager.ThreadExiting(this);

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
@@ -40,6 +40,8 @@ namespace SkiaSharp.Views.Android
 
 			renderTarget.Width = width;
 			renderTarget.Height = height;
+
+			CreateContext();
 		}
 
 		public void OnSurfaceCreated(IGL10 gl, EGLConfig config)
@@ -62,10 +64,6 @@ namespace SkiaSharp.Views.Android
 			int[] framebuffers = new int[1];
 			gl.GlGetIntegerv(GLES20.GlFramebufferBinding, framebuffers, 0);
 
-			// create the SkiaSharp context
-			var glInterface = GRGlInterface.CreateNativeGlInterface();
-			context = GRContext.Create(GRBackend.OpenGL, glInterface);
-
 			// create the render target
 			renderTarget = new GRBackendRenderTargetDesc
 			{
@@ -77,6 +75,8 @@ namespace SkiaSharp.Views.Android
 				StencilBits = stencilbuffers[0],
 				RenderTargetHandle = (IntPtr)framebuffers[0],
 			};
+
+			CreateContext();
 		}
 
 		public void OnSurfaceDestroyed()
@@ -99,6 +99,15 @@ namespace SkiaSharp.Views.Android
 			{
 				context.Dispose();
 				context = null;
+			}
+		}
+
+		private void CreateContext()
+		{
+			if (context == null)
+			{
+				var glInterface = GRGlInterface.CreateNativeGlInterface();
+				context = GRContext.Create(GRBackend.OpenGL, glInterface);
 			}
 		}
 	}


### PR DESCRIPTION
When the app is paused, the texture is destroyed. This is all good so far. 

However, when the app resumed, the texture is re-created under the hood and thus follows another path - and this is where I was missing logic to re-create the SkiaSharp context.