### PR TITLE
suffices to start the rotation matrix as the identity matrix

### DIFF
--- a/samples/Gallery/Shared/Samples/ThreeDSample.cs
+++ b/samples/Gallery/Shared/Samples/ThreeDSample.cs
@@ -21,7 +21,7 @@ namespace SkiaSharpSample.Samples
 		protected override async Task OnInit()
 		{
 			// create the base and step 3D rotation matrices (around the y-axis)
-			rotationMatrix = SKMatrix44.CreateRotationDegrees(0, 1, 0, 30);
+			rotationMatrix = SKMatrix44.CreateIdentity();
 			rotationStep = SKMatrix44.CreateRotationDegrees(0, 1, 0, 5);
 
 			await base.OnInit();


### PR DESCRIPTION
**Description of Change**

In the 3D orthogonal rotation sample, the initial rotation matrix was set to 30 degrees around the Y-axis.  This is not necessary.  It suffices to set the initial rotation matrix to the identity matrix.

**Bugs Fixed**

None.

**API Changes**

None

**Behavioral Changes**

None

**PR Checklist**

(not sure about this section)

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
