### PR TITLE
Fix target files for Tizen to use TizenTPKFiles

### DIFF
--- a/binding/HarfBuzzSharp.Tizen/nuget/build/tizen40/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.Tizen/nuget/build/tizen40/HarfBuzzSharp.targets
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- HACK: temporary until the Tizen/.NET Core tooling can understand the tizen-x86 RID as opposed to linux-x86 -->
-    <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\tizen-x86\native\libHarfBuzzSharp.so"
-              Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\tizen-x86\native\libHarfBuzzSharp.so')">
-            <Link>tpkroot\bin\runtimes\linux-x86\native\libHarfBuzzSharp.so</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
+  <!-- HACK: temporary until the Tizen/.NET Core tooling can understand the tizen-x86 RID as opposed to linux-x86 -->
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == ''">
+    <TizenTpkFiles Include="$(MSBuildThisFileDirectory)..\..\runtimes\tizen-x86\native\libHarfBuzzSharp.so">
+      <TizenTpkSubDir>bin\runtimes\linux-x86\native\</TizenTpkSubDir>
+      <TizenTpkFileName>libHarfBuzzSharp.so</TizenTpkFileName>
+    </TizenTpkFiles>
+  </ItemGroup>
 
 </Project>

--- a/binding/SkiaSharp.Tizen/nuget/build/tizen40/SkiaSharp.targets
+++ b/binding/SkiaSharp.Tizen/nuget/build/tizen40/SkiaSharp.targets
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- HACK: temporary until the Tizen/.NET Core tooling can understand the tizen-x86 RID as opposed to linux-x86 -->
-    <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\tizen-x86\native\libSkiaSharp.so"
-              Condition="Exists('$(MSBuildThisFileDirectory)..\..\runtimes\tizen-x86\native\libSkiaSharp.so')">
-            <Link>tpkroot\bin\runtimes\linux-x86\native\libSkiaSharp.so</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
+  <!-- HACK: temporary until the Tizen/.NET Core tooling can understand the tizen-x86 RID as opposed to linux-x86 -->
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == ''">
+    <TizenTpkFiles Include="$(MSBuildThisFileDirectory)..\..\runtimes\tizen-x86\native\libSkiaSharp.so">
+      <TizenTpkSubDir>bin\runtimes\linux-x86\native\</TizenTpkSubDir>
+      <TizenTpkFileName>libSkiaSharp.so</TizenTpkFileName>
+    </TizenTpkFiles>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Current temprary hacks for tizen-x86 RID are still needed because the Tizen 4.0 platform
including .NETCore 2.0 does not understand the tizen-x86 RID.

In this changes, Use TizenTPKFiles defined in Tizen.NET.Sdk instead of Link and CopyToOutputDirectory
to solve following problems.
- The linked file (runtime/linux-x86/native/foo.so) is displayed in VS Project tree.
- The linked file is always copied to tpkroot/bin even when RID is specified.
- The linked file can't be excluded with the file excluding features of Tizen.NET.Sdk.

The files added to TizenTPKFiles will be copied to tpkroot by Tizen.NET.Sdk, see
https://github.com/Samsung/build-task-tizen/blob/master/src/Tizen.NET.Build.Tasks/build/Tizen.NET.Sdk.Packaging.targets