### PR TITLE
WPF Mouse Wheel on Touch Event

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerElement.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerElement.cs
@@ -28,6 +28,7 @@ namespace SkiaSharp.Views.Forms
 				view.MouseDown -= OnMousePressed;
 				view.MouseMove -= OnMouseMoved;
 				view.MouseUp -= OnMouseReleased;
+				view.MouseWheel -= OnMouseWheel;
 
 				if (enableTouchEvents)
 				{
@@ -37,6 +38,7 @@ namespace SkiaSharp.Views.Forms
 					view.MouseDown += OnMousePressed;
 					view.MouseMove += OnMouseMoved;
 					view.MouseUp += OnMouseReleased;
+					view.MouseWheel += OnMouseWheel;
 				}
 			}
 		}
@@ -87,6 +89,11 @@ namespace SkiaSharp.Views.Forms
 			view.ReleaseMouseCapture();
 		}
 
+		private void OnMouseWheel(object sender, MouseWheelEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.WheelChanged, e);
+		}
+
 		// processing
 
 		private bool CommonHandler(object sender, SKTouchAction touchActionType, InputEventArgs evt)
@@ -103,8 +110,9 @@ namespace SkiaSharp.Views.Forms
 			var windowsPoint = GetPosition(evt, view);
 			var skPoint = scalePixels(windowsPoint.X, windowsPoint.Y);
 			var inContact = GetContact(evt);
+			var wheelDelta = evt is MouseWheelEventArgs wheelEvt ? wheelEvt.Delta : 0;
 
-			var args = new SKTouchEventArgs(id, action, mouse, device, skPoint, inContact);
+			var args = new SKTouchEventArgs(id, action, mouse, device, skPoint, inContact, wheelDelta);
 			onTouchAction(args);
 			return args.Handled;
 		}

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerWinForms.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerWinForms.cs
@@ -23,6 +23,7 @@ namespace SkiaSharp.Views.Forms
 				view.MouseDown -= OnMousePressed;
 				view.MouseMove -= OnMouseMoved;
 				view.MouseUp -= OnMouseReleased;
+				view.MouseWheel -= OnMouseWheel;
 
 				if (enableTouchEvents)
 				{
@@ -31,6 +32,7 @@ namespace SkiaSharp.Views.Forms
 					view.MouseDown += OnMousePressed;
 					view.MouseMove += OnMouseMoved;
 					view.MouseUp += OnMouseReleased;
+					view.MouseWheel += OnMouseWheel;
 				}
 			}
 		}
@@ -87,6 +89,11 @@ namespace SkiaSharp.Views.Forms
 			view.Capture = false;
 		}
 
+		private void OnMouseWheel(object sender, MouseEventArgs e)
+		{
+			var handled = CommonHandler(sender, SKTouchAction.WheelChanged, e);
+		}
+
 		// processing
 
 		private bool CommonHandler(object sender, SKTouchAction touchActionType, MouseEventArgs evt)
@@ -103,8 +110,9 @@ namespace SkiaSharp.Views.Forms
 			var windowsPoint = evt.Location;
 			var skPoint = scalePixels(windowsPoint.X, windowsPoint.Y);
 			var inContact = GetContact(evt);
+			var wheelDelta = evt.Delta;
 
-			var args = new SKTouchEventArgs(id, action, mouse, device, skPoint, inContact);
+			var args = new SKTouchEventArgs(id, action, mouse, device, skPoint, inContact, wheelDelta);
 			onTouchAction(args);
 			return args.Handled;
 		}


### PR DESCRIPTION
**Implement `SKTouchAction.WheelChanged` for WPF**

Add event handler for MouseWheel for both SKCanvasView and SKGLView Renderers

**API Changes**

Added: 
 
- `void SKTouchHandlerElement.OnMouseWheel(object sender, MouseWheelEventArgs e);`
- `void SKTouchHandlerWinForms.OnMouseWheel(object** sender, MouseEventArgs e);`

Changed:

 - `bool SKTouchHandlerElement.CommonHandler(object sender, SKTouchAction touchActionType, InputEventArgs evt);`
 - `bool SKTouchHandlerWinForms.CommonHandler(object sender, SKTouchAction touchActionType, MouseEventArgs evt);`

Implement WPF backend

**PR Checklist**

- [ ] No tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
