### PR TITLE
Publicly publish all the native artifacts

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -212,11 +212,11 @@ jobs:
             $nupkgs | Foreach-Object { Write-Host $_.Name }
             $nupkgs | ForEach-Object { Remove-Item -Path $_ -Recurse -Force }
           displayName: Remove all unrelated files
-        - task: PublishPipelineArtifact@0
+        - task: PublishBuildArtifacts@1
           displayName: Publish the native-default artifacts
           inputs:
             artifactName: native-default
-            targetPath: 'output/native'
+            pathToPublish: 'output/native'
         - task: PublishPipelineArtifact@0
           displayName: Publish the nuget-default artifacts
           inputs:


### PR DESCRIPTION
**Description of Change**

`PublishPipelineArtifact` does not allow for anonymous access, so use `PublishBuildArtifacts` instead to make `native-default` public.
