### PR TITLE
Properly copy bitmaps. Fixes #497

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -218,12 +218,12 @@ namespace SkiaSharp
 				return false;
 			}
 
-			SKPixmap srcPM = PeekPixels ();
+			var srcPM = PeekPixels ();
 			if (srcPM == null) {
 				return false;
 			}
 
-			SKImageInfo dstInfo = srcPM.Info.WithColorType (colorType);
+			var dstInfo = srcPM.Info.WithColorType (colorType);
 			switch (colorType) {
 				case SKColorType.Rgb565:
 					// CopyTo() is not strict on alpha type. Here we set the src to opaque to allow
@@ -245,14 +245,12 @@ namespace SkiaSharp
 					break;
 			}
 
-			// TODO: handle copying two Index8 images - copy/reference the color tables
-
 			var tmpDst = new SKBitmap ();
 			if (!tmpDst.TryAllocPixels (dstInfo, colorType == SKColorType.Index8 ? ColorTable : null)) {
 				return false;
 			}
 
-			SKPixmap dstPM = destination.PeekPixels ();
+			var dstPM = tmpDst.PeekPixels ();
 			if (dstPM == null) {
 				return false;
 			}

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -1366,6 +1366,9 @@ namespace SkiaSharp
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_bitmap_notify_pixels_changed(sk_bitmap_t cbitmap);
 
+		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_bitmap_swap(sk_bitmap_t cbitmap, sk_bitmap_t cother);
+
 		// SKColor
 
 		[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]

--- a/tests/Tests/SKBitmapTest.cs
+++ b/tests/Tests/SKBitmapTest.cs
@@ -26,6 +26,30 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void CopyIndex8ToPlatformPreservesData()
+		{
+			var path = Path.Combine(PathToImages, "index8.png");
+			var bmp = SKBitmap.Decode(path);
+
+			var platform = bmp.Copy(SKImageInfo.PlatformColorType);
+
+			Assert.Equal((SKColor)0x7EA4C639, platform.GetPixel(182, 348));
+			Assert.Equal(SKImageInfo.PlatformColorType, platform.ColorType);
+		}
+
+		[SkippableFact]
+		public void OverwriteIndex8ToPlatformPreservesData()
+		{
+			var path = Path.Combine(PathToImages, "index8.png");
+			var bmp = SKBitmap.Decode(path);
+
+			bmp.CopyTo(bmp, SKImageInfo.PlatformColorType);
+
+			Assert.Equal((SKColor)0x7EA4C639, bmp.GetPixel(182, 348));
+			Assert.Equal(SKImageInfo.PlatformColorType, bmp.ColorType);
+		}
+
+		[SkippableFact]
 		public void BitmapCopyToAlpha8PreservesData()
 		{
 			var bmp = CreateTestBitmap();


### PR DESCRIPTION
The original `SkBitmap::copyTo` method was removed from the native code. In an effort to preserve backwards compatibility, that method was ported to the managed API, however it was not done properly (by me).