### PR TITLE
Env.Is64BitOperatingSystem isn't in dotnet build

### DIFF
--- a/binding/HarfBuzzSharp.Desktop/nuget/build/net45/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.Desktop/nuget/build/net45/HarfBuzzSharp.targets
@@ -17,7 +17,8 @@
         <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(OS)' != 'Unix' and '$(Prefer32Bit)' == 'False' ">x64</PreferredNativeHarfBuzzSharp>  
         <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(OS)' != 'Unix' and '$(Prefer32Bit)' == 'True' ">x86</PreferredNativeHarfBuzzSharp> 
         <!-- fall back to x64 on 64-bit machines -->
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$([System.Environment]::Is64BitOperatingSystem)' == 'True' ">x64</PreferredNativeHarfBuzzSharp> 
+        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(MSBuildRuntimeType)' != 'Core' and '$([System.Environment]::Is64BitOperatingSystem)' == 'True' ">x64</PreferredNativeHarfBuzzSharp> 
+        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(MSBuildRuntimeType)' == 'Core' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">x64</PreferredNativeHarfBuzzSharp> 
         <!-- fall back to x86 -->
         <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' ">x86</PreferredNativeHarfBuzzSharp>
     </PropertyGroup>

--- a/binding/SkiaSharp.Desktop/nuget/build/net45/SkiaSharp.targets
+++ b/binding/SkiaSharp.Desktop/nuget/build/net45/SkiaSharp.targets
@@ -17,7 +17,8 @@
         <PreferredNativeSkiaSharp Condition=" '$(PreferredNativeSkiaSharp)' == '' and '$(OS)' != 'Unix' and '$(Prefer32Bit)' == 'False' ">x64</PreferredNativeSkiaSharp>  
         <PreferredNativeSkiaSharp Condition=" '$(PreferredNativeSkiaSharp)' == '' and '$(OS)' != 'Unix' and '$(Prefer32Bit)' == 'True' ">x86</PreferredNativeSkiaSharp> 
         <!-- fall back to x64 on 64-bit machines -->
-        <PreferredNativeSkiaSharp Condition=" '$(PreferredNativeSkiaSharp)' == '' and '$([System.Environment]::Is64BitOperatingSystem)' == 'True' ">x64</PreferredNativeSkiaSharp> 
+        <PreferredNativeSkiaSharp Condition=" '$(PreferredNativeSkiaSharp)' == '' and '$(MSBuildRuntimeType)' != 'Core' and '$([System.Environment]::Is64BitOperatingSystem)' == 'True' ">x64</PreferredNativeSkiaSharp> 
+        <PreferredNativeSkiaSharp Condition=" '$(PreferredNativeSkiaSharp)' == '' and '$(MSBuildRuntimeType)' == 'Core' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">x64</PreferredNativeSkiaSharp> 
         <!-- fall back to x86 -->
         <PreferredNativeSkiaSharp Condition=" '$(PreferredNativeSkiaSharp)' == '' ">x86</PreferredNativeSkiaSharp>
     </PropertyGroup>


### PR DESCRIPTION
**Description of Change**

`dotnet build` is not quite the same as `msbuild` and `[System.Environment]::Is64BitOperatingSystem` cannot be used. We should use `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` instead. Unfortunately, that type was added only in later MSBuilds based on net471+. 

However, `$(MSBuildRuntimeType)` was added in MSBuild 15 which is old enough.

**Bugs Fixed**

```
error MSB4185: The function "Is64BitOperatingSystem" on type "System.Environment" is not available for execution as an MSBuild property function.
```

**API Changes**

None.

**Behavioral Changes**

None. Except that it should now build net45+ with dotnet build.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
