### PR TITLE
HarfBuzzSharp: Add buffer UTF overloads

### DIFF
--- a/binding/HarfBuzzSharp.Android/HarfBuzzSharp.Android.csproj
+++ b/binding/HarfBuzzSharp.Android/HarfBuzzSharp.Android.csproj
@@ -9,6 +9,7 @@
     <PackagingPlatform>MonoAndroid</PackagingPlatform>
     <DefineConstants>$(DefineConstants);HARFBUZZ</DefineConstants>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -25,6 +26,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.Desktop/HarfBuzzSharp.Desktop.csproj
+++ b/binding/HarfBuzzSharp.Desktop/HarfBuzzSharp.Desktop.csproj
@@ -9,6 +9,7 @@
     <PackagingPlatform>net45</PackagingPlatform>
     <DefineConstants>$(DefineConstants);__DESKTOP__;HARFBUZZ</DefineConstants>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -26,6 +27,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.NetStandard/HarfBuzzSharp.NetStandard.csproj
+++ b/binding/HarfBuzzSharp.NetStandard/HarfBuzzSharp.NetStandard.csproj
@@ -9,6 +9,7 @@
     <PackagingPlatform>netstandard1.3</PackagingPlatform>
     <DefineConstants>$(DefineConstants);HARFBUZZ;NET_STANDARD</DefineConstants>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -19,6 +20,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.OSX/HarfBuzzSharp.OSX.csproj
+++ b/binding/HarfBuzzSharp.OSX/HarfBuzzSharp.OSX.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsBindingProject>true</IsBindingProject>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -18,6 +19,9 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="netstandard" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
@@ -27,6 +31,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -43,61 +43,61 @@ namespace HarfBuzzSharp
 			get { return HarfBuzzApi.hb_buffer_get_length(Handle); }
 		}
 
-		public void AddUtf8(string text)
+		public void AddUtf8(string utf8text)
 		{
-			var bytes = Encoding.UTF8.GetBytes(text);
+			var bytes = Encoding.UTF8.GetBytes(utf8text);
 			AddUtf8(bytes);
 		}
 
-		public unsafe void AddUtf8(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf8(byte[] bytes, uint itemOffset = 0, int itemLength = -1)
 		{
-			fixed (byte* bytes = text)
+			fixed (byte* b = bytes)
 			{
-				AddUtf8((IntPtr)bytes, text.Length, itemOffset, itemLength);
+				AddUtf8((IntPtr)b, bytes.Length, itemOffset, itemLength);
 			}
 		}
 
-		public void AddUtf8(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		public void AddUtf8(IntPtr buffer, int textLength, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf8(Handle, text, textLength, itemOffset, itemLength);
+			HarfBuzzApi.hb_buffer_add_utf8(Handle, buffer, textLength, itemOffset, itemLength);
 		}
 
-		public void AddUtf16(string text)
+		public void AddUtf16(string utf16text)
 		{
-			var bytes = Encoding.Unicode.GetBytes(text);
+			var bytes = Encoding.Unicode.GetBytes(utf16text);
 			AddUtf16(bytes, 0, bytes.Length / 2);
 		}
 
-		public unsafe void AddUtf16(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf16(byte[] bytes, uint itemOffset = 0, int itemLength = -1)
 		{
-			fixed (byte* bytes = text)
+			fixed (byte* b = bytes)
 			{
-				AddUtf16((IntPtr)bytes, text.Length, itemOffset, itemLength);
+				AddUtf16((IntPtr)b, bytes.Length, itemOffset, itemLength);
 			}
 		}
 
-		public void AddUtf16(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		public void AddUtf16(IntPtr buffer, int textLength, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf16(Handle, text, textLength, itemOffset, itemLength);
+			HarfBuzzApi.hb_buffer_add_utf16(Handle, buffer, textLength, itemOffset, itemLength);
 		}
 
-		public void AddUtf32(string text)
+		public void AddUtf32(string utf32text)
 		{
-			var bytes = Encoding.UTF32.GetBytes(text);
+			var bytes = Encoding.UTF32.GetBytes(utf32text);
 			AddUtf32(bytes, 0, bytes.Length / 4);
 		}
 
-		public unsafe void AddUtf32(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf32(byte[] bytes, uint itemOffset = 0, int itemLength = -1)
 		{
-			fixed (byte* bytes = text)
+			fixed (byte* b = bytes)
 			{
-				AddUtf32((IntPtr)bytes, text.Length, itemOffset, itemLength);
+				AddUtf32((IntPtr)b, bytes.Length, itemOffset, itemLength);
 			}
 		}
 
-		public void AddUtf32(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		public void AddUtf32(IntPtr buffer, int textLength, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf32(Handle, text, textLength, itemOffset, itemLength);
+			HarfBuzzApi.hb_buffer_add_utf32(Handle, buffer, textLength, itemOffset, itemLength);
 		}
 
 		public void GuessSegmentProperties() => HarfBuzzApi.hb_buffer_guess_segment_properties(Handle);

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -51,10 +51,6 @@ namespace HarfBuzzSharp
 
 		public void AddUtf8(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			if (itemLength == -1) {
-				itemLength = text.Length - (int)itemOffset;
-			}
-
 			HarfBuzzApi.hb_buffer_add_utf8(Handle, text, text.Length, itemOffset, itemLength);
 		}
 
@@ -66,25 +62,17 @@ namespace HarfBuzzSharp
 
 		public void AddUtf16(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			if (itemLength == -1) {
-				itemLength = text.Length / 2 - (int)itemOffset;
-			}
-
 			HarfBuzzApi.hb_buffer_add_utf16(Handle, text, text.Length, itemOffset, itemLength);
 		}
 
 		public void AddUtf32(string text)
 		{
-			var bytes = Encoding.UTF32.GetBytes (text);
+			var bytes = Encoding.UTF32.GetBytes(text);
 			AddUtf32(bytes);
 		}
 
 		public void AddUtf32(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			if (itemLength == -1) {
-				itemLength = text.Length / 4 - (int)itemOffset;
-			}
-
 			HarfBuzzApi.hb_buffer_add_utf32(Handle, text, text.Length, itemOffset, itemLength);
 		}
 
@@ -96,8 +84,7 @@ namespace HarfBuzzSharp
 		{
 			get
 			{
-				uint length;
-				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_infos(Handle, out length);
+				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_infos(Handle, out var length);
 				return PtrToStructureArray<GlyphInfo>(infoPtrs, (int)length);
 			}
 		}
@@ -106,8 +93,7 @@ namespace HarfBuzzSharp
 		{
 			get
 			{
-				uint length;
-				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_positions(Handle, out length);
+				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_positions(Handle, out var length);
 				return PtrToStructureArray<GlyphPosition>(infoPtrs, (int)length);
 			}
 		}

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace HarfBuzzSharp
@@ -44,15 +43,49 @@ namespace HarfBuzzSharp
 			get { return HarfBuzzApi.hb_buffer_get_length(Handle); }
 		}
 
-		public void AddUtf8(string utf8text)
+		public void AddUtf8(string text)
 		{
-			var bytes = Encoding.UTF8.GetBytes(utf8text);
+			var bytes = Encoding.UTF8.GetBytes(text);
 			AddUtf8(bytes);
 		}
 
-		public void AddUtf8(byte[] bytes)
+		public void AddUtf8(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf8(Handle, bytes, bytes.Length, 0, bytes.Length);
+			if (itemLength == -1) {
+				itemLength = text.Length - (int)itemOffset;
+			}
+
+			HarfBuzzApi.hb_buffer_add_utf8(Handle, text, text.Length, itemOffset, itemLength);
+		}
+
+		public void AddUtf16(string text)
+		{
+			var bytes = Encoding.Unicode.GetBytes(text);
+			AddUtf16(bytes);
+		}
+
+		public void AddUtf16(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		{
+			if (itemLength == -1) {
+				itemLength = text.Length / 2 - (int)itemOffset;
+			}
+
+			HarfBuzzApi.hb_buffer_add_utf16(Handle, text, text.Length, itemOffset, itemLength);
+		}
+
+		public void AddUtf32(string text)
+		{
+			var bytes = Encoding.UTF32.GetBytes (text);
+			AddUtf32(bytes);
+		}
+
+		public void AddUtf32(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		{
+			if (itemLength == -1) {
+				itemLength = text.Length / 4 - (int)itemOffset;
+			}
+
+			HarfBuzzApi.hb_buffer_add_utf32(Handle, text, text.Length, itemOffset, itemLength);
 		}
 
 		public void GuessSegmentProperties() => HarfBuzzApi.hb_buffer_guess_segment_properties(Handle);

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -82,7 +82,7 @@ namespace HarfBuzzSharp
 		{
 			fixed (char* chars = text)
 			{
-				AddUtf16 ((IntPtr)chars, text.Length, itemOffset, itemLength);
+				AddUtf16((IntPtr)chars, text.Length, itemOffset, itemLength);
 			}
 		}
 
@@ -90,7 +90,7 @@ namespace HarfBuzzSharp
 		{
 			fixed (byte* bytes = text)
 			{
-				AddUtf16((IntPtr)bytes, text.Length);
+				AddUtf16((IntPtr)bytes, text.Length / 2);
 			}
 		}
 
@@ -117,7 +117,7 @@ namespace HarfBuzzSharp
 		{
 			fixed (byte* bytes = text)
 			{
-				AddUtf32((IntPtr)bytes, text.Length);
+				AddUtf32((IntPtr)bytes, text.Length / 4);
 			}
 		}
 

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -43,61 +43,95 @@ namespace HarfBuzzSharp
 			get { return HarfBuzzApi.hb_buffer_get_length(Handle); }
 		}
 
-		public void AddUtf8(string utf8text)
+		public void Add(uint codepoint, uint cluster)
 		{
-			var bytes = Encoding.UTF8.GetBytes(utf8text);
-			AddUtf8(bytes);
+			HarfBuzzApi.hb_buffer_add(Handle, codepoint, cluster);
 		}
 
-		public unsafe void AddUtf8(byte[] bytes, uint itemOffset = 0, int itemLength = -1)
+		public void AddUtf8(string text)
+		{
+			var bytes = Encoding.UTF8.GetBytes(text);
+			AddUtf8 (bytes, 0, -1);
+		}
+
+		public void AddUtf8(byte[] bytes)
+		{
+			AddUtf8(bytes, 0, -1);
+		}
+		public unsafe void AddUtf8(byte[] bytes, uint itemOffset, int itemLength)
 		{
 			fixed (byte* b = bytes)
 			{
 				AddUtf8((IntPtr)b, bytes.Length, itemOffset, itemLength);
 			}
 		}
-
-		public void AddUtf8(IntPtr buffer, int textLength, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf8(ReadOnlySpan<byte> text, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf8(Handle, buffer, textLength, itemOffset, itemLength);
-		}
-
-		public void AddUtf16(string utf16text)
-		{
-			var bytes = Encoding.Unicode.GetBytes(utf16text);
-			AddUtf16(bytes, 0, bytes.Length / 2);
-		}
-
-		public unsafe void AddUtf16(byte[] bytes, uint itemOffset = 0, int itemLength = -1)
-		{
-			fixed (byte* b = bytes)
+			fixed (byte* bytes = text)
 			{
-				AddUtf16((IntPtr)b, bytes.Length, itemOffset, itemLength);
+				AddUtf8((IntPtr)bytes, text.Length, itemOffset, itemLength);
 			}
 		}
 
-		public void AddUtf16(IntPtr buffer, int textLength, uint itemOffset = 0, int itemLength = -1)
+		public void AddUtf8(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf16(Handle, buffer, textLength, itemOffset, itemLength);
+			HarfBuzzApi.hb_buffer_add_utf8(Handle, text, textLength, itemOffset, itemLength);
 		}
 
-		public void AddUtf32(string utf32text)
+		public unsafe void AddUtf16(string text, uint itemOffset = 0, int itemLength = -1)
 		{
-			var bytes = Encoding.UTF32.GetBytes(utf32text);
-			AddUtf32(bytes, 0, bytes.Length / 4);
-		}
-
-		public unsafe void AddUtf32(byte[] bytes, uint itemOffset = 0, int itemLength = -1)
-		{
-			fixed (byte* b = bytes)
+			fixed (char* chars = text)
 			{
-				AddUtf32((IntPtr)b, bytes.Length, itemOffset, itemLength);
+				AddUtf16 ((IntPtr)chars, text.Length, itemOffset, itemLength);
 			}
 		}
 
-		public void AddUtf32(IntPtr buffer, int textLength, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf16(byte[] text)
 		{
-			HarfBuzzApi.hb_buffer_add_utf32(Handle, buffer, textLength, itemOffset, itemLength);
+			fixed (byte* bytes = text)
+			{
+				AddUtf16((IntPtr)bytes, text.Length);
+			}
+		}
+
+		public unsafe void AddUtf16(ReadOnlySpan<char> text, uint itemOffset = 0, int itemLength = -1)
+		{
+			fixed (char* chars = text)
+			{
+				AddUtf16((IntPtr)chars, text.Length, itemOffset, itemLength);
+			}
+		}
+
+		public void AddUtf16(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		{
+			HarfBuzzApi.hb_buffer_add_utf16(Handle, text, textLength, itemOffset, itemLength);
+		}
+
+		public void AddUtf32(string text)
+		{
+			var bytes = Encoding.UTF32.GetBytes(text);
+			AddUtf32(bytes);
+		}
+
+		public unsafe void AddUtf32(byte[] text)
+		{
+			fixed (byte* bytes = text)
+			{
+				AddUtf32((IntPtr)bytes, text.Length);
+			}
+		}
+
+		public unsafe void AddUtf32(ReadOnlySpan<uint> text, uint itemOffset = 0, int itemLength = -1)
+		{
+			fixed (uint* integers = text)
+			{
+				AddUtf32((IntPtr)integers, text.Length, itemOffset, itemLength);
+			}
+		}
+
+		public void AddUtf32(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		{
+			HarfBuzzApi.hb_buffer_add_utf32(Handle, text, textLength, itemOffset, itemLength);
 		}
 
 		public void GuessSegmentProperties() => HarfBuzzApi.hb_buffer_guess_segment_properties(Handle);
@@ -108,7 +142,8 @@ namespace HarfBuzzSharp
 		{
 			get
 			{
-				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_infos(Handle, out var length);
+				uint length;
+				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_infos(Handle, out length);
 				return PtrToStructureArray<GlyphInfo>(infoPtrs, (int)length);
 			}
 		}
@@ -117,7 +152,8 @@ namespace HarfBuzzSharp
 		{
 			get
 			{
-				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_positions(Handle, out var length);
+				uint length;
+				var infoPtrs = HarfBuzzApi.hb_buffer_get_glyph_positions(Handle, out length);
 				return PtrToStructureArray<GlyphPosition>(infoPtrs, (int)length);
 			}
 		}

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -57,7 +57,7 @@ namespace HarfBuzzSharp
 		public void AddUtf16(string text)
 		{
 			var bytes = Encoding.Unicode.GetBytes(text);
-			AddUtf16(bytes);
+			AddUtf16(bytes, 0, bytes.Length / 2);
 		}
 
 		public void AddUtf16(byte[] text, uint itemOffset = 0, int itemLength = -1)
@@ -68,7 +68,7 @@ namespace HarfBuzzSharp
 		public void AddUtf32(string text)
 		{
 			var bytes = Encoding.UTF32.GetBytes(text);
-			AddUtf32(bytes);
+			AddUtf32(bytes, 0, bytes.Length / 4);
 		}
 
 		public void AddUtf32(byte[] text, uint itemOffset = 0, int itemLength = -1)

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -48,9 +48,9 @@ namespace HarfBuzzSharp
 			HarfBuzzApi.hb_buffer_add(Handle, codepoint, cluster);
 		}
 
-		public void AddUtf8(string text)
+		public void AddUtf8(string utf8text)
 		{
-			var bytes = Encoding.UTF8.GetBytes(text);
+			var bytes = Encoding.UTF8.GetBytes(utf8text);
 			AddUtf8 (bytes, 0, -1);
 		}
 

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -49,9 +49,17 @@ namespace HarfBuzzSharp
 			AddUtf8(bytes);
 		}
 
-		public void AddUtf8(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf8(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf8(Handle, text, text.Length, itemOffset, itemLength);
+			fixed (byte* bytes = text)
+			{
+				AddUtf8((IntPtr)bytes, text.Length, itemOffset, itemLength);
+			}
+		}
+
+		public void AddUtf8(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		{
+			HarfBuzzApi.hb_buffer_add_utf8(Handle, text, textLength, itemOffset, itemLength);
 		}
 
 		public void AddUtf16(string text)
@@ -60,9 +68,17 @@ namespace HarfBuzzSharp
 			AddUtf16(bytes, 0, bytes.Length / 2);
 		}
 
-		public void AddUtf16(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf16(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf16(Handle, text, text.Length, itemOffset, itemLength);
+			fixed (byte* bytes = text)
+			{
+				AddUtf16((IntPtr)bytes, text.Length, itemOffset, itemLength);
+			}
+		}
+
+		public void AddUtf16(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		{
+			HarfBuzzApi.hb_buffer_add_utf16(Handle, text, textLength, itemOffset, itemLength);
 		}
 
 		public void AddUtf32(string text)
@@ -71,9 +87,17 @@ namespace HarfBuzzSharp
 			AddUtf32(bytes, 0, bytes.Length / 4);
 		}
 
-		public void AddUtf32(byte[] text, uint itemOffset = 0, int itemLength = -1)
+		public unsafe void AddUtf32(byte[] text, uint itemOffset = 0, int itemLength = -1)
 		{
-			HarfBuzzApi.hb_buffer_add_utf32(Handle, text, text.Length, itemOffset, itemLength);
+			fixed (byte* bytes = text)
+			{
+				AddUtf32((IntPtr)bytes, text.Length, itemOffset, itemLength);
+			}
+		}
+
+		public void AddUtf32(IntPtr text, int textLength, uint itemOffset = 0, int itemLength = -1)
+		{
+			HarfBuzzApi.hb_buffer_add_utf32(Handle, text, textLength, itemOffset, itemLength);
 		}
 
 		public void GuessSegmentProperties() => HarfBuzzApi.hb_buffer_guess_segment_properties(Handle);

--- a/binding/HarfBuzzSharp.Shared/HarfBuzzApi.cs
+++ b/binding/HarfBuzzSharp.Shared/HarfBuzzApi.cs
@@ -96,13 +96,13 @@ namespace HarfBuzzSharp
 		public extern static void hb_buffer_destroy(hb_buffer_t buffer);
 
 		[DllImport(HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		public extern static void hb_buffer_add_utf8(hb_buffer_t buffer, byte[] text, int text_length, uint item_offset, int item_length);
+		public extern static void hb_buffer_add_utf8(hb_buffer_t buffer, IntPtr text, int text_length, uint item_offset, int item_length);
 
 		[DllImport(HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		public extern static void hb_buffer_add_utf16(hb_buffer_t buffer, byte[] text, int text_length, uint item_offset, int item_length);
+		public extern static void hb_buffer_add_utf16(hb_buffer_t buffer, IntPtr text, int text_length, uint item_offset, int item_length);
 
 		[DllImport(HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		public extern static void hb_buffer_add_utf32(hb_buffer_t buffer, byte[] text, int text_length, uint item_offset, int item_length);
+		public extern static void hb_buffer_add_utf32(hb_buffer_t buffer, IntPtr text, int text_length, uint item_offset, int item_length);
 
 		[DllImport(HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void hb_buffer_guess_segment_properties(hb_buffer_t buffer);

--- a/binding/HarfBuzzSharp.Shared/HarfBuzzApi.cs
+++ b/binding/HarfBuzzSharp.Shared/HarfBuzzApi.cs
@@ -95,6 +95,9 @@ namespace HarfBuzzSharp
 		[DllImport(HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void hb_buffer_destroy(hb_buffer_t buffer);
 
+		[DllImport (HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void hb_buffer_add (hb_buffer_t buffer, hb_codepoint_t codepoint, uint cluster);
+
 		[DllImport(HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void hb_buffer_add_utf8(hb_buffer_t buffer, IntPtr text, int text_length, uint item_offset, int item_length);
 

--- a/binding/HarfBuzzSharp.Tizen/HarfBuzzSharp.Tizen.csproj
+++ b/binding/HarfBuzzSharp.Tizen/HarfBuzzSharp.Tizen.csproj
@@ -10,6 +10,7 @@
     <PackagingGroup>HarfBuzzSharp</PackagingGroup>
     <PackagingPlatform>tizen40</PackagingPlatform>
     <DefineConstants>$(DefineConstants);HARFBUZZ;__TIZEN__;</DefineConstants>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -17,7 +18,11 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/binding/HarfBuzzSharp.UWP/HarfBuzzSharp.UWP.csproj
+++ b/binding/HarfBuzzSharp.UWP/HarfBuzzSharp.UWP.csproj
@@ -9,6 +9,7 @@
     <PackagingPlatform>uap10.0</PackagingPlatform>
     <DefineConstants>$(DefineConstants);NET_STANDARD;HARFBUZZ</DefineConstants>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -24,6 +25,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.iOS/HarfBuzzSharp.iOS.csproj
+++ b/binding/HarfBuzzSharp.iOS/HarfBuzzSharp.iOS.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsBindingProject>true</IsBindingProject>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -27,6 +28,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.tvOS/HarfBuzzSharp.tvOS.csproj
+++ b/binding/HarfBuzzSharp.tvOS/HarfBuzzSharp.tvOS.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsBindingProject>true</IsBindingProject>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -27,6 +28,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/binding/HarfBuzzSharp.watchOS/HarfBuzzSharp.watchOS.csproj
+++ b/binding/HarfBuzzSharp.watchOS/HarfBuzzSharp.watchOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
     <TargetFramework>xamarinwatchos1.0</TargetFramework>
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsBindingProject>true</IsBindingProject>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>full</DebugType>
@@ -27,6 +28,9 @@
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\HarfBuzzSharp.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <Import Project="..\..\source\SkiaSharp.Build.targets" />
 </Project>

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/SKShaper.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/SKShaper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Linq;
 
 using HarfBuzzSharp;
+using Buffer = HarfBuzzSharp.Buffer;
 
 namespace SkiaSharp.HarfBuzz
 {
@@ -9,13 +9,14 @@ namespace SkiaSharp.HarfBuzz
 	{
 		internal const int FONT_SIZE_SCALE = 512;
 
-		private Font font;
-		private HarfBuzzSharp.Buffer buffer;
+		private readonly Font font;
 
 		public SKShaper(SKTypeface typeface)
 		{
 			if (typeface == null)
-				throw new ArgumentNullException(nameof(typeface)); ;
+			{
+				throw new ArgumentNullException(nameof(typeface));
+			};
 
 			Typeface = typeface;
 
@@ -30,8 +31,6 @@ namespace SkiaSharp.HarfBuzz
 				font.SetScale(FONT_SIZE_SCALE, FONT_SIZE_SCALE);
 				font.SetFunctionsOpenType();
 			}
-
-			buffer = new HarfBuzzSharp.Buffer();
 		}
 
 		public SKTypeface Typeface { get; private set; }
@@ -39,30 +38,24 @@ namespace SkiaSharp.HarfBuzz
 		public void Dispose()
 		{
 			font?.Dispose();
-			buffer?.Dispose();
 		}
 
-		public Result Shape(string text, SKPaint paint)
+		public Result Shape(Buffer buffer, SKPaint paint)
 		{
-			return Shape(text, 0, 0, paint);
+			return Shape(buffer, 0, 0, paint);
 		}
 
-		public Result Shape(string text, float xOffset, float yOffset, SKPaint paint)
+		public Result Shape(Buffer buffer, float xOffset, float yOffset, SKPaint paint)
 		{
-			if (text == null)
-				throw new ArgumentNullException(nameof(text));
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
 			if (paint == null)
+			{
 				throw new ArgumentNullException(nameof(paint));
-
-			if (string.IsNullOrEmpty(text))
-				return new Result();
-
-			// add the text to the buffer
-			buffer.ClearContents();
-			buffer.AddUtf8(text);
-
-			// try to understand the text
-			buffer.GuessSegmentProperties();
+			}		
 
 			// do the shaping
 			font.Shape(buffer);
@@ -96,6 +89,41 @@ namespace SkiaSharp.HarfBuzz
 			}
 
 			return new Result(codepoints, clusters, points);
+		}
+
+		public Result Shape(string text, SKPaint paint)
+		{
+			return Shape(text, 0, 0, paint);
+		}
+
+		public Result Shape(string text, float xOffset, float yOffset, SKPaint paint)
+		{
+			if (string.IsNullOrEmpty(text))
+			{
+				return new Result();
+			}
+
+			using (var buffer = new Buffer())
+			{
+				switch (paint.TextEncoding)
+				{
+					case SKTextEncoding.Utf8:
+						buffer.AddUtf8(text);
+						break;
+					case SKTextEncoding.Utf16:
+						buffer.AddUtf16(text);
+						break;
+					case SKTextEncoding.Utf32:
+						buffer.AddUtf32(text);
+						break;
+					default:
+						throw new NotSupportedException("GlyphId encoding is not a valid value.");
+				}
+
+				buffer.GuessSegmentProperties();
+
+				return Shape(buffer, xOffset, yOffset, paint);
+			}
 		}
 
 		public class Result


### PR DESCRIPTION
This PR adds some missing overloads for the hb_buffer to add text with UTF-16 and UTF-32 encoding.
I have also added some overloads that make it possible to only shape some portion of an encoded sequence. 

Leave me comments if you have questions or find any mistake.
