### PR TITLE
Change native artifact name to match Azure Build.

### DIFF
--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -699,13 +699,17 @@ Task ("externals-download")
     if (string.IsNullOrEmpty (AZURE_BUILD_ID))
         throw new Exception ("Specify a build ID with --azureBuildId=<ID>");
 
-    var url = string.Format(AZURE_BUILD_URL, AZURE_BUILD_ID, "native");
+    var artifactName = "native-default";
+    var artifactFilename = $"{artifactName}.zip";
+    var url = string.Format(AZURE_BUILD_URL, AZURE_BUILD_ID, artifactName);
 
-    EnsureDirectoryExists ("./output");
-    CleanDirectories ("./output");
+    var outputPath = "./output";
+    EnsureDirectoryExists (outputPath);
+    CleanDirectories (outputPath);
 
-    DownloadFile(url, "./output/native.zip");
-    Unzip ($"./output/native.zip", $"./output");
+    DownloadFile (url, $"{outputPath}/{artifactFilename}");
+    Unzip ($"{outputPath}/{artifactFilename}", outputPath);
+    MoveDirectory ($"{outputPath}/{artifactName}", $"{outputPath}/native");
 });
 
 Task ("externals-angle-uwp")


### PR DESCRIPTION
**Description of Change**

Changes the artifact name for the externals-download target from "native" to "native-default" to match the Azure Build.
This allows the [Build Preparation instructions](https://github.com/mono/SkiaSharp/wiki/Building-SkiaSharp#preparation-1) to work as documented instead of returning a 404 error.

**Bugs Fixed**

- Related to issue #889, #883 
- Fixes #883

**Changes**

Changes the artifact name from "native" to "native-default" to match the Azure Build Pipeline.
Also some minor refactoring of local string constants for the output path.

**Behavioral Changes**

Since the unzipped folder is named "native-default", it is renamed back to "native" so the rest of the build scripts can still work.

**PR Checklist**

- [ NA ] Has tests (if omitted, state reason in description)
- [ Y ] Rebased on top of master at time of PR
- [ Y ] Changes adhere to coding standard
- [ NA ] Updated documentation
