### PR TITLE
Remove OpenTK references from View.WPF

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -13,10 +13,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.0.1" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.0.1" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />
     <ProjectReference Include="..\SkiaSharp.Views.Desktop.Common\SkiaSharp.Views.Desktop.Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
**Description of Change**

In addition to having no compile-time dependency (and pointed out in https://github.com/mono/SkiaSharp/issues/1029#issuecomment-568156345), the nuspec file for View.WPF does not reference any OpenTK packages, so Views.WPF shouldn't need to reference these packages either.

**Bugs Fixed**

Related to issue #1029.  This change removes two warnings when targeting .NET Core in View.WPF.

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
 - NA
- [x] Changes adhere to coding standard
- [ ] Updated documentation
