### PR TITLE
Add the .targets file to buildTransitive

### DIFF
--- a/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
+++ b/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
@@ -35,6 +35,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net45/HarfBuzzSharp.targets" target="build/net45/HarfBuzzSharp.NativeAssets.Linux.targets" />
+    <file src="build/net45/HarfBuzzSharp.targets" target="buildTransitive/net45/HarfBuzzSharp.NativeAssets.Linux.targets" />
 
     <!-- harfbuzz.dll and other native files -->
     <file platform="linux" src="runtimes/linux-x64/native/libHarfBuzzSharp.so" />

--- a/nuget/HarfbuzzSharp.nuspec
+++ b/nuget/HarfbuzzSharp.nuspec
@@ -84,6 +84,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net45/HarfBuzzSharp.targets" />
+    <file src="build/net45/HarfBuzzSharp.targets" target="buildTransitive/net45/HarfBuzzSharp.targets" />
     <file src="build/tizen40/HarfBuzzSharp.targets" />
 
     <!-- harfbuzz.dll and other native files -->

--- a/nuget/SkiaSharp.NativeAssets.Linux.NoDependencies.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.NoDependencies.nuspec
@@ -48,6 +48,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net45/SkiaSharp.targets" target="build/net45/SkiaSharp.NativeAssets.Linux.NoDependencies.targets" />
+    <file src="build/net45/SkiaSharp.targets" target="buildTransitive/net45/SkiaSharp.NativeAssets.Linux.NoDependencies.targets" />
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="linux" src="runtimes/linuxnodeps-x64/native/libSkiaSharp.so" target="runtimes/linux-x64/native/libSkiaSharp.so" />

--- a/nuget/SkiaSharp.NativeAssets.Linux.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.nuspec
@@ -36,6 +36,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net45/SkiaSharp.targets" target="build/net45/SkiaSharp.NativeAssets.Linux.targets" />
+    <file src="build/net45/SkiaSharp.targets" target="buildTransitive/net45/SkiaSharp.NativeAssets.Linux.targets" />
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="linux" src="runtimes/linux-x64/native/libSkiaSharp.so" />

--- a/nuget/SkiaSharp.NativeAssets.NanoServer.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.NanoServer.nuspec
@@ -38,6 +38,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net45/SkiaSharp.targets" target="build/net45/SkiaSharp.NativeAssets.NanoServer.targets" />
+    <file src="build/net45/SkiaSharp.targets" target="buildTransitive/net45/SkiaSharp.NativeAssets.NanoServer.targets" />
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="windows" src="runtimes/nanoserver-x64/native/libSkiaSharp.dll" target="runtimes/win-x64/native/libSkiaSharp.dll" />

--- a/nuget/SkiaSharp.nuspec
+++ b/nuget/SkiaSharp.nuspec
@@ -85,6 +85,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net45/SkiaSharp.targets" />
+    <file src="build/net45/SkiaSharp.targets" target="buildTransitive/net45/SkiaSharp.targets" />
     <file src="build/tizen40/SkiaSharp.targets" />
 
     <!-- libSkiaSharp.dll and other native files -->


### PR DESCRIPTION
**Description of Change**

Add the .targets file to the `buildTransitive` folder in the NuGet package. This only applies to net45 and Full Framework apps. This makes sure that the .targets file is always referenced and the native files are always copied as part of the build. 

The main issue this solves is for transitive dependencies with App -> Core -> ThirdParty -> SkiaSharp. In this scenario, the native libraries will only be copied as part of build for ThirdParty - which is not even part of the project. As a result, the app will never get the binaries. After this PR, each level will get the binaries, including the App and Core.

**Bugs Fixed**

- Fixes #1041

**API Changes**

None.

**Behavioral Changes**

The libSkiaSharp.* binaries will always be copied to the output folder for all projects in the build.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
