### PR TITLE
Fix bad colors

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -136,12 +136,12 @@ namespace SkiaSharp
 
 		public void Erase (SKColor color)
 		{
-			SkiaApi.sk_bitmap_erase (Handle, color);
+			SkiaApi.sk_bitmap_erase (Handle, (uint)color);
 		}
 
 		public void Erase (SKColor color, SKRectI rect)
 		{
-			SkiaApi.sk_bitmap_erase_rect (Handle, color, &rect);
+			SkiaApi.sk_bitmap_erase_rect (Handle, (uint)color, &rect);
 		}
 
 		public byte GetAddr8(int x, int y) => SkiaApi.sk_bitmap_get_addr_8 (Handle, x, y);
@@ -162,7 +162,7 @@ namespace SkiaSharp
 
 		public void SetPixel (int x, int y, SKColor color)
 		{
-			SkiaApi.sk_bitmap_set_pixel_color (Handle, x, y, color);
+			SkiaApi.sk_bitmap_set_pixel_color (Handle, x, y, (uint)color);
 		}
 
 		public bool CanCopyTo (SKColorType colorType)
@@ -413,13 +413,13 @@ namespace SkiaSharp
 				var info = Info;
 				var pixels = new SKColor [info.Width * info.Height];
 				fixed (SKColor* p = pixels) {
-					SkiaApi.sk_bitmap_get_pixel_colors (Handle, p);
+					SkiaApi.sk_bitmap_get_pixel_colors (Handle, (uint*)p);
 				}
 				return pixels;
 			}
 			set {
 				fixed (SKColor* v = value) {
-					SkiaApi.sk_bitmap_set_pixel_colors (Handle, v);
+					SkiaApi.sk_bitmap_set_pixel_colors (Handle, (uint*)v);
 				}
 			}
 		}

--- a/binding/Binding/SKCanvas.cs
+++ b/binding/Binding/SKCanvas.cs
@@ -69,7 +69,7 @@ namespace SkiaSharp
 
 		public void DrawColor (SKColor color, SKBlendMode mode = SKBlendMode.Src)
 		{
-			SkiaApi.sk_canvas_draw_color (Handle, color, mode);
+			SkiaApi.sk_canvas_draw_color (Handle, (uint)color, mode);
 		}
 
 		public void DrawLine (SKPoint p0, SKPoint p1, SKPaint paint)
@@ -741,7 +741,7 @@ namespace SkiaSharp
 					fXDivs = x,
 					fYCount = lattice.YDivs.Length,
 					fYDivs = y,
-					fColors = c,
+					fColors = (uint*)c,
 				};
 				if (lattice.Bounds != null) {
 					var bounds = lattice.Bounds.Value;
@@ -771,7 +771,7 @@ namespace SkiaSharp
 					fXDivs = x,
 					fYCount = lattice.YDivs.Length,
 					fYDivs = y,
-					fColors = c,
+					fColors = (uint*)c,
 				};
 				if (lattice.Bounds != null) {
 					var bounds = lattice.Bounds.Value;

--- a/binding/Binding/SKColor.cs
+++ b/binding/Binding/SKColor.cs
@@ -19,12 +19,12 @@ namespace SkiaSharp
 
 		public static SKPMColor PreMultiply (SKColor color)
 		{
-			return SkiaApi.sk_color_premultiply (color);
+			return SkiaApi.sk_color_premultiply ((uint)color);
 		}
 
 		public static SKColor UnPreMultiply (SKPMColor pmcolor)
 		{
-			return SkiaApi.sk_color_unpremultiply (pmcolor);
+			return SkiaApi.sk_color_unpremultiply ((uint)pmcolor);
 		}
 
 		public static SKPMColor[] PreMultiply (SKColor[] colors)
@@ -32,7 +32,7 @@ namespace SkiaSharp
 			var pmcolors = new SKPMColor [colors.Length];
 			fixed (SKColor* c = colors)
 			fixed (SKPMColor* pm = pmcolors) {
-				SkiaApi.sk_color_premultiply_array (c, colors.Length, pm);
+				SkiaApi.sk_color_premultiply_array ((uint*)c, colors.Length, (uint*)pm);
 			}
 			return pmcolors;
 		}
@@ -42,7 +42,7 @@ namespace SkiaSharp
 			var colors = new SKColor [pmcolors.Length];
 			fixed (SKColor* c = colors)
 			fixed (SKPMColor* pm = pmcolors) {
-				SkiaApi.sk_color_unpremultiply_array (pm, pmcolors.Length, c);
+				SkiaApi.sk_color_unpremultiply_array ((uint*)pm, pmcolors.Length, (uint*)c);
 			}
 			return colors;
 		}

--- a/binding/Binding/SKColorFilter.cs
+++ b/binding/Binding/SKColorFilter.cs
@@ -20,12 +20,12 @@ namespace SkiaSharp
 
 		public static SKColorFilter CreateBlendMode(SKColor c, SKBlendMode mode)
 		{
-			return GetObject<SKColorFilter>(SkiaApi.sk_colorfilter_new_mode(c, mode));
+			return GetObject<SKColorFilter>(SkiaApi.sk_colorfilter_new_mode((uint)c, mode));
 		}
 
 		public static SKColorFilter CreateLighting(SKColor mul, SKColor add)
 		{
-			return GetObject<SKColorFilter>(SkiaApi.sk_colorfilter_new_lighting(mul, add));
+			return GetObject<SKColorFilter>(SkiaApi.sk_colorfilter_new_lighting((uint)mul, (uint)add));
 		}
 
 		public static SKColorFilter CreateCompose(SKColorFilter outer, SKColorFilter inner)

--- a/binding/Binding/SKColorTable.cs
+++ b/binding/Binding/SKColorTable.cs
@@ -50,7 +50,7 @@ namespace SkiaSharp
 		private static IntPtr CreateNew (SKPMColor[] colors, int count)
 		{
 			fixed (SKPMColor* c = colors) {
-				return SkiaApi.sk_colortable_new (c, count);
+				return SkiaApi.sk_colortable_new ((uint*)c, count);
 			}
 		}
 
@@ -95,7 +95,7 @@ namespace SkiaSharp
 
 		public IntPtr ReadColors ()
 		{
-			SKPMColor* colors;
+			uint* colors;
 			SkiaApi.sk_colortable_read_colors (Handle, &colors);
 			return (IntPtr)colors;
 		}

--- a/binding/Binding/SKImageFilter.cs
+++ b/binding/Binding/SKImageFilter.cs
@@ -68,37 +68,37 @@ namespace SkiaSharp
 
 		public static SKImageFilter CreateDropShadow(float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKDropShadowImageFilterShadowMode shadowMode, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_drop_shadow(dx, dy, sigmaX, sigmaY, color, shadowMode, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_drop_shadow(dx, dy, sigmaX, sigmaY, (uint)color, shadowMode, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreateDistantLitDiffuse(SKPoint3 direction, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_distant_lit_diffuse(&direction, lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_distant_lit_diffuse(&direction, (uint)lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreatePointLitDiffuse(SKPoint3 location, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_point_lit_diffuse(&location, lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_point_lit_diffuse(&location, (uint)lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreateSpotLitDiffuse(SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_spot_lit_diffuse(&location, &target, specularExponent, cutoffAngle, lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_spot_lit_diffuse(&location, &target, specularExponent, cutoffAngle, (uint)lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreateDistantLitSpecular(SKPoint3 direction, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_distant_lit_specular(&direction, lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_distant_lit_specular(&direction, (uint)lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreatePointLitSpecular(SKPoint3 location, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_point_lit_specular(&location, lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_point_lit_specular(&location, (uint)lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreateSpotLitSpecular(SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
 		{
-			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_spot_lit_specular(&location, &target, specularExponent, cutoffAngle, lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject<SKImageFilter>(SkiaApi.sk_imagefilter_new_spot_lit_specular(&location, &target, specularExponent, cutoffAngle, (uint)lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		public static SKImageFilter CreateMagnifier(SKRect src, float inset, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -96,7 +96,7 @@ namespace SkiaSharp
 
 		public SKColor Color {
 			get => SkiaApi.sk_paint_get_color (Handle);
-			set => SkiaApi.sk_paint_set_color (Handle, value);
+			set => SkiaApi.sk_paint_set_color (Handle, (uint)value);
 		}
 
 		public float StrokeWidth {

--- a/binding/Binding/SKPixmap.cs
+++ b/binding/Binding/SKPixmap.cs
@@ -285,7 +285,7 @@ namespace SkiaSharp
 
 		public bool Erase (SKColor color, SKRectI subset)
 		{
-			return SkiaApi.sk_pixmap_erase_color (Handle, color, &subset);
+			return SkiaApi.sk_pixmap_erase_color (Handle, (uint)color, &subset);
 		}
 
 		public SKPixmap WithColorType (SKColorType newColorType)

--- a/binding/Binding/SKShader.cs
+++ b/binding/Binding/SKShader.cs
@@ -20,7 +20,7 @@ namespace SkiaSharp
 
 		public static SKShader CreateColor (SKColor color)
 		{
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_color (color));
+			return GetObject<SKShader> (SkiaApi.sk_shader_new_color ((uint)color));
 		}
 
 		public static SKShader CreateBitmap (SKBitmap src, SKShaderTileMode tmx, SKShaderTileMode tmy)
@@ -88,7 +88,7 @@ namespace SkiaSharp
 			fixed (SKPoint* p = points)
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (p, c, cp, colors.Length, mode, null));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (p, (uint*)c, cp, colors.Length, mode, null));
 			}
 		}
 
@@ -103,7 +103,7 @@ namespace SkiaSharp
 			fixed (SKPoint* p = points)
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (p, c, cp, colors.Length, mode, &localMatrix));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (p, (uint*)c, cp, colors.Length, mode, &localMatrix));
 			}
 		}
 
@@ -119,7 +119,7 @@ namespace SkiaSharp
 
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient (&center, radius, c, cp, colors.Length, mode, null));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient (&center, radius, (uint*)c, cp, colors.Length, mode, null));
 			}
 		}
 		
@@ -132,7 +132,7 @@ namespace SkiaSharp
 
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient (&center, radius, c, cp, colors.Length, mode, &localMatrix));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient (&center, radius, (uint*)c, cp, colors.Length, mode, &localMatrix));
 			}
 		}
 
@@ -161,7 +161,7 @@ namespace SkiaSharp
 
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient (&center, c, cp, colors.Length, tileMode, startAngle, endAngle, null));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient (&center, (uint*)c, cp, colors.Length, tileMode, startAngle, endAngle, null));
 			}
 		}
 		
@@ -174,7 +174,7 @@ namespace SkiaSharp
 
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient (&center, c, cp, colors.Length, tileMode, startAngle, endAngle, &localMatrix));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient (&center, (uint*)c, cp, colors.Length, tileMode, startAngle, endAngle, &localMatrix));
 			}
 		}
 
@@ -190,7 +190,7 @@ namespace SkiaSharp
 
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient (&start, startRadius, &end, endRadius, c, cp, colors.Length, mode, null));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient (&start, startRadius, &end, endRadius, (uint*)c, cp, colors.Length, mode, null));
 			}
 		}
 		
@@ -203,7 +203,7 @@ namespace SkiaSharp
 
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient (&start, startRadius, &end, endRadius, c, cp, colors.Length, mode, &localMatrix));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient (&start, startRadius, &end, endRadius, (uint*)c, cp, colors.Length, mode, &localMatrix));
 			}
 		}
 		

--- a/binding/Binding/SKVertices.cs
+++ b/binding/Binding/SKVertices.cs
@@ -48,7 +48,7 @@ namespace SkiaSharp
 			fixed (SKPoint* t = texs)
 			fixed (SKColor* c = colors)
 			fixed (UInt16* i = indices) {
-				return GetObject<SKVertices> (SkiaApi.sk_vertices_make_copy (vmode, vertexCount, p, t, c, indexCount, i));
+				return GetObject<SKVertices> (SkiaApi.sk_vertices_make_copy (vmode, vertexCount, p, t, (uint*)c, indexCount, i));
 			}
 		}
 	}

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -471,11 +471,11 @@ namespace SkiaSharp
 
 		// void sk_bitmap_erase(sk_bitmap_t* cbitmap, sk_color_t color)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_bitmap_erase (sk_bitmap_t cbitmap, SKColor color);
+		internal static extern void sk_bitmap_erase (sk_bitmap_t cbitmap, UInt32 color);
 
 		// void sk_bitmap_erase_rect(sk_bitmap_t* cbitmap, sk_color_t color, sk_irect_t* rect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_bitmap_erase_rect (sk_bitmap_t cbitmap, SKColor color, SKRectI* rect);
+		internal static extern void sk_bitmap_erase_rect (sk_bitmap_t cbitmap, UInt32 color, SKRectI* rect);
 
 		// bool sk_bitmap_extract_alpha(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, const sk_paint_t* paint, sk_ipoint_t* offset)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -509,7 +509,7 @@ namespace SkiaSharp
 
 		// sk_pmcolor_t sk_bitmap_get_index8_color(sk_bitmap_t* cbitmap, int x, int y)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKPMColor sk_bitmap_get_index8_color (sk_bitmap_t cbitmap, Int32 x, Int32 y);
+		internal static extern UInt32 sk_bitmap_get_index8_color (sk_bitmap_t cbitmap, Int32 x, Int32 y);
 
 		// void sk_bitmap_get_info(sk_bitmap_t* cbitmap, sk_imageinfo_t* info)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -517,11 +517,11 @@ namespace SkiaSharp
 
 		// sk_color_t sk_bitmap_get_pixel_color(sk_bitmap_t* cbitmap, int x, int y)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKColor sk_bitmap_get_pixel_color (sk_bitmap_t cbitmap, Int32 x, Int32 y);
+		internal static extern UInt32 sk_bitmap_get_pixel_color (sk_bitmap_t cbitmap, Int32 x, Int32 y);
 
 		// void sk_bitmap_get_pixel_colors(sk_bitmap_t* cbitmap, sk_color_t* colors)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_bitmap_get_pixel_colors (sk_bitmap_t cbitmap, SKColor* colors);
+		internal static extern void sk_bitmap_get_pixel_colors (sk_bitmap_t cbitmap, UInt32* colors);
 
 		// void* sk_bitmap_get_pixels(sk_bitmap_t* cbitmap, size_t* length)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -589,11 +589,11 @@ namespace SkiaSharp
 
 		// void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t color)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_bitmap_set_pixel_color (sk_bitmap_t cbitmap, Int32 x, Int32 y, SKColor color);
+		internal static extern void sk_bitmap_set_pixel_color (sk_bitmap_t cbitmap, Int32 x, Int32 y, UInt32 color);
 
 		// void sk_bitmap_set_pixel_colors(sk_bitmap_t* cbitmap, const sk_color_t* colors)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_bitmap_set_pixel_colors (sk_bitmap_t cbitmap, SKColor* colors);
+		internal static extern void sk_bitmap_set_pixel_colors (sk_bitmap_t cbitmap, UInt32* colors);
 
 		// void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -623,7 +623,7 @@ namespace SkiaSharp
 
 		// void sk_canvas_clear(sk_canvas_t*, sk_color_t)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_canvas_clear (sk_canvas_t param0, SKColor param1);
+		internal static extern void sk_canvas_clear (sk_canvas_t param0, UInt32 param1);
 
 		// void sk_canvas_clip_path_with_operation(sk_canvas_t* t, const sk_path_t* crect, sk_clipop_t op, bool doAA)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -679,7 +679,7 @@ namespace SkiaSharp
 
 		// void sk_canvas_draw_color(sk_canvas_t* ccanvas, sk_color_t color, sk_blendmode_t mode)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_canvas_draw_color (sk_canvas_t ccanvas, SKColor color, SKBlendMode mode);
+		internal static extern void sk_canvas_draw_color (sk_canvas_t ccanvas, UInt32 color, SKBlendMode mode);
 
 		// void sk_canvas_draw_drawable(sk_canvas_t*, sk_drawable_t*, const sk_matrix_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -993,19 +993,19 @@ namespace SkiaSharp
 
 		// sk_pmcolor_t sk_color_premultiply(const sk_color_t color)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKPMColor sk_color_premultiply (SKColor color);
+		internal static extern UInt32 sk_color_premultiply (UInt32 color);
 
 		// void sk_color_premultiply_array(const sk_color_t* colors, int size, sk_pmcolor_t* pmcolors)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_color_premultiply_array (SKColor* colors, Int32 size, SKPMColor* pmcolors);
+		internal static extern void sk_color_premultiply_array (UInt32* colors, Int32 size, UInt32* pmcolors);
 
 		// sk_color_t sk_color_unpremultiply(const sk_pmcolor_t pmcolor)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKColor sk_color_unpremultiply (SKPMColor pmcolor);
+		internal static extern UInt32 sk_color_unpremultiply (UInt32 pmcolor);
 
 		// void sk_color_unpremultiply_array(const sk_pmcolor_t* pmcolors, int size, sk_color_t* colors)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_color_unpremultiply_array (SKPMColor* pmcolors, Int32 size, SKColor* colors);
+		internal static extern void sk_color_unpremultiply_array (UInt32* pmcolors, Int32 size, UInt32* colors);
 
 		// bool sk_jpegencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_jpegencoder_options_t options)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1024,7 +1024,7 @@ namespace SkiaSharp
 		// bool sk_pixmap_erase_color(const sk_pixmap_t* cpixmap, sk_color_t color, const sk_irect_t* subset)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pixmap_erase_color (sk_pixmap_t cpixmap, SKColor color, SKRectI* subset);
+		internal static extern bool sk_pixmap_erase_color (sk_pixmap_t cpixmap, UInt32 color, SKRectI* subset);
 
 		// bool sk_pixmap_extract_subset(const sk_pixmap_t* cpixmap, sk_pixmap_t* result, const sk_irect_t* subset)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1037,7 +1037,7 @@ namespace SkiaSharp
 
 		// sk_color_t sk_pixmap_get_pixel_color(const sk_pixmap_t* cpixmap, int x, int y)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKColor sk_pixmap_get_pixel_color (sk_pixmap_t cpixmap, Int32 x, Int32 y);
+		internal static extern UInt32 sk_pixmap_get_pixel_color (sk_pixmap_t cpixmap, Int32 x, Int32 y);
 
 		// const void* sk_pixmap_get_pixels(const sk_pixmap_t* cpixmap)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1109,7 +1109,7 @@ namespace SkiaSharp
 
 		// sk_colorfilter_t* sk_colorfilter_new_lighting(sk_color_t mul, sk_color_t add)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_lighting (SKColor mul, SKColor add);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_lighting (UInt32 mul, UInt32 add);
 
 		// sk_colorfilter_t* sk_colorfilter_new_luma_color()
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1117,7 +1117,7 @@ namespace SkiaSharp
 
 		// sk_colorfilter_t* sk_colorfilter_new_mode(sk_color_t c, sk_blendmode_t mode)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_mode (SKColor c, SKBlendMode mode);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_mode (UInt32 c, SKBlendMode mode);
 
 		// sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t[256] table = 256)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1244,11 +1244,11 @@ namespace SkiaSharp
 
 		// sk_colortable_t* sk_colortable_new(const sk_pmcolor_t* colors, int count)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colortable_t sk_colortable_new (SKPMColor* colors, Int32 count);
+		internal static extern sk_colortable_t sk_colortable_new (UInt32* colors, Int32 count);
 
 		// void sk_colortable_read_colors(const sk_colortable_t* ctable, sk_pmcolor_t** colors)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_colortable_read_colors (sk_colortable_t ctable, SKPMColor** colors);
+		internal static extern void sk_colortable_read_colors (sk_colortable_t ctable, UInt32** colors);
 
 		// void sk_colortable_unref(sk_colortable_t* ctable)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -2044,15 +2044,15 @@ namespace SkiaSharp
 
 		// sk_imagefilter_t* sk_imagefilter_new_distant_lit_diffuse(const sk_point3_t* direction, sk_color_t lightColor, float surfaceScale, float kd, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_distant_lit_diffuse (SKPoint3* direction, SKColor lightColor, Single surfaceScale, Single kd, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_distant_lit_diffuse (SKPoint3* direction, UInt32 lightColor, Single surfaceScale, Single kd, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_distant_lit_specular(const sk_point3_t* direction, sk_color_t lightColor, float surfaceScale, float ks, float shininess, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_distant_lit_specular (SKPoint3* direction, SKColor lightColor, Single surfaceScale, Single ks, Single shininess, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_distant_lit_specular (SKPoint3* direction, UInt32 lightColor, Single surfaceScale, Single ks, Single shininess, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_drop_shadow(float dx, float dy, float sigmaX, float sigmaY, sk_color_t color, sk_drop_shadow_image_filter_shadow_mode_t shadowMode, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_drop_shadow (Single dx, Single dy, Single sigmaX, Single sigmaY, SKColor color, SKDropShadowImageFilterShadowMode shadowMode, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_drop_shadow (Single dx, Single dy, Single sigmaX, Single sigmaY, UInt32 color, SKDropShadowImageFilterShadowMode shadowMode, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_erode(int radiusX, int radiusY, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -2100,19 +2100,19 @@ namespace SkiaSharp
 
 		// sk_imagefilter_t* sk_imagefilter_new_point_lit_diffuse(const sk_point3_t* location, sk_color_t lightColor, float surfaceScale, float kd, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_point_lit_diffuse (SKPoint3* location, SKColor lightColor, Single surfaceScale, Single kd, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_point_lit_diffuse (SKPoint3* location, UInt32 lightColor, Single surfaceScale, Single kd, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_point_lit_specular(const sk_point3_t* location, sk_color_t lightColor, float surfaceScale, float ks, float shininess, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_point_lit_specular (SKPoint3* location, SKColor lightColor, Single surfaceScale, Single ks, Single shininess, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_point_lit_specular (SKPoint3* location, UInt32 lightColor, Single surfaceScale, Single ks, Single shininess, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_spot_lit_diffuse(const sk_point3_t* location, const sk_point3_t* target, float specularExponent, float cutoffAngle, sk_color_t lightColor, float surfaceScale, float kd, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_spot_lit_diffuse (SKPoint3* location, SKPoint3* target, Single specularExponent, Single cutoffAngle, SKColor lightColor, Single surfaceScale, Single kd, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_spot_lit_diffuse (SKPoint3* location, SKPoint3* target, Single specularExponent, Single cutoffAngle, UInt32 lightColor, Single surfaceScale, Single kd, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_spot_lit_specular(const sk_point3_t* location, const sk_point3_t* target, float specularExponent, float cutoffAngle, sk_color_t lightColor, float surfaceScale, float ks, float shininess, sk_imagefilter_t* input, const sk_imagefilter_croprect_t* cropRect)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_spot_lit_specular (SKPoint3* location, SKPoint3* target, Single specularExponent, Single cutoffAngle, SKColor lightColor, Single surfaceScale, Single ks, Single shininess, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
+		internal static extern sk_imagefilter_t sk_imagefilter_new_spot_lit_specular (SKPoint3* location, SKPoint3* target, Single specularExponent, Single cutoffAngle, UInt32 lightColor, Single surfaceScale, Single ks, Single shininess, sk_imagefilter_t input, sk_imagefilter_croprect_t cropRect);
 
 		// sk_imagefilter_t* sk_imagefilter_new_tile(const sk_rect_t* src, const sk_rect_t* dst, sk_imagefilter_t* input)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -2626,7 +2626,7 @@ namespace SkiaSharp
 
 		// sk_color_t sk_paint_get_color(const sk_paint_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKColor sk_paint_get_color (sk_paint_t param0);
+		internal static extern UInt32 sk_paint_get_color (sk_paint_t param0);
 
 		// sk_colorfilter_t* sk_paint_get_colorfilter(sk_paint_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -2813,7 +2813,7 @@ namespace SkiaSharp
 
 		// void sk_paint_set_color(sk_paint_t*, sk_color_t)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_color (sk_paint_t param0, SKColor param1);
+		internal static extern void sk_paint_set_color (sk_paint_t param0, UInt32 param1);
 
 		// void sk_paint_set_colorfilter(sk_paint_t*, sk_colorfilter_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -3173,7 +3173,7 @@ namespace SkiaSharp
 
 		// sk_shader_t* sk_shader_new_color(sk_color_t color)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_color (SKColor color);
+		internal static extern sk_shader_t sk_shader_new_color (UInt32 color);
 
 		// sk_shader_t* sk_shader_new_color_filter(sk_shader_t* proxy, sk_colorfilter_t* filter)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -3193,7 +3193,7 @@ namespace SkiaSharp
 
 		// sk_shader_t* sk_shader_new_linear_gradient(const sk_point_t[2] points = 2, const sk_color_t[-1] colors, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_linear_gradient (SKPoint* points, SKColor* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
+		internal static extern sk_shader_t sk_shader_new_linear_gradient (SKPoint* points, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
 		// sk_shader_t* sk_shader_new_local_matrix(sk_shader_t* proxy, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -3213,15 +3213,15 @@ namespace SkiaSharp
 
 		// sk_shader_t* sk_shader_new_radial_gradient(const sk_point_t* center, float radius, const sk_color_t[-1] colors, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_radial_gradient (SKPoint* center, Single radius, SKColor* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
+		internal static extern sk_shader_t sk_shader_new_radial_gradient (SKPoint* center, Single radius, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
 		// sk_shader_t* sk_shader_new_sweep_gradient(const sk_point_t* center, const sk_color_t[-1] colors, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, float startAngle, float endAngle, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_sweep_gradient (SKPoint* center, SKColor* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, Single startAngle, Single endAngle, SKMatrix* localMatrix);
+		internal static extern sk_shader_t sk_shader_new_sweep_gradient (SKPoint* center, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, Single startAngle, Single endAngle, SKMatrix* localMatrix);
 
 		// sk_shader_t* sk_shader_new_two_point_conical_gradient(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color_t[-1] colors, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_two_point_conical_gradient (SKPoint* start, Single startRadius, SKPoint* end, Single endRadius, SKColor* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
+		internal static extern sk_shader_t sk_shader_new_two_point_conical_gradient (SKPoint* start, Single startRadius, SKPoint* end, Single endRadius, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
 		// void sk_shader_ref(sk_shader_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -3391,7 +3391,7 @@ namespace SkiaSharp
 
 		// sk_vertices_t* sk_vertices_make_copy(sk_vertices_vertex_mode_t vmode, int vertexCount, const sk_point_t* positions, const sk_point_t* texs, const sk_color_t* colors, int indexCount, const uint16_t* indices)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_vertices_t sk_vertices_make_copy (SKVertexMode vmode, Int32 vertexCount, SKPoint* positions, SKPoint* texs, SKColor* colors, Int32 indexCount, UInt16* indices);
+		internal static extern sk_vertices_t sk_vertices_make_copy (SKVertexMode vmode, Int32 vertexCount, SKPoint* positions, SKPoint* texs, UInt32* colors, Int32 indexCount, UInt16* indices);
 
 		// void sk_vertices_ref(sk_vertices_t* cvertices)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -3982,7 +3982,7 @@ namespace SkiaSharp
 		// public const sk_irect_t* fBounds
 		public SKRectI* fBounds;
 		// public const sk_color_t* fColors
-		public SKColor* fColors;
+		public UInt32* fColors;
 	}
 
 	// sk_manageddrawable_procs_t

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -11,14 +11,13 @@
   },
   "mappings": {
     "types": {
-      // colors are actually uint, but we map them to structs
+      // type aliases
       "sk_color_t": {
-        "cs": "SKColor"
+        "cs": "UInt32"
       },
       "sk_pmcolor_t": {
-        "cs": "SKPMColor"
+        "cs": "UInt32"
       },
-      // type aliases
       "sk_vector_t": {
         "cs": "SKPoint"
       },

--- a/tests/Tests/SKColorTest.cs
+++ b/tests/Tests/SKColorTest.cs
@@ -217,5 +217,16 @@ namespace SkiaSharp.Tests
 				Assert.Equal(16, SKImageInfo.PlatformColorBlueShift);
 			}
 		}
+
+		[SkippableFact]
+		public void MakeSureColorsAreNotBroken()
+		{
+			var color = new SKColor(100, 0, 0, 100);
+
+			var paint = new SKPaint();
+			paint.Color = color;
+
+			Assert.Equal(color, paint.Color);
+		}
 	}
 }

--- a/tests/Tests/SKColorTest.cs
+++ b/tests/Tests/SKColorTest.cs
@@ -228,5 +228,29 @@ namespace SkiaSharp.Tests
 
 			Assert.Equal(color, paint.Color);
 		}
+
+		[Obsolete]
+		[SkippableFact]
+		public void CanPreMultiplyArrays()
+		{
+			var colors = new SKColor[] { 0x33008200, 0x33008200, 0x33008200, 0x33008200, 0x33008200 };
+			var pmcolors = new SKPMColor[] { 0x33001A00, 0x33001A00, 0x33001A00, 0x33001A00, 0x33001A00 };
+
+			var pm = SKPMColor.PreMultiply(colors);
+
+			Assert.Equal(pmcolors, pm);
+		}
+
+		[Obsolete]
+		[SkippableFact]
+		public void CanUnPreultiplyArrays()
+		{
+			var colors = new SKColor[] { 0x33008200, 0x33008200, 0x33008200, 0x33008200, 0x33008200 };
+			var pmcolors = new SKPMColor[] { 0x33001A00, 0x33001A00, 0x33001A00, 0x33001A00, 0x33001A00 };
+
+			var upm = SKPMColor.UnPreMultiply(pmcolors);
+
+			Assert.Equal(colors, upm);
+		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Seems that when colors go into the native world and back, we aren't passing it correctly.

This issue keeps coming up when I update the native interop. I add tests that catch it, but it looks like every time I update, I do something to bypass the tests. I am writing bad tests then.

The reason for this time is because I switched to the new interop generator, but the rules for `SKColor` are special. When being passed INTO a method as arguments, then you can just pass `SKColor` (the struct) directly. But, as part of a RETURN, you have to use the actual `uint`. This is all because we are working with a nice struct on the managed side, but in the native side it is just a `uint`.

In this PR, I just switch to `uint` everywhere, except for arrays where I explicitly cast from `SKColor*` to `uint*` so nothing can break accidentally.

**Bugs Fixed**

- Fixes #1017 
- Related to #307
- Related to #143 

**API Changes**

None.

**Behavioral Changes**

Correct colors.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
