### PR TITLE
netstandard SkiaSharp.Views.Forms.dll should be ref-only

### DIFF
--- a/nuget/SkiaSharp.Views.Forms.nuspec
+++ b/nuget/SkiaSharp.Views.Forms.nuspec
@@ -65,9 +65,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
   </metadata>
   <files>
 
+    <file src="ref/netstandard1.3/SkiaSharp.Views.Forms.dll" />
+    <file src="ref/netstandard1.3/SkiaSharp.Views.Forms.xml" />
+
     <!-- SkiaSharp.Views.Forms.dll -->
-    <file src="lib/netstandard1.3/SkiaSharp.Views.Forms.dll" />
-    <file src="lib/netstandard1.3/SkiaSharp.Views.Forms.xml" />
     <file platform="macos,windows" src="lib/MonoAndroid/SkiaSharp.Views.Forms.dll" />
     <file platform="macos,windows" src="lib/MonoAndroid/SkiaSharp.Views.Forms.xml" />
     <file platform="macos" src="lib/Xamarin.iOS/SkiaSharp.Views.Forms.dll" />

--- a/nuget/SkiaSharp.Views.Forms.nuspec
+++ b/nuget/SkiaSharp.Views.Forms.nuspec
@@ -65,11 +65,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
   </metadata>
   <files>
 
-    <file src="ref/netstandard1.3/SkiaSharp.Views.Forms.dll" />
-    <file src="ref/netstandard1.3/SkiaSharp.Views.Forms.xml" />
-    
+    <!-- the reference assembly must be in ref https://github.com/mono/SkiaSharp/issues/1011 -->
+    <file src="lib/netstandard1.3/SkiaSharp.Views.Forms.dll" target="ref/netstandard1.3/SkiaSharp.Views.Forms.dll" />
+    <file src="lib/netstandard1.3/SkiaSharp.Views.Forms.xml" target="ref/netstandard1.3/SkiaSharp.Views.Forms.xml" />
+
     <!-- workaround for https://github.com/xamarin/xamarin-android/issues/3920 -->
-    <file platform="macos,windows" src="ref/MonoAndroid/SkiaSharp.Views.Forms.dll" />
+    <file platform="macos,windows" src="lib/MonoAndroid/SkiaSharp.Views.Forms.dll" target="ref/MonoAndroid/SkiaSharp.Views.Forms.dll" />
 
     <!-- SkiaSharp.Views.Forms.dll -->
     <file platform="macos,windows" src="lib/MonoAndroid/SkiaSharp.Views.Forms.dll" />

--- a/nuget/SkiaSharp.Views.Forms.nuspec
+++ b/nuget/SkiaSharp.Views.Forms.nuspec
@@ -67,6 +67,9 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <file src="ref/netstandard1.3/SkiaSharp.Views.Forms.dll" />
     <file src="ref/netstandard1.3/SkiaSharp.Views.Forms.xml" />
+    
+    <!-- workaround for https://github.com/xamarin/xamarin-android/issues/3920 -->
+    <file platform="macos,windows" src="ref/MonoAndroid/SkiaSharp.Views.Forms.dll" />
 
     <!-- SkiaSharp.Views.Forms.dll -->
     <file platform="macos,windows" src="lib/MonoAndroid/SkiaSharp.Views.Forms.dll" />


### PR DESCRIPTION
**Description of Change**

Because the SkiaSharp.Views.Forms.WPF NuGet pulls in SkiaSharp.Views.Forms, we will get duplicate SkiaSharp.Views.Forms.dll files (1 from SkiaSharp.Views.Forms and one from SkiaSharp.Views.Forms.WPF).

This PR makes the SkiaSharp.Views.Forms version a reference assembly, and will never reach the app.

**Bugs Fixed**

- Fixes #1011

**API Changes**

None.

**Behavioral Changes**

The SkiaSharp.Views.Forms.dll is moved to the `ref` folder (from `lib`) in SkiaSharp.Views.Forms.nupkg

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
