### PR TITLE
Disable log compression in pipeline.groovy

### DIFF
--- a/scripts/pipeline.groovy
+++ b/scripts/pipeline.groovy
@@ -29,9 +29,10 @@ import groovy.transform.Field
     ]
 ]
 
-properties([
-    compressBuildLog()
-])
+// compression is incompatible with JEP-210 right now
+//properties([
+//    compressBuildLog()
+//])
 
 // ============================================================================
 // Stages


### PR DESCRIPTION
It's currently incompatible with the changes Jenkins is making as part of JEP-210: issues.jenkins-ci.org/browse/JENKINS-54680