### PR TITLE
Multitarget Views.WPF

### DIFF
--- a/nuget/SkiaSharp.Views.Desktop.Common.nuspec
+++ b/nuget/SkiaSharp.Views.Desktop.Common.nuspec
@@ -36,6 +36,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- SkiaSharp.Views.*.dll -->
     <file src="lib/net45/SkiaSharp.Views.Desktop.Common.dll" />
     <file src="lib/net45/SkiaSharp.Views.Desktop.Common.xml" />
+    <file src="lib/netcoreapp3.0/SkiaSharp.Views.Desktop.Common.dll" />
+    <file src="lib/netcoreapp3.0/SkiaSharp.Views.Desktop.Common.xml" />
     <file src="lib/netstandard2.0/SkiaSharp.Views.Desktop.Common.dll" />
     <file src="lib/netstandard2.0/SkiaSharp.Views.Desktop.Common.xml" />
 

--- a/nuget/SkiaSharp.Views.WPF.nuspec
+++ b/nuget/SkiaSharp.Views.WPF.nuspec
@@ -35,6 +35,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
   <files>
 
     <!-- SkiaSharp.Views.*.dll -->
+    <file src="lib/netcoreapp3.0/SkiaSharp.Views.WPF.dll" />
+    <file src="lib/netcoreapp3.0/SkiaSharp.Views.WPF.xml" />
     <file platform="windows" src="lib/net45/SkiaSharp.Views.WPF.dll" />
     <file platform="windows" src="lib/net45/SkiaSharp.Views.WPF.xml" />
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -1,12 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net451;netcoreapp3.0</TargetFrameworks>
+    <UseWpf>true</UseWpf>
     <RootNamespace>SkiaSharp.Views.WPF</RootNamespace>
     <AssemblyName>SkiaSharp.Views.WPF</AssemblyName>
     <PackagingGroup>SkiaSharp.Views.WPF</PackagingGroup>
     <DefineConstants>$(DefineConstants);__DESKTOP__;__WPF__</DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <RootNamespace>SkiaSharp.Views.WPF</RootNamespace>
     <AssemblyName>SkiaSharp.Views.WPF</AssemblyName>
     <PackagingGroup>SkiaSharp.Views.WPF</PackagingGroup>
     <DefineConstants>$(DefineConstants);__DESKTOP__;__WPF__</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />


### PR DESCRIPTION
**Description of Change**

`SkiaSharp.View.WPF` now targets `.NET Core 3.0` in addition to `.NET Framework 4.5.1`.

**Bugs Fixed**

Related to issue #1029, which is about getting both `SkiaSharp.View.WPF` as well as `SkiaSharp.View.WindowsForms` to target `.Net Core`.

**API Changes**

None

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
 - NA
- [x] Changes adhere to coding standard
- [ ] Updated documentation
