### PR TITLE
Don't go straight for the max samples

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
@@ -84,8 +84,12 @@ namespace SkiaSharp.Views.Desktop
 				renderTarget?.Dispose();
 				GL.GetInteger(GetPName.FramebufferBinding, out var framebuffer);
 				GL.GetInteger(GetPName.StencilBits, out var stencil);
+				GL.GetInteger(GetPName.Samples, out var samples);
+				var maxSamples = grContext.GetMaxSurfaceSampleCount(colorType);
+				if (samples > maxSamples)
+					samples = maxSamples;
 				var glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
-				renderTarget = new GRBackendRenderTarget(Width, Height, grContext.GetMaxSurfaceSampleCount(colorType), stencil, glInfo);
+				renderTarget = new GRBackendRenderTarget(Width, Height, samples, stencil, glInfo);
 
 				// create the surface
 				surface?.Dispose();


### PR DESCRIPTION
**Description of Change**

Don't go straight for the max samples as the max may be 32 which may be too many for some GPUs

**Bugs Fixed**

 - Fixes #1053

**API Changes**

None.

**Behavioral Changes**

`SKGLControl` now correctly respects the sample count of the control.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
