### PR TITLE
Build arm64_32 architecture for watchOS

### DIFF
--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -469,7 +469,6 @@ Task ("externals-watchos")
         StripSign ($"output/native/watchos/{arch}/libSkiaSharp.framework");
     });
 
-    buildArch ("watchsimulator", "x86_64", "x64");
     buildArch ("watchsimulator", "i386", "x86");
     buildArch ("watchos", "armv7k", "arm");
     buildArch ("watchos", "arm64_32", "arm64");

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -469,6 +469,7 @@ Task ("externals-watchos")
         StripSign ($"output/native/watchos/{arch}/libSkiaSharp.framework");
     });
 
+    buildArch ("watchsimulator", "x86_64", "x64");
     buildArch ("watchsimulator", "i386", "x86");
     buildArch ("watchos", "armv7k", "arm");
     buildArch ("watchos", "arm64_32", "arm64");

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -469,7 +469,6 @@ Task ("externals-watchos")
         StripSign ($"output/native/watchos/{arch}/libSkiaSharp.framework");
     });
 
-    buildArch ("watchsimulator", "x86_64", "x64");
     buildArch ("watchsimulator", "i386", "x86");
     buildArch ("watchos", "armv7k", "arm");
     buildArch ("watchos", "arm64_32", "arm64");
@@ -502,7 +501,6 @@ Task ("externals-watchos")
         StripSign ($"output/native/watchos/{arch}/libHarfBuzzSharp.a");
     });
 
-    buildHarfBuzzArch ("watchsimulator", "x86_64");
     buildHarfBuzzArch ("watchsimulator", "i386");
     buildHarfBuzzArch ("watchos", "armv7k");
     buildHarfBuzzArch ("watchos", "arm64_32");

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -471,13 +471,15 @@ Task ("externals-watchos")
 
     buildArch ("watchsimulator", "i386", "x86");
     buildArch ("watchos", "armv7k", "arm");
+    buildArch ("watchos", "arm64_32", "arm");
 
     // create the fat framework
     CopyDirectory ("output/native/watchos/armv7k/libSkiaSharp.framework/", "output/native/watchos/libSkiaSharp.framework/");
     DeleteFile ("output/native/watchos/libSkiaSharp.framework/libSkiaSharp");
     RunLipo ("output/native/watchos/", "libSkiaSharp.framework/libSkiaSharp", new [] {
         (FilePath) "i386/libSkiaSharp.framework/libSkiaSharp",
-        (FilePath) "armv7k/libSkiaSharp.framework/libSkiaSharp"
+        (FilePath) "armv7k/libSkiaSharp.framework/libSkiaSharp",
+        (FilePath) "arm64_32/libSkiaSharp.framework/libSkiaSharp"
     });
 
     // HarfBuzzSharp
@@ -501,11 +503,13 @@ Task ("externals-watchos")
 
     buildHarfBuzzArch ("watchsimulator", "i386");
     buildHarfBuzzArch ("watchos", "armv7k");
+    buildHarfBuzzArch ("watchos", "arm64_32");
 
     // create the fat framework
     RunLipo ("output/native/watchos/", "libHarfBuzzSharp.a", new [] {
         (FilePath) "i386/libHarfBuzzSharp.a",
-        (FilePath) "armv7k/libHarfBuzzSharp.a"
+        (FilePath) "armv7k/libHarfBuzzSharp.a",
+        (FilePath) "arm64_32/libHarfBuzzSharp.a"
     });
 });
 

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -469,9 +469,10 @@ Task ("externals-watchos")
         StripSign ($"output/native/watchos/{arch}/libSkiaSharp.framework");
     });
 
+    buildArch ("watchsimulator", "x86_64", "x64");
     buildArch ("watchsimulator", "i386", "x86");
     buildArch ("watchos", "armv7k", "arm");
-    buildArch ("watchos", "arm64_32", "arm");
+    buildArch ("watchos", "arm64_32", "arm64");
 
     // create the fat framework
     CopyDirectory ("output/native/watchos/armv7k/libSkiaSharp.framework/", "output/native/watchos/libSkiaSharp.framework/");
@@ -501,6 +502,7 @@ Task ("externals-watchos")
         StripSign ($"output/native/watchos/{arch}/libHarfBuzzSharp.a");
     });
 
+    buildHarfBuzzArch ("watchsimulator", "x86_64");
     buildHarfBuzzArch ("watchsimulator", "i386");
     buildHarfBuzzArch ("watchos", "armv7k");
     buildHarfBuzzArch ("watchos", "arm64_32");


### PR DESCRIPTION
**Description of Change**

Build the new `arm64_32` architecture for watchOS.

**Bugs Fixed**

- Related to issue #961

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
