### PR TITLE
Improve Generator & Structs

### DIFF
--- a/binding/Binding.Shared/HashCode.cs
+++ b/binding/Binding.Shared/HashCode.cs
@@ -1,0 +1,147 @@
+﻿// Partial code copied from:
+// https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+
+using System;
+using System.Runtime.CompilerServices;
+
+#if HARFBUZZ
+namespace HarfBuzzSharp
+#else
+namespace SkiaSharp
+#endif
+{
+	internal unsafe struct HashCode
+	{
+		private static readonly uint s_seed = GenerateGlobalSeed ();
+
+		private const uint Prime1 = 2654435761U;
+		private const uint Prime2 = 2246822519U;
+		private const uint Prime3 = 3266489917U;
+		private const uint Prime4 = 668265263U;
+		private const uint Prime5 = 374761393U;
+
+		private uint _v1, _v2, _v3, _v4;
+		private uint _queue1, _queue2, _queue3;
+		private uint _length;
+
+		private static unsafe uint GenerateGlobalSeed ()
+		{
+			var rnd = new Random ();
+			var result = rnd.Next ();
+			return unchecked((uint)result);
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static void Initialize (out uint v1, out uint v2, out uint v3, out uint v4)
+		{
+			v1 = s_seed + Prime1 + Prime2;
+			v2 = s_seed + Prime2;
+			v3 = s_seed;
+			v4 = s_seed - Prime1;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint Round (uint hash, uint input) =>
+			RotateLeft (hash + input * Prime2, 13) * Prime1;
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint QueueRound (uint hash, uint queuedValue) =>
+			RotateLeft (hash + queuedValue * Prime3, 17) * Prime4;
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint MixState (uint v1, uint v2, uint v3, uint v4) =>
+			RotateLeft (v1, 1) + RotateLeft (v2, 7) + RotateLeft (v3, 12) + RotateLeft (v4, 18);
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint RotateLeft (uint value, int offset) =>
+			(value << offset) | (value >> (32 - offset));
+
+		private static uint MixEmptyState () =>
+			s_seed + Prime5;
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint MixFinal (uint hash)
+		{
+			hash ^= hash >> 15;
+			hash *= Prime2;
+			hash ^= hash >> 13;
+			hash *= Prime3;
+			hash ^= hash >> 16;
+			return hash;
+		}
+
+		public void Add (void* value) =>
+			Add (value == null ? 0 : ((IntPtr)value).GetHashCode ());
+
+		public void Add<T> (T value) =>
+			Add (value?.GetHashCode () ?? 0);
+
+		private void Add (int value)
+		{
+			uint val = (uint)value;
+
+			// Storing the value of _length locally shaves of quite a few bytes
+			// in the resulting machine code.
+			uint previousLength = _length++;
+			uint position = previousLength % 4;
+
+			// Switch can't be inlined.
+
+			if (position == 0)
+				_queue1 = val;
+			else if (position == 1)
+				_queue2 = val;
+			else if (position == 2)
+				_queue3 = val;
+			else // position == 3
+			{
+				if (previousLength == 3)
+					Initialize (out _v1, out _v2, out _v3, out _v4);
+
+				_v1 = Round (_v1, _queue1);
+				_v2 = Round (_v2, _queue2);
+				_v3 = Round (_v3, _queue3);
+				_v4 = Round (_v4, val);
+			}
+		}
+
+		public int ToHashCode ()
+		{
+			// Storing the value of _length locally shaves of quite a few bytes
+			// in the resulting machine code.
+			uint length = _length;
+
+			// position refers to the *next* queue position in this method, so
+			// position == 1 means that _queue1 is populated; _queue2 would have
+			// been populated on the next call to Add.
+			uint position = length % 4;
+
+			// If the length is less than 4, _v1 to _v4 don't contain anything
+			// yet. xxHash32 treats this differently.
+
+			uint hash = length < 4 ? MixEmptyState () : MixState (_v1, _v2, _v3, _v4);
+
+			// _length is incremented once per Add(Int32) and is therefore 4
+			// times too small (xxHash length is in bytes, not ints).
+
+			hash += length * 4;
+
+			// Mix what remains in the queue
+
+			// Switch can't be inlined right now, so use as few branches as
+			// possible by manually excluding impossible scenarios (position > 1
+			// is always false if position is not > 0).
+			if (position > 0) {
+				hash = QueueRound (hash, _queue1);
+				if (position > 1) {
+					hash = QueueRound (hash, _queue2);
+					if (position > 2)
+						hash = QueueRound (hash, _queue3);
+				}
+			}
+
+			hash = MixFinal (hash);
+			return (int)hash;
+		}
+	}
+}

--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Globalization;
-
-using sk_string_t = System.IntPtr;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use SKEncodedOrigin instead.")]
-	public enum SKCodecOrigin {
+	public enum SKCodecOrigin
+	{
 		TopLeft = 1,
 		TopRight = 2,
 		BottomRight = 3,
@@ -18,33 +17,36 @@ namespace SkiaSharp
 		LeftBottom = 8,
 	}
 
-	public enum SKFontStyleWeight {
-		Invisible   =   0,
-		Thin        = 100,
-		ExtraLight  = 200,
-		Light       = 300,
-		Normal      = 400,
-		Medium      = 500,
-		SemiBold    = 600,
-		Bold        = 700,
-		ExtraBold   = 800,
-		Black       = 900,
-		ExtraBlack  =1000,
-	};
-
-	public enum SKFontStyleWidth {
-		UltraCondensed   = 1,
-		ExtraCondensed   = 2,
-		Condensed        = 3,
-		SemiCondensed    = 4,
-		Normal           = 5,
-		SemiExpanded     = 6,
-		Expanded         = 7,
-		ExtraExpanded    = 8,
-		UltraExpanded    = 9,
+	public enum SKFontStyleWeight
+	{
+		Invisible = 0,
+		Thin = 100,
+		ExtraLight = 200,
+		Light = 300,
+		Normal = 400,
+		Medium = 500,
+		SemiBold = 600,
+		Bold = 700,
+		ExtraBold = 800,
+		Black = 900,
+		ExtraBlack = 1000,
 	}
 
-	public static partial class SkiaExtensions {
+	public enum SKFontStyleWidth
+	{
+		UltraCondensed = 1,
+		ExtraCondensed = 2,
+		Condensed = 3,
+		SemiCondensed = 4,
+		Normal = 5,
+		SemiExpanded = 6,
+		Expanded = 7,
+		ExtraExpanded = 8,
+		UltraExpanded = 9,
+	}
+
+	public static partial class SkiaExtensions
+	{
 		public static bool IsBgr (this SKPixelGeometry pg) =>
 			pg == SKPixelGeometry.BgrHorizontal || pg == SKPixelGeometry.BgrVertical;
 
@@ -58,111 +60,178 @@ namespace SkiaSharp
 			pg == SKPixelGeometry.BgrHorizontal || pg == SKPixelGeometry.RgbHorizontal;
 	}
 
-	[Obsolete("Use SKSurfaceProperties instead.")]
-	public struct SKSurfaceProps {
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Obsolete ("Use SKSurfaceProperties instead.")]
+	public struct SKSurfaceProps
+	{
 		public SKPixelGeometry PixelGeometry { get; set; }
 		public SKSurfacePropsFlags Flags { get; set; }
 	}
 
-	public struct SKCodecOptions {
+	public struct SKCodecOptions : IEquatable<SKCodecOptions>
+	{
 		public static readonly SKCodecOptions Default;
 
 		static SKCodecOptions ()
 		{
 			Default = new SKCodecOptions (SKZeroInitialized.No);
 		}
-		public SKCodecOptions (SKZeroInitialized zeroInitialized) {
+
+		public SKCodecOptions (SKZeroInitialized zeroInitialized)
+		{
 			ZeroInitialized = zeroInitialized;
 			Subset = null;
 			FrameIndex = 0;
 			PriorFrame = -1;
 			PremulBehavior = SKTransferFunctionBehavior.Respect;
 		}
-		public SKCodecOptions (SKZeroInitialized zeroInitialized, SKRectI subset) {
+		public SKCodecOptions (SKZeroInitialized zeroInitialized, SKRectI subset)
+		{
 			ZeroInitialized = zeroInitialized;
 			Subset = subset;
 			FrameIndex = 0;
 			PriorFrame = -1;
 			PremulBehavior = SKTransferFunctionBehavior.Respect;
 		}
-		public SKCodecOptions (SKRectI subset) {
+		public SKCodecOptions (SKRectI subset)
+		{
 			ZeroInitialized = SKZeroInitialized.No;
 			Subset = subset;
 			FrameIndex = 0;
 			PriorFrame = -1;
 			PremulBehavior = SKTransferFunctionBehavior.Respect;
 		}
-		public SKCodecOptions (int frameIndex) {
+		public SKCodecOptions (int frameIndex)
+		{
 			ZeroInitialized = SKZeroInitialized.No;
 			Subset = null;
 			FrameIndex = frameIndex;
 			PriorFrame = -1;
 			PremulBehavior = SKTransferFunctionBehavior.Respect;
 		}
-		public SKCodecOptions (int frameIndex, int priorFrame) {
+		public SKCodecOptions (int frameIndex, int priorFrame)
+		{
 			ZeroInitialized = SKZeroInitialized.No;
 			Subset = null;
 			FrameIndex = frameIndex;
 			PriorFrame = priorFrame;
 			PremulBehavior = SKTransferFunctionBehavior.Respect;
 		}
+
 		public SKZeroInitialized ZeroInitialized { get; set; }
 		public SKRectI? Subset { get; set; }
 		public bool HasSubset => Subset != null;
 		public int FrameIndex { get; set; }
 		public int PriorFrame { get; set; }
 		public SKTransferFunctionBehavior PremulBehavior { get; set; }
+
+		public bool Equals (SKCodecOptions obj) =>
+			ZeroInitialized == obj.ZeroInitialized &&
+			Subset == obj.Subset &&
+			FrameIndex == obj.FrameIndex &&
+			PriorFrame == obj.PriorFrame &&
+			PremulBehavior == obj.PremulBehavior;
+
+		public override bool Equals (object obj) =>
+			obj is SKCodecOptions f && Equals (f);
+
+		public static bool operator == (SKCodecOptions left, SKCodecOptions right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKCodecOptions left, SKCodecOptions right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (ZeroInitialized);
+			hash.Add (Subset);
+			hash.Add (FrameIndex);
+			hash.Add (PriorFrame);
+			hash.Add (PremulBehavior);
+			return hash.ToHashCode ();
+		}
 	}
 
 	public partial struct SKFontMetrics
 	{
 		private const uint flagsUnderlineThicknessIsValid = (1U << 0);
-		private const uint flagsUnderlinePositionIsValid  = (1U << 1);
+		private const uint flagsUnderlinePositionIsValid = (1U << 1);
 		private const uint flagsStrikeoutThicknessIsValid = (1U << 2);
-		private const uint flagsStrikeoutPositionIsValid  = (1U << 3);
+		private const uint flagsStrikeoutPositionIsValid = (1U << 3);
 
-		public float Top => fTop;
+		public readonly float Top => fTop;
 
-		public float Ascent => fAscent;
+		public readonly float Ascent => fAscent;
 
-		public float Descent => fDescent;
+		public readonly float Descent => fDescent;
 
-		public float Bottom => fBottom;
+		public readonly float Bottom => fBottom;
 
-		public float Leading => fLeading;
+		public readonly float Leading => fLeading;
 
-		public float AverageCharacterWidth => fAvgCharWidth;
+		public readonly float AverageCharacterWidth => fAvgCharWidth;
 
-		public float MaxCharacterWidth => fMaxCharWidth;
+		public readonly float MaxCharacterWidth => fMaxCharWidth;
 
-		public float XMin => fXMin;
+		public readonly float XMin => fXMin;
 
-		public float XMax => fXMax;
+		public readonly float XMax => fXMax;
 
-		public float XHeight => fXHeight;
+		public readonly float XHeight => fXHeight;
 
-		public float CapHeight => fCapHeight;
+		public readonly float CapHeight => fCapHeight;
 
-		public float? UnderlineThickness => GetIfValid(fUnderlineThickness, flagsUnderlineThicknessIsValid);
-		public float? UnderlinePosition => GetIfValid(fUnderlinePosition, flagsUnderlinePositionIsValid);
-		public float? StrikeoutThickness => GetIfValid(fStrikeoutThickness, flagsStrikeoutThicknessIsValid);
-		public float? StrikeoutPosition => GetIfValid(fStrikeoutPosition, flagsStrikeoutPositionIsValid);
+		public readonly float? UnderlineThickness => GetIfValid (fUnderlineThickness, flagsUnderlineThicknessIsValid);
+		public readonly float? UnderlinePosition => GetIfValid (fUnderlinePosition, flagsUnderlinePositionIsValid);
+		public readonly float? StrikeoutThickness => GetIfValid (fStrikeoutThickness, flagsStrikeoutThicknessIsValid);
+		public readonly float? StrikeoutPosition => GetIfValid (fStrikeoutPosition, flagsStrikeoutPositionIsValid);
 
-		private float? GetIfValid (float value, uint flag) =>
+		private readonly float? GetIfValid (float value, uint flag) =>
 			(fFlags & flag) == flag ? value : (float?)null;
 	}
 
-	public struct SKLattice {
+	public struct SKLattice : IEquatable<SKLattice>
+	{
 		public int[] XDivs { get; set; }
 		public int[] YDivs { get; set; }
 		public SKLatticeRectType[] RectTypes { get; set; }
 		public SKRectI? Bounds { get; set; }
 		public SKColor[] Colors { get; set; }
+
+		public bool Equals (SKLattice obj) =>
+			XDivs == obj.XDivs &&
+			YDivs == obj.YDivs &&
+			RectTypes == obj.RectTypes &&
+			Bounds == obj.Bounds &&
+			Colors == obj.Colors;
+
+		public override bool Equals (object obj) =>
+			obj is SKLattice f && Equals (f);
+
+		public static bool operator == (SKLattice left, SKLattice right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKLattice left, SKLattice right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (XDivs);
+			hash.Add (YDivs);
+			hash.Add (RectTypes);
+			hash.Add (Bounds);
+			hash.Add (Colors);
+			return hash.ToHashCode ();
+		}
 	}
 
-	internal partial struct SKTimeDateTimeInternal {
-		public static SKTimeDateTimeInternal Create (DateTime datetime) {
-			var zone = datetime.Hour - datetime.ToUniversalTime().Hour;
+	internal partial struct SKTimeDateTimeInternal
+	{
+		public static SKTimeDateTimeInternal Create (DateTime datetime)
+		{
+			var zone = datetime.Hour - datetime.ToUniversalTime ().Hour;
 			return new SKTimeDateTimeInternal {
 				fTimeZoneMinutes = (Int16)(zone * 60),
 				fYear = (UInt16)datetime.Year,
@@ -176,7 +245,8 @@ namespace SkiaSharp
 		}
 	}
 
-	public struct SKDocumentPdfMetadata {
+	public struct SKDocumentPdfMetadata : IEquatable<SKDocumentPdfMetadata>
+	{
 		public const float DefaultRasterDpi = SKDocument.DefaultRasterDpi;
 		public const int DefaultEncodingQuality = 101;
 
@@ -247,16 +317,58 @@ namespace SkiaSharp
 		public float RasterDpi { get; set; }
 		public bool PdfA { get; set; }
 		public int EncodingQuality { get; set; }
+
+		public bool Equals (SKDocumentPdfMetadata obj) =>
+			Title == obj.Title &&
+			Author == obj.Author &&
+			Subject == obj.Subject &&
+			Keywords == obj.Keywords &&
+			Creator == obj.Creator &&
+			Producer == obj.Producer &&
+			Creation == obj.Creation &&
+			Modified == obj.Modified &&
+			RasterDpi == obj.RasterDpi &&
+			PdfA == obj.PdfA &&
+			EncodingQuality == obj.EncodingQuality;
+
+		public override bool Equals (object obj) =>
+			obj is SKDocumentPdfMetadata f && Equals (f);
+
+		public static bool operator == (SKDocumentPdfMetadata left, SKDocumentPdfMetadata right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKDocumentPdfMetadata left, SKDocumentPdfMetadata right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (Title);
+			hash.Add (Author);
+			hash.Add (Subject);
+			hash.Add (Keywords);
+			hash.Add (Creator);
+			hash.Add (Producer);
+			hash.Add (Creation);
+			hash.Add (Modified);
+			hash.Add (RasterDpi);
+			hash.Add (PdfA);
+			hash.Add (EncodingQuality);
+			return hash.ToHashCode ();
+		}
 	}
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete]
 	[Flags]
-	public enum SKColorSpaceFlags {
+	public enum SKColorSpaceFlags
+	{
 		None = 0,
 		NonLinearBlending = 0x1,
 	}
 
-	public partial struct SKHighContrastConfig {
+	public partial struct SKHighContrastConfig
+	{
 		public static readonly SKHighContrastConfig Default;
 
 		static SKHighContrastConfig ()
@@ -271,14 +383,15 @@ namespace SkiaSharp
 			fContrast = contrast;
 		}
 
-		public bool IsValid =>
+		public readonly bool IsValid =>
 			(int)fInvertStyle >= (int)SKHighContrastConfigInvertStyle.NoInvert &&
 			(int)fInvertStyle <= (int)SKHighContrastConfigInvertStyle.InvertLightness &&
 			fContrast >= -1.0 &&
 			fContrast <= 1.0;
 	}
 
-	public unsafe partial struct SKPngEncoderOptions {
+	public unsafe partial struct SKPngEncoderOptions
+	{
 		public static readonly SKPngEncoderOptions Default;
 
 		static SKPngEncoderOptions ()
@@ -303,20 +416,21 @@ namespace SkiaSharp
 		}
 
 		public SKPngEncoderFilterFlags FilterFlags {
-			get => fFilterFlags;
+			readonly get => fFilterFlags;
 			set => fFilterFlags = value;
 		}
 		public int ZLibLevel {
-			get => fZLibLevel;
+			readonly get => fZLibLevel;
 			set => fZLibLevel = value;
 		}
 		public SKTransferFunctionBehavior UnpremulBehavior {
-			get => fUnpremulBehavior;
+			readonly get => fUnpremulBehavior;
 			set => fUnpremulBehavior = value;
 		}
 	}
 
-	public partial struct SKJpegEncoderOptions {
+	public partial struct SKJpegEncoderOptions
+	{
 		public static readonly SKJpegEncoderOptions Default;
 
 		static SKJpegEncoderOptions ()
@@ -341,7 +455,8 @@ namespace SkiaSharp
 		}
 	}
 
-	public partial struct SKWebpEncoderOptions {
+	public partial struct SKWebpEncoderOptions
+	{
 		public static readonly SKWebpEncoderOptions Default;
 
 		static SKWebpEncoderOptions ()

--- a/binding/Binding/GRBackendRenderTarget.cs
+++ b/binding/Binding/GRBackendRenderTarget.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -10,6 +11,7 @@ namespace SkiaSharp
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GRBackendRenderTarget(int, int, int, int, GRGlFramebufferInfo) instead.")]
 		public GRBackendRenderTarget (GRBackend backend, GRBackendRenderTargetDesc desc)
 			: this (IntPtr.Zero, true)
@@ -58,12 +60,9 @@ namespace SkiaSharp
 		public SKSizeI Size => new SKSizeI (Width, Height);
 		public SKRectI Rect => new SKRectI (0, 0, Width, Height);
 
-		public GRGlFramebufferInfo GetGlFramebufferInfo ()
-		{
-			if (GetGlFramebufferInfo (out var info))
-				return info;
-			return default (GRGlFramebufferInfo);
-		}
+		public GRGlFramebufferInfo GetGlFramebufferInfo () =>
+			GetGlFramebufferInfo (out var info) ? info : default;
+
 		public bool GetGlFramebufferInfo (out GRGlFramebufferInfo glInfo)
 		{
 			fixed (GRGlFramebufferInfo* g = &glInfo) {

--- a/binding/Binding/GRBackendTexture.cs
+++ b/binding/Binding/GRBackendTexture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace SkiaSharp
@@ -11,6 +12,7 @@ namespace SkiaSharp
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GRBackendTexture(int, int, bool, GRGlTextureInfo) instead.")]
 		public GRBackendTexture (GRGlBackendTextureDesc desc)
 			: this (IntPtr.Zero, true)
@@ -22,6 +24,7 @@ namespace SkiaSharp
 			CreateGl (desc.Width, desc.Height, false, handle);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GRBackendTexture(int, int, bool, GRGlTextureInfo) instead.")]
 		public GRBackendTexture (GRBackendTextureDesc desc)
 			: this (IntPtr.Zero, true)
@@ -62,12 +65,9 @@ namespace SkiaSharp
 		public SKSizeI Size => new SKSizeI (Width, Height);
 		public SKRectI Rect => new SKRectI (0, 0, Width, Height);
 
-		public GRGlTextureInfo GetGlTextureInfo ()
-		{
-			if (GetGlTextureInfo (out var info))
-				return info;
-			return default (GRGlTextureInfo);
-		}
+		public GRGlTextureInfo GetGlTextureInfo () =>
+			GetGlTextureInfo (out var info) ? info : default;
+
 		public bool GetGlTextureInfo (out GRGlTextureInfo glInfo)
 		{
 			fixed (GRGlTextureInfo* g = &glInfo) {

--- a/binding/Binding/GRContext.cs
+++ b/binding/Binding/GRContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -13,68 +14,49 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public static GRContext Create (GRBackend backend)
-		{
-			switch (backend) {
-				case GRBackend.Metal:
-					throw new NotSupportedException ();
-				case GRBackend.OpenGL:
-					return CreateGl ();
-				case GRBackend.Vulkan:
-					throw new NotSupportedException ();
-				default:
-					throw new ArgumentOutOfRangeException (nameof (backend));
-			}
-		}
+		public static GRContext Create (GRBackend backend) =>
+			backend switch
+			{
+				GRBackend.Metal => throw new NotSupportedException (),
+				GRBackend.OpenGL => CreateGl (),
+				GRBackend.Vulkan => throw new NotSupportedException (),
+				_ => throw new ArgumentOutOfRangeException (nameof (backend)),
+			};
 
-		public static GRContext Create (GRBackend backend, GRGlInterface backendContext)
-		{
-			switch (backend) {
-				case GRBackend.Metal:
-					throw new NotSupportedException ();
-				case GRBackend.OpenGL:
-					return CreateGl (backendContext);
-				case GRBackend.Vulkan:
-					throw new NotSupportedException ();
-				default:
-					throw new ArgumentOutOfRangeException (nameof (backend));
-			}
-		}
+		public static GRContext Create (GRBackend backend, GRGlInterface backendContext) =>
+			backend switch
+			{
+				GRBackend.Metal => throw new NotSupportedException (),
+				GRBackend.OpenGL => CreateGl (backendContext),
+				GRBackend.Vulkan => throw new NotSupportedException (),
+				_ => throw new ArgumentOutOfRangeException (nameof (backend)),
+			};
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRBackend, GRGlInterface) instead.")]
-		public static GRContext Create (GRBackend backend, IntPtr backendContext)
-		{
-			switch (backend) {
-				case GRBackend.Metal:
-					throw new NotSupportedException ();
-				case GRBackend.OpenGL:
-					return GetObject<GRContext> (SkiaApi.gr_context_make_gl (backendContext));
-				case GRBackend.Vulkan:
-					throw new NotSupportedException ();
-				default:
-					throw new ArgumentOutOfRangeException (nameof (backend));
-			}
-		}
+		public static GRContext Create (GRBackend backend, IntPtr backendContext) =>
+			backend switch
+			{
+				GRBackend.Metal => throw new NotSupportedException (),
+				GRBackend.OpenGL => GetObject<GRContext> (SkiaApi.gr_context_make_gl (backendContext)),
+				GRBackend.Vulkan => throw new NotSupportedException (),
+				_ => throw new ArgumentOutOfRangeException (nameof (backend)),
+			};
 
-		public static GRContext CreateGl ()
-		{
-			return CreateGl (null);
-		}
+		public static GRContext CreateGl () =>
+			CreateGl (null);
 
-		public static GRContext CreateGl (GRGlInterface backendContext)
-		{
-			return GetObject<GRContext> (SkiaApi.gr_context_make_gl (backendContext == null ? IntPtr.Zero : backendContext.Handle));
-		}
+		public static GRContext CreateGl (GRGlInterface backendContext) =>
+			GetObject<GRContext> (SkiaApi.gr_context_make_gl (backendContext == null ? IntPtr.Zero : backendContext.Handle));
 
 		public GRBackend Backend => SkiaApi.gr_context_get_backend (Handle);
 
 		public void AbandonContext (bool releaseResources = false)
 		{
-			if (releaseResources) {
+			if (releaseResources)
 				SkiaApi.gr_context_release_resources_and_abandon_context (Handle);
-			} else {
+			else
 				SkiaApi.gr_context_abandon_context (Handle);
-			}
 		}
 
 		public void GetResourceCacheLimits (out int maxResources, out long maxResourceBytes)
@@ -86,10 +68,8 @@ namespace SkiaSharp
 			maxResourceBytes = (long)maxResBytes;
 		}
 
-		public void SetResourceCacheLimits (int maxResources, long maxResourceBytes)
-		{
+		public void SetResourceCacheLimits (int maxResources, long maxResourceBytes) =>
 			SkiaApi.gr_context_set_resource_cache_limits (Handle, maxResources, (IntPtr)maxResourceBytes);
-		}
 
 		public void GetResourceCacheUsage (out int maxResources, out long maxResourceBytes)
 		{
@@ -99,36 +79,24 @@ namespace SkiaSharp
 			}
 			maxResourceBytes = (long)maxResBytes;
 		}
-		
-		public void ResetContext (GRGlBackendState state)
-		{
-			ResetContext ((uint) state);
-		}
 
-		public void ResetContext (GRBackendState state = GRBackendState.All)
-		{
-			ResetContext ((uint) state);
-		}
+		public void ResetContext (GRGlBackendState state) =>
+			ResetContext ((uint)state);
 
-		public void ResetContext (uint state)
-		{
+		public void ResetContext (GRBackendState state = GRBackendState.All) =>
+			ResetContext ((uint)state);
+
+		public void ResetContext (uint state) =>
 			SkiaApi.gr_context_reset_context (Handle, state);
-		}
 
-		public void Flush ()
-		{
+		public void Flush () =>
 			SkiaApi.gr_context_flush (Handle);
-		}
 
-		public int GetMaxSurfaceSampleCount (SKColorType colorType)
-		{
-			return SkiaApi.gr_context_get_max_surface_sample_count_for_color_type (Handle, colorType);
-		}
+		public int GetMaxSurfaceSampleCount (SKColorType colorType) =>
+			SkiaApi.gr_context_get_max_surface_sample_count_for_color_type (Handle, colorType);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GetMaxSurfaceSampleCount(SKColorType) instead.")]
-		public int GetRecommendedSampleCount (GRPixelConfig config, float dpi)
-		{
-			return GetMaxSurfaceSampleCount (config.ToColorType ());
-		}
+		public int GetRecommendedSampleCount (GRPixelConfig config, float dpi) => 0;
 	}
 }

--- a/binding/Binding/GRDefinitions.cs
+++ b/binding/Binding/GRDefinitions.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 using GRBackendObject = System.IntPtr;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use GRBackendRenderTarget instead.")]
 	public struct GRBackendRenderTargetDesc
 	{
@@ -49,14 +51,14 @@ namespace SkiaSharp
 	{
 		public GRGlFramebufferInfo (uint fboId)
 		{
-			this.fFBOID = fboId;
-			this.fFormat = 0;
+			fFBOID = fboId;
+			fFormat = 0;
 		}
 
 		public GRGlFramebufferInfo (uint fboId, uint format)
 		{
-			this.fFBOID = fboId;
-			this.fFormat = format;
+			fFBOID = fboId;
+			fFormat = format;
 		}
 	}
 
@@ -64,12 +66,13 @@ namespace SkiaSharp
 	{
 		public GRGlTextureInfo (uint target, uint id, uint format)
 		{
-			this.fTarget = target;
-			this.fID = id;
-			this.fFormat = format;
+			fTarget = target;
+			fID = id;
+			fFormat = format;
 		}
-	};
+	}
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Flags]
 	[Obsolete]
 	public enum GRBackendTextureDescFlags
@@ -78,48 +81,21 @@ namespace SkiaSharp
 		RenderTarget = 1,
 	}
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use GRBackendTexture instead.")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct GRBackendTextureDesc
 	{
-		private GRBackendTextureDescFlags flags;
-		private GRSurfaceOrigin origin;
-		private int width;
-		private int height;
-		private GRPixelConfig config;
-		private int sampleCount;
-		private GRBackendObject textureHandle;
-
-		public GRBackendTextureDescFlags Flags {
-			get { return flags; }
-			set { flags = value; }
-		}
-		public GRSurfaceOrigin Origin {
-			get { return origin; }
-			set { origin = value; }
-		}
-		public int Width {
-			get { return width; }
-			set { width = value; }
-		}
-		public int Height {
-			get { return height; }
-			set { height = value; }
-		}
-		public GRPixelConfig Config {
-			get { return config; }
-			set { config = value; }
-		}
-		public int SampleCount {
-			get { return sampleCount; }
-			set { sampleCount = value; }
-		}
-		public GRBackendObject TextureHandle {
-			get { return textureHandle; }
-			set { textureHandle = value; }
-		}
+		public GRBackendTextureDescFlags Flags { get; set; }
+		public GRSurfaceOrigin Origin { get; set; }
+		public int Width { get; set; }
+		public int Height { get; set; }
+		public GRPixelConfig Config { get; set; }
+		public int SampleCount { get; set; }
+		public GRBackendObject TextureHandle { get; set; }
 	}
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use GRBackendTexture instead.")]
 	public struct GRGlBackendTextureDesc
 	{
@@ -134,141 +110,81 @@ namespace SkiaSharp
 
 	public static partial class SkiaExtensions
 	{
-		public static uint ToGlSizedFormat (this SKColorType colorType)
-		{
-			switch (colorType) {
-				case SKColorType.Unknown:
-					return 0;
-				case SKColorType.Alpha8:
-					return GRGlSizedFormat.ALPHA8;
-				case SKColorType.Rgb565:
-					return GRGlSizedFormat.RGB565;
-				case SKColorType.Argb4444:
-					return GRGlSizedFormat.RGBA4;
-				case SKColorType.Rgba8888:
-					return GRGlSizedFormat.RGBA8;
-				case SKColorType.Rgb888x:
-					return GRGlSizedFormat.RGB8;
-				case SKColorType.Bgra8888:
-					return GRGlSizedFormat.BGRA8;
-				case SKColorType.Rgba1010102:
-					return GRGlSizedFormat.RGB10_A2;
-				case SKColorType.Rgb101010x:
-					return 0;
-				case SKColorType.Gray8:
-					return GRGlSizedFormat.LUMINANCE8;
-				case SKColorType.RgbaF16:
-					return GRGlSizedFormat.RGBA16F;
-				default:
-					throw new ArgumentOutOfRangeException (nameof (colorType));
-			}
-		}
+		public static uint ToGlSizedFormat (this SKColorType colorType) =>
+			colorType switch
+			{
+				SKColorType.Unknown => 0,
+				SKColorType.Alpha8 => GRGlSizedFormat.ALPHA8,
+				SKColorType.Rgb565 => GRGlSizedFormat.RGB565,
+				SKColorType.Argb4444 => GRGlSizedFormat.RGBA4,
+				SKColorType.Rgba8888 => GRGlSizedFormat.RGBA8,
+				SKColorType.Rgb888x => GRGlSizedFormat.RGB8,
+				SKColorType.Bgra8888 => GRGlSizedFormat.BGRA8,
+				SKColorType.Rgba1010102 => GRGlSizedFormat.RGB10_A2,
+				SKColorType.Rgb101010x => 0,
+				SKColorType.Gray8 => GRGlSizedFormat.LUMINANCE8,
+				SKColorType.RgbaF16 => GRGlSizedFormat.RGBA16F,
+				_ => throw new ArgumentOutOfRangeException (nameof (colorType)),
+			};
 
-		public static uint ToGlSizedFormat (this GRPixelConfig config)
-		{
-			switch (config) {
-				case GRPixelConfig.Alpha8:
-					return GRGlSizedFormat.ALPHA8;
-				case GRPixelConfig.Gray8:
-					return GRGlSizedFormat.LUMINANCE8;
-				case GRPixelConfig.Rgb565:
-					return GRGlSizedFormat.RGB565;
-				case GRPixelConfig.Rgba4444:
-					return GRGlSizedFormat.RGBA4;
-				case GRPixelConfig.Rgba8888:
-					return GRGlSizedFormat.RGBA8;
-				case GRPixelConfig.Rgb888:
-					return GRGlSizedFormat.RGB8;
-				case GRPixelConfig.Bgra8888:
-					return GRGlSizedFormat.BGRA8;
-				case GRPixelConfig.Srgba8888:
-					return GRGlSizedFormat.SRGB8_ALPHA8;
-				case GRPixelConfig.Sbgra8888:
-					return GRGlSizedFormat.SRGB8_ALPHA8;
-				case GRPixelConfig.Rgba1010102:
-					return GRGlSizedFormat.RGB10_A2;
-				case GRPixelConfig.RgbaFloat:
-					return GRGlSizedFormat.RGBA32F;
-				case GRPixelConfig.RgFloat:
-					return GRGlSizedFormat.RG32F;
-				case GRPixelConfig.AlphaHalf:
-					return GRGlSizedFormat.R16F;
-				case GRPixelConfig.RgbaHalf:
-					return GRGlSizedFormat.RGBA16F;
-				case GRPixelConfig.Unknown:
-					return 0;
-				default:
-					throw new ArgumentOutOfRangeException (nameof (config));
-			}
-		}
+		public static uint ToGlSizedFormat (this GRPixelConfig config) =>
+			config switch
+			{
+				GRPixelConfig.Alpha8 => GRGlSizedFormat.ALPHA8,
+				GRPixelConfig.Gray8 => GRGlSizedFormat.LUMINANCE8,
+				GRPixelConfig.Rgb565 => GRGlSizedFormat.RGB565,
+				GRPixelConfig.Rgba4444 => GRGlSizedFormat.RGBA4,
+				GRPixelConfig.Rgba8888 => GRGlSizedFormat.RGBA8,
+				GRPixelConfig.Rgb888 => GRGlSizedFormat.RGB8,
+				GRPixelConfig.Bgra8888 => GRGlSizedFormat.BGRA8,
+				GRPixelConfig.Srgba8888 => GRGlSizedFormat.SRGB8_ALPHA8,
+				GRPixelConfig.Sbgra8888 => GRGlSizedFormat.SRGB8_ALPHA8,
+				GRPixelConfig.Rgba1010102 => GRGlSizedFormat.RGB10_A2,
+				GRPixelConfig.RgbaFloat => GRGlSizedFormat.RGBA32F,
+				GRPixelConfig.RgFloat => GRGlSizedFormat.RG32F,
+				GRPixelConfig.AlphaHalf => GRGlSizedFormat.R16F,
+				GRPixelConfig.RgbaHalf => GRGlSizedFormat.RGBA16F,
+				GRPixelConfig.Unknown => 0,
+				_ => throw new ArgumentOutOfRangeException (nameof (config)),
+			};
 
-		public static GRPixelConfig ToPixelConfig (this SKColorType colorType)
-		{
-			switch (colorType) {
-				case SKColorType.Unknown:
-					return GRPixelConfig.Unknown;
-				case SKColorType.Alpha8:
-					return GRPixelConfig.Alpha8;
-				case SKColorType.Gray8:
-					return GRPixelConfig.Gray8;
-				case SKColorType.Rgb565:
-					return GRPixelConfig.Rgb565;
-				case SKColorType.Argb4444:
-					return GRPixelConfig.Rgba4444;
-				case SKColorType.Rgba8888:
-					return GRPixelConfig.Rgba8888;
-				case SKColorType.Rgb888x:
-					return GRPixelConfig.Rgb888;
-				case SKColorType.Bgra8888:
-					return GRPixelConfig.Bgra8888;
-				case SKColorType.Rgba1010102:
-					return GRPixelConfig.Rgba1010102;
-				case SKColorType.RgbaF16:
-					return GRPixelConfig.RgbaHalf;
-				case SKColorType.Rgb101010x:
-					return GRPixelConfig.Unknown;
-				default:
-					throw new ArgumentOutOfRangeException (nameof (colorType));
-			}
-		}
+		public static GRPixelConfig ToPixelConfig (this SKColorType colorType) =>
+			colorType switch
+			{
+				SKColorType.Unknown => GRPixelConfig.Unknown,
+				SKColorType.Alpha8 => GRPixelConfig.Alpha8,
+				SKColorType.Gray8 => GRPixelConfig.Gray8,
+				SKColorType.Rgb565 => GRPixelConfig.Rgb565,
+				SKColorType.Argb4444 => GRPixelConfig.Rgba4444,
+				SKColorType.Rgba8888 => GRPixelConfig.Rgba8888,
+				SKColorType.Rgb888x => GRPixelConfig.Rgb888,
+				SKColorType.Bgra8888 => GRPixelConfig.Bgra8888,
+				SKColorType.Rgba1010102 => GRPixelConfig.Rgba1010102,
+				SKColorType.RgbaF16 => GRPixelConfig.RgbaHalf,
+				SKColorType.Rgb101010x => GRPixelConfig.Unknown,
+				_ => throw new ArgumentOutOfRangeException (nameof (colorType)),
+			};
 
-		public static SKColorType ToColorType (this GRPixelConfig config)
-		{
-			switch (config) {
-				case GRPixelConfig.Unknown:
-					return SKColorType.Unknown;
-				case GRPixelConfig.Alpha8:
-					return SKColorType.Alpha8;
-				case GRPixelConfig.Gray8:
-					return SKColorType.Gray8;
-				case GRPixelConfig.Rgb565:
-					return SKColorType.Rgb565;
-				case GRPixelConfig.Rgba4444:
-					return SKColorType.Argb4444;
-				case GRPixelConfig.Rgba8888:
-					return SKColorType.Rgba8888;
-				case GRPixelConfig.Rgb888:
-					return SKColorType.Rgb888x;
-				case GRPixelConfig.Bgra8888:
-					return SKColorType.Bgra8888;
-				case GRPixelConfig.Srgba8888:
-					return SKColorType.Rgba8888;
-				case GRPixelConfig.Sbgra8888:
-					return SKColorType.Bgra8888;
-				case GRPixelConfig.Rgba1010102:
-					return SKColorType.Rgba1010102;
-				case GRPixelConfig.RgbaFloat:
-					return SKColorType.Unknown;
-				case GRPixelConfig.RgFloat:
-					return SKColorType.Unknown;
-				case GRPixelConfig.AlphaHalf:
-					return SKColorType.Unknown;
-				case GRPixelConfig.RgbaHalf:
-					return SKColorType.RgbaF16;
-				default:
-					throw new ArgumentOutOfRangeException (nameof (config));
-			}
-		}
+		public static SKColorType ToColorType (this GRPixelConfig config) =>
+			config switch
+			{
+				GRPixelConfig.Unknown => SKColorType.Unknown,
+				GRPixelConfig.Alpha8 => SKColorType.Alpha8,
+				GRPixelConfig.Gray8 => SKColorType.Gray8,
+				GRPixelConfig.Rgb565 => SKColorType.Rgb565,
+				GRPixelConfig.Rgba4444 => SKColorType.Argb4444,
+				GRPixelConfig.Rgba8888 => SKColorType.Rgba8888,
+				GRPixelConfig.Rgb888 => SKColorType.Rgb888x,
+				GRPixelConfig.Bgra8888 => SKColorType.Bgra8888,
+				GRPixelConfig.Srgba8888 => SKColorType.Rgba8888,
+				GRPixelConfig.Sbgra8888 => SKColorType.Bgra8888,
+				GRPixelConfig.Rgba1010102 => SKColorType.Rgba1010102,
+				GRPixelConfig.RgbaFloat => SKColorType.Unknown,
+				GRPixelConfig.RgFloat => SKColorType.Unknown,
+				GRPixelConfig.AlphaHalf => SKColorType.Unknown,
+				GRPixelConfig.RgbaHalf => SKColorType.RgbaF16,
+				_ => throw new ArgumentOutOfRangeException (nameof (config)),
+			};
 	}
 
 	internal static class GRGlSizedFormat

--- a/binding/Binding/MathTypes.cs
+++ b/binding/Binding/MathTypes.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace SkiaSharp
 {
@@ -30,11 +29,6 @@ namespace SkiaSharp
 			x += dx;
 			y += dy;
 		}
-
-		public override bool Equals (object obj) =>
-			obj is SKPoint p && this == p;
-
-		public override int GetHashCode () => (int)x ^ (int)y;
 
 		public override string ToString () => $"{{X={x}, Y={y}}}";
 
@@ -95,11 +89,6 @@ namespace SkiaSharp
 			new SKPoint (pt.X - sz.X, pt.Y - sz.Y);
 		public static SKPoint operator - (SKPoint pt, SKPoint sz) =>
 			new SKPoint (pt.X - sz.X, pt.Y - sz.Y);
-
-		public static bool operator == (SKPoint left, SKPoint right) =>
-			(left.x == right.x) && (left.y == right.y);
-		public static bool operator != (SKPoint left, SKPoint right) =>
-			(left.x != right.x) || (left.y != right.y);
 	}
 
 	public partial struct SKPointI
@@ -135,11 +124,6 @@ namespace SkiaSharp
 			x += dx;
 			y += dy;
 		}
-
-		public override bool Equals (object obj) =>
-			obj is SKPointI p && this == p;
-
-		public override int GetHashCode () => x ^ y;
 
 		public override string ToString () => $"{{X={x},Y={y}}}";
 
@@ -217,11 +201,6 @@ namespace SkiaSharp
 		public static SKPointI operator + (SKPointI pt, SKPointI sz) =>
 			new SKPointI (pt.X + sz.X, pt.Y + sz.Y);
 
-		public static bool operator == (SKPointI left, SKPointI right) =>
-			(left.X == right.X) && (left.Y == right.Y);
-		public static bool operator != (SKPointI left, SKPointI right) =>
-			!(left == right);
-
 		public static SKPointI operator - (SKPointI pt, SKSizeI sz) =>
 			new SKPointI (pt.X - sz.Width, pt.Y - sz.Height);
 		public static SKPointI operator - (SKPointI pt, SKPointI sz) =>
@@ -246,11 +225,6 @@ namespace SkiaSharp
 
 		public bool IsEmpty => this == Empty;
 
-		public override bool Equals (object obj) =>
-			obj is SKPoint3 p && this == p;
-
-		public override int GetHashCode () => (int)x ^ (int)y ^ (int)z;
-
 		public override string ToString () => $"{{X={x}, Y={y}, Z={z}}}";
 
 		public static SKPoint3 Add (SKPoint3 pt, SKPoint3 sz) => pt + sz;
@@ -262,11 +236,6 @@ namespace SkiaSharp
 
 		public static SKPoint3 operator - (SKPoint3 pt, SKPoint3 sz) =>
 			new SKPoint3 (pt.X - sz.X, pt.Y - sz.Y, pt.Z - sz.Z);
-
-		public static bool operator == (SKPoint3 left, SKPoint3 right) =>
-			(left.x == right.x) && (left.y == right.y) && (left.z == right.z);
-		public static bool operator != (SKPoint3 left, SKPoint3 right) =>
-			!(left == right);
 	}
 
 	public partial struct SKSize
@@ -275,14 +244,14 @@ namespace SkiaSharp
 
 		public SKSize (float width, float height)
 		{
-			this.w = width;
-			this.h = height;
+			w = width;
+			h = height;
 		}
 
 		public SKSize (SKPoint pt)
 		{
-			this.w = pt.X;
-			this.h = pt.Y;
+			w = pt.X;
+			h = pt.Y;
 		}
 
 		public bool IsEmpty => this == Empty;
@@ -301,11 +270,6 @@ namespace SkiaSharp
 			return new SKSizeI (w, h);
 		}
 
-		public override bool Equals (object obj) =>
-			obj is SKSize s && this == s;
-
-		public override int GetHashCode () => (int)w ^ (int)h;
-
 		public override string ToString () =>
 			$"{{Width={w}, Height={h}}}";
 
@@ -319,11 +283,6 @@ namespace SkiaSharp
 		public static SKSize operator - (SKSize sz1, SKSize sz2) =>
 			new SKSize (sz1.Width - sz2.Width, sz1.Height - sz2.Height);
 
-		public static bool operator == (SKSize sz1, SKSize sz2) =>
-			(sz1.Width == sz2.Width) && (sz1.Height == sz2.Height);
-		public static bool operator != (SKSize sz1, SKSize sz2) =>
-			!(sz1 == sz2);
-
 		public static explicit operator SKPoint (SKSize size) =>
 			new SKPoint (size.Width, size.Height);
 		public static implicit operator SKSize (SKSizeI size) =>
@@ -336,24 +295,19 @@ namespace SkiaSharp
 
 		public SKSizeI (int width, int height)
 		{
-			this.w = width;
-			this.h = height;
+			w = width;
+			h = height;
 		}
 
 		public SKSizeI (SKPointI pt)
 		{
-			this.w = pt.X;
-			this.h = pt.Y;
+			w = pt.X;
+			h = pt.Y;
 		}
 
 		public bool IsEmpty => this == Empty;
 
 		public SKPointI ToPointI () => new SKPointI (w, h);
-
-		public override bool Equals (object obj) =>
-			obj is SKSizeI s && this == s;
-
-		public override int GetHashCode () => w ^ h;
 
 		public override string ToString () =>
 			$"{{Width={w}, Height={h}}}";
@@ -367,11 +321,6 @@ namespace SkiaSharp
 
 		public static SKSizeI operator - (SKSizeI sz1, SKSizeI sz2) =>
 			new SKSizeI (sz1.Width - sz2.Width, sz1.Height - sz2.Height);
-
-		public static bool operator == (SKSizeI sz1, SKSizeI sz2) =>
-			(sz1.Width == sz2.Width) && (sz1.Height == sz2.Height);
-		public static bool operator != (SKSizeI sz1, SKSizeI sz2) =>
-			!(sz1 == sz2);
 
 		public static explicit operator SKPointI (SKSizeI size) =>
 			new SKPointI (size.Width, size.Height);
@@ -501,13 +450,6 @@ namespace SkiaSharp
 		public void Union (SKRect rect) =>
 			this = Union (this, rect);
 
-		public static bool operator == (SKRect left, SKRect right) =>
-			(left.left == right.left) && (left.top == right.top) &&
-			(left.right == right.right) && (left.bottom == right.bottom);
-
-		public static bool operator != (SKRect left, SKRect right) =>
-			!(left == right);
-
 		public static implicit operator SKRect (SKRectI r) =>
 			new SKRect (r.Left, r.Top, r.Right, r.Bottom);
 
@@ -520,16 +462,6 @@ namespace SkiaSharp
 		public bool Contains (SKRect rect) =>
 			(left <= rect.left) && (right >= rect.right) &&
 			(top <= rect.top) && (bottom >= rect.bottom);
-
-		public override bool Equals (object obj) =>
-			obj is SKRect r && this == r;
-
-		public override int GetHashCode () =>
-			unchecked((int)(
-				(((uint)Left)) ^
-				(((uint)Top << 13) | ((uint)Top >> 19)) ^
-				(((uint)Width << 26) | ((uint)Width >> 6)) ^
-				(((uint)Height << 7) | ((uint)Height >> 25))));
 
 		public bool IntersectsWith (SKRect rect) =>
 			(left < rect.right) && (right > rect.left) && (top < rect.bottom) && (bottom > rect.top);
@@ -732,16 +664,6 @@ namespace SkiaSharp
 			(left <= rect.left) && (right >= rect.right) &&
 			(top <= rect.top) && (bottom >= rect.bottom);
 
-		public override bool Equals (object obj) =>
-			obj is SKRectI r && this == r;
-
-		public override int GetHashCode () =>
-			unchecked((int)(
-				(((uint)Left)) ^
-				(((uint)Top << 13) | ((uint)Top >> 19)) ^
-				(((uint)Width << 26) | ((uint)Width >> 6)) ^
-				(((uint)Height << 7) | ((uint)Height >> 25))));
-
 		public bool IntersectsWith (SKRectI rect) =>
 			(left < rect.right) && (right > rect.left) && (top < rect.bottom) && (bottom > rect.top);
 
@@ -760,13 +682,6 @@ namespace SkiaSharp
 
 		public override string ToString () =>
 			$"{{Left={Left},Top={Top},Width={Width},Height={Height}}}";
-
-		public static bool operator == (SKRectI left, SKRectI right) =>
-			(left.left == right.left) && (left.top == right.top) &&
-			(left.right == right.right) && (left.bottom == right.bottom);
-
-		public static bool operator != (SKRectI left, SKRectI right) =>
-			!(left == right);
 
 		public static SKRectI Create (SKSizeI size) =>
 			Create (SKPointI.Empty.X, SKPointI.Empty.Y, size.Width, size.Height);

--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete]
 	public enum SKBitmapResizeMethod
 	{
@@ -16,6 +17,7 @@ namespace SkiaSharp
 
 	public static partial class SkiaExtensions
 	{
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		public static SKFilterQuality ToFilterQuality (this SKBitmapResizeMethod method)
 		{
@@ -81,6 +83,7 @@ namespace SkiaSharp
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use SKBitmap(SKImageInfo, SKBitmapAllocFlags) instead.")]
 		public SKBitmap (SKImageInfo info, SKColorTable ctable, SKBitmapAllocFlags flags)
 			: this (info, SKBitmapAllocFlags.None)
@@ -95,6 +98,7 @@ namespace SkiaSharp
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use SKBitmap(SKImageInfo) instead.")]
 		public SKBitmap (SKImageInfo info, SKColorTable ctable)
 			: this (info, SKBitmapAllocFlags.None)
@@ -117,7 +121,7 @@ namespace SkiaSharp
 			var cinfo = SKImageInfoNative.FromManaged (ref info);
 			return SkiaApi.sk_bitmap_try_alloc_pixels (Handle, &cinfo, (IntPtr)rowBytes);
 		}
-		
+
 		public bool TryAllocPixels (SKImageInfo info, SKBitmapAllocFlags flags)
 		{
 			var cinfo = SKImageInfoNative.FromManaged (ref info);
@@ -144,15 +148,16 @@ namespace SkiaSharp
 			SkiaApi.sk_bitmap_erase_rect (Handle, (uint)color, &rect);
 		}
 
-		public byte GetAddr8(int x, int y) => SkiaApi.sk_bitmap_get_addr_8 (Handle, x, y);
-		public UInt16 GetAddr16(int x, int y) => SkiaApi.sk_bitmap_get_addr_16 (Handle, x, y);
-		public UInt32 GetAddr32(int x, int y) => SkiaApi.sk_bitmap_get_addr_32 (Handle, x, y);
-		public IntPtr GetAddr(int x, int y) => (IntPtr)SkiaApi.sk_bitmap_get_addr (Handle, x, y);
+		public byte GetAddr8 (int x, int y) => SkiaApi.sk_bitmap_get_addr_8 (Handle, x, y);
+		public UInt16 GetAddr16 (int x, int y) => SkiaApi.sk_bitmap_get_addr_16 (Handle, x, y);
+		public UInt32 GetAddr32 (int x, int y) => SkiaApi.sk_bitmap_get_addr_32 (Handle, x, y);
+		public IntPtr GetAddr (int x, int y) => (IntPtr)SkiaApi.sk_bitmap_get_addr (Handle, x, y);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixel(int, int) instead.")]
 		public SKPMColor GetIndex8Color (int x, int y)
 		{
-			return (SKPMColor) GetPixel (x, y);
+			return (SKPMColor)GetPixel (x, y);
 		}
 
 		public SKColor GetPixel (int x, int y)
@@ -194,7 +199,7 @@ namespace SkiaSharp
 					break;
 				case SKColorType.Argb4444:
 					return
-						sameConfigs || 
+						sameConfigs ||
 						srcCT == SKImageInfo.PlatformColorType;
 				default:
 					return false;
@@ -230,7 +235,7 @@ namespace SkiaSharp
 			if (destination == null) {
 				throw new ArgumentNullException (nameof (destination));
 			}
-			
+
 			if (!CanCopyTo (colorType)) {
 				return false;
 			}
@@ -293,7 +298,7 @@ namespace SkiaSharp
 			return true;
 		}
 
-		public bool ExtractSubset(SKBitmap destination, SKRectI subset)
+		public bool ExtractSubset (SKBitmap destination, SKRectI subset)
 		{
 			if (destination == null) {
 				throw new ArgumentNullException (nameof (destination));
@@ -301,22 +306,22 @@ namespace SkiaSharp
 			return SkiaApi.sk_bitmap_extract_subset (Handle, destination.Handle, &subset);
 		}
 
-		public bool ExtractAlpha(SKBitmap destination)
+		public bool ExtractAlpha (SKBitmap destination)
 		{
 			return ExtractAlpha (destination, null, out var offset);
 		}
 
-		public bool ExtractAlpha(SKBitmap destination, out SKPointI offset)
+		public bool ExtractAlpha (SKBitmap destination, out SKPointI offset)
 		{
 			return ExtractAlpha (destination, null, out offset);
 		}
 
-		public bool ExtractAlpha(SKBitmap destination, SKPaint paint)
+		public bool ExtractAlpha (SKBitmap destination, SKPaint paint)
 		{
 			return ExtractAlpha (destination, paint, out var offset);
 		}
 
-		public bool ExtractAlpha(SKBitmap destination, SKPaint paint, out SKPointI offset)
+		public bool ExtractAlpha (SKBitmap destination, SKPaint paint, out SKPointI offset)
 		{
 			if (destination == null) {
 				throw new ArgumentNullException (nameof (destination));
@@ -326,7 +331,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public bool ReadyToDraw => SkiaApi.sk_bitmap_ready_to_draw (Handle); 
+		public bool ReadyToDraw => SkiaApi.sk_bitmap_ready_to_draw (Handle);
 
 		public SKImageInfo Info {
 			get {
@@ -383,17 +388,19 @@ namespace SkiaSharp
 			}
 		}
 
-		public void SetPixels(IntPtr pixels)
+		public void SetPixels (IntPtr pixels)
 		{
 			SkiaApi.sk_bitmap_set_pixels (Handle, (void*)pixels);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use SetPixels(IntPtr) instead.")]
-		public void SetPixels(IntPtr pixels, SKColorTable ct)
+		public void SetPixels (IntPtr pixels, SKColorTable ct)
 		{
 			SetPixels (pixels);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported.")]
 		public void SetColorTable (SKColorTable ct)
 		{
@@ -409,9 +416,9 @@ namespace SkiaSharp
 		}
 
 		public SKColor[] Pixels {
-			get { 
+			get {
 				var info = Info;
-				var pixels = new SKColor [info.Width * info.Height];
+				var pixels = new SKColor[info.Width * info.Height];
 				fixed (SKColor* p = pixels) {
 					SkiaApi.sk_bitmap_get_pixel_colors (Handle, (uint*)p);
 				}
@@ -445,6 +452,7 @@ namespace SkiaSharp
 			set { SkiaApi.sk_bitmap_set_volatile (Handle, value); }
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported.")]
 		public SKColorTable ColorTable => null;
 
@@ -641,7 +649,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (buffer));
 			}
 			using (var stream = new SKMemoryStream (buffer)) {
-				return Decode(stream);
+				return Decode (stream);
 			}
 		}
 
@@ -669,12 +677,14 @@ namespace SkiaSharp
 			return InstallPixels (info, pixels, rowBytes, null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use InstallPixels(SKImageInfo, IntPtr, int) instead.")]
 		public bool InstallPixels (SKImageInfo info, IntPtr pixels, int rowBytes, SKColorTable ctable)
 		{
 			return InstallPixels (info, pixels, rowBytes, null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use InstallPixels(SKImageInfo, IntPtr, int, SKBitmapReleaseDelegate, object) instead.")]
 		public bool InstallPixels (SKImageInfo info, IntPtr pixels, int rowBytes, SKColorTable ctable, SKBitmapReleaseDelegate releaseProc, object context)
 		{
@@ -701,14 +711,14 @@ namespace SkiaSharp
 			return SkiaApi.sk_bitmap_install_pixels_with_pixmap (Handle, pixmap.Handle);
 		}
 
-		public bool InstallMaskPixels(SKMask mask)
+		public bool InstallMaskPixels (SKMask mask)
 		{
-			return SkiaApi.sk_bitmap_install_mask_pixels(Handle, &mask);
+			return SkiaApi.sk_bitmap_install_mask_pixels (Handle, &mask);
 		}
 
-		public void NotifyPixelsChanged()
+		public void NotifyPixelsChanged ()
 		{
-			SkiaApi.sk_bitmap_notify_pixels_changed(Handle);
+			SkiaApi.sk_bitmap_notify_pixels_changed (Handle);
 		}
 
 		public SKPixmap PeekPixels ()
@@ -731,14 +741,17 @@ namespace SkiaSharp
 			return SkiaApi.sk_bitmap_peek_pixels (Handle, pixmap.Handle);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Resize(SKImageInfo, SKFilterQuality) instead.")]
 		public SKBitmap Resize (SKImageInfo info, SKBitmapResizeMethod method) =>
 			Resize (info, method.ToFilterQuality ());
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use ScalePixels(SKBitmap, SKFilterQuality) instead.")]
 		public bool Resize (SKBitmap dst, SKBitmapResizeMethod method) =>
 			ScalePixels (dst, method.ToFilterQuality ());
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use ScalePixels(SKBitmap, SKFilterQuality) instead.")]
 		public static bool Resize (SKBitmap dst, SKBitmap src, SKBitmapResizeMethod method) =>
 			src.ScalePixels (dst, method.ToFilterQuality ());
@@ -784,14 +797,14 @@ namespace SkiaSharp
 
 			var info = new SKImageInfo (image.Width, image.Height, SKImageInfo.PlatformColorType, image.AlphaType);
 			var bmp = new SKBitmap (info);
-			if (!image.ReadPixels (info, bmp.GetPixels (), info.RowBytes, 0, 0))
-			{
+			if (!image.ReadPixels (info, bmp.GetPixels (), info.RowBytes, 0, 0)) {
 				bmp.Dispose ();
 				bmp = null;
 			}
 			return bmp;
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use SKPixmap.Encode instead.")]
 		public bool Encode (SKWStream dst, SKEncodedImageFormat format, int quality)
 		{

--- a/binding/Binding/SKCodec.cs
+++ b/binding/Binding/SKCodec.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 
 namespace SkiaSharp
@@ -31,6 +32,7 @@ namespace SkiaSharp
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use EncodedOrigin instead.")]
 		public SKCodecOrigin Origin =>
 			(SKCodecOrigin)EncodedOrigin;
@@ -139,26 +141,32 @@ namespace SkiaSharp
 			return SkiaApi.sk_codec_get_pixels (Handle, &nInfo, (void*)pixels, (IntPtr)rowBytes, &nOptions);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixels(SKImageInfo, IntPtr, int, SKCodecOptions) instead.")]
 		public SKCodecResult GetPixels (SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options, IntPtr colorTable, ref int colorTableCount) =>
 			GetPixels (info, pixels, rowBytes, options);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixels(SKImageInfo, IntPtr, SKCodecOptions) instead.")]
 		public SKCodecResult GetPixels (SKImageInfo info, IntPtr pixels, SKCodecOptions options, IntPtr colorTable, ref int colorTableCount) =>
 			GetPixels (info, pixels, info.RowBytes, options);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixels(SKImageInfo, IntPtr) instead.")]
 		public SKCodecResult GetPixels (SKImageInfo info, IntPtr pixels, IntPtr colorTable, ref int colorTableCount) =>
 			GetPixels (info, pixels, info.RowBytes, SKCodecOptions.Default);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixels(SKImageInfo, IntPtr, int, SKCodecOptions) instead.")]
 		public SKCodecResult GetPixels (SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options, SKColorTable colorTable, ref int colorTableCount) =>
 			GetPixels (info, pixels, rowBytes, options);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixels(SKImageInfo, IntPtr, SKCodecOptions) instead.")]
 		public SKCodecResult GetPixels (SKImageInfo info, IntPtr pixels, SKCodecOptions options, SKColorTable colorTable, ref int colorTableCount) =>
 			GetPixels (info, pixels, info.RowBytes, options);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use GetPixels(SKImageInfo, IntPtr) instead.")]
 		public SKCodecResult GetPixels (SKImageInfo info, IntPtr pixels, SKColorTable colorTable, ref int colorTableCount) =>
 			GetPixels (info, pixels, info.RowBytes, SKCodecOptions.Default);
@@ -193,10 +201,12 @@ namespace SkiaSharp
 			return SkiaApi.sk_codec_start_incremental_decode (Handle, &cinfo, (void*)pixels, (IntPtr)rowBytes, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use StartIncrementalDecode(SKImageInfo, IntPtr, int, SKCodecOptions) instead.")]
 		public SKCodecResult StartIncrementalDecode (SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options, IntPtr colorTable, ref int colorTableCount) =>
 			StartIncrementalDecode (info, pixels, rowBytes, options);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use StartIncrementalDecode(SKImageInfo, IntPtr, int, SKCodecOptions) instead.")]
 		public SKCodecResult StartIncrementalDecode (SKImageInfo info, IntPtr pixels, int rowBytes, SKCodecOptions options, SKColorTable colorTable, ref int colorTableCount) =>
 			StartIncrementalDecode (info, pixels, rowBytes, options);
@@ -240,10 +250,12 @@ namespace SkiaSharp
 			return SkiaApi.sk_codec_start_scanline_decode (Handle, &cinfo, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use StartScanlineDecode(SKImageInfo, SKCodecOptions) instead.")]
 		public SKCodecResult StartScanlineDecode (SKImageInfo info, SKCodecOptions options, IntPtr colorTable, ref int colorTableCount) =>
 			StartScanlineDecode (info, options);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use StartScanlineDecode(SKImageInfo, SKCodecOptions) instead.")]
 		public SKCodecResult StartScanlineDecode (SKImageInfo info, SKCodecOptions options, SKColorTable colorTable, ref int colorTableCount) =>
 			StartScanlineDecode (info, options);

--- a/binding/Binding/SKColor.cs
+++ b/binding/Binding/SKColor.cs
@@ -3,107 +3,11 @@ using System.Globalization;
 
 namespace SkiaSharp
 {
-	public unsafe struct SKPMColor
+	public readonly struct SKColor : IEquatable<SKColor>
 	{
-		private uint color;
-
-		public SKPMColor (uint value)
-		{
-			color = value;
-		}
-
-		public byte Alpha => (byte)((color >> SKImageInfo.PlatformColorAlphaShift) & 0xff);
-		public byte Red => (byte)((color >> SKImageInfo.PlatformColorRedShift) & 0xff);
-		public byte Green => (byte)((color >> SKImageInfo.PlatformColorGreenShift) & 0xff);
-		public byte Blue => (byte)((color >> SKImageInfo.PlatformColorBlueShift) & 0xff);
-
-		public static SKPMColor PreMultiply (SKColor color)
-		{
-			return SkiaApi.sk_color_premultiply ((uint)color);
-		}
-
-		public static SKColor UnPreMultiply (SKPMColor pmcolor)
-		{
-			return SkiaApi.sk_color_unpremultiply ((uint)pmcolor);
-		}
-
-		public static SKPMColor[] PreMultiply (SKColor[] colors)
-		{
-			var pmcolors = new SKPMColor [colors.Length];
-			fixed (SKColor* c = colors)
-			fixed (SKPMColor* pm = pmcolors) {
-				SkiaApi.sk_color_premultiply_array ((uint*)c, colors.Length, (uint*)pm);
-			}
-			return pmcolors;
-		}
-
-		public static SKColor[] UnPreMultiply (SKPMColor[] pmcolors)
-		{
-			var colors = new SKColor [pmcolors.Length];
-			fixed (SKColor* c = colors)
-			fixed (SKPMColor* pm = pmcolors) {
-				SkiaApi.sk_color_unpremultiply_array ((uint*)pm, pmcolors.Length, (uint*)c);
-			}
-			return colors;
-		}
-
-		public override bool Equals (object other)
-		{
-			if (!(other is SKPMColor))
-				return false;
-
-			var c = (SKPMColor)other;
-			return c.color == this.color;
-		}
-
-		public override int GetHashCode ()
-		{
-			return (int)color;
-		}
-
-		public static bool operator == (SKPMColor left, SKPMColor right)
-		{
-			return left.color == right.color;
-		}
-
-		public static bool operator != (SKPMColor left, SKPMColor right)
-		{
-			return !(left == right);
-		}
-
-		public static explicit operator SKPMColor (SKColor color)
-		{
-			return SKPMColor.PreMultiply (color);
-		}
-
-		public static explicit operator SKColor (SKPMColor color)
-		{
-			return SKPMColor.UnPreMultiply (color);
-		}
-
-		public static implicit operator SKPMColor (uint color)
-		{
-			return new SKPMColor (color);
-		}
-
-		public static explicit operator uint (SKPMColor color)
-		{
-			return color.color;
-		}
-
-		public override string ToString ()
-		{
-			return string.Format (CultureInfo.InvariantCulture, "#{0:x2}{1:x2}{2:x2}{3:x2}", Alpha, Red, Green, Blue);
-		}
-	}
-
-	public struct SKColor
-	{
-		private const float EPSILON = 0.001f;
-
 		public static readonly SKColor Empty;
 
-		private uint color;
+		private readonly uint color;
 
 		public SKColor (uint value)
 		{
@@ -120,25 +24,17 @@ namespace SkiaSharp
 			color = (0xff000000u | (uint)(red << 16) | (uint)(green << 8) | blue);
 		}
 
-		public SKColor WithRed (byte red)
-		{
-			return new SKColor (red, Green, Blue, Alpha);
-		}
+		public SKColor WithRed (byte red) =>
+			new SKColor (red, Green, Blue, Alpha);
 
-		public SKColor WithGreen (byte green)
-		{
-			return new SKColor (Red, green, Blue, Alpha);
-		}
+		public SKColor WithGreen (byte green) =>
+			new SKColor (Red, green, Blue, Alpha);
 
-		public SKColor WithBlue (byte blue)
-		{
-			return new SKColor (Red, Green, blue, Alpha);
-		}
+		public SKColor WithBlue (byte blue) =>
+			new SKColor (Red, Green, blue, Alpha);
 
-		public SKColor WithAlpha (byte alpha)
-		{
-			return new SKColor (Red, Green, Blue, alpha);
-		}
+		public SKColor WithAlpha (byte alpha) =>
+			new SKColor (Red, Green, Blue, alpha);
 
 		public byte Alpha => (byte)((color >> 24) & 0xff);
 		public byte Red => (byte)((color >> 16) & 0xff);
@@ -147,124 +43,31 @@ namespace SkiaSharp
 
 		public float Hue {
 			get {
-				ToHsv (out var h, out var s, out var v);
+				ToHsv (out var h, out _, out _);
 				return h;
 			}
 		}
-		
+
 		public static SKColor FromHsl (float h, float s, float l, byte a = 255)
 		{
-			// convert from percentages
-			h = h / 360f;
-			s = s / 100f;
-			l = l / 100f;
+			var colorf = SKColorF.FromHsl (h, s, l);
 
 			// RGB results from 0 to 255
-			var r = l * 255f;
-			var g = l * 255f;
-			var b = l * 255f;
-
-			// HSL from 0 to 1
-			if (Math.Abs (s) > EPSILON)
-			{
-				float v2;
-				if (l < 0.5f)
-					v2 = l * (1f + s);
-				else
-					v2 = (l + s) - (s * l);
-
-				var v1 = 2f * l - v2;
-
-				r = 255 * HueToRgb (v1, v2, h + (1f / 3f));
-				g = 255 * HueToRgb (v1, v2, h);
-				b = 255 * HueToRgb (v1, v2, h - (1f / 3f));
-			}
+			var r = colorf.Red * 255f;
+			var g = colorf.Green * 255f;
+			var b = colorf.Blue * 255f;
 
 			return new SKColor ((byte)r, (byte)g, (byte)b, a);
 		}
 
-		private static float HueToRgb (float v1, float v2, float vH)
+		public static SKColor FromHsv (float h, float s, float v, byte a = 255)
 		{
-			if (vH < 0f)
-				vH += 1f;
-			if (vH > 1f)
-				vH -= 1f;
-
-			if ((6f * vH) < 1f)
-				return (v1 + (v2 - v1) * 6f * vH);
-			if ((2f * vH) < 1f)
-				return (v2);
-			if ((3f * vH) < 2f)
-				return (v1 + (v2 - v1) * ((2f / 3f) - vH) * 6f);
-			return (v1);
-		}
-
-		public static SKColor FromHsv(float h, float s, float v, byte a = 255)
-		{
-			// convert from percentages
-			h = h / 360f;
-			s = s / 100f;
-			v = v / 100f;
+			var colorf = SKColorF.FromHsv (h, s, v);
 
 			// RGB results from 0 to 255
-			var r = v;
-			var g = v;
-			var b = v;
-
-			// HSL from 0 to 1
-			if (Math.Abs (s) > EPSILON)
-			{
-				h = h * 6f;
-				if (Math.Abs (h - 6f) < EPSILON)
-					h = 0f; // H must be < 1
-
-				var hInt = (int)h;
-				var v1 = v * (1f - s);
-				var v2 = v * (1f - s * (h - hInt));
-				var v3 = v * (1f - s * (1f - (h - hInt)));
-
-				if (hInt == 0)
-				{
-					r = v;
-					g = v3;
-					b = v1;
-				}
-				else if (hInt == 1)
-				{
-					r = v2;
-					g = v;
-					b = v1;
-				}
-				else if (hInt == 2)
-				{
-					r = v1;
-					g = v;
-					b = v3;
-				}
-				else if (hInt == 3)
-				{
-					r = v1;
-					g = v2;
-					b = v;
-				}
-				else if (hInt == 4)
-				{
-					r = v3;
-					g = v1;
-					b = v;
-				}
-				else
-				{
-					r = v;
-					g = v1;
-					b = v2;
-				}
-			}
-
-			// RGB results from 0 to 255
-			r = r * 255f;
-			g = g * 255f;
-			b = b * 255f;
+			var r = colorf.Red * 255f;
+			var g = colorf.Green * 255f;
+			var b = colorf.Blue * 255f;
 
 			return new SKColor ((byte)r, (byte)g, (byte)b, a);
 		}
@@ -272,132 +75,48 @@ namespace SkiaSharp
 		public void ToHsl (out float h, out float s, out float l)
 		{
 			// RGB from 0 to 255
-			var r = (Red / 255f);
-			var g = (Green / 255f);
-			var b = (Blue / 255f);
+			var r = Red / 255f;
+			var g = Green / 255f;
+			var b = Blue / 255f;
 
-			var min = Math.Min (Math.Min (r, g), b); // min value of RGB
-			var max = Math.Max (Math.Max (r, g), b); // max value of RGB
-			var delta = max - min; // delta RGB value
-
-			// default to a gray, no chroma...
-			h = 0f;
-			s = 0f;
-			l = (max + min) / 2f;
-
-			// chromatic data...
-			if (Math.Abs (delta) > EPSILON)
-			{
-				if (l < 0.5f)
-					s = delta / (max + min);
-				else
-					s = delta / (2f - max - min);
-
-				var deltaR = (((max - r) / 6f) + (delta / 2f)) / delta;
-				var deltaG = (((max - g) / 6f) + (delta / 2f)) / delta;
-				var deltaB = (((max - b) / 6f) + (delta / 2f)) / delta;
-
-				if (Math.Abs (r - max) < EPSILON) // r == max
-					h = deltaB - deltaG;
-				else if (Math.Abs (g - max) < EPSILON) // g == max
-					h = (1f / 3f) + deltaR - deltaB;
-				else // b == max
-					h = (2f / 3f) + deltaG - deltaR;
-
-				if (h < 0f)
-					h += 1f;
-				if (h > 1f)
-					h -= 1f;
-			}
-
-			// convert to percentages
-			h = h * 360f;
-			s = s * 100f;
-			l = l * 100f;
+			var colorf = new SKColorF (r, g, b);
+			colorf.ToHsl (out h, out s, out l);
 		}
 
 		public void ToHsv (out float h, out float s, out float v)
 		{
 			// RGB from 0 to 255
-			var r = (Red / 255f);
-			var g = (Green / 255f);
-			var b = (Blue / 255f);
+			var r = Red / 255f;
+			var g = Green / 255f;
+			var b = Blue / 255f;
 
-			var min = Math.Min (Math.Min (r, g), b); // min value of RGB
-			var max = Math.Max (Math.Max (r, g), b); // max value of RGB
-			var delta = max - min; // delta RGB value 
-
-			// default to a gray, no chroma...
-			h = 0;
-			s = 0;
-			v = max;
-
-			// chromatic data...
-			if (Math.Abs (delta) > EPSILON)
-			{
-				s = delta / max;
-
-				var deltaR = (((max - r) / 6f) + (delta / 2f)) / delta;
-				var deltaG = (((max - g) / 6f) + (delta / 2f)) / delta;
-				var deltaB = (((max - b) / 6f) + (delta / 2f)) / delta;
-
-				if (Math.Abs (r - max) < EPSILON) // r == max
-					h = deltaB - deltaG;
-				else if (Math.Abs (g - max) < EPSILON) // g == max
-					h = (1f / 3f) + deltaR - deltaB;
-				else // b == max
-					h = (2f / 3f) + deltaG - deltaR;
-
-				if (h < 0f)
-					h += 1f;
-				if (h > 1f)
-					h -= 1f;
-			}
-
-			// convert to percentages
-			h = h * 360f;
-			s = s * 100f;
-			v = v * 100f;
+			var colorf = new SKColorF (r, g, b);
+			colorf.ToHsv (out h, out s, out v);
 		}
 
-		public override string ToString ()
-		{
-			return string.Format (CultureInfo.InvariantCulture, "#{0:x2}{1:x2}{2:x2}{3:x2}",  Alpha, Red, Green, Blue);
-		}
+		public override string ToString () =>
+			$"#{Alpha:x2}{Red:x2}{Green:x2}{Blue:x2}";
 
-		public override bool Equals (object other)
-		{
-			if (!(other is SKColor))
-				return false;
+		public bool Equals (SKColor obj) =>
+			obj.color == color;
 
-			var c = (SKColor) other;
-			return c.color == this.color;
-		}
+		public override bool Equals (object obj) =>
+			obj is SKColor f && Equals (f);
 
-		public override int GetHashCode ()
-		{
-			return (int) color;
-		}
+		public static bool operator == (SKColor left, SKColor right) =>
+			left.Equals (right);
 
-		public static implicit operator SKColor (uint color)
-		{
-			return new SKColor (color);
-		}
+		public static bool operator != (SKColor left, SKColor right) =>
+			!left.Equals (right);
 
-		public static explicit operator uint (SKColor color)
-		{
-			return color.color;
-		}
+		public override int GetHashCode () =>
+			color.GetHashCode ();
 
-		public static bool operator == (SKColor left, SKColor right)
-		{
-			return left.color == right.color;
-		}
+		public static implicit operator SKColor (uint color) =>
+			new SKColor (color);
 
-		public static bool operator != (SKColor left, SKColor right)
-		{
-			return !(left == right);
-		}
+		public static explicit operator uint (SKColor color) =>
+			color.color;
 
 		public static SKColor Parse (string hexString)
 		{
@@ -416,7 +135,7 @@ namespace SkiaSharp
 
 			// clean up string
 			hexString = hexString.Trim ().ToUpperInvariant ();
-			if (hexString [0] == '#')
+			if (hexString[0] == '#')
 				hexString = hexString.Substring (1);
 
 			var len = hexString.Length;
@@ -424,7 +143,7 @@ namespace SkiaSharp
 				byte a;
 				// parse [A]
 				if (len == 4) {
-					if (!byte.TryParse (string.Concat (hexString [len - 4], hexString [len - 4]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a)) {
+					if (!byte.TryParse (string.Concat (hexString[len - 4], hexString[len - 4]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a)) {
 						// error
 						color = SKColor.Empty;
 						return false;
@@ -434,16 +153,16 @@ namespace SkiaSharp
 				}
 
 				// parse RGB
-				if (!byte.TryParse (string.Concat (hexString [len - 3], hexString [len - 3]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
-					!byte.TryParse (string.Concat (hexString [len - 2], hexString [len - 2]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
-					!byte.TryParse (string.Concat (hexString [len - 1], hexString [len - 1]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b)) {
+				if (!byte.TryParse (string.Concat (hexString[len - 3], hexString[len - 3]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
+					!byte.TryParse (string.Concat (hexString[len - 2], hexString[len - 2]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
+					!byte.TryParse (string.Concat (hexString[len - 1], hexString[len - 1]), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b)) {
 					// error
 					color = SKColor.Empty;
 					return false;
 				}
 
 				// success
-				color = new SKColor(r, g, b, a);
+				color = new SKColor (r, g, b, a);
 				return true;
 			}
 

--- a/binding/Binding/SKColorF.cs
+++ b/binding/Binding/SKColorF.cs
@@ -25,27 +25,27 @@ namespace SkiaSharp
 		}
 
 		public SKColorF WithRed (float red) =>
-			new SKColorF (red, Green, Blue, Alpha);
+			new SKColorF (red, fG, fB, fA);
 
 		public SKColorF WithGreen (float green) =>
-			new SKColorF (Red, green, Blue, Alpha);
+			new SKColorF (fR, green, fB, fA);
 
 		public SKColorF WithBlue (float blue) =>
-			new SKColorF (Red, Green, blue, Alpha);
+			new SKColorF (fR, fG, blue, fA);
 
 		public SKColorF WithAlpha (float alpha) =>
-			new SKColorF (Red, Green, Blue, alpha);
+			new SKColorF (fR, fG, fB, alpha);
 
 		public float Hue {
 			get {
-				ToHsv (out var h, out var s, out var v);
+				ToHsv (out var h, out _, out _);
 				return h;
 			}
 		}
 
 		public SKColorF Clamp ()
 		{
-			return new SKColorF (Clamp (Red), Clamp (Green), Clamp (Blue), Clamp (Alpha));
+			return new SKColorF (Clamp (fR), Clamp (fG), Clamp (fB), Clamp (fA));
 
 			static float Clamp (float v)
 			{
@@ -159,9 +159,9 @@ namespace SkiaSharp
 		public void ToHsl (out float h, out float s, out float l)
 		{
 			// RGB from 0 to 1
-			var r = Red;
-			var g = Green;
-			var b = Blue;
+			var r = fR;
+			var g = fG;
+			var b = fB;
 
 			var min = Math.Min (Math.Min (r, g), b); // min value of RGB
 			var max = Math.Max (Math.Max (r, g), b); // max value of RGB
@@ -205,9 +205,9 @@ namespace SkiaSharp
 		public void ToHsv (out float h, out float s, out float v)
 		{
 			// RGB from 0 to 1
-			var r = Red;
-			var g = Green;
-			var b = Blue;
+			var r = fR;
+			var g = fG;
+			var b = fB;
 
 			var min = Math.Min (Math.Min (r, g), b); // min value of RGB
 			var max = Math.Max (Math.Max (r, g), b); // max value of RGB
@@ -248,16 +248,6 @@ namespace SkiaSharp
 		public override string ToString () =>
 			((SKColor)this).ToString ();
 
-		public override bool Equals (object other) =>
-			other is SKColorF c &&
-			c.fR == fR &&
-			c.fG == fG &&
-			c.fB == fB &&
-			c.fA == fA;
-
-		public override int GetHashCode () =>
-			((SKColor)this).GetHashCode ();
-
 		public static implicit operator SKColorF (SKColor color)
 		{
 			SKColorF colorF;
@@ -267,14 +257,5 @@ namespace SkiaSharp
 
 		public static explicit operator SKColor (SKColorF color) =>
 			SkiaApi.sk_color4f_to_color (&color);
-
-		public static bool operator == (SKColorF left, SKColorF right) =>
-			left.fR == right.fR &&
-			left.fG == right.fG &&
-			left.fB == right.fB &&
-			left.fA == right.fA;
-
-		public static bool operator != (SKColorF left, SKColorF right) =>
-			!(left == right);
 	}
 }

--- a/binding/Binding/SKColorSpace.cs
+++ b/binding/Binding/SKColorSpace.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -186,18 +186,22 @@ namespace SkiaSharp
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateRgb (SKColorSpaceRenderTargetGamma, SKMatrix44) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceRenderTargetGamma gamma, SKMatrix44 toXyzD50, SKColorSpaceFlags flags) =>
 			CreateRgb (gamma, toXyzD50);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateRgb (SKColorSpaceRenderTargetGamma, SKColorSpaceGamut) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceRenderTargetGamma gamma, SKColorSpaceGamut gamut, SKColorSpaceFlags flags) =>
 			CreateRgb (gamma, gamut);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateRgb (SKColorSpaceTransferFn, SKMatrix44) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceTransferFn coeffs, SKMatrix44 toXyzD50, SKColorSpaceFlags flags) =>
 			CreateRgb (coeffs, toXyzD50);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateRgb (SKColorSpaceTransferFn, SKColorSpaceGamut) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceTransferFn coeffs, SKColorSpaceGamut gamut, SKColorSpaceFlags flags) =>
 			CreateRgb (coeffs, gamut);

--- a/binding/Binding/SKColorTable.cs
+++ b/binding/Binding/SKColorTable.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("The Index8 color type and color table is no longer supported.")]
 	public unsafe class SKColorTable : SKObject, ISKReferenceCounted
 	{
@@ -59,10 +60,8 @@ namespace SkiaSharp
 
 		public int Count => SkiaApi.sk_colortable_count (Handle);
 
-		public SKPMColor[] Colors
-		{
-			get
-			{
+		public SKPMColor[] Colors {
+			get {
 				var count = Count;
 				var pointer = ReadColors ();
 
@@ -70,16 +69,14 @@ namespace SkiaSharp
 					return new SKPMColor[0];
 				}
 
-				return PtrToStructureArray <SKPMColor> (pointer, count);
+				return PtrToStructureArray<SKPMColor> (pointer, count);
 			}
 		}
 
 		public SKColor[] UnPreMultipledColors => SKPMColor.UnPreMultiply (Colors);
 
-		public SKPMColor this [int index]
-		{
-			get
-			{
+		public SKPMColor this[int index] {
+			get {
 				var count = Count;
 				var pointer = ReadColors ();
 
@@ -87,11 +84,11 @@ namespace SkiaSharp
 					throw new ArgumentOutOfRangeException (nameof (index));
 				}
 
-				return PtrToStructure <SKPMColor> (pointer, index);
+				return PtrToStructure<SKPMColor> (pointer, index);
 			}
 		}
 
-		public SKColor GetUnPreMultipliedColor (int index) => SKPMColor.UnPreMultiply (this [index]);
+		public SKColor GetUnPreMultipliedColor (int index) => SKPMColor.UnPreMultiply (this[index]);
 
 		public IntPtr ReadColors ()
 		{

--- a/binding/Binding/SKDocument.cs
+++ b/binding/Binding/SKDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 
 namespace SkiaSharp
@@ -76,6 +77,7 @@ namespace SkiaSharp
 
 		// CreatePdf
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreatePdf(SKWStream, SKDocumentPdfMetadata) instead.")]
 		public static SKDocument CreatePdf (SKWStream stream, SKDocumentPdfMetadata metadata, float dpi)
 		{

--- a/binding/Binding/SKImage.cs
+++ b/binding/Binding/SKImage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -84,6 +85,7 @@ namespace SkiaSharp
 			return GetObject<SKImage> (SkiaApi.sk_image_new_raster_copy (&nInfo, (void*)pixels, (IntPtr)rowBytes));
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use FromPixelCopy(SKImageInfo, IntPtr, int) instead.")]
 		public static SKImage FromPixelCopy (SKImageInfo info, IntPtr pixels, int rowBytes, SKColorTable ctable) =>
 			FromPixelCopy (info, pixels, rowBytes);
@@ -254,24 +256,28 @@ namespace SkiaSharp
 
 		// create a new image from a GPU texture
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType) instead.")]
 		public static SKImage FromTexture (GRContext context, GRBackendTextureDesc desc)
 		{
 			return FromTexture (context, desc, SKAlphaType.Premul, null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType) instead.")]
 		public static SKImage FromTexture (GRContext context, GRBackendTextureDesc desc, SKAlphaType alpha)
 		{
 			return FromTexture (context, desc, alpha, null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType, SKColorSpace, SKImageTextureReleaseDelegate) instead.")]
 		public static SKImage FromTexture (GRContext context, GRBackendTextureDesc desc, SKAlphaType alpha, SKImageTextureReleaseDelegate releaseProc)
 		{
 			return FromTexture (context, desc, alpha, releaseProc, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType, SKColorSpace, SKImageTextureReleaseDelegate, object) instead.")]
 		public static SKImage FromTexture (GRContext context, GRBackendTextureDesc desc, SKAlphaType alpha, SKImageTextureReleaseDelegate releaseProc, object releaseContext)
 		{
@@ -282,24 +288,28 @@ namespace SkiaSharp
 			return FromTexture (context, texture, desc.Origin, desc.Config.ToColorType (), alpha, null, releaseProc, releaseContext);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType) instead.")]
 		public static SKImage FromTexture (GRContext context, GRGlBackendTextureDesc desc)
 		{
 			return FromTexture (context, desc, SKAlphaType.Premul, null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType) instead.")]
 		public static SKImage FromTexture (GRContext context, GRGlBackendTextureDesc desc, SKAlphaType alpha)
 		{
 			return FromTexture (context, desc, alpha, null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType, SKColorSpace, SKImageTextureReleaseDelegate) instead.")]
 		public static SKImage FromTexture (GRContext context, GRGlBackendTextureDesc desc, SKAlphaType alpha, SKImageTextureReleaseDelegate releaseProc)
 		{
 			return FromTexture (context, desc, alpha, releaseProc, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType, SKColorSpace, SKImageTextureReleaseDelegate, object) instead.")]
 		public static SKImage FromTexture (GRContext context, GRGlBackendTextureDesc desc, SKAlphaType alpha, SKImageTextureReleaseDelegate releaseProc, object releaseContext)
 		{
@@ -347,12 +357,14 @@ namespace SkiaSharp
 			return GetObject<SKImage> (SkiaApi.sk_image_new_from_texture (context.Handle, texture.Handle, origin, colorType, alpha, cs, proxy, (void*)ctx));
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromAdoptedTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType) instead.")]
 		public static SKImage FromAdoptedTexture (GRContext context, GRBackendTextureDesc desc)
 		{
 			return FromAdoptedTexture (context, desc, SKAlphaType.Premul);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromAdoptedTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType) instead.")]
 		public static SKImage FromAdoptedTexture (GRContext context, GRBackendTextureDesc desc, SKAlphaType alpha)
 		{
@@ -360,12 +372,14 @@ namespace SkiaSharp
 			return FromAdoptedTexture (context, texture, desc.Origin, desc.Config.ToColorType (), alpha, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromAdoptedTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType) instead.")]
 		public static SKImage FromAdoptedTexture (GRContext context, GRGlBackendTextureDesc desc)
 		{
 			return FromAdoptedTexture (context, desc, SKAlphaType.Premul);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromAdoptedTexture(GRContext, GRBackendTexture, GRSurfaceOrigin, SKColorType, SKAlphaType) instead.")]
 		public static SKImage FromAdoptedTexture (GRContext context, GRGlBackendTextureDesc desc, SKAlphaType alpha)
 		{
@@ -432,6 +446,7 @@ namespace SkiaSharp
 		public SKData Encode () =>
 			GetObject<SKData> (SkiaApi.sk_image_encode (Handle));
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		public SKData Encode (SKPixelSerializer serializer)
 		{

--- a/binding/Binding/SKImageFilter.cs
+++ b/binding/Binding/SKImageFilter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -117,6 +118,7 @@ namespace SkiaSharp
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use CreateMerge(SKImageFilter, SKImageFilter, SKImageFilter.CropRect) instead.")]
 		public static SKImageFilter CreateMerge(SKImageFilter first, SKImageFilter second, SKBlendMode mode, SKImageFilter.CropRect cropRect = null)
 		{
@@ -128,6 +130,7 @@ namespace SkiaSharp
 			return CreateMerge(new [] { first, second }, cropRect);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use CreateMerge(SKImageFilter[], SKImageFilter.CropRect) instead.")]
 		public static SKImageFilter CreateMerge(SKImageFilter[] filters, SKBlendMode[] modes, SKImageFilter.CropRect cropRect = null)
 		{

--- a/binding/Binding/SKImageInfo.cs
+++ b/binding/Binding/SKImageInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace SkiaSharp
 {
@@ -7,37 +6,33 @@ namespace SkiaSharp
 	{
 		public static void UpdateNative (ref SKImageInfo managed, ref SKImageInfoNative native)
 		{
-			native.colorspace = managed.ColorSpace == null ? IntPtr.Zero : managed.ColorSpace.Handle;
+			native.colorspace = managed.ColorSpace?.Handle ?? IntPtr.Zero;
 			native.width = managed.Width;
 			native.height = managed.Height;
 			native.colorType = managed.ColorType;
 			native.alphaType = managed.AlphaType;
 		}
 
-		public static SKImageInfoNative FromManaged (ref SKImageInfo managed)
-		{
-			return new SKImageInfoNative {
-				colorspace = managed.ColorSpace == null ? IntPtr.Zero : managed.ColorSpace.Handle,
+		public static SKImageInfoNative FromManaged (ref SKImageInfo managed) =>
+			new SKImageInfoNative {
+				colorspace = managed.ColorSpace?.Handle ?? IntPtr.Zero,
 				width = managed.Width,
 				height = managed.Height,
 				colorType = managed.ColorType,
 				alphaType = managed.AlphaType,
 			};
-		}
 
-		public static SKImageInfo ToManaged (ref SKImageInfoNative native)
-		{
-			return new SKImageInfo {
+		public static SKImageInfo ToManaged (ref SKImageInfoNative native) =>
+			new SKImageInfo {
 				ColorSpace = SKObject.GetObject<SKColorSpace> (native.colorspace),
 				Width = native.width,
 				Height = native.height,
 				ColorType = native.colorType,
 				AlphaType = native.alphaType,
 			};
-		}
 	}
 
-	public unsafe struct SKImageInfo
+	public unsafe struct SKImageInfo : IEquatable<SKImageInfo>
 	{
 		public static readonly SKImageInfo Empty;
 		public static readonly SKColorType PlatformColorType;
@@ -104,49 +99,42 @@ namespace SkiaSharp
 			ColorSpace = colorspace;
 		}
 
-		public int BytesPerPixel {
-			get {
-				switch (ColorType) {
-				case SKColorType.Unknown:
-					return 0;
-				case SKColorType.Alpha8:
-				case SKColorType.Gray8:
-					return 1;
-				case SKColorType.Rgb565:
-				case SKColorType.Argb4444:
-					return 2;
-				case SKColorType.Bgra8888:
-				case SKColorType.Rgba8888:
-				case SKColorType.Rgb888x:
-				case SKColorType.Rgba1010102:
-				case SKColorType.Rgb101010x:
-					return 4;
-				case SKColorType.RgbaF16:
-					return 8;
-				}
-				throw new ArgumentOutOfRangeException (nameof (ColorType));
-			}
-		}
+		public readonly int BytesPerPixel =>
+			ColorType switch
+			{
+				SKColorType.Unknown => 0,
+				SKColorType.Alpha8 => 1,
+				SKColorType.Gray8 => 1,
+				SKColorType.Rgb565 => 2,
+				SKColorType.Argb4444 => 2,
+				SKColorType.Bgra8888 => 4,
+				SKColorType.Rgba8888 => 4,
+				SKColorType.Rgb888x => 4,
+				SKColorType.Rgba1010102 => 4,
+				SKColorType.Rgb101010x => 4,
+				SKColorType.RgbaF16 => 8,
+				_ => throw new ArgumentOutOfRangeException (nameof (ColorType)),
+			};
 
-		public int BitsPerPixel => BytesPerPixel * 8;
+		public readonly int BitsPerPixel => BytesPerPixel * 8;
 
-		public int BytesSize => Width * Height * BytesPerPixel;
+		public readonly int BytesSize => Width * Height * BytesPerPixel;
 
-		public long BytesSize64 => (long)Width * (long)Height * (long)BytesPerPixel;
+		public readonly long BytesSize64 => (long)Width * (long)Height * (long)BytesPerPixel;
 
-		public int RowBytes => Width * BytesPerPixel;
+		public readonly int RowBytes => Width * BytesPerPixel;
 
-		public long RowBytes64 => (long)Width * (long)BytesPerPixel;
+		public readonly long RowBytes64 => (long)Width * (long)BytesPerPixel;
 
-		public bool IsEmpty => Width <= 0 || Height <= 0;
+		public readonly bool IsEmpty => Width <= 0 || Height <= 0;
 
-		public bool IsOpaque => AlphaType == SKAlphaType.Opaque;
+		public readonly bool IsOpaque => AlphaType == SKAlphaType.Opaque;
 
-		public SKSizeI Size => new SKSizeI (Width, Height);
+		public readonly SKSizeI Size => new SKSizeI (Width, Height);
 
-		public SKRectI Rect => SKRectI.Create (Width, Height);
+		public readonly SKRectI Rect => SKRectI.Create (Width, Height);
 
-		public SKImageInfo WithSize(int width, int height)
+		public SKImageInfo WithSize (int width, int height)
 		{
 			var copy = this;
 			copy.Width = width;
@@ -173,6 +161,33 @@ namespace SkiaSharp
 			var copy = this;
 			copy.AlphaType = newAlphaType;
 			return copy;
+		}
+
+		public bool Equals (SKImageInfo obj) =>
+			ColorSpace == obj.ColorSpace &&
+			Width == obj.Width &&
+			Height == obj.Height &&
+			ColorType == obj.ColorType &&
+			AlphaType == obj.AlphaType;
+
+		public override bool Equals (object obj) =>
+			obj is SKImageInfo f && Equals (f);
+
+		public static bool operator == (SKImageInfo left, SKImageInfo right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKImageInfo left, SKImageInfo right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (ColorSpace);
+			hash.Add (Width);
+			hash.Add (Height);
+			hash.Add (ColorType);
+			hash.Add (AlphaType);
+			return hash.ToHashCode ();
 		}
 	}
 }

--- a/binding/Binding/SKMask.cs
+++ b/binding/Binding/SKMask.cs
@@ -5,131 +5,148 @@ namespace SkiaSharp
 {
 	public unsafe partial struct SKMask
 	{
-		public SKMask(IntPtr image, SKRectI bounds, UInt32 rowBytes, SKMaskFormat format)
+		public SKMask (IntPtr image, SKRectI bounds, UInt32 rowBytes, SKMaskFormat format)
 		{
-			this.fBounds = bounds;
-			this.fRowBytes = rowBytes;
-			this.fFormat = format;
-			this.fImage = (byte*)image;
+			fBounds = bounds;
+			fRowBytes = rowBytes;
+			fFormat = format;
+			fImage = (byte*)image;
 		}
 
-		public SKMask(SKRectI bounds, UInt32 rowBytes, SKMaskFormat format)
+		public SKMask (SKRectI bounds, UInt32 rowBytes, SKMaskFormat format)
 		{
-			this.fBounds = bounds;
-			this.fRowBytes = rowBytes;
-			this.fFormat = format;
-			this.fImage = null;
+			fBounds = bounds;
+			fRowBytes = rowBytes;
+			fFormat = format;
+			fImage = null;
 		}
+
+		// properties
 
 		public IntPtr Image {
-			get => (IntPtr)fImage;
+			readonly get => (IntPtr)fImage;
 			set => fImage = (byte*)value;
 		}
+
 		public SKRectI Bounds {
-			get => fBounds;
+			readonly get => fBounds;
 			set => fBounds = value;
 		}
+
 		public UInt32 RowBytes {
-			get => fRowBytes;
+			readonly get => fRowBytes;
 			set => fRowBytes = value;
 		}
+
 		public SKMaskFormat Format {
-			get => fFormat;
+			readonly get => fFormat;
 			set => fFormat = value;
 		}
-		public bool IsEmpty {
+
+		public readonly bool IsEmpty {
 			get {
 				fixed (SKMask* t = &this) {
-					return SkiaApi.sk_mask_is_empty(t);
+					return SkiaApi.sk_mask_is_empty (t);
 				}
 			}
 		}
 
-		public long AllocateImage()
+		// allocate / free
+
+		public long AllocateImage ()
 		{
 			fixed (SKMask* t = &this) {
-				var size = SkiaApi.sk_mask_compute_total_image_size(t);
-				fImage = SkiaApi.sk_mask_alloc_image(size);
+				var size = SkiaApi.sk_mask_compute_total_image_size (t);
+				fImage = SkiaApi.sk_mask_alloc_image (size);
 				return (long)size;
 			}
 		}
-		public void FreeImage()
+
+		public void FreeImage ()
 		{
 			if (fImage != null) {
-				SKMask.FreeImage((IntPtr)fImage);
+				SKMask.FreeImage ((IntPtr)fImage);
 				fImage = null;
 			}
 		}
 
-		public long ComputeImageSize()
+		// Compute*
+
+		public readonly long ComputeImageSize ()
 		{
 			fixed (SKMask* t = &this) {
-				return (long)SkiaApi.sk_mask_compute_image_size(t);
+				return (long)SkiaApi.sk_mask_compute_image_size (t);
 			}
 		}
 
-		public long ComputeTotalImageSize()
+		public readonly long ComputeTotalImageSize ()
 		{
 			fixed (SKMask* t = &this) {
-				return (long)SkiaApi.sk_mask_compute_total_image_size(t);
+				return (long)SkiaApi.sk_mask_compute_total_image_size (t);
 			}
 		}
 
-		public byte GetAddr1(int x, int y)
+		// GetAddr*
+
+		public readonly byte GetAddr1 (int x, int y)
 		{
 			fixed (SKMask* t = &this) {
-				return SkiaApi.sk_mask_get_addr_1(t, x, y);
+				return SkiaApi.sk_mask_get_addr_1 (t, x, y);
 			}
 		}
 
-		public byte GetAddr8(int x, int y)
+		public readonly byte GetAddr8 (int x, int y)
 		{
 			fixed (SKMask* t = &this) {
-				return SkiaApi.sk_mask_get_addr_8(t, x, y);
+				return SkiaApi.sk_mask_get_addr_8 (t, x, y);
 			}
 		}
 
-		public UInt16 GetAddr16(int x, int y)
+		public readonly UInt16 GetAddr16 (int x, int y)
 		{
 			fixed (SKMask* t = &this) {
-				return SkiaApi.sk_mask_get_addr_lcd_16(t, x, y);
+				return SkiaApi.sk_mask_get_addr_lcd_16 (t, x, y);
 			}
 		}
 
-		public UInt32 GetAddr32 (int x, int y)
+		public readonly UInt32 GetAddr32 (int x, int y)
 		{
 			fixed (SKMask* t = &this) {
 				return SkiaApi.sk_mask_get_addr_32 (t, x, y);
 			}
 		}
 
-		public IntPtr GetAddr(int x, int y)
+		public IntPtr GetAddr (int x, int y)
 		{
 			fixed (SKMask* t = &this) {
-				return (IntPtr)SkiaApi.sk_mask_get_addr(t, x, y);
+				return (IntPtr)SkiaApi.sk_mask_get_addr (t, x, y);
 			}
 		}
 
-		public static IntPtr AllocateImage(long size) => (IntPtr)SkiaApi.sk_mask_alloc_image((IntPtr)size);
-		public static void FreeImage(IntPtr image) => SkiaApi.sk_mask_free_image((byte*)image);
+		// statics
 
-		public static SKMask Create(byte[] image, SKRectI bounds, UInt32 rowBytes, SKMaskFormat format)
+		public static IntPtr AllocateImage (long size) =>
+			(IntPtr)SkiaApi.sk_mask_alloc_image ((IntPtr)size);
+
+		public static void FreeImage (IntPtr image) =>
+			SkiaApi.sk_mask_free_image ((byte*)image);
+
+		public static SKMask Create (byte[] image, SKRectI bounds, UInt32 rowBytes, SKMaskFormat format)
 		{
 			// create the mask
-			var mask = new SKMask(bounds, rowBytes, format);
+			var mask = new SKMask (bounds, rowBytes, format);
 
 			// is there the right amount of space in the mask
-			if (image.Length != mask.ComputeTotalImageSize())
-			{
+			if (image.Length != mask.ComputeTotalImageSize ()) {
 				// Note: buffer.Length must match bounds.Height * rowBytes
 				var expectedHeight = bounds.Height * rowBytes;
-				var message = $"Length of image ({image.Length}) does not match the computed size of the mask ({expectedHeight}). Check the {nameof(bounds)} and {nameof(rowBytes)}.";
-				throw new ArgumentException(message);
+				var message = $"Length of image ({image.Length}) does not match the computed size of the mask ({expectedHeight}). Check the {nameof (bounds)} and {nameof (rowBytes)}.";
+				throw new ArgumentException (message);
 			}
 
 			// copy the image data
-			mask.AllocateImage();
-			Marshal.Copy(image, 0, (IntPtr)mask.fImage, image.Length);
+			mask.AllocateImage ();
+			Marshal.Copy (image, 0, (IntPtr)mask.fImage, image.Length);
 
 			// return the mask
 			return mask;
@@ -140,16 +157,15 @@ namespace SkiaSharp
 	{
 		private IntPtr image;
 
-		public SKAutoMaskFreeImage(IntPtr maskImage)
+		public SKAutoMaskFreeImage (IntPtr maskImage)
 		{
 			image = maskImage;
 		}
 
-		public void Dispose()
+		public void Dispose ()
 		{
-			if (image != IntPtr.Zero)
-			{
-				SKMask.FreeImage(image);
+			if (image != IntPtr.Zero) {
+				SKMask.FreeImage (image);
 				image = IntPtr.Zero;
 			}
 		}

--- a/binding/Binding/SKMaskFilter.cs
+++ b/binding/Binding/SKMaskFilter.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Flags]
 	[Obsolete]
 	public enum SKBlurMaskFilterFlags
@@ -30,12 +32,12 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public static float ConvertRadiusToSigma(float radius)
+		public static float ConvertRadiusToSigma (float radius)
 		{
 			return radius > 0 ? BlurSigmaScale * radius + 0.5f : 0.0f;
 		}
 
-		public static float ConvertSigmaToRadius(float sigma)
+		public static float ConvertSigmaToRadius (float sigma)
 		{
 			return sigma > 0.5f ? (sigma - 0.5f) / BlurSigmaScale : 0.0f;
 		}
@@ -45,7 +47,8 @@ namespace SkiaSharp
 			return GetObject<SKMaskFilter> (SkiaApi.sk_maskfilter_new_blur (blurStyle, sigma));
 		}
 
-		[Obsolete("Use CreateBlur(SKBlurStyle, float) instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use CreateBlur(SKBlurStyle, float) instead.")]
 		public static SKMaskFilter CreateBlur (SKBlurStyle blurStyle, float sigma, SKBlurMaskFilterFlags flags)
 		{
 			return CreateBlur (blurStyle, sigma, SKRect.Empty, true);
@@ -56,7 +59,8 @@ namespace SkiaSharp
 			return CreateBlur (blurStyle, sigma, occluder, true);
 		}
 
-		[Obsolete("Use CreateBlur(SKBlurStyle, float, SKRect) instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use CreateBlur(SKBlurStyle, float, SKRect) instead.")]
 		public static SKMaskFilter CreateBlur (SKBlurStyle blurStyle, float sigma, SKRect occluder, SKBlurMaskFilterFlags flags)
 		{
 			return CreateBlur (blurStyle, sigma, occluder, true);
@@ -67,25 +71,25 @@ namespace SkiaSharp
 			return GetObject<SKMaskFilter> (SkiaApi.sk_maskfilter_new_blur_with_flags (blurStyle, sigma, &occluder, respectCTM));
 		}
 
-		public static SKMaskFilter CreateTable(byte[] table)
+		public static SKMaskFilter CreateTable (byte[] table)
 		{
 			if (table == null)
-				throw new ArgumentNullException(nameof(table));
+				throw new ArgumentNullException (nameof (table));
 			if (table.Length != TableMaxLength)
-				throw new ArgumentException("Table must have a length of {SKColorTable.MaxLength}.", nameof(table));
+				throw new ArgumentException ("Table must have a length of {SKColorTable.MaxLength}.", nameof (table));
 			fixed (byte* t = table) {
 				return GetObject<SKMaskFilter> (SkiaApi.sk_maskfilter_new_table (t));
 			}
 		}
 
-		public static SKMaskFilter CreateGamma(float gamma)
+		public static SKMaskFilter CreateGamma (float gamma)
 		{
-			return GetObject<SKMaskFilter>(SkiaApi.sk_maskfilter_new_gamma(gamma));
+			return GetObject<SKMaskFilter> (SkiaApi.sk_maskfilter_new_gamma (gamma));
 		}
 
-		public static SKMaskFilter CreateClip(byte min, byte max)
+		public static SKMaskFilter CreateClip (byte min, byte max)
 		{
-			return GetObject<SKMaskFilter>(SkiaApi.sk_maskfilter_new_clip(min, max));
+			return GetObject<SKMaskFilter> (SkiaApi.sk_maskfilter_new_clip (min, max));
 		}
 	}
 }

--- a/binding/Binding/SKPMColor.cs
+++ b/binding/Binding/SKPMColor.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+namespace SkiaSharp
+{
+	public readonly unsafe struct SKPMColor : IEquatable<SKPMColor>
+	{
+		private readonly uint color;
+
+		public SKPMColor (uint value)
+		{
+			color = value;
+		}
+
+		public byte Alpha => (byte)((color >> SKImageInfo.PlatformColorAlphaShift) & 0xff);
+		public byte Red => (byte)((color >> SKImageInfo.PlatformColorRedShift) & 0xff);
+		public byte Green => (byte)((color >> SKImageInfo.PlatformColorGreenShift) & 0xff);
+		public byte Blue => (byte)((color >> SKImageInfo.PlatformColorBlueShift) & 0xff);
+
+		// PreMultiply
+
+		public static SKPMColor PreMultiply (SKColor color) =>
+			SkiaApi.sk_color_premultiply ((uint)color);
+
+		public static SKPMColor[] PreMultiply (SKColor[] colors)
+		{
+			var pmcolors = new SKPMColor[colors.Length];
+			fixed (SKColor* c = colors)
+			fixed (SKPMColor* pm = pmcolors) {
+				SkiaApi.sk_color_premultiply_array ((uint*)c, colors.Length, (uint*)pm);
+			}
+			return pmcolors;
+		}
+
+		// UnPreMultiply
+
+		public static SKColor UnPreMultiply (SKPMColor pmcolor) =>
+			SkiaApi.sk_color_unpremultiply ((uint)pmcolor);
+
+		public static SKColor[] UnPreMultiply (SKPMColor[] pmcolors)
+		{
+			var colors = new SKColor[pmcolors.Length];
+			fixed (SKColor* c = colors)
+			fixed (SKPMColor* pm = pmcolors) {
+				SkiaApi.sk_color_unpremultiply_array ((uint*)pm, pmcolors.Length, (uint*)c);
+			}
+			return colors;
+		}
+
+		public static explicit operator SKPMColor (SKColor color) =>
+			SKPMColor.PreMultiply (color);
+
+		public static explicit operator SKColor (SKPMColor color) =>
+			SKPMColor.UnPreMultiply (color);
+
+		public override string ToString () =>
+			$"#{Alpha:x2}{Red:x2}{Green:x2}{Blue:x2}";
+
+		public bool Equals (SKPMColor obj) =>
+			obj.color == color;
+
+		public override bool Equals (object obj) =>
+			obj is SKPMColor f && Equals (f);
+
+		public static bool operator == (SKPMColor left, SKPMColor right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPMColor left, SKPMColor right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode () =>
+			color.GetHashCode ();
+
+		public static implicit operator SKPMColor (uint color) =>
+			new SKPMColor (color);
+
+		public static explicit operator uint (SKPMColor color) =>
+			color.color;
+	}
+}

--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -359,6 +360,7 @@ namespace SkiaSharp
 		public void AddRoundRect (SKRect rect, float rx, float ry, SKPathDirection dir = SKPathDirection.Clockwise) =>
 			SkiaApi.sk_path_add_rounded_rect (Handle, &rect, rx, ry, dir);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use AddRoundRect instead.")]
 		public void AddRoundedRect (SKRect rect, float rx, float ry, SKPathDirection dir = SKPathDirection.Clockwise) =>
 			AddRoundRect (rect, rx, ry, dir);

--- a/binding/Binding/SKPixelSerializer.cs
+++ b/binding/Binding/SKPixelSerializer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete]
 	public abstract class SKPixelSerializer : SKObject
 	{
@@ -41,6 +43,7 @@ namespace SkiaSharp
 		}
 	}
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete]
 	internal class SKSimplePixelSerializer : SKPixelSerializer
 	{
@@ -64,10 +67,11 @@ namespace SkiaSharp
 		}
 	}
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete]
 	public abstract class SKManagedPixelSerializer : SKPixelSerializer
 	{
-		public SKManagedPixelSerializer()
+		public SKManagedPixelSerializer ()
 		{
 		}
 	}

--- a/binding/Binding/SKPixmap.cs
+++ b/binding/Binding/SKPixmap.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -25,6 +26,7 @@ namespace SkiaSharp
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use SKPixmap(SKImageInfo, IntPtr, int) instead.")]
 		public SKPixmap (SKImageInfo info, IntPtr addr, int rowBytes, SKColorTable ctable)
 			: this (info, addr, info.RowBytes)
@@ -52,6 +54,7 @@ namespace SkiaSharp
 			SkiaApi.sk_pixmap_reset (Handle);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported. Use Reset(SKImageInfo, IntPtr, int) instead.")]
 		public void Reset (SKImageInfo info, IntPtr addr, int rowBytes, SKColorTable ctable)
 		{
@@ -108,9 +111,11 @@ namespace SkiaSharp
 			return SkiaApi.sk_pixmap_get_pixel_color (Handle, x, y);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("The Index8 color type and color table is no longer supported.")]
 		public SKColorTable ColorTable => null;
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use ScalePixels(SKPixmap, SKFilterQuality) instead.")]
 		public static bool Resize (SKPixmap dst, SKPixmap src, SKBitmapResizeMethod method)
 		{

--- a/binding/Binding/SKSurface.cs
+++ b/binding/Binding/SKSurface.cs
@@ -1,16 +1,20 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
 	public unsafe class SKSurface : SKObject, ISKReferenceCounted
 	{
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKImageInfo) instead.")]
 		public static SKSurface Create (int width, int height, SKColorType colorType, SKAlphaType alphaType) => Create (new SKImageInfo (width, height, colorType, alphaType));
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKImageInfo, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (int width, int height, SKColorType colorType, SKAlphaType alphaType, SKSurfaceProps props) => Create (new SKImageInfo (width, height, colorType, alphaType), props);
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKImageInfo, IntPtr, int) instead.")]
 		public static SKSurface Create (int width, int height, SKColorType colorType, SKAlphaType alphaType, IntPtr pixels, int rowBytes) => Create (new SKImageInfo (width, height, colorType, alphaType), pixels, rowBytes);
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKImageInfo, IntPtr, int, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (int width, int height, SKColorType colorType, SKAlphaType alphaType, IntPtr pixels, int rowBytes, SKSurfaceProps props) => Create (new SKImageInfo (width, height, colorType, alphaType), pixels, rowBytes, props);
 
@@ -25,6 +29,7 @@ namespace SkiaSharp
 
 		// RASTER surface
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKImageInfo, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (SKImageInfo info, SKSurfaceProps props) =>
 			Create (info, 0, new SKSurfaceProperties (props));
@@ -46,6 +51,7 @@ namespace SkiaSharp
 
 		// convenience RASTER DIRECT to use a SKPixmap instead of SKImageInfo and IntPtr
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKPixmap, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (SKPixmap pixmap, SKSurfaceProps props) =>
 			Create (pixmap, new SKSurfaceProperties (props));
@@ -63,6 +69,7 @@ namespace SkiaSharp
 
 		// RASTER DIRECT surface
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(SKImageInfo, IntPtr, rowBytes, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (SKImageInfo info, IntPtr pixels, int rowBytes, SKSurfaceProps props) =>
 			Create (info, pixels, rowBytes, null, null, new SKSurfaceProperties (props));
@@ -94,6 +101,7 @@ namespace SkiaSharp
 
 		// GPU BACKEND RENDER TARGET surface
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, GRBackendRenderTarget, GRSurfaceOrigin, SKColorType) instead.")]
 		public static SKSurface Create (GRContext context, GRBackendRenderTargetDesc desc)
 		{
@@ -104,6 +112,7 @@ namespace SkiaSharp
 			return Create (context, renderTarget, desc.Origin, desc.Config.ToColorType (), null, null);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, GRBackendRenderTarget, GRSurfaceOrigin, SKColorType, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (GRContext context, GRBackendRenderTargetDesc desc, SKSurfaceProps props)
 		{
@@ -141,18 +150,22 @@ namespace SkiaSharp
 
 		// GPU BACKEND TEXTURE surface
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType) instead.")]
 		public static SKSurface Create (GRContext context, GRGlBackendTextureDesc desc) =>
 			Create (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, null);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType) instead.")]
 		public static SKSurface Create (GRContext context, GRBackendTextureDesc desc) =>
 			Create (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, null);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (GRContext context, GRGlBackendTextureDesc desc, SKSurfaceProps props) =>
 			Create (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, new SKSurfaceProperties (props));
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (GRContext context, GRBackendTextureDesc desc, SKSurfaceProps props) =>
 			Create (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, new SKSurfaceProperties (props));
@@ -190,18 +203,22 @@ namespace SkiaSharp
 
 		// GPU BACKEND TEXTURE AS RENDER TARGET surface
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateAsRenderTarget(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType) instead.")]
 		public static SKSurface CreateAsRenderTarget (GRContext context, GRGlBackendTextureDesc desc) =>
 			CreateAsRenderTarget (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, null);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateAsRenderTarget(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType) instead.")]
 		public static SKSurface CreateAsRenderTarget (GRContext context, GRBackendTextureDesc desc) =>
 			CreateAsRenderTarget (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, null);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateAsRenderTarget(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType, SKSurfaceProperties) instead.")]
 		public static SKSurface CreateAsRenderTarget (GRContext context, GRGlBackendTextureDesc desc, SKSurfaceProps props) =>
 			CreateAsRenderTarget (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, new SKSurfaceProperties (props));
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateAsRenderTarget(GRContext, GRBackendTexture, GRSurfaceOrigin, int, SKColorType, SKSurfaceProperties) instead.")]
 		public static SKSurface CreateAsRenderTarget (GRContext context, GRBackendTextureDesc desc, SKSurfaceProps props) =>
 			CreateAsRenderTarget (context, new GRBackendTexture (desc), desc.Origin, desc.SampleCount, desc.Config.ToColorType (), null, new SKSurfaceProperties (props));
@@ -239,6 +256,7 @@ namespace SkiaSharp
 
 		// GPU NEW surface
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use Create(GRContext, bool, SKImageInfo, int, SKSurfaceProperties) instead.")]
 		public static SKSurface Create (GRContext context, bool budgeted, SKImageInfo info, int sampleCount, SKSurfaceProps props) =>
 			Create (context, budgeted, info, sampleCount, GRSurfaceOrigin.BottomLeft, new SKSurfaceProperties (props), false);
@@ -277,6 +295,7 @@ namespace SkiaSharp
 		public SKCanvas Canvas =>
 			GetObject<SKCanvas> (SkiaApi.sk_surface_get_canvas (Handle), false);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use SurfaceProperties instead.")]
 		public SKSurfaceProps SurfaceProps {
 			get {

--- a/binding/Binding/SKSurfaceProperties.cs
+++ b/binding/Binding/SKSurfaceProperties.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
@@ -10,6 +11,7 @@ namespace SkiaSharp
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		public SKSurfaceProperties (SKSurfaceProps props)
 			: this (props.Flags, props.PixelGeometry)

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -1,15 +1,17 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace SkiaSharp
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Flags]
-	[Obsolete("Use SKFontStyleWeight and SKFontStyleSlant instead.")]
-	public enum SKTypefaceStyle {
-		Normal     = 0,
-		Bold       = 0x01,
-		Italic     = 0x02,
+	[Obsolete ("Use SKFontStyleWeight and SKFontStyleSlant instead.")]
+	public enum SKTypefaceStyle
+	{
+		Normal = 0,
+		Bold = 0x01,
+		Italic = 0x02,
 		BoldItalic = 0x03
 	}
 
@@ -44,6 +46,7 @@ namespace SkiaSharp
 			return GetObject<SKTypeface> (SkiaApi.sk_typeface_create_default ());
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FromFamilyName(string, SKFontStyleWeight, SKFontStyleWidth, SKFontStyleSlant) instead.")]
 		public static SKTypeface FromFamilyName (string familyName, SKTypefaceStyle style)
 		{
@@ -73,9 +76,10 @@ namespace SkiaSharp
 
 		public static SKTypeface FromFamilyName (string familyName, SKFontStyleWeight weight, SKFontStyleWidth width, SKFontStyleSlant slant)
 		{
-			return FromFamilyName(familyName, (int)weight, (int)width, slant);
+			return FromFamilyName (familyName, (int)weight, (int)width, slant);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		public static SKTypeface FromTypeface (SKTypeface typeface, SKTypefaceStyle style)
 		{
@@ -128,12 +132,14 @@ namespace SkiaSharp
 			return SKTypeface.FromStream (new SKMemoryStream (data), index);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GetGlyphs(string, out ushort[]) instead.")]
 		public int CharsToGlyphs (string chars, out ushort[] glyphs)
 			=> GetGlyphs (chars, out glyphs);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GetGlyphs(IntPtr, int, SKEncoding, out ushort[]) instead.")]
-		public int CharsToGlyphs (IntPtr str, int strlen, SKEncoding encoding, out ushort [] glyphs)
+		public int CharsToGlyphs (IntPtr str, int strlen, SKEncoding encoding, out ushort[] glyphs)
 			=> GetGlyphs (str, strlen, encoding, out glyphs);
 
 		public string FamilyName => (string)GetObject<SKString> (SkiaApi.sk_typeface_get_family_name (Handle));
@@ -152,6 +158,7 @@ namespace SkiaSharp
 
 		public bool IsFixedPitch => SkiaApi.sk_typeface_is_fixed_pitch (Handle);
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use FontWeight and FontSlant instead.")]
 		public SKTypefaceStyle Style {
 			get {
@@ -164,7 +171,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public int UnitsPerEm => SkiaApi.sk_typeface_get_units_per_em(Handle);
+		public int UnitsPerEm => SkiaApi.sk_typeface_get_units_per_em (Handle);
 
 		public int TableCount => SkiaApi.sk_typeface_count_tables (Handle);
 
@@ -252,9 +259,9 @@ namespace SkiaSharp
 			return SkiaApi.sk_typeface_chars_to_glyphs (Handle, (byte*)str, encoding, null, strLen);
 		}
 
-		public int GetGlyphs (string text, out ushort [] glyphs) => GetGlyphs (text, SKEncoding.Utf16, out glyphs);
+		public int GetGlyphs (string text, out ushort[] glyphs) => GetGlyphs (text, SKEncoding.Utf16, out glyphs);
 
-		public int GetGlyphs (string text, SKEncoding encoding, out ushort [] glyphs)
+		public int GetGlyphs (string text, SKEncoding encoding, out ushort[] glyphs)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -276,7 +283,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public int GetGlyphs (IntPtr text, int length, SKEncoding encoding, out ushort [] glyphs)
+		public int GetGlyphs (IntPtr text, int length, SKEncoding encoding, out ushort[] glyphs)
 		{
 			if (text == IntPtr.Zero && length != 0)
 				throw new ArgumentNullException (nameof (text));
@@ -294,9 +301,9 @@ namespace SkiaSharp
 			}
 		}
 
-		public ushort [] GetGlyphs (string text) => GetGlyphs (text, SKEncoding.Utf16);
+		public ushort[] GetGlyphs (string text) => GetGlyphs (text, SKEncoding.Utf16);
 
-		public ushort [] GetGlyphs (string text, SKEncoding encoding)
+		public ushort[] GetGlyphs (string text, SKEncoding encoding)
 		{
 			GetGlyphs (text, encoding, out var glyphs);
 			return glyphs;
@@ -311,7 +318,7 @@ namespace SkiaSharp
 			return glyphs;
 		}
 
-		public ushort [] GetGlyphs (IntPtr text, int length, SKEncoding encoding)
+		public ushort[] GetGlyphs (IntPtr text, int length, SKEncoding encoding)
 		{
 			GetGlyphs (text, length, encoding, out var glyphs);
 			return glyphs;

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -3603,817 +3603,1586 @@ namespace SkiaSharp
 
 	// gr_gl_framebufferinfo_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct GRGlFramebufferInfo {
+	public unsafe partial struct GRGlFramebufferInfo : IEquatable<GRGlFramebufferInfo> {
 		// public unsigned int fFBOID
 		private UInt32 fFBOID;
 		public UInt32 FramebufferObjectId {
-			get => fFBOID;
+			readonly get => fFBOID;
 			set => fFBOID = value;
 		}
 
 		// public unsigned int fFormat
 		private UInt32 fFormat;
 		public UInt32 Format {
-			get => fFormat;
+			readonly get => fFormat;
 			set => fFormat = value;
+		}
+
+		public bool Equals (GRGlFramebufferInfo obj) =>
+			fFBOID == obj.fFBOID && fFormat == obj.fFormat;
+
+		public override bool Equals (object obj) =>
+			obj is GRGlFramebufferInfo f && Equals (f);
+
+		public static bool operator == (GRGlFramebufferInfo left, GRGlFramebufferInfo right) =>
+			left.Equals (right);
+
+		public static bool operator != (GRGlFramebufferInfo left, GRGlFramebufferInfo right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fFBOID);
+			hash.Add (fFormat);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// gr_gl_textureinfo_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct GRGlTextureInfo {
+	public unsafe partial struct GRGlTextureInfo : IEquatable<GRGlTextureInfo> {
 		// public unsigned int fTarget
 		private UInt32 fTarget;
 		public UInt32 Target {
-			get => fTarget;
+			readonly get => fTarget;
 			set => fTarget = value;
 		}
 
 		// public unsigned int fID
 		private UInt32 fID;
 		public UInt32 Id {
-			get => fID;
+			readonly get => fID;
 			set => fID = value;
 		}
 
 		// public unsigned int fFormat
 		private UInt32 fFormat;
 		public UInt32 Format {
-			get => fFormat;
+			readonly get => fFormat;
 			set => fFormat = value;
+		}
+
+		public bool Equals (GRGlTextureInfo obj) =>
+			fTarget == obj.fTarget && fID == obj.fID && fFormat == obj.fFormat;
+
+		public override bool Equals (object obj) =>
+			obj is GRGlTextureInfo f && Equals (f);
+
+		public static bool operator == (GRGlTextureInfo left, GRGlTextureInfo right) =>
+			left.Equals (right);
+
+		public static bool operator != (GRGlTextureInfo left, GRGlTextureInfo right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fTarget);
+			hash.Add (fID);
+			hash.Add (fFormat);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_codec_frameinfo_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKCodecFrameInfo {
+	public unsafe partial struct SKCodecFrameInfo : IEquatable<SKCodecFrameInfo> {
 		// public int fRequiredFrame
 		private Int32 fRequiredFrame;
 		public Int32 RequiredFrame {
-			get => fRequiredFrame;
+			readonly get => fRequiredFrame;
 			set => fRequiredFrame = value;
 		}
 
 		// public int fDuration
 		private Int32 fDuration;
 		public Int32 Duration {
-			get => fDuration;
+			readonly get => fDuration;
 			set => fDuration = value;
 		}
 
 		// public bool fFullyReceived
 		private Byte fFullyReceived;
 		public bool FullyRecieved {
-			get => fFullyReceived > 0;
+			readonly get => fFullyReceived > 0;
 			set => fFullyReceived = value ? (byte)1 : (byte)0;
 		}
 
 		// public sk_alphatype_t fAlphaType
 		private SKAlphaType fAlphaType;
 		public SKAlphaType AlphaType {
-			get => fAlphaType;
+			readonly get => fAlphaType;
 			set => fAlphaType = value;
 		}
 
 		// public sk_codecanimation_disposalmethod_t fDisposalMethod
 		private SKCodecAnimationDisposalMethod fDisposalMethod;
 		public SKCodecAnimationDisposalMethod DisposalMethod {
-			get => fDisposalMethod;
+			readonly get => fDisposalMethod;
 			set => fDisposalMethod = value;
+		}
+
+		public bool Equals (SKCodecFrameInfo obj) =>
+			fRequiredFrame == obj.fRequiredFrame && fDuration == obj.fDuration && fFullyReceived == obj.fFullyReceived && fAlphaType == obj.fAlphaType && fDisposalMethod == obj.fDisposalMethod;
+
+		public override bool Equals (object obj) =>
+			obj is SKCodecFrameInfo f && Equals (f);
+
+		public static bool operator == (SKCodecFrameInfo left, SKCodecFrameInfo right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKCodecFrameInfo left, SKCodecFrameInfo right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fRequiredFrame);
+			hash.Add (fDuration);
+			hash.Add (fFullyReceived);
+			hash.Add (fAlphaType);
+			hash.Add (fDisposalMethod);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_codec_options_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKCodecOptionsInternal {
+	internal unsafe partial struct SKCodecOptionsInternal : IEquatable<SKCodecOptionsInternal> {
 		// public sk_codec_zero_initialized_t fZeroInitialized
 		public SKZeroInitialized fZeroInitialized;
+
 		// public sk_irect_t* fSubset
 		public SKRectI* fSubset;
+
 		// public int fFrameIndex
 		public Int32 fFrameIndex;
+
 		// public int fPriorFrame
 		public Int32 fPriorFrame;
+
 		// public sk_transfer_function_behavior_t fPremulBehavior
 		public SKTransferFunctionBehavior fPremulBehavior;
+
+		public bool Equals (SKCodecOptionsInternal obj) =>
+			fZeroInitialized == obj.fZeroInitialized && fSubset == obj.fSubset && fFrameIndex == obj.fFrameIndex && fPriorFrame == obj.fPriorFrame && fPremulBehavior == obj.fPremulBehavior;
+
+		public override bool Equals (object obj) =>
+			obj is SKCodecOptionsInternal f && Equals (f);
+
+		public static bool operator == (SKCodecOptionsInternal left, SKCodecOptionsInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKCodecOptionsInternal left, SKCodecOptionsInternal right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fZeroInitialized);
+			hash.Add (fSubset);
+			hash.Add (fFrameIndex);
+			hash.Add (fPriorFrame);
+			hash.Add (fPremulBehavior);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_color4f_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKColorF {
+	public readonly unsafe partial struct SKColorF : IEquatable<SKColorF> {
 		// public float fR
-		private Single fR;
-		public Single Red {
-			get => fR;
-			set => fR = value;
-		}
+		private readonly Single fR;
+		public readonly Single Red => fR;
 
 		// public float fG
-		private Single fG;
-		public Single Green {
-			get => fG;
-			set => fG = value;
-		}
+		private readonly Single fG;
+		public readonly Single Green => fG;
 
 		// public float fB
-		private Single fB;
-		public Single Blue {
-			get => fB;
-			set => fB = value;
-		}
+		private readonly Single fB;
+		public readonly Single Blue => fB;
 
 		// public float fA
-		private Single fA;
-		public Single Alpha {
-			get => fA;
-			set => fA = value;
+		private readonly Single fA;
+		public readonly Single Alpha => fA;
+
+		public bool Equals (SKColorF obj) =>
+			fR == obj.fR && fG == obj.fG && fB == obj.fB && fA == obj.fA;
+
+		public override bool Equals (object obj) =>
+			obj is SKColorF f && Equals (f);
+
+		public static bool operator == (SKColorF left, SKColorF right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKColorF left, SKColorF right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fR);
+			hash.Add (fG);
+			hash.Add (fB);
+			hash.Add (fA);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_colorspace_transfer_fn_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKColorSpaceTransferFn {
+	public unsafe partial struct SKColorSpaceTransferFn : IEquatable<SKColorSpaceTransferFn> {
 		// public float fG
 		private Single fG;
 		public Single G {
-			get => fG;
+			readonly get => fG;
 			set => fG = value;
 		}
 
 		// public float fA
 		private Single fA;
 		public Single A {
-			get => fA;
+			readonly get => fA;
 			set => fA = value;
 		}
 
 		// public float fB
 		private Single fB;
 		public Single B {
-			get => fB;
+			readonly get => fB;
 			set => fB = value;
 		}
 
 		// public float fC
 		private Single fC;
 		public Single C {
-			get => fC;
+			readonly get => fC;
 			set => fC = value;
 		}
 
 		// public float fD
 		private Single fD;
 		public Single D {
-			get => fD;
+			readonly get => fD;
 			set => fD = value;
 		}
 
 		// public float fE
 		private Single fE;
 		public Single E {
-			get => fE;
+			readonly get => fE;
 			set => fE = value;
 		}
 
 		// public float fF
 		private Single fF;
 		public Single F {
-			get => fF;
+			readonly get => fF;
 			set => fF = value;
+		}
+
+		public bool Equals (SKColorSpaceTransferFn obj) =>
+			fG == obj.fG && fA == obj.fA && fB == obj.fB && fC == obj.fC && fD == obj.fD && fE == obj.fE && fF == obj.fF;
+
+		public override bool Equals (object obj) =>
+			obj is SKColorSpaceTransferFn f && Equals (f);
+
+		public static bool operator == (SKColorSpaceTransferFn left, SKColorSpaceTransferFn right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKColorSpaceTransferFn left, SKColorSpaceTransferFn right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fG);
+			hash.Add (fA);
+			hash.Add (fB);
+			hash.Add (fC);
+			hash.Add (fD);
+			hash.Add (fE);
+			hash.Add (fF);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_colorspaceprimaries_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKColorSpacePrimaries {
+	public unsafe partial struct SKColorSpacePrimaries : IEquatable<SKColorSpacePrimaries> {
 		// public float fRX
 		private Single fRX;
 		public Single RX {
-			get => fRX;
+			readonly get => fRX;
 			set => fRX = value;
 		}
 
 		// public float fRY
 		private Single fRY;
 		public Single RY {
-			get => fRY;
+			readonly get => fRY;
 			set => fRY = value;
 		}
 
 		// public float fGX
 		private Single fGX;
 		public Single GX {
-			get => fGX;
+			readonly get => fGX;
 			set => fGX = value;
 		}
 
 		// public float fGY
 		private Single fGY;
 		public Single GY {
-			get => fGY;
+			readonly get => fGY;
 			set => fGY = value;
 		}
 
 		// public float fBX
 		private Single fBX;
 		public Single BX {
-			get => fBX;
+			readonly get => fBX;
 			set => fBX = value;
 		}
 
 		// public float fBY
 		private Single fBY;
 		public Single BY {
-			get => fBY;
+			readonly get => fBY;
 			set => fBY = value;
 		}
 
 		// public float fWX
 		private Single fWX;
 		public Single WX {
-			get => fWX;
+			readonly get => fWX;
 			set => fWX = value;
 		}
 
 		// public float fWY
 		private Single fWY;
 		public Single WY {
-			get => fWY;
+			readonly get => fWY;
 			set => fWY = value;
+		}
+
+		public bool Equals (SKColorSpacePrimaries obj) =>
+			fRX == obj.fRX && fRY == obj.fRY && fGX == obj.fGX && fGY == obj.fGY && fBX == obj.fBX && fBY == obj.fBY && fWX == obj.fWX && fWY == obj.fWY;
+
+		public override bool Equals (object obj) =>
+			obj is SKColorSpacePrimaries f && Equals (f);
+
+		public static bool operator == (SKColorSpacePrimaries left, SKColorSpacePrimaries right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKColorSpacePrimaries left, SKColorSpacePrimaries right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fRX);
+			hash.Add (fRY);
+			hash.Add (fGX);
+			hash.Add (fGY);
+			hash.Add (fBX);
+			hash.Add (fBY);
+			hash.Add (fWX);
+			hash.Add (fWY);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_document_pdf_metadata_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKDocumentPdfMetadataInternal {
+	internal unsafe partial struct SKDocumentPdfMetadataInternal : IEquatable<SKDocumentPdfMetadataInternal> {
 		// public sk_string_t* fTitle
 		public sk_string_t fTitle;
+
 		// public sk_string_t* fAuthor
 		public sk_string_t fAuthor;
+
 		// public sk_string_t* fSubject
 		public sk_string_t fSubject;
+
 		// public sk_string_t* fKeywords
 		public sk_string_t fKeywords;
+
 		// public sk_string_t* fCreator
 		public sk_string_t fCreator;
+
 		// public sk_string_t* fProducer
 		public sk_string_t fProducer;
+
 		// public sk_time_datetime_t* fCreation
 		public SKTimeDateTimeInternal* fCreation;
+
 		// public sk_time_datetime_t* fModified
 		public SKTimeDateTimeInternal* fModified;
+
 		// public float fRasterDPI
 		public Single fRasterDPI;
+
 		// public bool fPDFA
 		public Byte fPDFA;
+
 		// public int fEncodingQuality
 		public Int32 fEncodingQuality;
+
+		public bool Equals (SKDocumentPdfMetadataInternal obj) =>
+			fTitle == obj.fTitle && fAuthor == obj.fAuthor && fSubject == obj.fSubject && fKeywords == obj.fKeywords && fCreator == obj.fCreator && fProducer == obj.fProducer && fCreation == obj.fCreation && fModified == obj.fModified && fRasterDPI == obj.fRasterDPI && fPDFA == obj.fPDFA && fEncodingQuality == obj.fEncodingQuality;
+
+		public override bool Equals (object obj) =>
+			obj is SKDocumentPdfMetadataInternal f && Equals (f);
+
+		public static bool operator == (SKDocumentPdfMetadataInternal left, SKDocumentPdfMetadataInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKDocumentPdfMetadataInternal left, SKDocumentPdfMetadataInternal right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fTitle);
+			hash.Add (fAuthor);
+			hash.Add (fSubject);
+			hash.Add (fKeywords);
+			hash.Add (fCreator);
+			hash.Add (fProducer);
+			hash.Add (fCreation);
+			hash.Add (fModified);
+			hash.Add (fRasterDPI);
+			hash.Add (fPDFA);
+			hash.Add (fEncodingQuality);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_fontmetrics_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKFontMetrics {
+	public unsafe partial struct SKFontMetrics : IEquatable<SKFontMetrics> {
 		// public uint32_t fFlags
 		private UInt32 fFlags;
+
 		// public float fTop
 		private Single fTop;
+
 		// public float fAscent
 		private Single fAscent;
+
 		// public float fDescent
 		private Single fDescent;
+
 		// public float fBottom
 		private Single fBottom;
+
 		// public float fLeading
 		private Single fLeading;
+
 		// public float fAvgCharWidth
 		private Single fAvgCharWidth;
+
 		// public float fMaxCharWidth
 		private Single fMaxCharWidth;
+
 		// public float fXMin
 		private Single fXMin;
+
 		// public float fXMax
 		private Single fXMax;
+
 		// public float fXHeight
 		private Single fXHeight;
+
 		// public float fCapHeight
 		private Single fCapHeight;
+
 		// public float fUnderlineThickness
 		private Single fUnderlineThickness;
+
 		// public float fUnderlinePosition
 		private Single fUnderlinePosition;
+
 		// public float fStrikeoutThickness
 		private Single fStrikeoutThickness;
+
 		// public float fStrikeoutPosition
 		private Single fStrikeoutPosition;
+
+		public bool Equals (SKFontMetrics obj) =>
+			fFlags == obj.fFlags && fTop == obj.fTop && fAscent == obj.fAscent && fDescent == obj.fDescent && fBottom == obj.fBottom && fLeading == obj.fLeading && fAvgCharWidth == obj.fAvgCharWidth && fMaxCharWidth == obj.fMaxCharWidth && fXMin == obj.fXMin && fXMax == obj.fXMax && fXHeight == obj.fXHeight && fCapHeight == obj.fCapHeight && fUnderlineThickness == obj.fUnderlineThickness && fUnderlinePosition == obj.fUnderlinePosition && fStrikeoutThickness == obj.fStrikeoutThickness && fStrikeoutPosition == obj.fStrikeoutPosition;
+
+		public override bool Equals (object obj) =>
+			obj is SKFontMetrics f && Equals (f);
+
+		public static bool operator == (SKFontMetrics left, SKFontMetrics right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKFontMetrics left, SKFontMetrics right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fFlags);
+			hash.Add (fTop);
+			hash.Add (fAscent);
+			hash.Add (fDescent);
+			hash.Add (fBottom);
+			hash.Add (fLeading);
+			hash.Add (fAvgCharWidth);
+			hash.Add (fMaxCharWidth);
+			hash.Add (fXMin);
+			hash.Add (fXMax);
+			hash.Add (fXHeight);
+			hash.Add (fCapHeight);
+			hash.Add (fUnderlineThickness);
+			hash.Add (fUnderlinePosition);
+			hash.Add (fStrikeoutThickness);
+			hash.Add (fStrikeoutPosition);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_highcontrastconfig_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKHighContrastConfig {
+	public unsafe partial struct SKHighContrastConfig : IEquatable<SKHighContrastConfig> {
 		// public bool fGrayscale
 		private Byte fGrayscale;
 		public bool Grayscale {
-			get => fGrayscale > 0;
+			readonly get => fGrayscale > 0;
 			set => fGrayscale = value ? (byte)1 : (byte)0;
 		}
 
 		// public sk_highcontrastconfig_invertstyle_t fInvertStyle
 		private SKHighContrastConfigInvertStyle fInvertStyle;
 		public SKHighContrastConfigInvertStyle InvertStyle {
-			get => fInvertStyle;
+			readonly get => fInvertStyle;
 			set => fInvertStyle = value;
 		}
 
 		// public float fContrast
 		private Single fContrast;
 		public Single Contrast {
-			get => fContrast;
+			readonly get => fContrast;
 			set => fContrast = value;
+		}
+
+		public bool Equals (SKHighContrastConfig obj) =>
+			fGrayscale == obj.fGrayscale && fInvertStyle == obj.fInvertStyle && fContrast == obj.fContrast;
+
+		public override bool Equals (object obj) =>
+			obj is SKHighContrastConfig f && Equals (f);
+
+		public static bool operator == (SKHighContrastConfig left, SKHighContrastConfig right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKHighContrastConfig left, SKHighContrastConfig right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fGrayscale);
+			hash.Add (fInvertStyle);
+			hash.Add (fContrast);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_imageinfo_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKImageInfoNative {
+	internal unsafe partial struct SKImageInfoNative : IEquatable<SKImageInfoNative> {
 		// public sk_colorspace_t* colorspace
 		public sk_colorspace_t colorspace;
+
 		// public int32_t width
 		public Int32 width;
+
 		// public int32_t height
 		public Int32 height;
+
 		// public sk_colortype_t colorType
 		public SKColorType colorType;
+
 		// public sk_alphatype_t alphaType
 		public SKAlphaType alphaType;
+
+		public bool Equals (SKImageInfoNative obj) =>
+			colorspace == obj.colorspace && width == obj.width && height == obj.height && colorType == obj.colorType && alphaType == obj.alphaType;
+
+		public override bool Equals (object obj) =>
+			obj is SKImageInfoNative f && Equals (f);
+
+		public static bool operator == (SKImageInfoNative left, SKImageInfoNative right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKImageInfoNative left, SKImageInfoNative right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (colorspace);
+			hash.Add (width);
+			hash.Add (height);
+			hash.Add (colorType);
+			hash.Add (alphaType);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_ipoint_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKPointI {
+	public unsafe partial struct SKPointI : IEquatable<SKPointI> {
 		// public int32_t x
 		private Int32 x;
 		public Int32 X {
-			get => x;
+			readonly get => x;
 			set => x = value;
 		}
 
 		// public int32_t y
 		private Int32 y;
 		public Int32 Y {
-			get => y;
+			readonly get => y;
 			set => y = value;
+		}
+
+		public bool Equals (SKPointI obj) =>
+			x == obj.x && y == obj.y;
+
+		public override bool Equals (object obj) =>
+			obj is SKPointI f && Equals (f);
+
+		public static bool operator == (SKPointI left, SKPointI right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPointI left, SKPointI right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (x);
+			hash.Add (y);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_irect_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKRectI {
+	public unsafe partial struct SKRectI : IEquatable<SKRectI> {
 		// public int32_t left
 		private Int32 left;
 		public Int32 Left {
-			get => left;
+			readonly get => left;
 			set => left = value;
 		}
 
 		// public int32_t top
 		private Int32 top;
 		public Int32 Top {
-			get => top;
+			readonly get => top;
 			set => top = value;
 		}
 
 		// public int32_t right
 		private Int32 right;
 		public Int32 Right {
-			get => right;
+			readonly get => right;
 			set => right = value;
 		}
 
 		// public int32_t bottom
 		private Int32 bottom;
 		public Int32 Bottom {
-			get => bottom;
+			readonly get => bottom;
 			set => bottom = value;
+		}
+
+		public bool Equals (SKRectI obj) =>
+			left == obj.left && top == obj.top && right == obj.right && bottom == obj.bottom;
+
+		public override bool Equals (object obj) =>
+			obj is SKRectI f && Equals (f);
+
+		public static bool operator == (SKRectI left, SKRectI right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKRectI left, SKRectI right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (left);
+			hash.Add (top);
+			hash.Add (right);
+			hash.Add (bottom);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_isize_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKSizeI {
+	public unsafe partial struct SKSizeI : IEquatable<SKSizeI> {
 		// public int32_t w
 		private Int32 w;
 		public Int32 Width {
-			get => w;
+			readonly get => w;
 			set => w = value;
 		}
 
 		// public int32_t h
 		private Int32 h;
 		public Int32 Height {
-			get => h;
+			readonly get => h;
 			set => h = value;
+		}
+
+		public bool Equals (SKSizeI obj) =>
+			w == obj.w && h == obj.h;
+
+		public override bool Equals (object obj) =>
+			obj is SKSizeI f && Equals (f);
+
+		public static bool operator == (SKSizeI left, SKSizeI right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKSizeI left, SKSizeI right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (w);
+			hash.Add (h);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_jpegencoder_options_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKJpegEncoderOptions {
+	public unsafe partial struct SKJpegEncoderOptions : IEquatable<SKJpegEncoderOptions> {
 		// public int fQuality
 		private Int32 fQuality;
 		public Int32 Quality {
-			get => fQuality;
+			readonly get => fQuality;
 			set => fQuality = value;
 		}
 
 		// public sk_jpegencoder_downsample_t fDownsample
 		private SKJpegEncoderDownsample fDownsample;
 		public SKJpegEncoderDownsample Downsample {
-			get => fDownsample;
+			readonly get => fDownsample;
 			set => fDownsample = value;
 		}
 
 		// public sk_jpegencoder_alphaoption_t fAlphaOption
 		private SKJpegEncoderAlphaOption fAlphaOption;
 		public SKJpegEncoderAlphaOption AlphaOption {
-			get => fAlphaOption;
+			readonly get => fAlphaOption;
 			set => fAlphaOption = value;
 		}
 
 		// public sk_transfer_function_behavior_t fBlendBehavior
 		private SKTransferFunctionBehavior fBlendBehavior;
 		public SKTransferFunctionBehavior BlendBehavior {
-			get => fBlendBehavior;
+			readonly get => fBlendBehavior;
 			set => fBlendBehavior = value;
+		}
+
+		public bool Equals (SKJpegEncoderOptions obj) =>
+			fQuality == obj.fQuality && fDownsample == obj.fDownsample && fAlphaOption == obj.fAlphaOption && fBlendBehavior == obj.fBlendBehavior;
+
+		public override bool Equals (object obj) =>
+			obj is SKJpegEncoderOptions f && Equals (f);
+
+		public static bool operator == (SKJpegEncoderOptions left, SKJpegEncoderOptions right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKJpegEncoderOptions left, SKJpegEncoderOptions right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fQuality);
+			hash.Add (fDownsample);
+			hash.Add (fAlphaOption);
+			hash.Add (fBlendBehavior);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_lattice_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKLatticeInternal {
+	internal unsafe partial struct SKLatticeInternal : IEquatable<SKLatticeInternal> {
 		// public const int* fXDivs
 		public Int32* fXDivs;
+
 		// public const int* fYDivs
 		public Int32* fYDivs;
+
 		// public const sk_lattice_recttype_t* fRectTypes
 		public SKLatticeRectType* fRectTypes;
+
 		// public int fXCount
 		public Int32 fXCount;
+
 		// public int fYCount
 		public Int32 fYCount;
+
 		// public const sk_irect_t* fBounds
 		public SKRectI* fBounds;
+
 		// public const sk_color_t* fColors
 		public UInt32* fColors;
+
+		public bool Equals (SKLatticeInternal obj) =>
+			fXDivs == obj.fXDivs && fYDivs == obj.fYDivs && fRectTypes == obj.fRectTypes && fXCount == obj.fXCount && fYCount == obj.fYCount && fBounds == obj.fBounds && fColors == obj.fColors;
+
+		public override bool Equals (object obj) =>
+			obj is SKLatticeInternal f && Equals (f);
+
+		public static bool operator == (SKLatticeInternal left, SKLatticeInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKLatticeInternal left, SKLatticeInternal right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fXDivs);
+			hash.Add (fYDivs);
+			hash.Add (fRectTypes);
+			hash.Add (fXCount);
+			hash.Add (fYCount);
+			hash.Add (fBounds);
+			hash.Add (fColors);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_manageddrawable_procs_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKManagedDrawableDelegates {
+	internal unsafe partial struct SKManagedDrawableDelegates : IEquatable<SKManagedDrawableDelegates> {
 		// public sk_manageddrawable_draw_proc fDraw
 		public SKManagedDrawableDrawProxyDelegate fDraw;
+
 		// public sk_manageddrawable_getBounds_proc fGetBounds
 		public SKManagedDrawableGetBoundsProxyDelegate fGetBounds;
+
 		// public sk_manageddrawable_newPictureSnapshot_proc fNewPictureSnapshot
 		public SKManagedDrawableNewPictureSnapshotProxyDelegate fNewPictureSnapshot;
+
 		// public sk_manageddrawable_destroy_proc fDestroy
 		public SKManagedDrawableDestroyProxyDelegate fDestroy;
+
+		public bool Equals (SKManagedDrawableDelegates obj) =>
+			fDraw == obj.fDraw && fGetBounds == obj.fGetBounds && fNewPictureSnapshot == obj.fNewPictureSnapshot && fDestroy == obj.fDestroy;
+
+		public override bool Equals (object obj) =>
+			obj is SKManagedDrawableDelegates f && Equals (f);
+
+		public static bool operator == (SKManagedDrawableDelegates left, SKManagedDrawableDelegates right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKManagedDrawableDelegates left, SKManagedDrawableDelegates right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fDraw);
+			hash.Add (fGetBounds);
+			hash.Add (fNewPictureSnapshot);
+			hash.Add (fDestroy);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_managedstream_procs_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKManagedStreamDelegates {
+	internal unsafe partial struct SKManagedStreamDelegates : IEquatable<SKManagedStreamDelegates> {
 		// public sk_managedstream_read_proc fRead
 		public SKManagedStreamReadProxyDelegate fRead;
+
 		// public sk_managedstream_peek_proc fPeek
 		public SKManagedStreamPeekProxyDelegate fPeek;
+
 		// public sk_managedstream_isAtEnd_proc fIsAtEnd
 		public SKManagedStreamIsAtEndProxyDelegate fIsAtEnd;
+
 		// public sk_managedstream_hasPosition_proc fHasPosition
 		public SKManagedStreamHasPositionProxyDelegate fHasPosition;
+
 		// public sk_managedstream_hasLength_proc fHasLength
 		public SKManagedStreamHasLengthProxyDelegate fHasLength;
+
 		// public sk_managedstream_rewind_proc fRewind
 		public SKManagedStreamRewindProxyDelegate fRewind;
+
 		// public sk_managedstream_getPosition_proc fGetPosition
 		public SKManagedStreamGetPositionProxyDelegate fGetPosition;
+
 		// public sk_managedstream_seek_proc fSeek
 		public SKManagedStreamSeekProxyDelegate fSeek;
+
 		// public sk_managedstream_move_proc fMove
 		public SKManagedStreamMoveProxyDelegate fMove;
+
 		// public sk_managedstream_getLength_proc fGetLength
 		public SKManagedStreamGetLengthProxyDelegate fGetLength;
+
 		// public sk_managedstream_duplicate_proc fDuplicate
 		public SKManagedStreamDuplicateProxyDelegate fDuplicate;
+
 		// public sk_managedstream_fork_proc fFork
 		public SKManagedStreamForkProxyDelegate fFork;
+
 		// public sk_managedstream_destroy_proc fDestroy
 		public SKManagedStreamDestroyProxyDelegate fDestroy;
+
+		public bool Equals (SKManagedStreamDelegates obj) =>
+			fRead == obj.fRead && fPeek == obj.fPeek && fIsAtEnd == obj.fIsAtEnd && fHasPosition == obj.fHasPosition && fHasLength == obj.fHasLength && fRewind == obj.fRewind && fGetPosition == obj.fGetPosition && fSeek == obj.fSeek && fMove == obj.fMove && fGetLength == obj.fGetLength && fDuplicate == obj.fDuplicate && fFork == obj.fFork && fDestroy == obj.fDestroy;
+
+		public override bool Equals (object obj) =>
+			obj is SKManagedStreamDelegates f && Equals (f);
+
+		public static bool operator == (SKManagedStreamDelegates left, SKManagedStreamDelegates right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKManagedStreamDelegates left, SKManagedStreamDelegates right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fRead);
+			hash.Add (fPeek);
+			hash.Add (fIsAtEnd);
+			hash.Add (fHasPosition);
+			hash.Add (fHasLength);
+			hash.Add (fRewind);
+			hash.Add (fGetPosition);
+			hash.Add (fSeek);
+			hash.Add (fMove);
+			hash.Add (fGetLength);
+			hash.Add (fDuplicate);
+			hash.Add (fFork);
+			hash.Add (fDestroy);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_managedwstream_procs_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKManagedWStreamDelegates {
+	internal unsafe partial struct SKManagedWStreamDelegates : IEquatable<SKManagedWStreamDelegates> {
 		// public sk_managedwstream_write_proc fWrite
 		public SKManagedWStreamWriteProxyDelegate fWrite;
+
 		// public sk_managedwstream_flush_proc fFlush
 		public SKManagedWStreamFlushProxyDelegate fFlush;
+
 		// public sk_managedwstream_bytesWritten_proc fBytesWritten
 		public SKManagedWStreamBytesWrittenProxyDelegate fBytesWritten;
+
 		// public sk_managedwstream_destroy_proc fDestroy
 		public SKManagedWStreamDestroyProxyDelegate fDestroy;
+
+		public bool Equals (SKManagedWStreamDelegates obj) =>
+			fWrite == obj.fWrite && fFlush == obj.fFlush && fBytesWritten == obj.fBytesWritten && fDestroy == obj.fDestroy;
+
+		public override bool Equals (object obj) =>
+			obj is SKManagedWStreamDelegates f && Equals (f);
+
+		public static bool operator == (SKManagedWStreamDelegates left, SKManagedWStreamDelegates right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKManagedWStreamDelegates left, SKManagedWStreamDelegates right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fWrite);
+			hash.Add (fFlush);
+			hash.Add (fBytesWritten);
+			hash.Add (fDestroy);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_mask_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKMask {
+	public unsafe partial struct SKMask : IEquatable<SKMask> {
 		// public uint8_t* fImage
 		private Byte* fImage;
+
 		// public sk_irect_t fBounds
 		private SKRectI fBounds;
+
 		// public uint32_t fRowBytes
 		private UInt32 fRowBytes;
+
 		// public sk_mask_format_t fFormat
 		private SKMaskFormat fFormat;
+
+		public bool Equals (SKMask obj) =>
+			fImage == obj.fImage && fBounds == obj.fBounds && fRowBytes == obj.fRowBytes && fFormat == obj.fFormat;
+
+		public override bool Equals (object obj) =>
+			obj is SKMask f && Equals (f);
+
+		public static bool operator == (SKMask left, SKMask right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKMask left, SKMask right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fImage);
+			hash.Add (fBounds);
+			hash.Add (fRowBytes);
+			hash.Add (fFormat);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_matrix_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKMatrix {
+	public unsafe partial struct SKMatrix : IEquatable<SKMatrix> {
 		// public float scaleX
 		private Single scaleX;
 		public Single ScaleX {
-			get => scaleX;
+			readonly get => scaleX;
 			set => scaleX = value;
 		}
 
 		// public float skewX
 		private Single skewX;
 		public Single SkewX {
-			get => skewX;
+			readonly get => skewX;
 			set => skewX = value;
 		}
 
 		// public float transX
 		private Single transX;
 		public Single TransX {
-			get => transX;
+			readonly get => transX;
 			set => transX = value;
 		}
 
 		// public float skewY
 		private Single skewY;
 		public Single SkewY {
-			get => skewY;
+			readonly get => skewY;
 			set => skewY = value;
 		}
 
 		// public float scaleY
 		private Single scaleY;
 		public Single ScaleY {
-			get => scaleY;
+			readonly get => scaleY;
 			set => scaleY = value;
 		}
 
 		// public float transY
 		private Single transY;
 		public Single TransY {
-			get => transY;
+			readonly get => transY;
 			set => transY = value;
 		}
 
 		// public float persp0
 		private Single persp0;
 		public Single Persp0 {
-			get => persp0;
+			readonly get => persp0;
 			set => persp0 = value;
 		}
 
 		// public float persp1
 		private Single persp1;
 		public Single Persp1 {
-			get => persp1;
+			readonly get => persp1;
 			set => persp1 = value;
 		}
 
 		// public float persp2
 		private Single persp2;
 		public Single Persp2 {
-			get => persp2;
+			readonly get => persp2;
 			set => persp2 = value;
+		}
+
+		public bool Equals (SKMatrix obj) =>
+			scaleX == obj.scaleX && skewX == obj.skewX && transX == obj.transX && skewY == obj.skewY && scaleY == obj.scaleY && transY == obj.transY && persp0 == obj.persp0 && persp1 == obj.persp1 && persp2 == obj.persp2;
+
+		public override bool Equals (object obj) =>
+			obj is SKMatrix f && Equals (f);
+
+		public static bool operator == (SKMatrix left, SKMatrix right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKMatrix left, SKMatrix right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (scaleX);
+			hash.Add (skewX);
+			hash.Add (transX);
+			hash.Add (skewY);
+			hash.Add (scaleY);
+			hash.Add (transY);
+			hash.Add (persp0);
+			hash.Add (persp1);
+			hash.Add (persp2);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_pngencoder_options_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKPngEncoderOptions {
+	public unsafe partial struct SKPngEncoderOptions : IEquatable<SKPngEncoderOptions> {
 		// public sk_pngencoder_filterflags_t fFilterFlags
 		private SKPngEncoderFilterFlags fFilterFlags;
+
 		// public int fZLibLevel
 		private Int32 fZLibLevel;
+
 		// public sk_transfer_function_behavior_t fUnpremulBehavior
 		private SKTransferFunctionBehavior fUnpremulBehavior;
+
 		// public void* fComments
 		private void* fComments;
+
+		public bool Equals (SKPngEncoderOptions obj) =>
+			fFilterFlags == obj.fFilterFlags && fZLibLevel == obj.fZLibLevel && fUnpremulBehavior == obj.fUnpremulBehavior && fComments == obj.fComments;
+
+		public override bool Equals (object obj) =>
+			obj is SKPngEncoderOptions f && Equals (f);
+
+		public static bool operator == (SKPngEncoderOptions left, SKPngEncoderOptions right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPngEncoderOptions left, SKPngEncoderOptions right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fFilterFlags);
+			hash.Add (fZLibLevel);
+			hash.Add (fUnpremulBehavior);
+			hash.Add (fComments);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_point_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKPoint {
+	public unsafe partial struct SKPoint : IEquatable<SKPoint> {
 		// public float x
 		private Single x;
 		public Single X {
-			get => x;
+			readonly get => x;
 			set => x = value;
 		}
 
 		// public float y
 		private Single y;
 		public Single Y {
-			get => y;
+			readonly get => y;
 			set => y = value;
+		}
+
+		public bool Equals (SKPoint obj) =>
+			x == obj.x && y == obj.y;
+
+		public override bool Equals (object obj) =>
+			obj is SKPoint f && Equals (f);
+
+		public static bool operator == (SKPoint left, SKPoint right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPoint left, SKPoint right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (x);
+			hash.Add (y);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_point3_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKPoint3 {
+	public unsafe partial struct SKPoint3 : IEquatable<SKPoint3> {
 		// public float x
 		private Single x;
 		public Single X {
-			get => x;
+			readonly get => x;
 			set => x = value;
 		}
 
 		// public float y
 		private Single y;
 		public Single Y {
-			get => y;
+			readonly get => y;
 			set => y = value;
 		}
 
 		// public float z
 		private Single z;
 		public Single Z {
-			get => z;
+			readonly get => z;
 			set => z = value;
+		}
+
+		public bool Equals (SKPoint3 obj) =>
+			x == obj.x && y == obj.y && z == obj.z;
+
+		public override bool Equals (object obj) =>
+			obj is SKPoint3 f && Equals (f);
+
+		public static bool operator == (SKPoint3 left, SKPoint3 right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPoint3 left, SKPoint3 right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (x);
+			hash.Add (y);
+			hash.Add (z);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_rect_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKRect {
+	public unsafe partial struct SKRect : IEquatable<SKRect> {
 		// public float left
 		private Single left;
 		public Single Left {
-			get => left;
+			readonly get => left;
 			set => left = value;
 		}
 
 		// public float top
 		private Single top;
 		public Single Top {
-			get => top;
+			readonly get => top;
 			set => top = value;
 		}
 
 		// public float right
 		private Single right;
 		public Single Right {
-			get => right;
+			readonly get => right;
 			set => right = value;
 		}
 
 		// public float bottom
 		private Single bottom;
 		public Single Bottom {
-			get => bottom;
+			readonly get => bottom;
 			set => bottom = value;
+		}
+
+		public bool Equals (SKRect obj) =>
+			left == obj.left && top == obj.top && right == obj.right && bottom == obj.bottom;
+
+		public override bool Equals (object obj) =>
+			obj is SKRect f && Equals (f);
+
+		public static bool operator == (SKRect left, SKRect right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKRect left, SKRect right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (left);
+			hash.Add (top);
+			hash.Add (right);
+			hash.Add (bottom);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_rsxform_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKRotationScaleMatrix {
+	public unsafe partial struct SKRotationScaleMatrix : IEquatable<SKRotationScaleMatrix> {
 		// public float fSCos
 		private Single fSCos;
 		public Single SCos {
-			get => fSCos;
+			readonly get => fSCos;
 			set => fSCos = value;
 		}
 
 		// public float fSSin
 		private Single fSSin;
 		public Single SSin {
-			get => fSSin;
+			readonly get => fSSin;
 			set => fSSin = value;
 		}
 
 		// public float fTX
 		private Single fTX;
 		public Single TX {
-			get => fTX;
+			readonly get => fTX;
 			set => fTX = value;
 		}
 
 		// public float fTY
 		private Single fTY;
 		public Single TY {
-			get => fTY;
+			readonly get => fTY;
 			set => fTY = value;
+		}
+
+		public bool Equals (SKRotationScaleMatrix obj) =>
+			fSCos == obj.fSCos && fSSin == obj.fSSin && fTX == obj.fTX && fTY == obj.fTY;
+
+		public override bool Equals (object obj) =>
+			obj is SKRotationScaleMatrix f && Equals (f);
+
+		public static bool operator == (SKRotationScaleMatrix left, SKRotationScaleMatrix right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKRotationScaleMatrix left, SKRotationScaleMatrix right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fSCos);
+			hash.Add (fSSin);
+			hash.Add (fTX);
+			hash.Add (fTY);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_size_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKSize {
+	public unsafe partial struct SKSize : IEquatable<SKSize> {
 		// public float w
 		private Single w;
 		public Single Width {
-			get => w;
+			readonly get => w;
 			set => w = value;
 		}
 
 		// public float h
 		private Single h;
 		public Single Height {
-			get => h;
+			readonly get => h;
 			set => h = value;
+		}
+
+		public bool Equals (SKSize obj) =>
+			w == obj.w && h == obj.h;
+
+		public override bool Equals (object obj) =>
+			obj is SKSize f && Equals (f);
+
+		public static bool operator == (SKSize left, SKSize right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKSize left, SKSize right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (w);
+			hash.Add (h);
+			return hash.ToHashCode ();
 		}
 
 	}
 
 	// sk_textblob_builder_runbuffer_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKRunBufferInternal {
+	internal unsafe partial struct SKRunBufferInternal : IEquatable<SKRunBufferInternal> {
 		// public void* glyphs
 		public void* glyphs;
+
 		// public void* pos
 		public void* pos;
+
 		// public void* utf8text
 		public void* utf8text;
+
 		// public void* clusters
 		public void* clusters;
+
+		public bool Equals (SKRunBufferInternal obj) =>
+			glyphs == obj.glyphs && pos == obj.pos && utf8text == obj.utf8text && clusters == obj.clusters;
+
+		public override bool Equals (object obj) =>
+			obj is SKRunBufferInternal f && Equals (f);
+
+		public static bool operator == (SKRunBufferInternal left, SKRunBufferInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKRunBufferInternal left, SKRunBufferInternal right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (glyphs);
+			hash.Add (pos);
+			hash.Add (utf8text);
+			hash.Add (clusters);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_time_datetime_t
 	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKTimeDateTimeInternal {
+	internal unsafe partial struct SKTimeDateTimeInternal : IEquatable<SKTimeDateTimeInternal> {
 		// public int16_t fTimeZoneMinutes
 		public Int16 fTimeZoneMinutes;
+
 		// public uint16_t fYear
 		public UInt16 fYear;
+
 		// public uint8_t fMonth
 		public Byte fMonth;
+
 		// public uint8_t fDayOfWeek
 		public Byte fDayOfWeek;
+
 		// public uint8_t fDay
 		public Byte fDay;
+
 		// public uint8_t fHour
 		public Byte fHour;
+
 		// public uint8_t fMinute
 		public Byte fMinute;
+
 		// public uint8_t fSecond
 		public Byte fSecond;
+
+		public bool Equals (SKTimeDateTimeInternal obj) =>
+			fTimeZoneMinutes == obj.fTimeZoneMinutes && fYear == obj.fYear && fMonth == obj.fMonth && fDayOfWeek == obj.fDayOfWeek && fDay == obj.fDay && fHour == obj.fHour && fMinute == obj.fMinute && fSecond == obj.fSecond;
+
+		public override bool Equals (object obj) =>
+			obj is SKTimeDateTimeInternal f && Equals (f);
+
+		public static bool operator == (SKTimeDateTimeInternal left, SKTimeDateTimeInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKTimeDateTimeInternal left, SKTimeDateTimeInternal right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fTimeZoneMinutes);
+			hash.Add (fYear);
+			hash.Add (fMonth);
+			hash.Add (fDayOfWeek);
+			hash.Add (fDay);
+			hash.Add (fHour);
+			hash.Add (fMinute);
+			hash.Add (fSecond);
+			return hash.ToHashCode ();
+		}
+
 	}
 
 	// sk_webpencoder_options_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKWebpEncoderOptions {
+	public unsafe partial struct SKWebpEncoderOptions : IEquatable<SKWebpEncoderOptions> {
 		// public sk_webpencoder_compression_t fCompression
 		private SKWebpEncoderCompression fCompression;
 		public SKWebpEncoderCompression Compression {
-			get => fCompression;
+			readonly get => fCompression;
 			set => fCompression = value;
 		}
 
 		// public float fQuality
 		private Single fQuality;
 		public Single Quality {
-			get => fQuality;
+			readonly get => fQuality;
 			set => fQuality = value;
 		}
 
 		// public sk_transfer_function_behavior_t fUnpremulBehavior
 		private SKTransferFunctionBehavior fUnpremulBehavior;
 		public SKTransferFunctionBehavior UnpremulBehavior {
-			get => fUnpremulBehavior;
+			readonly get => fUnpremulBehavior;
 			set => fUnpremulBehavior = value;
+		}
+
+		public bool Equals (SKWebpEncoderOptions obj) =>
+			fCompression == obj.fCompression && fQuality == obj.fQuality && fUnpremulBehavior == obj.fUnpremulBehavior;
+
+		public override bool Equals (object obj) =>
+			obj is SKWebpEncoderOptions f && Equals (f);
+
+		public static bool operator == (SKWebpEncoderOptions left, SKWebpEncoderOptions right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKWebpEncoderOptions left, SKWebpEncoderOptions right) =>
+			!left.Equals (right);
+
+		public override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fCompression);
+			hash.Add (fQuality);
+			hash.Add (fUnpremulBehavior);
+			return hash.ToHashCode ();
 		}
 
 	}

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -50,6 +50,7 @@
       },
       "sk_color4f_t": {
         "cs": "SKColorF",
+        "readonly": true,
         "members": {
           "fR": "Red",
           "fG": "Green",

--- a/tests/Tests/SKColorTest.cs
+++ b/tests/Tests/SKColorTest.cs
@@ -229,6 +229,15 @@ namespace SkiaSharp.Tests
 			Assert.Equal(color, paint.Color);
 		}
 
+		[SkippableFact]
+		public void GetHashCodeIsConsistent()
+		{
+			var color1 = new SKColor(100, 0, 0, 100);
+			var color2 = new SKColor(100, 0, 0, 100);
+
+			Assert.Equal(color1.GetHashCode(), color2.GetHashCode());
+		}
+
 		[Obsolete]
 		[SkippableFact]
 		public void CanPreMultiplyArrays()

--- a/utils/SkiaSharpGenerator/Generate/TypeMapping.cs
+++ b/utils/SkiaSharpGenerator/Generate/TypeMapping.cs
@@ -17,6 +17,12 @@ namespace SkiaSharpGenerator
 		[JsonPropertyName("properties")]
 		public bool GenerateProperties { get; set; } = true;
 
+		[JsonPropertyName("readonly")]
+		public bool IsReadOnly { get; set; } = false;
+
+		[JsonPropertyName("equality")]
+		public bool GenerateEquality { get; set; } = true;
+
 		[JsonPropertyName("members")]
 		public Dictionary<string, string> Members { get; set; } = new Dictionary<string, string>();
 	}


### PR DESCRIPTION
**Description of Change**

Generator:
 - make getters readonly
 - implement IEquatable<T>

Managed API:
 - mark obsolete members as invisible to the editor
 - make struct getters readonly
 - implement struct equality/hashcodes
 - SKColor calculations use the SKColorF implementations
 - some whitespace fixes to conform to styles
 - split SKPMColor out into a new file

**Bugs Fixed**

None.

**API Changes**

All public structs (excluding obsolete ones) are now implementing IEquatable<T> and have overrides for the Equals and GetHashCode members.

**Behavioral Changes**

None visible.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
