### PR TITLE
Update HarfBuzz 2.5.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "externals/harfbuzz"]
 	path = externals/harfbuzz
 	url = https://github.com/harfbuzz/harfbuzz.git
-	branch = 2.3.1
+	branch = 2.5.2
 [submodule "docs"]
 	path = docs
 	url = https://github.com/mono/SkiaSharp-API-docs

--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -2,7 +2,7 @@
 ANGLE.WindowsStore      release     2.1.13
 mdoc.targets            release     5.7.4.3
 mdoc                    release     master
-harfbuzz                release     2.3.1
+harfbuzz                release     2.5.2
 skia                    release     m68
 xunit                   release     2.4.0
 xunit.runner.console    release     2.4.0

--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -14,7 +14,7 @@ Cake                    release     0.31.0
 
 # native sonames
 libSkiaSharp            soname      68.1.0
-HarfBuzz                soname      0.20301.0
+HarfBuzz                soname      0.20502.0
 
 # SkiaSharp.dll
 SkiaSharp               assembly    1.68.0.0
@@ -22,7 +22,7 @@ SkiaSharp               file        1.68.1.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        2.3.1.0
+HarfBuzzSharp           file        2.5.2.0
 
 # nuget versions
 SkiaSharp                                       nuget       1.68.1
@@ -31,5 +31,5 @@ SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       1.68.1
 SkiaSharp.Views                                 nuget       1.68.1
 SkiaSharp.Views.Forms                           nuget       1.68.1
 SkiaSharp.HarfBuzz                              nuget       1.68.1
-HarfBuzzSharp                                   nuget       2.3.1
-HarfBuzzSharp.NativeAssets.Linux                nuget       2.3.1
+HarfBuzzSharp                                   nuget       2.5.2
+HarfBuzzSharp.NativeAssets.Linux                nuget       2.5.2

--- a/native-builds/libHarfBuzzSharp_android/config.h
+++ b/native-builds/libHarfBuzzSharp_android/config.h
@@ -141,7 +141,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -150,7 +150,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_android/config.h
+++ b/native-builds/libHarfBuzzSharp_android/config.h
@@ -20,19 +20,19 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
-#define HAVE_FONTCONFIG 1
+/* #undef HAVE_FONTCONFIG */
 
 /* Have FreeType 2 library */
-#define HAVE_FREETYPE 1
+/* #undef HAVE_FREETYPE */
 
 /* Define to 1 if you have the `FT_Get_Var_Blend_Coordinates' function. */
 /* #undef HAVE_FT_GET_VAR_BLEND_COORDINATES */
@@ -114,9 +114,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_android/jni/Application.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-9
-NDK_TOOLCHAIN_VERSION := 4.9
-APP_STL := gnustl_static
+NDK_TOOLCHAIN_VERSION := clang
+APP_STL := c++_static
 APP_OPTIM := release

--- a/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
@@ -3,32 +3,21 @@ include $(CLEAR_VARS)
 
 cmd-strip = $(PRIVATE_STRIP) --strip-all $(call host-path,$1)
 
-# LOCAL_LDLIBS           := -llog -lEGL -lGLESv2
-
-# LOCAL_LDFLAGS          := -s -Wl,--gc-sections
-
 LOCAL_MODULE           := HarfBuzzSharp
 
 LOCAL_C_INCLUDES       := .                                    \
                           ../../externals/harfbuzz/src         \
                           ../../externals/harfbuzz
 
-# LOCAL_CFLAGS           := -DSK_INTERNAL -DSK_GAMMA_APPLY_TO_A8                                   \
-#                           -DSK_ALLOW_STATIC_GLOBAL_INITIALIZERS=0 -DSK_SUPPORT_GPU=1             \
-#                           -DSK_SUPPORT_OPENCL=0 -DSK_FORCE_DISTANCE_FIELD_TEXT=0                 \
-#                           -DSK_BUILD_FOR_ANDROID -DSK_GAMMA_EXPONENT=1.4 -DSK_GAMMA_CONTRAST=0.0 \
-#                           -DSKIA_C_DLL -DSKIA_IMPLEMENTATION=1                                   \
-#                           -DSK_SUPPORT_LEGACY_CLIPTOLAYERFLAG -DNDEBUG
+LOCAL_LDFLAGS          := -s -Wl,--gc-sections
 
-# LOCAL_CFLAGS           += -fPIC -g -fno-exceptions -fstrict-aliasing -Wall -Wextra               \
-#                           -Winit-self -Wpointer-arith -Wsign-compare -Wno-unused-parameter       \
-#                           -Werror -fuse-ld=gold                                                  \
-#                           -Os -ffunction-sections -fdata-sections -fno-rtti
+LOCAL_CFLAGS           := -DHAVE_CONFIG_H -DNDEBUG                                                  \
+                          -fno-rtti -fno-exceptions -fno-threadsafe-statics -fPIC                   \
+                          -g -Os -ffunction-sections -fdata-sections
 
-# LOCAL_CPPFLAGS         := -std=c++11 -fno-rtti -fno-threadsafe-statics -Wnon-virtual-dtor        \
-#                           -Os -ffunction-sections -fdata-sections
-
-LOCAL_CFLAGS           := -DHAVE_CONFIG_H -DNDEBUG
+LOCAL_CPPFLAGS         := -std=c++11                                                                \
+                          -fno-rtti -fno-exceptions -fno-threadsafe-statics                         \
+                          -Os -ffunction-sections -fdata-sections
 
 LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-aat-layout.cc                          \
                           ../../../externals/harfbuzz/src/hb-aat-map.cc                             \
@@ -48,7 +37,6 @@ LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-aat-layout.cc      
                           ../../../externals/harfbuzz/src/hb-ot-layout.cc                           \
                           ../../../externals/harfbuzz/src/hb-ot-map.cc                              \
                           ../../../externals/harfbuzz/src/hb-ot-math.cc                             \
-                          ../../../externals/harfbuzz/src/hb-ot-name-language.cc                    \
                           ../../../externals/harfbuzz/src/hb-ot-name.cc                             \
                           ../../../externals/harfbuzz/src/hb-ot-shape-complex-arabic.cc             \
                           ../../../externals/harfbuzz/src/hb-ot-shape-complex-default.cc            \
@@ -72,9 +60,14 @@ LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-aat-layout.cc      
                           ../../../externals/harfbuzz/src/hb-shape.cc                               \
                           ../../../externals/harfbuzz/src/hb-shaper.cc                              \
                           ../../../externals/harfbuzz/src/hb-static.cc                              \
+                          ../../../externals/harfbuzz/src/hb-subset-cff-common.cc                   \
+                          ../../../externals/harfbuzz/src/hb-subset-cff1.cc                         \
+                          ../../../externals/harfbuzz/src/hb-subset-cff2.cc                         \
+                          ../../../externals/harfbuzz/src/hb-subset-input.cc                        \
+                          ../../../externals/harfbuzz/src/hb-subset-plan.cc                         \
+                          ../../../externals/harfbuzz/src/hb-subset.cc                              \
                           ../../../externals/harfbuzz/src/hb-ucd.cc                                 \
                           ../../../externals/harfbuzz/src/hb-unicode.cc                             \
-                          ../../../externals/harfbuzz/src/hb-warning.cc                             \
-                          ../../externals/harfbuzz/src/hb-ft.cc
+                          ../../../externals/harfbuzz/src/hb-warning.cc
 
 include $(BUILD_SHARED_LIBRARY)

--- a/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
@@ -6,8 +6,7 @@ cmd-strip = $(PRIVATE_STRIP) --strip-all $(call host-path,$1)
 LOCAL_MODULE           := HarfBuzzSharp
 
 LOCAL_C_INCLUDES       := .                                    \
-                          ../../externals/harfbuzz/src         \
-                          ../../externals/harfbuzz
+                          ../../externals/harfbuzz/src
 
 LOCAL_LDFLAGS          := -s -Wl,--gc-sections
 

--- a/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
@@ -10,7 +10,6 @@ cmd-strip = $(PRIVATE_STRIP) --strip-all $(call host-path,$1)
 LOCAL_MODULE           := HarfBuzzSharp
 
 LOCAL_C_INCLUDES       := .                                    \
-                          ../../externals/harfbuzz/src/hb-ucdn \
                           ../../externals/harfbuzz/src         \
                           ../../externals/harfbuzz
 
@@ -31,8 +30,7 @@ LOCAL_C_INCLUDES       := .                                    \
 
 LOCAL_CFLAGS           := -DHAVE_CONFIG_H -DNDEBUG
 
-LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-ucdn/ucdn.c                            \
-                          ../../../externals/harfbuzz/src/hb-ucdn.cc                                \
+LOCAL_SRC_FILES        := 
                           ../../../externals/harfbuzz/src/hb-aat-layout.cc                          \
                           ../../../externals/harfbuzz/src/hb-aat-map.cc                             \
                           ../../../externals/harfbuzz/src/hb-blob.cc                                \
@@ -40,6 +38,7 @@ LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-ucdn/ucdn.c        
                           ../../../externals/harfbuzz/src/hb-buffer.cc                              \
                           ../../../externals/harfbuzz/src/hb-common.cc                              \
                           ../../../externals/harfbuzz/src/hb-face.cc                                \
+						  ../../../externals/harfbuzz/src/hb-fallback-shape.cc                      \
                           ../../../externals/harfbuzz/src/hb-font.cc                                \
                           ../../../externals/harfbuzz/src/hb-map.cc                                 \
                           ../../../externals/harfbuzz/src/hb-ot-cff1-table.cc                       \
@@ -74,8 +73,9 @@ LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-ucdn/ucdn.c        
                           ../../../externals/harfbuzz/src/hb-shape.cc                               \
                           ../../../externals/harfbuzz/src/hb-shaper.cc                              \
                           ../../../externals/harfbuzz/src/hb-static.cc                              \
+						  ../../../externals/harfbuzz/src/hb-ucd.cc                                 \
                           ../../../externals/harfbuzz/src/hb-unicode.cc                             \
                           ../../../externals/harfbuzz/src/hb-warning.cc                             \
-                          ../../../externals/harfbuzz/src/hb-fallback-shape.cc
+						  ../../externals/harfbuzz/src/hb-ft.cc
 
 include $(BUILD_SHARED_LIBRARY)

--- a/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
@@ -14,9 +14,7 @@ LOCAL_CFLAGS           := -DHAVE_CONFIG_H -DNDEBUG                              
                           -fno-rtti -fno-exceptions -fno-threadsafe-statics -fPIC                   \
                           -g -Os -ffunction-sections -fdata-sections
 
-LOCAL_CPPFLAGS         := -std=c++11                                                                \
-                          -fno-rtti -fno-exceptions -fno-threadsafe-statics                         \
-                          -Os -ffunction-sections -fdata-sections
+LOCAL_CPPFLAGS         := -std=c++11
 
 LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-aat-layout.cc                          \
                           ../../../externals/harfbuzz/src/hb-aat-map.cc                             \

--- a/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
@@ -38,7 +38,7 @@ LOCAL_SRC_FILES        :=
                           ../../../externals/harfbuzz/src/hb-buffer.cc                              \
                           ../../../externals/harfbuzz/src/hb-common.cc                              \
                           ../../../externals/harfbuzz/src/hb-face.cc                                \
-						  ../../../externals/harfbuzz/src/hb-fallback-shape.cc                      \
+                          ../../../externals/harfbuzz/src/hb-fallback-shape.cc                      \
                           ../../../externals/harfbuzz/src/hb-font.cc                                \
                           ../../../externals/harfbuzz/src/hb-map.cc                                 \
                           ../../../externals/harfbuzz/src/hb-ot-cff1-table.cc                       \
@@ -73,9 +73,9 @@ LOCAL_SRC_FILES        :=
                           ../../../externals/harfbuzz/src/hb-shape.cc                               \
                           ../../../externals/harfbuzz/src/hb-shaper.cc                              \
                           ../../../externals/harfbuzz/src/hb-static.cc                              \
-						  ../../../externals/harfbuzz/src/hb-ucd.cc                                 \
+                          ../../../externals/harfbuzz/src/hb-ucd.cc                                 \
                           ../../../externals/harfbuzz/src/hb-unicode.cc                             \
                           ../../../externals/harfbuzz/src/hb-warning.cc                             \
-						  ../../externals/harfbuzz/src/hb-ft.cc
+                          ../../externals/harfbuzz/src/hb-ft.cc
 
 include $(BUILD_SHARED_LIBRARY)

--- a/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
+++ b/native-builds/libHarfBuzzSharp_android/jni/HarfBuzzSharp.mk
@@ -30,8 +30,7 @@ LOCAL_C_INCLUDES       := .                                    \
 
 LOCAL_CFLAGS           := -DHAVE_CONFIG_H -DNDEBUG
 
-LOCAL_SRC_FILES        := 
-                          ../../../externals/harfbuzz/src/hb-aat-layout.cc                          \
+LOCAL_SRC_FILES        := ../../../externals/harfbuzz/src/hb-aat-layout.cc                          \
                           ../../../externals/harfbuzz/src/hb-aat-map.cc                             \
                           ../../../externals/harfbuzz/src/hb-blob.cc                                \
                           ../../../externals/harfbuzz/src/hb-buffer-serialize.cc                    \

--- a/native-builds/libHarfBuzzSharp_ios/config.h
+++ b/native-builds/libHarfBuzzSharp_ios/config.h
@@ -24,13 +24,13 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
 /* #undef HAVE_FONTCONFIG */
@@ -136,9 +136,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_ios/config.h
+++ b/native-builds/libHarfBuzzSharp_ios/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -174,7 +174,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_ios/libHarfBuzzSharp.xcodeproj/project.pbxproj
+++ b/native-builds/libHarfBuzzSharp_ios/libHarfBuzzSharp.xcodeproj/project.pbxproj
@@ -7,8 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		34B817C222BD8F6F00508F73 /* hb-subset-cff2.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817BB22BD8F6F00508F73 /* hb-subset-cff2.cc */; };
+		34B817C322BD8F6F00508F73 /* hb-subset-cff-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817BC22BD8F6F00508F73 /* hb-subset-cff-common.cc */; };
+		34B817C422BD8F6F00508F73 /* hb-subset-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817BD22BD8F6F00508F73 /* hb-subset-plan.cc */; };
+		34B817C522BD8F6F00508F73 /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817BE22BD8F6F00508F73 /* hb-ucd.cc */; };
+		34B817C622BD8F6F00508F73 /* hb-subset.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817BF22BD8F6F00508F73 /* hb-subset.cc */; };
+		34B817C722BD8F6F00508F73 /* hb-subset-input.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817C022BD8F6F00508F73 /* hb-subset-input.cc */; };
+		34B817C822BD8F6F00508F73 /* hb-subset-cff1.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34B817C122BD8F6F00508F73 /* hb-subset-cff1.cc */; };
 		34C9309E21FA5A77002D729C /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9307121FA5A76002D729C /* hb-shape-plan.cc */; };
-		34C9309F21FA5A77002D729C /* hb-ucdn.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9307221FA5A76002D729C /* hb-ucdn.cc */; };
 		34C930A021FA5A77002D729C /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9307321FA5A76002D729C /* hb-ot-shape-complex-indic-table.cc */; };
 		34C930A121FA5A77002D729C /* hb-ot-shape-complex-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9307421FA5A76002D729C /* hb-ot-shape-complex-myanmar.cc */; };
 		34C930A221FA5A77002D729C /* hb-ot-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9307521FA5A76002D729C /* hb-ot-map.cc */; };
@@ -45,14 +51,12 @@
 		34C930C121FA5A77002D729C /* hb-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309421FA5A77002D729C /* hb-map.cc */; };
 		34C930C221FA5A77002D729C /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309521FA5A77002D729C /* hb-font.cc */; };
 		34C930C321FA5A77002D729C /* hb-set.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309621FA5A77002D729C /* hb-set.cc */; };
-		34C930C421FA5A77002D729C /* hb-ot-name-language.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309721FA5A77002D729C /* hb-ot-name-language.cc */; };
 		34C930C521FA5A77002D729C /* hb-ot-shape-complex-use-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309821FA5A77002D729C /* hb-ot-shape-complex-use-table.cc */; };
 		34C930C621FA5A77002D729C /* hb-ot-tag.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309921FA5A77002D729C /* hb-ot-tag.cc */; };
 		34C930C721FA5A77002D729C /* hb-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309A21FA5A77002D729C /* hb-shape.cc */; };
 		34C930C821FA5A77002D729C /* hb-warning.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309B21FA5A77002D729C /* hb-warning.cc */; };
 		34C930C921FA5A77002D729C /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309C21FA5A77002D729C /* hb-fallback-shape.cc */; };
 		34C930CA21FA5A77002D729C /* hb-ot-var.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34C9309D21FA5A77002D729C /* hb-ot-var.cc */; };
-		34C930CD21FA5AFC002D729C /* ucdn.c in Sources */ = {isa = PBXBuildFile; fileRef = 34C930CC21FA5AFB002D729C /* ucdn.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -68,9 +72,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		34B817BB22BD8F6F00508F73 /* hb-subset-cff2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff2.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff2.cc"; sourceTree = "<group>"; };
+		34B817BC22BD8F6F00508F73 /* hb-subset-cff-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff-common.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff-common.cc"; sourceTree = "<group>"; };
+		34B817BD22BD8F6F00508F73 /* hb-subset-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-plan.cc"; path = "../../externals/harfbuzz/src/hb-subset-plan.cc"; sourceTree = "<group>"; };
+		34B817BE22BD8F6F00508F73 /* hb-ucd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucd.cc"; path = "../../externals/harfbuzz/src/hb-ucd.cc"; sourceTree = "<group>"; };
+		34B817BF22BD8F6F00508F73 /* hb-subset.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset.cc"; path = "../../externals/harfbuzz/src/hb-subset.cc"; sourceTree = "<group>"; };
+		34B817C022BD8F6F00508F73 /* hb-subset-input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-input.cc"; path = "../../externals/harfbuzz/src/hb-subset-input.cc"; sourceTree = "<group>"; };
+		34B817C122BD8F6F00508F73 /* hb-subset-cff1.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff1.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff1.cc"; sourceTree = "<group>"; };
 		34C92F8D21FA593F002D729C /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = SOURCE_ROOT; };
 		34C9307121FA5A76002D729C /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "../../externals/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
-		34C9307221FA5A76002D729C /* hb-ucdn.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucdn.cc"; path = "../../externals/harfbuzz/src/hb-ucdn.cc"; sourceTree = "<group>"; };
 		34C9307321FA5A76002D729C /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
 		34C9307421FA5A76002D729C /* hb-ot-shape-complex-myanmar.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-myanmar.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-myanmar.cc"; sourceTree = "<group>"; };
 		34C9307521FA5A76002D729C /* hb-ot-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-map.cc"; path = "../../externals/harfbuzz/src/hb-ot-map.cc"; sourceTree = "<group>"; };
@@ -107,15 +117,12 @@
 		34C9309421FA5A77002D729C /* hb-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-map.cc"; path = "../../externals/harfbuzz/src/hb-map.cc"; sourceTree = "<group>"; };
 		34C9309521FA5A77002D729C /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "../../externals/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
 		34C9309621FA5A77002D729C /* hb-set.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-set.cc"; path = "../../externals/harfbuzz/src/hb-set.cc"; sourceTree = "<group>"; };
-		34C9309721FA5A77002D729C /* hb-ot-name-language.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name-language.cc"; path = "../../externals/harfbuzz/src/hb-ot-name-language.cc"; sourceTree = "<group>"; };
 		34C9309821FA5A77002D729C /* hb-ot-shape-complex-use-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-use-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-use-table.cc"; sourceTree = "<group>"; };
 		34C9309921FA5A77002D729C /* hb-ot-tag.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-tag.cc"; path = "../../externals/harfbuzz/src/hb-ot-tag.cc"; sourceTree = "<group>"; };
 		34C9309A21FA5A77002D729C /* hb-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape.cc"; path = "../../externals/harfbuzz/src/hb-shape.cc"; sourceTree = "<group>"; };
 		34C9309B21FA5A77002D729C /* hb-warning.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-warning.cc"; path = "../../externals/harfbuzz/src/hb-warning.cc"; sourceTree = "<group>"; };
 		34C9309C21FA5A77002D729C /* hb-fallback-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-fallback-shape.cc"; path = "../../externals/harfbuzz/src/hb-fallback-shape.cc"; sourceTree = "<group>"; };
 		34C9309D21FA5A77002D729C /* hb-ot-var.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-var.cc"; path = "../../externals/harfbuzz/src/hb-ot-var.cc"; sourceTree = "<group>"; };
-		34C930CC21FA5AFB002D729C /* ucdn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ucdn.c; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.c"; sourceTree = "<group>"; };
-		34C930CE21FA5E06002D729C /* ucdn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ucdn.h; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.h"; sourceTree = "<group>"; };
 		34D723421EB385E900E6210E /* libHarfBuzzSharp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHarfBuzzSharp.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -133,7 +140,6 @@
 		34C9307021FA5A6D002D729C /* src */ = {
 			isa = PBXGroup;
 			children = (
-				34C930CB21FA5AF0002D729C /* hb-ucdn */,
 				34C9307721FA5A76002D729C /* hb-aat-layout.cc */,
 				34C9307E21FA5A76002D729C /* hb-aat-map.cc */,
 				34C9308521FA5A76002D729C /* hb-blob.cc */,
@@ -152,7 +158,6 @@
 				34C9308621FA5A76002D729C /* hb-ot-layout.cc */,
 				34C9307521FA5A76002D729C /* hb-ot-map.cc */,
 				34C9309321FA5A77002D729C /* hb-ot-math.cc */,
-				34C9309721FA5A77002D729C /* hb-ot-name-language.cc */,
 				34C9308F21FA5A77002D729C /* hb-ot-name.cc */,
 				34C9308C21FA5A76002D729C /* hb-ot-shape-complex-arabic.cc */,
 				34C9308021FA5A76002D729C /* hb-ot-shape-complex-default.cc */,
@@ -176,20 +181,17 @@
 				34C9309A21FA5A77002D729C /* hb-shape.cc */,
 				34C9308221FA5A76002D729C /* hb-shaper.cc */,
 				34C9308D21FA5A76002D729C /* hb-static.cc */,
-				34C9307221FA5A76002D729C /* hb-ucdn.cc */,
+				34B817BC22BD8F6F00508F73 /* hb-subset-cff-common.cc */,
+				34B817C122BD8F6F00508F73 /* hb-subset-cff1.cc */,
+				34B817BB22BD8F6F00508F73 /* hb-subset-cff2.cc */,
+				34B817C022BD8F6F00508F73 /* hb-subset-input.cc */,
+				34B817BD22BD8F6F00508F73 /* hb-subset-plan.cc */,
+				34B817BF22BD8F6F00508F73 /* hb-subset.cc */,
+				34B817BE22BD8F6F00508F73 /* hb-ucd.cc */,
 				34C9308E21FA5A76002D729C /* hb-unicode.cc */,
 				34C9309B21FA5A77002D729C /* hb-warning.cc */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		34C930CB21FA5AF0002D729C /* hb-ucdn */ = {
-			isa = PBXGroup;
-			children = (
-				34C930CE21FA5E06002D729C /* ucdn.h */,
-				34C930CC21FA5AFB002D729C /* ucdn.c */,
-			);
-			name = "hb-ucdn";
 			sourceTree = "<group>";
 		};
 		34D723391EB385E800E6210E = {
@@ -249,6 +251,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 34D723391EB385E800E6210E;
@@ -274,13 +277,16 @@
 				34C930B621FA5A77002D729C /* hb-ot-shape-complex-thai.cc in Sources */,
 				34C930A621FA5A77002D729C /* hb-common.cc in Sources */,
 				34C9309E21FA5A77002D729C /* hb-shape-plan.cc in Sources */,
+				34B817C422BD8F6F00508F73 /* hb-subset-plan.cc in Sources */,
+				34B817C222BD8F6F00508F73 /* hb-subset-cff2.cc in Sources */,
 				34C930A121FA5A77002D729C /* hb-ot-shape-complex-myanmar.cc in Sources */,
+				34B817C322BD8F6F00508F73 /* hb-subset-cff-common.cc in Sources */,
 				34C930BC21FA5A77002D729C /* hb-ot-name.cc in Sources */,
 				34C930B721FA5A77002D729C /* hb-ot-shape-normalize.cc in Sources */,
 				34C930A221FA5A77002D729C /* hb-ot-map.cc in Sources */,
-				34C9309F21FA5A77002D729C /* hb-ucdn.cc in Sources */,
 				34C930B521FA5A77002D729C /* hb-ot-shape-complex-indic.cc in Sources */,
 				34C930C221FA5A77002D729C /* hb-font.cc in Sources */,
+				34B817C522BD8F6F00508F73 /* hb-ucd.cc in Sources */,
 				34C930C321FA5A77002D729C /* hb-set.cc in Sources */,
 				34C930A021FA5A77002D729C /* hb-ot-shape-complex-indic-table.cc in Sources */,
 				34C930AA21FA5A77002D729C /* hb-ot-cff2-table.cc in Sources */,
@@ -288,21 +294,22 @@
 				34C930CA21FA5A77002D729C /* hb-ot-var.cc in Sources */,
 				34C930C821FA5A77002D729C /* hb-warning.cc in Sources */,
 				34C930A921FA5A77002D729C /* hb-ot-cff1-table.cc in Sources */,
+				34B817C822BD8F6F00508F73 /* hb-subset-cff1.cc in Sources */,
 				34C930B321FA5A77002D729C /* hb-ot-layout.cc in Sources */,
 				34C930A821FA5A77002D729C /* hb-ot-shape-complex-hebrew.cc in Sources */,
 				34C930AF21FA5A77002D729C /* hb-shaper.cc in Sources */,
-				34C930CD21FA5AFC002D729C /* ucdn.c in Sources */,
 				34C930A721FA5A77002D729C /* hb-ot-font.cc in Sources */,
+				34B817C622BD8F6F00508F73 /* hb-subset.cc in Sources */,
 				34C930A321FA5A77002D729C /* hb-buffer.cc in Sources */,
 				34C930C621FA5A77002D729C /* hb-ot-tag.cc in Sources */,
 				34C930C021FA5A77002D729C /* hb-ot-math.cc in Sources */,
 				34C930BF21FA5A77002D729C /* hb-face.cc in Sources */,
 				34C930B921FA5A77002D729C /* hb-ot-shape-complex-arabic.cc in Sources */,
 				34C930B121FA5A77002D729C /* hb-ot-shape-fallback.cc in Sources */,
+				34B817C722BD8F6F00508F73 /* hb-subset-input.cc in Sources */,
 				34C930C121FA5A77002D729C /* hb-map.cc in Sources */,
 				34C930BE21FA5A77002D729C /* hb-ot-shape-complex-hangul.cc in Sources */,
 				34C930C921FA5A77002D729C /* hb-fallback-shape.cc in Sources */,
-				34C930C421FA5A77002D729C /* hb-ot-name-language.cc in Sources */,
 				34C930B821FA5A77002D729C /* hb-ot-shape-complex-vowel-constraints.cc in Sources */,
 				34C930B221FA5A77002D729C /* hb-blob.cc in Sources */,
 				34C930BD21FA5A77002D729C /* hb-ot-shape.cc in Sources */,
@@ -412,8 +419,8 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = ( 
-				    HAVE_CONFIG_H, 
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					HAVE_CONFIG_H,
 					NDEBUG,
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/native-builds/libHarfBuzzSharp_linux/Makefile
+++ b/native-builds/libHarfBuzzSharp_linux/Makefile
@@ -17,8 +17,7 @@ target = ${bin_root}/${ARCH}/${target_name}.${SONAME_VERSION}
 library_dirs = 
 include_dirs = .                     \
 	           ${src_root}/..        \
-	           ${src_root}           \
-	           ${src_root}/hb-ucdn
+	           ${src_root}           
 library_paths = 
 defines = \
 	-DHAVE_CONFIG_H -DNDEBUG
@@ -38,8 +37,6 @@ library_names = $(notdir ${library_paths})
 libraries = $(library_names:lib%.a=-l%)
 
 src = \
-	${src_root}/hb-ucdn/ucdn.c	\
-	${src_root}/hb-ucdn.cc	\
 	${src_root}/hb-aat-layout.cc	\
 	${src_root}/hb-aat-map.cc	\
     ${src_root}/hb-blob.cc	\
@@ -47,6 +44,7 @@ src = \
     ${src_root}/hb-buffer.cc\
     ${src_root}/hb-common.cc\
     ${src_root}/hb-face.cc	\
+	${src_root}/hb-fallback-shape.cc  \
 	${src_root}/hb-font.cc	\
 	${src_root}/hb-map.cc	\
 	${src_root}/hb-ot-cff1-table.cc	\
@@ -81,9 +79,9 @@ src = \
 	${src_root}/hb-shape.cc	\
 	${src_root}/hb-shaper.cc	\
 	${src_root}/hb-static.cc	\
+	${src_root}/hb-ucd.cc  \
 	${src_root}/hb-unicode.cc	\
-	${src_root}/hb-warning.cc	\
-	${src_root}/hb-fallback-shape.cc
+	${src_root}/hb-warning.cc
 
 src_names = $(subst ${src_root}/,${noop},${src})
 objs = $(src_names:%=${objarch_root}/%.o)

--- a/native-builds/libHarfBuzzSharp_linux/Makefile
+++ b/native-builds/libHarfBuzzSharp_linux/Makefile
@@ -15,9 +15,9 @@ target_name = libHarfBuzzSharp.so
 target = ${bin_root}/${ARCH}/${target_name}.${SONAME_VERSION}
 
 library_dirs = 
-include_dirs = .                     \
-	           ${src_root}/..        \
-	           ${src_root}           
+include_dirs = .             \
+	           ${src_root}/..\
+	           ${src_root}
 library_paths = 
 defines = \
 	-DHAVE_CONFIG_H -DNDEBUG
@@ -37,51 +37,51 @@ library_names = $(notdir ${library_paths})
 libraries = $(library_names:lib%.a=-l%)
 
 src = \
-	${src_root}/hb-aat-layout.cc	\
-	${src_root}/hb-aat-map.cc	\
-    ${src_root}/hb-blob.cc	\
-    ${src_root}/hb-buffer-serialize.cc	\
+    ${src_root}/hb-aat-layout.cc\
+    ${src_root}/hb-aat-map.cc\
+    ${src_root}/hb-blob.cc\
+    ${src_root}/hb-buffer-serialize.cc\
     ${src_root}/hb-buffer.cc\
     ${src_root}/hb-common.cc\
-    ${src_root}/hb-face.cc	\
-	${src_root}/hb-fallback-shape.cc  \
-	${src_root}/hb-font.cc	\
-	${src_root}/hb-map.cc	\
-	${src_root}/hb-ot-cff1-table.cc	\
-	${src_root}/hb-ot-cff2-table.cc	\
-	${src_root}/hb-ot-color.cc	\
-	${src_root}/hb-ot-face.cc	\
-	${src_root}/hb-ot-font.cc	\
-	${src_root}/hb-ot-layout.cc	\
-	${src_root}/hb-ot-map.cc	\
-	${src_root}/hb-ot-math.cc	\
-	${src_root}/hb-ot-name-language.cc	\
-	${src_root}/hb-ot-name.cc	\
-	${src_root}/hb-ot-shape-complex-arabic.cc	\
-	${src_root}/hb-ot-shape-complex-default.cc	\
-	${src_root}/hb-ot-shape-complex-hangul.cc	\
-	${src_root}/hb-ot-shape-complex-hebrew.cc	\
-	${src_root}/hb-ot-shape-complex-indic-table.cc	\
-	${src_root}/hb-ot-shape-complex-indic.cc	\
-	${src_root}/hb-ot-shape-complex-khmer.cc	\
-	${src_root}/hb-ot-shape-complex-myanmar.cc	\
-	${src_root}/hb-ot-shape-complex-thai.cc	\
-	${src_root}/hb-ot-shape-complex-use-table.cc	\
-	${src_root}/hb-ot-shape-complex-use.cc	\
-	${src_root}/hb-ot-shape-complex-vowel-constraints.cc	\
-	${src_root}/hb-ot-shape-fallback.cc	\
-	${src_root}/hb-ot-shape-normalize.cc	\
-	${src_root}/hb-ot-shape.cc	\
-	${src_root}/hb-ot-tag.cc	\
-	${src_root}/hb-ot-var.cc	\
-	${src_root}/hb-set.cc	\
-	${src_root}/hb-shape-plan.cc	\
-	${src_root}/hb-shape.cc	\
-	${src_root}/hb-shaper.cc	\
-	${src_root}/hb-static.cc	\
-	${src_root}/hb-ucd.cc  \
-	${src_root}/hb-unicode.cc	\
-	${src_root}/hb-warning.cc
+    ${src_root}/hb-face.cc\
+    ${src_root}/hb-fallback-shape.cc\
+    ${src_root}/hb-font.cc\
+    ${src_root}/hb-map.cc\
+    ${src_root}/hb-ot-cff1-table.cc\
+    ${src_root}/hb-ot-cff2-table.cc\
+    ${src_root}/hb-ot-color.cc\
+    ${src_root}/hb-ot-face.cc\
+    ${src_root}/hb-ot-font.cc\
+    ${src_root}/hb-ot-layout.cc\
+    ${src_root}/hb-ot-map.cc\
+    ${src_root}/hb-ot-math.cc\
+    ${src_root}/hb-ot-name-language.cc\
+    ${src_root}/hb-ot-name.cc\
+    ${src_root}/hb-ot-shape-complex-arabic.cc\
+    ${src_root}/hb-ot-shape-complex-default.cc\
+    ${src_root}/hb-ot-shape-complex-hangul.cc\
+    ${src_root}/hb-ot-shape-complex-hebrew.cc\
+    ${src_root}/hb-ot-shape-complex-indic-table.cc\
+    ${src_root}/hb-ot-shape-complex-indic.cc\
+    ${src_root}/hb-ot-shape-complex-khmer.cc\
+    ${src_root}/hb-ot-shape-complex-myanmar.cc\
+    ${src_root}/hb-ot-shape-complex-thai.cc\
+    ${src_root}/hb-ot-shape-complex-use-table.cc\
+    ${src_root}/hb-ot-shape-complex-use.cc\
+    ${src_root}/hb-ot-shape-complex-vowel-constraints.cc\
+    ${src_root}/hb-ot-shape-fallback.cc\
+    ${src_root}/hb-ot-shape-normalize.cc\
+    ${src_root}/hb-ot-shape.cc\
+    ${src_root}/hb-ot-tag.cc\
+    ${src_root}/hb-ot-var.cc\
+    ${src_root}/hb-set.cc\
+    ${src_root}/hb-shape-plan.cc\
+    ${src_root}/hb-shape.cc\
+    ${src_root}/hb-shaper.cc\
+    ${src_root}/hb-static.cc\
+    ${src_root}/hb-ucd.cc\
+    ${src_root}/hb-unicode.cc\
+    ${src_root}/hb-warning.cc
 
 src_names = $(subst ${src_root}/,${noop},${src})
 objs = $(src_names:%=${objarch_root}/%.o)

--- a/native-builds/libHarfBuzzSharp_linux/Makefile
+++ b/native-builds/libHarfBuzzSharp_linux/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= x64
 SONAME_VERSION ?= 0.0.0
-CC ?= gcc
-CXX ?= g++
+CC ?= clang
+CXX ?= clang++
 LDFLAGS += 
 
 noop = 
@@ -15,19 +15,19 @@ target_name = libHarfBuzzSharp.so
 target = ${bin_root}/${ARCH}/${target_name}.${SONAME_VERSION}
 
 library_dirs = 
-include_dirs = .             \
-	           ${src_root}/..\
-	           ${src_root}
+include_dirs = \
+    .                       \
+    ${src_root}
 library_paths = 
 defines = \
-	-DHAVE_CONFIG_H -DNDEBUG
+    -DHAVE_CONFIG_H -DNDEBUG
 cflags = \
-	-fno-exceptions -Wcast-align                       \
-	-g -Os -fPIC -fdata-sections -ffunction-sections
+    -fno-exceptions -Wcast-align                          \
+    -g -Os -fPIC -fdata-sections -ffunction-sections
 ifeq "${ARCH}" "x86"
-  arch_cflags = -m32
+      arch_cflags = -m32
 else
-  arch_cflags = 
+      arch_cflags = 
 endif
 cflags_c = ${cflags} ${CFLAGS}
 cflags_cc = -fno-rtti -fvisibility-inlines-hidden ${CXXFLAGS}
@@ -37,50 +37,55 @@ library_names = $(notdir ${library_paths})
 libraries = $(library_names:lib%.a=-l%)
 
 src = \
-    ${src_root}/hb-aat-layout.cc\
-    ${src_root}/hb-aat-map.cc\
-    ${src_root}/hb-blob.cc\
-    ${src_root}/hb-buffer-serialize.cc\
-    ${src_root}/hb-buffer.cc\
-    ${src_root}/hb-common.cc\
-    ${src_root}/hb-face.cc\
-    ${src_root}/hb-fallback-shape.cc\
-    ${src_root}/hb-font.cc\
-    ${src_root}/hb-map.cc\
-    ${src_root}/hb-ot-cff1-table.cc\
-    ${src_root}/hb-ot-cff2-table.cc\
-    ${src_root}/hb-ot-color.cc\
-    ${src_root}/hb-ot-face.cc\
-    ${src_root}/hb-ot-font.cc\
-    ${src_root}/hb-ot-layout.cc\
-    ${src_root}/hb-ot-map.cc\
-    ${src_root}/hb-ot-math.cc\
-    ${src_root}/hb-ot-name-language.cc\
-    ${src_root}/hb-ot-name.cc\
-    ${src_root}/hb-ot-shape-complex-arabic.cc\
-    ${src_root}/hb-ot-shape-complex-default.cc\
-    ${src_root}/hb-ot-shape-complex-hangul.cc\
-    ${src_root}/hb-ot-shape-complex-hebrew.cc\
-    ${src_root}/hb-ot-shape-complex-indic-table.cc\
-    ${src_root}/hb-ot-shape-complex-indic.cc\
-    ${src_root}/hb-ot-shape-complex-khmer.cc\
-    ${src_root}/hb-ot-shape-complex-myanmar.cc\
-    ${src_root}/hb-ot-shape-complex-thai.cc\
-    ${src_root}/hb-ot-shape-complex-use-table.cc\
-    ${src_root}/hb-ot-shape-complex-use.cc\
-    ${src_root}/hb-ot-shape-complex-vowel-constraints.cc\
-    ${src_root}/hb-ot-shape-fallback.cc\
-    ${src_root}/hb-ot-shape-normalize.cc\
-    ${src_root}/hb-ot-shape.cc\
-    ${src_root}/hb-ot-tag.cc\
-    ${src_root}/hb-ot-var.cc\
-    ${src_root}/hb-set.cc\
-    ${src_root}/hb-shape-plan.cc\
-    ${src_root}/hb-shape.cc\
-    ${src_root}/hb-shaper.cc\
-    ${src_root}/hb-static.cc\
-    ${src_root}/hb-ucd.cc\
-    ${src_root}/hb-unicode.cc\
+    ${src_root}/hb-aat-layout.cc                          \
+    ${src_root}/hb-aat-map.cc                             \
+    ${src_root}/hb-blob.cc                                \
+    ${src_root}/hb-buffer-serialize.cc                    \
+    ${src_root}/hb-buffer.cc                              \
+    ${src_root}/hb-common.cc                              \
+    ${src_root}/hb-face.cc                                \
+    ${src_root}/hb-fallback-shape.cc                      \
+    ${src_root}/hb-font.cc                                \
+    ${src_root}/hb-map.cc                                 \
+    ${src_root}/hb-ot-cff1-table.cc                       \
+    ${src_root}/hb-ot-cff2-table.cc                       \
+    ${src_root}/hb-ot-color.cc                            \
+    ${src_root}/hb-ot-face.cc                             \
+    ${src_root}/hb-ot-font.cc                             \
+    ${src_root}/hb-ot-layout.cc                           \
+    ${src_root}/hb-ot-map.cc                              \
+    ${src_root}/hb-ot-math.cc                             \
+    ${src_root}/hb-ot-name.cc                             \
+    ${src_root}/hb-ot-shape-complex-arabic.cc             \
+    ${src_root}/hb-ot-shape-complex-default.cc            \
+    ${src_root}/hb-ot-shape-complex-hangul.cc             \
+    ${src_root}/hb-ot-shape-complex-hebrew.cc             \
+    ${src_root}/hb-ot-shape-complex-indic-table.cc        \
+    ${src_root}/hb-ot-shape-complex-indic.cc              \
+    ${src_root}/hb-ot-shape-complex-khmer.cc              \
+    ${src_root}/hb-ot-shape-complex-myanmar.cc            \
+    ${src_root}/hb-ot-shape-complex-thai.cc               \
+    ${src_root}/hb-ot-shape-complex-use-table.cc          \
+    ${src_root}/hb-ot-shape-complex-use.cc                \
+    ${src_root}/hb-ot-shape-complex-vowel-constraints.cc  \
+    ${src_root}/hb-ot-shape-fallback.cc                   \
+    ${src_root}/hb-ot-shape-normalize.cc                  \
+    ${src_root}/hb-ot-shape.cc                            \
+    ${src_root}/hb-ot-tag.cc                              \
+    ${src_root}/hb-ot-var.cc                              \
+    ${src_root}/hb-set.cc                                 \
+    ${src_root}/hb-shape-plan.cc                          \
+    ${src_root}/hb-shape.cc                               \
+    ${src_root}/hb-shaper.cc                              \
+    ${src_root}/hb-static.cc                              \
+    ${src_root}/hb-subset-cff-common.cc                   \
+    ${src_root}/hb-subset-cff1.cc                         \
+    ${src_root}/hb-subset-cff2.cc                         \
+    ${src_root}/hb-subset-input.cc                        \
+    ${src_root}/hb-subset-plan.cc                         \
+    ${src_root}/hb-subset.cc                              \
+    ${src_root}/hb-ucd.cc                                 \
+    ${src_root}/hb-unicode.cc                             \
     ${src_root}/hb-warning.cc
 
 src_names = $(subst ${src_root}/,${noop},${src})
@@ -89,29 +94,29 @@ deps = $(objs:.o=.d)
 
 ${objarch_root}/%.o: ${src_root}/%
 # build the local source
-	@echo Building $<...
-	@mkdir -p $(dir $@)
-	@if [ "$(filter %.cc,$<)" = "" ]; then                                   \
-		$(CC) -MMD -MF $@.d                                                  \
-			${defines} ${includes} ${arch_cflags} ${cflags_c}                \
-			-c $< -o $@                                                      \
-	; else                                                                   \
-		$(CXX) -MMD -MF $@.d                                                 \
-			${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}   \
-			-c $< -o $@                                                      \
-	; fi
+    @echo Building $<...
+    @mkdir -p $(dir $@)
+    @if [ "$(filter %.cc,$<)" = "" ]; then                                   \
+        $(CC) -MMD -MF $@.d                                                  \
+            ${defines} ${includes} ${arch_cflags} ${cflags_c}                \
+            -c $< -o $@                                                      \
+    ; else                                                                   \
+        $(CXX) -MMD -MF $@.d                                                 \
+            ${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}   \
+            -c $< -o $@                                                      \
+    ; fi
 
 ${target}: ${objs}
-# link with skia
-	@echo Linking $@...
-	@mkdir -p $(dir $@)
-	$(CXX) -shared -rdynamic -s -o $@                                               \
-		${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}               \
-		-Wl,--start-group ${objarch_root}/*.o ${objarch_root}/**/*.o  ${library_paths} -Wl,--end-group   \
-		${ldflags} -Wl,--gc-sections -Wl,--no-undefined                              \
-		-Wl,-soname,libHarfBuzzSharp.so.${SONAME_VERSION}
+# link
+    @echo Linking $@...
+    @mkdir -p $(dir $@)
+    $(CXX) -shared -rdynamic -s -o $@                                                                   \
+        ${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}                                  \
+        -Wl,--start-group ${objarch_root}/*.o ${objarch_root}/**/*.o ${library_paths} -Wl,--end-group   \
+        ${ldflags} -Wl,--gc-sections -Wl,--no-undefined                                                 \
+        -Wl,-soname,libHarfBuzzSharp.so.${SONAME_VERSION}
 
 all: ${target}
 
 clean:
-	rm -rf ${obj_root} ${bin_root}
+    rm -rf ${obj_root} ${bin_root}

--- a/native-builds/libHarfBuzzSharp_linux/Makefile
+++ b/native-builds/libHarfBuzzSharp_linux/Makefile
@@ -16,77 +16,77 @@ target = ${bin_root}/${ARCH}/${target_name}.${SONAME_VERSION}
 
 library_dirs = 
 include_dirs = \
-    .                       \
-    ${src_root}
+	.                       \
+	${src_root}
 library_paths = 
 defines = \
-    -DHAVE_CONFIG_H -DNDEBUG
+	-DHAVE_CONFIG_H -DNDEBUG
 cflags = \
-    -fno-exceptions -Wcast-align                          \
-    -g -Os -fPIC -fdata-sections -ffunction-sections
+	-fno-rtti -fno-exceptions -fno-threadsafe-statics -fPIC                   \
+	-g -Os -ffunction-sections -fdata-sections
 ifeq "${ARCH}" "x86"
-      arch_cflags = -m32
+	  arch_cflags = -m32
 else
-      arch_cflags = 
+	  arch_cflags = 
 endif
 cflags_c = ${cflags} ${CFLAGS}
-cflags_cc = -fno-rtti -fvisibility-inlines-hidden ${CXXFLAGS}
-ldflags = $(library_dirs:%=-L%) ${LDFLAGS}
+cflags_cc = -std=c++11 ${CXXFLAGS}
+ldflags = -s -Wl,--gc-sections $(library_dirs:%=-L%) ${LDFLAGS}
 includes = $(include_dirs:%=-I%)
 library_names = $(notdir ${library_paths})
 libraries = $(library_names:lib%.a=-l%)
 
 src = \
-    ${src_root}/hb-aat-layout.cc                          \
-    ${src_root}/hb-aat-map.cc                             \
-    ${src_root}/hb-blob.cc                                \
-    ${src_root}/hb-buffer-serialize.cc                    \
-    ${src_root}/hb-buffer.cc                              \
-    ${src_root}/hb-common.cc                              \
-    ${src_root}/hb-face.cc                                \
-    ${src_root}/hb-fallback-shape.cc                      \
-    ${src_root}/hb-font.cc                                \
-    ${src_root}/hb-map.cc                                 \
-    ${src_root}/hb-ot-cff1-table.cc                       \
-    ${src_root}/hb-ot-cff2-table.cc                       \
-    ${src_root}/hb-ot-color.cc                            \
-    ${src_root}/hb-ot-face.cc                             \
-    ${src_root}/hb-ot-font.cc                             \
-    ${src_root}/hb-ot-layout.cc                           \
-    ${src_root}/hb-ot-map.cc                              \
-    ${src_root}/hb-ot-math.cc                             \
-    ${src_root}/hb-ot-name.cc                             \
-    ${src_root}/hb-ot-shape-complex-arabic.cc             \
-    ${src_root}/hb-ot-shape-complex-default.cc            \
-    ${src_root}/hb-ot-shape-complex-hangul.cc             \
-    ${src_root}/hb-ot-shape-complex-hebrew.cc             \
-    ${src_root}/hb-ot-shape-complex-indic-table.cc        \
-    ${src_root}/hb-ot-shape-complex-indic.cc              \
-    ${src_root}/hb-ot-shape-complex-khmer.cc              \
-    ${src_root}/hb-ot-shape-complex-myanmar.cc            \
-    ${src_root}/hb-ot-shape-complex-thai.cc               \
-    ${src_root}/hb-ot-shape-complex-use-table.cc          \
-    ${src_root}/hb-ot-shape-complex-use.cc                \
-    ${src_root}/hb-ot-shape-complex-vowel-constraints.cc  \
-    ${src_root}/hb-ot-shape-fallback.cc                   \
-    ${src_root}/hb-ot-shape-normalize.cc                  \
-    ${src_root}/hb-ot-shape.cc                            \
-    ${src_root}/hb-ot-tag.cc                              \
-    ${src_root}/hb-ot-var.cc                              \
-    ${src_root}/hb-set.cc                                 \
-    ${src_root}/hb-shape-plan.cc                          \
-    ${src_root}/hb-shape.cc                               \
-    ${src_root}/hb-shaper.cc                              \
-    ${src_root}/hb-static.cc                              \
-    ${src_root}/hb-subset-cff-common.cc                   \
-    ${src_root}/hb-subset-cff1.cc                         \
-    ${src_root}/hb-subset-cff2.cc                         \
-    ${src_root}/hb-subset-input.cc                        \
-    ${src_root}/hb-subset-plan.cc                         \
-    ${src_root}/hb-subset.cc                              \
-    ${src_root}/hb-ucd.cc                                 \
-    ${src_root}/hb-unicode.cc                             \
-    ${src_root}/hb-warning.cc
+	${src_root}/hb-aat-layout.cc                          \
+	${src_root}/hb-aat-map.cc                             \
+	${src_root}/hb-blob.cc                                \
+	${src_root}/hb-buffer-serialize.cc                    \
+	${src_root}/hb-buffer.cc                              \
+	${src_root}/hb-common.cc                              \
+	${src_root}/hb-face.cc                                \
+	${src_root}/hb-fallback-shape.cc                      \
+	${src_root}/hb-font.cc                                \
+	${src_root}/hb-map.cc                                 \
+	${src_root}/hb-ot-cff1-table.cc                       \
+	${src_root}/hb-ot-cff2-table.cc                       \
+	${src_root}/hb-ot-color.cc                            \
+	${src_root}/hb-ot-face.cc                             \
+	${src_root}/hb-ot-font.cc                             \
+	${src_root}/hb-ot-layout.cc                           \
+	${src_root}/hb-ot-map.cc                              \
+	${src_root}/hb-ot-math.cc                             \
+	${src_root}/hb-ot-name.cc                             \
+	${src_root}/hb-ot-shape-complex-arabic.cc             \
+	${src_root}/hb-ot-shape-complex-default.cc            \
+	${src_root}/hb-ot-shape-complex-hangul.cc             \
+	${src_root}/hb-ot-shape-complex-hebrew.cc             \
+	${src_root}/hb-ot-shape-complex-indic-table.cc        \
+	${src_root}/hb-ot-shape-complex-indic.cc              \
+	${src_root}/hb-ot-shape-complex-khmer.cc              \
+	${src_root}/hb-ot-shape-complex-myanmar.cc            \
+	${src_root}/hb-ot-shape-complex-thai.cc               \
+	${src_root}/hb-ot-shape-complex-use-table.cc          \
+	${src_root}/hb-ot-shape-complex-use.cc                \
+	${src_root}/hb-ot-shape-complex-vowel-constraints.cc  \
+	${src_root}/hb-ot-shape-fallback.cc                   \
+	${src_root}/hb-ot-shape-normalize.cc                  \
+	${src_root}/hb-ot-shape.cc                            \
+	${src_root}/hb-ot-tag.cc                              \
+	${src_root}/hb-ot-var.cc                              \
+	${src_root}/hb-set.cc                                 \
+	${src_root}/hb-shape-plan.cc                          \
+	${src_root}/hb-shape.cc                               \
+	${src_root}/hb-shaper.cc                              \
+	${src_root}/hb-static.cc                              \
+	${src_root}/hb-subset-cff-common.cc                   \
+	${src_root}/hb-subset-cff1.cc                         \
+	${src_root}/hb-subset-cff2.cc                         \
+	${src_root}/hb-subset-input.cc                        \
+	${src_root}/hb-subset-plan.cc                         \
+	${src_root}/hb-subset.cc                              \
+	${src_root}/hb-ucd.cc                                 \
+	${src_root}/hb-unicode.cc                             \
+	${src_root}/hb-warning.cc
 
 src_names = $(subst ${src_root}/,${noop},${src})
 objs = $(src_names:%=${objarch_root}/%.o)
@@ -94,29 +94,29 @@ deps = $(objs:.o=.d)
 
 ${objarch_root}/%.o: ${src_root}/%
 # build the local source
-    @echo Building $<...
-    @mkdir -p $(dir $@)
-    @if [ "$(filter %.cc,$<)" = "" ]; then                                   \
-        $(CC) -MMD -MF $@.d                                                  \
-            ${defines} ${includes} ${arch_cflags} ${cflags_c}                \
-            -c $< -o $@                                                      \
-    ; else                                                                   \
-        $(CXX) -MMD -MF $@.d                                                 \
-            ${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}   \
-            -c $< -o $@                                                      \
-    ; fi
+	@echo Building $<...
+	@mkdir -p $(dir $@)
+	@if [ "$(filter %.cc,$<)" = "" ]; then                                   \
+		$(CC) -MMD -MF $@.d                                                  \
+			${defines} ${includes} ${arch_cflags} ${cflags_c}                \
+			-c $< -o $@                                                      \
+	; else                                                                   \
+		$(CXX) -MMD -MF $@.d                                                 \
+			${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}   \
+			-c $< -o $@                                                      \
+	; fi
 
 ${target}: ${objs}
 # link
-    @echo Linking $@...
-    @mkdir -p $(dir $@)
-    $(CXX) -shared -rdynamic -s -o $@                                                                   \
-        ${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}                                  \
-        -Wl,--start-group ${objarch_root}/*.o ${objarch_root}/**/*.o ${library_paths} -Wl,--end-group   \
-        ${ldflags} -Wl,--gc-sections -Wl,--no-undefined                                                 \
-        -Wl,-soname,libHarfBuzzSharp.so.${SONAME_VERSION}
+	@echo Linking $@...
+	@mkdir -p $(dir $@)
+	$(CXX) -shared -rdynamic -s -o $@                                                                   \
+		${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}                                  \
+		-Wl,--start-group ${objarch_root}/*.o ${objarch_root}/**/*.o ${library_paths} -Wl,--end-group   \
+		${ldflags} -Wl,--gc-sections -Wl,--no-undefined                                                 \
+		-Wl,-soname,libHarfBuzzSharp.so.${SONAME_VERSION}
 
 all: ${target}
 
 clean:
-    rm -rf ${obj_root} ${bin_root}
+	rm -rf ${obj_root} ${bin_root}

--- a/native-builds/libHarfBuzzSharp_linux/Makefile
+++ b/native-builds/libHarfBuzzSharp_linux/Makefile
@@ -112,7 +112,7 @@ ${target}: ${objs}
 	@mkdir -p $(dir $@)
 	$(CXX) -shared -rdynamic -s -o $@                                                                   \
 		${defines} ${includes} ${arch_cflags} ${cflags_c} ${cflags_cc}                                  \
-		-Wl,--start-group ${objarch_root}/*.o ${objarch_root}/**/*.o ${library_paths} -Wl,--end-group   \
+		-Wl,--start-group ${objarch_root}/*.o ${library_paths} -Wl,--end-group   \
 		${ldflags} -Wl,--gc-sections -Wl,--no-undefined                                                 \
 		-Wl,-soname,libHarfBuzzSharp.so.${SONAME_VERSION}
 

--- a/native-builds/libHarfBuzzSharp_linux/config.h
+++ b/native-builds/libHarfBuzzSharp_linux/config.h
@@ -24,19 +24,19 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
-#define HAVE_FONTCONFIG 1
+/* #undef HAVE_FONTCONFIG */
 
 /* Have FreeType 2 library */
-#define HAVE_FREETYPE 1
+/* #undef HAVE_FREETYPE */
 
 /* Define to 1 if you have the `FT_Done_MM_Var' function. */
 /* #undef HAVE_FT_DONE_MM_VAR */
@@ -136,9 +136,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_linux/config.h
+++ b/native-builds/libHarfBuzzSharp_linux/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -174,7 +174,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_osx/config.h
+++ b/native-builds/libHarfBuzzSharp_osx/config.h
@@ -24,13 +24,13 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
 /* #undef HAVE_FONTCONFIG */
@@ -136,9 +136,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_osx/config.h
+++ b/native-builds/libHarfBuzzSharp_osx/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -174,7 +174,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_osx/libHarfBuzzSharp.xcodeproj/project.pbxproj
+++ b/native-builds/libHarfBuzzSharp_osx/libHarfBuzzSharp.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		34F64B6C21FA5EC3008FBDBD /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B3F21FA5EC1008FBDBD /* hb-ot-shape-complex-indic-table.cc */; };
 		34F64B6D21FA5EC3008FBDBD /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B4021FA5EC1008FBDBD /* hb-ot-font.cc */; };
 		34F64B6E21FA5EC3008FBDBD /* hb-ot-color.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B4121FA5EC1008FBDBD /* hb-ot-color.cc */; };
-		34F64B6F21FA5EC3008FBDBD /* hb-ot-name-language.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B4221FA5EC1008FBDBD /* hb-ot-name-language.cc */; };
 		34F64B7021FA5EC3008FBDBD /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B4321FA5EC1008FBDBD /* hb-ot-shape-complex-thai.cc */; };
 		34F64B7121FA5EC3008FBDBD /* hb-blob.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B4421FA5EC1008FBDBD /* hb-blob.cc */; };
 		34F64B7221FA5EC3008FBDBD /* hb-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B4521FA5EC1008FBDBD /* hb-map.cc */; };
@@ -41,7 +40,6 @@
 		34F64B8A21FA5EC3008FBDBD /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B5D21FA5EC2008FBDBD /* hb-ot-layout.cc */; };
 		34F64B8B21FA5EC3008FBDBD /* hb-aat-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B5E21FA5EC2008FBDBD /* hb-aat-layout.cc */; };
 		34F64B8C21FA5EC3008FBDBD /* hb-ot-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B5F21FA5EC2008FBDBD /* hb-ot-face.cc */; };
-		34F64B8D21FA5EC3008FBDBD /* hb-ucdn.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6021FA5EC2008FBDBD /* hb-ucdn.cc */; };
 		34F64B8E21FA5EC3008FBDBD /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6121FA5EC2008FBDBD /* hb-fallback-shape.cc */; };
 		34F64B8F21FA5EC3008FBDBD /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6221FA5EC2008FBDBD /* hb-shape-plan.cc */; };
 		34F64B9021FA5EC3008FBDBD /* hb-ot-math.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6321FA5EC2008FBDBD /* hb-ot-math.cc */; };
@@ -52,9 +50,14 @@
 		34F64B9521FA5EC3008FBDBD /* hb-ot-name.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6821FA5EC2008FBDBD /* hb-ot-name.cc */; };
 		34F64B9621FA5EC3008FBDBD /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6921FA5EC2008FBDBD /* hb-buffer.cc */; };
 		34F64B9721FA5EC3008FBDBD /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B6A21FA5EC2008FBDBD /* hb-font.cc */; };
-		34F64B9B21FA5EE2008FBDBD /* ucdn.c in Sources */ = {isa = PBXBuildFile; fileRef = 34F64B9821FA5EE2008FBDBD /* ucdn.c */; };
-		34F64B9D21FA5EE2008FBDBD /* ucdn.h in Headers */ = {isa = PBXBuildFile; fileRef = 34F64B9A21FA5EE2008FBDBD /* ucdn.h */; };
 		34F64B9F21FA5F1D008FBDBD /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 34F64B9E21FA5F1D008FBDBD /* config.h */; };
+		34FEAB0A22BD8FE2007299F0 /* hb-subset-cff-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0322BD8FE2007299F0 /* hb-subset-cff-common.cc */; };
+		34FEAB0B22BD8FE2007299F0 /* hb-subset.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0422BD8FE2007299F0 /* hb-subset.cc */; };
+		34FEAB0C22BD8FE2007299F0 /* hb-subset-input.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0522BD8FE2007299F0 /* hb-subset-input.cc */; };
+		34FEAB0D22BD8FE2007299F0 /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0622BD8FE2007299F0 /* hb-ucd.cc */; };
+		34FEAB0E22BD8FE2007299F0 /* hb-subset-cff1.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0722BD8FE2007299F0 /* hb-subset-cff1.cc */; };
+		34FEAB0F22BD8FE2007299F0 /* hb-subset-cff2.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0822BD8FE2007299F0 /* hb-subset-cff2.cc */; };
+		34FEAB1022BD8FE2007299F0 /* hb-subset-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAB0922BD8FE2007299F0 /* hb-subset-plan.cc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,7 +66,6 @@
 		34F64B3F21FA5EC1008FBDBD /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
 		34F64B4021FA5EC1008FBDBD /* hb-ot-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-font.cc"; path = "../../externals/harfbuzz/src/hb-ot-font.cc"; sourceTree = "<group>"; };
 		34F64B4121FA5EC1008FBDBD /* hb-ot-color.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-color.cc"; path = "../../externals/harfbuzz/src/hb-ot-color.cc"; sourceTree = "<group>"; };
-		34F64B4221FA5EC1008FBDBD /* hb-ot-name-language.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name-language.cc"; path = "../../externals/harfbuzz/src/hb-ot-name-language.cc"; sourceTree = "<group>"; };
 		34F64B4321FA5EC1008FBDBD /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-thai.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = "<group>"; };
 		34F64B4421FA5EC1008FBDBD /* hb-blob.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-blob.cc"; path = "../../externals/harfbuzz/src/hb-blob.cc"; sourceTree = "<group>"; };
 		34F64B4521FA5EC1008FBDBD /* hb-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-map.cc"; path = "../../externals/harfbuzz/src/hb-map.cc"; sourceTree = "<group>"; };
@@ -93,7 +95,6 @@
 		34F64B5D21FA5EC2008FBDBD /* hb-ot-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-layout.cc"; path = "../../externals/harfbuzz/src/hb-ot-layout.cc"; sourceTree = "<group>"; };
 		34F64B5E21FA5EC2008FBDBD /* hb-aat-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-aat-layout.cc"; path = "../../externals/harfbuzz/src/hb-aat-layout.cc"; sourceTree = "<group>"; };
 		34F64B5F21FA5EC2008FBDBD /* hb-ot-face.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-face.cc"; path = "../../externals/harfbuzz/src/hb-ot-face.cc"; sourceTree = "<group>"; };
-		34F64B6021FA5EC2008FBDBD /* hb-ucdn.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucdn.cc"; path = "../../externals/harfbuzz/src/hb-ucdn.cc"; sourceTree = "<group>"; };
 		34F64B6121FA5EC2008FBDBD /* hb-fallback-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-fallback-shape.cc"; path = "../../externals/harfbuzz/src/hb-fallback-shape.cc"; sourceTree = "<group>"; };
 		34F64B6221FA5EC2008FBDBD /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "../../externals/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
 		34F64B6321FA5EC2008FBDBD /* hb-ot-math.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-math.cc"; path = "../../externals/harfbuzz/src/hb-ot-math.cc"; sourceTree = "<group>"; };
@@ -104,9 +105,14 @@
 		34F64B6821FA5EC2008FBDBD /* hb-ot-name.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name.cc"; path = "../../externals/harfbuzz/src/hb-ot-name.cc"; sourceTree = "<group>"; };
 		34F64B6921FA5EC2008FBDBD /* hb-buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer.cc"; path = "../../externals/harfbuzz/src/hb-buffer.cc"; sourceTree = "<group>"; };
 		34F64B6A21FA5EC2008FBDBD /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "../../externals/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
-		34F64B9821FA5EE2008FBDBD /* ucdn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ucdn.c; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.c"; sourceTree = "<group>"; };
-		34F64B9A21FA5EE2008FBDBD /* ucdn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ucdn.h; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.h"; sourceTree = "<group>"; };
 		34F64B9E21FA5F1D008FBDBD /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		34FEAB0322BD8FE2007299F0 /* hb-subset-cff-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff-common.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff-common.cc"; sourceTree = "<group>"; };
+		34FEAB0422BD8FE2007299F0 /* hb-subset.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset.cc"; path = "../../externals/harfbuzz/src/hb-subset.cc"; sourceTree = "<group>"; };
+		34FEAB0522BD8FE2007299F0 /* hb-subset-input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-input.cc"; path = "../../externals/harfbuzz/src/hb-subset-input.cc"; sourceTree = "<group>"; };
+		34FEAB0622BD8FE2007299F0 /* hb-ucd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucd.cc"; path = "../../externals/harfbuzz/src/hb-ucd.cc"; sourceTree = "<group>"; };
+		34FEAB0722BD8FE2007299F0 /* hb-subset-cff1.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff1.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff1.cc"; sourceTree = "<group>"; };
+		34FEAB0822BD8FE2007299F0 /* hb-subset-cff2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff2.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff2.cc"; sourceTree = "<group>"; };
+		34FEAB0922BD8FE2007299F0 /* hb-subset-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-plan.cc"; path = "../../externals/harfbuzz/src/hb-subset-plan.cc"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,7 +146,6 @@
 		34F64B3C21FA5EAE008FBDBD /* src */ = {
 			isa = PBXGroup;
 			children = (
-				34F64B3D21FA5EB5008FBDBD /* hb-ucdn */,
 				34F64B5E21FA5EC2008FBDBD /* hb-aat-layout.cc */,
 				34F64B4A21FA5EC1008FBDBD /* hb-aat-map.cc */,
 				34F64B4421FA5EC1008FBDBD /* hb-blob.cc */,
@@ -159,7 +164,6 @@
 				34F64B5D21FA5EC2008FBDBD /* hb-ot-layout.cc */,
 				34F64B6721FA5EC2008FBDBD /* hb-ot-map.cc */,
 				34F64B6321FA5EC2008FBDBD /* hb-ot-math.cc */,
-				34F64B4221FA5EC1008FBDBD /* hb-ot-name-language.cc */,
 				34F64B6821FA5EC2008FBDBD /* hb-ot-name.cc */,
 				34F64B5321FA5EC1008FBDBD /* hb-ot-shape-complex-arabic.cc */,
 				34F64B6521FA5EC2008FBDBD /* hb-ot-shape-complex-default.cc */,
@@ -183,20 +187,17 @@
 				34F64B5621FA5EC1008FBDBD /* hb-shape.cc */,
 				34F64B5A21FA5EC2008FBDBD /* hb-shaper.cc */,
 				34F64B6621FA5EC2008FBDBD /* hb-static.cc */,
-				34F64B6021FA5EC2008FBDBD /* hb-ucdn.cc */,
+				34FEAB0322BD8FE2007299F0 /* hb-subset-cff-common.cc */,
+				34FEAB0722BD8FE2007299F0 /* hb-subset-cff1.cc */,
+				34FEAB0822BD8FE2007299F0 /* hb-subset-cff2.cc */,
+				34FEAB0522BD8FE2007299F0 /* hb-subset-input.cc */,
+				34FEAB0922BD8FE2007299F0 /* hb-subset-plan.cc */,
+				34FEAB0422BD8FE2007299F0 /* hb-subset.cc */,
+				34FEAB0622BD8FE2007299F0 /* hb-ucd.cc */,
 				34F64B4C21FA5EC1008FBDBD /* hb-unicode.cc */,
 				34F64B4D21FA5EC1008FBDBD /* hb-warning.cc */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		34F64B3D21FA5EB5008FBDBD /* hb-ucdn */ = {
-			isa = PBXGroup;
-			children = (
-				34F64B9A21FA5EE2008FBDBD /* ucdn.h */,
-				34F64B9821FA5EE2008FBDBD /* ucdn.c */,
-			);
-			name = "hb-ucdn";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -207,7 +208,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				34F64B9F21FA5F1D008FBDBD /* config.h in Headers */,
-				34F64B9D21FA5EE2008FBDBD /* ucdn.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -251,6 +251,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 346E0ABC1EB38F6300F3DE96;
@@ -270,6 +271,7 @@
 			files = (
 				34F64B8621FA5EC3008FBDBD /* hb-face.cc in Sources */,
 				34F64B9221FA5EC3008FBDBD /* hb-ot-shape-complex-default.cc in Sources */,
+				34FEAB0C22BD8FE2007299F0 /* hb-subset-input.cc in Sources */,
 				34F64B7C21FA5EC3008FBDBD /* hb-ot-shape-complex-hangul.cc in Sources */,
 				34F64B9321FA5EC3008FBDBD /* hb-static.cc in Sources */,
 				34F64B6E21FA5EC3008FBDBD /* hb-ot-color.cc in Sources */,
@@ -284,16 +286,16 @@
 				34F64B8B21FA5EC3008FBDBD /* hb-aat-layout.cc in Sources */,
 				34F64B8C21FA5EC3008FBDBD /* hb-ot-face.cc in Sources */,
 				34F64B8A21FA5EC3008FBDBD /* hb-ot-layout.cc in Sources */,
+				34FEAB0D22BD8FE2007299F0 /* hb-ucd.cc in Sources */,
 				34F64B7221FA5EC3008FBDBD /* hb-map.cc in Sources */,
 				34F64B7D21FA5EC3008FBDBD /* hb-ot-shape-fallback.cc in Sources */,
-				34F64B6F21FA5EC3008FBDBD /* hb-ot-name-language.cc in Sources */,
 				34F64B8021FA5EC3008FBDBD /* hb-ot-shape-complex-arabic.cc in Sources */,
-				34F64B8D21FA5EC3008FBDBD /* hb-ucdn.cc in Sources */,
 				34F64B7121FA5EC3008FBDBD /* hb-blob.cc in Sources */,
+				34FEAB0F22BD8FE2007299F0 /* hb-subset-cff2.cc in Sources */,
 				34F64B8421FA5EC3008FBDBD /* hb-ot-shape-complex-khmer.cc in Sources */,
+				34FEAB1022BD8FE2007299F0 /* hb-subset-plan.cc in Sources */,
 				34F64B7821FA5EC3008FBDBD /* hb-ot-shape-normalize.cc in Sources */,
 				34F64B7021FA5EC3008FBDBD /* hb-ot-shape-complex-thai.cc in Sources */,
-				34F64B9B21FA5EE2008FBDBD /* ucdn.c in Sources */,
 				34F64B7E21FA5EC3008FBDBD /* hb-ot-cff2-table.cc in Sources */,
 				34F64B7B21FA5EC3008FBDBD /* hb-ot-shape-complex-myanmar.cc in Sources */,
 				34F64B7921FA5EC3008FBDBD /* hb-unicode.cc in Sources */,
@@ -303,17 +305,20 @@
 				34F64B8E21FA5EC3008FBDBD /* hb-fallback-shape.cc in Sources */,
 				34F64B8321FA5EC3008FBDBD /* hb-shape.cc in Sources */,
 				34F64B8921FA5EC3008FBDBD /* hb-common.cc in Sources */,
+				34FEAB0B22BD8FE2007299F0 /* hb-subset.cc in Sources */,
 				34F64B9621FA5EC3008FBDBD /* hb-buffer.cc in Sources */,
 				34F64B7721FA5EC3008FBDBD /* hb-aat-map.cc in Sources */,
 				34F64B7521FA5EC3008FBDBD /* hb-buffer-serialize.cc in Sources */,
 				34F64B7A21FA5EC3008FBDBD /* hb-warning.cc in Sources */,
 				34F64B7F21FA5EC3008FBDBD /* hb-ot-shape-complex-hebrew.cc in Sources */,
 				34F64B8121FA5EC3008FBDBD /* hb-ot-shape.cc in Sources */,
+				34FEAB0A22BD8FE2007299F0 /* hb-subset-cff-common.cc in Sources */,
 				34F64B8721FA5EC3008FBDBD /* hb-shaper.cc in Sources */,
 				34F64B6B21FA5EC3008FBDBD /* hb-ot-cff1-table.cc in Sources */,
 				34F64B8521FA5EC3008FBDBD /* hb-set.cc in Sources */,
 				34F64B9521FA5EC3008FBDBD /* hb-ot-name.cc in Sources */,
 				34F64B9421FA5EC3008FBDBD /* hb-ot-map.cc in Sources */,
+				34FEAB0E22BD8FE2007299F0 /* hb-subset-cff1.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -414,8 +419,8 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = ( 
-				    HAVE_CONFIG_H, 
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					HAVE_CONFIG_H,
 					NDEBUG,
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/native-builds/libHarfBuzzSharp_tizen/config.h
+++ b/native-builds/libHarfBuzzSharp_tizen/config.h
@@ -24,19 +24,19 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
-#define HAVE_FONTCONFIG 1
+/* #undef HAVE_FONTCONFIG */
 
 /* Have FreeType 2 library */
-#define HAVE_FREETYPE 1
+/* #undef HAVE_FREETYPE */
 
 /* Define to 1 if you have the `FT_Done_MM_Var' function. */
 /* #undef HAVE_FT_DONE_MM_VAR */
@@ -136,9 +136,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_tizen/config.h
+++ b/native-builds/libHarfBuzzSharp_tizen/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -174,7 +174,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_tizen/project_def.prop
+++ b/native-builds/libHarfBuzzSharp_tizen/project_def.prop
@@ -11,8 +11,7 @@ USER_DEFS = HAVE_CONFIG_H NDEBUG
 
 USER_CPP_DEFS = $(USER_DEFS)
 
-USER_SRCS = 
-            ../../externals/harfbuzz/src/hb-aat-layout.cc                            \
+USER_SRCS = ../../externals/harfbuzz/src/hb-aat-layout.cc                            \
             ../../externals/harfbuzz/src/hb-aat-map.cc                               \
             ../../externals/harfbuzz/src/hb-blob.cc                                  \
             ../../externals/harfbuzz/src/hb-buffer-serialize.cc                      \

--- a/native-builds/libHarfBuzzSharp_tizen/project_def.prop
+++ b/native-builds/libHarfBuzzSharp_tizen/project_def.prop
@@ -19,7 +19,7 @@ USER_SRCS =
             ../../externals/harfbuzz/src/hb-buffer.cc                                \
             ../../externals/harfbuzz/src/hb-common.cc                                \
             ../../externals/harfbuzz/src/hb-face.cc                                  \
-			../../externals/harfbuzz/src/hb-fallback-shape.cc                        \
+            ../../externals/harfbuzz/src/hb-fallback-shape.cc                        \
             ../../externals/harfbuzz/src/hb-font.cc                                  \
             ../../externals/harfbuzz/src/hb-map.cc                                   \
             ../../externals/harfbuzz/src/hb-ot-cff1-table.cc                         \
@@ -54,7 +54,7 @@ USER_SRCS =
             ../../externals/harfbuzz/src/hb-shape.cc                                 \
             ../../externals/harfbuzz/src/hb-shaper.cc                                \
             ../../externals/harfbuzz/src/hb-static.cc                                \
-			../../externals/harfbuzz/src/hb-ucd.cc                                   \
+            ../../externals/harfbuzz/src/hb-ucd.cc                                   \
             ../../externals/harfbuzz/src/hb-unicode.cc                               \
             ../../externals/harfbuzz/src/hb-warning.cc                               \
-            ../../externals/harfbuzz/src/hb-ft.cc 			
+            ../../externals/harfbuzz/src/hb-ft.cc

--- a/native-builds/libHarfBuzzSharp_tizen/project_def.prop
+++ b/native-builds/libHarfBuzzSharp_tizen/project_def.prop
@@ -29,7 +29,6 @@ USER_SRCS = ../../externals/harfbuzz/src/hb-aat-layout.cc                       
             ../../externals/harfbuzz/src/hb-ot-layout.cc                             \
             ../../externals/harfbuzz/src/hb-ot-map.cc                                \
             ../../externals/harfbuzz/src/hb-ot-math.cc                               \
-            ../../externals/harfbuzz/src/hb-ot-name-language.cc                      \
             ../../externals/harfbuzz/src/hb-ot-name.cc                               \
             ../../externals/harfbuzz/src/hb-ot-shape-complex-arabic.cc               \
             ../../externals/harfbuzz/src/hb-ot-shape-complex-default.cc              \

--- a/native-builds/libHarfBuzzSharp_tizen/project_def.prop
+++ b/native-builds/libHarfBuzzSharp_tizen/project_def.prop
@@ -52,7 +52,12 @@ USER_SRCS = ../../externals/harfbuzz/src/hb-aat-layout.cc                       
             ../../externals/harfbuzz/src/hb-shape.cc                                 \
             ../../externals/harfbuzz/src/hb-shaper.cc                                \
             ../../externals/harfbuzz/src/hb-static.cc                                \
+            ../../externals/harfbuzz/src/hb-subset-cff-common.cc                     \
+            ../../externals/harfbuzz/src/hb-subset-cff1.cc                           \
+            ../../externals/harfbuzz/src/hb-subset-cff2.cc                           \
+            ../../externals/harfbuzz/src/hb-subset-input.cc                          \
+            ../../externals/harfbuzz/src/hb-subset-plan.cc                           \
+            ../../externals/harfbuzz/src/hb-subset.cc                                \
             ../../externals/harfbuzz/src/hb-ucd.cc                                   \
             ../../externals/harfbuzz/src/hb-unicode.cc                               \
-            ../../externals/harfbuzz/src/hb-warning.cc                               \
-            ../../externals/harfbuzz/src/hb-ft.cc
+            ../../externals/harfbuzz/src/hb-warning.cc

--- a/native-builds/libHarfBuzzSharp_tizen/project_def.prop
+++ b/native-builds/libHarfBuzzSharp_tizen/project_def.prop
@@ -4,7 +4,6 @@ profile = mobile-4.0
 APPNAME = HarfBuzzSharp
 
 USER_INC_DIRS = .                                    \
-                ../../externals/harfbuzz/src/hb-ucdn \
                 ../../externals/harfbuzz/src         \
                 ../../externals/harfbuzz
 
@@ -12,8 +11,7 @@ USER_DEFS = HAVE_CONFIG_H NDEBUG
 
 USER_CPP_DEFS = $(USER_DEFS)
 
-USER_SRCS = ../../externals/harfbuzz/src/hb-ucdn/ucdn.c                              \
-            ../../externals/harfbuzz/src/hb-ucdn.cc                                  \
+USER_SRCS = 
             ../../externals/harfbuzz/src/hb-aat-layout.cc                            \
             ../../externals/harfbuzz/src/hb-aat-map.cc                               \
             ../../externals/harfbuzz/src/hb-blob.cc                                  \
@@ -21,6 +19,7 @@ USER_SRCS = ../../externals/harfbuzz/src/hb-ucdn/ucdn.c                         
             ../../externals/harfbuzz/src/hb-buffer.cc                                \
             ../../externals/harfbuzz/src/hb-common.cc                                \
             ../../externals/harfbuzz/src/hb-face.cc                                  \
+			../../externals/harfbuzz/src/hb-fallback-shape.cc                        \
             ../../externals/harfbuzz/src/hb-font.cc                                  \
             ../../externals/harfbuzz/src/hb-map.cc                                   \
             ../../externals/harfbuzz/src/hb-ot-cff1-table.cc                         \
@@ -55,7 +54,7 @@ USER_SRCS = ../../externals/harfbuzz/src/hb-ucdn/ucdn.c                         
             ../../externals/harfbuzz/src/hb-shape.cc                                 \
             ../../externals/harfbuzz/src/hb-shaper.cc                                \
             ../../externals/harfbuzz/src/hb-static.cc                                \
+			../../externals/harfbuzz/src/hb-ucd.cc                                   \
             ../../externals/harfbuzz/src/hb-unicode.cc                               \
             ../../externals/harfbuzz/src/hb-warning.cc                               \
-            ../../externals/harfbuzz/src/hb-ft.cc                                    \
-            ../../externals/harfbuzz/src/hb-fallback-shape.cc
+            ../../externals/harfbuzz/src/hb-ft.cc 			

--- a/native-builds/libHarfBuzzSharp_tvos/config.h
+++ b/native-builds/libHarfBuzzSharp_tvos/config.h
@@ -24,13 +24,13 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
 /* #undef HAVE_FONTCONFIG */
@@ -136,9 +136,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_tvos/config.h
+++ b/native-builds/libHarfBuzzSharp_tvos/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -174,7 +174,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_tvos/libHarfBuzzSharp.xcodeproj/project.pbxproj
+++ b/native-builds/libHarfBuzzSharp_tvos/libHarfBuzzSharp.xcodeproj/project.pbxproj
@@ -7,11 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3460E11422BD90090022F04C /* hb-subset-input.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E10D22BD90080022F04C /* hb-subset-input.cc */; };
+		3460E11522BD90090022F04C /* hb-subset-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E10E22BD90080022F04C /* hb-subset-plan.cc */; };
+		3460E11622BD90090022F04C /* hb-subset-cff-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E10F22BD90090022F04C /* hb-subset-cff-common.cc */; };
+		3460E11722BD90090022F04C /* hb-subset.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E11022BD90090022F04C /* hb-subset.cc */; };
+		3460E11822BD90090022F04C /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E11122BD90090022F04C /* hb-ucd.cc */; };
+		3460E11922BD90090022F04C /* hb-subset-cff1.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E11222BD90090022F04C /* hb-subset-cff1.cc */; };
+		3460E11A22BD90090022F04C /* hb-subset-cff2.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3460E11322BD90090022F04C /* hb-subset-cff2.cc */; };
 		34F64BCE21FA5F51008FBDBD /* hb-ot-cff1-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA121FA5F4F008FBDBD /* hb-ot-cff1-table.cc */; };
 		34F64BCF21FA5F51008FBDBD /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA221FA5F4F008FBDBD /* hb-ot-shape-complex-indic-table.cc */; };
 		34F64BD021FA5F51008FBDBD /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA321FA5F4F008FBDBD /* hb-ot-font.cc */; };
 		34F64BD121FA5F51008FBDBD /* hb-ot-color.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA421FA5F4F008FBDBD /* hb-ot-color.cc */; };
-		34F64BD221FA5F51008FBDBD /* hb-ot-name-language.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA521FA5F4F008FBDBD /* hb-ot-name-language.cc */; };
 		34F64BD321FA5F51008FBDBD /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA621FA5F4F008FBDBD /* hb-ot-shape-complex-thai.cc */; };
 		34F64BD421FA5F51008FBDBD /* hb-blob.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA721FA5F4F008FBDBD /* hb-blob.cc */; };
 		34F64BD521FA5F51008FBDBD /* hb-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BA821FA5F4F008FBDBD /* hb-map.cc */; };
@@ -41,7 +47,6 @@
 		34F64BED21FA5F51008FBDBD /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC021FA5F50008FBDBD /* hb-ot-layout.cc */; };
 		34F64BEE21FA5F51008FBDBD /* hb-aat-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC121FA5F50008FBDBD /* hb-aat-layout.cc */; };
 		34F64BEF21FA5F51008FBDBD /* hb-ot-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC221FA5F50008FBDBD /* hb-ot-face.cc */; };
-		34F64BF021FA5F51008FBDBD /* hb-ucdn.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC321FA5F50008FBDBD /* hb-ucdn.cc */; };
 		34F64BF121FA5F51008FBDBD /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC421FA5F50008FBDBD /* hb-fallback-shape.cc */; };
 		34F64BF221FA5F51008FBDBD /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC521FA5F50008FBDBD /* hb-shape-plan.cc */; };
 		34F64BF321FA5F51008FBDBD /* hb-ot-math.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BC621FA5F50008FBDBD /* hb-ot-math.cc */; };
@@ -52,7 +57,6 @@
 		34F64BF821FA5F51008FBDBD /* hb-ot-name.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BCB21FA5F51008FBDBD /* hb-ot-name.cc */; };
 		34F64BF921FA5F51008FBDBD /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BCC21FA5F51008FBDBD /* hb-buffer.cc */; };
 		34F64BFA21FA5F51008FBDBD /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BCD21FA5F51008FBDBD /* hb-font.cc */; };
-		34F64BFE21FA5F66008FBDBD /* ucdn.c in Sources */ = {isa = PBXBuildFile; fileRef = 34F64BFC21FA5F66008FBDBD /* ucdn.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -69,11 +73,17 @@
 
 /* Begin PBXFileReference section */
 		341E97BC1EB3CE10008E2876 /* libHarfBuzzSharp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHarfBuzzSharp.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3460E10D22BD90080022F04C /* hb-subset-input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-input.cc"; path = "../../externals/harfbuzz/src/hb-subset-input.cc"; sourceTree = "<group>"; };
+		3460E10E22BD90080022F04C /* hb-subset-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-plan.cc"; path = "../../externals/harfbuzz/src/hb-subset-plan.cc"; sourceTree = "<group>"; };
+		3460E10F22BD90090022F04C /* hb-subset-cff-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff-common.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff-common.cc"; sourceTree = "<group>"; };
+		3460E11022BD90090022F04C /* hb-subset.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset.cc"; path = "../../externals/harfbuzz/src/hb-subset.cc"; sourceTree = "<group>"; };
+		3460E11122BD90090022F04C /* hb-ucd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucd.cc"; path = "../../externals/harfbuzz/src/hb-ucd.cc"; sourceTree = "<group>"; };
+		3460E11222BD90090022F04C /* hb-subset-cff1.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff1.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff1.cc"; sourceTree = "<group>"; };
+		3460E11322BD90090022F04C /* hb-subset-cff2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff2.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff2.cc"; sourceTree = "<group>"; };
 		34F64BA121FA5F4F008FBDBD /* hb-ot-cff1-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-cff1-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-cff1-table.cc"; sourceTree = "<group>"; };
 		34F64BA221FA5F4F008FBDBD /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
 		34F64BA321FA5F4F008FBDBD /* hb-ot-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-font.cc"; path = "../../externals/harfbuzz/src/hb-ot-font.cc"; sourceTree = "<group>"; };
 		34F64BA421FA5F4F008FBDBD /* hb-ot-color.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-color.cc"; path = "../../externals/harfbuzz/src/hb-ot-color.cc"; sourceTree = "<group>"; };
-		34F64BA521FA5F4F008FBDBD /* hb-ot-name-language.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name-language.cc"; path = "../../externals/harfbuzz/src/hb-ot-name-language.cc"; sourceTree = "<group>"; };
 		34F64BA621FA5F4F008FBDBD /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-thai.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = "<group>"; };
 		34F64BA721FA5F4F008FBDBD /* hb-blob.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-blob.cc"; path = "../../externals/harfbuzz/src/hb-blob.cc"; sourceTree = "<group>"; };
 		34F64BA821FA5F4F008FBDBD /* hb-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-map.cc"; path = "../../externals/harfbuzz/src/hb-map.cc"; sourceTree = "<group>"; };
@@ -103,7 +113,6 @@
 		34F64BC021FA5F50008FBDBD /* hb-ot-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-layout.cc"; path = "../../externals/harfbuzz/src/hb-ot-layout.cc"; sourceTree = "<group>"; };
 		34F64BC121FA5F50008FBDBD /* hb-aat-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-aat-layout.cc"; path = "../../externals/harfbuzz/src/hb-aat-layout.cc"; sourceTree = "<group>"; };
 		34F64BC221FA5F50008FBDBD /* hb-ot-face.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-face.cc"; path = "../../externals/harfbuzz/src/hb-ot-face.cc"; sourceTree = "<group>"; };
-		34F64BC321FA5F50008FBDBD /* hb-ucdn.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucdn.cc"; path = "../../externals/harfbuzz/src/hb-ucdn.cc"; sourceTree = "<group>"; };
 		34F64BC421FA5F50008FBDBD /* hb-fallback-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-fallback-shape.cc"; path = "../../externals/harfbuzz/src/hb-fallback-shape.cc"; sourceTree = "<group>"; };
 		34F64BC521FA5F50008FBDBD /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "../../externals/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
 		34F64BC621FA5F50008FBDBD /* hb-ot-math.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-math.cc"; path = "../../externals/harfbuzz/src/hb-ot-math.cc"; sourceTree = "<group>"; };
@@ -114,8 +123,6 @@
 		34F64BCB21FA5F51008FBDBD /* hb-ot-name.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name.cc"; path = "../../externals/harfbuzz/src/hb-ot-name.cc"; sourceTree = "<group>"; };
 		34F64BCC21FA5F51008FBDBD /* hb-buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer.cc"; path = "../../externals/harfbuzz/src/hb-buffer.cc"; sourceTree = "<group>"; };
 		34F64BCD21FA5F51008FBDBD /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "../../externals/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
-		34F64BFC21FA5F66008FBDBD /* ucdn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ucdn.c; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.c"; sourceTree = "<group>"; };
-		34F64BFD21FA5F66008FBDBD /* ucdn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ucdn.h; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.h"; sourceTree = "<group>"; };
 		34F64BFF21FA5F81008FBDBD /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -150,7 +157,6 @@
 		34F64BA021FA5F43008FBDBD /* src */ = {
 			isa = PBXGroup;
 			children = (
-				34F64BFB21FA5F54008FBDBD /* hb-ucdn */,
 				34F64BC121FA5F50008FBDBD /* hb-aat-layout.cc */,
 				34F64BAD21FA5F4F008FBDBD /* hb-aat-map.cc */,
 				34F64BA721FA5F4F008FBDBD /* hb-blob.cc */,
@@ -169,7 +175,6 @@
 				34F64BC021FA5F50008FBDBD /* hb-ot-layout.cc */,
 				34F64BCA21FA5F51008FBDBD /* hb-ot-map.cc */,
 				34F64BC621FA5F50008FBDBD /* hb-ot-math.cc */,
-				34F64BA521FA5F4F008FBDBD /* hb-ot-name-language.cc */,
 				34F64BCB21FA5F51008FBDBD /* hb-ot-name.cc */,
 				34F64BB621FA5F4F008FBDBD /* hb-ot-shape-complex-arabic.cc */,
 				34F64BC821FA5F50008FBDBD /* hb-ot-shape-complex-default.cc */,
@@ -193,20 +198,17 @@
 				34F64BB921FA5F50008FBDBD /* hb-shape.cc */,
 				34F64BBD21FA5F50008FBDBD /* hb-shaper.cc */,
 				34F64BC921FA5F51008FBDBD /* hb-static.cc */,
-				34F64BC321FA5F50008FBDBD /* hb-ucdn.cc */,
+				3460E10F22BD90090022F04C /* hb-subset-cff-common.cc */,
+				3460E11222BD90090022F04C /* hb-subset-cff1.cc */,
+				3460E11322BD90090022F04C /* hb-subset-cff2.cc */,
+				3460E10D22BD90080022F04C /* hb-subset-input.cc */,
+				3460E10E22BD90080022F04C /* hb-subset-plan.cc */,
+				3460E11022BD90090022F04C /* hb-subset.cc */,
+				3460E11122BD90090022F04C /* hb-ucd.cc */,
 				34F64BAF21FA5F4F008FBDBD /* hb-unicode.cc */,
 				34F64BB021FA5F4F008FBDBD /* hb-warning.cc */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		34F64BFB21FA5F54008FBDBD /* hb-ucdn */ = {
-			isa = PBXGroup;
-			children = (
-				34F64BFD21FA5F66008FBDBD /* ucdn.h */,
-				34F64BFC21FA5F66008FBDBD /* ucdn.c */,
-			);
-			name = "hb-ucdn";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -249,6 +251,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 341E97B31EB3CE10008E2876;
@@ -270,6 +273,7 @@
 				34F64BF521FA5F51008FBDBD /* hb-ot-shape-complex-default.cc in Sources */,
 				34F64BDF21FA5F51008FBDBD /* hb-ot-shape-complex-hangul.cc in Sources */,
 				34F64BF621FA5F51008FBDBD /* hb-static.cc in Sources */,
+				3460E11422BD90090022F04C /* hb-subset-input.cc in Sources */,
 				34F64BD121FA5F51008FBDBD /* hb-ot-color.cc in Sources */,
 				34F64BEB21FA5F51008FBDBD /* hb-ot-shape-complex-indic.cc in Sources */,
 				34F64BF321FA5F51008FBDBD /* hb-ot-math.cc in Sources */,
@@ -279,24 +283,26 @@
 				34F64BF421FA5F51008FBDBD /* hb-ot-tag.cc in Sources */,
 				34F64BD921FA5F51008FBDBD /* hb-ot-shape-complex-vowel-constraints.cc in Sources */,
 				34F64BF221FA5F51008FBDBD /* hb-shape-plan.cc in Sources */,
+				3460E11A22BD90090022F04C /* hb-subset-cff2.cc in Sources */,
+				3460E11522BD90090022F04C /* hb-subset-plan.cc in Sources */,
 				34F64BEE21FA5F51008FBDBD /* hb-aat-layout.cc in Sources */,
 				34F64BEF21FA5F51008FBDBD /* hb-ot-face.cc in Sources */,
 				34F64BED21FA5F51008FBDBD /* hb-ot-layout.cc in Sources */,
 				34F64BD521FA5F51008FBDBD /* hb-map.cc in Sources */,
 				34F64BE021FA5F51008FBDBD /* hb-ot-shape-fallback.cc in Sources */,
-				34F64BD221FA5F51008FBDBD /* hb-ot-name-language.cc in Sources */,
 				34F64BE321FA5F51008FBDBD /* hb-ot-shape-complex-arabic.cc in Sources */,
-				34F64BF021FA5F51008FBDBD /* hb-ucdn.cc in Sources */,
 				34F64BD421FA5F51008FBDBD /* hb-blob.cc in Sources */,
+				3460E11622BD90090022F04C /* hb-subset-cff-common.cc in Sources */,
 				34F64BE721FA5F51008FBDBD /* hb-ot-shape-complex-khmer.cc in Sources */,
 				34F64BDB21FA5F51008FBDBD /* hb-ot-shape-normalize.cc in Sources */,
 				34F64BD321FA5F51008FBDBD /* hb-ot-shape-complex-thai.cc in Sources */,
-				34F64BFE21FA5F66008FBDBD /* ucdn.c in Sources */,
 				34F64BE121FA5F51008FBDBD /* hb-ot-cff2-table.cc in Sources */,
 				34F64BDE21FA5F51008FBDBD /* hb-ot-shape-complex-myanmar.cc in Sources */,
 				34F64BDC21FA5F51008FBDBD /* hb-unicode.cc in Sources */,
 				34F64BE521FA5F51008FBDBD /* hb-ot-var.cc in Sources */,
 				34F64BD021FA5F51008FBDBD /* hb-ot-font.cc in Sources */,
+				3460E11722BD90090022F04C /* hb-subset.cc in Sources */,
+				3460E11822BD90090022F04C /* hb-ucd.cc in Sources */,
 				34F64BFA21FA5F51008FBDBD /* hb-font.cc in Sources */,
 				34F64BF121FA5F51008FBDBD /* hb-fallback-shape.cc in Sources */,
 				34F64BE621FA5F51008FBDBD /* hb-shape.cc in Sources */,
@@ -312,6 +318,7 @@
 				34F64BE821FA5F51008FBDBD /* hb-set.cc in Sources */,
 				34F64BF821FA5F51008FBDBD /* hb-ot-name.cc in Sources */,
 				34F64BF721FA5F51008FBDBD /* hb-ot-map.cc in Sources */,
+				3460E11922BD90090022F04C /* hb-subset-cff1.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -410,8 +417,8 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = ( 
-				    HAVE_CONFIG_H, 
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					HAVE_CONFIG_H,
 					NDEBUG,
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/native-builds/libHarfBuzzSharp_uwp/config.h
+++ b/native-builds/libHarfBuzzSharp_uwp/config.h
@@ -22,7 +22,7 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
 /* #undef HAVE_FONTCONFIG */
@@ -110,9 +110,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_uwp/config.h
+++ b/native-builds/libHarfBuzzSharp_uwp/config.h
@@ -139,7 +139,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -148,7 +148,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_uwp/libHarfBuzzSharp.vcxproj
+++ b/native-builds/libHarfBuzzSharp_uwp/libHarfBuzzSharp.vcxproj
@@ -46,7 +46,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-ltag-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-aat-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-map.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-algs.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-algs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-array.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-atomic.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-blob.cc" />
@@ -61,12 +61,12 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff1-interp-cs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff2-interp-cs.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-common.cc" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-config.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-config.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-debug.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-dispatch.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-face.hh" />
-	<ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
+    <ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-font.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-iter.hh" />
@@ -74,7 +74,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-machinery.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-map.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-meta.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-meta.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-mutex.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-null.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-object.hh" />
@@ -94,7 +94,7 @@
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-color.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face-table-list.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face-table-list.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-gasp-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-glyf-table.hh" />
@@ -162,9 +162,9 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-var-mvar-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-var.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-vorg-table.hh" />	
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-pool.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-sanitize.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-serialize.hh" />	
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-pool.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-sanitize.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-serialize.hh" />	
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set-digest.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-set.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set.hh" />
@@ -177,7 +177,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shaper.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-static.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-string-array.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ucd-table.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ucd-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucd.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode-emoji-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-unicode.cc" />
@@ -186,11 +186,11 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-vector.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-warning.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb.hh" />
-	<!--HB_BASE_RAGEL_GENERATED_sources-->
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-json.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-text.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-indic-machine.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-khmer-machine.hh" />
+    <!--HB_BASE_RAGEL_GENERATED_sources-->
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-json.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-text.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-indic-machine.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-khmer-machine.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-myanmar-machine.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-use-machine.hh" />
     <!--HB_BASE_headers-->
@@ -216,7 +216,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape-plan.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode.h" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb.h" />  
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/native-builds/libHarfBuzzSharp_uwp/libHarfBuzzSharp.vcxproj
+++ b/native-builds/libHarfBuzzSharp_uwp/libHarfBuzzSharp.vcxproj
@@ -29,16 +29,7 @@
    <ItemGroup>
     <ClInclude Include="config.h" />
   </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ucdn\ucdn.h" />
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucdn\ucdn.c" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ucdn\ucdn_db.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--HB_UCDN_sources-->
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucdn.cc" />
-  </ItemGroup>
-  <ItemGroup>
+   <ItemGroup>
     <!--HB_BASE_sources-->
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-fdsc-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-layout-ankr-table.hh" />
@@ -55,6 +46,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-ltag-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-aat-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-map.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-algs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-array.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-atomic.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-blob.cc" />
@@ -69,10 +61,12 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff1-interp-cs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff2-interp-cs.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-common.cc" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-config.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-debug.hh" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-dsalgs.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-dispatch.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-face.hh" />
+	<ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-font.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-iter.hh" />
@@ -80,6 +74,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-machinery.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-map.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-meta.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-mutex.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-null.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-object.hh" />
@@ -99,6 +94,7 @@
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-color.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face-table-list.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-gasp-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-glyf-table.hh" />
@@ -121,7 +117,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-math-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-math.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-maxp-table.hh" />
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-name-language.cc" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-name-language-static.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-name-language.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-name-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-name.cc" />
@@ -165,7 +161,10 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-var-hvar-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-var-mvar-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-var.cc" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-vorg-table.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-vorg-table.hh" />	
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-pool.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-sanitize.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-serialize.hh" />	
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set-digest.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-set.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set.hh" />
@@ -178,6 +177,8 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shaper.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-static.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-string-array.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ucd-table.hh" />
+    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucd.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode-emoji-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-unicode.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode.hh" />
@@ -185,6 +186,13 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-vector.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-warning.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb.hh" />
+	<!--HB_BASE_RAGEL_GENERATED_sources-->
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-json.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-text.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-indic-machine.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-khmer-machine.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-myanmar-machine.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-use-machine.hh" />
     <!--HB_BASE_headers-->
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-layout.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat.h" />
@@ -208,11 +216,8 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape-plan.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode.h" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb.h" />
-    <!--HB_NODIST_headers-->
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
-    <!--HB_FALLBACK_sources-->
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb.h" />  
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{25b54d3d-b0f8-4e7e-8928-ffaf116fcce9}</ProjectGuid>

--- a/native-builds/libHarfBuzzSharp_uwp/libHarfBuzzSharp.vcxproj
+++ b/native-builds/libHarfBuzzSharp_uwp/libHarfBuzzSharp.vcxproj
@@ -323,8 +323,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <PrecompiledHeaderFile />
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4267;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -338,8 +338,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <PrecompiledHeaderFile />
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4267;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -353,8 +353,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <PrecompiledHeaderFile />
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4267;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -368,8 +368,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <PrecompiledHeaderFile />
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4267;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -383,8 +383,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <PrecompiledHeaderFile />
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4267;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -398,8 +398,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <PrecompiledHeaderFile />
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4267;4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>

--- a/native-builds/libHarfBuzzSharp_watchos/config.h
+++ b/native-builds/libHarfBuzzSharp_watchos/config.h
@@ -24,13 +24,13 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+/* #undef HAVE_DLFCN_H */
 
 /* Define to 1 if you have the <dwrite.h> header file. */
 /* #undef HAVE_DWRITE_H */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
 /* #undef HAVE_FONTCONFIG */
@@ -136,9 +136,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_watchos/config.h
+++ b/native-builds/libHarfBuzzSharp_watchos/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -174,7 +174,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_watchos/libHarfBuzzSharp.xcodeproj/project.pbxproj
+++ b/native-builds/libHarfBuzzSharp_watchos/libHarfBuzzSharp.xcodeproj/project.pbxproj
@@ -7,12 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		34F64C0321FA5FB4008FBDBD /* ucdn.c in Sources */ = {isa = PBXBuildFile; fileRef = 34F64C0221FA5FB4008FBDBD /* ucdn.c */; };
 		34F64D3C21FA6048008FBDBD /* hb-ot-cff1-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D0F21FA6047008FBDBD /* hb-ot-cff1-table.cc */; };
 		34F64D3D21FA6048008FBDBD /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1021FA6047008FBDBD /* hb-ot-shape-complex-indic-table.cc */; };
 		34F64D3E21FA6048008FBDBD /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1121FA6047008FBDBD /* hb-ot-font.cc */; };
 		34F64D3F21FA6048008FBDBD /* hb-ot-color.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1221FA6047008FBDBD /* hb-ot-color.cc */; };
-		34F64D4021FA6048008FBDBD /* hb-ot-name-language.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1321FA6047008FBDBD /* hb-ot-name-language.cc */; };
 		34F64D4121FA6048008FBDBD /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1421FA6047008FBDBD /* hb-ot-shape-complex-thai.cc */; };
 		34F64D4221FA6048008FBDBD /* hb-blob.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1521FA6047008FBDBD /* hb-blob.cc */; };
 		34F64D4321FA6048008FBDBD /* hb-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D1621FA6047008FBDBD /* hb-map.cc */; };
@@ -42,7 +40,6 @@
 		34F64D5B21FA6048008FBDBD /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D2E21FA6048008FBDBD /* hb-ot-layout.cc */; };
 		34F64D5C21FA6048008FBDBD /* hb-aat-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D2F21FA6048008FBDBD /* hb-aat-layout.cc */; };
 		34F64D5D21FA6048008FBDBD /* hb-ot-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3021FA6048008FBDBD /* hb-ot-face.cc */; };
-		34F64D5E21FA6048008FBDBD /* hb-ucdn.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3121FA6048008FBDBD /* hb-ucdn.cc */; };
 		34F64D5F21FA6048008FBDBD /* hb-fallback-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3221FA6048008FBDBD /* hb-fallback-shape.cc */; };
 		34F64D6021FA6048008FBDBD /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3321FA6048008FBDBD /* hb-shape-plan.cc */; };
 		34F64D6121FA6048008FBDBD /* hb-ot-math.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3421FA6048008FBDBD /* hb-ot-math.cc */; };
@@ -53,6 +50,13 @@
 		34F64D6621FA6048008FBDBD /* hb-ot-name.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3921FA6048008FBDBD /* hb-ot-name.cc */; };
 		34F64D6721FA6048008FBDBD /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3A21FA6048008FBDBD /* hb-buffer.cc */; };
 		34F64D6821FA6048008FBDBD /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34F64D3B21FA6048008FBDBD /* hb-font.cc */; };
+		34FEAAFC22BD8FAC007299F0 /* hb-subset.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAF522BD8FAB007299F0 /* hb-subset.cc */; };
+		34FEAAFD22BD8FAC007299F0 /* hb-subset-input.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAF622BD8FAB007299F0 /* hb-subset-input.cc */; };
+		34FEAAFE22BD8FAC007299F0 /* hb-subset-cff1.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAF722BD8FAC007299F0 /* hb-subset-cff1.cc */; };
+		34FEAAFF22BD8FAC007299F0 /* hb-ucd.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAF822BD8FAC007299F0 /* hb-ucd.cc */; };
+		34FEAB0022BD8FAC007299F0 /* hb-subset-cff-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAF922BD8FAC007299F0 /* hb-subset-cff-common.cc */; };
+		34FEAB0122BD8FAC007299F0 /* hb-subset-cff2.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAFA22BD8FAC007299F0 /* hb-subset-cff2.cc */; };
+		34FEAB0222BD8FAC007299F0 /* hb-subset-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = 34FEAAFB22BD8FAC007299F0 /* hb-subset-plan.cc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -69,14 +73,11 @@
 
 /* Begin PBXFileReference section */
 		341E97BC1EB3CE10008E2876 /* libHarfBuzzSharp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHarfBuzzSharp.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		34F64C0221FA5FB4008FBDBD /* ucdn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ucdn.c; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.c"; sourceTree = "<group>"; };
-		34F64C0421FA5FB9008FBDBD /* ucdn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ucdn.h; path = "../../externals/harfbuzz/src/hb-ucdn/ucdn.h"; sourceTree = "<group>"; };
 		34F64C0521FA5FC6008FBDBD /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		34F64D0F21FA6047008FBDBD /* hb-ot-cff1-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-cff1-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-cff1-table.cc"; sourceTree = "<group>"; };
 		34F64D1021FA6047008FBDBD /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
 		34F64D1121FA6047008FBDBD /* hb-ot-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-font.cc"; path = "../../externals/harfbuzz/src/hb-ot-font.cc"; sourceTree = "<group>"; };
 		34F64D1221FA6047008FBDBD /* hb-ot-color.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-color.cc"; path = "../../externals/harfbuzz/src/hb-ot-color.cc"; sourceTree = "<group>"; };
-		34F64D1321FA6047008FBDBD /* hb-ot-name-language.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name-language.cc"; path = "../../externals/harfbuzz/src/hb-ot-name-language.cc"; sourceTree = "<group>"; };
 		34F64D1421FA6047008FBDBD /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-thai.cc"; path = "../../externals/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = "<group>"; };
 		34F64D1521FA6047008FBDBD /* hb-blob.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-blob.cc"; path = "../../externals/harfbuzz/src/hb-blob.cc"; sourceTree = "<group>"; };
 		34F64D1621FA6047008FBDBD /* hb-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-map.cc"; path = "../../externals/harfbuzz/src/hb-map.cc"; sourceTree = "<group>"; };
@@ -106,7 +107,6 @@
 		34F64D2E21FA6048008FBDBD /* hb-ot-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-layout.cc"; path = "../../externals/harfbuzz/src/hb-ot-layout.cc"; sourceTree = "<group>"; };
 		34F64D2F21FA6048008FBDBD /* hb-aat-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-aat-layout.cc"; path = "../../externals/harfbuzz/src/hb-aat-layout.cc"; sourceTree = "<group>"; };
 		34F64D3021FA6048008FBDBD /* hb-ot-face.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-face.cc"; path = "../../externals/harfbuzz/src/hb-ot-face.cc"; sourceTree = "<group>"; };
-		34F64D3121FA6048008FBDBD /* hb-ucdn.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucdn.cc"; path = "../../externals/harfbuzz/src/hb-ucdn.cc"; sourceTree = "<group>"; };
 		34F64D3221FA6048008FBDBD /* hb-fallback-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-fallback-shape.cc"; path = "../../externals/harfbuzz/src/hb-fallback-shape.cc"; sourceTree = "<group>"; };
 		34F64D3321FA6048008FBDBD /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "../../externals/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
 		34F64D3421FA6048008FBDBD /* hb-ot-math.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-math.cc"; path = "../../externals/harfbuzz/src/hb-ot-math.cc"; sourceTree = "<group>"; };
@@ -117,6 +117,13 @@
 		34F64D3921FA6048008FBDBD /* hb-ot-name.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-name.cc"; path = "../../externals/harfbuzz/src/hb-ot-name.cc"; sourceTree = "<group>"; };
 		34F64D3A21FA6048008FBDBD /* hb-buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer.cc"; path = "../../externals/harfbuzz/src/hb-buffer.cc"; sourceTree = "<group>"; };
 		34F64D3B21FA6048008FBDBD /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "../../externals/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
+		34FEAAF522BD8FAB007299F0 /* hb-subset.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset.cc"; path = "../../externals/harfbuzz/src/hb-subset.cc"; sourceTree = "<group>"; };
+		34FEAAF622BD8FAB007299F0 /* hb-subset-input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-input.cc"; path = "../../externals/harfbuzz/src/hb-subset-input.cc"; sourceTree = "<group>"; };
+		34FEAAF722BD8FAC007299F0 /* hb-subset-cff1.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff1.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff1.cc"; sourceTree = "<group>"; };
+		34FEAAF822BD8FAC007299F0 /* hb-ucd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucd.cc"; path = "../../externals/harfbuzz/src/hb-ucd.cc"; sourceTree = "<group>"; };
+		34FEAAF922BD8FAC007299F0 /* hb-subset-cff-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff-common.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff-common.cc"; sourceTree = "<group>"; };
+		34FEAAFA22BD8FAC007299F0 /* hb-subset-cff2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-cff2.cc"; path = "../../externals/harfbuzz/src/hb-subset-cff2.cc"; sourceTree = "<group>"; };
+		34FEAAFB22BD8FAC007299F0 /* hb-subset-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-subset-plan.cc"; path = "../../externals/harfbuzz/src/hb-subset-plan.cc"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,7 +157,6 @@
 		34F64C0021FA5FA1008FBDBD /* src */ = {
 			isa = PBXGroup;
 			children = (
-				34F64C0121FA5FA6008FBDBD /* hb-ucdn */,
 				34F64D2F21FA6048008FBDBD /* hb-aat-layout.cc */,
 				34F64D1B21FA6047008FBDBD /* hb-aat-map.cc */,
 				34F64D1521FA6047008FBDBD /* hb-blob.cc */,
@@ -169,7 +175,6 @@
 				34F64D2E21FA6048008FBDBD /* hb-ot-layout.cc */,
 				34F64D3821FA6048008FBDBD /* hb-ot-map.cc */,
 				34F64D3421FA6048008FBDBD /* hb-ot-math.cc */,
-				34F64D1321FA6047008FBDBD /* hb-ot-name-language.cc */,
 				34F64D3921FA6048008FBDBD /* hb-ot-name.cc */,
 				34F64D2421FA6047008FBDBD /* hb-ot-shape-complex-arabic.cc */,
 				34F64D3621FA6048008FBDBD /* hb-ot-shape-complex-default.cc */,
@@ -193,20 +198,17 @@
 				34F64D2721FA6047008FBDBD /* hb-shape.cc */,
 				34F64D2B21FA6048008FBDBD /* hb-shaper.cc */,
 				34F64D3721FA6048008FBDBD /* hb-static.cc */,
-				34F64D3121FA6048008FBDBD /* hb-ucdn.cc */,
+				34FEAAF922BD8FAC007299F0 /* hb-subset-cff-common.cc */,
+				34FEAAF722BD8FAC007299F0 /* hb-subset-cff1.cc */,
+				34FEAAFA22BD8FAC007299F0 /* hb-subset-cff2.cc */,
+				34FEAAF622BD8FAB007299F0 /* hb-subset-input.cc */,
+				34FEAAFB22BD8FAC007299F0 /* hb-subset-plan.cc */,
+				34FEAAF522BD8FAB007299F0 /* hb-subset.cc */,
+				34FEAAF822BD8FAC007299F0 /* hb-ucd.cc */,
 				34F64D1D21FA6047008FBDBD /* hb-unicode.cc */,
 				34F64D1E21FA6047008FBDBD /* hb-warning.cc */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		34F64C0121FA5FA6008FBDBD /* hb-ucdn */ = {
-			isa = PBXGroup;
-			children = (
-				34F64C0421FA5FB9008FBDBD /* ucdn.h */,
-				34F64C0221FA5FB4008FBDBD /* ucdn.c */,
-			);
-			name = "hb-ucdn";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -249,6 +251,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 341E97B31EB3CE10008E2876;
@@ -271,14 +274,12 @@
 				34F64D6721FA6048008FBDBD /* hb-buffer.cc in Sources */,
 				34F64D5121FA6048008FBDBD /* hb-ot-shape-complex-arabic.cc in Sources */,
 				34F64D6221FA6048008FBDBD /* hb-ot-tag.cc in Sources */,
+				34FEAB0222BD8FAC007299F0 /* hb-subset-plan.cc in Sources */,
 				34F64D4F21FA6048008FBDBD /* hb-ot-cff2-table.cc in Sources */,
-				34F64C0321FA5FB4008FBDBD /* ucdn.c in Sources */,
 				34F64D5321FA6048008FBDBD /* hb-ot-var.cc in Sources */,
 				34F64D3F21FA6048008FBDBD /* hb-ot-color.cc in Sources */,
-				34F64D5E21FA6048008FBDBD /* hb-ucdn.cc in Sources */,
 				34F64D6621FA6048008FBDBD /* hb-ot-name.cc in Sources */,
 				34F64D3C21FA6048008FBDBD /* hb-ot-cff1-table.cc in Sources */,
-				34F64D4021FA6048008FBDBD /* hb-ot-name-language.cc in Sources */,
 				34F64D4221FA6048008FBDBD /* hb-blob.cc in Sources */,
 				34F64D4121FA6048008FBDBD /* hb-ot-shape-complex-thai.cc in Sources */,
 				34F64D3D21FA6048008FBDBD /* hb-ot-shape-complex-indic-table.cc in Sources */,
@@ -286,6 +287,7 @@
 				34F64D4621FA6048008FBDBD /* hb-buffer-serialize.cc in Sources */,
 				34F64D4921FA6048008FBDBD /* hb-ot-shape-normalize.cc in Sources */,
 				34F64D3E21FA6048008FBDBD /* hb-ot-font.cc in Sources */,
+				34FEAB0122BD8FAC007299F0 /* hb-subset-cff2.cc in Sources */,
 				34F64D4B21FA6048008FBDBD /* hb-warning.cc in Sources */,
 				34F64D5621FA6048008FBDBD /* hb-set.cc in Sources */,
 				34F64D4321FA6048008FBDBD /* hb-map.cc in Sources */,
@@ -297,11 +299,15 @@
 				34F64D5B21FA6048008FBDBD /* hb-ot-layout.cc in Sources */,
 				34F64D4E21FA6048008FBDBD /* hb-ot-shape-fallback.cc in Sources */,
 				34F64D6021FA6048008FBDBD /* hb-shape-plan.cc in Sources */,
+				34FEAAFC22BD8FAC007299F0 /* hb-subset.cc in Sources */,
+				34FEAAFD22BD8FAC007299F0 /* hb-subset-input.cc in Sources */,
 				34F64D5521FA6048008FBDBD /* hb-ot-shape-complex-khmer.cc in Sources */,
+				34FEAB0022BD8FAC007299F0 /* hb-subset-cff-common.cc in Sources */,
 				34F64D5C21FA6048008FBDBD /* hb-aat-layout.cc in Sources */,
 				34F64D5421FA6048008FBDBD /* hb-shape.cc in Sources */,
 				34F64D6521FA6048008FBDBD /* hb-ot-map.cc in Sources */,
 				34F64D5721FA6048008FBDBD /* hb-face.cc in Sources */,
+				34FEAAFF22BD8FAC007299F0 /* hb-ucd.cc in Sources */,
 				34F64D5021FA6048008FBDBD /* hb-ot-shape-complex-hebrew.cc in Sources */,
 				34F64D4821FA6048008FBDBD /* hb-aat-map.cc in Sources */,
 				34F64D5921FA6048008FBDBD /* hb-ot-shape-complex-indic.cc in Sources */,
@@ -312,6 +318,7 @@
 				34F64D6121FA6048008FBDBD /* hb-ot-math.cc in Sources */,
 				34F64D6821FA6048008FBDBD /* hb-font.cc in Sources */,
 				34F64D5D21FA6048008FBDBD /* hb-ot-face.cc in Sources */,
+				34FEAAFE22BD8FAC007299F0 /* hb-subset-cff1.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -413,8 +420,8 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = ( 
-				    HAVE_CONFIG_H, 
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					HAVE_CONFIG_H,
 					NDEBUG,
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/native-builds/libHarfBuzzSharp_windows/config.h
+++ b/native-builds/libHarfBuzzSharp_windows/config.h
@@ -22,7 +22,7 @@
 /* #undef HAVE_DIRECTWRITE */
 
 /* Have simple TrueType Layout backend */
-#define HAVE_FALLBACK 1
+/* #undef HAVE_FALLBACK */
 
 /* Have fontconfig library */
 /* #undef HAVE_FONTCONFIG */
@@ -110,9 +110,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Have UCDN Unicode functions */
-#define HAVE_UCDN 1
 
 /* Have Uniscribe library */
 /* #undef HAVE_UNISCRIBE */

--- a/native-builds/libHarfBuzzSharp_windows/config.h
+++ b/native-builds/libHarfBuzzSharp_windows/config.h
@@ -139,7 +139,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.3.1"
+#define PACKAGE_STRING "HarfBuzz 2.5.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -148,7 +148,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.3.1"
+#define PACKAGE_VERSION "2.5.2"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */

--- a/native-builds/libHarfBuzzSharp_windows/libHarfBuzzSharp.vcxproj
+++ b/native-builds/libHarfBuzzSharp_windows/libHarfBuzzSharp.vcxproj
@@ -285,8 +285,8 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ObjectFileName>$(IntDir)</ObjectFileName>
@@ -301,8 +301,8 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_DEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_DEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -318,8 +318,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
@@ -337,8 +337,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HAVE_UCDN=1;HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\externals\harfbuzz\src\hb-ucdn;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;HB_EXTERN=__declspec (dllexport) extern;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;HARFBUZZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>

--- a/native-builds/libHarfBuzzSharp_windows/libHarfBuzzSharp.vcxproj
+++ b/native-builds/libHarfBuzzSharp_windows/libHarfBuzzSharp.vcxproj
@@ -22,15 +22,6 @@
     <ClInclude Include="config.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ucdn\ucdn.h" />
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucdn\ucdn.c" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ucdn\ucdn_db.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--HB_UCDN_sources-->
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucdn.cc" />
-  </ItemGroup>
-  <ItemGroup>
     <!--HB_BASE_sources-->
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-fdsc-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-layout-ankr-table.hh" />
@@ -47,6 +38,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-ltag-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-aat-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-map.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-algs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-array.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-atomic.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-blob.cc" />
@@ -61,10 +53,12 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff1-interp-cs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff2-interp-cs.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-common.cc" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-config.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-debug.hh" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-dsalgs.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-dispatch.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-face.hh" />
+	<ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-font.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-iter.hh" />
@@ -72,6 +66,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-machinery.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-map.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-meta.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-mutex.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-null.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-object.hh" />
@@ -91,6 +86,7 @@
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-color.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face-table-list.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-gasp-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-glyf-table.hh" />
@@ -113,7 +109,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-math-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-math.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-maxp-table.hh" />
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-name-language.cc" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-name-language-static.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-name-language.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-name-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-name.cc" />
@@ -157,7 +153,10 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-var-hvar-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-var-mvar-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-var.cc" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-vorg-table.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-vorg-table.hh" />	
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-pool.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-sanitize.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-serialize.hh" />	
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set-digest.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-set.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set.hh" />
@@ -170,6 +169,8 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shaper.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-static.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-string-array.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ucd-table.hh" />
+    <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucd.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode-emoji-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-unicode.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode.hh" />
@@ -177,6 +178,13 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-vector.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-warning.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb.hh" />
+	<!--HB_BASE_RAGEL_GENERATED_sources-->
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-json.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-text.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-indic-machine.hh" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-khmer-machine.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-myanmar-machine.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-use-machine.hh" />
     <!--HB_BASE_headers-->
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-layout.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat.h" />
@@ -200,11 +208,8 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape-plan.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode.h" />
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb.h" />
-    <!--HB_NODIST_headers-->
-    <ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
-    <!--HB_FALLBACK_sources-->
-    <ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
+	<ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb.h" />  
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/native-builds/libHarfBuzzSharp_windows/libHarfBuzzSharp.vcxproj
+++ b/native-builds/libHarfBuzzSharp_windows/libHarfBuzzSharp.vcxproj
@@ -38,7 +38,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-ltag-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-aat-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-aat-map.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-algs.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-algs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-array.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-atomic.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-blob.cc" />
@@ -53,12 +53,12 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff1-interp-cs.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-cff2-interp-cs.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-common.cc" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-config.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-config.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-debug.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-dispatch.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-face.hh" />
-	<ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
+    <ClCompile Include="..\..\externals\harfbuzz\src\hb-fallback-shape.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-font.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-iter.hh" />
@@ -66,7 +66,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-machinery.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-map.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-map.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-meta.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-meta.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-mutex.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-null.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-object.hh" />
@@ -86,7 +86,7 @@
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-color.cc" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-face.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face-table-list.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-face-table-list.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-font.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-gasp-table.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-glyf-table.hh" />
@@ -154,9 +154,9 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-var-mvar-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ot-var.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-vorg-table.hh" />	
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-pool.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-sanitize.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-serialize.hh" />	
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-pool.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-sanitize.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-serialize.hh" />	
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set-digest.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-set.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-set.hh" />
@@ -169,7 +169,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shaper.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-static.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-string-array.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ucd-table.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ucd-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-ucd.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode-emoji-table.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-unicode.cc" />
@@ -178,11 +178,11 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-vector.hh" />
     <ClCompile Include="..\..\externals\harfbuzz\src\hb-warning.cc" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb.hh" />
-	<!--HB_BASE_RAGEL_GENERATED_sources-->
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-json.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-text.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-indic-machine.hh" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-khmer-machine.hh" />
+    <!--HB_BASE_RAGEL_GENERATED_sources-->
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-json.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-buffer-deserialize-text.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-indic-machine.hh" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-khmer-machine.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-myanmar-machine.hh" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-ot-shape-complex-use-machine.hh" />
     <!--HB_BASE_headers-->
@@ -208,7 +208,7 @@
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape-plan.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-shape.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb-unicode.h" />
-	<ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
+    <ClInclude Include="..\..\externals\harfbuzz\src\hb-version.h" />
     <ClInclude Include="..\..\externals\harfbuzz\src\hb.h" />  
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/samples/Gallery/Shared/SamplesManager.cs
+++ b/samples/Gallery/Shared/SamplesManager.cs
@@ -19,7 +19,14 @@ namespace SkiaSharpSample
 				.Where(t => samplesBase.IsAssignableFrom(t) && !t.IsAbstract)
 				.Select(t => (SampleBase)Activator.CreateInstance(t.AsType()))
 				.ToArray();
+
+			SkiaSharpVersion = GetAssemblyVersion<SkiaSharp.SKSurface>();
+			HarfBuzzSharpVersion = GetAssemblyVersion<HarfBuzzSharp.Blob>();
 		}
+
+		public static string SkiaSharpVersion { get; }
+
+		public static string HarfBuzzSharpVersion { get; }
 
 		public static string TempDataPath { get; set; }
 
@@ -57,6 +64,14 @@ namespace SkiaSharpSample
 		public static SampleBase GetSample(string title)
 		{
 			return sampleList.Where(s => s.Title == title).FirstOrDefault();
+		}
+
+		private static string GetAssemblyVersion<T>()
+		{
+			var apiAssembly = typeof(T).Assembly;
+			var attributes = apiAssembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute));
+			var attribute = (AssemblyInformationalVersionAttribute)attributes.FirstOrDefault();
+			return attribute.InformationalVersion;
 		}
 	}
 }

--- a/samples/Gallery/Xamarin.Forms/Core/DetailContentsPage.xaml.cs
+++ b/samples/Gallery/Xamarin.Forms/Core/DetailContentsPage.xaml.cs
@@ -10,10 +10,17 @@ namespace SkiaSharpSample
 	{
 		private SampleBase sample;
 		//private SKImage lastImage;
+		private SKPaint textPaint;
 
 		public DetailContentsPage(SampleBase showcase)
 		{
 			InitializeComponent();
+
+			textPaint = new SKPaint
+			{
+				TextSize = 16,
+				IsAntialias = true
+			};
 
 			Sample = showcase;
 			BindingContext = this;
@@ -120,7 +127,7 @@ namespace SkiaSharpSample
 			//lastImage = e.Surface.Snapshot();
 
 			var view = sender as SKCanvasView;
-			DrawScaling(view, e.Surface.Canvas, view.CanvasSize);
+			DrawOverlayText(view, e.Surface.Canvas, view.CanvasSize);
 		}
 
 		private void OnPaintGLSample(object sender, SKPaintGLSurfaceEventArgs e)
@@ -131,27 +138,33 @@ namespace SkiaSharpSample
 			//lastImage = e.Surface.Snapshot();
 
 			var view = sender as SKGLView;
-			DrawScaling(view, e.Surface.Canvas, view.CanvasSize);
+			DrawOverlayText(view, e.Surface.Canvas, view.CanvasSize);
 		}
 
-		private void DrawScaling(View view, SKCanvas canvas, SKSize canvasSize)
+		private void DrawOverlayText(View view, SKCanvas canvas, SKSize canvasSize)
 		{
 			// make sure no previous transforms still apply
 			canvas.ResetMatrix();
 
-			// get the current scale
+			// get and apply the current scale
 			var scale = canvasSize.Width / (float)view.Width;
+			canvas.Scale(scale);
 
-			// write the scale into the bottom left
-			using (var paint = new SKPaint())
-			{
-				paint.IsAntialias = true;
-				paint.TextSize = 20 * scale;
+			var padding = 8;
+			var y = (float)view.Height - padding;
 
-				var text = $"Current scaling = {scale:0.0}x";
-				var padding = 10 * scale;
-				canvas.DrawText(text, padding, canvasSize.Height - padding, paint);
-			}
+			var text = $"Current scaling = {scale:0.0}x";
+			canvas.DrawText(text, padding, y, textPaint);
+
+			y -= textPaint.TextSize + padding;
+
+			text = "SkiaSharp: " + SamplesManager.SkiaSharpVersion;
+			canvas.DrawText(text, padding, y, textPaint);
+
+			y -= textPaint.TextSize + padding;
+
+			text = "HarfBuzzSharp: " + SamplesManager.HarfBuzzSharpVersion;
+			canvas.DrawText(text, padding, y, textPaint);
 		}
 
 		private void OnRefreshRequested(object sender, EventArgs e)

--- a/tests/SkiaSharp.NetCore.Tests/SkiaSharp.NetCore.Tests.csproj
+++ b/tests/SkiaSharp.NetCore.Tests/SkiaSharp.NetCore.Tests.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="xunit.categories" Version="2.0.4" />
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.1" />
-    <PackageReference Include="HarfBuzzSharp" Version="2.3.1" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.3.1" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.5.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.5.2" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="1.68.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Windows [x] 
- Linux [x] 
- Tizen [x] 
- Android [x] 
- Mac [x] 

On Linux the compiler seems to have issues. Can we use clang to build HarfBuzz?
@mattleibow