### PR TITLE
Fix broken antialiasing with UWP SKSwapChainPanel

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
@@ -49,8 +49,13 @@ namespace SkiaSharp.Views.UWP
 				renderTarget?.Dispose();
 				Gles.glGetIntegerv(Gles.GL_FRAMEBUFFER_BINDING, out var framebuffer);
 				Gles.glGetIntegerv(Gles.GL_STENCIL_BITS, out var stencil);
+				Gles.glGetIntegerv(Gles.GL_SAMPLES, out var samples);
+				var maxSamples = context.GetMaxSurfaceSampleCount(colorType);
+				if (samples > maxSamples)
+					samples = maxSamples;
+
 				var glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
-				renderTarget = new GRBackendRenderTarget((int)rect.Width, (int)rect.Height, context.GetMaxSurfaceSampleCount(colorType), stencil, glInfo);
+				renderTarget = new GRBackendRenderTarget((int)rect.Width, (int)rect.Height, samples, stencil, glInfo);
 
 				// create the surface
 				surface?.Dispose();


### PR DESCRIPTION
**Description of Change**

Fix broken antialiasing with UWP SKSwapChainPanel.

**Bugs Fixed**

- Antialiasing is broken on GPU backend with UWP SKSwapChainPanel like #1053. Reproduced with NVIDIA GeForce GTX 970.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation