### PR TITLE
Add Reset method to SKPaint and add constructor to SKMatrix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "externals/skia"]
 	path = externals/skia
-	url = https://github.com/MarchingCube/skia.git
-	branch = skpaint-reset
+	url = https://github.com/mono/skia.git
+	branch = xamarin-mobile-bindings
 [submodule "externals/depot_tools"]
 	path = externals/depot_tools
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "externals/skia"]
 	path = externals/skia
-	url = https://github.com/mono/skia.git
-	branch = xamarin-mobile-bindings
+	url = https://github.com/MarchingCube/skia.git
+	branch = skpaint-reset
 [submodule "externals/depot_tools"]
 	path = externals/depot_tools
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/binding/Binding/SKMatrix.cs
+++ b/binding/Binding/SKMatrix.cs
@@ -68,6 +68,22 @@ namespace SkiaSharp
 			set { persp2 = value; }
 		}
 
+		public SKMatrix (
+			float scaleX, float skewX, float transX,
+			float skewY, float scaleY, float transY,
+			float persp0, float persp1, float persp2)
+		{
+			this.scaleX = scaleX;
+			this.skewX = skewX;
+			this.transX = transX;
+			this.skewY = skewY;
+			this.scaleY = scaleY;
+            this.transY = transY;
+			this.persp0 = persp0;
+			this.persp1 = persp1;
+			this.persp2 = persp2;
+		}
+
 		public float [] Values {
 			get {
 				return new float [9] {

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -27,6 +27,11 @@ namespace SkiaSharp
 			base.Dispose (disposing);
 		}
 
+		public void Reset ()
+		{
+			SkiaApi.sk_paint_reset (Handle);
+		}
+
 		public bool IsAntialias {
 			get => SkiaApi.sk_paint_is_antialias (Handle);
 			set => SkiaApi.sk_paint_set_antialias (Handle, value);

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -354,6 +354,8 @@ namespace SkiaSharp
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		public extern static void sk_paint_delete (sk_paint_t t);
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		public extern static void sk_paint_reset (sk_paint_t t);
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		public extern static bool sk_paint_is_antialias (sk_paint_t t);
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
It's quite a bit faster to reuse `SKPaint` objects (due to the all pinvoke, extra bookkeeping for the references, etc.). But without having an reset method (https://skia.org/user/api/SkPaint_Reference#SkPaint_reset) it is hard to actually reuse objects, as it will be quite slow to reset properties one by one.

Native changes in: https://github.com/mono/skia/pull/59

Additionally I added a constructor to `SKMatrix` as it leads to better codegen, especially when inlining (like Avalonia conversion methods).

Benchmark code: https://gist.github.com/MarchingCube/3bcfbc8894a93b92cb2997b650a05508
Benchmark results for `SKPaint` reuse:

``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.316 (1809/October2018Update/Redstone5)
AMD Ryzen 7 2700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.0.100-preview-009812
  [Host]     : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.9 (CoreCLR 4.6.26614.01, CoreFX 4.6.26614.01), 64bit RyuJIT

```
|        Method |     Mean |      Error |     StdDev | Ratio |
|-------------- |---------:|-----------:|-----------:|------:|
| AllocatePaint | 697.9 us | 15.9502 us | 13.3191 us |  1.00 |
|    ResetPaint | 211.7 us |  0.5672 us |  0.5028 us |  0.30 |

Results for `SKMatrix` change:

|                       Method |      Mean |     Error |    StdDev | Ratio |
|----------------------------- |----------:|----------:|----------:|------:|
|            MatrixConstructor |  7.926 ns | 0.0267 ns | 0.0250 ns |  0.79 |
| MatrixPropertyInitialization | 10.050 ns | 0.1238 ns | 0.1158 ns |  1.00 |

> VS bug [#817073](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/817073)