### PR TITLE
Update some versions and fix the sample builds

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -6,7 +6,7 @@ harfbuzz                release     2.3.1
 skia                    release     m68
 xunit                   release     2.4.0
 xunit.runner.console    release     2.4.0
-Xamarin.Forms           release     3.3.0.912540
+Xamarin.Forms           release     3.6.0.344457
 Tizen.NET               release     4.0.0
 OpenTK.GLControl        release     1.1.2349.61993
 MSBuild.Sdk.Extras      release     1.6.65

--- a/binding/HarfBuzzSharp.Android/HarfBuzzSharp.Android.csproj
+++ b/binding/HarfBuzzSharp.Android/HarfBuzzSharp.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid4.4</TargetFramework>
+    <TargetFramework>monoandroid9.0</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>HarfBuzzSharp</RootNamespace>
     <AssemblyName>HarfBuzzSharp</AssemblyName>

--- a/binding/HarfBuzzSharp.UWP/HarfBuzzSharp.UWP.csproj
+++ b/binding/HarfBuzzSharp.UWP/HarfBuzzSharp.UWP.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
   <ItemGroup>

--- a/binding/SkiaSharp.Android/SkiaSharp.Android.csproj
+++ b/binding/SkiaSharp.Android/SkiaSharp.Android.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\source\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid4.4</TargetFramework>
+    <TargetFramework>monoandroid9.0</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>SkiaSharp</RootNamespace>
     <AssemblyName>SkiaSharp</AssemblyName>

--- a/binding/SkiaSharp.UWP/SkiaSharp.UWP.csproj
+++ b/binding/SkiaSharp.UWP/SkiaSharp.UWP.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\output\native\uwp\x64\libSkiaSharp.dll" Link="nuget\runtimes\win10-x64\nativeassets\uap10.0\libSkiaSharp.dll" />

--- a/cake/UtilsManaged.cake
+++ b/cake/UtilsManaged.cake
@@ -344,7 +344,7 @@ string[] GetReferenceSearchPaths ()
         refs.AddRange (GetDirectories ("./output/docs/temp/*").Select (d => d.FullPath));
         refs.Add ($"{referenceAssemblies}/MonoTouch/v1.0");
         refs.Add ($"{referenceAssemblies}/MonoAndroid/v1.0");
-        refs.Add ($"{referenceAssemblies}/MonoAndroid/v4.4");
+        refs.Add ($"{referenceAssemblies}/MonoAndroid/v9.0");
         refs.Add ($"{referenceAssemblies}/Xamarin.iOS/v1.0");
         refs.Add ($"{referenceAssemblies}/Xamarin.TVOS/v1.0");
         refs.Add ($"{referenceAssemblies}/Xamarin.WatchOS/v1.0");

--- a/nuget/SkiaSharp.Views.Forms.nuspec
+++ b/nuget/SkiaSharp.Views.Forms.nuspec
@@ -28,31 +28,31 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <dependencies>
       <group>
-        <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+        <dependency id="Xamarin.Forms" version="3.6.0.344457" />
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
       <group targetFramework="MonoAndroid">
-        <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+        <dependency id="Xamarin.Forms" version="3.6.0.344457" />
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views" version="1.0.0" />
       </group>
       <group targetFramework="XamariniOS">
-        <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+        <dependency id="Xamarin.Forms" version="3.6.0.344457" />
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views" version="1.0.0" />
       </group>
       <group targetFramework="XamarinMac">
-        <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+        <dependency id="Xamarin.Forms" version="3.6.0.344457" />
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views" version="1.0.0" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+        <dependency id="Xamarin.Forms" version="3.6.0.344457" />
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views" version="1.0.0" />
       </group>
       <group targetFramework="tizen40">
-        <dependency id="Xamarin.Forms" version="3.3.0.912540" />
+        <dependency id="Xamarin.Forms" version="3.6.0.344457" />
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views" version="1.0.0" />
       </group>

--- a/samples/Basic/Android/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/Android/SkiaSharpSample/SkiaSharpSample.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SkiaSharpSample</RootNamespace>
     <AssemblyName>SkiaSharpSample</AssemblyName>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>

--- a/samples/Basic/Tizen/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/Tizen/SkiaSharpSample/SkiaSharpSample.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Basic/UWP/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/UWP/SkiaSharpSample/SkiaSharpSample.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>SkiaSharpSample</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.10240.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -90,7 +90,7 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp.UWP\SkiaSharp.UWP.csproj">

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample.Android/SkiaSharpSample.Android.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample.Android/SkiaSharpSample.Android.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SkiaSharpSample.Droid</RootNamespace>
     <AssemblyName>SkiaSharpSample.Android</AssemblyName>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -47,7 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp.Android\SkiaSharp.Android.csproj">

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample.Tizen/SkiaSharpSample.Tizen.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample.Tizen/SkiaSharpSample.Tizen.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample.UWP/SkiaSharpSample.UWP.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample.UWP/SkiaSharpSample.UWP.csproj
@@ -91,8 +91,8 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp.UWP\SkiaSharp.UWP.csproj">

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample.iOS/SkiaSharpSample.iOS.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample.iOS/SkiaSharpSample.iOS.csproj
@@ -70,7 +70,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp.iOS\SkiaSharp.iOS.csproj">

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample.macOS/SkiaSharpSample.macOS.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample.macOS/SkiaSharpSample.macOS.csproj
@@ -55,7 +55,7 @@
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.Mac\SkiaSharp.Views.Mac.csproj">

--- a/samples/Basic/Xamarin.Forms/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/Xamarin.Forms/SkiaSharpSample/SkiaSharpSample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Gallery/UWP/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Gallery/UWP/SkiaSharpSample/SkiaSharpSample.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>SkiaSharpSample</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.10240.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -90,7 +90,7 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp.UWP\HarfBuzzSharp.UWP.csproj">

--- a/samples/Gallery/Xamarin.Forms/Android/Android.csproj
+++ b/samples/Gallery/Xamarin.Forms/Android/Android.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -51,7 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp.Android\HarfBuzzSharp.Android.csproj">

--- a/samples/Gallery/Xamarin.Forms/Core/Core.csproj
+++ b/samples/Gallery/Xamarin.Forms/Core/Core.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Gallery/Xamarin.Forms/Mac/Mac.csproj
+++ b/samples/Gallery/Xamarin.Forms/Mac/Mac.csproj
@@ -55,7 +55,7 @@
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp.OSX\HarfBuzzSharp.OSX.csproj">

--- a/samples/Gallery/Xamarin.Forms/Tizen/TizenOS.csproj
+++ b/samples/Gallery/Xamarin.Forms/Tizen/TizenOS.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Gallery/Xamarin.Forms/UWP/UWP.csproj
+++ b/samples/Gallery/Xamarin.Forms/UWP/UWP.csproj
@@ -91,8 +91,8 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp.UWP\HarfBuzzSharp.UWP.csproj">

--- a/samples/Gallery/Xamarin.Forms/iOS/iOS.csproj
+++ b/samples/Gallery/Xamarin.Forms/iOS/iOS.csproj
@@ -112,7 +112,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp.iOS\HarfBuzzSharp.iOS.csproj">

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -338,45 +338,45 @@ jobs:
             testResultsFormat: xUnit
             testResultsFiles: 'output/tests/**/*.xml'
 
-#  # SAMPLES JOBS
-#   - template: azure-templates-bootstrapper.yml
-#     parameters:
-#       name: samples_windows
-#       displayName: Build Samples (Windows)
-#       vmImage: vs2017-win2016
-#       target: samples
-#       dependsOn:
-#         - managed_windows
-#   - template: azure-templates-bootstrapper.yml
-#     parameters:
-#       name: samples_macos
-#       displayName: Build Samples (macOS)
-#       vmImage: macos-10.13
-#       target: samples
-#       dependsOn:
-#         - managed_macos
-#       preBuildSteps:
-#         - task: InstallAppleCertificate@2
-#           inputs:
-#             certSecureFile: 'SkiaSharp iOS Certificate.p12'
-#         - task: InstallAppleCertificate@2
-#           inputs:
-#             certSecureFile: 'SkiaSharp Mac Certificate.p12'
-#         - task: InstallAppleProvisioningProfile@1
-#           inputs:
-#             provProfileSecureFile: 'SkiaSharp iOS Provisioning.mobileprovision'
-#         - task: InstallAppleProvisioningProfile@1
-#           inputs:
-#             provProfileSecureFile: 'SkiaSharp Mac Provisioning.provisionprofile'
-#         - task: InstallAppleProvisioningProfile@1
-#           inputs:
-#             provProfileSecureFile: 'SkiaSharp tvOS Provisioning.mobileprovision'
-#   - template: azure-templates-bootstrapper.yml
-#     parameters:
-#       name: samples_linux
-#       displayName: Build Samples (Linux)
-#       vmImage: ubuntu-16.04
-#       packages: $(MANAGED_LINUX_PACKAGES)
-#       target: samples
-#       dependsOn:
-#         - managed_linux
+ # SAMPLES JOBS
+  - template: azure-templates-bootstrapper.yml
+    parameters:
+      name: samples_windows
+      displayName: Build Samples (Windows)
+      vmImage: vs2017-win2016
+      target: samples
+      dependsOn:
+        - managed_windows
+  - template: azure-templates-bootstrapper.yml
+    parameters:
+      name: samples_macos
+      displayName: Build Samples (macOS)
+      vmImage: macos-10.13
+      target: samples
+      dependsOn:
+        - managed_macos
+      preBuildSteps:
+        - task: InstallAppleCertificate@2
+          inputs:
+            certSecureFile: 'SkiaSharp iOS Certificate.p12'
+        - task: InstallAppleCertificate@2
+          inputs:
+            certSecureFile: 'SkiaSharp Mac Certificate.p12'
+        - task: InstallAppleProvisioningProfile@1
+          inputs:
+            provProfileSecureFile: 'SkiaSharp iOS Provisioning.mobileprovision'
+        - task: InstallAppleProvisioningProfile@1
+          inputs:
+            provProfileSecureFile: 'SkiaSharp Mac Provisioning.provisionprofile'
+        - task: InstallAppleProvisioningProfile@1
+          inputs:
+            provProfileSecureFile: 'SkiaSharp tvOS Provisioning.mobileprovision'
+  - template: azure-templates-bootstrapper.yml
+    parameters:
+      name: samples_linux
+      displayName: Build Samples (Linux)
+      vmImage: ubuntu-16.04
+      packages: $(MANAGED_LINUX_PACKAGES)
+      target: samples
+      dependsOn:
+        - managed_linux

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SkiaSharp.Views.Forms.Android.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SkiaSharp.Views.Forms.Android.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid8.1</TargetFramework>
+    <TargetFramework>monoandroid9.0</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>SkiaSharp.Views.Forms</RootNamespace>
     <AssemblyName>SkiaSharp.Views.Forms</AssemblyName>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.Android\SkiaSharp.Android.csproj" />

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SkiaSharp.Views.Forms.Mac.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SkiaSharp.Views.Forms.Mac.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.OSX\SkiaSharp.OSX.csproj" />

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SkiaSharp.Views.Forms.Tizen.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SkiaSharp.Views.Forms.Tizen.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
     <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.UWP/SkiaSharp.Views.Forms.UWP.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.UWP/SkiaSharp.Views.Forms.UWP.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.UWP\SkiaSharp.UWP.csproj" />

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SkiaSharp.Views.Forms.iOS.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SkiaSharp.Views.Forms.iOS.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.iOS\SkiaSharp.iOS.csproj" />

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.csproj
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.csproj
@@ -11,7 +11,7 @@
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.3.0.912540" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.NetStandard\SkiaSharp.NetStandard.csproj" />

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SkiaSharp.Views.Android.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SkiaSharp.Views.Android.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SkiaSharp.Build.props" />
   <PropertyGroup>
-    <TargetFramework>monoandroid4.4</TargetFramework>
+    <TargetFramework>monoandroid9.0</TargetFramework>
     <OutputTypeEx>library</OutputTypeEx>
     <RootNamespace>SkiaSharp.Views.Android</RootNamespace>
     <AssemblyName>SkiaSharp.Views.Android</AssemblyName>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SkiaSharp.Views.UWP.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SkiaSharp.Views.UWP.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.65" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.UWP\SkiaSharp.UWP.csproj" />


### PR DESCRIPTION
 - Xamarin.Forms is now the last v3.x (v3.6)
 - Build using the latest Android (v9.0)
 - Update UWP samples so they can build again