### PR TITLE
Adding the SKColorF (with SKColorSpace) overloads

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -802,5 +802,16 @@ namespace SkiaSharp
 		{
 			SkiaApi.sk_bitmap_swap (Handle, other.Handle);
 		}
+
+		// ToShader
+
+		public SKShader ToShader () =>
+			ToShader (SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy) =>
+			SKShader.CreateBitmap (this, tmx, tmy);
+
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix) =>
+			SKShader.CreateBitmap (this, tmx, tmy, localMatrix);
 	}
 }

--- a/binding/Binding/SKColorF.cs
+++ b/binding/Binding/SKColorF.cs
@@ -1,0 +1,280 @@
+﻿using System;
+
+namespace SkiaSharp
+{
+	public unsafe partial struct SKColorF
+	{
+		private const float EPSILON = 0.001f;
+
+		public static readonly SKColorF Empty;
+
+		public SKColorF (float red, float green, float blue)
+		{
+			fR = red;
+			fG = green;
+			fB = blue;
+			fA = 1f;
+		}
+
+		public SKColorF (float red, float green, float blue, float alpha)
+		{
+			fR = red;
+			fG = green;
+			fB = blue;
+			fA = alpha;
+		}
+
+		public SKColorF WithRed (float red) =>
+			new SKColorF (red, Green, Blue, Alpha);
+
+		public SKColorF WithGreen (float green) =>
+			new SKColorF (Red, green, Blue, Alpha);
+
+		public SKColorF WithBlue (float blue) =>
+			new SKColorF (Red, Green, blue, Alpha);
+
+		public SKColorF WithAlpha (float alpha) =>
+			new SKColorF (Red, Green, Blue, alpha);
+
+		public float Hue {
+			get {
+				ToHsv (out var h, out var s, out var v);
+				return h;
+			}
+		}
+
+		public SKColorF Clamp ()
+		{
+			return new SKColorF (Clamp (Red), Clamp (Green), Clamp (Blue), Clamp (Alpha));
+
+			static float Clamp (float v)
+			{
+				if (v > 1f)
+					return 1f;
+				if (v < 0f)
+					return 0f;
+				return v;
+			}
+		}
+
+		public static SKColorF FromHsl (float h, float s, float l, float a = 1f)
+		{
+			// convert from percentages
+			h = h / 360f;
+			s = s / 100f;
+			l = l / 100f;
+
+			// RGB results from 0 to 1
+			var r = l;
+			var g = l;
+			var b = l;
+
+			// HSL from 0 to 1
+			if (Math.Abs (s) > EPSILON) {
+				float v2;
+				if (l < 0.5f)
+					v2 = l * (1f + s);
+				else
+					v2 = (l + s) - (s * l);
+
+				var v1 = 2f * l - v2;
+
+				r = HueToRgb (v1, v2, h + (1f / 3f));
+				g = HueToRgb (v1, v2, h);
+				b = HueToRgb (v1, v2, h - (1f / 3f));
+			}
+
+			return new SKColorF (r, g, b, a);
+		}
+
+		private static float HueToRgb (float v1, float v2, float vH)
+		{
+			if (vH < 0f)
+				vH += 1f;
+			if (vH > 1f)
+				vH -= 1f;
+
+			if ((6f * vH) < 1f)
+				return (v1 + (v2 - v1) * 6f * vH);
+			if ((2f * vH) < 1f)
+				return (v2);
+			if ((3f * vH) < 2f)
+				return (v1 + (v2 - v1) * ((2f / 3f) - vH) * 6f);
+			return (v1);
+		}
+
+		public static SKColorF FromHsv (float h, float s, float v, float a = 1f)
+		{
+			// convert from percentages
+			h = h / 360f;
+			s = s / 100f;
+			v = v / 100f;
+
+			// RGB results from 0 to 1
+			var r = v;
+			var g = v;
+			var b = v;
+
+			// HSL from 0 to 1
+			if (Math.Abs (s) > EPSILON) {
+				h = h * 6f;
+				if (Math.Abs (h - 6f) < EPSILON)
+					h = 0f; // H must be < 1
+
+				var hInt = (int)h;
+				var v1 = v * (1f - s);
+				var v2 = v * (1f - s * (h - hInt));
+				var v3 = v * (1f - s * (1f - (h - hInt)));
+
+				if (hInt == 0) {
+					r = v;
+					g = v3;
+					b = v1;
+				} else if (hInt == 1) {
+					r = v2;
+					g = v;
+					b = v1;
+				} else if (hInt == 2) {
+					r = v1;
+					g = v;
+					b = v3;
+				} else if (hInt == 3) {
+					r = v1;
+					g = v2;
+					b = v;
+				} else if (hInt == 4) {
+					r = v3;
+					g = v1;
+					b = v;
+				} else {
+					r = v;
+					g = v1;
+					b = v2;
+				}
+			}
+
+			return new SKColorF (r, g, b, a);
+		}
+
+		public void ToHsl (out float h, out float s, out float l)
+		{
+			// RGB from 0 to 1
+			var r = Red;
+			var g = Green;
+			var b = Blue;
+
+			var min = Math.Min (Math.Min (r, g), b); // min value of RGB
+			var max = Math.Max (Math.Max (r, g), b); // max value of RGB
+			var delta = max - min; // delta RGB value
+
+			// default to a gray, no chroma...
+			h = 0f;
+			s = 0f;
+			l = (max + min) / 2f;
+
+			// chromatic data...
+			if (Math.Abs (delta) > EPSILON) {
+				if (l < 0.5f)
+					s = delta / (max + min);
+				else
+					s = delta / (2f - max - min);
+
+				var deltaR = (((max - r) / 6f) + (delta / 2f)) / delta;
+				var deltaG = (((max - g) / 6f) + (delta / 2f)) / delta;
+				var deltaB = (((max - b) / 6f) + (delta / 2f)) / delta;
+
+				if (Math.Abs (r - max) < EPSILON) // r == max
+					h = deltaB - deltaG;
+				else if (Math.Abs (g - max) < EPSILON) // g == max
+					h = (1f / 3f) + deltaR - deltaB;
+				else // b == max
+					h = (2f / 3f) + deltaG - deltaR;
+
+				if (h < 0f)
+					h += 1f;
+				if (h > 1f)
+					h -= 1f;
+			}
+
+			// convert to percentages
+			h = h * 360f;
+			s = s * 100f;
+			l = l * 100f;
+		}
+
+		public void ToHsv (out float h, out float s, out float v)
+		{
+			// RGB from 0 to 1
+			var r = Red;
+			var g = Green;
+			var b = Blue;
+
+			var min = Math.Min (Math.Min (r, g), b); // min value of RGB
+			var max = Math.Max (Math.Max (r, g), b); // max value of RGB
+			var delta = max - min; // delta RGB value 
+
+			// default to a gray, no chroma...
+			h = 0;
+			s = 0;
+			v = max;
+
+			// chromatic data...
+			if (Math.Abs (delta) > EPSILON) {
+				s = delta / max;
+
+				var deltaR = (((max - r) / 6f) + (delta / 2f)) / delta;
+				var deltaG = (((max - g) / 6f) + (delta / 2f)) / delta;
+				var deltaB = (((max - b) / 6f) + (delta / 2f)) / delta;
+
+				if (Math.Abs (r - max) < EPSILON) // r == max
+					h = deltaB - deltaG;
+				else if (Math.Abs (g - max) < EPSILON) // g == max
+					h = (1f / 3f) + deltaR - deltaB;
+				else // b == max
+					h = (2f / 3f) + deltaG - deltaR;
+
+				if (h < 0f)
+					h += 1f;
+				if (h > 1f)
+					h -= 1f;
+			}
+
+			// convert to percentages
+			h = h * 360f;
+			s = s * 100f;
+			v = v * 100f;
+		}
+
+		public override string ToString () =>
+			((SKColor)this).ToString ();
+
+		public override bool Equals (object other) =>
+			other is SKColorF c &&
+			c.fR == fR &&
+			c.fG == fG &&
+			c.fB == fB &&
+			c.fA == fA;
+
+		public override int GetHashCode () =>
+			((SKColor)this).GetHashCode ();
+
+		public static implicit operator SKColorF (SKColor color)
+		{
+			SKColorF colorF;
+			SkiaApi.sk_color4f_from_color ((uint)color, &colorF);
+			return colorF;
+		}
+
+		public static explicit operator SKColor (SKColorF color) =>
+			SkiaApi.sk_color4f_to_color (&color);
+
+		public static bool operator == (SKColorF left, SKColorF right) =>
+			left.fR == right.fR &&
+			left.fG == right.fG &&
+			left.fB == right.fB &&
+			left.fA == right.fA;
+
+		public static bool operator != (SKColorF left, SKColorF right) =>
+			!(left == right);
+	}
+}

--- a/binding/Binding/SKImage.cs
+++ b/binding/Binding/SKImage.cs
@@ -486,17 +486,18 @@ namespace SkiaSharp
 		public bool IsAlphaOnly => SkiaApi.sk_image_is_alpha_only (Handle);
 		public SKData EncodedData => GetObject<SKData> (SkiaApi.sk_image_ref_encoded (Handle));
 
-		public SKShader ToShader () => ToShader (SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+		// ToShader
 
-		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY)
-		{
-			return GetObject<SKShader> (SkiaApi.sk_image_make_shader (Handle, tileX, tileY, null));
-		}
+		public SKShader ToShader () =>
+			ToShader (SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
 
-		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKMatrix localMatrix)
-		{
-			return GetObject<SKShader> (SkiaApi.sk_image_make_shader (Handle, tileX, tileY, &localMatrix));
-		}
+		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY) =>
+			GetObject<SKShader> (SkiaApi.sk_image_make_shader (Handle, tileX, tileY, null));
+
+		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKMatrix localMatrix) =>
+			GetObject<SKShader> (SkiaApi.sk_image_make_shader (Handle, tileX, tileY, &localMatrix));
+
+		// PeekPixels
 
 		public bool PeekPixels (SKPixmap pixmap)
 		{

--- a/binding/Binding/SKPicture.cs
+++ b/binding/Binding/SKPicture.cs
@@ -13,7 +13,8 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public uint UniqueId => SkiaApi.sk_picture_get_unique_id (Handle);
+		public uint UniqueId =>
+			SkiaApi.sk_picture_get_unique_id (Handle);
 
 		public SKRect CullRect {
 			get {
@@ -22,5 +23,19 @@ namespace SkiaSharp
 				return rect;
 			}
 		}
+
+		// ToShader
+
+		public SKShader ToShader () =>
+			ToShader (SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy) =>
+			SKShader.CreatePicture (this, tmx, tmy);
+
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKRect tile) =>
+			SKShader.CreatePicture (this, tmx, tmy, tile);
+
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix, SKRect tile) =>
+			SKShader.CreatePicture (this, tmx, tmy, localMatrix, tile);
 	}
 }

--- a/binding/Binding/SKPixmap.cs
+++ b/binding/Binding/SKPixmap.cs
@@ -288,6 +288,12 @@ namespace SkiaSharp
 			return SkiaApi.sk_pixmap_erase_color (Handle, (uint)color, &subset);
 		}
 
+		public bool Erase (SKColorF color) =>
+			Erase (color, Rect);
+
+		public bool Erase (SKColorF color, SKRectI subset) =>
+			SkiaApi.sk_pixmap_erase_color4f (Handle, &color, &subset);
+
 		public SKPixmap WithColorType (SKColorType newColorType)
 		{
 			return new SKPixmap (Info.WithColorType (newColorType), GetPixels (), RowBytes);

--- a/binding/Binding/SKShader.cs
+++ b/binding/Binding/SKShader.cs
@@ -13,7 +13,7 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		// With*
+		// WithColorFilter
 
 		public SKShader WithColorFilter (SKColorFilter filter)
 		{
@@ -22,6 +22,8 @@ namespace SkiaSharp
 
 			return GetObject<SKShader> (SkiaApi.sk_shader_with_color_filter (Handle, filter.Handle));
 		}
+
+		// WithLocalMatrix
 
 		public SKShader WithLocalMatrix (SKMatrix localMatrix) =>
 			GetObject<SKShader> (SkiaApi.sk_shader_with_local_matrix (Handle, &localMatrix));
@@ -46,6 +48,9 @@ namespace SkiaSharp
 
 		// CreateBitmap
 
+		public static SKShader CreateBitmap (SKBitmap src) =>
+			CreateBitmap (src, SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+
 		public static SKShader CreateBitmap (SKBitmap src, SKShaderTileMode tmx, SKShaderTileMode tmy)
 		{
 			if (src == null)
@@ -62,7 +67,31 @@ namespace SkiaSharp
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_bitmap (src.Handle, tmx, tmy, &localMatrix));
 		}
 
+		// CreateImage
+
+		public static SKShader CreateImage (SKImage src) =>
+			CreateImage (src, SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
+
+		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy)
+		{
+			if (src == null)
+				throw new ArgumentNullException (nameof (src));
+
+			return src.ToShader (tmx, tmy);
+		}
+
+		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix)
+		{
+			if (src == null)
+				throw new ArgumentNullException (nameof (src));
+
+			return src.ToShader (tmx, tmy, localMatrix);
+		}
+
 		// CreatePicture
+
+		public static SKShader CreatePicture (SKPicture src) =>
+			CreatePicture (src, SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
 
 		public static SKShader CreatePicture (SKPicture src, SKShaderTileMode tmx, SKShaderTileMode tmy)
 		{
@@ -86,28 +115,6 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (src));
 
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_picture (src.Handle, tmx, tmy, &localMatrix, &tile));
-		}
-
-		// CreateColorFilter
-
-		public static SKShader CreateColorFilter (SKShader shader, SKColorFilter filter)
-		{
-			if (shader == null)
-				throw new ArgumentNullException (nameof (shader));
-			if (filter == null)
-				throw new ArgumentNullException (nameof (filter));
-
-			return shader.WithColorFilter (filter);
-		}
-
-		// CreateLocalMatrix
-
-		public static SKShader CreateLocalMatrix (SKShader shader, SKMatrix localMatrix)
-		{
-			if (shader == null)
-				throw new ArgumentNullException (nameof (shader));
-
-			return shader.WithLocalMatrix (localMatrix);
 		}
 
 		// CreateLinearGradient
@@ -237,7 +244,7 @@ namespace SkiaSharp
 		// CreateSweepGradient
 
 		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors) =>
-			CreateSweepGradient (center, colors, null);
+			CreateSweepGradient (center, colors, null, SKShaderTileMode.Clamp, 0, 360);
 
 		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors, float[] colorPos) =>
 			CreateSweepGradient (center, colors, colorPos, SKShaderTileMode.Clamp, 0, 360);
@@ -275,7 +282,7 @@ namespace SkiaSharp
 		}
 
 		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace) =>
-			CreateSweepGradient (center, colors, colorspace, null);
+			CreateSweepGradient (center, colors, colorspace, null, SKShaderTileMode.Clamp, 0, 360);
 
 		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos) =>
 			CreateSweepGradient (center, colors, colorspace, colorPos, SKShaderTileMode.Clamp, 0, 360);
@@ -410,7 +417,30 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (shaderA));
 			if (shaderB == null)
 				throw new ArgumentNullException (nameof (shaderB));
+
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_compose (shaderA.Handle, shaderB.Handle, mode));
+		}
+
+		// CreateColorFilter
+
+		public static SKShader CreateColorFilter (SKShader shader, SKColorFilter filter)
+		{
+			if (shader == null)
+				throw new ArgumentNullException (nameof (shader));
+			if (filter == null)
+				throw new ArgumentNullException (nameof (filter));
+
+			return shader.WithColorFilter (filter);
+		}
+
+		// CreateLocalMatrix
+
+		public static SKShader CreateLocalMatrix (SKShader shader, SKMatrix localMatrix)
+		{
+			if (shader == null)
+				throw new ArgumentNullException (nameof (shader));
+
+			return shader.WithLocalMatrix (localMatrix);
 		}
 	}
 }

--- a/binding/Binding/SKShader.cs
+++ b/binding/Binding/SKShader.cs
@@ -13,20 +13,44 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public static SKShader CreateEmpty ()
+		// With*
+
+		public SKShader WithColorFilter (SKColorFilter filter)
 		{
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_empty ());
+			if (filter == null)
+				throw new ArgumentNullException (nameof (filter));
+
+			return GetObject<SKShader> (SkiaApi.sk_shader_with_color_filter (Handle, filter.Handle));
 		}
 
-		public static SKShader CreateColor (SKColor color)
+		public SKShader WithLocalMatrix (SKMatrix localMatrix) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_with_local_matrix (Handle, &localMatrix));
+
+		// CreateEmpty
+
+		public static SKShader CreateEmpty () =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_empty ());
+
+		// CreateColor
+
+		public static SKShader CreateColor (SKColor color) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_color ((uint)color));
+
+		public static SKShader CreateColor (SKColorF color, SKColorSpace colorspace)
 		{
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_color ((uint)color));
+			if (colorspace == null)
+				throw new ArgumentNullException (nameof (colorspace));
+
+			return GetObject<SKShader> (SkiaApi.sk_shader_new_color4f (&color, colorspace.Handle));
 		}
+
+		// CreateBitmap
 
 		public static SKShader CreateBitmap (SKBitmap src, SKShaderTileMode tmx, SKShaderTileMode tmy)
 		{
 			if (src == null)
 				throw new ArgumentNullException (nameof (src));
+
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_bitmap (src.Handle, tmx, tmy, null));
 		}
 
@@ -34,13 +58,17 @@ namespace SkiaSharp
 		{
 			if (src == null)
 				throw new ArgumentNullException (nameof (src));
+
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_bitmap (src.Handle, tmx, tmy, &localMatrix));
 		}
+
+		// CreatePicture
 
 		public static SKShader CreatePicture (SKPicture src, SKShaderTileMode tmx, SKShaderTileMode tmy)
 		{
 			if (src == null)
 				throw new ArgumentNullException (nameof (src));
+
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_picture (src.Handle, tmx, tmy, null, null));
 		}
 
@@ -48,6 +76,7 @@ namespace SkiaSharp
 		{
 			if (src == null)
 				throw new ArgumentNullException (nameof (src));
+
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_picture (src.Handle, tmx, tmy, null, &tile));
 		}
 
@@ -55,8 +84,11 @@ namespace SkiaSharp
 		{
 			if (src == null)
 				throw new ArgumentNullException (nameof (src));
+
 			return GetObject<SKShader> (SkiaApi.sk_shader_new_picture (src.Handle, tmx, tmy, &localMatrix, &tile));
 		}
+
+		// CreateColorFilter
 
 		public static SKShader CreateColorFilter (SKShader shader, SKColorFilter filter)
 		{
@@ -64,57 +96,94 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (shader));
 			if (filter == null)
 				throw new ArgumentNullException (nameof (filter));
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_color_filter (shader.Handle, filter.Handle));
+
+			return shader.WithColorFilter (filter);
 		}
+
+		// CreateLocalMatrix
 
 		public static SKShader CreateLocalMatrix (SKShader shader, SKMatrix localMatrix)
 		{
 			if (shader == null)
 				throw new ArgumentNullException (nameof (shader));
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_local_matrix (shader.Handle, &localMatrix));
+
+			return shader.WithLocalMatrix (localMatrix);
 		}
+
+		// CreateLinearGradient
 
 		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColor[] colors, SKShaderTileMode mode) =>
 			CreateLinearGradient (start, end, colors, null, mode);
 
-		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColor [] colors, float [] colorPos, SKShaderTileMode mode)
+		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColor[] colors, float[] colorPos, SKShaderTileMode mode)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
 			if (colorPos != null && colors.Length != colorPos.Length)
 				throw new ArgumentException ("The number of colors must match the number of color positions.");
 
-			var points = new SKPoint[] { start, end };
-			fixed (SKPoint* p = points)
+			var points = stackalloc SKPoint[] { start, end };
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (p, (uint*)c, cp, colors.Length, mode, null));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (points, (uint*)c, cp, colors.Length, mode, null));
 			}
 		}
 
-		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColor [] colors, float [] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColor[] colors, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
 			if (colorPos != null && colors.Length != colorPos.Length)
 				throw new ArgumentException ("The number of colors must match the number of color positions.");
 
-			var points = new SKPoint[] { start, end };
-			fixed (SKPoint* p = points)
+			var points = stackalloc SKPoint[] { start, end };
 			fixed (SKColor* c = colors)
 			fixed (float* cp = colorPos) {
-				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (p, (uint*)c, cp, colors.Length, mode, &localMatrix));
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient (points, (uint*)c, cp, colors.Length, mode, &localMatrix));
 			}
 		}
+
+		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode mode) =>
+			CreateLinearGradient (start, end, colors, colorspace, null, mode);
+
+		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode)
+		{
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			var points = stackalloc SKPoint[] { start, end };
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient_color4f (points, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, mode, null));
+			}
+		}
+
+		public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+		{
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			var points = stackalloc SKPoint[] { start, end };
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_linear_gradient_color4f (points, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, mode, &localMatrix));
+			}
+		}
+
+		// CreateRadialGradient
 
 		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColor[] colors, SKShaderTileMode mode) =>
 			CreateRadialGradient (center, radius, colors, null, mode);
 
-		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColor [] colors, float [] colorPos, SKShaderTileMode mode)
+		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColor[] colors, float[] colorPos, SKShaderTileMode mode)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
-			if (colorPos!=null && colors.Length != colorPos.Length)
+			if (colorPos != null && colors.Length != colorPos.Length)
 				throw new ArgumentException ("The number of colors must match the number of color positions.");
 
 			fixed (SKColor* c = colors)
@@ -122,8 +191,8 @@ namespace SkiaSharp
 				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient (&center, radius, (uint*)c, cp, colors.Length, mode, null));
 			}
 		}
-		
-		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColor [] colors, float [] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+
+		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColor[] colors, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
@@ -136,23 +205,50 @@ namespace SkiaSharp
 			}
 		}
 
+		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode mode) =>
+			CreateRadialGradient (center, radius, colors, colorspace, null, mode);
+
+		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode)
+		{
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient_color4f (&center, radius, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, mode, null));
+			}
+		}
+
+		public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+		{
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_radial_gradient_color4f (&center, radius, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, mode, &localMatrix));
+			}
+		}
+
+		// CreateSweepGradient
+
 		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors) =>
 			CreateSweepGradient (center, colors, null);
 
-		public static SKShader CreateSweepGradient (SKPoint center, SKColor [] colors, float [] colorPos)
-		{
-			return CreateSweepGradient (center, colors, colorPos, SKShaderTileMode.Clamp, 0, 360);
-		}
+		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors, float[] colorPos) =>
+			CreateSweepGradient (center, colors, colorPos, SKShaderTileMode.Clamp, 0, 360);
 
-		public static SKShader CreateSweepGradient (SKPoint center, SKColor [] colors, float [] colorPos, SKMatrix localMatrix)
-		{
-			return CreateSweepGradient (center, colors, colorPos, SKShaderTileMode.Clamp, 0, 360, localMatrix);
-		}
+		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors, float[] colorPos, SKMatrix localMatrix) =>
+			CreateSweepGradient (center, colors, colorPos, SKShaderTileMode.Clamp, 0, 360, localMatrix);
 
 		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors, SKShaderTileMode tileMode, float startAngle, float endAngle) =>
 			CreateSweepGradient (center, colors, null, tileMode, startAngle, endAngle);
 
-		public static SKShader CreateSweepGradient (SKPoint center, SKColor [] colors, float [] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle)
+		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors, float[] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
@@ -164,8 +260,8 @@ namespace SkiaSharp
 				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient (&center, (uint*)c, cp, colors.Length, tileMode, startAngle, endAngle, null));
 			}
 		}
-		
-		public static SKShader CreateSweepGradient (SKPoint center, SKColor [] colors, float [] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle, SKMatrix localMatrix)
+
+		public static SKShader CreateSweepGradient (SKPoint center, SKColor[] colors, float[] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle, SKMatrix localMatrix)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
@@ -178,10 +274,50 @@ namespace SkiaSharp
 			}
 		}
 
+		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace) =>
+			CreateSweepGradient (center, colors, colorspace, null);
+
+		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos) =>
+			CreateSweepGradient (center, colors, colorspace, colorPos, SKShaderTileMode.Clamp, 0, 360);
+
+		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKMatrix localMatrix) =>
+			CreateSweepGradient (center, colors, colorspace, colorPos, SKShaderTileMode.Clamp, 0, 360, localMatrix);
+
+		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode tileMode, float startAngle, float endAngle) =>
+			CreateSweepGradient (center, colors, colorspace, null, tileMode, startAngle, endAngle);
+
+		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle)
+		{
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient_color4f (&center, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, tileMode, startAngle, endAngle, null));
+			}
+		}
+
+		public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle, SKMatrix localMatrix)
+		{
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_sweep_gradient_color4f (&center, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, tileMode, startAngle, endAngle, &localMatrix));
+			}
+		}
+
+		// CreateTwoPointConicalGradient
+
 		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColor[] colors, SKShaderTileMode mode) =>
 			CreateTwoPointConicalGradient (start, startRadius, end, endRadius, colors, null, mode);
 
-		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColor [] colors, float [] colorPos, SKShaderTileMode mode)
+		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColor[] colors, float[] colorPos, SKShaderTileMode mode)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
@@ -193,8 +329,8 @@ namespace SkiaSharp
 				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient (&start, startRadius, &end, endRadius, (uint*)c, cp, colors.Length, mode, null));
 			}
 		}
-		
-		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColor [] colors, float [] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
+
+		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColor[] colors, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
 		{
 			if (colors == null)
 				throw new ArgumentNullException (nameof (colors));
@@ -206,42 +342,67 @@ namespace SkiaSharp
 				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient (&start, startRadius, &end, endRadius, (uint*)c, cp, colors.Length, mode, &localMatrix));
 			}
 		}
-		
-		public static SKShader CreatePerlinNoiseFractalNoise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed)
+
+		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode mode) =>
+			CreateTwoPointConicalGradient (start, startRadius, end, endRadius, colors, colorspace, null, mode);
+
+		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode)
 		{
-			return GetObject<SKShader>(SkiaApi.sk_shader_new_perlin_noise_fractal_noise(baseFrequencyX, baseFrequencyY, numOctaves, seed, null));
-		}
-		
-		public static SKShader CreatePerlinNoiseImprovedNoise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float z)
-		{
-			return GetObject<SKShader>(SkiaApi.sk_shader_new_perlin_noise_improved_noise(baseFrequencyX, baseFrequencyY, numOctaves, z));
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient_color4f (&start, startRadius, &end, endRadius, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, mode, null));
+			}
 		}
 
-		public static SKShader CreatePerlinNoiseFractalNoise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKPointI tileSize)
+		public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix)
 		{
-			var size = (SKSizeI)tileSize;
-			return GetObject<SKShader>(SkiaApi.sk_shader_new_perlin_noise_fractal_noise(baseFrequencyX, baseFrequencyY, numOctaves, seed, &size));
+			if (colors == null)
+				throw new ArgumentNullException (nameof (colors));
+			if (colorPos != null && colors.Length != colorPos.Length)
+				throw new ArgumentException ("The number of colors must match the number of color positions.");
+
+			fixed (SKColorF* c = colors)
+			fixed (float* cp = colorPos) {
+				return GetObject<SKShader> (SkiaApi.sk_shader_new_two_point_conical_gradient_color4f (&start, startRadius, &end, endRadius, c, colorspace?.Handle ?? IntPtr.Zero, cp, colors.Length, mode, &localMatrix));
+			}
 		}
 
-		public static SKShader CreatePerlinNoiseTurbulence(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed)
-		{
-			return GetObject<SKShader>(SkiaApi.sk_shader_new_perlin_noise_turbulence(baseFrequencyX, baseFrequencyY, numOctaves, seed, null));
-		}
+		// CreatePerlinNoiseFractalNoise
 
-		public static SKShader CreatePerlinNoiseTurbulence(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKPointI tileSize)
-		{
-			var size = (SKSizeI)tileSize;
-			return GetObject<SKShader>(SkiaApi.sk_shader_new_perlin_noise_turbulence(baseFrequencyX, baseFrequencyY, numOctaves, seed, &size));
-		}
+		public static SKShader CreatePerlinNoiseFractalNoise (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_perlin_noise_fractal_noise (baseFrequencyX, baseFrequencyY, numOctaves, seed, null));
 
-		public static SKShader CreateCompose (SKShader shaderA, SKShader shaderB)
-		{
-			if (shaderA == null)
-				throw new ArgumentNullException (nameof (shaderA));
-			if (shaderB == null)
-				throw new ArgumentNullException (nameof (shaderB));
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_compose (shaderA.Handle, shaderB.Handle));
-		}
+		public static SKShader CreatePerlinNoiseFractalNoise (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKPointI tileSize) =>
+			CreatePerlinNoiseFractalNoise (baseFrequencyX, baseFrequencyY, numOctaves, seed, (SKSizeI)tileSize);
+
+		public static SKShader CreatePerlinNoiseFractalNoise (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKSizeI tileSize) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_perlin_noise_fractal_noise (baseFrequencyX, baseFrequencyY, numOctaves, seed, &tileSize));
+
+		// CreatePerlinNoiseImprovedNoise
+
+		public static SKShader CreatePerlinNoiseImprovedNoise (float baseFrequencyX, float baseFrequencyY, int numOctaves, float z) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_perlin_noise_improved_noise (baseFrequencyX, baseFrequencyY, numOctaves, z));
+
+		// CreatePerlinNoiseTurbulence
+
+		public static SKShader CreatePerlinNoiseTurbulence (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_perlin_noise_turbulence (baseFrequencyX, baseFrequencyY, numOctaves, seed, null));
+
+		public static SKShader CreatePerlinNoiseTurbulence (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKPointI tileSize) =>
+			CreatePerlinNoiseTurbulence (baseFrequencyX, baseFrequencyY, numOctaves, seed, (SKSizeI)tileSize);
+
+		public static SKShader CreatePerlinNoiseTurbulence (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKSizeI tileSize) =>
+			GetObject<SKShader> (SkiaApi.sk_shader_new_perlin_noise_turbulence (baseFrequencyX, baseFrequencyY, numOctaves, seed, &tileSize));
+
+		// CreateCompose
+
+		public static SKShader CreateCompose (SKShader shaderA, SKShader shaderB) =>
+			CreateCompose (shaderA, shaderB, SKBlendMode.SrcOver);
 
 		public static SKShader CreateCompose (SKShader shaderA, SKShader shaderB, SKBlendMode mode)
 		{
@@ -249,8 +410,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (shaderA));
 			if (shaderB == null)
 				throw new ArgumentNullException (nameof (shaderB));
-			return GetObject<SKShader> (SkiaApi.sk_shader_new_compose_with_mode (shaderA.Handle, shaderB.Handle, mode));
+			return GetObject<SKShader> (SkiaApi.sk_shader_new_compose (shaderA.Handle, shaderB.Handle, mode));
 		}
 	}
 }
-

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -2727,17 +2727,13 @@ namespace SkiaSharp
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_shader_t sk_shader_new_color (UInt32 color);
 
-		// sk_shader_t* sk_shader_new_color_filter(sk_shader_t* proxy, sk_colorfilter_t* filter)
+		// sk_shader_t* sk_shader_new_color4f(const sk_color4f_t* color, const sk_colorspace_t* colorspace)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_color_filter (sk_shader_t proxy, sk_colorfilter_t filter);
+		internal static extern sk_shader_t sk_shader_new_color4f (SKColorF* color, sk_colorspace_t colorspace);
 
-		// sk_shader_t* sk_shader_new_compose(sk_shader_t* shaderA, sk_shader_t* shaderB)
+		// sk_shader_t* sk_shader_new_compose(const sk_shader_t* shaderA, const sk_shader_t* shaderB, sk_blendmode_t mode)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_compose (sk_shader_t shaderA, sk_shader_t shaderB);
-
-		// sk_shader_t* sk_shader_new_compose_with_mode(sk_shader_t* shaderA, sk_shader_t* shaderB, sk_blendmode_t mode)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_compose_with_mode (sk_shader_t shaderA, sk_shader_t shaderB, SKBlendMode mode);
+		internal static extern sk_shader_t sk_shader_new_compose (sk_shader_t shaderA, sk_shader_t shaderB, SKBlendMode mode);
 
 		// sk_shader_t* sk_shader_new_empty()
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -2747,9 +2743,9 @@ namespace SkiaSharp
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_shader_t sk_shader_new_linear_gradient (SKPoint* points, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
-		// sk_shader_t* sk_shader_new_local_matrix(sk_shader_t* proxy, const sk_matrix_t* localMatrix)
+		// sk_shader_t* sk_shader_new_linear_gradient_color4f(const sk_point_t[2] points = 2, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_shader_new_local_matrix (sk_shader_t proxy, SKMatrix* localMatrix);
+		internal static extern sk_shader_t sk_shader_new_linear_gradient_color4f (SKPoint* points, SKColorF* colors, sk_colorspace_t colorspace, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
 		// sk_shader_t* sk_shader_new_perlin_noise_fractal_noise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, const sk_isize_t* tileSize)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -2771,21 +2767,41 @@ namespace SkiaSharp
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_shader_t sk_shader_new_radial_gradient (SKPoint* center, Single radius, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
+		// sk_shader_t* sk_shader_new_radial_gradient_color4f(const sk_point_t* center, float radius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_shader_t sk_shader_new_radial_gradient_color4f (SKPoint* center, Single radius, SKColorF* colors, sk_colorspace_t colorspace, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
+
 		// sk_shader_t* sk_shader_new_sweep_gradient(const sk_point_t* center, const sk_color_t[-1] colors, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, float startAngle, float endAngle, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_shader_t sk_shader_new_sweep_gradient (SKPoint* center, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, Single startAngle, Single endAngle, SKMatrix* localMatrix);
+
+		// sk_shader_t* sk_shader_new_sweep_gradient_color4f(const sk_point_t* center, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, float startAngle, float endAngle, const sk_matrix_t* localMatrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_shader_t sk_shader_new_sweep_gradient_color4f (SKPoint* center, SKColorF* colors, sk_colorspace_t colorspace, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, Single startAngle, Single endAngle, SKMatrix* localMatrix);
 
 		// sk_shader_t* sk_shader_new_two_point_conical_gradient(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color_t[-1] colors, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_shader_t sk_shader_new_two_point_conical_gradient (SKPoint* start, Single startRadius, SKPoint* end, Single endRadius, UInt32* colors, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
-		// void sk_shader_ref(sk_shader_t*)
+		// sk_shader_t* sk_shader_new_two_point_conical_gradient_color4f(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float[-1] colorPos, int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_shader_ref (sk_shader_t param0);
+		internal static extern sk_shader_t sk_shader_new_two_point_conical_gradient_color4f (SKPoint* start, Single startRadius, SKPoint* end, Single endRadius, SKColorF* colors, sk_colorspace_t colorspace, Single* colorPos, Int32 colorCount, SKShaderTileMode tileMode, SKMatrix* localMatrix);
 
-		// void sk_shader_unref(sk_shader_t*)
+		// void sk_shader_ref(sk_shader_t* shader)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_shader_unref (sk_shader_t param0);
+		internal static extern void sk_shader_ref (sk_shader_t shader);
+
+		// void sk_shader_unref(sk_shader_t* shader)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_shader_unref (sk_shader_t shader);
+
+		// sk_shader_t* sk_shader_with_color_filter(const sk_shader_t* shader, const sk_colorfilter_t* filter)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_shader_t sk_shader_with_color_filter (sk_shader_t shader, sk_colorfilter_t filter);
+
+		// sk_shader_t* sk_shader_with_local_matrix(const sk_shader_t* shader, const sk_matrix_t* localMatrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_shader_t sk_shader_with_local_matrix (sk_shader_t shader, SKMatrix* localMatrix);
 
 		#endregion
 

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -2493,6 +2493,11 @@ namespace SkiaSharp
 		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool sk_pixmap_erase_color (sk_pixmap_t cpixmap, UInt32 color, SKRectI* subset);
 
+		// bool sk_pixmap_erase_color4f(const sk_pixmap_t* cpixmap, const sk_color4f_t* color, const sk_irect_t* subset)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pixmap_erase_color4f (sk_pixmap_t cpixmap, SKColorF* color, SKRectI* subset);
+
 		// bool sk_pixmap_extract_subset(const sk_pixmap_t* cpixmap, sk_pixmap_t* result, const sk_irect_t* subset)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -1115,47 +1115,19 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_colorfilter.h
-
-		// sk_colorfilter_t* sk_colorfilter_new_color_matrix(const float[20] array = 20)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_color_matrix (Single* array);
-
-		// sk_colorfilter_t* sk_colorfilter_new_compose(sk_colorfilter_t* outer, sk_colorfilter_t* inner)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_compose (sk_colorfilter_t outer, sk_colorfilter_t inner);
-
-		// sk_colorfilter_t* sk_colorfilter_new_high_contrast(const sk_highcontrastconfig_t* config)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_high_contrast (SKHighContrastConfig* config);
-
-		// sk_colorfilter_t* sk_colorfilter_new_lighting(sk_color_t mul, sk_color_t add)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_lighting (UInt32 mul, UInt32 add);
-
-		// sk_colorfilter_t* sk_colorfilter_new_luma_color()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_luma_color ();
-
-		// sk_colorfilter_t* sk_colorfilter_new_mode(sk_color_t c, sk_blendmode_t mode)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_mode (UInt32 c, SKBlendMode mode);
-
-		// sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t[256] table = 256)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_table (Byte* table);
-
-		// sk_colorfilter_t* sk_colorfilter_new_table_argb(const uint8_t[256] tableA = 256, const uint8_t[256] tableR = 256, const uint8_t[256] tableG = 256, const uint8_t[256] tableB = 256)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_table_argb (Byte* tableA, Byte* tableR, Byte* tableG, Byte* tableB);
-
-		// void sk_colorfilter_unref(sk_colorfilter_t* filter)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_colorfilter_unref (sk_colorfilter_t filter);
-
-		#endregion
-
 		#region sk_colorspace.h
+
+		// void sk_color4f_from_color(sk_color_t color, sk_color4f_t* color4f)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_color4f_from_color (UInt32 color, SKColorF* color4f);
+
+		// void sk_color4f_pin(const sk_color4f_t* color4f, sk_color4f_t* pinned)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_color4f_pin (SKColorF* color4f, SKColorF* pinned);
+
+		// sk_color_t sk_color4f_to_color(const sk_color4f_t* color4f)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern UInt32 sk_color4f_to_color (SKColorF* color4f);
 
 		// const sk_matrix44_t* sk_colorspace_as_from_xyzd50(const sk_colorspace_t* cColorSpace)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -1255,6 +1227,46 @@ namespace SkiaSharp
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]
 		internal static extern bool sk_colorspaceprimaries_to_xyzd50 (SKColorSpacePrimaries* primaries, sk_matrix44_t toXYZD50);
+
+		#endregion
+
+		#region sk_colorfilter.h
+
+		// sk_colorfilter_t* sk_colorfilter_new_color_matrix(const float[20] array = 20)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_color_matrix (Single* array);
+
+		// sk_colorfilter_t* sk_colorfilter_new_compose(sk_colorfilter_t* outer, sk_colorfilter_t* inner)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_compose (sk_colorfilter_t outer, sk_colorfilter_t inner);
+
+		// sk_colorfilter_t* sk_colorfilter_new_high_contrast(const sk_highcontrastconfig_t* config)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_high_contrast (SKHighContrastConfig* config);
+
+		// sk_colorfilter_t* sk_colorfilter_new_lighting(sk_color_t mul, sk_color_t add)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_lighting (UInt32 mul, UInt32 add);
+
+		// sk_colorfilter_t* sk_colorfilter_new_luma_color()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_luma_color ();
+
+		// sk_colorfilter_t* sk_colorfilter_new_mode(sk_color_t c, sk_blendmode_t mode)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_mode (UInt32 c, SKBlendMode mode);
+
+		// sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t[256] table = 256)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_table (Byte* table);
+
+		// sk_colorfilter_t* sk_colorfilter_new_table_argb(const uint8_t[256] tableA = 256, const uint8_t[256] tableR = 256, const uint8_t[256] tableG = 256, const uint8_t[256] tableB = 256)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_colorfilter_new_table_argb (Byte* tableA, Byte* tableR, Byte* tableG, Byte* tableB);
+
+		// void sk_colorfilter_unref(sk_colorfilter_t* filter)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_colorfilter_unref (sk_colorfilter_t filter);
 
 		#endregion
 
@@ -3666,6 +3678,39 @@ namespace SkiaSharp
 		public Int32 fPriorFrame;
 		// public sk_transfer_function_behavior_t fPremulBehavior
 		public SKTransferFunctionBehavior fPremulBehavior;
+	}
+
+	// sk_color4f_t
+	[StructLayout (LayoutKind.Sequential)]
+	public unsafe partial struct SKColorF {
+		// public float fR
+		private Single fR;
+		public Single Red {
+			get => fR;
+			set => fR = value;
+		}
+
+		// public float fG
+		private Single fG;
+		public Single Green {
+			get => fG;
+			set => fG = value;
+		}
+
+		// public float fB
+		private Single fB;
+		public Single Blue {
+			get => fB;
+			set => fB = value;
+		}
+
+		// public float fA
+		private Single fA;
+		public Single Alpha {
+			get => fA;
+			set => fA = value;
+		}
+
 	}
 
 	// sk_colorspace_transfer_fn_t

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -223,246 +223,6 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_matrix.h
-
-		// void sk_3dview_apply_to_canvas(sk_3dview_t* cview, sk_canvas_t* ccanvas)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_apply_to_canvas (sk_3dview_t cview, sk_canvas_t ccanvas);
-
-		// void sk_3dview_destroy(sk_3dview_t* cview)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_destroy (sk_3dview_t cview);
-
-		// float sk_3dview_dot_with_normal(sk_3dview_t* cview, float dx, float dy, float dz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_3dview_dot_with_normal (sk_3dview_t cview, Single dx, Single dy, Single dz);
-
-		// void sk_3dview_get_matrix(sk_3dview_t* cview, sk_matrix_t* cmatrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_get_matrix (sk_3dview_t cview, SKMatrix* cmatrix);
-
-		// sk_3dview_t* sk_3dview_new()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_3dview_t sk_3dview_new ();
-
-		// void sk_3dview_restore(sk_3dview_t* cview)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_restore (sk_3dview_t cview);
-
-		// void sk_3dview_rotate_x_degrees(sk_3dview_t* cview, float degrees)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_rotate_x_degrees (sk_3dview_t cview, Single degrees);
-
-		// void sk_3dview_rotate_x_radians(sk_3dview_t* cview, float radians)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_rotate_x_radians (sk_3dview_t cview, Single radians);
-
-		// void sk_3dview_rotate_y_degrees(sk_3dview_t* cview, float degrees)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_rotate_y_degrees (sk_3dview_t cview, Single degrees);
-
-		// void sk_3dview_rotate_y_radians(sk_3dview_t* cview, float radians)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_rotate_y_radians (sk_3dview_t cview, Single radians);
-
-		// void sk_3dview_rotate_z_degrees(sk_3dview_t* cview, float degrees)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_rotate_z_degrees (sk_3dview_t cview, Single degrees);
-
-		// void sk_3dview_rotate_z_radians(sk_3dview_t* cview, float radians)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_rotate_z_radians (sk_3dview_t cview, Single radians);
-
-		// void sk_3dview_save(sk_3dview_t* cview)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_save (sk_3dview_t cview);
-
-		// void sk_3dview_translate(sk_3dview_t* cview, float x, float y, float z)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_3dview_translate (sk_3dview_t cview, Single x, Single y, Single z);
-
-		// void sk_matrix_concat(sk_matrix_t* result, sk_matrix_t* first, sk_matrix_t* second)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_concat (SKMatrix* result, SKMatrix* first, SKMatrix* second);
-
-		// void sk_matrix_map_points(sk_matrix_t* matrix, sk_point_t* dst, sk_point_t* src, int count)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_map_points (SKMatrix* matrix, SKPoint* dst, SKPoint* src, Int32 count);
-
-		// float sk_matrix_map_radius(sk_matrix_t* matrix, float radius)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_matrix_map_radius (SKMatrix* matrix, Single radius);
-
-		// void sk_matrix_map_rect(sk_matrix_t* matrix, sk_rect_t* dest, sk_rect_t* source)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_map_rect (SKMatrix* matrix, SKRect* dest, SKRect* source);
-
-		// void sk_matrix_map_vector(sk_matrix_t* matrix, float x, float y, sk_point_t* result)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_map_vector (SKMatrix* matrix, Single x, Single y, SKPoint* result);
-
-		// void sk_matrix_map_vectors(sk_matrix_t* matrix, sk_point_t* dst, sk_point_t* src, int count)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_map_vectors (SKMatrix* matrix, SKPoint* dst, SKPoint* src, Int32 count);
-
-		// void sk_matrix_map_xy(sk_matrix_t* matrix, float x, float y, sk_point_t* result)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_map_xy (SKMatrix* matrix, Single x, Single y, SKPoint* result);
-
-		// void sk_matrix_post_concat(sk_matrix_t* result, sk_matrix_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_post_concat (SKMatrix* result, SKMatrix* matrix);
-
-		// void sk_matrix_pre_concat(sk_matrix_t* result, sk_matrix_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix_pre_concat (SKMatrix* result, SKMatrix* matrix);
-
-		// bool sk_matrix_try_invert(sk_matrix_t* matrix, sk_matrix_t* result)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_matrix_try_invert (SKMatrix* matrix, SKMatrix* result);
-
-		// void sk_matrix44_as_col_major(sk_matrix44_t* matrix, float* dst)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_as_col_major (sk_matrix44_t matrix, Single* dst);
-
-		// void sk_matrix44_as_row_major(sk_matrix44_t* matrix, float* dst)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_as_row_major (sk_matrix44_t matrix, Single* dst);
-
-		// void sk_matrix44_destroy(sk_matrix44_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_destroy (sk_matrix44_t matrix);
-
-		// double sk_matrix44_determinant(sk_matrix44_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Double sk_matrix44_determinant (sk_matrix44_t matrix);
-
-		// bool sk_matrix44_equals(sk_matrix44_t* matrix, const sk_matrix44_t* other)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_matrix44_equals (sk_matrix44_t matrix, sk_matrix44_t other);
-
-		// float sk_matrix44_get(sk_matrix44_t* matrix, int row, int col)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_matrix44_get (sk_matrix44_t matrix, Int32 row, Int32 col);
-
-		// sk_matrix44_type_mask_t sk_matrix44_get_type(sk_matrix44_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKMatrix44TypeMask sk_matrix44_get_type (sk_matrix44_t matrix);
-
-		// bool sk_matrix44_invert(sk_matrix44_t* matrix, sk_matrix44_t* inverse)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_matrix44_invert (sk_matrix44_t matrix, sk_matrix44_t inverse);
-
-		// void sk_matrix44_map_scalars(sk_matrix44_t* matrix, const float* src, float* dst)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_map_scalars (sk_matrix44_t matrix, Single* src, Single* dst);
-
-		// void sk_matrix44_map2(sk_matrix44_t* matrix, const float* src2, int count, float* dst4)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_map2 (sk_matrix44_t matrix, Single* src2, Int32 count, Single* dst4);
-
-		// sk_matrix44_t* sk_matrix44_new()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_matrix44_t sk_matrix44_new ();
-
-		// sk_matrix44_t* sk_matrix44_new_concat(const sk_matrix44_t* a, const sk_matrix44_t* b)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_matrix44_t sk_matrix44_new_concat (sk_matrix44_t a, sk_matrix44_t b);
-
-		// sk_matrix44_t* sk_matrix44_new_copy(const sk_matrix44_t* src)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_matrix44_t sk_matrix44_new_copy (sk_matrix44_t src);
-
-		// sk_matrix44_t* sk_matrix44_new_identity()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_matrix44_t sk_matrix44_new_identity ();
-
-		// sk_matrix44_t* sk_matrix44_new_matrix(const sk_matrix_t* src)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_matrix44_t sk_matrix44_new_matrix (SKMatrix* src);
-
-		// void sk_matrix44_post_concat(sk_matrix44_t* matrix, const sk_matrix44_t* m)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_post_concat (sk_matrix44_t matrix, sk_matrix44_t m);
-
-		// void sk_matrix44_post_scale(sk_matrix44_t* matrix, float sx, float sy, float sz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_post_scale (sk_matrix44_t matrix, Single sx, Single sy, Single sz);
-
-		// void sk_matrix44_post_translate(sk_matrix44_t* matrix, float dx, float dy, float dz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_post_translate (sk_matrix44_t matrix, Single dx, Single dy, Single dz);
-
-		// void sk_matrix44_pre_concat(sk_matrix44_t* matrix, const sk_matrix44_t* m)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_pre_concat (sk_matrix44_t matrix, sk_matrix44_t m);
-
-		// void sk_matrix44_pre_scale(sk_matrix44_t* matrix, float sx, float sy, float sz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_pre_scale (sk_matrix44_t matrix, Single sx, Single sy, Single sz);
-
-		// void sk_matrix44_pre_translate(sk_matrix44_t* matrix, float dx, float dy, float dz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_pre_translate (sk_matrix44_t matrix, Single dx, Single dy, Single dz);
-
-		// bool sk_matrix44_preserves_2d_axis_alignment(sk_matrix44_t* matrix, float epsilon)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_matrix44_preserves_2d_axis_alignment (sk_matrix44_t matrix, Single epsilon);
-
-		// void sk_matrix44_set(sk_matrix44_t* matrix, int row, int col, float value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set (sk_matrix44_t matrix, Int32 row, Int32 col, Single value);
-
-		// void sk_matrix44_set_col_major(sk_matrix44_t* matrix, float* dst)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_col_major (sk_matrix44_t matrix, Single* dst);
-
-		// void sk_matrix44_set_concat(sk_matrix44_t* matrix, const sk_matrix44_t* a, const sk_matrix44_t* b)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_concat (sk_matrix44_t matrix, sk_matrix44_t a, sk_matrix44_t b);
-
-		// void sk_matrix44_set_identity(sk_matrix44_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_identity (sk_matrix44_t matrix);
-
-		// void sk_matrix44_set_rotate_about_degrees(sk_matrix44_t* matrix, float x, float y, float z, float degrees)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_rotate_about_degrees (sk_matrix44_t matrix, Single x, Single y, Single z, Single degrees);
-
-		// void sk_matrix44_set_rotate_about_radians(sk_matrix44_t* matrix, float x, float y, float z, float radians)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_rotate_about_radians (sk_matrix44_t matrix, Single x, Single y, Single z, Single radians);
-
-		// void sk_matrix44_set_rotate_about_radians_unit(sk_matrix44_t* matrix, float x, float y, float z, float radians)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_rotate_about_radians_unit (sk_matrix44_t matrix, Single x, Single y, Single z, Single radians);
-
-		// void sk_matrix44_set_row_major(sk_matrix44_t* matrix, float* dst)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_row_major (sk_matrix44_t matrix, Single* dst);
-
-		// void sk_matrix44_set_scale(sk_matrix44_t* matrix, float sx, float sy, float sz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_scale (sk_matrix44_t matrix, Single sx, Single sy, Single sz);
-
-		// void sk_matrix44_set_translate(sk_matrix44_t* matrix, float dx, float dy, float dz)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_set_translate (sk_matrix44_t matrix, Single dx, Single dy, Single dz);
-
-		// void sk_matrix44_to_matrix(sk_matrix44_t* matrix, sk_matrix_t* dst)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_to_matrix (sk_matrix44_t matrix, SKMatrix* dst);
-
-		// void sk_matrix44_transpose(sk_matrix44_t* matrix)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_matrix44_transpose (sk_matrix44_t matrix);
-
-		#endregion
-
 		#region sk_bitmap.h
 
 		// void sk_bitmap_destructor(sk_bitmap_t* cbitmap)
@@ -1007,111 +767,43 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_pixmap.h
+		#region sk_colorfilter.h
 
-		// void sk_color_get_bit_shift(int* a, int* r, int* g, int* b)
+		// sk_colorfilter_t* sk_colorfilter_new_color_matrix(const float[20] array = 20)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_color_get_bit_shift (Int32* a, Int32* r, Int32* g, Int32* b);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_color_matrix (Single* array);
 
-		// sk_pmcolor_t sk_color_premultiply(const sk_color_t color)
+		// sk_colorfilter_t* sk_colorfilter_new_compose(sk_colorfilter_t* outer, sk_colorfilter_t* inner)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern UInt32 sk_color_premultiply (UInt32 color);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_compose (sk_colorfilter_t outer, sk_colorfilter_t inner);
 
-		// void sk_color_premultiply_array(const sk_color_t* colors, int size, sk_pmcolor_t* pmcolors)
+		// sk_colorfilter_t* sk_colorfilter_new_high_contrast(const sk_highcontrastconfig_t* config)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_color_premultiply_array (UInt32* colors, Int32 size, UInt32* pmcolors);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_high_contrast (SKHighContrastConfig* config);
 
-		// sk_color_t sk_color_unpremultiply(const sk_pmcolor_t pmcolor)
+		// sk_colorfilter_t* sk_colorfilter_new_lighting(sk_color_t mul, sk_color_t add)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern UInt32 sk_color_unpremultiply (UInt32 pmcolor);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_lighting (UInt32 mul, UInt32 add);
 
-		// void sk_color_unpremultiply_array(const sk_pmcolor_t* pmcolors, int size, sk_color_t* colors)
+		// sk_colorfilter_t* sk_colorfilter_new_luma_color()
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_color_unpremultiply_array (UInt32* pmcolors, Int32 size, UInt32* colors);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_luma_color ();
 
-		// bool sk_jpegencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_jpegencoder_options_t options)
+		// sk_colorfilter_t* sk_colorfilter_new_mode(sk_color_t c, sk_blendmode_t mode)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_jpegencoder_encode (sk_wstream_t dst, sk_pixmap_t src, SKJpegEncoderOptions options);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_mode (UInt32 c, SKBlendMode mode);
 
-		// void sk_pixmap_destructor(sk_pixmap_t* cpixmap)
+		// sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t[256] table = 256)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pixmap_destructor (sk_pixmap_t cpixmap);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_table (Byte* table);
 
-		// bool sk_pixmap_encode_image(sk_wstream_t* dst, const sk_pixmap_t* src, sk_encoded_image_format_t encoder, int quality)
+		// sk_colorfilter_t* sk_colorfilter_new_table_argb(const uint8_t[256] tableA = 256, const uint8_t[256] tableR = 256, const uint8_t[256] tableG = 256, const uint8_t[256] tableB = 256)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pixmap_encode_image (sk_wstream_t dst, sk_pixmap_t src, SKEncodedImageFormat encoder, Int32 quality);
+		internal static extern sk_colorfilter_t sk_colorfilter_new_table_argb (Byte* tableA, Byte* tableR, Byte* tableG, Byte* tableB);
 
-		// bool sk_pixmap_erase_color(const sk_pixmap_t* cpixmap, sk_color_t color, const sk_irect_t* subset)
+		// void sk_colorfilter_unref(sk_colorfilter_t* filter)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pixmap_erase_color (sk_pixmap_t cpixmap, UInt32 color, SKRectI* subset);
-
-		// bool sk_pixmap_extract_subset(const sk_pixmap_t* cpixmap, sk_pixmap_t* result, const sk_irect_t* subset)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pixmap_extract_subset (sk_pixmap_t cpixmap, sk_pixmap_t result, SKRectI* subset);
-
-		// void sk_pixmap_get_info(const sk_pixmap_t* cpixmap, sk_imageinfo_t* cinfo)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pixmap_get_info (sk_pixmap_t cpixmap, SKImageInfoNative* cinfo);
-
-		// sk_color_t sk_pixmap_get_pixel_color(const sk_pixmap_t* cpixmap, int x, int y)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern UInt32 sk_pixmap_get_pixel_color (sk_pixmap_t cpixmap, Int32 x, Int32 y);
-
-		// const void* sk_pixmap_get_pixels(const sk_pixmap_t* cpixmap)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void* sk_pixmap_get_pixels (sk_pixmap_t cpixmap);
-
-		// const void* sk_pixmap_get_pixels_with_xy(const sk_pixmap_t* cpixmap, int x, int y)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void* sk_pixmap_get_pixels_with_xy (sk_pixmap_t cpixmap, Int32 x, Int32 y);
-
-		// size_t sk_pixmap_get_row_bytes(const sk_pixmap_t* cpixmap)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_pixmap_get_row_bytes (sk_pixmap_t cpixmap);
-
-		// sk_pixmap_t* sk_pixmap_new()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_pixmap_t sk_pixmap_new ();
-
-		// sk_pixmap_t* sk_pixmap_new_with_params(const sk_imageinfo_t* cinfo, const void* addr, size_t rowBytes)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_pixmap_t sk_pixmap_new_with_params (SKImageInfoNative* cinfo, void* addr, /* size_t */ IntPtr rowBytes);
-
-		// bool sk_pixmap_read_pixels(const sk_pixmap_t* cpixmap, const sk_imageinfo_t* dstInfo, void* dstPixels, size_t dstRowBytes, int srcX, int srcY, sk_transfer_function_behavior_t behavior)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pixmap_read_pixels (sk_pixmap_t cpixmap, SKImageInfoNative* dstInfo, void* dstPixels, /* size_t */ IntPtr dstRowBytes, Int32 srcX, Int32 srcY, SKTransferFunctionBehavior behavior);
-
-		// void sk_pixmap_reset(sk_pixmap_t* cpixmap)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pixmap_reset (sk_pixmap_t cpixmap);
-
-		// void sk_pixmap_reset_with_params(sk_pixmap_t* cpixmap, const sk_imageinfo_t* cinfo, const void* addr, size_t rowBytes)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pixmap_reset_with_params (sk_pixmap_t cpixmap, SKImageInfoNative* cinfo, void* addr, /* size_t */ IntPtr rowBytes);
-
-		// bool sk_pixmap_scale_pixels(const sk_pixmap_t* cpixmap, const sk_pixmap_t* dst, sk_filter_quality_t quality)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pixmap_scale_pixels (sk_pixmap_t cpixmap, sk_pixmap_t dst, SKFilterQuality quality);
-
-		// bool sk_pngencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_pngencoder_options_t options)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_pngencoder_encode (sk_wstream_t dst, sk_pixmap_t src, SKPngEncoderOptions options);
-
-		// void sk_swizzle_swap_rb(uint32_t* dest, const uint32_t* src, int count)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_swizzle_swap_rb (UInt32* dest, UInt32* src, Int32 count);
-
-		// bool sk_webpencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_webpencoder_options_t options)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_webpencoder_encode (sk_wstream_t dst, sk_pixmap_t src, SKWebpEncoderOptions options);
+		internal static extern void sk_colorfilter_unref (sk_colorfilter_t filter);
 
 		#endregion
 
@@ -1230,46 +922,6 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_colorfilter.h
-
-		// sk_colorfilter_t* sk_colorfilter_new_color_matrix(const float[20] array = 20)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_color_matrix (Single* array);
-
-		// sk_colorfilter_t* sk_colorfilter_new_compose(sk_colorfilter_t* outer, sk_colorfilter_t* inner)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_compose (sk_colorfilter_t outer, sk_colorfilter_t inner);
-
-		// sk_colorfilter_t* sk_colorfilter_new_high_contrast(const sk_highcontrastconfig_t* config)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_high_contrast (SKHighContrastConfig* config);
-
-		// sk_colorfilter_t* sk_colorfilter_new_lighting(sk_color_t mul, sk_color_t add)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_lighting (UInt32 mul, UInt32 add);
-
-		// sk_colorfilter_t* sk_colorfilter_new_luma_color()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_luma_color ();
-
-		// sk_colorfilter_t* sk_colorfilter_new_mode(sk_color_t c, sk_blendmode_t mode)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_mode (UInt32 c, SKBlendMode mode);
-
-		// sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t[256] table = 256)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_table (Byte* table);
-
-		// sk_colorfilter_t* sk_colorfilter_new_table_argb(const uint8_t[256] tableA = 256, const uint8_t[256] tableR = 256, const uint8_t[256] tableG = 256, const uint8_t[256] tableB = 256)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_colorfilter_new_table_argb (Byte* tableA, Byte* tableR, Byte* tableG, Byte* tableB);
-
-		// void sk_colorfilter_unref(sk_colorfilter_t* filter)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_colorfilter_unref (sk_colorfilter_t filter);
-
-		#endregion
-
 		#region sk_colortable.h
 
 		// int sk_colortable_count(const sk_colortable_t* ctable)
@@ -1287,48 +939,6 @@ namespace SkiaSharp
 		// void sk_colortable_unref(sk_colortable_t* ctable)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void sk_colortable_unref (sk_colortable_t ctable);
-
-		#endregion
-
-		#region sk_general.h
-
-		// sk_colortype_t sk_colortype_get_default_8888()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKColorType sk_colortype_get_default_8888 ();
-
-		// int sk_nvrefcnt_get_ref_count(const sk_nvrefcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_nvrefcnt_get_ref_count (sk_nvrefcnt_t refcnt);
-
-		// void sk_nvrefcnt_safe_ref(sk_nvrefcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_nvrefcnt_safe_ref (sk_nvrefcnt_t refcnt);
-
-		// void sk_nvrefcnt_safe_unref(sk_nvrefcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_nvrefcnt_safe_unref (sk_nvrefcnt_t refcnt);
-
-		// bool sk_nvrefcnt_unique(const sk_nvrefcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_nvrefcnt_unique (sk_nvrefcnt_t refcnt);
-
-		// int sk_refcnt_get_ref_count(const sk_refcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_refcnt_get_ref_count (sk_refcnt_t refcnt);
-
-		// void sk_refcnt_safe_ref(sk_refcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_refcnt_safe_ref (sk_refcnt_t refcnt);
-
-		// void sk_refcnt_safe_unref(sk_refcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_refcnt_safe_unref (sk_refcnt_t refcnt);
-
-		// bool sk_refcnt_unique(const sk_refcnt_t* refcnt)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_refcnt_unique (sk_refcnt_t refcnt);
 
 		#endregion
 
@@ -1448,446 +1058,45 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_stream.h
+		#region sk_general.h
 
-		// void sk_dynamicmemorywstream_copy_to(sk_wstream_dynamicmemorystream_t* cstream, void* data)
+		// sk_colortype_t sk_colortype_get_default_8888()
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_dynamicmemorywstream_copy_to (sk_wstream_dynamicmemorystream_t cstream, void* data);
+		internal static extern SKColorType sk_colortype_get_default_8888 ();
 
-		// void sk_dynamicmemorywstream_destroy(sk_wstream_dynamicmemorystream_t* cstream)
+		// int sk_nvrefcnt_get_ref_count(const sk_nvrefcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_dynamicmemorywstream_destroy (sk_wstream_dynamicmemorystream_t cstream);
+		internal static extern Int32 sk_nvrefcnt_get_ref_count (sk_nvrefcnt_t refcnt);
 
-		// sk_data_t* sk_dynamicmemorywstream_detach_as_data(sk_wstream_dynamicmemorystream_t* cstream)
+		// void sk_nvrefcnt_safe_ref(sk_nvrefcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_data_t sk_dynamicmemorywstream_detach_as_data (sk_wstream_dynamicmemorystream_t cstream);
+		internal static extern void sk_nvrefcnt_safe_ref (sk_nvrefcnt_t refcnt);
 
-		// sk_stream_asset_t* sk_dynamicmemorywstream_detach_as_stream(sk_wstream_dynamicmemorystream_t* cstream)
+		// void sk_nvrefcnt_safe_unref(sk_nvrefcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_asset_t sk_dynamicmemorywstream_detach_as_stream (sk_wstream_dynamicmemorystream_t cstream);
+		internal static extern void sk_nvrefcnt_safe_unref (sk_nvrefcnt_t refcnt);
 
-		// sk_wstream_dynamicmemorystream_t* sk_dynamicmemorywstream_new()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_wstream_dynamicmemorystream_t sk_dynamicmemorywstream_new ();
-
-		// bool sk_dynamicmemorywstream_write_to_stream(sk_wstream_dynamicmemorystream_t* cstream, sk_wstream_t* dst)
+		// bool sk_nvrefcnt_unique(const sk_nvrefcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_dynamicmemorywstream_write_to_stream (sk_wstream_dynamicmemorystream_t cstream, sk_wstream_t dst);
+		internal static extern bool sk_nvrefcnt_unique (sk_nvrefcnt_t refcnt);
 
-		// void sk_filestream_destroy(sk_stream_filestream_t* cstream)
+		// int sk_refcnt_get_ref_count(const sk_refcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_filestream_destroy (sk_stream_filestream_t cstream);
+		internal static extern Int32 sk_refcnt_get_ref_count (sk_refcnt_t refcnt);
 
-		// bool sk_filestream_is_valid(sk_stream_filestream_t* cstream)
+		// void sk_refcnt_safe_ref(sk_refcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_filestream_is_valid (sk_stream_filestream_t cstream);
+		internal static extern void sk_refcnt_safe_ref (sk_refcnt_t refcnt);
 
-		// sk_stream_filestream_t* sk_filestream_new(const char* path)
+		// void sk_refcnt_safe_unref(sk_refcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_filestream_t sk_filestream_new (/* char */ void* path);
+		internal static extern void sk_refcnt_safe_unref (sk_refcnt_t refcnt);
 
-		// void sk_filewstream_destroy(sk_wstream_filestream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_filewstream_destroy (sk_wstream_filestream_t cstream);
-
-		// bool sk_filewstream_is_valid(sk_wstream_filestream_t* cstream)
+		// bool sk_refcnt_unique(const sk_refcnt_t* refcnt)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_filewstream_is_valid (sk_wstream_filestream_t cstream);
-
-		// sk_wstream_filestream_t* sk_filewstream_new(const char* path)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_wstream_filestream_t sk_filewstream_new (/* char */ void* path);
-
-		// void sk_memorystream_destroy(sk_stream_memorystream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_memorystream_destroy (sk_stream_memorystream_t cstream);
-
-		// sk_stream_memorystream_t* sk_memorystream_new()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_memorystream_t sk_memorystream_new ();
-
-		// sk_stream_memorystream_t* sk_memorystream_new_with_data(const void* data, size_t length, bool copyData)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_memorystream_t sk_memorystream_new_with_data (void* data, /* size_t */ IntPtr length, [MarshalAs (UnmanagedType.I1)] bool copyData);
-
-		// sk_stream_memorystream_t* sk_memorystream_new_with_length(size_t length)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_memorystream_t sk_memorystream_new_with_length (/* size_t */ IntPtr length);
-
-		// sk_stream_memorystream_t* sk_memorystream_new_with_skdata(sk_data_t* data)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_memorystream_t sk_memorystream_new_with_skdata (sk_data_t data);
-
-		// void sk_memorystream_set_memory(sk_stream_memorystream_t* cmemorystream, const void* data, size_t length, bool copyData)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_memorystream_set_memory (sk_stream_memorystream_t cmemorystream, void* data, /* size_t */ IntPtr length, [MarshalAs (UnmanagedType.I1)] bool copyData);
-
-		// void sk_stream_asset_destroy(sk_stream_asset_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_stream_asset_destroy (sk_stream_asset_t cstream);
-
-		// void sk_stream_destroy(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_stream_destroy (sk_stream_t cstream);
-
-		// sk_stream_t* sk_stream_duplicate(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_t sk_stream_duplicate (sk_stream_t cstream);
-
-		// sk_stream_t* sk_stream_fork(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_t sk_stream_fork (sk_stream_t cstream);
-
-		// size_t sk_stream_get_length(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_stream_get_length (sk_stream_t cstream);
-
-		// const void* sk_stream_get_memory_base(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void* sk_stream_get_memory_base (sk_stream_t cstream);
-
-		// size_t sk_stream_get_position(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_stream_get_position (sk_stream_t cstream);
-
-		// bool sk_stream_has_length(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_has_length (sk_stream_t cstream);
-
-		// bool sk_stream_has_position(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_has_position (sk_stream_t cstream);
-
-		// bool sk_stream_is_at_end(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_is_at_end (sk_stream_t cstream);
-
-		// bool sk_stream_move(sk_stream_t* cstream, int offset)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_move (sk_stream_t cstream, Int32 offset);
-
-		// size_t sk_stream_peek(sk_stream_t* cstream, void* buffer, size_t size)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_stream_peek (sk_stream_t cstream, void* buffer, /* size_t */ IntPtr size);
-
-		// size_t sk_stream_read(sk_stream_t* cstream, void* buffer, size_t size)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_stream_read (sk_stream_t cstream, void* buffer, /* size_t */ IntPtr size);
-
-		// bool sk_stream_read_bool(sk_stream_t* cstream, bool* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_bool (sk_stream_t cstream, Byte* buffer);
-
-		// bool sk_stream_read_s16(sk_stream_t* cstream, int16_t* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_s16 (sk_stream_t cstream, Int16* buffer);
-
-		// bool sk_stream_read_s32(sk_stream_t* cstream, int32_t* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_s32 (sk_stream_t cstream, Int32* buffer);
-
-		// bool sk_stream_read_s8(sk_stream_t* cstream, int8_t* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_s8 (sk_stream_t cstream, SByte* buffer);
-
-		// bool sk_stream_read_u16(sk_stream_t* cstream, uint16_t* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_u16 (sk_stream_t cstream, UInt16* buffer);
-
-		// bool sk_stream_read_u32(sk_stream_t* cstream, uint32_t* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_u32 (sk_stream_t cstream, UInt32* buffer);
-
-		// bool sk_stream_read_u8(sk_stream_t* cstream, uint8_t* buffer)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_read_u8 (sk_stream_t cstream, Byte* buffer);
-
-		// bool sk_stream_rewind(sk_stream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_rewind (sk_stream_t cstream);
-
-		// bool sk_stream_seek(sk_stream_t* cstream, size_t position)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_stream_seek (sk_stream_t cstream, /* size_t */ IntPtr position);
-
-		// size_t sk_stream_skip(sk_stream_t* cstream, size_t size)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_stream_skip (sk_stream_t cstream, /* size_t */ IntPtr size);
-
-		// size_t sk_wstream_bytes_written(sk_wstream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_wstream_bytes_written (sk_wstream_t cstream);
-
-		// void sk_wstream_flush(sk_wstream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_wstream_flush (sk_wstream_t cstream);
-
-		// int sk_wstream_get_size_of_packed_uint(size_t value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_wstream_get_size_of_packed_uint (/* size_t */ IntPtr value);
-
-		// bool sk_wstream_newline(sk_wstream_t* cstream)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_newline (sk_wstream_t cstream);
-
-		// bool sk_wstream_write(sk_wstream_t* cstream, const void* buffer, size_t size)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write (sk_wstream_t cstream, void* buffer, /* size_t */ IntPtr size);
-
-		// bool sk_wstream_write_16(sk_wstream_t* cstream, uint16_t value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_16 (sk_wstream_t cstream, UInt16 value);
-
-		// bool sk_wstream_write_32(sk_wstream_t* cstream, uint32_t value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_32 (sk_wstream_t cstream, UInt32 value);
-
-		// bool sk_wstream_write_8(sk_wstream_t* cstream, uint8_t value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_8 (sk_wstream_t cstream, Byte value);
-
-		// bool sk_wstream_write_bigdec_as_text(sk_wstream_t* cstream, int64_t value, int minDigits)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_bigdec_as_text (sk_wstream_t cstream, Int64 value, Int32 minDigits);
-
-		// bool sk_wstream_write_bool(sk_wstream_t* cstream, bool value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_bool (sk_wstream_t cstream, [MarshalAs (UnmanagedType.I1)] bool value);
-
-		// bool sk_wstream_write_dec_as_text(sk_wstream_t* cstream, int32_t value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_dec_as_text (sk_wstream_t cstream, Int32 value);
-
-		// bool sk_wstream_write_hex_as_text(sk_wstream_t* cstream, uint32_t value, int minDigits)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_hex_as_text (sk_wstream_t cstream, UInt32 value, Int32 minDigits);
-
-		// bool sk_wstream_write_packed_uint(sk_wstream_t* cstream, size_t value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_packed_uint (sk_wstream_t cstream, /* size_t */ IntPtr value);
-
-		// bool sk_wstream_write_scalar(sk_wstream_t* cstream, float value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_scalar (sk_wstream_t cstream, Single value);
-
-		// bool sk_wstream_write_scalar_as_text(sk_wstream_t* cstream, float value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_scalar_as_text (sk_wstream_t cstream, Single value);
-
-		// bool sk_wstream_write_stream(sk_wstream_t* cstream, sk_stream_t* input, size_t length)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_stream (sk_wstream_t cstream, sk_stream_t input, /* size_t */ IntPtr length);
-
-		// bool sk_wstream_write_text(sk_wstream_t* cstream, const char* value)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_wstream_write_text (sk_wstream_t cstream, [MarshalAs (UnmanagedType.LPStr)] String value);
-
-		#endregion
-
-		#region sk_typeface.h
-
-		// int sk_fontmgr_count_families(sk_fontmgr_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_fontmgr_count_families (sk_fontmgr_t param0);
-
-		// sk_fontmgr_t* sk_fontmgr_create_default()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontmgr_t sk_fontmgr_create_default ();
-
-		// sk_typeface_t* sk_fontmgr_create_from_data(sk_fontmgr_t*, sk_data_t* data, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_create_from_data (sk_fontmgr_t param0, sk_data_t data, Int32 index);
-
-		// sk_typeface_t* sk_fontmgr_create_from_file(sk_fontmgr_t*, const char* path, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_create_from_file (sk_fontmgr_t param0, /* char */ void* path, Int32 index);
-
-		// sk_typeface_t* sk_fontmgr_create_from_stream(sk_fontmgr_t*, sk_stream_asset_t* stream, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_create_from_stream (sk_fontmgr_t param0, sk_stream_asset_t stream, Int32 index);
-
-		// sk_fontstyleset_t* sk_fontmgr_create_styleset(sk_fontmgr_t*, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontstyleset_t sk_fontmgr_create_styleset (sk_fontmgr_t param0, Int32 index);
-
-		// void sk_fontmgr_get_family_name(sk_fontmgr_t*, int index, sk_string_t* familyName)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_fontmgr_get_family_name (sk_fontmgr_t param0, Int32 index, sk_string_t familyName);
-
-		// sk_typeface_t* sk_fontmgr_match_face_style(sk_fontmgr_t*, const sk_typeface_t* face, sk_fontstyle_t* style)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_match_face_style (sk_fontmgr_t param0, sk_typeface_t face, sk_fontstyle_t style);
-
-		// sk_fontstyleset_t* sk_fontmgr_match_family(sk_fontmgr_t*, const char* familyName)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName);
-
-		// sk_typeface_t* sk_fontmgr_match_family_style(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
-
-		// sk_typeface_t* sk_fontmgr_match_family_style_character(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style, const char** bcp47, int bcp47Count, int32_t character)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
-
-		// sk_fontmgr_t* sk_fontmgr_ref_default()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontmgr_t sk_fontmgr_ref_default ();
-
-		// void sk_fontmgr_unref(sk_fontmgr_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_fontmgr_unref (sk_fontmgr_t param0);
-
-		// void sk_fontstyle_delete(sk_fontstyle_t* fs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_fontstyle_delete (sk_fontstyle_t fs);
-
-		// sk_font_style_slant_t sk_fontstyle_get_slant(const sk_fontstyle_t* fs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKFontStyleSlant sk_fontstyle_get_slant (sk_fontstyle_t fs);
-
-		// int sk_fontstyle_get_weight(const sk_fontstyle_t* fs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_fontstyle_get_weight (sk_fontstyle_t fs);
-
-		// int sk_fontstyle_get_width(const sk_fontstyle_t* fs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_fontstyle_get_width (sk_fontstyle_t fs);
-
-		// sk_fontstyle_t* sk_fontstyle_new(int weight, int width, sk_font_style_slant_t slant)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontstyle_t sk_fontstyle_new (Int32 weight, Int32 width, SKFontStyleSlant slant);
-
-		// sk_fontstyleset_t* sk_fontstyleset_create_empty()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontstyleset_t sk_fontstyleset_create_empty ();
-
-		// sk_typeface_t* sk_fontstyleset_create_typeface(sk_fontstyleset_t* fss, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontstyleset_create_typeface (sk_fontstyleset_t fss, Int32 index);
-
-		// int sk_fontstyleset_get_count(sk_fontstyleset_t* fss)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_fontstyleset_get_count (sk_fontstyleset_t fss);
-
-		// void sk_fontstyleset_get_style(sk_fontstyleset_t* fss, int index, sk_fontstyle_t* fs, sk_string_t* style)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_fontstyleset_get_style (sk_fontstyleset_t fss, Int32 index, sk_fontstyle_t fs, sk_string_t style);
-
-		// sk_typeface_t* sk_fontstyleset_match_style(sk_fontstyleset_t* fss, sk_fontstyle_t* style)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontstyleset_match_style (sk_fontstyleset_t fss, sk_fontstyle_t style);
-
-		// void sk_fontstyleset_unref(sk_fontstyleset_t* fss)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_fontstyleset_unref (sk_fontstyleset_t fss);
-
-		// int sk_typeface_chars_to_glyphs(sk_typeface_t* typeface, const char* chars, sk_encoding_t encoding, uint16_t[-1] glyphs, int glyphCount)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_typeface_chars_to_glyphs (sk_typeface_t typeface, /* char */ void* chars, SKEncoding encoding, UInt16* glyphs, Int32 glyphCount);
-
-		// int sk_typeface_count_tables(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_typeface_count_tables (sk_typeface_t typeface);
-
-		// sk_typeface_t* sk_typeface_create_default()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_typeface_create_default ();
-
-		// sk_typeface_t* sk_typeface_create_from_file(const char* path, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_typeface_create_from_file (/* char */ void* path, Int32 index);
-
-		// sk_typeface_t* sk_typeface_create_from_name_with_font_style(const char* familyName, sk_fontstyle_t* style)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_typeface_create_from_name_with_font_style ([MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
-
-		// sk_typeface_t* sk_typeface_create_from_stream(sk_stream_asset_t* stream, int index)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_typeface_create_from_stream (sk_stream_asset_t stream, Int32 index);
-
-		// sk_string_t* sk_typeface_get_family_name(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_string_t sk_typeface_get_family_name (sk_typeface_t typeface);
-
-		// sk_font_style_slant_t sk_typeface_get_font_slant(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKFontStyleSlant sk_typeface_get_font_slant (sk_typeface_t typeface);
-
-		// int sk_typeface_get_font_weight(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_typeface_get_font_weight (sk_typeface_t typeface);
-
-		// int sk_typeface_get_font_width(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_typeface_get_font_width (sk_typeface_t typeface);
-
-		// sk_fontstyle_t* sk_typeface_get_fontstyle(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontstyle_t sk_typeface_get_fontstyle (sk_typeface_t typeface);
-
-		// size_t sk_typeface_get_table_data(sk_typeface_t* typeface, sk_font_table_tag_t tag, size_t offset, size_t length, void* data)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_typeface_get_table_data (sk_typeface_t typeface, UInt32 tag, /* size_t */ IntPtr offset, /* size_t */ IntPtr length, void* data);
-
-		// size_t sk_typeface_get_table_size(sk_typeface_t* typeface, sk_font_table_tag_t tag)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_typeface_get_table_size (sk_typeface_t typeface, UInt32 tag);
-
-		// int sk_typeface_get_table_tags(sk_typeface_t* typeface, sk_font_table_tag_t[-1] tags)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_typeface_get_table_tags (sk_typeface_t typeface, UInt32* tags);
-
-		// int sk_typeface_get_units_per_em(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_typeface_get_units_per_em (sk_typeface_t typeface);
-
-		// bool sk_typeface_is_fixed_pitch(sk_typeface_t* typeface)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_typeface_is_fixed_pitch (sk_typeface_t typeface);
-
-		// sk_stream_asset_t* sk_typeface_open_stream(sk_typeface_t* typeface, int* ttcIndex)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_asset_t sk_typeface_open_stream (sk_typeface_t typeface, Int32* ttcIndex);
-
-		// sk_typeface_t* sk_typeface_ref_default()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_typeface_ref_default ();
-
-		// void sk_typeface_unref(sk_typeface_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_typeface_unref (sk_typeface_t param0);
+		internal static extern bool sk_refcnt_unique (sk_refcnt_t refcnt);
 
 		#endregion
 
@@ -2162,50 +1371,6 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_manageddrawable.h
-
-		// sk_manageddrawable_t* sk_manageddrawable_new(void* context)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_manageddrawable_t sk_manageddrawable_new (void* context);
-
-		// void sk_manageddrawable_set_procs(sk_manageddrawable_procs_t procs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_manageddrawable_set_procs (SKManagedDrawableDelegates procs);
-
-		// void sk_manageddrawable_unref(sk_manageddrawable_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_manageddrawable_unref (sk_manageddrawable_t param0);
-
-		#endregion
-
-		#region sk_managedstream.h
-
-		// void sk_managedstream_destroy(sk_stream_managedstream_t* s)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_managedstream_destroy (sk_stream_managedstream_t s);
-
-		// sk_stream_managedstream_t* sk_managedstream_new(void* context)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_stream_managedstream_t sk_managedstream_new (void* context);
-
-		// void sk_managedstream_set_procs(sk_managedstream_procs_t procs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_managedstream_set_procs (SKManagedStreamDelegates procs);
-
-		// void sk_managedwstream_destroy(sk_wstream_managedstream_t* s)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_managedwstream_destroy (sk_wstream_managedstream_t s);
-
-		// sk_wstream_managedstream_t* sk_managedwstream_new(void* context)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_wstream_managedstream_t sk_managedwstream_new (void* context);
-
-		// void sk_managedwstream_set_procs(sk_managedwstream_procs_t procs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_managedwstream_set_procs (SKManagedWStreamDelegates procs);
-
-		#endregion
-
 		#region sk_mask.h
 
 		// uint8_t* sk_mask_alloc_image(size_t bytes)
@@ -2280,6 +1445,574 @@ namespace SkiaSharp
 		// void sk_maskfilter_unref(sk_maskfilter_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void sk_maskfilter_unref (sk_maskfilter_t param0);
+
+		#endregion
+
+		#region sk_matrix.h
+
+		// void sk_3dview_apply_to_canvas(sk_3dview_t* cview, sk_canvas_t* ccanvas)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_apply_to_canvas (sk_3dview_t cview, sk_canvas_t ccanvas);
+
+		// void sk_3dview_destroy(sk_3dview_t* cview)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_destroy (sk_3dview_t cview);
+
+		// float sk_3dview_dot_with_normal(sk_3dview_t* cview, float dx, float dy, float dz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_3dview_dot_with_normal (sk_3dview_t cview, Single dx, Single dy, Single dz);
+
+		// void sk_3dview_get_matrix(sk_3dview_t* cview, sk_matrix_t* cmatrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_get_matrix (sk_3dview_t cview, SKMatrix* cmatrix);
+
+		// sk_3dview_t* sk_3dview_new()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_3dview_t sk_3dview_new ();
+
+		// void sk_3dview_restore(sk_3dview_t* cview)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_restore (sk_3dview_t cview);
+
+		// void sk_3dview_rotate_x_degrees(sk_3dview_t* cview, float degrees)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_rotate_x_degrees (sk_3dview_t cview, Single degrees);
+
+		// void sk_3dview_rotate_x_radians(sk_3dview_t* cview, float radians)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_rotate_x_radians (sk_3dview_t cview, Single radians);
+
+		// void sk_3dview_rotate_y_degrees(sk_3dview_t* cview, float degrees)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_rotate_y_degrees (sk_3dview_t cview, Single degrees);
+
+		// void sk_3dview_rotate_y_radians(sk_3dview_t* cview, float radians)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_rotate_y_radians (sk_3dview_t cview, Single radians);
+
+		// void sk_3dview_rotate_z_degrees(sk_3dview_t* cview, float degrees)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_rotate_z_degrees (sk_3dview_t cview, Single degrees);
+
+		// void sk_3dview_rotate_z_radians(sk_3dview_t* cview, float radians)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_rotate_z_radians (sk_3dview_t cview, Single radians);
+
+		// void sk_3dview_save(sk_3dview_t* cview)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_save (sk_3dview_t cview);
+
+		// void sk_3dview_translate(sk_3dview_t* cview, float x, float y, float z)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_3dview_translate (sk_3dview_t cview, Single x, Single y, Single z);
+
+		// void sk_matrix_concat(sk_matrix_t* result, sk_matrix_t* first, sk_matrix_t* second)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_concat (SKMatrix* result, SKMatrix* first, SKMatrix* second);
+
+		// void sk_matrix_map_points(sk_matrix_t* matrix, sk_point_t* dst, sk_point_t* src, int count)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_map_points (SKMatrix* matrix, SKPoint* dst, SKPoint* src, Int32 count);
+
+		// float sk_matrix_map_radius(sk_matrix_t* matrix, float radius)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_matrix_map_radius (SKMatrix* matrix, Single radius);
+
+		// void sk_matrix_map_rect(sk_matrix_t* matrix, sk_rect_t* dest, sk_rect_t* source)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_map_rect (SKMatrix* matrix, SKRect* dest, SKRect* source);
+
+		// void sk_matrix_map_vector(sk_matrix_t* matrix, float x, float y, sk_point_t* result)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_map_vector (SKMatrix* matrix, Single x, Single y, SKPoint* result);
+
+		// void sk_matrix_map_vectors(sk_matrix_t* matrix, sk_point_t* dst, sk_point_t* src, int count)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_map_vectors (SKMatrix* matrix, SKPoint* dst, SKPoint* src, Int32 count);
+
+		// void sk_matrix_map_xy(sk_matrix_t* matrix, float x, float y, sk_point_t* result)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_map_xy (SKMatrix* matrix, Single x, Single y, SKPoint* result);
+
+		// void sk_matrix_post_concat(sk_matrix_t* result, sk_matrix_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_post_concat (SKMatrix* result, SKMatrix* matrix);
+
+		// void sk_matrix_pre_concat(sk_matrix_t* result, sk_matrix_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix_pre_concat (SKMatrix* result, SKMatrix* matrix);
+
+		// bool sk_matrix_try_invert(sk_matrix_t* matrix, sk_matrix_t* result)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_matrix_try_invert (SKMatrix* matrix, SKMatrix* result);
+
+		// void sk_matrix44_as_col_major(sk_matrix44_t* matrix, float* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_as_col_major (sk_matrix44_t matrix, Single* dst);
+
+		// void sk_matrix44_as_row_major(sk_matrix44_t* matrix, float* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_as_row_major (sk_matrix44_t matrix, Single* dst);
+
+		// void sk_matrix44_destroy(sk_matrix44_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_destroy (sk_matrix44_t matrix);
+
+		// double sk_matrix44_determinant(sk_matrix44_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Double sk_matrix44_determinant (sk_matrix44_t matrix);
+
+		// bool sk_matrix44_equals(sk_matrix44_t* matrix, const sk_matrix44_t* other)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_matrix44_equals (sk_matrix44_t matrix, sk_matrix44_t other);
+
+		// float sk_matrix44_get(sk_matrix44_t* matrix, int row, int col)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_matrix44_get (sk_matrix44_t matrix, Int32 row, Int32 col);
+
+		// sk_matrix44_type_mask_t sk_matrix44_get_type(sk_matrix44_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKMatrix44TypeMask sk_matrix44_get_type (sk_matrix44_t matrix);
+
+		// bool sk_matrix44_invert(sk_matrix44_t* matrix, sk_matrix44_t* inverse)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_matrix44_invert (sk_matrix44_t matrix, sk_matrix44_t inverse);
+
+		// void sk_matrix44_map_scalars(sk_matrix44_t* matrix, const float* src, float* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_map_scalars (sk_matrix44_t matrix, Single* src, Single* dst);
+
+		// void sk_matrix44_map2(sk_matrix44_t* matrix, const float* src2, int count, float* dst4)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_map2 (sk_matrix44_t matrix, Single* src2, Int32 count, Single* dst4);
+
+		// sk_matrix44_t* sk_matrix44_new()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_matrix44_t sk_matrix44_new ();
+
+		// sk_matrix44_t* sk_matrix44_new_concat(const sk_matrix44_t* a, const sk_matrix44_t* b)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_matrix44_t sk_matrix44_new_concat (sk_matrix44_t a, sk_matrix44_t b);
+
+		// sk_matrix44_t* sk_matrix44_new_copy(const sk_matrix44_t* src)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_matrix44_t sk_matrix44_new_copy (sk_matrix44_t src);
+
+		// sk_matrix44_t* sk_matrix44_new_identity()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_matrix44_t sk_matrix44_new_identity ();
+
+		// sk_matrix44_t* sk_matrix44_new_matrix(const sk_matrix_t* src)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_matrix44_t sk_matrix44_new_matrix (SKMatrix* src);
+
+		// void sk_matrix44_post_concat(sk_matrix44_t* matrix, const sk_matrix44_t* m)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_post_concat (sk_matrix44_t matrix, sk_matrix44_t m);
+
+		// void sk_matrix44_post_scale(sk_matrix44_t* matrix, float sx, float sy, float sz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_post_scale (sk_matrix44_t matrix, Single sx, Single sy, Single sz);
+
+		// void sk_matrix44_post_translate(sk_matrix44_t* matrix, float dx, float dy, float dz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_post_translate (sk_matrix44_t matrix, Single dx, Single dy, Single dz);
+
+		// void sk_matrix44_pre_concat(sk_matrix44_t* matrix, const sk_matrix44_t* m)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_pre_concat (sk_matrix44_t matrix, sk_matrix44_t m);
+
+		// void sk_matrix44_pre_scale(sk_matrix44_t* matrix, float sx, float sy, float sz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_pre_scale (sk_matrix44_t matrix, Single sx, Single sy, Single sz);
+
+		// void sk_matrix44_pre_translate(sk_matrix44_t* matrix, float dx, float dy, float dz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_pre_translate (sk_matrix44_t matrix, Single dx, Single dy, Single dz);
+
+		// bool sk_matrix44_preserves_2d_axis_alignment(sk_matrix44_t* matrix, float epsilon)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_matrix44_preserves_2d_axis_alignment (sk_matrix44_t matrix, Single epsilon);
+
+		// void sk_matrix44_set(sk_matrix44_t* matrix, int row, int col, float value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set (sk_matrix44_t matrix, Int32 row, Int32 col, Single value);
+
+		// void sk_matrix44_set_col_major(sk_matrix44_t* matrix, float* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_col_major (sk_matrix44_t matrix, Single* dst);
+
+		// void sk_matrix44_set_concat(sk_matrix44_t* matrix, const sk_matrix44_t* a, const sk_matrix44_t* b)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_concat (sk_matrix44_t matrix, sk_matrix44_t a, sk_matrix44_t b);
+
+		// void sk_matrix44_set_identity(sk_matrix44_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_identity (sk_matrix44_t matrix);
+
+		// void sk_matrix44_set_rotate_about_degrees(sk_matrix44_t* matrix, float x, float y, float z, float degrees)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_rotate_about_degrees (sk_matrix44_t matrix, Single x, Single y, Single z, Single degrees);
+
+		// void sk_matrix44_set_rotate_about_radians(sk_matrix44_t* matrix, float x, float y, float z, float radians)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_rotate_about_radians (sk_matrix44_t matrix, Single x, Single y, Single z, Single radians);
+
+		// void sk_matrix44_set_rotate_about_radians_unit(sk_matrix44_t* matrix, float x, float y, float z, float radians)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_rotate_about_radians_unit (sk_matrix44_t matrix, Single x, Single y, Single z, Single radians);
+
+		// void sk_matrix44_set_row_major(sk_matrix44_t* matrix, float* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_row_major (sk_matrix44_t matrix, Single* dst);
+
+		// void sk_matrix44_set_scale(sk_matrix44_t* matrix, float sx, float sy, float sz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_scale (sk_matrix44_t matrix, Single sx, Single sy, Single sz);
+
+		// void sk_matrix44_set_translate(sk_matrix44_t* matrix, float dx, float dy, float dz)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_set_translate (sk_matrix44_t matrix, Single dx, Single dy, Single dz);
+
+		// void sk_matrix44_to_matrix(sk_matrix44_t* matrix, sk_matrix_t* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_to_matrix (sk_matrix44_t matrix, SKMatrix* dst);
+
+		// void sk_matrix44_transpose(sk_matrix44_t* matrix)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_matrix44_transpose (sk_matrix44_t matrix);
+
+		#endregion
+
+		#region sk_paint.h
+
+		// size_t sk_paint_break_text(const sk_paint_t* cpaint, const void* text, size_t length, float maxWidth, float* measuredWidth)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_paint_break_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, Single maxWidth, Single* measuredWidth);
+
+		// sk_paint_t* sk_paint_clone(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_paint_t sk_paint_clone (sk_paint_t param0);
+
+		// bool sk_paint_contains_text(const sk_paint_t* cpaint, const void* text, size_t byteLength)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_contains_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength);
+
+		// int sk_paint_count_text(const sk_paint_t* cpaint, const void* text, size_t byteLength)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_count_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength);
+
+		// void sk_paint_delete(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_delete (sk_paint_t param0);
+
+		// sk_blendmode_t sk_paint_get_blendmode(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKBlendMode sk_paint_get_blendmode (sk_paint_t param0);
+
+		// sk_color_t sk_paint_get_color(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern UInt32 sk_paint_get_color (sk_paint_t param0);
+
+		// sk_colorfilter_t* sk_paint_get_colorfilter(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorfilter_t sk_paint_get_colorfilter (sk_paint_t param0);
+
+		// bool sk_paint_get_fill_path(const sk_paint_t*, const sk_path_t* src, sk_path_t* dst, const sk_rect_t* cullRect, float resScale)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_get_fill_path (sk_paint_t param0, sk_path_t src, sk_path_t dst, SKRect* cullRect, Single resScale);
+
+		// sk_filter_quality_t sk_paint_get_filter_quality(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKFilterQuality sk_paint_get_filter_quality (sk_paint_t param0);
+
+		// float sk_paint_get_fontmetrics(sk_paint_t* cpaint, sk_fontmetrics_t* cfontmetrics, float scale)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_get_fontmetrics (sk_paint_t cpaint, SKFontMetrics* cfontmetrics, Single scale);
+
+		// sk_paint_hinting_t sk_paint_get_hinting(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKPaintHinting sk_paint_get_hinting (sk_paint_t param0);
+
+		// sk_imagefilter_t* sk_paint_get_imagefilter(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_imagefilter_t sk_paint_get_imagefilter (sk_paint_t param0);
+
+		// sk_maskfilter_t* sk_paint_get_maskfilter(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_maskfilter_t sk_paint_get_maskfilter (sk_paint_t param0);
+
+		// sk_path_effect_t* sk_paint_get_path_effect(sk_paint_t* cpaint)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_path_effect_t sk_paint_get_path_effect (sk_paint_t cpaint);
+
+		// int sk_paint_get_pos_text_blob_intercepts(const sk_paint_t* cpaint, sk_textblob_t* blob, const float[2] bounds = 2, float* intervals)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_get_pos_text_blob_intercepts (sk_paint_t cpaint, sk_textblob_t blob, Single* bounds, Single* intervals);
+
+		// int sk_paint_get_pos_text_h_intercepts(const sk_paint_t* cpaint, const void* text, size_t byteLength, float* xpos, float y, const float[2] bounds = 2, float* intervals)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_get_pos_text_h_intercepts (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, Single* xpos, Single y, Single* bounds, Single* intervals);
+
+		// int sk_paint_get_pos_text_intercepts(const sk_paint_t* cpaint, const void* text, size_t byteLength, sk_point_t* pos, const float[2] bounds = 2, float* intervals)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_get_pos_text_intercepts (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, SKPoint* pos, Single* bounds, Single* intervals);
+
+		// sk_path_t* sk_paint_get_pos_text_path(sk_paint_t* cpaint, const void* text, size_t length, const sk_point_t[-1] pos)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_path_t sk_paint_get_pos_text_path (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, SKPoint* pos);
+
+		// sk_shader_t* sk_paint_get_shader(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_shader_t sk_paint_get_shader (sk_paint_t param0);
+
+		// sk_stroke_cap_t sk_paint_get_stroke_cap(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKStrokeCap sk_paint_get_stroke_cap (sk_paint_t param0);
+
+		// sk_stroke_join_t sk_paint_get_stroke_join(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKStrokeJoin sk_paint_get_stroke_join (sk_paint_t param0);
+
+		// float sk_paint_get_stroke_miter(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_get_stroke_miter (sk_paint_t param0);
+
+		// float sk_paint_get_stroke_width(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_get_stroke_width (sk_paint_t param0);
+
+		// sk_paint_style_t sk_paint_get_style(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKPaintStyle sk_paint_get_style (sk_paint_t param0);
+
+		// sk_text_align_t sk_paint_get_text_align(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKTextAlign sk_paint_get_text_align (sk_paint_t param0);
+
+		// sk_text_encoding_t sk_paint_get_text_encoding(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKTextEncoding sk_paint_get_text_encoding (sk_paint_t param0);
+
+		// int sk_paint_get_text_intercepts(const sk_paint_t* cpaint, const void* text, size_t byteLength, float x, float y, const float[2] bounds = 2, float* intervals)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_get_text_intercepts (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, Single x, Single y, Single* bounds, Single* intervals);
+
+		// sk_path_t* sk_paint_get_text_path(sk_paint_t* cpaint, const void* text, size_t length, float x, float y)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_path_t sk_paint_get_text_path (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, Single x, Single y);
+
+		// float sk_paint_get_text_scale_x(const sk_paint_t* cpaint)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_get_text_scale_x (sk_paint_t cpaint);
+
+		// float sk_paint_get_text_skew_x(const sk_paint_t* cpaint)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_get_text_skew_x (sk_paint_t cpaint);
+
+		// int sk_paint_get_text_widths(const sk_paint_t* cpaint, const void* text, size_t byteLength, float* widths, sk_rect_t* bounds)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_get_text_widths (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, Single* widths, SKRect* bounds);
+
+		// float sk_paint_get_textsize(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_get_textsize (sk_paint_t param0);
+
+		// sk_typeface_t* sk_paint_get_typeface(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_paint_get_typeface (sk_paint_t param0);
+
+		// bool sk_paint_is_antialias(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_antialias (sk_paint_t param0);
+
+		// bool sk_paint_is_autohinted(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_autohinted (sk_paint_t param0);
+
+		// bool sk_paint_is_dev_kern_text(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_dev_kern_text (sk_paint_t param0);
+
+		// bool sk_paint_is_dither(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_dither (sk_paint_t param0);
+
+		// bool sk_paint_is_embedded_bitmap_text(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_embedded_bitmap_text (sk_paint_t param0);
+
+		// bool sk_paint_is_fake_bold_text(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_fake_bold_text (sk_paint_t param0);
+
+		// bool sk_paint_is_lcd_render_text(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_lcd_render_text (sk_paint_t param0);
+
+		// bool sk_paint_is_linear_text(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_linear_text (sk_paint_t param0);
+
+		// bool sk_paint_is_subpixel_text(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_subpixel_text (sk_paint_t param0);
+
+		// bool sk_paint_is_verticaltext(const sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_paint_is_verticaltext (sk_paint_t param0);
+
+		// float sk_paint_measure_text(const sk_paint_t* cpaint, const void* text, size_t length, sk_rect_t* cbounds)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Single sk_paint_measure_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, SKRect* cbounds);
+
+		// sk_paint_t* sk_paint_new()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_paint_t sk_paint_new ();
+
+		// void sk_paint_reset(sk_paint_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_reset (sk_paint_t param0);
+
+		// void sk_paint_set_antialias(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_antialias (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_autohinted(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_autohinted (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_blendmode(sk_paint_t*, sk_blendmode_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_blendmode (sk_paint_t param0, SKBlendMode param1);
+
+		// void sk_paint_set_color(sk_paint_t*, sk_color_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_color (sk_paint_t param0, UInt32 param1);
+
+		// void sk_paint_set_colorfilter(sk_paint_t*, sk_colorfilter_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_colorfilter (sk_paint_t param0, sk_colorfilter_t param1);
+
+		// void sk_paint_set_dev_kern_text(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_dev_kern_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_dither(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_dither (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_embedded_bitmap_text(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_embedded_bitmap_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_fake_bold_text(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_fake_bold_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_filter_quality(sk_paint_t*, sk_filter_quality_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_filter_quality (sk_paint_t param0, SKFilterQuality param1);
+
+		// void sk_paint_set_hinting(sk_paint_t*, sk_paint_hinting_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_hinting (sk_paint_t param0, SKPaintHinting param1);
+
+		// void sk_paint_set_imagefilter(sk_paint_t*, sk_imagefilter_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_imagefilter (sk_paint_t param0, sk_imagefilter_t param1);
+
+		// void sk_paint_set_lcd_render_text(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_lcd_render_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_linear_text(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_linear_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_maskfilter(sk_paint_t*, sk_maskfilter_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_maskfilter (sk_paint_t param0, sk_maskfilter_t param1);
+
+		// void sk_paint_set_path_effect(sk_paint_t* cpaint, sk_path_effect_t* effect)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_path_effect (sk_paint_t cpaint, sk_path_effect_t effect);
+
+		// void sk_paint_set_shader(sk_paint_t*, sk_shader_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_shader (sk_paint_t param0, sk_shader_t param1);
+
+		// void sk_paint_set_stroke_cap(sk_paint_t*, sk_stroke_cap_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_stroke_cap (sk_paint_t param0, SKStrokeCap param1);
+
+		// void sk_paint_set_stroke_join(sk_paint_t*, sk_stroke_join_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_stroke_join (sk_paint_t param0, SKStrokeJoin param1);
+
+		// void sk_paint_set_stroke_miter(sk_paint_t*, float miter)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_stroke_miter (sk_paint_t param0, Single miter);
+
+		// void sk_paint_set_stroke_width(sk_paint_t*, float width)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_stroke_width (sk_paint_t param0, Single width);
+
+		// void sk_paint_set_style(sk_paint_t*, sk_paint_style_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_style (sk_paint_t param0, SKPaintStyle param1);
+
+		// void sk_paint_set_subpixel_text(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_subpixel_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// void sk_paint_set_text_align(sk_paint_t*, sk_text_align_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_text_align (sk_paint_t param0, SKTextAlign param1);
+
+		// void sk_paint_set_text_encoding(sk_paint_t*, sk_text_encoding_t)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_text_encoding (sk_paint_t param0, SKTextEncoding param1);
+
+		// void sk_paint_set_text_scale_x(sk_paint_t* cpaint, float scale)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_text_scale_x (sk_paint_t cpaint, Single scale);
+
+		// void sk_paint_set_text_skew_x(sk_paint_t* cpaint, float skew)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_text_skew_x (sk_paint_t cpaint, Single skew);
+
+		// void sk_paint_set_textsize(sk_paint_t*, float)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_textsize (sk_paint_t param0, Single param1);
+
+		// void sk_paint_set_typeface(sk_paint_t*, sk_typeface_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_typeface (sk_paint_t param0, sk_typeface_t param1);
+
+		// void sk_paint_set_verticaltext(sk_paint_t*, bool)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_paint_set_verticaltext (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
+
+		// int sk_paint_text_to_glyphs(const sk_paint_t* cpaint, const void* text, size_t byteLength, uint16_t* glyphs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_paint_text_to_glyphs (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, UInt16* glyphs);
 
 		#endregion
 
@@ -2631,334 +2364,6 @@ namespace SkiaSharp
 
 		#endregion
 
-		#region sk_paint.h
-
-		// size_t sk_paint_break_text(const sk_paint_t* cpaint, const void* text, size_t length, float maxWidth, float* measuredWidth)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern /* size_t */ IntPtr sk_paint_break_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, Single maxWidth, Single* measuredWidth);
-
-		// sk_paint_t* sk_paint_clone(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_paint_t sk_paint_clone (sk_paint_t param0);
-
-		// bool sk_paint_contains_text(const sk_paint_t* cpaint, const void* text, size_t byteLength)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_contains_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength);
-
-		// int sk_paint_count_text(const sk_paint_t* cpaint, const void* text, size_t byteLength)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_count_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength);
-
-		// void sk_paint_delete(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_delete (sk_paint_t param0);
-
-		// sk_blendmode_t sk_paint_get_blendmode(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKBlendMode sk_paint_get_blendmode (sk_paint_t param0);
-
-		// sk_color_t sk_paint_get_color(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern UInt32 sk_paint_get_color (sk_paint_t param0);
-
-		// sk_colorfilter_t* sk_paint_get_colorfilter(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_colorfilter_t sk_paint_get_colorfilter (sk_paint_t param0);
-
-		// bool sk_paint_get_fill_path(const sk_paint_t*, const sk_path_t* src, sk_path_t* dst, const sk_rect_t* cullRect, float resScale)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_get_fill_path (sk_paint_t param0, sk_path_t src, sk_path_t dst, SKRect* cullRect, Single resScale);
-
-		// sk_filter_quality_t sk_paint_get_filter_quality(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKFilterQuality sk_paint_get_filter_quality (sk_paint_t param0);
-
-		// float sk_paint_get_fontmetrics(sk_paint_t* cpaint, sk_fontmetrics_t* cfontmetrics, float scale)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_get_fontmetrics (sk_paint_t cpaint, SKFontMetrics* cfontmetrics, Single scale);
-
-		// sk_paint_hinting_t sk_paint_get_hinting(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKPaintHinting sk_paint_get_hinting (sk_paint_t param0);
-
-		// sk_imagefilter_t* sk_paint_get_imagefilter(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_paint_get_imagefilter (sk_paint_t param0);
-
-		// sk_maskfilter_t* sk_paint_get_maskfilter(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_maskfilter_t sk_paint_get_maskfilter (sk_paint_t param0);
-
-		// sk_path_effect_t* sk_paint_get_path_effect(sk_paint_t* cpaint)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_path_effect_t sk_paint_get_path_effect (sk_paint_t cpaint);
-
-		// int sk_paint_get_pos_text_blob_intercepts(const sk_paint_t* cpaint, sk_textblob_t* blob, const float[2] bounds = 2, float* intervals)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_get_pos_text_blob_intercepts (sk_paint_t cpaint, sk_textblob_t blob, Single* bounds, Single* intervals);
-
-		// int sk_paint_get_pos_text_h_intercepts(const sk_paint_t* cpaint, const void* text, size_t byteLength, float* xpos, float y, const float[2] bounds = 2, float* intervals)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_get_pos_text_h_intercepts (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, Single* xpos, Single y, Single* bounds, Single* intervals);
-
-		// int sk_paint_get_pos_text_intercepts(const sk_paint_t* cpaint, const void* text, size_t byteLength, sk_point_t* pos, const float[2] bounds = 2, float* intervals)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_get_pos_text_intercepts (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, SKPoint* pos, Single* bounds, Single* intervals);
-
-		// sk_path_t* sk_paint_get_pos_text_path(sk_paint_t* cpaint, const void* text, size_t length, const sk_point_t[-1] pos)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_path_t sk_paint_get_pos_text_path (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, SKPoint* pos);
-
-		// sk_shader_t* sk_paint_get_shader(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_paint_get_shader (sk_paint_t param0);
-
-		// sk_stroke_cap_t sk_paint_get_stroke_cap(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKStrokeCap sk_paint_get_stroke_cap (sk_paint_t param0);
-
-		// sk_stroke_join_t sk_paint_get_stroke_join(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKStrokeJoin sk_paint_get_stroke_join (sk_paint_t param0);
-
-		// float sk_paint_get_stroke_miter(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_get_stroke_miter (sk_paint_t param0);
-
-		// float sk_paint_get_stroke_width(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_get_stroke_width (sk_paint_t param0);
-
-		// sk_paint_style_t sk_paint_get_style(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKPaintStyle sk_paint_get_style (sk_paint_t param0);
-
-		// sk_text_align_t sk_paint_get_text_align(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKTextAlign sk_paint_get_text_align (sk_paint_t param0);
-
-		// sk_text_encoding_t sk_paint_get_text_encoding(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKTextEncoding sk_paint_get_text_encoding (sk_paint_t param0);
-
-		// int sk_paint_get_text_intercepts(const sk_paint_t* cpaint, const void* text, size_t byteLength, float x, float y, const float[2] bounds = 2, float* intervals)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_get_text_intercepts (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, Single x, Single y, Single* bounds, Single* intervals);
-
-		// sk_path_t* sk_paint_get_text_path(sk_paint_t* cpaint, const void* text, size_t length, float x, float y)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_path_t sk_paint_get_text_path (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, Single x, Single y);
-
-		// float sk_paint_get_text_scale_x(const sk_paint_t* cpaint)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_get_text_scale_x (sk_paint_t cpaint);
-
-		// float sk_paint_get_text_skew_x(const sk_paint_t* cpaint)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_get_text_skew_x (sk_paint_t cpaint);
-
-		// int sk_paint_get_text_widths(const sk_paint_t* cpaint, const void* text, size_t byteLength, float* widths, sk_rect_t* bounds)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_get_text_widths (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, Single* widths, SKRect* bounds);
-
-		// float sk_paint_get_textsize(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_get_textsize (sk_paint_t param0);
-
-		// sk_typeface_t* sk_paint_get_typeface(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_paint_get_typeface (sk_paint_t param0);
-
-		// bool sk_paint_is_antialias(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_antialias (sk_paint_t param0);
-
-		// bool sk_paint_is_autohinted(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_autohinted (sk_paint_t param0);
-
-		// bool sk_paint_is_dev_kern_text(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_dev_kern_text (sk_paint_t param0);
-
-		// bool sk_paint_is_dither(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_dither (sk_paint_t param0);
-
-		// bool sk_paint_is_embedded_bitmap_text(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_embedded_bitmap_text (sk_paint_t param0);
-
-		// bool sk_paint_is_fake_bold_text(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_fake_bold_text (sk_paint_t param0);
-
-		// bool sk_paint_is_lcd_render_text(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_lcd_render_text (sk_paint_t param0);
-
-		// bool sk_paint_is_linear_text(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_linear_text (sk_paint_t param0);
-
-		// bool sk_paint_is_subpixel_text(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_subpixel_text (sk_paint_t param0);
-
-		// bool sk_paint_is_verticaltext(const sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_paint_is_verticaltext (sk_paint_t param0);
-
-		// float sk_paint_measure_text(const sk_paint_t* cpaint, const void* text, size_t length, sk_rect_t* cbounds)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Single sk_paint_measure_text (sk_paint_t cpaint, void* text, /* size_t */ IntPtr length, SKRect* cbounds);
-
-		// sk_paint_t* sk_paint_new()
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_paint_t sk_paint_new ();
-
-		// void sk_paint_reset(sk_paint_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_reset (sk_paint_t param0);
-
-		// void sk_paint_set_antialias(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_antialias (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_autohinted(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_autohinted (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_blendmode(sk_paint_t*, sk_blendmode_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_blendmode (sk_paint_t param0, SKBlendMode param1);
-
-		// void sk_paint_set_color(sk_paint_t*, sk_color_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_color (sk_paint_t param0, UInt32 param1);
-
-		// void sk_paint_set_colorfilter(sk_paint_t*, sk_colorfilter_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_colorfilter (sk_paint_t param0, sk_colorfilter_t param1);
-
-		// void sk_paint_set_dev_kern_text(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_dev_kern_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_dither(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_dither (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_embedded_bitmap_text(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_embedded_bitmap_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_fake_bold_text(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_fake_bold_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_filter_quality(sk_paint_t*, sk_filter_quality_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_filter_quality (sk_paint_t param0, SKFilterQuality param1);
-
-		// void sk_paint_set_hinting(sk_paint_t*, sk_paint_hinting_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_hinting (sk_paint_t param0, SKPaintHinting param1);
-
-		// void sk_paint_set_imagefilter(sk_paint_t*, sk_imagefilter_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_imagefilter (sk_paint_t param0, sk_imagefilter_t param1);
-
-		// void sk_paint_set_lcd_render_text(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_lcd_render_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_linear_text(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_linear_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_maskfilter(sk_paint_t*, sk_maskfilter_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_maskfilter (sk_paint_t param0, sk_maskfilter_t param1);
-
-		// void sk_paint_set_path_effect(sk_paint_t* cpaint, sk_path_effect_t* effect)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_path_effect (sk_paint_t cpaint, sk_path_effect_t effect);
-
-		// void sk_paint_set_shader(sk_paint_t*, sk_shader_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_shader (sk_paint_t param0, sk_shader_t param1);
-
-		// void sk_paint_set_stroke_cap(sk_paint_t*, sk_stroke_cap_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_stroke_cap (sk_paint_t param0, SKStrokeCap param1);
-
-		// void sk_paint_set_stroke_join(sk_paint_t*, sk_stroke_join_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_stroke_join (sk_paint_t param0, SKStrokeJoin param1);
-
-		// void sk_paint_set_stroke_miter(sk_paint_t*, float miter)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_stroke_miter (sk_paint_t param0, Single miter);
-
-		// void sk_paint_set_stroke_width(sk_paint_t*, float width)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_stroke_width (sk_paint_t param0, Single width);
-
-		// void sk_paint_set_style(sk_paint_t*, sk_paint_style_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_style (sk_paint_t param0, SKPaintStyle param1);
-
-		// void sk_paint_set_subpixel_text(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_subpixel_text (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// void sk_paint_set_text_align(sk_paint_t*, sk_text_align_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_text_align (sk_paint_t param0, SKTextAlign param1);
-
-		// void sk_paint_set_text_encoding(sk_paint_t*, sk_text_encoding_t)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_text_encoding (sk_paint_t param0, SKTextEncoding param1);
-
-		// void sk_paint_set_text_scale_x(sk_paint_t* cpaint, float scale)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_text_scale_x (sk_paint_t cpaint, Single scale);
-
-		// void sk_paint_set_text_skew_x(sk_paint_t* cpaint, float skew)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_text_skew_x (sk_paint_t cpaint, Single skew);
-
-		// void sk_paint_set_textsize(sk_paint_t*, float)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_textsize (sk_paint_t param0, Single param1);
-
-		// void sk_paint_set_typeface(sk_paint_t*, sk_typeface_t*)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_typeface (sk_paint_t param0, sk_typeface_t param1);
-
-		// void sk_paint_set_verticaltext(sk_paint_t*, bool)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_paint_set_verticaltext (sk_paint_t param0, [MarshalAs (UnmanagedType.I1)] bool param1);
-
-		// int sk_paint_text_to_glyphs(const sk_paint_t* cpaint, const void* text, size_t byteLength, uint16_t* glyphs)
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_paint_text_to_glyphs (sk_paint_t cpaint, void* text, /* size_t */ IntPtr byteLength, UInt16* glyphs);
-
-		#endregion
-
 		#region sk_patheffect.h
 
 		// sk_path_effect_t* sk_path_effect_create_1d_path(const sk_path_t* path, float advance, float phase, sk_path_effect_1d_style_t style)
@@ -3044,6 +2449,114 @@ namespace SkiaSharp
 		// void sk_picture_unref(sk_picture_t*)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern void sk_picture_unref (sk_picture_t param0);
+
+		#endregion
+
+		#region sk_pixmap.h
+
+		// void sk_color_get_bit_shift(int* a, int* r, int* g, int* b)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_color_get_bit_shift (Int32* a, Int32* r, Int32* g, Int32* b);
+
+		// sk_pmcolor_t sk_color_premultiply(const sk_color_t color)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern UInt32 sk_color_premultiply (UInt32 color);
+
+		// void sk_color_premultiply_array(const sk_color_t* colors, int size, sk_pmcolor_t* pmcolors)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_color_premultiply_array (UInt32* colors, Int32 size, UInt32* pmcolors);
+
+		// sk_color_t sk_color_unpremultiply(const sk_pmcolor_t pmcolor)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern UInt32 sk_color_unpremultiply (UInt32 pmcolor);
+
+		// void sk_color_unpremultiply_array(const sk_pmcolor_t* pmcolors, int size, sk_color_t* colors)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_color_unpremultiply_array (UInt32* pmcolors, Int32 size, UInt32* colors);
+
+		// bool sk_jpegencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_jpegencoder_options_t options)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_jpegencoder_encode (sk_wstream_t dst, sk_pixmap_t src, SKJpegEncoderOptions options);
+
+		// void sk_pixmap_destructor(sk_pixmap_t* cpixmap)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pixmap_destructor (sk_pixmap_t cpixmap);
+
+		// bool sk_pixmap_encode_image(sk_wstream_t* dst, const sk_pixmap_t* src, sk_encoded_image_format_t encoder, int quality)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pixmap_encode_image (sk_wstream_t dst, sk_pixmap_t src, SKEncodedImageFormat encoder, Int32 quality);
+
+		// bool sk_pixmap_erase_color(const sk_pixmap_t* cpixmap, sk_color_t color, const sk_irect_t* subset)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pixmap_erase_color (sk_pixmap_t cpixmap, UInt32 color, SKRectI* subset);
+
+		// bool sk_pixmap_extract_subset(const sk_pixmap_t* cpixmap, sk_pixmap_t* result, const sk_irect_t* subset)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pixmap_extract_subset (sk_pixmap_t cpixmap, sk_pixmap_t result, SKRectI* subset);
+
+		// void sk_pixmap_get_info(const sk_pixmap_t* cpixmap, sk_imageinfo_t* cinfo)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pixmap_get_info (sk_pixmap_t cpixmap, SKImageInfoNative* cinfo);
+
+		// sk_color_t sk_pixmap_get_pixel_color(const sk_pixmap_t* cpixmap, int x, int y)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern UInt32 sk_pixmap_get_pixel_color (sk_pixmap_t cpixmap, Int32 x, Int32 y);
+
+		// const void* sk_pixmap_get_pixels(const sk_pixmap_t* cpixmap)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void* sk_pixmap_get_pixels (sk_pixmap_t cpixmap);
+
+		// const void* sk_pixmap_get_pixels_with_xy(const sk_pixmap_t* cpixmap, int x, int y)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void* sk_pixmap_get_pixels_with_xy (sk_pixmap_t cpixmap, Int32 x, Int32 y);
+
+		// size_t sk_pixmap_get_row_bytes(const sk_pixmap_t* cpixmap)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_pixmap_get_row_bytes (sk_pixmap_t cpixmap);
+
+		// sk_pixmap_t* sk_pixmap_new()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_pixmap_t sk_pixmap_new ();
+
+		// sk_pixmap_t* sk_pixmap_new_with_params(const sk_imageinfo_t* cinfo, const void* addr, size_t rowBytes)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_pixmap_t sk_pixmap_new_with_params (SKImageInfoNative* cinfo, void* addr, /* size_t */ IntPtr rowBytes);
+
+		// bool sk_pixmap_read_pixels(const sk_pixmap_t* cpixmap, const sk_imageinfo_t* dstInfo, void* dstPixels, size_t dstRowBytes, int srcX, int srcY, sk_transfer_function_behavior_t behavior)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pixmap_read_pixels (sk_pixmap_t cpixmap, SKImageInfoNative* dstInfo, void* dstPixels, /* size_t */ IntPtr dstRowBytes, Int32 srcX, Int32 srcY, SKTransferFunctionBehavior behavior);
+
+		// void sk_pixmap_reset(sk_pixmap_t* cpixmap)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pixmap_reset (sk_pixmap_t cpixmap);
+
+		// void sk_pixmap_reset_with_params(sk_pixmap_t* cpixmap, const sk_imageinfo_t* cinfo, const void* addr, size_t rowBytes)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pixmap_reset_with_params (sk_pixmap_t cpixmap, SKImageInfoNative* cinfo, void* addr, /* size_t */ IntPtr rowBytes);
+
+		// bool sk_pixmap_scale_pixels(const sk_pixmap_t* cpixmap, const sk_pixmap_t* dst, sk_filter_quality_t quality)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pixmap_scale_pixels (sk_pixmap_t cpixmap, sk_pixmap_t dst, SKFilterQuality quality);
+
+		// bool sk_pngencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_pngencoder_options_t options)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_pngencoder_encode (sk_wstream_t dst, sk_pixmap_t src, SKPngEncoderOptions options);
+
+		// void sk_swizzle_swap_rb(uint32_t* dest, const uint32_t* src, int count)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_swizzle_swap_rb (UInt32* dest, UInt32* src, Int32 count);
+
+		// bool sk_webpencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, sk_webpencoder_options_t options)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_webpencoder_encode (sk_wstream_t dst, sk_pixmap_t src, SKWebpEncoderOptions options);
 
 		#endregion
 
@@ -3271,6 +2784,272 @@ namespace SkiaSharp
 
 		#endregion
 
+		#region sk_stream.h
+
+		// void sk_dynamicmemorywstream_copy_to(sk_wstream_dynamicmemorystream_t* cstream, void* data)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_dynamicmemorywstream_copy_to (sk_wstream_dynamicmemorystream_t cstream, void* data);
+
+		// void sk_dynamicmemorywstream_destroy(sk_wstream_dynamicmemorystream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_dynamicmemorywstream_destroy (sk_wstream_dynamicmemorystream_t cstream);
+
+		// sk_data_t* sk_dynamicmemorywstream_detach_as_data(sk_wstream_dynamicmemorystream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_data_t sk_dynamicmemorywstream_detach_as_data (sk_wstream_dynamicmemorystream_t cstream);
+
+		// sk_stream_asset_t* sk_dynamicmemorywstream_detach_as_stream(sk_wstream_dynamicmemorystream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_asset_t sk_dynamicmemorywstream_detach_as_stream (sk_wstream_dynamicmemorystream_t cstream);
+
+		// sk_wstream_dynamicmemorystream_t* sk_dynamicmemorywstream_new()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_wstream_dynamicmemorystream_t sk_dynamicmemorywstream_new ();
+
+		// bool sk_dynamicmemorywstream_write_to_stream(sk_wstream_dynamicmemorystream_t* cstream, sk_wstream_t* dst)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_dynamicmemorywstream_write_to_stream (sk_wstream_dynamicmemorystream_t cstream, sk_wstream_t dst);
+
+		// void sk_filestream_destroy(sk_stream_filestream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_filestream_destroy (sk_stream_filestream_t cstream);
+
+		// bool sk_filestream_is_valid(sk_stream_filestream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_filestream_is_valid (sk_stream_filestream_t cstream);
+
+		// sk_stream_filestream_t* sk_filestream_new(const char* path)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_filestream_t sk_filestream_new (/* char */ void* path);
+
+		// void sk_filewstream_destroy(sk_wstream_filestream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_filewstream_destroy (sk_wstream_filestream_t cstream);
+
+		// bool sk_filewstream_is_valid(sk_wstream_filestream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_filewstream_is_valid (sk_wstream_filestream_t cstream);
+
+		// sk_wstream_filestream_t* sk_filewstream_new(const char* path)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_wstream_filestream_t sk_filewstream_new (/* char */ void* path);
+
+		// void sk_memorystream_destroy(sk_stream_memorystream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_memorystream_destroy (sk_stream_memorystream_t cstream);
+
+		// sk_stream_memorystream_t* sk_memorystream_new()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_memorystream_t sk_memorystream_new ();
+
+		// sk_stream_memorystream_t* sk_memorystream_new_with_data(const void* data, size_t length, bool copyData)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_memorystream_t sk_memorystream_new_with_data (void* data, /* size_t */ IntPtr length, [MarshalAs (UnmanagedType.I1)] bool copyData);
+
+		// sk_stream_memorystream_t* sk_memorystream_new_with_length(size_t length)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_memorystream_t sk_memorystream_new_with_length (/* size_t */ IntPtr length);
+
+		// sk_stream_memorystream_t* sk_memorystream_new_with_skdata(sk_data_t* data)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_memorystream_t sk_memorystream_new_with_skdata (sk_data_t data);
+
+		// void sk_memorystream_set_memory(sk_stream_memorystream_t* cmemorystream, const void* data, size_t length, bool copyData)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_memorystream_set_memory (sk_stream_memorystream_t cmemorystream, void* data, /* size_t */ IntPtr length, [MarshalAs (UnmanagedType.I1)] bool copyData);
+
+		// void sk_stream_asset_destroy(sk_stream_asset_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_stream_asset_destroy (sk_stream_asset_t cstream);
+
+		// void sk_stream_destroy(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_stream_destroy (sk_stream_t cstream);
+
+		// sk_stream_t* sk_stream_duplicate(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_t sk_stream_duplicate (sk_stream_t cstream);
+
+		// sk_stream_t* sk_stream_fork(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_t sk_stream_fork (sk_stream_t cstream);
+
+		// size_t sk_stream_get_length(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_stream_get_length (sk_stream_t cstream);
+
+		// const void* sk_stream_get_memory_base(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void* sk_stream_get_memory_base (sk_stream_t cstream);
+
+		// size_t sk_stream_get_position(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_stream_get_position (sk_stream_t cstream);
+
+		// bool sk_stream_has_length(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_has_length (sk_stream_t cstream);
+
+		// bool sk_stream_has_position(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_has_position (sk_stream_t cstream);
+
+		// bool sk_stream_is_at_end(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_is_at_end (sk_stream_t cstream);
+
+		// bool sk_stream_move(sk_stream_t* cstream, int offset)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_move (sk_stream_t cstream, Int32 offset);
+
+		// size_t sk_stream_peek(sk_stream_t* cstream, void* buffer, size_t size)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_stream_peek (sk_stream_t cstream, void* buffer, /* size_t */ IntPtr size);
+
+		// size_t sk_stream_read(sk_stream_t* cstream, void* buffer, size_t size)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_stream_read (sk_stream_t cstream, void* buffer, /* size_t */ IntPtr size);
+
+		// bool sk_stream_read_bool(sk_stream_t* cstream, bool* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_bool (sk_stream_t cstream, Byte* buffer);
+
+		// bool sk_stream_read_s16(sk_stream_t* cstream, int16_t* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_s16 (sk_stream_t cstream, Int16* buffer);
+
+		// bool sk_stream_read_s32(sk_stream_t* cstream, int32_t* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_s32 (sk_stream_t cstream, Int32* buffer);
+
+		// bool sk_stream_read_s8(sk_stream_t* cstream, int8_t* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_s8 (sk_stream_t cstream, SByte* buffer);
+
+		// bool sk_stream_read_u16(sk_stream_t* cstream, uint16_t* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_u16 (sk_stream_t cstream, UInt16* buffer);
+
+		// bool sk_stream_read_u32(sk_stream_t* cstream, uint32_t* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_u32 (sk_stream_t cstream, UInt32* buffer);
+
+		// bool sk_stream_read_u8(sk_stream_t* cstream, uint8_t* buffer)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_read_u8 (sk_stream_t cstream, Byte* buffer);
+
+		// bool sk_stream_rewind(sk_stream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_rewind (sk_stream_t cstream);
+
+		// bool sk_stream_seek(sk_stream_t* cstream, size_t position)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_stream_seek (sk_stream_t cstream, /* size_t */ IntPtr position);
+
+		// size_t sk_stream_skip(sk_stream_t* cstream, size_t size)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_stream_skip (sk_stream_t cstream, /* size_t */ IntPtr size);
+
+		// size_t sk_wstream_bytes_written(sk_wstream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_wstream_bytes_written (sk_wstream_t cstream);
+
+		// void sk_wstream_flush(sk_wstream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_wstream_flush (sk_wstream_t cstream);
+
+		// int sk_wstream_get_size_of_packed_uint(size_t value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_wstream_get_size_of_packed_uint (/* size_t */ IntPtr value);
+
+		// bool sk_wstream_newline(sk_wstream_t* cstream)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_newline (sk_wstream_t cstream);
+
+		// bool sk_wstream_write(sk_wstream_t* cstream, const void* buffer, size_t size)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write (sk_wstream_t cstream, void* buffer, /* size_t */ IntPtr size);
+
+		// bool sk_wstream_write_16(sk_wstream_t* cstream, uint16_t value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_16 (sk_wstream_t cstream, UInt16 value);
+
+		// bool sk_wstream_write_32(sk_wstream_t* cstream, uint32_t value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_32 (sk_wstream_t cstream, UInt32 value);
+
+		// bool sk_wstream_write_8(sk_wstream_t* cstream, uint8_t value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_8 (sk_wstream_t cstream, Byte value);
+
+		// bool sk_wstream_write_bigdec_as_text(sk_wstream_t* cstream, int64_t value, int minDigits)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_bigdec_as_text (sk_wstream_t cstream, Int64 value, Int32 minDigits);
+
+		// bool sk_wstream_write_bool(sk_wstream_t* cstream, bool value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_bool (sk_wstream_t cstream, [MarshalAs (UnmanagedType.I1)] bool value);
+
+		// bool sk_wstream_write_dec_as_text(sk_wstream_t* cstream, int32_t value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_dec_as_text (sk_wstream_t cstream, Int32 value);
+
+		// bool sk_wstream_write_hex_as_text(sk_wstream_t* cstream, uint32_t value, int minDigits)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_hex_as_text (sk_wstream_t cstream, UInt32 value, Int32 minDigits);
+
+		// bool sk_wstream_write_packed_uint(sk_wstream_t* cstream, size_t value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_packed_uint (sk_wstream_t cstream, /* size_t */ IntPtr value);
+
+		// bool sk_wstream_write_scalar(sk_wstream_t* cstream, float value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_scalar (sk_wstream_t cstream, Single value);
+
+		// bool sk_wstream_write_scalar_as_text(sk_wstream_t* cstream, float value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_scalar_as_text (sk_wstream_t cstream, Single value);
+
+		// bool sk_wstream_write_stream(sk_wstream_t* cstream, sk_stream_t* input, size_t length)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_stream (sk_wstream_t cstream, sk_stream_t input, /* size_t */ IntPtr length);
+
+		// bool sk_wstream_write_text(sk_wstream_t* cstream, const char* value)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_wstream_write_text (sk_wstream_t cstream, [MarshalAs (UnmanagedType.LPStr)] String value);
+
+		#endregion
+
 		#region sk_string.h
 
 		// void sk_string_destructor(const sk_string_t*)
@@ -3425,6 +3204,183 @@ namespace SkiaSharp
 
 		#endregion
 
+		#region sk_typeface.h
+
+		// int sk_fontmgr_count_families(sk_fontmgr_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_fontmgr_count_families (sk_fontmgr_t param0);
+
+		// sk_fontmgr_t* sk_fontmgr_create_default()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontmgr_t sk_fontmgr_create_default ();
+
+		// sk_typeface_t* sk_fontmgr_create_from_data(sk_fontmgr_t*, sk_data_t* data, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontmgr_create_from_data (sk_fontmgr_t param0, sk_data_t data, Int32 index);
+
+		// sk_typeface_t* sk_fontmgr_create_from_file(sk_fontmgr_t*, const char* path, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontmgr_create_from_file (sk_fontmgr_t param0, /* char */ void* path, Int32 index);
+
+		// sk_typeface_t* sk_fontmgr_create_from_stream(sk_fontmgr_t*, sk_stream_asset_t* stream, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontmgr_create_from_stream (sk_fontmgr_t param0, sk_stream_asset_t stream, Int32 index);
+
+		// sk_fontstyleset_t* sk_fontmgr_create_styleset(sk_fontmgr_t*, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontstyleset_t sk_fontmgr_create_styleset (sk_fontmgr_t param0, Int32 index);
+
+		// void sk_fontmgr_get_family_name(sk_fontmgr_t*, int index, sk_string_t* familyName)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_fontmgr_get_family_name (sk_fontmgr_t param0, Int32 index, sk_string_t familyName);
+
+		// sk_typeface_t* sk_fontmgr_match_face_style(sk_fontmgr_t*, const sk_typeface_t* face, sk_fontstyle_t* style)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontmgr_match_face_style (sk_fontmgr_t param0, sk_typeface_t face, sk_fontstyle_t style);
+
+		// sk_fontstyleset_t* sk_fontmgr_match_family(sk_fontmgr_t*, const char* familyName)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName);
+
+		// sk_typeface_t* sk_fontmgr_match_family_style(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
+
+		// sk_typeface_t* sk_fontmgr_match_family_style_character(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style, const char** bcp47, int bcp47Count, int32_t character)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
+
+		// sk_fontmgr_t* sk_fontmgr_ref_default()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontmgr_t sk_fontmgr_ref_default ();
+
+		// void sk_fontmgr_unref(sk_fontmgr_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_fontmgr_unref (sk_fontmgr_t param0);
+
+		// void sk_fontstyle_delete(sk_fontstyle_t* fs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_fontstyle_delete (sk_fontstyle_t fs);
+
+		// sk_font_style_slant_t sk_fontstyle_get_slant(const sk_fontstyle_t* fs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKFontStyleSlant sk_fontstyle_get_slant (sk_fontstyle_t fs);
+
+		// int sk_fontstyle_get_weight(const sk_fontstyle_t* fs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_fontstyle_get_weight (sk_fontstyle_t fs);
+
+		// int sk_fontstyle_get_width(const sk_fontstyle_t* fs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_fontstyle_get_width (sk_fontstyle_t fs);
+
+		// sk_fontstyle_t* sk_fontstyle_new(int weight, int width, sk_font_style_slant_t slant)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontstyle_t sk_fontstyle_new (Int32 weight, Int32 width, SKFontStyleSlant slant);
+
+		// sk_fontstyleset_t* sk_fontstyleset_create_empty()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontstyleset_t sk_fontstyleset_create_empty ();
+
+		// sk_typeface_t* sk_fontstyleset_create_typeface(sk_fontstyleset_t* fss, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontstyleset_create_typeface (sk_fontstyleset_t fss, Int32 index);
+
+		// int sk_fontstyleset_get_count(sk_fontstyleset_t* fss)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_fontstyleset_get_count (sk_fontstyleset_t fss);
+
+		// void sk_fontstyleset_get_style(sk_fontstyleset_t* fss, int index, sk_fontstyle_t* fs, sk_string_t* style)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_fontstyleset_get_style (sk_fontstyleset_t fss, Int32 index, sk_fontstyle_t fs, sk_string_t style);
+
+		// sk_typeface_t* sk_fontstyleset_match_style(sk_fontstyleset_t* fss, sk_fontstyle_t* style)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_fontstyleset_match_style (sk_fontstyleset_t fss, sk_fontstyle_t style);
+
+		// void sk_fontstyleset_unref(sk_fontstyleset_t* fss)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_fontstyleset_unref (sk_fontstyleset_t fss);
+
+		// int sk_typeface_chars_to_glyphs(sk_typeface_t* typeface, const char* chars, sk_encoding_t encoding, uint16_t[-1] glyphs, int glyphCount)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_typeface_chars_to_glyphs (sk_typeface_t typeface, /* char */ void* chars, SKEncoding encoding, UInt16* glyphs, Int32 glyphCount);
+
+		// int sk_typeface_count_tables(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_typeface_count_tables (sk_typeface_t typeface);
+
+		// sk_typeface_t* sk_typeface_create_default()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_typeface_create_default ();
+
+		// sk_typeface_t* sk_typeface_create_from_file(const char* path, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_typeface_create_from_file (/* char */ void* path, Int32 index);
+
+		// sk_typeface_t* sk_typeface_create_from_name_with_font_style(const char* familyName, sk_fontstyle_t* style)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_typeface_create_from_name_with_font_style ([MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
+
+		// sk_typeface_t* sk_typeface_create_from_stream(sk_stream_asset_t* stream, int index)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_typeface_create_from_stream (sk_stream_asset_t stream, Int32 index);
+
+		// sk_string_t* sk_typeface_get_family_name(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_string_t sk_typeface_get_family_name (sk_typeface_t typeface);
+
+		// sk_font_style_slant_t sk_typeface_get_font_slant(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKFontStyleSlant sk_typeface_get_font_slant (sk_typeface_t typeface);
+
+		// int sk_typeface_get_font_weight(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_typeface_get_font_weight (sk_typeface_t typeface);
+
+		// int sk_typeface_get_font_width(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_typeface_get_font_width (sk_typeface_t typeface);
+
+		// sk_fontstyle_t* sk_typeface_get_fontstyle(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_fontstyle_t sk_typeface_get_fontstyle (sk_typeface_t typeface);
+
+		// size_t sk_typeface_get_table_data(sk_typeface_t* typeface, sk_font_table_tag_t tag, size_t offset, size_t length, void* data)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_typeface_get_table_data (sk_typeface_t typeface, UInt32 tag, /* size_t */ IntPtr offset, /* size_t */ IntPtr length, void* data);
+
+		// size_t sk_typeface_get_table_size(sk_typeface_t* typeface, sk_font_table_tag_t tag)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_typeface_get_table_size (sk_typeface_t typeface, UInt32 tag);
+
+		// int sk_typeface_get_table_tags(sk_typeface_t* typeface, sk_font_table_tag_t[-1] tags)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_typeface_get_table_tags (sk_typeface_t typeface, UInt32* tags);
+
+		// int sk_typeface_get_units_per_em(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_typeface_get_units_per_em (sk_typeface_t typeface);
+
+		// bool sk_typeface_is_fixed_pitch(sk_typeface_t* typeface)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_typeface_is_fixed_pitch (sk_typeface_t typeface);
+
+		// sk_stream_asset_t* sk_typeface_open_stream(sk_typeface_t* typeface, int* ttcIndex)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_asset_t sk_typeface_open_stream (sk_typeface_t typeface, Int32* ttcIndex);
+
+		// sk_typeface_t* sk_typeface_ref_default()
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_typeface_t sk_typeface_ref_default ();
+
+		// void sk_typeface_unref(sk_typeface_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_typeface_unref (sk_typeface_t param0);
+
+		#endregion
+
 		#region sk_vertices.h
 
 		// sk_vertices_t* sk_vertices_make_copy(sk_vertices_vertex_mode_t vmode, int vertexCount, const sk_point_t* positions, const sk_point_t* texs, const sk_color_t* colors, int indexCount, const uint16_t* indices)
@@ -3450,6 +3406,50 @@ namespace SkiaSharp
 		// sk_xmlstreamwriter_t* sk_xmlstreamwriter_new(sk_wstream_t* stream)
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_xmlstreamwriter_t sk_xmlstreamwriter_new (sk_wstream_t stream);
+
+		#endregion
+
+		#region sk_manageddrawable.h
+
+		// sk_manageddrawable_t* sk_manageddrawable_new(void* context)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_manageddrawable_t sk_manageddrawable_new (void* context);
+
+		// void sk_manageddrawable_set_procs(sk_manageddrawable_procs_t procs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_manageddrawable_set_procs (SKManagedDrawableDelegates procs);
+
+		// void sk_manageddrawable_unref(sk_manageddrawable_t*)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_manageddrawable_unref (sk_manageddrawable_t param0);
+
+		#endregion
+
+		#region sk_managedstream.h
+
+		// void sk_managedstream_destroy(sk_stream_managedstream_t* s)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_managedstream_destroy (sk_stream_managedstream_t s);
+
+		// sk_stream_managedstream_t* sk_managedstream_new(void* context)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_stream_managedstream_t sk_managedstream_new (void* context);
+
+		// void sk_managedstream_set_procs(sk_managedstream_procs_t procs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_managedstream_set_procs (SKManagedStreamDelegates procs);
+
+		// void sk_managedwstream_destroy(sk_wstream_managedstream_t* s)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_managedwstream_destroy (sk_wstream_managedstream_t s);
+
+		// sk_wstream_managedstream_t* sk_managedwstream_new(void* context)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_wstream_managedstream_t sk_managedwstream_new (void* context);
+
+		// void sk_managedwstream_set_procs(sk_managedwstream_procs_t procs)
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_managedwstream_set_procs (SKManagedWStreamDelegates procs);
 
 		#endregion
 

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -48,6 +48,15 @@
           "fID": "Id"
         }
       },
+      "sk_color4f_t": {
+        "cs": "SKColorF",
+        "members": {
+          "fR": "Red",
+          "fG": "Green",
+          "fB": "Blue",
+          "fA": "Alpha"
+        }
+      },
       "sk_jpegencoder_options_t": {
         "cs": "SKJpegEncoderOptions"
       },

--- a/tests/Tests/SKColorFTest.cs
+++ b/tests/Tests/SKColorFTest.cs
@@ -1,0 +1,184 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+using SKOtherColor = System.Tuple<float, float, float>;
+
+namespace SkiaSharp.Tests
+{
+	public class SKColorFTest : SKTest
+	{
+		private const int Precision = 2;
+
+		[SkippableFact]
+		public void ColorWithComponent()
+		{
+			var color = new SKColorF();
+			Assert.Equal(0, color.Red);
+			Assert.Equal(0, color.Green);
+			Assert.Equal(0, color.Blue);
+			Assert.Equal(0, color.Alpha);
+
+			var red = color.WithRed(0.5f);
+			Assert.Equal(0.5f, red.Red);
+			Assert.Equal(0, red.Green);
+			Assert.Equal(0, red.Blue);
+			Assert.Equal(0, red.Alpha);
+
+			var green = color.WithGreen(0.5f);
+			Assert.Equal(0, green.Red);
+			Assert.Equal(0.5f, green.Green);
+			Assert.Equal(0, green.Blue);
+			Assert.Equal(0, green.Alpha);
+
+			var blue = color.WithBlue(0.5f);
+			Assert.Equal(0, blue.Red);
+			Assert.Equal(0, blue.Green);
+			Assert.Equal(0.5f, blue.Blue);
+			Assert.Equal(0, blue.Alpha);
+
+			var alpha = color.WithAlpha(0.5f);
+			Assert.Equal(0, alpha.Red);
+			Assert.Equal(0, alpha.Green);
+			Assert.Equal(0, alpha.Blue);
+			Assert.Equal(0.5f, alpha.Alpha);
+		}
+
+		public static IEnumerable<object[]> GetBasicColorFToColorConversionData()
+		{
+			// B/W
+			yield return new object[] { SKColors.Black, new SKColorF(0, 0, 0, 1) };
+			yield return new object[] { SKColors.White, new SKColorF(1, 1, 1, 1) };
+			// R/G/B
+			yield return new object[] { SKColors.Red, new SKColorF(1, 0, 0, 1) };
+			yield return new object[] { SKColors.Lime, new SKColorF(0, 1, 0, 1) };
+			yield return new object[] { SKColors.Blue, new SKColorF(0, 0, 1, 1) };
+			// Empty
+			yield return new object[] { new SKColor(0, 0, 0, 0), new SKColorF(0, 0, 0, 0) };
+			yield return new object[] { new SKColor(0), new SKColorF(0, 0, 0, 0) };
+			yield return new object[] { new SKColor(), new SKColorF() };
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetBasicColorFToColorConversionData))]
+		public void BasicColorFToColorConversion(SKColor color, SKColorF colorf)
+		{
+			var fromF = (SKColor)colorf;
+
+			Assert.Equal(color, fromF);
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetBasicColorFToColorConversionData))]
+		public void BasicColorToColorFConversion(SKColor color, SKColorF colorf)
+		{
+			var toF = (SKColorF)color;
+
+			Assert.Equal(colorf, toF);
+		}
+
+		public static IEnumerable<object[]> GetColorRgbToHslData()
+		{
+			yield return new object[] { new SKColorF(0.0f, 0.0f, 0.0f), new SKOtherColor(000f, 000.0f, 000.0f) };
+			yield return new object[] { new SKColorF(1.0f, 0.0f, 0.0f), new SKOtherColor(000f, 100.0f, 050.0f) };
+			yield return new object[] { new SKColorF(1.0f, 1.0f, 0.0f), new SKOtherColor(060f, 100.0f, 050.0f) };
+			yield return new object[] { new SKColorF(1.0f, 1.0f, 1.0f), new SKOtherColor(000f, 000.0f, 100.0f) };
+			yield return new object[] { new SKColorF(0.5f, 0.5f, 0.5f), new SKOtherColor(000f, 000.0f, 050.0f) };
+			yield return new object[] { new SKColorF(0.5f, 0.5f, 0.0f), new SKOtherColor(060f, 100.0f, 025.0f) };
+			yield return new object[] { new SKColorF(0.0f, 0.5f, 0.0f), new SKOtherColor(120f, 100.0f, 025.0f) };
+			yield return new object[] { new SKColorF(0.0f, 0.0f, 0.5f), new SKOtherColor(240f, 100.0f, 025.0f) };
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetColorRgbToHslData))]
+		public void ColorRgbToHsl(SKColorF rgb, SKOtherColor other)
+		{
+			rgb.ToHsl(out var h, out var s, out var l);
+
+			Assert.Equal(other.Item1, h, Precision);
+			Assert.Equal(other.Item2, s, Precision);
+			Assert.Equal(other.Item3, l, Precision);
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetColorRgbToHslData))]
+		public void ColorHsltoRgb(SKColorF rgb, SKOtherColor other)
+		{
+			var back = SKColorF.FromHsl(other.Item1, other.Item2, other.Item3);
+
+			Assert.Equal(rgb.Red, back.Red, Precision);
+			Assert.Equal(rgb.Green, back.Green, Precision);
+			Assert.Equal(rgb.Blue, back.Blue, Precision);
+			Assert.Equal(rgb.Alpha, back.Alpha, Precision);
+		}
+
+		public static IEnumerable<object[]> GetColorRgbToHsvData()
+		{
+			yield return new object[] { new SKColorF(0.0f, 0.0f, 0.0f), new SKOtherColor(000f, 000.0f, 000.0f) };
+			yield return new object[] { new SKColorF(1.0f, 0.0f, 0.0f), new SKOtherColor(000f, 100.0f, 100.0f) };
+			yield return new object[] { new SKColorF(1.0f, 1.0f, 0.0f), new SKOtherColor(060f, 100.0f, 100.0f) };
+			yield return new object[] { new SKColorF(1.0f, 1.0f, 1.0f), new SKOtherColor(000f, 000.0f, 100.0f) };
+			yield return new object[] { new SKColorF(0.5f, 0.5f, 0.5f), new SKOtherColor(000f, 000.0f, 050.0f) };
+			yield return new object[] { new SKColorF(0.5f, 0.5f, 0.0f), new SKOtherColor(060f, 100.0f, 050.0f) };
+			yield return new object[] { new SKColorF(0.0f, 0.5f, 0.0f), new SKOtherColor(120f, 100.0f, 050.0f) };
+			yield return new object[] { new SKColorF(0.0f, 0.0f, 0.5f), new SKOtherColor(240f, 100.0f, 050.0f) };
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetColorRgbToHsvData))]
+		public void ColorRgbToHsv(SKColorF rgb, SKOtherColor other)
+		{
+			rgb.ToHsv(out var h, out var s, out var v);
+
+			Assert.Equal(other.Item1, h, Precision);
+			Assert.Equal(other.Item2, s, Precision);
+			Assert.Equal(other.Item3, v, Precision);
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetColorRgbToHsvData))]
+		public void ColorHsvtoRgb(SKColorF rgb, SKOtherColor other)
+		{
+			var back = SKColorF.FromHsv(other.Item1, other.Item2, other.Item3);
+
+			Assert.Equal(rgb.Red, back.Red, Precision);
+			Assert.Equal(rgb.Green, back.Green, Precision);
+			Assert.Equal(rgb.Blue, back.Blue, Precision);
+			Assert.Equal(rgb.Alpha, back.Alpha, Precision);
+		}
+
+		public static IEnumerable<object[]> GetClampData()
+		{
+			// base
+			yield return new object[] { new SKColorF(0, 0, 0, 0), new SKColorF(0, 0, 0, 0) };
+			yield return new object[] { new SKColorF(0, 1, 0, 1), new SKColorF(0, 1, 0, 1) };
+			yield return new object[] { new SKColorF(0, 0, 1, 1), new SKColorF(0, 0, 1, 1) };
+			yield return new object[] { new SKColorF(1, 0, 0, 1), new SKColorF(1, 0, 0, 1) };
+			yield return new object[] { new SKColorF(0, 1, 0, 1), new SKColorF(0, 1, 0, 1) };
+			yield return new object[] { new SKColorF(1, 1, 1, 1), new SKColorF(1, 1, 1, 1) };
+			// below
+			yield return new object[] { new SKColorF(0, 0, 0, 0), new SKColorF(0, 0, 0, 0) };
+			yield return new object[] { new SKColorF(0, -0.5f, 0, 1), new SKColorF(0, 0, 0, 1) };
+			yield return new object[] { new SKColorF(0, 0, -0.5f, 1), new SKColorF(0, 0, 0, 1) };
+			yield return new object[] { new SKColorF(-0.5f, 0, 0, 1), new SKColorF(0, 0, 0, 1) };
+			yield return new object[] { new SKColorF(0, -0.5f, 0, 1), new SKColorF(0, 0, 0, 1) };
+			yield return new object[] { new SKColorF(-0.5f, -0.5f, -0.5f, -0.5f), new SKColorF(0, 0, 0, 0) };
+			// above
+			yield return new object[] { new SKColorF(0, 0, 0, 0), new SKColorF(0, 0, 0, 0) };
+			yield return new object[] { new SKColorF(0, 1.5f, 0, 1), new SKColorF(0, 1, 0, 1) };
+			yield return new object[] { new SKColorF(0, 0, 1.5f, 1), new SKColorF(0, 0, 1, 1) };
+			yield return new object[] { new SKColorF(1.5f, 0, 0, 1), new SKColorF(1, 0, 0, 1) };
+			yield return new object[] { new SKColorF(0, 1.5f, 0, 1), new SKColorF(0, 1, 0, 1) };
+			yield return new object[] { new SKColorF(1.5f, 1.5f, 1.5f, 1.5f), new SKColorF(1, 1, 1, 1) };
+		}
+
+		[SkippableTheory]
+		[MemberData(nameof(GetClampData))]
+		public void Clamp(SKColorF before, SKColorF after)
+		{
+			var clamp = before.Clamp();
+
+			Assert.Equal(after, clamp);
+		}
+
+	}
+}

--- a/tests/Tests/SKPixmapTest.cs
+++ b/tests/Tests/SKPixmapTest.cs
@@ -107,6 +107,32 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void EraseWithColor()
+		{
+			var info = new SKImageInfo(1, 1);
+
+			using var bmp = new SKBitmap(info);
+			using var pixmap = bmp.PeekPixels();
+
+			pixmap.Erase(SKColors.Red);
+
+			Assert.Equal(SKColors.Red, pixmap.GetPixelColor(0, 0));
+		}
+
+		[SkippableFact]
+		public void EraseWithColorF()
+		{
+			var info = new SKImageInfo(1, 1);
+
+			using var bmp = new SKBitmap(info);
+			using var pixmap = bmp.PeekPixels();
+
+			pixmap.Erase(new SKColorF(1, 0, 0));
+
+			Assert.Equal(SKColors.Red, pixmap.GetPixelColor(0, 0));
+		}
+
+		[SkippableFact]
 		public void EncodeWithPngEncoder()
 		{
 			var bitmap = CreateTestBitmap();

--- a/tests/Tests/SKShaderTest.cs
+++ b/tests/Tests/SKShaderTest.cs
@@ -8,38 +8,104 @@ namespace SkiaSharp.Tests
 		[SkippableTheory]
 		[InlineData(null)]
 		[InlineData(new[] { 0f, 0.3f, 1f })]
+		[InlineData(new[] { 0f, 0f, 1f })]
+		[InlineData(new[] { 0f, 1f, 1f })]
 		public void CanDrawWithCreateLinearGradientShader(float[] colorPositions)
 		{
 			var size = 160;
 			var colors = new[] { SKColors.Blue, SKColors.Yellow, SKColors.Green };
 
-			using (var bitmap = new SKBitmap(new SKImageInfo(size, size)))
-			using (var canvas = new SKCanvas(bitmap))
-			using (var p = new SKPaint())
+			using var bitmap = new SKBitmap(new SKImageInfo(size, size));
+			using var canvas = new SKCanvas(bitmap);
+			using var p = new SKPaint
 			{
-				p.Shader = SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, colorPositions, SKShaderTileMode.Clamp);
+				Shader = SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, colorPositions, SKShaderTileMode.Clamp)
+			};
 
-				canvas.DrawRect(SKRect.Create(size, size), p);
-			}
+			canvas.DrawRect(SKRect.Create(size, size), p);
+		}
+
+		[SkippableTheory]
+		[InlineData(null)]
+		[InlineData(new[] { 0f, 0.3f, 1f })]
+		[InlineData(new[] { 0f, 0f, 1f })]
+		[InlineData(new[] { 0f, 1f, 1f })]
+		public void CanDrawWithCreateLinearGradientShaderColorF(float[] colorPositions)
+		{
+			var size = 160;
+			var colors = new SKColorF[] { SKColors.Blue, SKColors.Yellow, SKColors.Green };
+			using var colorspace = SKColorSpace.CreateSrgb();
+
+			using var bitmap = new SKBitmap(new SKImageInfo(size, size));
+			using var canvas = new SKCanvas(bitmap);
+			using var p = new SKPaint
+			{
+				Shader = SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, colorspace, colorPositions, SKShaderTileMode.Clamp)
+			};
+
+			canvas.DrawRect(SKRect.Create(size, size), p);
+		}
+
+		[SkippableFact]
+		public void LinearShaderDrawColorCorrectly()
+		{
+			var size = 160;
+			var colors = new[] { SKColors.Blue, SKColors.Gray, SKColors.Gray, SKColors.Red };
+			var positions = new[] { 0.1f, 0.4f, 0.6f, 0.9f };
+
+			using var bitmap = new SKBitmap(new SKImageInfo(size, size));
+			using var canvas = new SKCanvas(bitmap);
+			using var p = new SKPaint
+			{
+				Shader = SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, positions, SKShaderTileMode.Clamp)
+			};
+
+			canvas.DrawRect(SKRect.Create(size, size), p);
+
+			Assert.Equal(SKColors.Blue, bitmap.GetPixel(1, 0));
+			Assert.Equal(SKColors.Gray, bitmap.GetPixel(80, 0));
+			Assert.Equal(SKColors.Red, bitmap.GetPixel(159, 0));
+		}
+
+		[SkippableFact]
+		public void LinearShaderDrawColorFCorrectly()
+		{
+			var size = 160;
+			var colors = new SKColorF[] { SKColors.Blue, SKColors.Gray, SKColors.Gray, SKColors.Red };
+			var positions = new[] { 0.1f, 0.4f, 0.6f, 0.9f };
+			using var colorspace = SKColorSpace.CreateSrgb();
+
+			using var bitmap = new SKBitmap(new SKImageInfo(size, size));
+			using var canvas = new SKCanvas(bitmap);
+			using var p = new SKPaint
+			{
+				Shader = SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, colorspace, positions, SKShaderTileMode.Clamp)
+			};
+
+			canvas.DrawRect(SKRect.Create(size, size), p);
+
+			Assert.Equal(SKColors.Blue, bitmap.GetPixel(1, 0));
+			Assert.Equal(SKColors.Gray, bitmap.GetPixel(80, 0));
+			Assert.Equal(SKColors.Red, bitmap.GetPixel(159, 0));
 		}
 
 		[SkippableFact]
 		public void LinearGradientWithIncorrectColorPositionsThrows()
 		{
-			var size = 160;
 			var colors = new[] { SKColors.Blue, SKColors.Yellow, SKColors.Green };
+			var pos = new float[] { 0f, 0.1f, 0.2f, 0.3f, 0.4f, 1f };
 
-			using (var bitmap = new SKBitmap(new SKImageInfo(size, size)))
-			using (var canvas = new SKCanvas(bitmap))
-			using (var p = new SKPaint())
-			{
-				Assert.Throws<ArgumentException>(() => SKShader.CreateLinearGradient(
-					new SKPoint(10, 10),
-					new SKPoint(150, 10),
-					colors,
-					new float[] { 0f, 0.1f, 0.2f, 0.3f, 0.4f, 1f },
-					SKShaderTileMode.Clamp));
-			}
+			Assert.Throws<ArgumentException>(() => SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, pos, SKShaderTileMode.Clamp));
+		}
+
+		[SkippableFact]
+		public void LinearGradientWithIncorrectColorPositionsThrowsColorF()
+		{
+			var colors = new SKColorF[] { SKColors.Blue, SKColors.Yellow, SKColors.Green };
+			var pos = new float[] { 0f, 0.1f, 0.2f, 0.3f, 0.4f, 1f };
+			using var colorspace = SKColorSpace.CreateSrgb();
+
+			Assert.Throws<ArgumentException>(() => SKShader.CreateLinearGradient(new SKPoint(10, 10), new SKPoint(150, 10), colors, colorspace, pos, SKShaderTileMode.Clamp));
 		}
 
 		[SkippableFact]
@@ -57,27 +123,26 @@ namespace SkiaSharp.Tests
 				(start:  -30, end:  800),
 			};
 
-			using (var bitmap = new SKBitmap(new SKImageInfo(690, 512)))
-			using (var canvas = new SKCanvas(bitmap))
-			using (var p = new SKPaint())
+			using var bitmap = new SKBitmap(new SKImageInfo(690, 512));
+			using var canvas = new SKCanvas(bitmap);
+			using var p = new SKPaint();
+
+			var r = SKRect.Create(size, size);
+
+			foreach (var mode in modes)
 			{
-				var r = SKRect.Create(size, size);
-
-				foreach (var mode in modes)
+				using (new SKAutoCanvasRestore(canvas, true))
 				{
-					using (new SKAutoCanvasRestore(canvas, true))
+					foreach (var (start, end) in angles)
 					{
-						foreach (var angle in angles)
-						{
-							p.Shader = SKShader.CreateSweepGradient(new SKPoint(size / 2f, size / 2f), colors, pos, mode, angle.start, angle.end);
+						p.Shader = SKShader.CreateSweepGradient(new SKPoint(size / 2f, size / 2f), colors, pos, mode, start, end);
 
-							canvas.DrawRect(r, p);
-							canvas.Translate(size * 1.1f, 0);
-						}
+						canvas.DrawRect(r, p);
+						canvas.Translate(size * 1.1f, 0);
 					}
-
-					canvas.Translate(0, size * 1.1f);
 				}
+
+				canvas.Translate(0, size * 1.1f);
 			}
 		}
 
@@ -89,31 +154,31 @@ namespace SkiaSharp.Tests
 			var indentHalf = 2;
 			var tile = SKRect.Create(0, 0, breakSize.Width * 2 + indentHalf * 4, breakSize.Height * 2 + indentHalf * 4);
 
-			using (var bitmap = new SKBitmap(new SKImageInfo((int)(breakSize.Width * 5 + indentHalf * 2 * 5), (int)(breakSize.Height * 5 + indentHalf * 2 * 5))))
-			using (var canvas = new SKCanvas(bitmap))
-			using (var pictureRecorder = new SKPictureRecorder())
-			using (var pictureCanvas = pictureRecorder.BeginRecording(tile))
-			using (var pictureBreak = new SKPaint { Color = SKColors.DarkRed, Style = SKPaintStyle.Fill })
-			using (var p = new SKPaint())
-			{
-				pictureCanvas.Translate(indentHalf, indentHalf);
-				pictureCanvas.DrawRect(breakRect, pictureBreak);
-				pictureCanvas.Translate(breakSize.Width + indentHalf * 2, 0);
-				pictureCanvas.DrawRect(breakRect, pictureBreak);
-				pictureCanvas.Translate(-(breakSize.Width * 1.5F + indentHalf * 3), breakSize.Height + indentHalf * 2);
-				pictureCanvas.DrawRect(breakRect, pictureBreak);
-				pictureCanvas.Translate(breakSize.Width + indentHalf * 2, 0);
-				pictureCanvas.DrawRect(breakRect, pictureBreak);
-				pictureCanvas.Translate(breakSize.Width + indentHalf * 2, 0);
-				pictureCanvas.DrawRect(breakRect, pictureBreak);
+			using var bitmap = new SKBitmap(new SKImageInfo((int)(breakSize.Width * 5 + indentHalf * 2 * 5), (int)(breakSize.Height * 5 + indentHalf * 2 * 5)));
+			using var canvas = new SKCanvas(bitmap);
+			using var pictureRecorder = new SKPictureRecorder();
+			using var pictureCanvas = pictureRecorder.BeginRecording(tile);
+			using var pictureBreak = new SKPaint { Color = SKColors.DarkRed, Style = SKPaintStyle.Fill };
 
-				using (var picture = pictureRecorder.EndRecording())
-				{
-					p.Shader = SKShader.CreatePicture(picture, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat, SKMatrix.MakeIdentity(), tile);
-					var r = SKRect.Create(bitmap.Width, bitmap.Height);
-					canvas.DrawRect(r, p);
-				}
-			}
+			pictureCanvas.Translate(indentHalf, indentHalf);
+			pictureCanvas.DrawRect(breakRect, pictureBreak);
+			pictureCanvas.Translate(breakSize.Width + indentHalf * 2, 0);
+			pictureCanvas.DrawRect(breakRect, pictureBreak);
+			pictureCanvas.Translate(-(breakSize.Width * 1.5F + indentHalf * 3), breakSize.Height + indentHalf * 2);
+			pictureCanvas.DrawRect(breakRect, pictureBreak);
+			pictureCanvas.Translate(breakSize.Width + indentHalf * 2, 0);
+			pictureCanvas.DrawRect(breakRect, pictureBreak);
+			pictureCanvas.Translate(breakSize.Width + indentHalf * 2, 0);
+			pictureCanvas.DrawRect(breakRect, pictureBreak);
+
+			using var picture = pictureRecorder.EndRecording();
+
+			using var p = new SKPaint
+			{
+				Shader = SKShader.CreatePicture(picture, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat, SKMatrix.MakeIdentity(), tile)
+			};
+			var r = SKRect.Create(bitmap.Width, bitmap.Height);
+			canvas.DrawRect(r, p);
 		}
 	}
 }

--- a/utils/SkiaSharpGenerator/Generate/Generator.cs
+++ b/utils/SkiaSharpGenerator/Generate/Generator.cs
@@ -418,7 +418,9 @@ namespace SkiaSharpGenerator
 
 			var functionGroups = compilation.Functions
 				.OrderBy(f => f.Name)
-				.GroupBy(f => f.Span.Start.File);
+				.GroupBy(f => f.Span.Start.File.ToLower().Replace("\\", "/"))
+				.OrderBy(g => Path.GetDirectoryName(g.Key) + "/" + Path.GetFileName(g.Key));
+
 			foreach (var group in functionGroups)
 			{
 				writer.WriteLine($"\t\t#region {Path.GetFileName(group.Key)}");


### PR DESCRIPTION
**Description of Change**

Adding the overloads that accept `SKColorF` and usually a `SKColorSpace`.

**Bugs Fixed**

- Fixes #1115
- Related https://github.com/mono/skia/pull/74

**API Changes**

Added: 
 
- `class SKColorF`

**Behavioral Changes**

New members.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
