### PR TITLE
Remove the concept of "user data"

### DIFF
--- a/binding/Binding.Shared/DelegateProxies.shared.cs
+++ b/binding/Binding.Shared/DelegateProxies.shared.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/binding/HarfBuzzSharp.Shared/Blob.cs
+++ b/binding/HarfBuzzSharp.Shared/Blob.cs
@@ -26,7 +26,7 @@ namespace HarfBuzzSharp
 		}
 
 		public Blob (IntPtr data, int length, MemoryMode mode, ReleaseDelegate releaseDelegate)
-			: this (Create (data, length, mode, new ReleaseDelegate (releaseDelegate)))
+			: this (Create (data, length, mode, releaseDelegate))
 		{
 		}
 

--- a/binding/HarfBuzzSharp.Shared/Face.cs
+++ b/binding/HarfBuzzSharp.Shared/Face.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace HarfBuzzSharp
 {
@@ -29,22 +28,17 @@ namespace HarfBuzzSharp
 		}
 
 		public Face (GetTableDelegate getTable)
-			: this (getTable, null, null)
+			: this (getTable, null)
 		{
 		}
 
-		public Face (GetTableDelegate getTable, object context)
-			: this (getTable, context, null)
-		{
-		}
-
-		public Face (GetTableDelegate getTable, object context, ReleaseDelegate destroy)
+		public Face (GetTableDelegate getTable, ReleaseDelegate destroy)
 			: this (IntPtr.Zero)
 		{
 			if (getTable == null)
 				throw new ArgumentNullException (nameof (getTable));
 
-			var ctx = DelegateProxies.CreateMulti<GetTableDelegate> ((_, t, __) => getTable.Invoke (this, t, context), context, destroy);
+			var ctx = DelegateProxies.CreateMulti<GetTableDelegate> ((_, t) => getTable.Invoke (this, t), destroy);
 			Handle = HarfBuzzApi.hb_face_create_for_tables (DelegateProxies.GetTableDelegateProxy, ctx, DelegateProxies.ReleaseDelegateProxyForMulti);
 		}
 

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/BlobExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/BlobExtensions.cs
@@ -21,13 +21,13 @@ namespace SkiaSharp.HarfBuzz
 			var memoryBase = asset.GetMemoryBase();
 			if (memoryBase != IntPtr.Zero)
 			{
-				blob = new Blob(memoryBase, size, MemoryMode.ReadOnly, asset, p => ((SKStreamAsset)p).Dispose());
+				blob = new Blob(memoryBase, size, MemoryMode.ReadOnly, () => asset.Dispose());
 			}
 			else
 			{
 				var ptr = Marshal.AllocCoTaskMem(size);
 				asset.Read(ptr, size);
-				blob = new Blob(ptr, size, MemoryMode.ReadOnly, ptr, p => Marshal.FreeCoTaskMem((IntPtr)p));
+				blob = new Blob(ptr, size, MemoryMode.ReadOnly, () => Marshal.FreeCoTaskMem(ptr));
 			}
 
 			blob.MakeImmutable();

--- a/tests/Tests/HBFaceTest.cs
+++ b/tests/Tests/HBFaceTest.cs
@@ -68,7 +68,7 @@ namespace HarfBuzzSharp.Tests
 		{
 			var tag = new Tag("kern");
 
-			using (var face = new Face((f, t, u) => Face.ReferenceTable(t)))
+			using (var face = new Face((f, t) => Face.ReferenceTable(t)))
 			{
 				var blob = face.ReferenceTable(tag);
 
@@ -86,19 +86,15 @@ namespace HarfBuzzSharp.Tests
 
 			Face face = null;
 			face = new Face(
-				(f, t, u) =>
+				(f, t) =>
 				{
-					Assert.Equal("User Data", u);
 					Assert.Equal(face, f);
 
 					didReference++;
 					return Face.ReferenceTable(t);
 				},
-				"User Data",
-				u =>
+				() =>
 				{
-					Assert.Equal("User Data", u);
-
 					didDestroy++;
 				});
 

--- a/tests/Tests/SKShaperTest.cs
+++ b/tests/Tests/SKShaperTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using HarfBuzzSharp;
@@ -81,7 +80,7 @@ namespace SkiaSharp.HarfBuzz.Tests
 			var clusters = new uint[] { 4, 2, 0 };
 			var codepoints = new uint[] { 629, 668, 891 };
 
-			using (var face = new Face(GetFaceBlob, skiaTypeface, ctx => ((SKTypeface)ctx).Dispose()))
+			using (var face = new Face(GetFaceBlob, () => skiaTypeface.Dispose()))
 			using (var font = new Font(face))
 			using (var buffer = new HarfBuzzSharp.Buffer())
 			{
@@ -94,12 +93,12 @@ namespace SkiaSharp.HarfBuzz.Tests
 				Assert.Equal(codepoints, buffer.GlyphInfos.Select(i => i.Codepoint));
 			}
 
-			Blob GetFaceBlob(Face face, Tag tag, object context)
+			Blob GetFaceBlob(Face face, Tag tag)
 			{
 				var size = skiaTypeface.GetTableSize(tag);
 				var data = Marshal.AllocCoTaskMem(size);
 				skiaTypeface.TryGetTableData(tag, 0, size, data);
-				return new Blob(data, size, MemoryMode.Writeable, data, ctx => Marshal.FreeCoTaskMem((IntPtr)ctx));
+				return new Blob(data, size, MemoryMode.Writeable, () => Marshal.FreeCoTaskMem(data));
 			}
 		}
 	}


### PR DESCRIPTION
**Description of Change**

Remove the concept of "user data" from the delegates.

 - User data is not really useful to C# and delegates because they can capture the data directly. This is more of a C/C++ thing.
 - User data adds complexity and overhead because new delegates have to be constructed to wrap the context.
