### PR TITLE
Remove an unused argument of type TaskScheduler from AnimatedSampleBase

### DIFF
--- a/samples/Gallery/Shared/SampleBase.cs
+++ b/samples/Gallery/Shared/SampleBase.cs
@@ -163,7 +163,7 @@ namespace SkiaSharpSample
 			{
 				while (!cts.IsCancellationRequested)
 				{
-					await OnUpdate(cts.Token, scheduler);
+					await OnUpdate(cts.Token);
 
 					new Task(Refresh).Start(scheduler);
 				}
@@ -177,7 +177,7 @@ namespace SkiaSharpSample
 			cts.Cancel();
 		}
 
-		protected abstract Task OnUpdate(CancellationToken token, TaskScheduler mainScheduler);
+		protected abstract Task OnUpdate(CancellationToken token);
 	}
 
 	public enum GestureState

--- a/samples/Gallery/Shared/Samples/DecodeGifFramesSample.cs
+++ b/samples/Gallery/Shared/Samples/DecodeGifFramesSample.cs
@@ -37,8 +37,7 @@ namespace SkiaSharpSample.Samples
 			await base.OnInit();
 		}
 
-		protected override async Task OnUpdate(CancellationToken token, TaskScheduler mainScheduler)
-		{
+		protected override async Task OnUpdate(CancellationToken token) {
 			var duration = frames[currentFrame].Duration;
 			if (duration <= 0)
 				duration = 100;

--- a/samples/Gallery/Shared/Samples/DecodeGifFramesSample.cs
+++ b/samples/Gallery/Shared/Samples/DecodeGifFramesSample.cs
@@ -37,7 +37,8 @@ namespace SkiaSharpSample.Samples
 			await base.OnInit();
 		}
 
-		protected override async Task OnUpdate(CancellationToken token) {
+		protected override async Task OnUpdate(CancellationToken token)
+		{
 			var duration = frames[currentFrame].Duration;
 			if (duration <= 0)
 				duration = 100;

--- a/samples/Gallery/Shared/Samples/ThreeDSample.cs
+++ b/samples/Gallery/Shared/Samples/ThreeDSample.cs
@@ -27,8 +27,7 @@ namespace SkiaSharpSample.Samples
 			await base.OnInit();
 		}
 
-		protected override async Task OnUpdate(CancellationToken token, TaskScheduler mainScheduler)
-		{
+		protected override async Task OnUpdate(CancellationToken token) {
 			await Task.Delay(25, token);
 
 			// step the rotation matrix

--- a/samples/Gallery/Shared/Samples/ThreeDSample.cs
+++ b/samples/Gallery/Shared/Samples/ThreeDSample.cs
@@ -27,7 +27,8 @@ namespace SkiaSharpSample.Samples
 			await base.OnInit();
 		}
 
-		protected override async Task OnUpdate(CancellationToken token) {
+		protected override async Task OnUpdate(CancellationToken token)
+		{
 			await Task.Delay(25, token);
 
 			// step the rotation matrix

--- a/samples/Gallery/Shared/Samples/ThreeDSamplePerspective.cs
+++ b/samples/Gallery/Shared/Samples/ThreeDSamplePerspective.cs
@@ -26,7 +26,8 @@ namespace SkiaSharpSample.Samples
 			await base.OnInit();
 		}
 
-		protected override async Task OnUpdate(CancellationToken token) {
+		protected override async Task OnUpdate(CancellationToken token)
+		{
 			await Task.Delay(25, token);
 
 			// step the rotation matrix

--- a/samples/Gallery/Shared/Samples/ThreeDSamplePerspective.cs
+++ b/samples/Gallery/Shared/Samples/ThreeDSamplePerspective.cs
@@ -26,8 +26,7 @@ namespace SkiaSharpSample.Samples
 			await base.OnInit();
 		}
 
-		protected override async Task OnUpdate(CancellationToken token, TaskScheduler mainScheduler)
-		{
+		protected override async Task OnUpdate(CancellationToken token) {
 			await Task.Delay(25, token);
 
 			// step the rotation matrix


### PR DESCRIPTION
**Description of Change**

Removed an unused argument of type `TaskScheduler` from `AnimatedSampleBase`.

**Bugs Fixed**

None

**API Changes**

None

**Behavioral Changes**

None

**PR Checklist**

(not sure about this section)

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
