### PR TITLE
Build Native Linux on Ubuntu 14 with Clang

### DIFF
--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -573,8 +573,8 @@ Task ("externals-linux")
     var BUILD_ARCH = arches.Split (',').Select (a => a.Trim ()).ToArray ();
     var SUPPORT_GPU = (EnvironmentVariable ("SUPPORT_GPU") ?? "1") == "1"; // 1 == true, 0 == false
 
-    var CC = EnvironmentVariable ("CC");
-    var CXX = EnvironmentVariable ("CXX");
+    var CC = EnvironmentVariable ("CC") ?? "clang";
+    var CXX = EnvironmentVariable ("CXX") ?? "clang++";
     var AR = EnvironmentVariable ("AR");
     var CUSTOM_COMPILERS = "";
     if (!string.IsNullOrEmpty (CC))
@@ -592,7 +592,7 @@ Task ("externals-linux")
             $"is_official_build=true skia_enable_tools=false " +
             $"target_os='linux' target_cpu='{arch}' " +
             $"skia_use_icu=false skia_use_sfntly=false skia_use_piex=true " +
-            $"skia_use_system_expat=false skia_use_system_freetype2=true skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false " +
+            $"skia_use_system_expat=false skia_use_system_freetype2=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false " +
             $"skia_enable_gpu={(SUPPORT_GPU ? "true" : "false")} " +
             $"extra_cflags=[ '-DSKIA_C_DLL' ] " +
             $"extra_ldflags=[ ] " +

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -595,7 +595,7 @@ Task ("externals-linux")
             $"skia_use_system_expat=false skia_use_system_freetype2=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false " +
             $"skia_enable_gpu={(SUPPORT_GPU ? "true" : "false")} " +
             $"extra_cflags=[ '-DSKIA_C_DLL' ] " +
-            $"extra_ldflags=[ ] " +
+            $"extra_ldflags=[ '-static-libstdc++', '-static-libgcc' ] " +
             $"{CUSTOM_COMPILERS} " +
             $"linux_soname_version='{soname}'");
 

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -573,8 +573,8 @@ Task ("externals-linux")
     var BUILD_ARCH = arches.Split (',').Select (a => a.Trim ()).ToArray ();
     var SUPPORT_GPU = (EnvironmentVariable ("SUPPORT_GPU") ?? "1") == "1"; // 1 == true, 0 == false
 
-    var CC = EnvironmentVariable ("CC") ?? "clang";
-    var CXX = EnvironmentVariable ("CXX") ?? "clang++";
+    var CC = EnvironmentVariable ("CC");
+    var CXX = EnvironmentVariable ("CXX");
     var AR = EnvironmentVariable ("AR");
     var CUSTOM_COMPILERS = "";
     if (!string.IsNullOrEmpty (CC))

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -45,7 +45,7 @@ CUSTOM_COMPILERS=
     is_official_build=true skia_enable_tools=false
     target_os=\"linux\" target_cpu=\"$ARCH\"
     skia_use_icu=false skia_use_sfntly=false skia_use_piex=true
-    skia_use_system_expat=false skia_use_system_freetype2=true skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false
+    skia_use_system_expat=false skia_use_system_freetype2=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false
     skia_enable_gpu=true
     extra_cflags=[ \"-DSKIA_C_DLL\" ]
     extra_ldflags=[ ]

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -48,7 +48,7 @@ CUSTOM_COMPILERS=
     skia_use_system_expat=false skia_use_system_freetype2=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false
     skia_enable_gpu=true
     extra_cflags=[ \"-DSKIA_C_DLL\" ]
-    extra_ldflags=[ ]
+    extra_ldflags=[ \"-static-libstdc++\", \"-static-libgcc\" ]
     $CUSTOM_COMPILERS
     linux_soname_version=\"$SONAME\"")
 

--- a/scripts/pipeline.groovy
+++ b/scripts/pipeline.groovy
@@ -70,23 +70,25 @@ node("ubuntu-1604-amd64") {
         parallel([
             failFast: true,
 
-            // windows
-            uwp:                createNativeBuilder("UWP",        "Windows",  "components-windows",     ""),
-            win32:              createNativeBuilder("Windows",    "Windows",  "components-windows",     ""),
-            android_windows:    createNativeBuilder("Android",    "Windows",  "components-windows",     ""),
-            tizen_windows:      createNativeBuilder("Tizen",      "Windows",  "components-windows",     ""),
+            //// windows
+            //uwp:                createNativeBuilder("UWP",        "Windows",  "components-windows",     ""),
+            //win32:              createNativeBuilder("Windows",    "Windows",  "components-windows",     ""),
+            //android_windows:    createNativeBuilder("Android",    "Windows",  "components-windows",     ""),
+            //tizen_windows:      createNativeBuilder("Tizen",      "Windows",  "components-windows",     ""),
+            //
+            //// macos
+            //android_macos:      createNativeBuilder("Android",    "macOS",    "components",             ""),
+            //tizen_macos:        createNativeBuilder("Tizen",      "macOS",    "components",             ""),
+            //tvos:               createNativeBuilder("tvOS",       "macOS",    "components",             ""),
+            //ios:                createNativeBuilder("iOS",        "macOS",    "components",             ""),
+            //macos:              createNativeBuilder("macOS",      "macOS",    "components",             ""),
+            //watchos:            createNativeBuilder("watchOS",    "macOS",    "components",             ""),
+            //
+            //// linux
+            //linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1604-amd64",      nativeLinuxPackages),
+            //tizen_linux:        createNativeBuilder("Tizen",      "Linux",    "ubuntu-1604-amd64",      nativeTizenPackages),
 
-            // macos
-            android_macos:      createNativeBuilder("Android",    "macOS",    "components",             ""),
-            tizen_macos:        createNativeBuilder("Tizen",      "macOS",    "components",             ""),
-            tvos:               createNativeBuilder("tvOS",       "macOS",    "components",             ""),
-            ios:                createNativeBuilder("iOS",        "macOS",    "components",             ""),
-            macos:              createNativeBuilder("macOS",      "macOS",    "components",             ""),
-            watchos:            createNativeBuilder("watchOS",    "macOS",    "components",             ""),
-
-            // linux
-            linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1604-amd64",      nativeLinuxPackages),
-            tizen_linux:        createNativeBuilder("Tizen",      "Linux",    "ubuntu-1604-amd64",      nativeTizenPackages),
+            linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1404-amd64",      nativeLinuxPackages),
         ])
     }
 

--- a/scripts/pipeline.groovy
+++ b/scripts/pipeline.groovy
@@ -87,10 +87,8 @@ node("ubuntu-1604-amd64") {
             watchos:            createNativeBuilder("watchOS",    "macOS",    "components",             ""),
 
             // linux
-            linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1604-amd64",      nativeLinuxPackages),
-            tizen_linux:        createNativeBuilder("Tizen",      "Linux",    "ubuntu-1604-amd64",      nativeTizenPackages),
-
             linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1404-amd64",      nativeLinuxPackages),
+            tizen_linux:        createNativeBuilder("Tizen",      "Linux",    "ubuntu-1604-amd64",      nativeTizenPackages),
         ])
     }
 

--- a/scripts/pipeline.groovy
+++ b/scripts/pipeline.groovy
@@ -26,6 +26,8 @@ import groovy.transform.Field
         "ANDROID_NDK_HOME=/Users/builder/Library/Developer/Xamarin/android-ndk",
     ],
     "linux": [
+        "CC=clang-3.8",
+        "CXX=clang++-3.8",
     ]
 ]
 

--- a/scripts/pipeline.groovy
+++ b/scripts/pipeline.groovy
@@ -72,23 +72,23 @@ node("ubuntu-1604-amd64") {
         parallel([
             failFast: true,
 
-            //// windows
-            //uwp:                createNativeBuilder("UWP",        "Windows",  "components-windows",     ""),
-            //win32:              createNativeBuilder("Windows",    "Windows",  "components-windows",     ""),
-            //android_windows:    createNativeBuilder("Android",    "Windows",  "components-windows",     ""),
-            //tizen_windows:      createNativeBuilder("Tizen",      "Windows",  "components-windows",     ""),
-            //
-            //// macos
-            //android_macos:      createNativeBuilder("Android",    "macOS",    "components",             ""),
-            //tizen_macos:        createNativeBuilder("Tizen",      "macOS",    "components",             ""),
-            //tvos:               createNativeBuilder("tvOS",       "macOS",    "components",             ""),
-            //ios:                createNativeBuilder("iOS",        "macOS",    "components",             ""),
-            //macos:              createNativeBuilder("macOS",      "macOS",    "components",             ""),
-            //watchos:            createNativeBuilder("watchOS",    "macOS",    "components",             ""),
-            //
-            //// linux
-            //linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1604-amd64",      nativeLinuxPackages),
-            //tizen_linux:        createNativeBuilder("Tizen",      "Linux",    "ubuntu-1604-amd64",      nativeTizenPackages),
+            // windows
+            uwp:                createNativeBuilder("UWP",        "Windows",  "components-windows",     ""),
+            win32:              createNativeBuilder("Windows",    "Windows",  "components-windows",     ""),
+            android_windows:    createNativeBuilder("Android",    "Windows",  "components-windows",     ""),
+            tizen_windows:      createNativeBuilder("Tizen",      "Windows",  "components-windows",     ""),
+
+            // macos
+            android_macos:      createNativeBuilder("Android",    "macOS",    "components",             ""),
+            tizen_macos:        createNativeBuilder("Tizen",      "macOS",    "components",             ""),
+            tvos:               createNativeBuilder("tvOS",       "macOS",    "components",             ""),
+            ios:                createNativeBuilder("iOS",        "macOS",    "components",             ""),
+            macos:              createNativeBuilder("macOS",      "macOS",    "components",             ""),
+            watchos:            createNativeBuilder("watchOS",    "macOS",    "components",             ""),
+
+            // linux
+            linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1604-amd64",      nativeLinuxPackages),
+            tizen_linux:        createNativeBuilder("Tizen",      "Linux",    "ubuntu-1604-amd64",      nativeTizenPackages),
 
             linux:              createNativeBuilder("Linux",      "Linux",    "ubuntu-1404-amd64",      nativeLinuxPackages),
         ])

--- a/scripts/pipeline.groovy
+++ b/scripts/pipeline.groovy
@@ -10,7 +10,7 @@ import groovy.transform.Field
 @Field def featureNamePrefix = "feature/"
 
 @Field def minimalLinuxPackages = "curl mono-complete msbuild"
-@Field def nativeLinuxPackages = "python git libfontconfig1-dev"
+@Field def nativeLinuxPackages = "python git libfontconfig1-dev clang-3.8"
 @Field def nativeTizenPackages = "python git openjdk-8-jdk zip libxcb-xfixes0 libxcb-render-util0 libwebkitgtk-1.0-0 libxcb-image0 acl libsdl1.2debian libv4l-0 libxcb-randr0 libxcb-shape0 libxcb-icccm4 libsm6 gettext rpm2cpio cpio bridge-utils openvpn"
 @Field def managedLinuxPackages = "dotnet-sdk-2.1 ttf-ancient-fonts"
 


### PR DESCRIPTION
There appears to be some major performance boosts with `clang` (#686), so I am trying out a build for that. And, I am going to drop the version of Ubuntu used for building to 14.04 for increased compatibility with older Linux distros.

 - [x] switch to clang
 - [x] use Ubuntu 14
 - [x] statically link libstdc++ and libgcc

> VS bug [#777658](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/777658)