### PR TITLE
Use Clang for Windows (m68)

### DIFF
--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -307,12 +307,11 @@ namespace SkiaSharp
 			if (Interlocked.CompareExchange (ref isDisposed, 1, 0) != 0)
 				return;
 
-			if (disposing) {
-				DisposeManaged ();
-			}
-
 			if (Handle != IntPtr.Zero && OwnsHandle)
 				DisposeNative ();
+
+			if (disposing)
+				DisposeManaged ();
 
 			Handle = IntPtr.Zero;
 		}

--- a/build.cake
+++ b/build.cake
@@ -50,6 +50,7 @@ DirectoryPath NUGET_PACKAGES = EnvironmentVariable ("NUGET_PACKAGES") ?? PROFILE
 DirectoryPath ANDROID_SDK_ROOT = EnvironmentVariable ("ANDROID_SDK_ROOT") ?? EnvironmentVariable ("ANDROID_HOME") ?? PROFILE_PATH.Combine ("android-sdk");
 DirectoryPath ANDROID_NDK_HOME = EnvironmentVariable ("ANDROID_NDK_HOME") ?? EnvironmentVariable ("ANDROID_NDK_ROOT") ?? PROFILE_PATH.Combine ("android-ndk");
 DirectoryPath TIZEN_STUDIO_HOME = EnvironmentVariable ("TIZEN_STUDIO_HOME") ?? PROFILE_PATH.Combine ("tizen-studio");
+DirectoryPath LLVM_HOME = EnvironmentVariable ("LLVM_HOME") ?? "C:/Program Files/LLVM";
 
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("."));
 DirectoryPath DEPOT_PATH = MakeAbsolute(ROOT_PATH.Combine("externals/depot_tools"));

--- a/build.cake
+++ b/build.cake
@@ -573,6 +573,7 @@ Information ("SDK Paths:");
 Information ("  Android SDK:   {0}", ANDROID_SDK_ROOT);
 Information ("  Android NDK:   {0}", ANDROID_NDK_HOME);
 Information ("  Tizen Studio:  {0}", TIZEN_STUDIO_HOME);
+Information ("  LLVM/Clang:    {0}", LLVM_HOME);
 Information ("");
 
 Information ("Environment Variables (whitelisted):");
@@ -583,7 +584,7 @@ var envVarsWhitelist = new [] {
     "node_label", "build_id", "git_sha", "git_branch_name",
     "feature_name", "msbuild_exe", "python_exe", "preview_label",
     "home", "userprofile", "nuget_packages", "build_arch",
-    "android_sdk_root", "android_ndk_root",
+    "android_sdk_root", "android_ndk_root", "llvm_home",
     "android_home", "android_ndk_home", "tizen_studio_home"
 };
 var envVars = EnvironmentVariables ();

--- a/cake/BuildExternals.cake
+++ b/cake/BuildExternals.cake
@@ -89,10 +89,13 @@ Task ("externals-windows")
             return;
         }
 
+        var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
+
         // generate native skia build files
         GnNinja ($"win/{arch}", "SkiaSharp",
             $"is_official_build=true skia_enable_tools=false " +
             $"target_os='win' target_cpu='{skiaArch}' " +
+            clang +
             $"skia_use_icu=false skia_use_sfntly=false skia_use_piex=true skia_use_dng_sdk=true " +
             $"skia_use_system_expat=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false " +
             $"extra_cflags=[ '-DSKIA_C_DLL', '/MT', '/EHsc', '/Z7' ] " +

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -73,6 +73,10 @@ jobs:
         - ${{ if contains(parameters.name, '_android_') }}:
           - pwsh: .\scripts\install-android-ndk.ps1
             displayName: Install the Android NDK
+        # install llvm
+        - ${{ if endsWith(parameters.name, '_windows') }}:
+          - pwsh: .\scripts\install-llvm.ps1
+            displayName: Install LLVM
       # install extra bits for the manged builds
       - ${{ if not(startsWith(parameters.name, 'native_')) }}:
         - task: UseDotNet@2
@@ -106,6 +110,7 @@ jobs:
         - pwsh: .\scripts\retry-command.ps1 -RetryCount ${{ parameters.retryCount }} { .\bootstrapper.ps1 -t ${{ parameters.target }} -v ${{ parameters.verbosity }} -c ${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }} }
           env:
             JavaSdkDirectory: $(JAVA_HOME)
+            LLVM_HOME: $(LLVM_HOME)
           displayName: Run the bootstrapper for ${{ parameters.target }}
       - ${{ if not(endsWith(parameters.name, '_windows')) }}:
         - bash: ./scripts/retry-command.sh ${{ parameters.retryCount }} ./bootstrapper.sh -t ${{ parameters.target }} -v ${{ parameters.verbosity }} -c ${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}

--- a/scripts/install-llvm.ps1
+++ b/scripts/install-llvm.ps1
@@ -1,0 +1,24 @@
+Param(
+    [string] $Version = "9.0.0"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$url = "http://releases.llvm.org/${Version}/LLVM-${Version}-win64.exe"
+
+$llvmTemp = "$HOME/llvm-temp"
+$install = "$llvmTemp/llvm.exe"
+
+# download
+Write-Host "Downloading LLVM..."
+New-Item -ItemType Directory -Force -Path "$llvmTemp" | Out-Null
+(New-Object System.Net.WebClient).DownloadFile("$url", "$install")
+
+# install
+Write-Host "Installing LLVM..."
+& $install /S
+
+# make sure that LLVM is in LLVM_HOME
+Write-Host "##vso[task.setvariable variable=LLVM_HOME;]C:\Program Files\LLVM";
+
+exit $LASTEXITCODE

--- a/tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.csproj
+++ b/tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.csproj
@@ -112,7 +112,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\output\native\windows\$(Platform)\libSkiaSharp.dll" CopyToOutputDirectory="Always" Condition=" '$(IsWindows)' == 'true' " />
+    <Content Include="..\..\output\native\windows\$(Platform)\libSkiaSharp.pdb" CopyToOutputDirectory="Always" Condition=" '$(IsWindows)' == 'true' " />
     <Content Include="..\..\output\native\windows\$(Platform)\libHarfBuzzSharp.dll" CopyToOutputDirectory="Always" Condition=" '$(IsWindows)' == 'true' " />
+    <Content Include="..\..\output\native\windows\$(Platform)\libHarfBuzzSharp.pdb" CopyToOutputDirectory="Always" Condition=" '$(IsWindows)' == 'true' " />
     <Content Include="..\..\output\native\osx\libSkiaSharp.dylib" CopyToOutputDirectory="Always" Condition=" '$(IsMacOS)' == 'true' " />
     <Content Include="..\..\output\native\osx\libHarfBuzzSharp.dylib" CopyToOutputDirectory="Always" Condition=" '$(IsMacOS)' == 'true' " />
     <Content Include="..\..\output\native\linux\$(Platform)\libSkiaSharp.so" CopyToOutputDirectory="Always" Condition=" '$(IsLinux)' == 'true' " />


### PR DESCRIPTION
**Description of Change**

Switch to using Clang 9 instead of MSVC for Win32 builds.

**Bugs Fixed**

- Resolves #758 
- Related to #686 

**API Changes**

None.

**Behavioral Changes**

There shouldn't be any visible _changes_ except for performance improvements. Google has been optimizing skia for Clang, and as a result the MSVC binaries are significantly slower. With this PR, we are using Clang on Windows desktop/Win32 so we get all those improvements now.

UWP is still using MSVC, but that will be changed at a later stage.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
