### PR TITLE
Dropping the macOS minimum version to 10.7

### DIFF
--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -216,8 +216,8 @@ Task ("externals-osx")
             $"target_os='mac' target_cpu='{skiaArch}' " +
             $"skia_use_icu=false skia_use_sfntly=false skia_use_piex=true " +
             $"skia_use_system_expat=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-mmacosx-version-min=10.9' ] " +
-            $"extra_ldflags=[ '-Wl,macosx_version_min=10.9' ]");
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-mmacosx-version-min=10.7', '-stdlib=libc++' ] " +
+            $"extra_ldflags=[ '-Wl,macosx_version_min=10.7', '-stdlib=libc++' ]");
 
         // build libSkiaSharp
         XCodeBuild (new XCodeBuildSettings {

--- a/native-builds/libSkiaSharp_osx/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native-builds/libSkiaSharp_osx/libSkiaSharp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		346D1BC421D405D30066C82D /* sk_manageddrawable.h in Headers */ = {isa = PBXBuildFile; fileRef = 346D1BC021D405D30066C82D /* sk_manageddrawable.h */; };
 		346D1BC521D405D30066C82D /* sk_manageddrawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 346D1BC121D405D30066C82D /* sk_manageddrawable.cpp */; };
 		346D1BC621D405D30066C82D /* SkManagedDrawable.h in Headers */ = {isa = PBXBuildFile; fileRef = 346D1BC221D405D30066C82D /* SkManagedDrawable.h */; };
+		3477EF0D221654DE00527FC7 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3477EF0C221654DE00527FC7 /* CoreServices.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		346D1BC021D405D30066C82D /* sk_manageddrawable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sk_manageddrawable.h; path = ../../../externals/skia/include/xamarin/sk_manageddrawable.h; sourceTree = "<group>"; };
 		346D1BC121D405D30066C82D /* sk_manageddrawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_manageddrawable.cpp; path = ../../../externals/skia/src/xamarin/sk_manageddrawable.cpp; sourceTree = "<group>"; };
 		346D1BC221D405D30066C82D /* SkManagedDrawable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SkManagedDrawable.h; path = ../../../externals/skia/include/xamarin/SkManagedDrawable.h; sourceTree = "<group>"; };
+		3477EF0C221654DE00527FC7 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3477EF0D221654DE00527FC7 /* CoreServices.framework in Frameworks */,
 				343CCD311E75FF71000EC0A6 /* Cocoa.framework in Frameworks */,
 				343CCD2F1E75FF54000EC0A6 /* CoreFoundation.framework in Frameworks */,
 				343CCD2D1E75FF47000EC0A6 /* CoreGraphics.framework in Frameworks */,
@@ -84,6 +87,7 @@
 		343CCD251E75FD47000EC0A6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3477EF0C221654DE00527FC7 /* CoreServices.framework */,
 				343CCD301E75FF71000EC0A6 /* Cocoa.framework */,
 				343CCD2E1E75FF54000EC0A6 /* CoreFoundation.framework */,
 				343CCD2C1E75FF47000EC0A6 /* CoreGraphics.framework */,
@@ -217,7 +221,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					SK_INTERNAL,
@@ -239,7 +243,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				MTL_ENABLE_DEBUG_INFO = YES;
 			};
 			name = Debug;
@@ -264,7 +268,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					SK_INTERNAL,
@@ -286,7 +290,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				MTL_ENABLE_DEBUG_INFO = NO;
 			};
 			name = Release;
@@ -319,7 +323,7 @@
 				);
 				INSTALL_PATH = "@rpath";
 				LIBRARY_SEARCH_PATHS = "../../externals/skia/out/mac/$(ARCHS)";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-lskia";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -353,7 +357,7 @@
 				);
 				INSTALL_PATH = "@rpath";
 				LIBRARY_SEARCH_PATHS = "../../externals/skia/out/mac/$(ARCHS)";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-lskia";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
Apple moved our cheese with macOS 10.7, so apps using SkiaSharp cannot run on 10.7.

This PR drops the minimum version and fixes #775.

This app was built with SkiaSharp targeting macOS 10.14 and a minimum of 10.7: [SkiaSharpSample.app.zip](https://github.com/mono/SkiaSharp/files/2867589/SkiaSharpSample.app.zip)

Here it is running on my machine (10.14):
<img width="534" alt="screen shot 2019-02-15 at 04 23 05" src="https://user-images.githubusercontent.com/1096616/52831011-9fe3fa80-30db-11e9-9080-4674a3d426e3.png">

> VS bug [#793482](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/793482)