### PR TITLE
SKRegion: Add constructors and methods for easier interaction with SKRectI and SKPath

### DIFF
--- a/binding/Binding/SKRegion.cs
+++ b/binding/Binding/SKRegion.cs
@@ -20,6 +20,18 @@ namespace SkiaSharp
 		{
 		}
 
+		public SKRegion(SKRectI rect)
+			: this(SkiaApi.sk_region_new2(region.Handle), true)
+		{
+			SetRect(rect);
+		}
+
+		public SKRegion(SKPath path)
+			: this(SKRectI.Ceiling(path.Bounds))
+		{
+			SetPath(path);
+		}
+
 		public SKRectI Bounds {
 			get {
 				SkiaApi.sk_region_get_bounds (Handle, out var rect);
@@ -42,6 +54,16 @@ namespace SkiaSharp
 		public bool Contains(int x, int y)
 		{
 			return SkiaApi.sk_region_contains2(Handle, x, y);
+		}
+
+		public bool Intersects(SKPath path)
+		{
+			if (path == null)
+				throw new ArgumentNullException(nameof(path));
+			using (SKRegion pathRegion = new SKRegion(path, true))
+			{
+				return SkiaApi.sk_region_intersects(Handle, pathRegion.Handle);
+			}
 		}
 
 		public bool Intersects(SKRegion region)
@@ -80,18 +102,13 @@ namespace SkiaSharp
 		public bool SetPath(SKPath path)
 		{
 			if (path == null)
-				throw new ArgumentNullException (nameof (path));
+				throw new ArgumentNullException(nameof(path));
 
-			using (var clip = new SKRegion()) {
-				var rect = path.Bounds;
-				if (!rect.IsEmpty) {
-					var recti = new SKRectI (
-						(int)rect.Left,
-						(int)rect.Top,
-						(int)Math.Ceiling (rect.Right),
-						(int)Math.Ceiling (rect.Bottom));
-					clip.SetRect (recti);
-				}
+			using (var clip = new SKRegion())
+			{
+				var rect = SKRectI.Ceiling(path.Bounds);
+				if (!rect.IsEmpty)
+					clip.SetRect(rect);
 
 				return SkiaApi.sk_region_set_path(Handle, path.Handle, clip.Handle);
 			}
@@ -110,6 +127,14 @@ namespace SkiaSharp
 		public bool Op(SKRegion region, SKRegionOperation op)
 		{
 			return SkiaApi.sk_region_op2(Handle, region.Handle, op);
+		}
+
+		public bool Op(SKPath path, SKRegionOperation op)
+		{
+			using (SKRegion pathRegion = new SKRegion(path, true))
+			{
+				return SkiaApi.sk_region_op2(Handle, pathRegion.Handle, op);
+			}
 		}
 	}
 }


### PR DESCRIPTION
1. Cleaned up SKRegion file in terms of style. Style was inconsistent at best in this file.
    * To assist with this in future, I have added `omnisharp.json` to the project root, which OmniSharp can utilize to format the C# source files automatically. Nobody should need to deal with repo style on a manual basis where possible.
    * If this file doesn't quite meet every standard set in the style guide, please feel free to alter the rules laid out therein. I just want to make it as easy as possible for potential contributors to get it right the first time. 😊 
2. Added some constructors to SKRegion:
    * `new SKRegion(SKRect rect)` -- creates a new region and calls `SetRect(rect)`
    * `new SKRegion(SKPath path)` -- creates a new region and calls `SetPath(path)`
3. Altered `SetPath(SKPath path)` method to utilize `SKRectI.Ceiling()` method rather than use a custom implementation. It seemed inconsistent and tricky to verify that the existing method would work as intended, and moving to an existing, standardized, and (hopefully) tested method seems like a better move. Let me know if there's a specific reason it was done the way it was, happy to learn here.
4. Added `Intersects(SKPath path)` method to complement the existing SKRectI and SKRegion `Intersects` overloads.
5. Added `Op(SKPath path, SKRegionOperation op)` method to complement the existing similar methods for `SKRectI` and `SKRegion`.

Resolves #778 (for the most part... I'd need someone to talk me through the native methods and if/why they demand integer values for SKRegion bounds in order to look at potentially allowing direct use of SKRect with SKRegion without rounding values all over the place.)