### PR TITLE
Disallow intercept of touch event by adding option in SKTouchEventArgs

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
@@ -55,6 +55,10 @@ namespace SkiaSharp.Views.Forms
 						var args = new SKTouchEventArgs(id, SKTouchAction.Pressed, coords, true);
 						onTouchAction(args);
 						e.Handled = args.Handled;
+
+						if (args.RequestDisallowIntercept && (sender is View view))
+							view.Parent?.RequestDisallowInterceptTouchEvent(true);
+
 						break;
 					}
 
@@ -69,6 +73,10 @@ namespace SkiaSharp.Views.Forms
 							var args = new SKTouchEventArgs(id, SKTouchAction.Moved, coords, true);
 							onTouchAction(args);
 							e.Handled = e.Handled || args.Handled;
+
+							if (args.RequestDisallowIntercept && (sender is View view))
+								view.Parent?.RequestDisallowInterceptTouchEvent(true);
+
 						}
 						break;
 					}
@@ -79,6 +87,10 @@ namespace SkiaSharp.Views.Forms
 						var args = new SKTouchEventArgs(id, SKTouchAction.Released, coords, false);
 						onTouchAction(args);
 						e.Handled = args.Handled;
+
+						if (sender is View view)
+							view.Parent?.RequestDisallowInterceptTouchEvent(false);
+
 						break;
 					}
 
@@ -87,6 +99,10 @@ namespace SkiaSharp.Views.Forms
 						var args = new SKTouchEventArgs(id, SKTouchAction.Cancelled, coords, false);
 						onTouchAction(args);
 						e.Handled = args.Handled;
+
+						if (sender is View view)
+							view.Parent?.RequestDisallowInterceptTouchEvent(false);
+
 						break;
 					}
 			}

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKTouchEventArgs.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKTouchEventArgs.cs
@@ -28,6 +28,12 @@ namespace SkiaSharp.Views.Forms
 
 		public bool Handled { get; set; }
 
+		/// <summary>
+        /// Disallow Touch intercept hook for Andriod systems
+        /// 
+        /// </summary>
+		public bool RequestDisallowIntercept { get; set; }
+
 		public long Id { get; private set; }
 
 		public SKTouchAction ActionType { get; private set; }
@@ -44,7 +50,7 @@ namespace SkiaSharp.Views.Forms
 
 		public override string ToString()
 		{
-			return $"{{ActionType={ActionType}, DeviceType={DeviceType}, Handled={Handled}, Id={Id}, InContact={InContact}, Location={Location}, MouseButton={MouseButton}, WheelDelta={WheelDelta}}}";
+			return $"{{ActionType={ActionType}, DeviceType={DeviceType}, Handled={Handled},RequestDisallowIntercept={RequestDisallowIntercept}, Id={Id}, InContact={InContact}, Location={Location}, MouseButton={MouseButton}, WheelDelta={WheelDelta}}}";
 		}
 	}
 


### PR DESCRIPTION

**Description of Change**

Updated "SKTouchEventArgs" so it contains boolean "RequestDisallowIntercept" which will call the equal function in Androids SKTouchHandler to enable more control for the user like the solution of @FoggyFinder in #953 

Tests made but hang after "SkiaSharp.Tests.SKCodecTest.ReadOnlyStream [FINISHED] Time: 0,0163149s"

**Bugs Fixed**

- Related to issue #937 

**API Changes**

List all API changes here (or just put None), example:

Added: 
 
- bool SkiaSharp.Views.Forms.SKTouchEventArgs.RequestDisallowIntercept { get; set; }

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
