### PR TITLE
Fix a memory leak in SKRoundRect

### DIFF
--- a/binding/Binding/SKRoundRect.cs
+++ b/binding/Binding/SKRoundRect.cs
@@ -162,11 +162,21 @@ namespace SkiaSharp
 			SkiaApi.sk_rrect_offset (Handle, dx, dy);
 		}
 
-		public SKRoundRect Transform (SKMatrix matrix)
+		public bool TryTransform (SKMatrix matrix, out SKRoundRect transformed)
 		{
 			var destHandle = SkiaApi.sk_rrect_new ();
 			if (SkiaApi.sk_rrect_transform (Handle, ref matrix, destHandle)) {
-				return new SKRoundRect (destHandle, true);
+				transformed = new SKRoundRect (destHandle, true);
+				return true;
+			}
+			transformed = null;
+			return false;
+		}
+
+		public SKRoundRect Transform (SKMatrix matrix)
+		{
+			if (TryTransform (matrix, out var transformed)) {
+				return transformed;
 			}
 			return null;
 		}

--- a/tests/Tests/SKRoundRectTest.cs
+++ b/tests/Tests/SKRoundRectTest.cs
@@ -221,8 +221,23 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void WillFailToTransformWithInvalidTransformation()
+		{
+			var rect = SKRect.Create(10, 10, 100, 100);
+			var offset = rect;
+			offset.Offset(2, 2);
+
+			var rrect = new SKRoundRect(rect, 5, 5);
+			var transformed = rrect.Transform(SKMatrix.MakeRotationDegrees(30));
+
+			Assert.Null(transformed);
+		}
+
+		[SkippableFact]
 		public void CanTransform()
 		{
+			var radii = new[] { new SKPoint(5, 5), new SKPoint(5, 5), new SKPoint(5, 5), new SKPoint(5, 5) };
+
 			var rect = SKRect.Create(10, 10, 100, 100);
 			var offset = rect;
 			offset.Offset(2, 2);
@@ -231,6 +246,7 @@ namespace SkiaSharp.Tests
 			var transformed = rrect.Transform(SKMatrix.MakeTranslation(2, 2));
 
 			Assert.Equal(offset, transformed.Rect);
+			Assert.Equal(radii, transformed.Radii);
 		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Resolves a memory leak when the transformation fails, the allocated round rect that should have been deleted.

**Bugs Fixed**

- Resolves #994

**API Changes**

Added: 
 
- `public bool SKRoundRect.TryTransform (SKMatrix matrix, out SKRoundRect transformed)`

**Behavioral Changes**

None public. Just no longer leaks an instance.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
