### PR TITLE
Updated image paths in API docs to match OPS requirements

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -30,7 +30,8 @@
         "exclude": [
           "**/obj/**",
           "**/includes/**"
-        ]
+        ],
+        "dest":"api/xamarin-media"
       }
     ],
     "overwrite": {

--- a/docs/xml/SkiaSharp/SKPaint.xml
+++ b/docs/xml/SkiaSharp/SKPaint.xml
@@ -22,14 +22,14 @@
       <para></para>
       <para>The example above produces the following:</para>
       <para>
-        <img href="SKPaintText.png" />
+        <img href="xamarin-media/SkiaSharp/_images/SKPaintText.png" />
       </para>
       <para>This shows three different paints, each set up to draw in a different style. Now the caller can intermix these paints freely, either using them as is, or modifying them as the drawing proceeds.</para>
       <para>Beyond simple attributes such as color, strokes, and text values, paints support effects. These are subclasses of different aspects of the drawing pipeline, that when referenced by a paint (each of them is reference-counted), are called to override some part of the drawing pipeline.</para>
       <para>For example, to draw using a gradient instead of a single color, assign a SkShader to the paint.</para>
       <para></para>
       <para>
-        <img href="gradient.png" />
+        <img href="xamarin-media/SkiaSharp/_images/gradient.png" />
       </para>
       <para>Now, anything drawn with that paint will be drawn with the gradient specified in the call to CreateLinearGradient.</para>
       <para>There are five types of effects that can be assigned to an <see cref="T:SkiaSharp.SKPaint" /> object:</para>

--- a/docs/xml/SkiaSharp/SKShader.xml
+++ b/docs/xml/SkiaSharp/SKShader.xml
@@ -32,7 +32,7 @@ canvas.DrawPaint (paint);
 ]]></code>
       </example>
       <para>
-        <img href="linear.png" />
+        <img href="xamarin-media/SkiaSharp/_images/linear.png" />
       </para>
       <format type="text/html">
         <h2>Radial Gradient Shader</h2>
@@ -49,7 +49,7 @@ var paint = new SKPaint () {
 canvas.DrawPaint (paint);]]></code>
       </example>
       <para>
-        <img href="radial.png" />
+        <img href="rxamarin-media/SkiaSharp/_images/adial.png" />
       </para>
       <format type="text/html">
         <h2>Two-point Conical Gradient Shader</h2>
@@ -66,7 +66,7 @@ var paint = new SKPaint () {
 canvas.DrawPaint (paint);]]></code>
       </example>
       <para>
-        <img href="twopoint.png" />
+        <img href="xamarin-media/SkiaSharp/_images/twopoint.png" />
       </para>
       <format type="text/html">
         <h2>Sweep Gradient Shader</h2>
@@ -93,7 +93,7 @@ var paint = new SKPaint () { Shader = shader };
 canvas.DrawPaint (paint);]]></code>
       </example>
       <para>
-        <img href="fractalnoise.png" />
+        <img href="xamarin-media/SkiaSharp/_images/fractalnoise.png" />
       </para>
       <format type="text/html">
         <h2>Turbulence Perlin Noise</h2>
@@ -104,7 +104,7 @@ var paint = new SKPaint () { Shader = turbulence };
 canvas.DrawPaint (paint);]]></code>
       </example>
       <para>
-        <img href="turbulence.png" />
+        <img href="xamarin-media/SkiaSharp/_images/turbulence.png" />
       </para>
       <format type="text/html">
         <h2>Compose Shader</h2>
@@ -119,7 +119,7 @@ var paint = new SKPaint () { Shader = shader };
 canvas.DrawPaint (paint);]]></code>
       </example>
       <para>
-        <img href="compose.png" />
+        <img href="xamarin-media/SkiaSharp/_images/compose.png" />
       </para>
     </remarks>
   </Docs>
@@ -279,7 +279,7 @@ var paint = new SKPaint () { Shader = shader };
 canvas.DrawPaint (paint);]]></code>
           </example>
           <para>
-            <img href="compose.png" />
+            <img href="xamarin-media/SkiaSharp/_images/compose.png" />
           </para>
         </remarks>
       </Docs>
@@ -414,7 +414,7 @@ canvas.DrawPaint (paint);
 ]]></code>
           </example>
           <para>
-            <img href="linear.png" />
+            <img href="xamarin-media/SkiaSharp/_images/linear.png" />
           </para>
         </remarks>
       </Docs>


### PR DESCRIPTION
As discussed ... this is a small change in the way we reference images, due to the way docfx copies the resources to the server. To sum it up, going forward keep the images in the same `_images` folder in the namespace, but prefix the path with `xamarin-media/<The Namespace>/_images/`