### PR TITLE
Use better PR labels for build artifacts

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -172,6 +172,8 @@ Task ("tests-only")
 Task ("samples")
     .Does (() =>
 {
+    EnsureDirectoryExists ("./output/");
+
     var isLinux = IsRunningOnLinux ();
     var isMac = IsRunningOnMac ();
     var isWin = IsRunningOnWindows ();

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranchName)
-  BUILD_NUMBER: $[counter(variables['Build.SourceBranch'], 150)]
+  BUILD_NUMBER: $[counter(variables['Build.SourceBranch'], 1)]
   FEATURE_NAME: ''
   PREVIEW_LABEL: 'rc'
   NATIVE_LINUX_PACKAGES: curl mono-complete msbuild python git libfontconfig1-dev clang-3.8 make

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -41,11 +41,14 @@ jobs:
       - pwsh: |
           if ($env:GIT_BRANCH_NAME.StartsWith($env:FEATURE_NAME_PREFIX)) {
             $feature = $env:GIT_BRANCH_NAME.Substring($env:FEATURE_NAME_PREFIX.Length)
+            Write-Host "Feature name: $feature"
             Write-Host "##vso[task.setvariable variable=FEATURE_NAME]$feature"
           }
         displayName: Determine the feature name, if any
       - pwsh: |
-          Write-Host "##vso[task.setvariable variable=PREVIEW_LABEL]pr"
+          $pr = "pr." + $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+          Write-Host "Preview label: $pr"
+          Write-Host "##vso[task.setvariable variable=PREVIEW_LABEL]$pr"
         displayName: Use a special preview label for PRs
         condition: eq(variables['Build.Reason'], 'PullRequest')
       # install any packages on linux


### PR DESCRIPTION
**Description of Change**

The PRs should use the format vX.X.X-pr.<pr-number>.<build-number>

**Bugs Fixed**

None

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
