### PR TITLE
Updated the projects

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -8,7 +8,7 @@ xunit.runner.console    release     2.4.0
 Xamarin.Forms           release     3.3.0.912540
 Tizen.NET               release     4.0.0
 OpenTK.GLControl        release     1.1.2349.61993
-MSBuild.Sdk.Extras      release     1.6.55
+MSBuild.Sdk.Extras      release     2.0.0-preview.14
 
 # native sonames
 libSkiaSharp            soname      68.0.0

--- a/binding/HarfBuzzSharp.Android/HarfBuzzSharp.Android.csproj
+++ b/binding/HarfBuzzSharp.Android/HarfBuzzSharp.Android.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid2.3</TargetFramework>
+    <TargetFramework>monoandroid4.4</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>HarfBuzzSharp</RootNamespace>
     <AssemblyName>HarfBuzzSharp</AssemblyName>
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="..\..\output\native\android\arm64-v8a\libHarfBuzzSharp.so" Link="libs\arm64-v8a\libHarfBuzzSharp.so" />
@@ -31,5 +30,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.Desktop/HarfBuzzSharp.Desktop.csproj
+++ b/binding/HarfBuzzSharp.Desktop/HarfBuzzSharp.Desktop.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\output\native\windows\x64\libHarfBuzzSharp.dll" Link="nuget\runtimes\win-x64\native\libHarfBuzzSharp.dll" Condition=" '$(IsWindows)' == 'true' " />
@@ -32,5 +31,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.NetStandard/HarfBuzzSharp.NetStandard.csproj
+++ b/binding/HarfBuzzSharp.NetStandard/HarfBuzzSharp.NetStandard.csproj
@@ -18,12 +18,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.OSX/HarfBuzzSharp.OSX.csproj
+++ b/binding/HarfBuzzSharp.OSX/HarfBuzzSharp.OSX.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinmac2.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.Tizen/HarfBuzzSharp.Tizen.csproj
+++ b/binding/HarfBuzzSharp.Tizen/HarfBuzzSharp.Tizen.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -18,8 +18,6 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
   </ItemGroup>
@@ -32,5 +30,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.UWP/HarfBuzzSharp.UWP.csproj
+++ b/binding/HarfBuzzSharp.UWP/HarfBuzzSharp.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>uap10.0.10240</TargetFramework>
@@ -18,8 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\output\native\uwp\x64\libHarfBuzzSharp.dll" Link="nuget\runtimes\win10-x64\nativeassets\uap10.0\libHarfBuzzSharp.dll" />
@@ -31,5 +29,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.iOS/HarfBuzzSharp.iOS.csproj
+++ b/binding/HarfBuzzSharp.iOS/HarfBuzzSharp.iOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinios1.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.tvOS/HarfBuzzSharp.tvOS.csproj
+++ b/binding/HarfBuzzSharp.tvOS/HarfBuzzSharp.tvOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarintvos1.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/HarfBuzzSharp.watchOS/HarfBuzzSharp.watchOS.csproj
+++ b/binding/HarfBuzzSharp.watchOS/HarfBuzzSharp.watchOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinwatchos1.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.Android/SkiaSharp.Android.csproj
+++ b/binding/SkiaSharp.Android/SkiaSharp.Android.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid2.3</TargetFramework>
+    <TargetFramework>monoandroid4.4</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>SkiaSharp</RootNamespace>
     <AssemblyName>SkiaSharp</AssemblyName>
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="..\..\output\native\android\arm64-v8a\libSkiaSharp.so" Link="libs\arm64-v8a\libSkiaSharp.so" />
@@ -31,5 +30,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.Desktop/SkiaSharp.Desktop.csproj
+++ b/binding/SkiaSharp.Desktop/SkiaSharp.Desktop.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\output\native\windows\x64\libSkiaSharp.dll" Link="nuget\runtimes\win-x64\native\libSkiaSharp.dll" Condition=" '$(IsWindows)' == 'true' " />
@@ -32,5 +31,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.NetStandard/SkiaSharp.NetStandard.csproj
+++ b/binding/SkiaSharp.NetStandard/SkiaSharp.NetStandard.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
@@ -26,5 +25,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.OSX/SkiaSharp.OSX.csproj
+++ b/binding/SkiaSharp.OSX/SkiaSharp.OSX.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinmac2.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.Tizen/SkiaSharp.Tizen.csproj
+++ b/binding/SkiaSharp.Tizen/SkiaSharp.Tizen.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -19,8 +19,6 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
@@ -34,5 +32,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.UWP/SkiaSharp.UWP.csproj
+++ b/binding/SkiaSharp.UWP/SkiaSharp.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>uap10.0.10240</TargetFramework>
@@ -18,8 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\output\native\uwp\x64\libSkiaSharp.dll" Link="nuget\runtimes\win10-x64\nativeassets\uap10.0\libSkiaSharp.dll" />
@@ -37,5 +35,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.iOS/SkiaSharp.iOS.csproj
+++ b/binding/SkiaSharp.iOS/SkiaSharp.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinios1.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.tvOS/SkiaSharp.tvOS.csproj
+++ b/binding/SkiaSharp.tvOS/SkiaSharp.tvOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarintvos1.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/binding/SkiaSharp.watchOS/SkiaSharp.watchOS.csproj
+++ b/binding/SkiaSharp.watchOS/SkiaSharp.watchOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinwatchos1.0</TargetFramework>
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -33,5 +32,4 @@
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "sdk": {
+    "version": "2.2.100"
+  },
+  "msbuild-sdks": {
+    "MSBuild.Sdk.Extras": "2.0.0-preview.14"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,4 @@
 {
-  "sdk": {
-    "version": "2.2.100"
-  },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.0-preview.14"
   }

--- a/samples/Basic/ElmSharp/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/ElmSharp/SkiaSharpSample/SkiaSharpSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
   </ItemGroup>
 

--- a/samples/Basic/Tizen/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/Tizen/SkiaSharpSample/SkiaSharpSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
   </ItemGroup>

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample.Tizen/SkiaSharpSample.Tizen.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample.Tizen/SkiaSharpSample.Tizen.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
   </ItemGroup>

--- a/samples/Gallery/Xamarin.Forms/Tizen/TizenOS.csproj
+++ b/samples/Gallery/Xamarin.Forms/Tizen/TizenOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
   </ItemGroup>

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Desktop/SkiaSharp.HarfBuzz.Desktop.csproj
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Desktop/SkiaSharp.HarfBuzz.Desktop.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.Desktop\SkiaSharp.Desktop.csproj" />
@@ -21,5 +20,4 @@
     <Compile Include="..\SkiaSharp.HarfBuzz.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.csproj
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.NetStandard\SkiaSharp.NetStandard.csproj" />
@@ -21,5 +20,4 @@
     <Compile Include="..\SkiaSharp.HarfBuzz.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SkiaSharp.Views.Forms.Android.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SkiaSharp.Views.Forms.Android.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>monoandroid8.1</TargetFramework>
@@ -12,7 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
   </ItemGroup>
   <ItemGroup>
@@ -24,5 +23,4 @@
     <Compile Include="..\SkiaSharp.Views.Forms.Native.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SkiaSharp.Views.Forms.Mac.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SkiaSharp.Views.Forms.Mac.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinmac2.0</TargetFramework>
@@ -12,7 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
   </ItemGroup>
   <ItemGroup>
@@ -24,5 +23,4 @@
     <Compile Include="..\SkiaSharp.Views.Forms.Native.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SkiaSharp.Views.Forms.Tizen.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SkiaSharp.Views.Forms.Tizen.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -14,10 +14,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.Tizen\SkiaSharp.Tizen.csproj" />
@@ -28,5 +26,4 @@
     <Compile Include="..\SkiaSharp.Views.Forms.Native.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.UWP/SkiaSharp.Views.Forms.UWP.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.UWP/SkiaSharp.Views.Forms.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>uap10.0.16299</TargetFramework>
@@ -13,8 +13,6 @@
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.UWP\SkiaSharp.UWP.csproj" />
@@ -25,5 +23,4 @@
     <Compile Include="..\SkiaSharp.Views.Forms.Native.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SkiaSharp.Views.Forms.iOS.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SkiaSharp.Views.Forms.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinios1.0</TargetFramework>
@@ -12,7 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
   </ItemGroup>
   <ItemGroup>
@@ -24,5 +23,4 @@
     <Compile Include="..\SkiaSharp.Views.Forms.Native.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.NetStandard\SkiaSharp.NetStandard.csproj" />
@@ -22,5 +21,4 @@
     <Compile Include="..\SkiaSharp.Views.Forms.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
@@ -3,6 +3,8 @@ using Android.Opengl;
 using Javax.Microedition.Khronos.Egl;
 using Javax.Microedition.Khronos.Opengles;
 
+using EGLConfig = Javax.Microedition.Khronos.Egl.EGLConfig;
+
 namespace SkiaSharp.Views.Android
 {
 	public abstract class SKGLSurfaceViewRenderer : Java.Lang.Object, GLSurfaceView.IRenderer

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
@@ -3,6 +3,8 @@ using Android.Opengl;
 using Javax.Microedition.Khronos.Egl;
 using Javax.Microedition.Khronos.Opengles;
 
+using EGLConfig = Javax.Microedition.Khronos.Egl.EGLConfig;
+
 namespace SkiaSharp.Views.Android
 {
 	public abstract class SKGLTextureViewRenderer : Java.Lang.Object, GLTextureView.IRenderer

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SkiaSharp.Views.Android.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SkiaSharp.Views.Android.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid4.0.3</TargetFramework>
+    <TargetFramework>monoandroid4.4</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>SkiaSharp.Views.Android</RootNamespace>
     <AssemblyName>SkiaSharp.Views.Android</AssemblyName>
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.Android\SkiaSharp.Android.csproj" />
@@ -20,5 +19,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Desktop/SkiaSharp.Views.Desktop.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Desktop/SkiaSharp.Views.Desktop.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="OpenTK" Version="1.1.2349.61993" />
     <PackageReference Include="OpenTK.GLControl" Version="1.1.2349.61993" />
   </ItemGroup>
@@ -25,5 +24,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Gtk/SkiaSharp.Views.Gtk.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Gtk/SkiaSharp.Views.Gtk.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="OpenTK" Version="1.1.2349.61993" />
     <PackageReference Include="OpenTK.GLControl" Version="1.1.2349.61993" />
   </ItemGroup>
@@ -37,5 +36,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\Properties\SkiaSharpViewsAssemblyInfo.cs" Link="Properties\SkiaSharpViewsAssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SkiaSharp.Views.Mac.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SkiaSharp.Views.Mac.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinmac2.0</TargetFramework>
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.OSX\SkiaSharp.OSX.csproj" />
@@ -21,5 +20,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SkiaSharp.Views.Tizen.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SkiaSharp.Views.Tizen.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
@@ -12,9 +12,7 @@
     <DefineConstants>$(DefineConstants);__TIZEN__;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
   </ItemGroup>
@@ -25,5 +23,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SkiaSharp.Views.UWP.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SkiaSharp.Views.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>uap10.0.10240</TargetFramework>
@@ -11,8 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.UWP\SkiaSharp.UWP.csproj" />
@@ -26,5 +24,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -11,8 +11,12 @@
     <DefineConstants>$(DefineConstants);__DESKTOP__;__WPF__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="OpenTK" Version="1.1.2349.61993" />
     <PackageReference Include="OpenTK.GLControl" Version="1.1.2349.61993" />
   </ItemGroup>
@@ -24,5 +28,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\Properties\SkiaSharpViewsAssemblyInfo.cs" Link="Properties\SkiaSharpViewsAssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.iOS/SkiaSharp.Views.iOS.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.iOS/SkiaSharp.Views.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinios1.0</TargetFramework>
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.iOS\SkiaSharp.iOS.csproj" />
@@ -22,5 +21,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.tvOS/SkiaSharp.Views.tvOS.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.tvOS/SkiaSharp.Views.tvOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarintvos1.0</TargetFramework>
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.tvOS\SkiaSharp.tvOS.csproj" />
@@ -22,5 +21,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.watchOS/SkiaSharp.Views.watchOS.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.watchOS/SkiaSharp.Views.watchOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinwatchos1.0</TargetFramework>
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.3.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.watchOS\SkiaSharp.watchOS.csproj" />
@@ -22,5 +21,4 @@
     <Compile Include="..\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <Import Project="..\..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/source/SkiaSharp.Workbooks/SkiaSharp.Workbooks.csproj
+++ b/source/SkiaSharp.Workbooks/SkiaSharp.Workbooks.csproj
@@ -11,12 +11,10 @@
     <PackagingLocation>xamarin.interactive</PackagingLocation>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Workbooks.Integration" Version="1.0.0-rc5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\binding\SkiaSharp.NetStandard\SkiaSharp.NetStandard.csproj" />
   </ItemGroup>
   <Import Project="..\SkiaSharp.Build.targets" />
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>


### PR DESCRIPTION
 - Use the latest version of MSBuild.Sdk.Extras
 - No longer use MSBuild.Sdk.Extras for the net and netstandard monikers as the new .NET Core already supports these nicely
 - Update all the Android projects to be 4.4+ as below is no longer realistically supported - both by Xamarin and Google
 - Using the Sdk attribute to specify the new project SDK