### PR TITLE
Add the libSkiaSharp.dylib to the app bundle when using the full framework

### DIFF
--- a/binding/HarfBuzzSharp.Desktop/nuget/build/net45/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.Desktop/nuget/build/net45/HarfBuzzSharp.targets
@@ -44,6 +44,14 @@
         </None>
     </ItemGroup>
 
+    <!-- handle the case where this is a Xamarin.Mac Full app/extension -->
+    <ItemGroup Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' != 'False' and '$(XamarinMacFrameworkRoot)' != '' and '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' and '$(UseXamMacFullFramework)' == 'true' and ('$(OutputType)' == 'Exe' or '$(IsAppExtension)' == 'true') ">
+        <NativeReference Include="$(PreferredOSXNativeHarfBuzzSharpPath)" Condition=" Exists('$(PreferredOSXNativeHarfBuzzSharpPath)') ">
+            <Link>$([System.IO.Path]::GetFilename('$(PreferredOSXNativeHarfBuzzSharpPath)'))</Link>
+            <Kind>Dynamic</Kind>
+        </NativeReference>
+    </ItemGroup>
+
     <!-- a special case for Any CPU -->
     <ItemGroup Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' != 'False' and ( '$(PlatformTarget)' != 'x64' and '$(PlatformTarget)' != 'x86' ) ">
         <!-- Windows -->

--- a/binding/SkiaSharp.Desktop/nuget/build/net45/SkiaSharp.targets
+++ b/binding/SkiaSharp.Desktop/nuget/build/net45/SkiaSharp.targets
@@ -44,6 +44,14 @@
         </None>
     </ItemGroup>
 
+    <!-- handle the case where this is a Xamarin.Mac Full app/extension -->
+    <ItemGroup Condition=" '$(ShouldIncludeNativeSkiaSharp)' != 'False' and '$(XamarinMacFrameworkRoot)' != '' and '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' and '$(UseXamMacFullFramework)' == 'true' and ('$(OutputType)' == 'Exe' or '$(IsAppExtension)' == 'true') ">
+        <NativeReference Include="$(PreferredOSXNativeSkiaSharpPath)" Condition=" Exists('$(PreferredOSXNativeSkiaSharpPath)') ">
+            <Link>$([System.IO.Path]::GetFilename('$(PreferredOSXNativeSkiaSharpPath)'))</Link>
+            <Kind>Dynamic</Kind>
+        </NativeReference>
+    </ItemGroup>
+
     <!-- a special case for Any CPU -->
     <ItemGroup Condition=" '$(ShouldIncludeNativeSkiaSharp)' != 'False' and ( '$(PlatformTarget)' != 'x64' and '$(PlatformTarget)' != 'x86' ) ">
         <!-- Windows -->


### PR DESCRIPTION

**Description of Change**

Add the libSkiaSharp.dylib to the app bundle when using the full framework


**Bugs Fixed**

- Fixes #913


**API Changes**

None.

**Behavioral Changes**

The libSkiaSharp.dylib and libHarfBuzzSharp.dylib should now be added to the app bundles for full framework mac apps.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
