### PR TITLE
Add note about MSVC requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Before building SkiaSharp:
  * [Python 2.7](https://www.python.org/downloads) is available in the `PATH` environment variable on Windows
  * [Android NDK r14](https://developer.android.com/ndk/downloads/index.html) is available in the `ANDROID_NDK_HOME` environment variable on macOS
  * [.NET Core](https://www.microsoft.com/net/core) is installed on all platforms
+ * C/C++ Compiler (MSVC / "Desktop development" package on Windows)
 
 First, clone the repository:
 


### PR DESCRIPTION
I'm not sure if this is the wording you would prefer, but externals-windows fails with an unintuitive python exception if you don't have MSVC installed (e.g., a user with Visual Studio and only the .NET development pack) so I added it to the pre-reqs for running bootstrapper. 