### PR TITLE
Add branch info for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "skia"]
 	path = externals/skia
 	url = https://github.com/mono/skia.git
+	branch = xamarin-mobile-bindings
 [submodule "depot_tools"]
 	path = externals/depot_tools
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git


### PR DESCRIPTION
Because master is not default branch and doesn't exist. So we need to explicitly specify branch information.