### PR TITLE
None of the raster views should try allocate 0x0 memory. Fixes #759

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKCanvasView.cs
@@ -71,7 +71,10 @@ namespace SkiaSharp.Views.Android
 				return;
 
 			if (info.Width == 0 || info.Height == 0 || Visibility != ViewStates.Visible)
+			{
+				FreeBitmap();
 				return;
+			}
 
 			// create the bitmap data if we need it
 			if (bitmap == null || bitmap.Handle == IntPtr.Zero || bitmap.Width != info.Width || bitmap.Height != info.Height)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCGSurfaceFactory.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCGSurfaceFactory.cs
@@ -29,8 +29,14 @@ namespace SkiaSharp.Views.Mac
 			contentsBounds.Height *= scale;
 
 			// get context details
-			info = new SKImageInfo((int)contentsBounds.Width, (int)contentsBounds.Height, SKColorType.Rgba8888, SKAlphaType.Premul);
-			Info = info;
+			Info = info = CreateInfo((int)contentsBounds.Width, (int)contentsBounds.Height);
+
+			// if there are no pixels, clean up and return
+			if (info.Width == 0 || info.Height == 0 || lastLength == 0)
+			{
+				Dispose();
+				return null;
+			}
 
 			// allocate a memory block for the drawing process
 			var newLength = info.BytesSize;
@@ -48,8 +54,10 @@ namespace SkiaSharp.Views.Mac
 
 		public void DrawSurface(CGContext ctx, CGRect viewBounds, SKImageInfo info, SKSurface surface)
 		{
+			if (info.Width == 0 || info.Height == 0 || lastLength == 0)
+				return;
+
 			surface.Canvas.Flush();
-			surface.Dispose();
 
 			// draw the image onto the context
 			using (var dataProvider = new CGDataProvider(bitmapData, lastLength))
@@ -82,6 +90,10 @@ namespace SkiaSharp.Views.Mac
 				Marshal.FreeCoTaskMem(bitmapData);
 				bitmapData = IntPtr.Zero;
 			}
+			Info = CreateInfo(0, 0);
 		}
+
+		private SKImageInfo CreateInfo(int width, int height) =>
+			new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCanvasLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCanvasLayer.cs
@@ -47,6 +47,9 @@ namespace SkiaSharp.Views.Mac
 			// create the skia context
 			using (var surface = drawable.CreateSurface(Bounds, IgnorePixelScaling ? 1 : ContentsScale, out var info))
 			{
+				if (info.Width == 0 || info.Height == 0)
+					return;
+
 				// draw on the image using SKiaSharp
 				OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info));
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
@@ -85,11 +85,13 @@ namespace SkiaSharp.Views.iOS
 			if (designMode || drawable == null)
 				return;
 
-			using (var ctx = UIGraphics.GetCurrentContext())
+			// create the skia context
+			using (var surface = drawable.CreateSurface(Bounds, IgnorePixelScaling ? 1 : ContentScaleFactor, out var info))
 			{
-				// create the skia context
-				SKImageInfo info;
-				using (var surface = drawable.CreateSurface(Bounds, IgnorePixelScaling ? 1 : ContentScaleFactor, out info))
+				if (info.Width == 0 || info.Height == 0)
+					return;
+
+				using (var ctx = UIGraphics.GetCurrentContext())
 				{
 					// draw on the image using SKiaSharp
 					OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info));

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Desktop/SKControl.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Desktop/SKControl.cs
@@ -39,11 +39,14 @@ namespace SkiaSharp.Views.Desktop
 			base.OnPaint(e);
 
 			// get the bitmap
-			CreateBitmap();
+			var info = CreateBitmap();
+
+			if (info.Width == 0 || info.Height == 0)
+				return;
+
 			var data = bitmap.LockBits(new Rectangle(0, 0, Width, Height), ImageLockMode.WriteOnly, bitmap.PixelFormat);
 
 			// create the surface
-			var info = new SKImageInfo(Width, Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
 			using (var surface = SKSurface.Create(info, data.Scan0, data.Stride))
 			{
 				// start drawing
@@ -62,7 +65,7 @@ namespace SkiaSharp.Views.Desktop
 			// invoke the event
 			PaintSurface?.Invoke(this, e);
 		}
-		
+
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
@@ -70,14 +73,19 @@ namespace SkiaSharp.Views.Desktop
 			FreeBitmap();
 		}
 
-		private void CreateBitmap()
+		private SKImageInfo CreateBitmap()
 		{
-			if (bitmap == null || bitmap.Width != Width || bitmap.Height != Height)
+			var info = new SKImageInfo(Width, Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+
+			if (bitmap == null || bitmap.Width != info.Width || bitmap.Height != info.Height)
 			{
 				FreeBitmap();
 
-				bitmap = new Bitmap(Width, Height, PixelFormat.Format32bppPArgb);
+				if (info.Width != 0 && info.Height != 0)
+					bitmap = new Bitmap(info.Width, info.Height, PixelFormat.Format32bppPArgb);
 			}
+
+			return info;
 		}
 
 		private void FreeBitmap()

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKCanvasView.cs
@@ -72,19 +72,23 @@ namespace SkiaSharp.Views.Mac
 		{
 			base.DrawRect(dirtyRect);
 
-			var ctx = NSGraphicsContext.CurrentContext.CGContext;
-
 			// create the skia context
 			using (var surface = drawable.CreateSurface(Bounds, IgnorePixelScaling ? 1 : Window.BackingScaleFactor, out var info))
 			{
-				// draw on the image using SKiaSharp
-				OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info));
+				if (info.Width == 0 || info.Height == 0)
+					return;
+
+				using (var ctx = NSGraphicsContext.CurrentContext.CGContext)
+				{
+					// draw on the image using SKiaSharp
+					OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info));
 #pragma warning disable CS0618 // Type or member is obsolete
-				DrawInSurface(surface, info);
+					DrawInSurface(surface, info);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-				// draw the surface to the context
-				drawable.DrawSurface(ctx, Bounds, info, surface);
+					// draw the surface to the context
+					drawable.DrawSurface(ctx, Bounds, info, surface);
+				}
 			}
 		}
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.cs
@@ -39,6 +39,9 @@ namespace SkiaSharp.Views.Tizen
 
 		protected sealed override void OnDrawFrame()
 		{
+			if (info.Width == 0 || info.Height == 0)
+				return;
+
 			// draw directly into the EFL image data
 			using (var surface = SKSurface.Create(info, Evas.evas_object_image_data_get(evasImage, true), info.RowBytes))
 			{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
@@ -51,35 +51,19 @@ namespace SkiaSharp.Views.WPF
 			if (designMode)
 				return;
 
-			if (ActualWidth == 0 || ActualHeight == 0 ||
-				double.IsNaN(ActualWidth) || double.IsNaN(ActualHeight) ||
-				double.IsInfinity(ActualWidth) || double.IsInfinity(ActualHeight) ||
-				Visibility != Visibility.Visible)
+			if (Visibility != Visibility.Visible)
 				return;
 
-			int width, height;
-			double dpiScaleX = 1.0;
-			double dpiScaleY = 1.0;
-			if (IgnorePixelScaling)
-			{
-				width = (int)ActualWidth;
-				height = (int)ActualHeight;
-			}
-			else
-			{
-				var m = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice;
-				dpiScaleX = m.M11;
-				dpiScaleY = m.M22;
-				width = (int)(ActualWidth * dpiScaleX);
-				height = (int)(ActualHeight * dpiScaleY);
-			}
+			var size = CreateSize(out var scaleX, out var scaleY);
+			if (size.Width <= 0 || size.Height <= 0)
+				return;
 
-			var info = new SKImageInfo(width, height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
 
 			// reset the bitmap if the size has changed
 			if (bitmap == null || info.Width != bitmap.PixelWidth || info.Height != bitmap.PixelHeight)
 			{
-				bitmap = new WriteableBitmap(width, height, 96 * dpiScaleX, 96 * dpiScaleY, PixelFormats.Pbgra32, null);
+				bitmap = new WriteableBitmap(info.Width, size.Height, 96 * scaleX, 96 * scaleY, PixelFormats.Pbgra32, null);
 			}
 
 			// draw on the bitmap
@@ -90,7 +74,7 @@ namespace SkiaSharp.Views.WPF
 			}
 
 			// draw the bitmap to the screen
-			bitmap.AddDirtyRect(new Int32Rect(0, 0, width, height));
+			bitmap.AddDirtyRect(new Int32Rect(0, 0, info.Width, size.Height));
 			bitmap.Unlock();
 			drawingContext.DrawImage(bitmap, new Rect(0, 0, ActualWidth, ActualHeight));
 		}
@@ -106,6 +90,31 @@ namespace SkiaSharp.Views.WPF
 			base.OnRenderSizeChanged(sizeInfo);
 
 			InvalidateVisual();
+		}
+
+		private SKSizeI CreateSize(out double scaleX, out double scaleY)
+		{
+			scaleX = 1.0;
+			scaleY = 1.0;
+
+			var w = ActualWidth;
+			var h = ActualHeight;
+
+			if (!IsPositive(w) || !IsPositive(h))
+				return SKSizeI.Empty;
+
+			if (IgnorePixelScaling)
+				return new SKSizeI((int)w, (int)h);
+
+			var m = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice;
+			scaleX = m.M11;
+			scaleY = m.M22;
+			return new SKSizeI((int)(w * scaleX), (int)(h * scaleY));
+
+			bool IsPositive(double value)
+			{
+				return !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
In some cases, a view dimension may be < 1, thus the allocation for 0 bytes of memory is not actually possible.

Fixes #759

> VS bug [#770231](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/770231), VS bug [#934149](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/934149)