### PR TITLE
More Improvements

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -15,6 +15,7 @@ OpenTK.GLControl                                release     3.0.1
 MSBuild.Sdk.Extras                              release     1.6.65
 Cake                                            release     0.35.0
 GtkSharp                                        release     3.22.24.37
+GdkSharp                                        release     3.22.24.37
 GLibSharp                                       release     3.22.24.37
 AtkSharp                                        release     3.22.24.37
 System.Memory                                   release     4.5.3

--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -62,10 +62,31 @@ namespace SkiaSharp
 
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use SKSurfaceProperties instead.")]
-	public struct SKSurfaceProps
+	public struct SKSurfaceProps : IEquatable<SKSurfaceProps>
 	{
 		public SKPixelGeometry PixelGeometry { get; set; }
 		public SKSurfacePropsFlags Flags { get; set; }
+
+		public readonly bool Equals (SKSurfaceProps obj) =>
+			PixelGeometry == obj.PixelGeometry &&
+			Flags == obj.Flags;
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKSurfaceProps f && Equals (f);
+
+		public static bool operator == (SKSurfaceProps left, SKSurfaceProps right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKSurfaceProps left, SKSurfaceProps right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (PixelGeometry);
+			hash.Add (Flags);
+			return hash.ToHashCode ();
+		}
 	}
 
 	public struct SKCodecOptions : IEquatable<SKCodecOptions>

--- a/binding/Binding/Definitions.cs
+++ b/binding/Binding/Definitions.cs
@@ -120,19 +120,19 @@ namespace SkiaSharp
 
 		public SKZeroInitialized ZeroInitialized { get; set; }
 		public SKRectI? Subset { get; set; }
-		public bool HasSubset => Subset != null;
+		public readonly bool HasSubset => Subset != null;
 		public int FrameIndex { get; set; }
 		public int PriorFrame { get; set; }
 		public SKTransferFunctionBehavior PremulBehavior { get; set; }
 
-		public bool Equals (SKCodecOptions obj) =>
+		public readonly bool Equals (SKCodecOptions obj) =>
 			ZeroInitialized == obj.ZeroInitialized &&
 			Subset == obj.Subset &&
 			FrameIndex == obj.FrameIndex &&
 			PriorFrame == obj.PriorFrame &&
 			PremulBehavior == obj.PremulBehavior;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKCodecOptions f && Equals (f);
 
 		public static bool operator == (SKCodecOptions left, SKCodecOptions right) =>
@@ -141,7 +141,7 @@ namespace SkiaSharp
 		public static bool operator != (SKCodecOptions left, SKCodecOptions right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (ZeroInitialized);
@@ -199,14 +199,14 @@ namespace SkiaSharp
 		public SKRectI? Bounds { get; set; }
 		public SKColor[] Colors { get; set; }
 
-		public bool Equals (SKLattice obj) =>
+		public readonly bool Equals (SKLattice obj) =>
 			XDivs == obj.XDivs &&
 			YDivs == obj.YDivs &&
 			RectTypes == obj.RectTypes &&
 			Bounds == obj.Bounds &&
 			Colors == obj.Colors;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKLattice f && Equals (f);
 
 		public static bool operator == (SKLattice left, SKLattice right) =>
@@ -215,7 +215,7 @@ namespace SkiaSharp
 		public static bool operator != (SKLattice left, SKLattice right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (XDivs);
@@ -318,7 +318,7 @@ namespace SkiaSharp
 		public bool PdfA { get; set; }
 		public int EncodingQuality { get; set; }
 
-		public bool Equals (SKDocumentPdfMetadata obj) =>
+		public readonly bool Equals (SKDocumentPdfMetadata obj) =>
 			Title == obj.Title &&
 			Author == obj.Author &&
 			Subject == obj.Subject &&
@@ -331,7 +331,7 @@ namespace SkiaSharp
 			PdfA == obj.PdfA &&
 			EncodingQuality == obj.EncodingQuality;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKDocumentPdfMetadata f && Equals (f);
 
 		public static bool operator == (SKDocumentPdfMetadata left, SKDocumentPdfMetadata right) =>
@@ -340,7 +340,7 @@ namespace SkiaSharp
 		public static bool operator != (SKDocumentPdfMetadata left, SKDocumentPdfMetadata right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (Title);

--- a/binding/Binding/GRDefinitions.cs
+++ b/binding/Binding/GRDefinitions.cs
@@ -17,8 +17,8 @@ namespace SkiaSharp
 		public int SampleCount { get; set; }
 		public int StencilBits { get; set; }
 		public GRBackendObject RenderTargetHandle { get; set; }
-		public SKSizeI Size => new SKSizeI (Width, Height);
-		public SKRectI Rect => new SKRectI (0, 0, Width, Height);
+		public readonly SKSizeI Size => new SKSizeI (Width, Height);
+		public readonly SKRectI Rect => new SKRectI (0, 0, Width, Height);
 	}
 
 	[Flags]
@@ -64,6 +64,13 @@ namespace SkiaSharp
 
 	public partial struct GRGlTextureInfo
 	{
+		public GRGlTextureInfo (uint target, uint id)
+		{
+			fTarget = target;
+			fID = id;
+			fFormat = 0;
+		}
+
 		public GRGlTextureInfo (uint target, uint id, uint format)
 		{
 			fTarget = target;

--- a/binding/Binding/GRDefinitions.cs
+++ b/binding/Binding/GRDefinitions.cs
@@ -8,7 +8,7 @@ namespace SkiaSharp
 {
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use GRBackendRenderTarget instead.")]
-	public struct GRBackendRenderTargetDesc
+	public struct GRBackendRenderTargetDesc : IEquatable<GRBackendRenderTargetDesc>
 	{
 		public int Width { get; set; }
 		public int Height { get; set; }
@@ -19,6 +19,37 @@ namespace SkiaSharp
 		public GRBackendObject RenderTargetHandle { get; set; }
 		public readonly SKSizeI Size => new SKSizeI (Width, Height);
 		public readonly SKRectI Rect => new SKRectI (0, 0, Width, Height);
+
+		public readonly bool Equals (GRBackendRenderTargetDesc obj) =>
+			Width == obj.Width &&
+			Height == obj.Height &&
+			Config == obj.Config &&
+			Origin == obj.Origin &&
+			SampleCount == obj.SampleCount &&
+			StencilBits == obj.StencilBits &&
+			RenderTargetHandle == obj.RenderTargetHandle;
+
+		public readonly override bool Equals (object obj) =>
+			obj is GRBackendRenderTargetDesc f && Equals (f);
+
+		public static bool operator == (GRBackendRenderTargetDesc left, GRBackendRenderTargetDesc right) =>
+			left.Equals (right);
+
+		public static bool operator != (GRBackendRenderTargetDesc left, GRBackendRenderTargetDesc right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (Width);
+			hash.Add (Height);
+			hash.Add (Config);
+			hash.Add (Origin);
+			hash.Add (SampleCount);
+			hash.Add (StencilBits);
+			hash.Add (RenderTargetHandle);
+			return hash.ToHashCode ();
+		}
 	}
 
 	[Flags]
@@ -91,7 +122,7 @@ namespace SkiaSharp
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use GRBackendTexture instead.")]
 	[StructLayout (LayoutKind.Sequential)]
-	public struct GRBackendTextureDesc
+	public struct GRBackendTextureDesc : IEquatable<GRBackendTextureDesc>
 	{
 		public GRBackendTextureDescFlags Flags { get; set; }
 		public GRSurfaceOrigin Origin { get; set; }
@@ -100,11 +131,44 @@ namespace SkiaSharp
 		public GRPixelConfig Config { get; set; }
 		public int SampleCount { get; set; }
 		public GRBackendObject TextureHandle { get; set; }
+		public readonly SKSizeI Size => new SKSizeI (Width, Height);
+		public readonly SKRectI Rect => new SKRectI (0, 0, Width, Height);
+
+		public readonly bool Equals (GRBackendTextureDesc obj) =>
+			Flags == obj.Flags &&
+			Origin == obj.Origin &&
+			Width == obj.Width &&
+			Height == obj.Height &&
+			Config == obj.Config &&
+			SampleCount == obj.SampleCount &&
+			TextureHandle == obj.TextureHandle;
+
+		public readonly override bool Equals (object obj) =>
+			obj is GRBackendTextureDesc f && Equals (f);
+
+		public static bool operator == (GRBackendTextureDesc left, GRBackendTextureDesc right) =>
+			left.Equals (right);
+
+		public static bool operator != (GRBackendTextureDesc left, GRBackendTextureDesc right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (Flags);
+			hash.Add (Origin);
+			hash.Add (Width);
+			hash.Add (Height);
+			hash.Add (Config);
+			hash.Add (SampleCount);
+			hash.Add (TextureHandle);
+			return hash.ToHashCode ();
+		}
 	}
 
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use GRBackendTexture instead.")]
-	public struct GRGlBackendTextureDesc
+	public struct GRGlBackendTextureDesc : IEquatable<GRGlBackendTextureDesc>
 	{
 		public GRBackendTextureDescFlags Flags { get; set; }
 		public GRSurfaceOrigin Origin { get; set; }
@@ -113,6 +177,39 @@ namespace SkiaSharp
 		public GRPixelConfig Config { get; set; }
 		public int SampleCount { get; set; }
 		public GRGlTextureInfo TextureHandle { get; set; }
+		public readonly SKSizeI Size => new SKSizeI (Width, Height);
+		public readonly SKRectI Rect => new SKRectI (0, 0, Width, Height);
+
+		public readonly bool Equals (GRGlBackendTextureDesc obj) =>
+			Flags == obj.Flags &&
+			Origin == obj.Origin &&
+			Width == obj.Width &&
+			Height == obj.Height &&
+			Config == obj.Config &&
+			SampleCount == obj.SampleCount &&
+			TextureHandle == obj.TextureHandle;
+
+		public readonly override bool Equals (object obj) =>
+			obj is GRGlBackendTextureDesc f && Equals (f);
+
+		public static bool operator == (GRGlBackendTextureDesc left, GRGlBackendTextureDesc right) =>
+			left.Equals (right);
+
+		public static bool operator != (GRGlBackendTextureDesc left, GRGlBackendTextureDesc right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (Flags);
+			hash.Add (Origin);
+			hash.Add (Width);
+			hash.Add (Height);
+			hash.Add (Config);
+			hash.Add (SampleCount);
+			hash.Add (TextureHandle);
+			return hash.ToHashCode ();
+		}
 	}
 
 	public static partial class SkiaExtensions

--- a/binding/Binding/MathTypes.cs
+++ b/binding/Binding/MathTypes.cs
@@ -12,11 +12,11 @@ namespace SkiaSharp
 			this.y = y;
 		}
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
-		public float Length => (float)Math.Sqrt (x * x + y * y);
+		public readonly float Length => (float)Math.Sqrt (x * x + y * y);
 
-		public float LengthSquared => x * x + y * y;
+		public readonly float LengthSquared => x * x + y * y;
 
 		public void Offset (SKPoint p)
 		{
@@ -30,7 +30,7 @@ namespace SkiaSharp
 			y += dy;
 		}
 
-		public override string ToString () => $"{{X={x}, Y={y}}}";
+		public readonly override string ToString () => $"{{X={x}, Y={y}}}";
 
 		public static SKPoint Normalize (SKPoint point)
 		{
@@ -107,11 +107,11 @@ namespace SkiaSharp
 			this.y = y;
 		}
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
-		public int Length => (int)Math.Sqrt (x * x + y * y);
+		public readonly int Length => (int)Math.Sqrt (x * x + y * y);
 
-		public int LengthSquared => x * x + y * y;
+		public readonly int LengthSquared => x * x + y * y;
 
 		public void Offset (SKPointI p)
 		{
@@ -125,7 +125,7 @@ namespace SkiaSharp
 			y += dy;
 		}
 
-		public override string ToString () => $"{{X={x},Y={y}}}";
+		public readonly override string ToString () => $"{{X={x},Y={y}}}";
 
 		public static SKPointI Normalize (SKPointI point)
 		{
@@ -223,9 +223,9 @@ namespace SkiaSharp
 			this.z = z;
 		}
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
-		public override string ToString () => $"{{X={x}, Y={y}, Z={z}}}";
+		public readonly override string ToString () => $"{{X={x}, Y={y}, Z={z}}}";
 
 		public static SKPoint3 Add (SKPoint3 pt, SKPoint3 sz) => pt + sz;
 
@@ -254,12 +254,12 @@ namespace SkiaSharp
 			h = pt.Y;
 		}
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
-		public SKPoint ToPoint () =>
+		public readonly SKPoint ToPoint () =>
 			new SKPoint (w, h);
 
-		public SKSizeI ToSizeI ()
+		public readonly SKSizeI ToSizeI ()
 		{
 			int w, h;
 			checked {
@@ -270,7 +270,7 @@ namespace SkiaSharp
 			return new SKSizeI (w, h);
 		}
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			$"{{Width={w}, Height={h}}}";
 
 		public static SKSize Add (SKSize sz1, SKSize sz2) => sz1 + sz2;
@@ -305,11 +305,11 @@ namespace SkiaSharp
 			h = pt.Y;
 		}
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
-		public SKPointI ToPointI () => new SKPointI (w, h);
+		public readonly SKPointI ToPointI () => new SKPointI (w, h);
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			$"{{Width={w}, Height={h}}}";
 
 		public static SKSizeI Add (SKSizeI sz1, SKSizeI sz2) => sz1 + sz2;
@@ -338,18 +338,18 @@ namespace SkiaSharp
 			this.bottom = bottom;
 		}
 
-		public float MidX => left + (Width / 2f);
+		public readonly float MidX => left + (Width / 2f);
 
-		public float MidY => top + (Height / 2f);
+		public readonly float MidY => top + (Height / 2f);
 
-		public float Width => right - left;
+		public readonly float Width => right - left;
 
-		public float Height => bottom - top;
+		public readonly float Height => bottom - top;
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
 		public SKSize Size {
-			get => new SKSize (Width, Height);
+			readonly get => new SKSize (Width, Height);
 			set {
 				right = left + value.Width;
 				bottom = top + value.Height;
@@ -357,11 +357,11 @@ namespace SkiaSharp
 		}
 
 		public SKPoint Location {
-			get => new SKPoint (left, top);
+			readonly get => new SKPoint (left, top);
 			set => this = SKRect.Create (value, Size);
 		}
 
-		public SKRect Standardized {
+		public readonly SKRect Standardized {
 			get {
 				if (left > right) {
 					if (top > bottom) {
@@ -379,11 +379,11 @@ namespace SkiaSharp
 			}
 		}
 
-		public SKRect AspectFit (SKSize size) => AspectResize (size, true);
+		public readonly SKRect AspectFit (SKSize size) => AspectResize (size, true);
 
-		public SKRect AspectFill (SKSize size) => AspectResize (size, false);
+		public readonly SKRect AspectFill (SKSize size) => AspectResize (size, false);
 
-		private SKRect AspectResize (SKSize size, bool fit)
+		private readonly SKRect AspectResize (SKSize size, bool fit)
 		{
 			if (size.Width == 0 || size.Height == 0 || Width == 0 || Height == 0)
 				return Create (MidX, MidY, 0, 0);
@@ -453,20 +453,20 @@ namespace SkiaSharp
 		public static implicit operator SKRect (SKRectI r) =>
 			new SKRect (r.Left, r.Top, r.Right, r.Bottom);
 
-		public bool Contains (float x, float y) =>
+		public readonly bool Contains (float x, float y) =>
 			(x >= left) && (x < right) && (y >= top) && (y < bottom);
 
-		public bool Contains (SKPoint pt) =>
+		public readonly bool Contains (SKPoint pt) =>
 			Contains (pt.X, pt.Y);
 
-		public bool Contains (SKRect rect) =>
+		public readonly bool Contains (SKRect rect) =>
 			(left <= rect.left) && (right >= rect.right) &&
 			(top <= rect.top) && (bottom >= rect.bottom);
 
-		public bool IntersectsWith (SKRect rect) =>
+		public readonly bool IntersectsWith (SKRect rect) =>
 			(left < rect.right) && (right > rect.left) && (top < rect.bottom) && (bottom > rect.top);
 
-		public bool IntersectsWithInclusive (SKRect rect) =>
+		public readonly bool IntersectsWithInclusive (SKRect rect) =>
 			(left <= rect.right) && (right >= rect.left) && (top <= rect.bottom) && (bottom >= rect.top);
 
 		public void Offset (float x, float y)
@@ -479,7 +479,7 @@ namespace SkiaSharp
 
 		public void Offset (SKPoint pos) => Offset (pos.X, pos.Y);
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			$"{{Left={Left},Top={Top},Width={Width},Height={Height}}}";
 
 		public static SKRect Create (SKPoint location, SKSize size) =>
@@ -507,18 +507,18 @@ namespace SkiaSharp
 			this.bottom = bottom;
 		}
 
-		public int MidX => left + (Width / 2);
+		public readonly int MidX => left + (Width / 2);
 
-		public int MidY => top + (Height / 2);
+		public readonly int MidY => top + (Height / 2);
 
-		public int Width => right - left;
+		public readonly int Width => right - left;
 
-		public int Height => bottom - top;
+		public readonly int Height => bottom - top;
 
-		public bool IsEmpty => this == Empty;
+		public readonly bool IsEmpty => this == Empty;
 
 		public SKSizeI Size {
-			get => new SKSizeI (Width, Height);
+			readonly get => new SKSizeI (Width, Height);
 			set {
 				right = left + value.Width;
 				bottom = top + value.Height;
@@ -526,11 +526,11 @@ namespace SkiaSharp
 		}
 
 		public SKPointI Location {
-			get => new SKPointI (left, top);
+			readonly get => new SKPointI (left, top);
 			set => this = SKRectI.Create (value, Size);
 		}
 
-		public SKRectI Standardized {
+		public readonly SKRectI Standardized {
 			get {
 				if (left > right) {
 					if (top > bottom) {
@@ -548,10 +548,10 @@ namespace SkiaSharp
 			}
 		}
 
-		public SKRectI AspectFit (SKSizeI size) =>
+		public readonly SKRectI AspectFit (SKSizeI size) =>
 			Truncate (((SKRect)this).AspectFit (size));
 
-		public SKRectI AspectFill (SKSizeI size) =>
+		public readonly SKRectI AspectFill (SKSizeI size) =>
 			Truncate (((SKRect)this).AspectFill (size));
 
 		public static SKRectI Ceiling (SKRect value) =>
@@ -654,20 +654,20 @@ namespace SkiaSharp
 		public void Union (SKRectI rect) =>
 			this = Union (this, rect);
 
-		public bool Contains (int x, int y) =>
+		public readonly bool Contains (int x, int y) =>
 			(x >= left) && (x < right) && (y >= top) && (y < bottom);
 
-		public bool Contains (SKPointI pt) =>
+		public readonly bool Contains (SKPointI pt) =>
 			Contains (pt.X, pt.Y);
 
-		public bool Contains (SKRectI rect) =>
+		public readonly bool Contains (SKRectI rect) =>
 			(left <= rect.left) && (right >= rect.right) &&
 			(top <= rect.top) && (bottom >= rect.bottom);
 
-		public bool IntersectsWith (SKRectI rect) =>
+		public readonly bool IntersectsWith (SKRectI rect) =>
 			(left < rect.right) && (right > rect.left) && (top < rect.bottom) && (bottom > rect.top);
 
-		public bool IntersectsWithInclusive (SKRectI rect) =>
+		public readonly bool IntersectsWithInclusive (SKRectI rect) =>
 			(left <= rect.right) && (right >= rect.left) && (top <= rect.bottom) && (bottom >= rect.top);
 
 		public void Offset (int x, int y)
@@ -680,7 +680,7 @@ namespace SkiaSharp
 
 		public void Offset (SKPointI pos) => Offset (pos.X, pos.Y);
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			$"{{Left={Left},Top={Top},Width={Width},Height={Height}}}";
 
 		public static SKRectI Create (SKSizeI size) =>

--- a/binding/Binding/SK3dView.cs
+++ b/binding/Binding/SK3dView.cs
@@ -1,0 +1,105 @@
+﻿using System;
+
+namespace SkiaSharp
+{
+	public unsafe class SK3dView : SKObject
+	{
+		[Preserve]
+		internal SK3dView (IntPtr x, bool owns)
+			: base (x, owns)
+		{
+		}
+
+		public SK3dView ()
+			: this (SkiaApi.sk_3dview_new (), true)
+		{
+			if (Handle == IntPtr.Zero) {
+				throw new InvalidOperationException ("Unable to create a new SK3dView instance.");
+			}
+		}
+
+		protected override void Dispose (bool disposing) =>
+			base.Dispose (disposing);
+
+		protected override void DisposeNative () =>
+			SkiaApi.sk_3dview_destroy (Handle);
+
+		// Matrix
+
+		public SKMatrix Matrix {
+			get {
+				var matrix = SKMatrix.MakeIdentity ();
+				GetMatrix (ref matrix);
+				return matrix;
+			}
+		}
+
+		public void GetMatrix (ref SKMatrix matrix)
+		{
+			fixed (SKMatrix* m = &matrix) {
+				SkiaApi.sk_3dview_get_matrix (Handle, m);
+			}
+		}
+
+		// Save
+
+		public void Save () =>
+			SkiaApi.sk_3dview_save (Handle);
+
+		// Restore
+
+		public void Restore () =>
+			SkiaApi.sk_3dview_restore (Handle);
+
+		// Translate
+
+		public void Translate (float x, float y, float z) =>
+			SkiaApi.sk_3dview_translate (Handle, x, y, z);
+
+		public void TranslateX (float x) =>
+			Translate (x, 0, 0);
+
+		public void TranslateY (float y) =>
+			Translate (0, y, 0);
+
+		public void TranslateZ (float z) =>
+			Translate (0, 0, z);
+
+		// Rotate*Degrees
+
+		public void RotateXDegrees (float degrees) =>
+			SkiaApi.sk_3dview_rotate_x_degrees (Handle, degrees);
+
+		public void RotateYDegrees (float degrees) =>
+			SkiaApi.sk_3dview_rotate_y_degrees (Handle, degrees);
+
+		public void RotateZDegrees (float degrees) =>
+			SkiaApi.sk_3dview_rotate_z_degrees (Handle, degrees);
+
+		// Rotate*Radians
+
+		public void RotateXRadians (float radians) =>
+			SkiaApi.sk_3dview_rotate_x_radians (Handle, radians);
+
+		public void RotateYRadians (float radians) =>
+			SkiaApi.sk_3dview_rotate_y_radians (Handle, radians);
+
+		public void RotateZRadians (float radians) =>
+			SkiaApi.sk_3dview_rotate_z_radians (Handle, radians);
+
+		// DotWithNormal
+
+		public float DotWithNormal (float dx, float dy, float dz) =>
+			SkiaApi.sk_3dview_dot_with_normal (Handle, dx, dy, dz);
+
+		// Apply
+
+		public void ApplyToCanvas (SKCanvas canvas)
+		{
+			if (canvas == null)
+				throw new ArgumentNullException (nameof (canvas));
+
+			SkiaApi.sk_3dview_apply_to_canvas (Handle, canvas.Handle);
+		}
+	}
+}

--- a/binding/Binding/SKCanvas.cs
+++ b/binding/Binding/SKCanvas.cs
@@ -851,23 +851,14 @@ namespace SkiaSharp
 			SkiaApi.sk_canvas_draw_drrect (Handle, outer.Handle, inner.Handle, paint.Handle);
 		}
 
-		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKPaint paint)
-			=> DrawAtlas (atlas, sprites, transforms, null, SKBlendMode.Dst, null, paint);
+		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKPaint paint) =>
+			DrawAtlas (atlas, sprites, transforms, null, SKBlendMode.Dst, null, paint);
 
-		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKRect cullRect, SKPaint paint)
-			=> DrawAtlas (atlas, sprites, transforms, null, SKBlendMode.Dst, &cullRect, paint);
+		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKPaint paint) =>
+			DrawAtlas (atlas, sprites, transforms, colors, mode, null, paint);
 
-		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKBlendMode mode, SKPaint paint)
-			=> DrawAtlas (atlas, sprites, transforms, null, mode, null, paint);
-
-		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKBlendMode mode, SKRect cullRect, SKPaint paint)
-			=> DrawAtlas (atlas, sprites, transforms, null, mode, &cullRect, paint);
-
-		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKPaint paint)
-			=> DrawAtlas (atlas, sprites, transforms, colors, mode, null, paint);
-
-		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKRect cullRect, SKPaint paint)
-			=> DrawAtlas (atlas, sprites, transforms, colors, mode, &cullRect, paint);
+		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKRect cullRect, SKPaint paint) =>
+			DrawAtlas (atlas, sprites, transforms, colors, mode, &cullRect, paint);
 
 		private void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKRect* cullRect, SKPaint paint)
 		{
@@ -890,20 +881,8 @@ namespace SkiaSharp
 			}
 		}
 
-		public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPaint paint)
-			=> DrawPatch (cubics, colors, null, SKBlendMode.Modulate, paint);
-
-		public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKBlendMode mode, SKPaint paint)
-			=> DrawPatch (cubics, colors, null, mode, paint);
-
-		public void DrawPatch (SKPoint[] cubics, SKPoint[] texCoords, SKPaint paint)
-			=> DrawPatch (cubics, null, texCoords, SKBlendMode.Modulate, paint);
-
-		public void DrawPatch (SKPoint[] cubics, SKPoint[] texCoords, SKBlendMode mode, SKPaint paint)
-			=> DrawPatch (cubics, null, texCoords, mode, paint);
-
-		public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKPaint paint)
-			=> DrawPatch (cubics, colors, texCoords, SKBlendMode.Modulate, paint);
+		public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKPaint paint) =>
+			DrawPatch (cubics, colors, texCoords, SKBlendMode.Modulate, paint);
 
 		public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKBlendMode mode, SKPaint paint)
 		{

--- a/binding/Binding/SKColor.cs
+++ b/binding/Binding/SKColor.cs
@@ -24,24 +24,24 @@ namespace SkiaSharp
 			color = (0xff000000u | (uint)(red << 16) | (uint)(green << 8) | blue);
 		}
 
-		public SKColor WithRed (byte red) =>
+		public readonly SKColor WithRed (byte red) =>
 			new SKColor (red, Green, Blue, Alpha);
 
-		public SKColor WithGreen (byte green) =>
+		public readonly SKColor WithGreen (byte green) =>
 			new SKColor (Red, green, Blue, Alpha);
 
-		public SKColor WithBlue (byte blue) =>
+		public readonly SKColor WithBlue (byte blue) =>
 			new SKColor (Red, Green, blue, Alpha);
 
-		public SKColor WithAlpha (byte alpha) =>
+		public readonly SKColor WithAlpha (byte alpha) =>
 			new SKColor (Red, Green, Blue, alpha);
 
-		public byte Alpha => (byte)((color >> 24) & 0xff);
-		public byte Red => (byte)((color >> 16) & 0xff);
-		public byte Green => (byte)((color >> 8) & 0xff);
-		public byte Blue => (byte)((color) & 0xff);
+		public readonly byte Alpha => (byte)((color >> 24) & 0xff);
+		public readonly byte Red => (byte)((color >> 16) & 0xff);
+		public readonly byte Green => (byte)((color >> 8) & 0xff);
+		public readonly byte Blue => (byte)((color) & 0xff);
 
-		public float Hue {
+		public readonly float Hue {
 			get {
 				ToHsv (out var h, out _, out _);
 				return h;
@@ -72,7 +72,7 @@ namespace SkiaSharp
 			return new SKColor ((byte)r, (byte)g, (byte)b, a);
 		}
 
-		public void ToHsl (out float h, out float s, out float l)
+		public readonly void ToHsl (out float h, out float s, out float l)
 		{
 			// RGB from 0 to 255
 			var r = Red / 255f;
@@ -83,7 +83,7 @@ namespace SkiaSharp
 			colorf.ToHsl (out h, out s, out l);
 		}
 
-		public void ToHsv (out float h, out float s, out float v)
+		public readonly void ToHsv (out float h, out float s, out float v)
 		{
 			// RGB from 0 to 255
 			var r = Red / 255f;
@@ -94,13 +94,13 @@ namespace SkiaSharp
 			colorf.ToHsv (out h, out s, out v);
 		}
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			$"#{Alpha:x2}{Red:x2}{Green:x2}{Blue:x2}";
 
-		public bool Equals (SKColor obj) =>
+		public readonly bool Equals (SKColor obj) =>
 			obj.color == color;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKColor f && Equals (f);
 
 		public static bool operator == (SKColor left, SKColor right) =>
@@ -109,7 +109,7 @@ namespace SkiaSharp
 		public static bool operator != (SKColor left, SKColor right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode () =>
+		public readonly override int GetHashCode () =>
 			color.GetHashCode ();
 
 		public static implicit operator SKColor (uint color) =>

--- a/binding/Binding/SKColorF.cs
+++ b/binding/Binding/SKColorF.cs
@@ -24,26 +24,26 @@ namespace SkiaSharp
 			fA = alpha;
 		}
 
-		public SKColorF WithRed (float red) =>
+		public readonly SKColorF WithRed (float red) =>
 			new SKColorF (red, fG, fB, fA);
 
-		public SKColorF WithGreen (float green) =>
+		public readonly SKColorF WithGreen (float green) =>
 			new SKColorF (fR, green, fB, fA);
 
-		public SKColorF WithBlue (float blue) =>
+		public readonly SKColorF WithBlue (float blue) =>
 			new SKColorF (fR, fG, blue, fA);
 
-		public SKColorF WithAlpha (float alpha) =>
+		public readonly SKColorF WithAlpha (float alpha) =>
 			new SKColorF (fR, fG, fB, alpha);
 
-		public float Hue {
+		public readonly float Hue {
 			get {
 				ToHsv (out var h, out _, out _);
 				return h;
 			}
 		}
 
-		public SKColorF Clamp ()
+		public readonly SKColorF Clamp ()
 		{
 			return new SKColorF (Clamp (fR), Clamp (fG), Clamp (fB), Clamp (fA));
 
@@ -156,7 +156,7 @@ namespace SkiaSharp
 			return new SKColorF (r, g, b, a);
 		}
 
-		public void ToHsl (out float h, out float s, out float l)
+		public readonly void ToHsl (out float h, out float s, out float l)
 		{
 			// RGB from 0 to 1
 			var r = fR;
@@ -202,7 +202,7 @@ namespace SkiaSharp
 			l = l * 100f;
 		}
 
-		public void ToHsv (out float h, out float s, out float v)
+		public readonly void ToHsv (out float h, out float s, out float v)
 		{
 			// RGB from 0 to 1
 			var r = fR;
@@ -245,7 +245,7 @@ namespace SkiaSharp
 			v = v * 100f;
 		}
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			((SKColor)this).ToString ();
 
 		public static implicit operator SKColorF (SKColor color)

--- a/binding/Binding/SKColorF.cs
+++ b/binding/Binding/SKColorF.cs
@@ -2,7 +2,7 @@
 
 namespace SkiaSharp
 {
-	public unsafe partial struct SKColorF
+	public readonly unsafe partial struct SKColorF
 	{
 		private const float EPSILON = 0.001f;
 

--- a/binding/Binding/SKColorSpace.cs
+++ b/binding/Binding/SKColorSpace.cs
@@ -3,107 +3,6 @@ using System.ComponentModel;
 
 namespace SkiaSharp
 {
-	public unsafe partial struct SKColorSpacePrimaries
-	{
-		public SKColorSpacePrimaries (float[] values)
-		{
-			if (values == null)
-				throw new ArgumentNullException (nameof (values));
-			if (values.Length != 8)
-				throw new ArgumentException ("The values must have exactly 8 items, one for each of [RX, RY, GX, GY, BX, BY, WX, WY].", nameof (values));
-
-			fRX = values[0];
-			fRY = values[1];
-			fGX = values[2];
-			fGY = values[3];
-			fBX = values[4];
-			fBY = values[5];
-			fWX = values[6];
-			fWY = values[7];
-		}
-
-		public SKColorSpacePrimaries (float rx, float ry, float gx, float gy, float bx, float by, float wx, float wy)
-		{
-			fRX = rx;
-			fRY = ry;
-			fGX = gx;
-			fGY = gy;
-			fBX = bx;
-			fBY = by;
-			fWX = wx;
-			fWY = wy;
-		}
-
-		public float[] Values => new[] { fRX, fRY, fGX, fGY, fBX, fBY, fWX, fWY };
-
-		public bool ToXyzD50 (SKMatrix44 toXyzD50)
-		{
-			if (toXyzD50 == null)
-				throw new ArgumentNullException (nameof (toXyzD50));
-			fixed (SKColorSpacePrimaries* t = &this) {
-				return SkiaApi.sk_colorspaceprimaries_to_xyzd50 (t, toXyzD50.Handle);
-			}
-		}
-
-		public SKMatrix44 ToXyzD50 ()
-		{
-			var xyzD50 = new SKMatrix44 ();
-			if (!ToXyzD50 (xyzD50)) {
-				xyzD50.Dispose ();
-				xyzD50 = null;
-			}
-			return xyzD50;
-		}
-	}
-
-	public unsafe partial struct SKColorSpaceTransferFn
-	{
-		public SKColorSpaceTransferFn (float[] values)
-		{
-			if (values == null)
-				throw new ArgumentNullException (nameof (values));
-			if (values.Length != 7)
-				throw new ArgumentException ("The values must have exactly 7 items, one for each of [G, A, B, C, D, E, F].", nameof (values));
-
-			fG = values[0];
-			fA = values[1];
-			fB = values[2];
-			fC = values[3];
-			fD = values[4];
-			fE = values[5];
-			fF = values[6];
-		}
-
-		public SKColorSpaceTransferFn (float g, float a, float b, float c, float d, float e, float f)
-		{
-			fG = g;
-			fA = a;
-			fB = b;
-			fC = c;
-			fD = d;
-			fE = e;
-			fF = f;
-		}
-
-		public float[] Values => new[] { fG, fA, fB, fC, fD, fE, fF };
-
-		public SKColorSpaceTransferFn Invert ()
-		{
-			SKColorSpaceTransferFn inverted;
-			fixed (SKColorSpaceTransferFn* t = &this) {
-				SkiaApi.sk_colorspace_transfer_fn_invert (t, &inverted);
-			}
-			return inverted;
-		}
-
-		public float Transform (float x)
-		{
-			fixed (SKColorSpaceTransferFn* t = &this) {
-				return SkiaApi.sk_colorspace_transfer_fn_transform (t, x);
-			}
-		}
-	}
-
 	public unsafe class SKColorSpace : SKObject, ISKReferenceCounted
 	{
 		private static readonly SKColorSpace srgb;
@@ -130,26 +29,30 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public bool GammaIsCloseToSrgb => SkiaApi.sk_colorspace_gamma_close_to_srgb (Handle);
+		public bool GammaIsCloseToSrgb =>
+			SkiaApi.sk_colorspace_gamma_close_to_srgb (Handle);
 
-		public bool GammaIsLinear => SkiaApi.sk_colorspace_gamma_is_linear (Handle);
+		public bool GammaIsLinear =>
+			SkiaApi.sk_colorspace_gamma_is_linear (Handle);
 
-		public bool IsSrgb => SkiaApi.sk_colorspace_is_srgb (Handle);
+		public bool IsSrgb =>
+			SkiaApi.sk_colorspace_is_srgb (Handle);
 
-		public SKColorSpaceType Type => SkiaApi.sk_colorspace_gamma_get_type (Handle);
+		public SKColorSpaceType Type =>
+			SkiaApi.sk_colorspace_gamma_get_type (Handle);
 
-		public SKNamedGamma NamedGamma => SkiaApi.sk_colorspace_gamma_get_gamma_named (Handle);
+		public SKNamedGamma NamedGamma =>
+			SkiaApi.sk_colorspace_gamma_get_gamma_named (Handle);
 
-		public bool IsNumericalTransferFunction => GetNumericalTransferFunction (out _);
+		public bool IsNumericalTransferFunction =>
+			GetNumericalTransferFunction (out _);
 
 		public static bool Equal (SKColorSpace left, SKColorSpace right)
 		{
-			if (left == null) {
+			if (left == null)
 				throw new ArgumentNullException (nameof (left));
-			}
-			if (right == null) {
+			if (right == null)
 				throw new ArgumentNullException (nameof (right));
-			}
 
 			return SkiaApi.sk_colorspace_equals (left.Handle, right.Handle);
 		}
@@ -187,22 +90,22 @@ namespace SkiaSharp
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use CreateRgb (SKColorSpaceRenderTargetGamma, SKMatrix44) instead.")]
+		[Obsolete ("Use CreateRgb(SKColorSpaceRenderTargetGamma, SKMatrix44) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceRenderTargetGamma gamma, SKMatrix44 toXyzD50, SKColorSpaceFlags flags) =>
 			CreateRgb (gamma, toXyzD50);
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use CreateRgb (SKColorSpaceRenderTargetGamma, SKColorSpaceGamut) instead.")]
+		[Obsolete ("Use CreateRgb(SKColorSpaceRenderTargetGamma, SKColorSpaceGamut) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceRenderTargetGamma gamma, SKColorSpaceGamut gamut, SKColorSpaceFlags flags) =>
 			CreateRgb (gamma, gamut);
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use CreateRgb (SKColorSpaceTransferFn, SKMatrix44) instead.")]
+		[Obsolete ("Use CreateRgb(SKColorSpaceTransferFn, SKMatrix44) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceTransferFn coeffs, SKMatrix44 toXyzD50, SKColorSpaceFlags flags) =>
 			CreateRgb (coeffs, toXyzD50);
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use CreateRgb (SKColorSpaceTransferFn, SKColorSpaceGamut) instead.")]
+		[Obsolete ("Use CreateRgb(SKColorSpaceTransferFn, SKColorSpaceGamut) instead.")]
 		public static SKColorSpace CreateRgb (SKColorSpaceTransferFn coeffs, SKColorSpaceGamut gamut, SKColorSpaceFlags flags) =>
 			CreateRgb (coeffs, gamut);
 
@@ -210,6 +113,7 @@ namespace SkiaSharp
 		{
 			if (toXyzD50 == null)
 				throw new ArgumentNullException (nameof (toXyzD50));
+
 			return GetObject<SKColorSpace> (SkiaApi.sk_colorspace_new_rgb_with_gamma (gamma, toXyzD50.Handle));
 		}
 
@@ -220,6 +124,7 @@ namespace SkiaSharp
 		{
 			if (toXyzD50 == null)
 				throw new ArgumentNullException (nameof (toXyzD50));
+
 			return GetObject<SKColorSpace> (SkiaApi.sk_colorspace_new_rgb_with_coeffs (&coeffs, toXyzD50.Handle));
 		}
 
@@ -230,6 +135,7 @@ namespace SkiaSharp
 		{
 			if (toXyzD50 == null)
 				throw new ArgumentNullException (nameof (toXyzD50));
+
 			return GetObject<SKColorSpace> (SkiaApi.sk_colorspace_new_rgb_with_gamma_named (gamma, toXyzD50.Handle));
 		}
 
@@ -240,6 +146,7 @@ namespace SkiaSharp
 		{
 			if (toXyzD50 == null)
 				throw new ArgumentNullException (nameof (toXyzD50));
+
 			return SkiaApi.sk_colorspace_to_xyzd50 (Handle, toXyzD50.Handle);
 		}
 

--- a/binding/Binding/SKColorSpaceStructs.cs
+++ b/binding/Binding/SKColorSpaceStructs.cs
@@ -1,0 +1,112 @@
+﻿using System;
+
+namespace SkiaSharp
+{
+	public unsafe partial struct SKColorSpacePrimaries
+	{
+		public static readonly SKColorSpacePrimaries Empty;
+
+		public SKColorSpacePrimaries (float[] values)
+		{
+			if (values == null)
+				throw new ArgumentNullException (nameof (values));
+			if (values.Length != 8)
+				throw new ArgumentException ("The values must have exactly 8 items, one for each of [RX, RY, GX, GY, BX, BY, WX, WY].", nameof (values));
+
+			fRX = values[0];
+			fRY = values[1];
+			fGX = values[2];
+			fGY = values[3];
+			fBX = values[4];
+			fBY = values[5];
+			fWX = values[6];
+			fWY = values[7];
+		}
+
+		public SKColorSpacePrimaries (float rx, float ry, float gx, float gy, float bx, float by, float wx, float wy)
+		{
+			fRX = rx;
+			fRY = ry;
+			fGX = gx;
+			fGY = gy;
+			fBX = bx;
+			fBY = by;
+			fWX = wx;
+			fWY = wy;
+		}
+
+		public readonly float[] Values =>
+			new[] { fRX, fRY, fGX, fGY, fBX, fBY, fWX, fWY };
+
+		public readonly SKMatrix44 ToXyzD50 ()
+		{
+			var xyzD50 = new SKMatrix44 ();
+			if (!ToXyzD50 (xyzD50)) {
+				xyzD50.Dispose ();
+				xyzD50 = null;
+			}
+			return xyzD50;
+		}
+
+		public readonly bool ToXyzD50 (SKMatrix44 toXyzD50)
+		{
+			if (toXyzD50 == null)
+				throw new ArgumentNullException (nameof (toXyzD50));
+
+			fixed (SKColorSpacePrimaries* t = &this) {
+				return SkiaApi.sk_colorspaceprimaries_to_xyzd50 (t, toXyzD50.Handle);
+			}
+		}
+	}
+
+	public unsafe partial struct SKColorSpaceTransferFn
+	{
+		public static readonly SKColorSpaceTransferFn Empty;
+
+		public SKColorSpaceTransferFn (float[] values)
+		{
+			if (values == null)
+				throw new ArgumentNullException (nameof (values));
+			if (values.Length != 7)
+				throw new ArgumentException ("The values must have exactly 7 items, one for each of [G, A, B, C, D, E, F].", nameof (values));
+
+			fG = values[0];
+			fA = values[1];
+			fB = values[2];
+			fC = values[3];
+			fD = values[4];
+			fE = values[5];
+			fF = values[6];
+		}
+
+		public SKColorSpaceTransferFn (float g, float a, float b, float c, float d, float e, float f)
+		{
+			fG = g;
+			fA = a;
+			fB = b;
+			fC = c;
+			fD = d;
+			fE = e;
+			fF = f;
+		}
+
+		public readonly float[] Values =>
+			new[] { fG, fA, fB, fC, fD, fE, fF };
+
+		public readonly SKColorSpaceTransferFn Invert ()
+		{
+			SKColorSpaceTransferFn inverted;
+			fixed (SKColorSpaceTransferFn* t = &this) {
+				SkiaApi.sk_colorspace_transfer_fn_invert (t, &inverted);
+			}
+			return inverted;
+		}
+
+		public readonly float Transform (float x)
+		{
+			fixed (SKColorSpaceTransferFn* t = &this) {
+				return SkiaApi.sk_colorspace_transfer_fn_transform (t, x);
+			}
+		}
+	}
+}

--- a/binding/Binding/SKImageInfo.cs
+++ b/binding/Binding/SKImageInfo.cs
@@ -134,7 +134,7 @@ namespace SkiaSharp
 
 		public readonly SKRectI Rect => SKRectI.Create (Width, Height);
 
-		public SKImageInfo WithSize (int width, int height)
+		public readonly SKImageInfo WithSize (int width, int height)
 		{
 			var copy = this;
 			copy.Width = width;
@@ -142,35 +142,35 @@ namespace SkiaSharp
 			return copy;
 		}
 
-		public SKImageInfo WithColorType (SKColorType newColorType)
+		public readonly SKImageInfo WithColorType (SKColorType newColorType)
 		{
 			var copy = this;
 			copy.ColorType = newColorType;
 			return copy;
 		}
 
-		public SKImageInfo WithColorSpace (SKColorSpace newColorSpace)
+		public readonly SKImageInfo WithColorSpace (SKColorSpace newColorSpace)
 		{
 			var copy = this;
 			copy.ColorSpace = newColorSpace;
 			return copy;
 		}
 
-		public SKImageInfo WithAlphaType (SKAlphaType newAlphaType)
+		public readonly SKImageInfo WithAlphaType (SKAlphaType newAlphaType)
 		{
 			var copy = this;
 			copy.AlphaType = newAlphaType;
 			return copy;
 		}
 
-		public bool Equals (SKImageInfo obj) =>
+		public readonly bool Equals (SKImageInfo obj) =>
 			ColorSpace == obj.ColorSpace &&
 			Width == obj.Width &&
 			Height == obj.Height &&
 			ColorType == obj.ColorType &&
 			AlphaType == obj.AlphaType;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKImageInfo f && Equals (f);
 
 		public static bool operator == (SKImageInfo left, SKImageInfo right) =>
@@ -179,7 +179,7 @@ namespace SkiaSharp
 		public static bool operator != (SKImageInfo left, SKImageInfo right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (ColorSpace);

--- a/binding/Binding/SKMask.cs
+++ b/binding/Binding/SKMask.cs
@@ -116,7 +116,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public IntPtr GetAddr (int x, int y)
+		public readonly IntPtr GetAddr (int x, int y)
 		{
 			fixed (SKMask* t = &this) {
 				return (IntPtr)SkiaApi.sk_mask_get_addr (t, x, y);

--- a/binding/Binding/SKMatrix.cs
+++ b/binding/Binding/SKMatrix.cs
@@ -339,8 +339,6 @@ namespace SkiaSharp
 			return target;
 		}
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use SKMatrix.Concat(SKMatrix, SKMatrix) instead.")]
 		public static void Concat (ref SKMatrix target, SKMatrix first, SKMatrix second)
 		{
 			fixed (SKMatrix* t = &target) {
@@ -348,8 +346,6 @@ namespace SkiaSharp
 			}
 		}
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use SKMatrix.Concat(SKMatrix, SKMatrix) instead.")]
 		public static void Concat (ref SKMatrix target, ref SKMatrix first, ref SKMatrix second)
 		{
 			fixed (SKMatrix* t = &target)

--- a/binding/Binding/SKMatrix.cs
+++ b/binding/Binding/SKMatrix.cs
@@ -1,13 +1,18 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace SkiaSharp
 {
 	public unsafe partial struct SKMatrix
 	{
-		internal const float DegreesToRadians = (float)System.Math.PI / 180.0f;
+		internal const float DegreesToRadians = (float)Math.PI / 180.0f;
 
-		private class Indices {
+		public readonly static SKMatrix Empty;
+
+		public readonly static SKMatrix Identity = new SKMatrix { scaleX = 1, scaleY = 1, persp2 = 1 };
+
+		private class Indices
+		{
 			public const int ScaleX = 0;
 			public const int SkewX = 1;
 			public const int TransX = 2;
@@ -19,7 +24,7 @@ namespace SkiaSharp
 			public const int Persp2 = 8;
 
 			public const int Count = 9;
-		};
+		}
 
 		public SKMatrix (
 			float scaleX, float skewX, float transX,
@@ -31,102 +36,207 @@ namespace SkiaSharp
 			this.transX = transX;
 			this.skewY = skewY;
 			this.scaleY = scaleY;
-            this.transY = transY;
+			this.transY = transY;
 			this.persp0 = persp0;
 			this.persp1 = persp1;
 			this.persp2 = persp2;
 		}
 
-		public float [] Values {
-			get {
-				return new float [9] {
+		// Values
+
+		public float[] Values {
+			readonly get =>
+				new float[9] {
 					scaleX, skewX, transX,
 					skewY, scaleY, transY,
-					persp0, persp1, persp2 };
-			}
+					persp0, persp1, persp2
+				};
 			set {
 				if (value == null)
 					throw new ArgumentNullException (nameof (Values));
 				if (value.Length != Indices.Count)
 					throw new ArgumentException ($"The matrix array must have a length of {Indices.Count}.", nameof (Values));
 
-				scaleX = value [Indices.ScaleX];
-				skewX = value [Indices.SkewX];
-				transX = value [Indices.TransX];
+				scaleX = value[Indices.ScaleX];
+				skewX = value[Indices.SkewX];
+				transX = value[Indices.TransX];
 
-				skewY = value [Indices.SkewY];
-				scaleY = value [Indices.ScaleY];
-				transY = value [Indices.TransY];
+				skewY = value[Indices.SkewY];
+				scaleY = value[Indices.ScaleY];
+				transY = value[Indices.TransY];
 
-				persp0 = value [Indices.Persp0];
-				persp1 = value [Indices.Persp1];
-				persp2 = value [Indices.Persp2];
+				persp0 = value[Indices.Persp0];
+				persp1 = value[Indices.Persp1];
+				persp2 = value[Indices.Persp2];
 			}
 		}
 
-		public void GetValues(float[] values)
+		public readonly void GetValues (float[] values)
 		{
 			if (values == null)
 				throw new ArgumentNullException (nameof (values));
 			if (values.Length != Indices.Count)
 				throw new ArgumentException ($"The matrix array must have a length of {Indices.Count}.", nameof (values));
 
-			values [Indices.ScaleX] = scaleX;
-			values [Indices.SkewX] = skewX;
-			values [Indices.TransX] = transX;
-			values [Indices.SkewY] = skewY;
-			values [Indices.ScaleY] = scaleY;
-			values [Indices.TransY] = transY;
-			values [Indices.Persp0] = persp0;
-			values [Indices.Persp1] = persp1;
-			values [Indices.Persp2] = persp2;
+			values[Indices.ScaleX] = scaleX;
+			values[Indices.SkewX] = skewX;
+			values[Indices.TransX] = transX;
+
+			values[Indices.SkewY] = skewY;
+			values[Indices.ScaleY] = scaleY;
+			values[Indices.TransY] = transY;
+
+			values[Indices.Persp0] = persp0;
+			values[Indices.Persp1] = persp1;
+			values[Indices.Persp2] = persp2;
 		}
 
-#if OPTIMIZED_SKMATRIX
+		// Create*
 
-		//
-		// If we manage to get an sk_matrix_t that contains the extra
-		// the fTypeMask flag, we could accelerate various operations
-		// as well, as this caches state of what is needed to be done.
-		//
-	
-		[Flags]
-		enum Mask : uint {
-			Identity = 0,
-			Translate = 1,
-			Scale = 2,
-			Affine = 4,
-			Perspective = 8,
-			RectStaysRect = 0x10,
-			OnlyPerspectiveValid = 0x40,
-			Unknown = 0x80,
-			OrableMasks = Translate | Scale | Affine | Perspective,
-			AllMasks = OrableMasks | RectStaysRect
-		}
-		Mask typeMask;
+		public static SKMatrix CreateIdentity () =>
+			new SKMatrix { scaleX = 1, scaleY = 1, persp2 = 1 };
 
-		Mask GetMask ()
+		public static SKMatrix CreateTranslation (float x, float y)
 		{
-			if (typeMask.HasFlag (Mask.Unknown))
-				typeMask = (Mask) SkiaApi.sk_matrix_get_type (ref this);
+			if (x == 0 && y == 0)
+				return Identity;
 
-		        // only return the public masks
-			return (Mask) ((uint)typeMask & 0xf);
-		}
-#endif
-
-		static float sdot (float a, float b, float c, float d) => a * b + c * d;
-		static float scross(float a, float b, float c, float d) => a * b - c * d;
-
-		public static SKMatrix MakeIdentity ()
-		{
-			return new SKMatrix () { scaleX = 1, scaleY = 1, persp2 = 1
-#if OPTIMIZED_SKMATRIX
-					, typeMask = Mask.Identity | Mask.RectStaysRect
-#endif
+			return new SKMatrix {
+				scaleX = 1,
+				scaleY = 1,
+				transX = x,
+				transY = y,
+				persp2 = 1,
 			};
 		}
 
+		public static SKMatrix CreateScale (float x, float y)
+		{
+			if (x == 1 && y == 1)
+				return Identity;
+
+			return new SKMatrix {
+				scaleX = x,
+				scaleY = y,
+				persp2 = 1,
+			};
+		}
+
+		public static SKMatrix CreateScale (float x, float y, float pivotX, float pivotY)
+		{
+			if (x == 1 && y == 1)
+				return Identity;
+
+			var tx = pivotX - x * pivotX;
+			var ty = pivotY - y * pivotY;
+
+			return new SKMatrix {
+				scaleX = x,
+				scaleY = y,
+				transX = tx,
+				transY = ty,
+				persp2 = 1,
+			};
+		}
+
+		public static SKMatrix CreateRotation (float radians)
+		{
+			if (radians == 0)
+				return Identity;
+
+			var sin = (float)Math.Sin (radians);
+			var cos = (float)Math.Cos (radians);
+
+			var matrix = Identity;
+			SetSinCos (ref matrix, sin, cos);
+			return matrix;
+		}
+
+		public static SKMatrix CreateRotation (float radians, float pivotX, float pivotY)
+		{
+			if (radians == 0)
+				return Identity;
+
+			var sin = (float)Math.Sin (radians);
+			var cos = (float)Math.Cos (radians);
+
+			var matrix = Identity;
+			SetSinCos (ref matrix, sin, cos, pivotX, pivotY);
+			return matrix;
+		}
+
+		public static SKMatrix CreateRotationDegrees (float degrees)
+		{
+			if (degrees == 0)
+				return Identity;
+
+			return CreateRotation (degrees * DegreesToRadians);
+		}
+
+		public static SKMatrix CreateRotationDegrees (float degrees, float pivotX, float pivotY)
+		{
+			if (degrees == 0)
+				return Identity;
+
+			return CreateRotation (degrees * DegreesToRadians, pivotX, pivotY);
+		}
+
+		public static SKMatrix CreateSkew (float x, float y)
+		{
+			if (x == 0 && y == 0)
+				return Identity;
+
+			return new SKMatrix {
+				scaleX = 1,
+				skewX = x,
+				skewY = y,
+				scaleY = 1,
+				persp2 = 1,
+			};
+		}
+
+		// Make*
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeIdentity () =>
+			CreateIdentity ();
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeScale (float sx, float sy) =>
+			CreateScale (sx, sy);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeScale (float sx, float sy, float pivotX, float pivotY) =>
+			CreateScale (sx, sy, pivotX, pivotY);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeTranslation (float dx, float dy) =>
+			CreateTranslation (dx, dy);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeRotation (float radians) =>
+			CreateRotation (radians);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeRotation (float radians, float pivotx, float pivoty) =>
+			CreateRotation (radians, pivotx, pivoty);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeRotationDegrees (float degrees) =>
+			CreateRotationDegrees (degrees);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeRotationDegrees (float degrees, float pivotx, float pivoty) =>
+			CreateRotationDegrees (degrees, pivotx, pivoty);
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix MakeSkew (float sx, float sy) =>
+			CreateSkew (sx, sy);
+
+		// Set*
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete]
 		public void SetScaleTranslate (float sx, float sy, float tx, float ty)
 		{
 			scaleX = sx;
@@ -140,178 +250,57 @@ namespace SkiaSharp
 			persp0 = 0;
 			persp1 = 0;
 			persp2 = 1;
-
-#if OPTIMIZED_SKMATRIX
-			typeMask = Mask.RectStaysRect | 
-				((sx != 1 || sy != 1) ? Mask.Scale : 0) |
-				((tx != 0 || ty != 0) ? Mask.Translate : 0);
-#endif
 		}
 
-		public static SKMatrix MakeScale (float sx, float sy)
-		{
-			if (sx == 1 && sy == 1)
-				return MakeIdentity ();
-			return new SKMatrix () { scaleX = sx, scaleY = sy, persp2 = 1, 
-#if OPTIMIZED_SKMATRIX
-typeMask = Mask.Scale | Mask.RectStaysRect
-#endif
-			};
-				
-		}
+		// Rotate
 
-		/// <summary>
-		/// Set the matrix to scale by sx and sy, with a pivot point at (px, py).
-		/// The pivot point is the coordinate that should remain unchanged by the
-		/// specified transformation.
-		public static SKMatrix MakeScale (float sx, float sy, float pivotX, float pivotY)
-		{
-			if (sx == 1 && sy == 1)
-				return MakeIdentity ();
-			float tx = pivotX - sx * pivotX;
-			float ty = pivotY - sy * pivotY;
-
-#if OPTIMIZED_SKMATRIX
-			Mask mask = Mask.RectStaysRect | 
-				((sx != 1 || sy != 1) ? Mask.Scale : 0) |
-				((tx != 0 || ty != 0) ? Mask.Translate : 0);
-#endif
-			return new SKMatrix () { 
-				scaleX = sx, scaleY = sy, 
-				transX = tx, transY = ty,
-				persp2 = 1,
-#if OPTIMIZED_SKMATRIX
-				typeMask = mask
-#endif
-			};
-		}
-
-		public static SKMatrix MakeTranslation (float dx, float dy)
-		{
-			if (dx == 0 && dy == 0)
-				return MakeIdentity ();
-			
-			return new SKMatrix () { 
-				scaleX = 1, scaleY = 1,
-				transX = dx, transY = dy,
-				persp2 = 1,
-#if OPTIMIZED_SKMATRIX
-				typeMask = Mask.Translate | Mask.RectStaysRect
-#endif
-			};
-		}
-
-		public static SKMatrix MakeRotation (float radians)
-		{
-			var sin = (float) Math.Sin (radians);
-			var cos = (float) Math.Cos (radians);
-
-			var matrix = new SKMatrix ();
-			SetSinCos (ref matrix, sin, cos);
-			return matrix;
-		}
-
-		public static SKMatrix MakeRotation (float radians, float pivotx, float pivoty)
-		{
-			var sin = (float) Math.Sin (radians);
-			var cos = (float) Math.Cos (radians);
-
-			var matrix = new SKMatrix ();
-			SetSinCos (ref matrix, sin, cos, pivotx, pivoty);
-			return matrix;
-		}
-
-		public static SKMatrix MakeRotationDegrees (float degrees)
-		{
-			return MakeRotation (degrees * DegreesToRadians);
-		}
-
-		public static SKMatrix MakeRotationDegrees (float degrees, float pivotx, float pivoty)
-		{
-			return MakeRotation (degrees * DegreesToRadians, pivotx, pivoty);
-		}
-
-		private static void SetSinCos (ref SKMatrix matrix, float sin, float cos)
-		{
-			matrix.scaleX = cos;
-			matrix.skewX = -sin;
-			matrix.transX = 0;
-			matrix.skewY = sin;
-			matrix.scaleY = cos;
-			matrix.transY = 0;
-			matrix.persp0 = 0;
-			matrix.persp1 = 0;
-			matrix.persp2 = 1;
-#if OPTIMIZED_SKMATRIX
-			matrix.typeMask = Mask.Unknown | Mask.OnlyPerspectiveValid;
-#endif
-		}
-
-		private static void SetSinCos (ref SKMatrix matrix, float sin, float cos, float pivotx, float pivoty)
-		{
-			float oneMinusCos = 1-cos;
-			
-			matrix.scaleX = cos;
-			matrix.skewX = -sin;
-			matrix.transX = sdot(sin, pivoty, oneMinusCos, pivotx);
-			matrix.skewY = sin;
-			matrix.scaleY = cos;
-			matrix.transY = sdot(-sin, pivotx, oneMinusCos, pivoty);
-			matrix.persp0 = 0;
-			matrix.persp1 = 0;
-			matrix.persp2 = 1;
-#if OPTIMIZED_SKMATRIX
-			matrix.typeMask = Mask.Unknown | Mask.OnlyPerspectiveValid;
-#endif
-		}
-		
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use CreateRotation(float, float, float) instead.")]
 		public static void Rotate (ref SKMatrix matrix, float radians, float pivotx, float pivoty)
 		{
-			var sin = (float) Math.Sin (radians);
-			var cos = (float) Math.Cos (radians);
+			var sin = (float)Math.Sin (radians);
+			var cos = (float)Math.Cos (radians);
 			SetSinCos (ref matrix, sin, cos, pivotx, pivoty);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use CreateRotationDegrees(float, float, float) instead.")]
 		public static void RotateDegrees (ref SKMatrix matrix, float degrees, float pivotx, float pivoty)
 		{
-			var sin = (float) Math.Sin (degrees * DegreesToRadians);
-			var cos = (float) Math.Cos (degrees * DegreesToRadians);
+			var sin = (float)Math.Sin (degrees * DegreesToRadians);
+			var cos = (float)Math.Cos (degrees * DegreesToRadians);
 			SetSinCos (ref matrix, sin, cos, pivotx, pivoty);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use CreateRotation(float) instead.")]
 		public static void Rotate (ref SKMatrix matrix, float radians)
 		{
-			var sin = (float) Math.Sin (radians);
-			var cos = (float) Math.Cos (radians);
+			var sin = (float)Math.Sin (radians);
+			var cos = (float)Math.Cos (radians);
 			SetSinCos (ref matrix, sin, cos);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use CreateRotationDegrees(float) instead.")]
 		public static void RotateDegrees (ref SKMatrix matrix, float degrees)
 		{
-			var sin = (float) Math.Sin (degrees * DegreesToRadians);
-			var cos = (float) Math.Cos (degrees * DegreesToRadians);
+			var sin = (float)Math.Sin (degrees * DegreesToRadians);
+			var cos = (float)Math.Cos (degrees * DegreesToRadians);
 			SetSinCos (ref matrix, sin, cos);
 		}
 
-		public static SKMatrix MakeSkew (float sx, float sy)
-		{
-			return new SKMatrix () {
-				scaleX = 1,
-				skewX = sx,
-				transX = 0,
-				skewY = sy,
-				scaleY = 1,
-				transY = 0,
-				persp0 = 0,
-				persp1 = 0,
-				persp2 = 1,
-#if OPTIMIZED_SKMATRIX
-				typeMask = Mask.Unknown | Mask.OnlyPerspectiveValid
-#endif
-			};
+		// Invert
+
+		public readonly bool IsInvertible {
+			get {
+				fixed (SKMatrix* t = &this) {
+					return SkiaApi.sk_matrix_try_invert (t, null);
+				}
+			}
 		}
 
-		public bool TryInvert (out SKMatrix inverse)
+		public readonly bool TryInvert (out SKMatrix inverse)
 		{
 			fixed (SKMatrix* i = &inverse)
 			fixed (SKMatrix* t = &this) {
@@ -319,6 +308,39 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		public readonly SKMatrix Invert ()
+		{
+			if (TryInvert (out var matrix))
+				return matrix;
+
+			return Empty;
+		}
+
+		// *Concat
+
+		public static SKMatrix Concat (SKMatrix first, SKMatrix second)
+		{
+			SKMatrix target;
+			SkiaApi.sk_matrix_concat (&target, &first, &second);
+			return target;
+		}
+
+		public readonly SKMatrix PreConcat (SKMatrix matrix)
+		{
+			var target = this;
+			SkiaApi.sk_matrix_pre_concat (&target, &matrix);
+			return target;
+		}
+
+		public readonly SKMatrix PostConcat (SKMatrix matrix)
+		{
+			var target = this;
+			SkiaApi.sk_matrix_post_concat (&target, &matrix);
+			return target;
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use SKMatrix.Concat(SKMatrix, SKMatrix) instead.")]
 		public static void Concat (ref SKMatrix target, SKMatrix first, SKMatrix second)
 		{
 			fixed (SKMatrix* t = &target) {
@@ -326,6 +348,8 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use SKMatrix.Concat(SKMatrix, SKMatrix) instead.")]
 		public static void Concat (ref SKMatrix target, ref SKMatrix first, ref SKMatrix second)
 		{
 			fixed (SKMatrix* t = &target)
@@ -335,6 +359,8 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use PreConcat(SKMatrix) instead.")]
 		public static void PreConcat (ref SKMatrix target, SKMatrix matrix)
 		{
 			fixed (SKMatrix* t = &target) {
@@ -342,6 +368,8 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use PreConcat(SKMatrix) instead.")]
 		public static void PreConcat (ref SKMatrix target, ref SKMatrix matrix)
 		{
 			fixed (SKMatrix* t = &target)
@@ -350,6 +378,8 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use PostConcat(SKMatrix) instead.")]
 		public static void PostConcat (ref SKMatrix target, SKMatrix matrix)
 		{
 			fixed (SKMatrix* t = &target) {
@@ -357,6 +387,8 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use PostConcat(SKMatrix) instead.")]
 		public static void PostConcat (ref SKMatrix target, ref SKMatrix matrix)
 		{
 			fixed (SKMatrix* t = &target)
@@ -365,6 +397,19 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
+		// MapRect
+
+		public readonly SKRect MapRect (SKRect source)
+		{
+			SKRect dest;
+			fixed (SKMatrix* m = &this) {
+				SkiaApi.sk_matrix_map_rect (m, &dest, &source);
+			}
+			return dest;
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use MapRect(SKRect) instead.")]
 		public static void MapRect (ref SKMatrix matrix, out SKRect dest, ref SKRect source)
 		{
 			fixed (SKMatrix* m = &matrix)
@@ -374,13 +419,21 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
-		public SKRect MapRect (SKRect source)
+		// MapPoints
+
+		public readonly SKPoint MapPoint (SKPoint point) =>
+			MapPoint (point.X, point.Y);
+
+		public readonly SKPoint MapPoint (float x, float y)
 		{
-			MapRect (ref this, out var result, ref source);
+			SKPoint result;
+			fixed (SKMatrix* t = &this) {
+				SkiaApi.sk_matrix_map_xy (t, x, y, &result);
+			}
 			return result;
 		}
 
-		public void MapPoints (SKPoint [] result, SKPoint [] points)
+		public readonly void MapPoints (SKPoint[] result, SKPoint[] points)
 		{
 			if (result == null)
 				throw new ArgumentNullException (nameof (result));
@@ -396,17 +449,28 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
-		public SKPoint [] MapPoints (SKPoint [] points)
+		public readonly SKPoint[] MapPoints (SKPoint[] points)
 		{
 			if (points == null)
 				throw new ArgumentNullException (nameof (points));
 
-			var res = new SKPoint [points.Length];
+			var res = new SKPoint[points.Length];
 			MapPoints (res, points);
 			return res;
 		}
 
-		public void MapVectors (SKPoint [] result, SKPoint [] vectors)
+		// MapVectors
+
+		public readonly SKPoint MapVector (float x, float y)
+		{
+			SKPoint result;
+			fixed (SKMatrix* t = &this) {
+				SkiaApi.sk_matrix_map_vector (t, x, y, &result);
+			}
+			return result;
+		}
+
+		public readonly void MapVectors (SKPoint[] result, SKPoint[] vectors)
 		{
 			if (result == null)
 				throw new ArgumentNullException (nameof (result));
@@ -422,632 +486,59 @@ typeMask = Mask.Scale | Mask.RectStaysRect
 			}
 		}
 
-		public SKPoint [] MapVectors (SKPoint [] vectors)
+		public readonly SKPoint[] MapVectors (SKPoint[] vectors)
 		{
 			if (vectors == null)
 				throw new ArgumentNullException (nameof (vectors));
 
-			var res = new SKPoint [vectors.Length];
+			var res = new SKPoint[vectors.Length];
 			MapVectors (res, vectors);
 			return res;
 		}
 
-		public SKPoint MapPoint (SKPoint point)
-		{
-			return MapPoint (point.X, point.Y);
-		}
+		// MapRadius
 
-		public SKPoint MapPoint (float x, float y)
-		{
-			SKPoint result;
-			fixed (SKMatrix* t = &this) {
-				SkiaApi.sk_matrix_map_xy (t, x, y, &result);
-			}
-			return result;
-		}
-
-		public SKPoint MapVector (float x, float y)
-		{
-			SKPoint result;
-			fixed (SKMatrix* t = &this) {
-				SkiaApi.sk_matrix_map_vector (t, x, y, &result);
-			}
-			return result;
-		}
-
-		public float MapRadius (float radius)
+		public readonly float MapRadius (float radius)
 		{
 			fixed (SKMatrix* t = &this) {
 				return SkiaApi.sk_matrix_map_radius (t, radius);
 			}
 		}
-	}
 
-	public unsafe class SK3dView : SKObject
-	{
-		[Preserve]
-		internal SK3dView (IntPtr x, bool owns)
-			: base (x, owns)
-		{
-		}
-
-		public SK3dView ()
-			: this (SkiaApi.sk_3dview_new (), true)
-		{
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SK3dView instance.");
-			}
-		}
-
-		protected override void Dispose (bool disposing) =>
-			base.Dispose (disposing);
-
-		protected override void DisposeNative () =>
-			SkiaApi.sk_3dview_destroy (Handle);
-
-		public SKMatrix Matrix {
-			get {
-				SKMatrix matrix = SKMatrix.MakeIdentity ();
-				GetMatrix (ref matrix);
-				return matrix;
-			}
-		}
-		
-		public void GetMatrix (ref SKMatrix matrix)
-		{
-			fixed (SKMatrix* m = &matrix) {
-				SkiaApi.sk_3dview_get_matrix (Handle, m);
-			}
-		}
-		
-		public void Save ()
-		{
-			SkiaApi.sk_3dview_save (Handle);
-		}
-		
-		public void Restore ()
-		{
-			SkiaApi.sk_3dview_restore (Handle);
-		}
-		
-		public void Translate (float x, float y, float z)
-		{
-			SkiaApi.sk_3dview_translate (Handle, x, y, z);
-		}
-		
-		public void TranslateX (float x)
-		{
-			Translate (x, 0, 0);
-		}
-		
-		public void TranslateY (float y)
-		{
-			Translate (0, y, 0);
-		}
-		
-		public void TranslateZ (float z)
-		{
-			Translate (0, 0, z);
-		}
-		
-		public void RotateXDegrees (float degrees)
-		{
-			SkiaApi.sk_3dview_rotate_x_degrees (Handle, degrees);
-		}
-		
-		public void RotateXRadians (float radians)
-		{
-			SkiaApi.sk_3dview_rotate_x_radians (Handle, radians);
-		}
-		
-		public void RotateYDegrees (float degrees)
-		{
-			SkiaApi.sk_3dview_rotate_y_degrees (Handle, degrees);
-		}
-		
-		public void RotateYRadians (float radians)
-		{
-			SkiaApi.sk_3dview_rotate_y_radians (Handle, radians);
-		}
-		
-		public void RotateZDegrees (float degrees)
-		{
-			SkiaApi.sk_3dview_rotate_z_degrees (Handle, degrees);
-		}
-		
-		public void RotateZRadians (float radians)
-		{
-			SkiaApi.sk_3dview_rotate_z_radians (Handle, radians);
-		}
-		
-		public void ApplyToCanvas (SKCanvas canvas)
-		{
-			if (canvas == null)
-				throw new ArgumentNullException (nameof (canvas));
-
-			SkiaApi.sk_3dview_apply_to_canvas (Handle, canvas.Handle);
-		}
-
-		public float DotWithNormal (float dx, float dy, float dz)
-		{
-			return SkiaApi.sk_3dview_dot_with_normal (Handle, dx, dy, dz);
-		}
-	}
-
-	public unsafe class SKMatrix44 : SKObject
-	{
-		[Preserve]
-		internal SKMatrix44 (IntPtr x, bool owns)
-			: base (x, owns)
-		{
-		}
-
-		protected override void Dispose (bool disposing) =>
-			base.Dispose (disposing);
-
-		protected override void DisposeNative () =>
-			SkiaApi.sk_matrix44_destroy (Handle);
-
-		public SKMatrix44 ()
-			: this (SkiaApi.sk_matrix44_new(), true)
-		{
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
-			}
-		}
-
-		public SKMatrix44 (SKMatrix44 src)
-			: this (IntPtr.Zero, true)
-		{
-			if (src == null) {
-				throw new ArgumentNullException (nameof (src));
-			}
-			Handle = SkiaApi.sk_matrix44_new_copy (src.Handle);
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
-			}
-		}
-
-		public SKMatrix44 (SKMatrix44 a, SKMatrix44 b)
-			: this (IntPtr.Zero, true)
-		{
-			if (a == null) {
-				throw new ArgumentNullException (nameof (a));
-			}
-			if (b == null) {
-				throw new ArgumentNullException (nameof (b));
-			}
-
-			Handle = SkiaApi.sk_matrix44_new_concat (a.Handle, b.Handle);
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
-			}
-		}
-
-		public SKMatrix44 (SKMatrix src)
-			: this (CreateNew (ref src), true)
-		{
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
-			}
-		}
-
-		private static IntPtr CreateNew (ref SKMatrix src)
-		{
-			fixed (SKMatrix* s = &src) {
-				return SkiaApi.sk_matrix44_new_matrix (s);
-			}
-		}
-
-		public static SKMatrix44 CreateIdentity ()
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetIdentity ();
-			return matrix;
-		}
-
-		public static SKMatrix44 CreateTranslate (float x, float y, float z)
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetTranslate (x, y, z);
-			return matrix;
-		}
-
-		public static SKMatrix44 CreateScale (float x, float y, float z)
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetScale (x, y, z);
-			return matrix;
-		}
-
-		public static SKMatrix44 CreateRotation (float x, float y, float z, float radians)
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetRotationAbout (x, y, z, radians);
-			return matrix;
-		}
-
-		public static SKMatrix44 CreateRotationDegrees (float x, float y, float z, float degrees)
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetRotationAboutDegrees (x, y, z, degrees);
-			return matrix;
-		}
-
-		public static SKMatrix44 FromRowMajor (float [] src)
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetRowMajor (src);
-			return matrix;
-		}
-
-		public static SKMatrix44 FromColumnMajor (float [] src)
-		{
-			var matrix = new SKMatrix44();
-			matrix.SetColumnMajor (src);
-			return matrix;
-		}
-
-		public static bool Equal (SKMatrix44 left, SKMatrix44 right)
-		{
-			if (left == null) {
-				throw new ArgumentNullException (nameof (left));
-			}
-			if (right == null) {
-				throw new ArgumentNullException (nameof (right));
-			}
-
-			return SkiaApi.sk_matrix44_equals (left.Handle, right.Handle);
-		}
-
-		public SKMatrix Matrix {
-			get {
-				SKMatrix matrix;
-				SkiaApi.sk_matrix44_to_matrix (Handle, &matrix);
-				return matrix;
-			}
-		}
-
-		public SKMatrix44TypeMask Type => SkiaApi.sk_matrix44_get_type (Handle);
-
-		public void SetIdentity ()
-		{
-			SkiaApi.sk_matrix44_set_identity (Handle);
-		}
-
-		public float this [int row, int column] {
-			get {
-				return SkiaApi.sk_matrix44_get (Handle, row, column);
-			}
-			set {
-				SkiaApi.sk_matrix44_set (Handle, row, column, value);
-			}
-		}
-
-		public float [] ToColumnMajor ()
-		{
-			var dst = new float [16];
-			ToColumnMajor (dst);
-			return dst;
-		}
-
-		public void ToColumnMajor (float [] dst)
-		{
-			if (dst == null) {
-				throw new ArgumentNullException (nameof (dst));
-			}
-			if (dst.Length != 16) {
-				throw new ArgumentException ("The destination array must be 16 entries.", nameof (dst));
-			}
-			fixed (float* d = dst) {
-				SkiaApi.sk_matrix44_as_col_major (Handle, d);
-			}
-		}
-
-		public float [] ToRowMajor ()
-		{
-			var dst = new float [16];
-			ToRowMajor (dst);
-			return dst;
-		}
-
-		public void ToRowMajor (float [] dst)
-		{
-			if (dst == null) {
-				throw new ArgumentNullException (nameof (dst));
-			}
-			if (dst.Length != 16) {
-				throw new ArgumentException ("The destination array must be 16 entries.", nameof (dst));
-			}
-			fixed (float* d = dst) {
-				SkiaApi.sk_matrix44_as_row_major (Handle, d);
-			}
-		}
-
-		public void SetColumnMajor (float [] src)
-		{
-			if (src == null) {
-				throw new ArgumentNullException (nameof (src));
-			}
-			if (src.Length != 16) {
-				throw new ArgumentException ("The source array must be 16 entries.", nameof (src));
-			}
-			fixed (float* s = src) {
-				SkiaApi.sk_matrix44_set_col_major (Handle, s);
-			}
-		}
-
-		public void SetRowMajor (float [] src)
-		{
-			if (src == null) {
-				throw new ArgumentNullException (nameof (src));
-			}
-			if (src.Length != 16) {
-				throw new ArgumentException ("The source array must be 16 entries.", nameof (src));
-			}
-			fixed (float* s = src) {
-				SkiaApi.sk_matrix44_set_row_major (Handle, s);
-			}
-		}
-
-		public void SetTranslate (float dx, float dy, float dz)
-		{
-			SkiaApi.sk_matrix44_set_translate (Handle, dx, dy, dz);
-		}
-
-		public void PreTranslate (float dx, float dy, float dz)
-		{
-			SkiaApi.sk_matrix44_pre_translate (Handle, dx, dy, dz);
-		}
-
-		public void PostTranslate (float dx, float dy, float dz)
-		{
-			SkiaApi.sk_matrix44_post_translate (Handle, dx, dy, dz);
-		}
-
-		public void SetScale (float sx, float sy, float sz)
-		{
-			SkiaApi.sk_matrix44_set_scale (Handle, sx, sy, sz);
-		}
-
-		public void PreScale (float sx, float sy, float sz)
-		{
-			SkiaApi.sk_matrix44_pre_scale (Handle, sx, sy, sz);
-		}
-
-		public void PostScale (float sx, float sy, float sz)
-		{
-			SkiaApi.sk_matrix44_post_scale (Handle, sx, sy, sz);
-		}
-
-		public void SetRotationAboutDegrees (float x, float y, float z, float degrees)
-		{
-			SkiaApi.sk_matrix44_set_rotate_about_degrees (Handle, x, y, z, degrees);
-		}
-
-		public void SetRotationAbout (float x, float y, float z, float radians)
-		{
-			SkiaApi.sk_matrix44_set_rotate_about_radians (Handle, x, y, z, radians);
-		}
-
-		public void SetRotationAboutUnit (float x, float y, float z, float radians)
-		{
-			SkiaApi.sk_matrix44_set_rotate_about_radians_unit (Handle, x, y, z, radians);
-		}
-
-		public void SetConcat (SKMatrix44 a, SKMatrix44 b)
-		{
-			if (a == null) {
-				throw new ArgumentNullException (nameof (a));
-			}
-			if (b == null) {
-				throw new ArgumentNullException (nameof (b));
-			}
-
-			SkiaApi.sk_matrix44_set_concat (Handle, a.Handle, b.Handle);
-		}
-
-		public void PreConcat (SKMatrix44 m)
-		{
-			if (m == null) {
-				throw new ArgumentNullException (nameof (m));
-			}
-
-			SkiaApi.sk_matrix44_pre_concat (Handle, m.Handle);
-		}
-
-		public void PostConcat (SKMatrix44 m)
-		{
-			if (m == null) {
-				throw new ArgumentNullException (nameof (m));
-			}
+		// private
 
-			SkiaApi.sk_matrix44_post_concat (Handle, m.Handle);
-		}
-
-		public SKMatrix44 Invert ()
-		{
-			var inverse = new SKMatrix44 ();
-			if (Invert (inverse)) {
-				return inverse;
-			} else {
-				inverse.Dispose ();
-				return null;
-			}
-		}
-
-		public bool Invert (SKMatrix44 inverse)
-		{
-			if (inverse == null) {
-				throw new ArgumentNullException (nameof (inverse));
-			}
-
-			return SkiaApi.sk_matrix44_invert (Handle, inverse.Handle);
-		}
-
-		public void Transpose ()
-		{
-			SkiaApi.sk_matrix44_transpose (Handle);
-		}
-
-		public float [] MapScalars (float x, float y, float z, float w)
-		{
-			var srcVector4 = new float [4] { x, y, z, w };
-			var dstVector4 = new float [4];
-			MapScalars (srcVector4, dstVector4);
-			return dstVector4;
-		}
-
-		public float [] MapScalars (float [] srcVector4)
-		{
-			var dstVector4 = new float [4];
-			MapScalars (srcVector4, dstVector4);
-			return dstVector4;
-		}
-
-		public void MapScalars (float [] srcVector4, float [] dstVector4)
-		{
-			if (srcVector4 == null) {
-				throw new ArgumentNullException (nameof (srcVector4));
-			}
-			if (srcVector4.Length != 4) {
-				throw new ArgumentException ("The source vector array must be 4 entries.", nameof (srcVector4));
-			}
-			if (dstVector4 == null) {
-				throw new ArgumentNullException (nameof (dstVector4));
-			}
-			if (dstVector4.Length != 4) {
-				throw new ArgumentException ("The destination vector array must be 4 entries.", nameof (dstVector4));
-			}
-
-			fixed (float* s = srcVector4)
-			fixed (float* d = dstVector4) {
-				SkiaApi.sk_matrix44_map_scalars (Handle, s, d);
-			}
-		}
-
-		public SKPoint MapPoint (SKPoint src)
-		{
-			return MapPoints (new [] { src }) [0];
-		}
-
-		public SKPoint [] MapPoints (SKPoint[] src)
+		private static void SetSinCos (ref SKMatrix matrix, float sin, float cos)
 		{
-			if (src == null) {
-				throw new ArgumentNullException (nameof (src));
-			}
-			
-			var count = src.Length;
-			var src2Length = count * 2;
-			//var src4Length = count * 4;
-
-			var src2 = new float [src2Length];
-			for (int i = 0, i2 = 0; i < count; i++, i2 += 2) {
-				src2 [i2] = src [i].X;
-				src2 [i2 + 1] = src [i].Y;
-			}
-
-			var dst4 = MapVector2 (src2);
-
-			var dst = new SKPoint [count];
-			for (int i = 0, i4 = 0; i < count; i++, i4 += 4) {
-				dst [i].X = dst4 [i4];
-				dst [i].Y = dst4 [i4 + 1];
-			}
-
-			return dst;
-		}
-		
-		public float [] MapVector2 (float [] src2)
-		{
-			if (src2 == null) {
-				throw new ArgumentNullException (nameof (src2));
-			}
-			if (src2.Length % 2 != 0) {
-				throw new ArgumentException ("The source vector array must be a set of pairs.", nameof (src2));
-			}
-
-			var dst4 = new float [src2.Length * 2];
-			MapVector2 (src2, dst4);
-			return dst4;
-		}
-
-		public void MapVector2 (float [] src2, float [] dst4)
-		{
-			if (src2 == null) {
-				throw new ArgumentNullException (nameof (src2));
-			}
-			if (src2.Length % 2 != 0) {
-				throw new ArgumentException ("The source vector array must be a set of pairs.", nameof (src2));
-			}
-			if (dst4 == null) {
-				throw new ArgumentNullException (nameof (dst4));
-			}
-			if (dst4.Length % 4 != 0) {
-				throw new ArgumentException ("The destination vector array must be a set quads.", nameof (dst4));
-			}
-			if (src2.Length / 2 != dst4.Length / 4) {
-				throw new ArgumentException ("The source vector array must have the same number of pairs as the destination vector array has quads.", nameof (dst4));
-			}
-
-			fixed (float* s = src2)
-			fixed (float* d = dst4) {
-				SkiaApi.sk_matrix44_map2 (Handle, s, src2.Length / 2, d);
-			}
-		}
-
-		public bool Preserves2DAxisAlignment (float epsilon)
-		{
-			return SkiaApi.sk_matrix44_preserves_2d_axis_alignment (Handle, epsilon);
-		}
-
-		public double Determinant ()
-		{
-			return SkiaApi.sk_matrix44_determinant (Handle);
-		}
-	}
-
-	public unsafe partial struct SKRotationScaleMatrix
-	{
-		public static readonly SKRotationScaleMatrix Empty;
-
-		public SKRotationScaleMatrix (float scos, float ssin, float tx, float ty)
-		{
-			fSCos = scos;
-			fSSin = ssin;
-			fTX = tx;
-			fTY = ty;
+			matrix.scaleX = cos;
+			matrix.skewX = -sin;
+			matrix.transX = 0;
+			matrix.skewY = sin;
+			matrix.scaleY = cos;
+			matrix.transY = 0;
+			matrix.persp0 = 0;
+			matrix.persp1 = 0;
+			matrix.persp2 = 1;
 		}
-
-		public SKMatrix ToMatrix () =>
-			new SKMatrix (fSCos, -fSSin, fTX, fSSin, fSCos, fTY, 0, 0, 1);
 
-		public static SKRotationScaleMatrix FromDegrees (float scale, float degrees, float tx, float ty, float anchorX, float anchorY) =>
-			FromRadians (scale, degrees * SKMatrix.DegreesToRadians, tx, ty, anchorX, anchorY);
-
-		public static SKRotationScaleMatrix FromRadians (float scale, float radians, float tx, float ty, float anchorX, float anchorY)
+		private static void SetSinCos (ref SKMatrix matrix, float sin, float cos, float pivotx, float pivoty)
 		{
-			var s = (float)Math.Sin (radians) * scale;
-			var c = (float)Math.Cos (radians) * scale;
-			var x = tx + -c * anchorX + s * anchorY;
-			var y = ty + -s * anchorX - c * anchorY;
+			float oneMinusCos = 1 - cos;
 
-			return new SKRotationScaleMatrix (c, s, x, y);
+			matrix.scaleX = cos;
+			matrix.skewX = -sin;
+			matrix.transX = Dot (sin, pivoty, oneMinusCos, pivotx);
+			matrix.skewY = sin;
+			matrix.scaleY = cos;
+			matrix.transY = Dot (-sin, pivotx, oneMinusCos, pivoty);
+			matrix.persp0 = 0;
+			matrix.persp1 = 0;
+			matrix.persp2 = 1;
 		}
-
-		public static SKRotationScaleMatrix CreateIdentity () =>
-			new SKRotationScaleMatrix (1, 0, 0, 0);
-
-		public static SKRotationScaleMatrix CreateTranslate (float x, float y) =>
-			new SKRotationScaleMatrix (1, 0, x, y);
-
-		public static SKRotationScaleMatrix CreateScale (float s) =>
-			new SKRotationScaleMatrix (s, 0, 0, 0);
 
-		public static SKRotationScaleMatrix CreateRotation (float radians, float anchorX, float anchorY) =>
-			FromRadians (1, radians, 0, 0, anchorX, anchorY);
+		private static float Dot (float a, float b, float c, float d) =>
+			a * b + c * d;
 
-		public static SKRotationScaleMatrix CreateRotationDegrees (float degrees, float anchorX, float anchorY) =>
-			FromDegrees (1, degrees, 0, 0, anchorX, anchorY);
+		private static float Cross (float a, float b, float c, float d) =>
+			a * b - c * d;
 	}
 }

--- a/binding/Binding/SKMatrix44.cs
+++ b/binding/Binding/SKMatrix44.cs
@@ -1,0 +1,419 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace SkiaSharp
+{
+	public unsafe class SKMatrix44 : SKObject
+	{
+		[Preserve]
+		internal SKMatrix44 (IntPtr x, bool owns)
+			: base (x, owns)
+		{
+		}
+
+		protected override void Dispose (bool disposing) =>
+			base.Dispose (disposing);
+
+		protected override void DisposeNative () =>
+			SkiaApi.sk_matrix44_destroy (Handle);
+
+		public SKMatrix44 ()
+			: this (SkiaApi.sk_matrix44_new (), true)
+		{
+			if (Handle == IntPtr.Zero)
+				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
+		}
+
+		public SKMatrix44 (SKMatrix44 src)
+			: this (IntPtr.Zero, true)
+		{
+			if (src == null)
+				throw new ArgumentNullException (nameof (src));
+
+			Handle = SkiaApi.sk_matrix44_new_copy (src.Handle);
+
+			if (Handle == IntPtr.Zero)
+				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
+		}
+
+		public SKMatrix44 (SKMatrix44 a, SKMatrix44 b)
+			: this (IntPtr.Zero, true)
+		{
+			if (a == null)
+				throw new ArgumentNullException (nameof (a));
+			if (b == null)
+				throw new ArgumentNullException (nameof (b));
+
+			Handle = SkiaApi.sk_matrix44_new_concat (a.Handle, b.Handle);
+
+			if (Handle == IntPtr.Zero)
+				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
+		}
+
+		public SKMatrix44 (SKMatrix src)
+			: this (CreateNew (ref src), true)
+		{
+			if (Handle == IntPtr.Zero)
+				throw new InvalidOperationException ("Unable to create a new SKMatrix44 instance.");
+		}
+
+		private static IntPtr CreateNew (ref SKMatrix src)
+		{
+			fixed (SKMatrix* s = &src) {
+				return SkiaApi.sk_matrix44_new_matrix (s);
+			}
+		}
+
+		// properties
+
+		public SKMatrix Matrix {
+			get {
+				SKMatrix matrix;
+				SkiaApi.sk_matrix44_to_matrix (Handle, &matrix);
+				return matrix;
+			}
+		}
+
+		public SKMatrix44TypeMask Type =>
+			SkiaApi.sk_matrix44_get_type (Handle);
+
+		public float this[int row, int column] {
+			get => SkiaApi.sk_matrix44_get (Handle, row, column);
+			set => SkiaApi.sk_matrix44_set (Handle, row, column, value);
+		}
+
+		// Create*
+
+		public static SKMatrix44 CreateIdentity ()
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetIdentity ();
+			return matrix;
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public static SKMatrix44 CreateTranslate (float x, float y, float z) =>
+			CreateTranslation (x, y, z);
+
+		public static SKMatrix44 CreateTranslation (float x, float y, float z)
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetTranslate (x, y, z);
+			return matrix;
+		}
+
+		public static SKMatrix44 CreateScale (float x, float y, float z)
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetScale (x, y, z);
+			return matrix;
+		}
+
+		public static SKMatrix44 CreateRotation (float x, float y, float z, float radians)
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetRotationAbout (x, y, z, radians);
+			return matrix;
+		}
+
+		public static SKMatrix44 CreateRotationDegrees (float x, float y, float z, float degrees)
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetRotationAboutDegrees (x, y, z, degrees);
+			return matrix;
+		}
+
+		// From
+
+		public static SKMatrix44 FromRowMajor (float[] src)
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetRowMajor (src);
+			return matrix;
+		}
+
+		public static SKMatrix44 FromColumnMajor (float[] src)
+		{
+			var matrix = new SKMatrix44 ();
+			matrix.SetColumnMajor (src);
+			return matrix;
+		}
+
+		// To*
+
+		public float[] ToColumnMajor ()
+		{
+			var dst = new float[16];
+			ToColumnMajor (dst);
+			return dst;
+		}
+
+		public void ToColumnMajor (float[] dst)
+		{
+			if (dst == null)
+				throw new ArgumentNullException (nameof (dst));
+			if (dst.Length != 16)
+				throw new ArgumentException ("The destination array must be 16 entries.", nameof (dst));
+
+			fixed (float* d = dst) {
+				SkiaApi.sk_matrix44_as_col_major (Handle, d);
+			}
+		}
+
+		public float[] ToRowMajor ()
+		{
+			var dst = new float[16];
+			ToRowMajor (dst);
+			return dst;
+		}
+
+		public void ToRowMajor (float[] dst)
+		{
+			if (dst == null)
+				throw new ArgumentNullException (nameof (dst));
+			if (dst.Length != 16)
+				throw new ArgumentException ("The destination array must be 16 entries.", nameof (dst));
+
+			fixed (float* d = dst) {
+				SkiaApi.sk_matrix44_as_row_major (Handle, d);
+			}
+		}
+
+		// Equal
+
+		public static bool Equal (SKMatrix44 left, SKMatrix44 right)
+		{
+			if (left == null)
+				throw new ArgumentNullException (nameof (left));
+			if (right == null)
+				throw new ArgumentNullException (nameof (right));
+
+			return SkiaApi.sk_matrix44_equals (left.Handle, right.Handle);
+		}
+
+		// Set*
+
+		public void SetIdentity () =>
+			SkiaApi.sk_matrix44_set_identity (Handle);
+
+		public void SetColumnMajor (float[] src)
+		{
+			if (src == null)
+				throw new ArgumentNullException (nameof (src));
+			if (src.Length != 16)
+				throw new ArgumentException ("The source array must be 16 entries.", nameof (src));
+
+			fixed (float* s = src) {
+				SkiaApi.sk_matrix44_set_col_major (Handle, s);
+			}
+		}
+
+		public void SetRowMajor (float[] src)
+		{
+			if (src == null)
+				throw new ArgumentNullException (nameof (src));
+			if (src.Length != 16)
+				throw new ArgumentException ("The source array must be 16 entries.", nameof (src));
+
+			fixed (float* s = src) {
+				SkiaApi.sk_matrix44_set_row_major (Handle, s);
+			}
+		}
+
+		public void SetTranslate (float dx, float dy, float dz) =>
+			SkiaApi.sk_matrix44_set_translate (Handle, dx, dy, dz);
+
+		public void SetScale (float sx, float sy, float sz) =>
+			SkiaApi.sk_matrix44_set_scale (Handle, sx, sy, sz);
+
+		public void SetRotationAboutDegrees (float x, float y, float z, float degrees) =>
+			SkiaApi.sk_matrix44_set_rotate_about_degrees (Handle, x, y, z, degrees);
+
+		public void SetRotationAbout (float x, float y, float z, float radians) =>
+			SkiaApi.sk_matrix44_set_rotate_about_radians (Handle, x, y, z, radians);
+
+		public void SetRotationAboutUnit (float x, float y, float z, float radians) =>
+			SkiaApi.sk_matrix44_set_rotate_about_radians_unit (Handle, x, y, z, radians);
+
+		public void SetConcat (SKMatrix44 a, SKMatrix44 b)
+		{
+			if (a == null)
+				throw new ArgumentNullException (nameof (a));
+			if (b == null)
+				throw new ArgumentNullException (nameof (b));
+
+			SkiaApi.sk_matrix44_set_concat (Handle, a.Handle, b.Handle);
+		}
+
+		// Pre* / Post*
+
+		public void PreTranslate (float dx, float dy, float dz) =>
+			SkiaApi.sk_matrix44_pre_translate (Handle, dx, dy, dz);
+
+		public void PostTranslate (float dx, float dy, float dz) =>
+			SkiaApi.sk_matrix44_post_translate (Handle, dx, dy, dz);
+
+		public void PreScale (float sx, float sy, float sz) =>
+			SkiaApi.sk_matrix44_pre_scale (Handle, sx, sy, sz);
+
+		public void PostScale (float sx, float sy, float sz) =>
+			SkiaApi.sk_matrix44_post_scale (Handle, sx, sy, sz);
+
+		public void PreConcat (SKMatrix44 m)
+		{
+			if (m == null)
+				throw new ArgumentNullException (nameof (m));
+
+			SkiaApi.sk_matrix44_pre_concat (Handle, m.Handle);
+		}
+
+		public void PostConcat (SKMatrix44 m)
+		{
+			if (m == null)
+				throw new ArgumentNullException (nameof (m));
+
+			SkiaApi.sk_matrix44_post_concat (Handle, m.Handle);
+		}
+
+		// Invert
+
+		public bool IsInvertible =>
+			SkiaApi.sk_matrix44_invert (Handle, IntPtr.Zero);
+
+		public SKMatrix44 Invert ()
+		{
+			var inverse = new SKMatrix44 ();
+			if (!Invert (inverse)) {
+				inverse.Dispose ();
+				inverse = null;
+			}
+			return inverse;
+		}
+
+		public bool Invert (SKMatrix44 inverse)
+		{
+			if (inverse == null)
+				throw new ArgumentNullException (nameof (inverse));
+
+			return SkiaApi.sk_matrix44_invert (Handle, inverse.Handle);
+		}
+
+		// Transpose
+
+		public void Transpose () =>
+			SkiaApi.sk_matrix44_transpose (Handle);
+
+		// MapScalars
+
+		public float[] MapScalars (float x, float y, float z, float w)
+		{
+			var srcVector4 = new float[4] { x, y, z, w };
+			var dstVector4 = new float[4];
+			MapScalars (srcVector4, dstVector4);
+			return dstVector4;
+		}
+
+		public float[] MapScalars (float[] srcVector4)
+		{
+			var dstVector4 = new float[4];
+			MapScalars (srcVector4, dstVector4);
+			return dstVector4;
+		}
+
+		public void MapScalars (float[] srcVector4, float[] dstVector4)
+		{
+			if (srcVector4 == null)
+				throw new ArgumentNullException (nameof (srcVector4));
+			if (srcVector4.Length != 4)
+				throw new ArgumentException ("The source vector array must be 4 entries.", nameof (srcVector4));
+			if (dstVector4 == null)
+				throw new ArgumentNullException (nameof (dstVector4));
+			if (dstVector4.Length != 4)
+				throw new ArgumentException ("The destination vector array must be 4 entries.", nameof (dstVector4));
+
+			fixed (float* s = srcVector4)
+			fixed (float* d = dstVector4) {
+				SkiaApi.sk_matrix44_map_scalars (Handle, s, d);
+			}
+		}
+
+		// MapPoints
+
+		public SKPoint MapPoint (SKPoint src) =>
+			MapPoints (new[] { src })[0];
+
+		public SKPoint[] MapPoints (SKPoint[] src)
+		{
+			if (src == null)
+				throw new ArgumentNullException (nameof (src));
+
+			var count = src.Length;
+			var src2Length = count * 2;
+			//var src4Length = count * 4;
+
+			var src2 = new float[src2Length];
+			for (int i = 0, i2 = 0; i < count; i++, i2 += 2) {
+				src2[i2] = src[i].X;
+				src2[i2 + 1] = src[i].Y;
+			}
+
+			var dst4 = MapVector2 (src2);
+
+			var dst = new SKPoint[count];
+			for (int i = 0, i4 = 0; i < count; i++, i4 += 4) {
+				dst[i].X = dst4[i4];
+				dst[i].Y = dst4[i4 + 1];
+			}
+
+			return dst;
+		}
+
+		// MapVector2
+
+		public float[] MapVector2 (float[] src2)
+		{
+			if (src2 == null)
+				throw new ArgumentNullException (nameof (src2));
+			if (src2.Length % 2 != 0)
+				throw new ArgumentException ("The source vector array must be a set of pairs.", nameof (src2));
+
+			var dst4 = new float[src2.Length * 2];
+			MapVector2 (src2, dst4);
+			return dst4;
+		}
+
+		public void MapVector2 (float[] src2, float[] dst4)
+		{
+			if (src2 == null)
+				throw new ArgumentNullException (nameof (src2));
+			if (src2.Length % 2 != 0)
+				throw new ArgumentException ("The source vector array must be a set of pairs.", nameof (src2));
+			if (dst4 == null)
+				throw new ArgumentNullException (nameof (dst4));
+			if (dst4.Length % 4 != 0)
+				throw new ArgumentException ("The destination vector array must be a set quads.", nameof (dst4));
+			if (src2.Length / 2 != dst4.Length / 4)
+				throw new ArgumentException ("The source vector array must have the same number of pairs as the destination vector array has quads.", nameof (dst4));
+
+			fixed (float* s = src2)
+			fixed (float* d = dst4) {
+				SkiaApi.sk_matrix44_map2 (Handle, s, src2.Length / 2, d);
+			}
+		}
+
+		// Preserves2DAxisAlignment
+
+		public bool Preserves2DAxisAlignment (float epsilon) =>
+			SkiaApi.sk_matrix44_preserves_2d_axis_alignment (Handle, epsilon);
+
+		// Determinant
+
+		public double Determinant () =>
+			SkiaApi.sk_matrix44_determinant (Handle);
+
+		// operators
+
+		public static implicit operator SKMatrix44 (SKMatrix matrix) =>
+			new SKMatrix44 (matrix);
+	}
+}

--- a/binding/Binding/SKPMColor.cs
+++ b/binding/Binding/SKPMColor.cs
@@ -11,10 +11,10 @@ namespace SkiaSharp
 			color = value;
 		}
 
-		public byte Alpha => (byte)((color >> SKImageInfo.PlatformColorAlphaShift) & 0xff);
-		public byte Red => (byte)((color >> SKImageInfo.PlatformColorRedShift) & 0xff);
-		public byte Green => (byte)((color >> SKImageInfo.PlatformColorGreenShift) & 0xff);
-		public byte Blue => (byte)((color >> SKImageInfo.PlatformColorBlueShift) & 0xff);
+		public readonly byte Alpha => (byte)((color >> SKImageInfo.PlatformColorAlphaShift) & 0xff);
+		public readonly byte Red => (byte)((color >> SKImageInfo.PlatformColorRedShift) & 0xff);
+		public readonly byte Green => (byte)((color >> SKImageInfo.PlatformColorGreenShift) & 0xff);
+		public readonly byte Blue => (byte)((color >> SKImageInfo.PlatformColorBlueShift) & 0xff);
 
 		// PreMultiply
 
@@ -52,13 +52,13 @@ namespace SkiaSharp
 		public static explicit operator SKColor (SKPMColor color) =>
 			SKPMColor.UnPreMultiply (color);
 
-		public override string ToString () =>
+		public readonly override string ToString () =>
 			$"#{Alpha:x2}{Red:x2}{Green:x2}{Blue:x2}";
 
-		public bool Equals (SKPMColor obj) =>
+		public readonly bool Equals (SKPMColor obj) =>
 			obj.color == color;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKPMColor f && Equals (f);
 
 		public static bool operator == (SKPMColor left, SKPMColor right) =>
@@ -67,7 +67,7 @@ namespace SkiaSharp
 		public static bool operator != (SKPMColor left, SKPMColor right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode () =>
+		public readonly override int GetHashCode () =>
 			color.GetHashCode ();
 
 		public static implicit operator SKPMColor (uint color) =>

--- a/binding/Binding/SKRotationScaleMatrix.cs
+++ b/binding/Binding/SKRotationScaleMatrix.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace SkiaSharp
+{
+	public unsafe partial struct SKRotationScaleMatrix
+	{
+		public static readonly SKRotationScaleMatrix Empty;
+
+		public static readonly SKRotationScaleMatrix Identity = new SKRotationScaleMatrix (1, 0, 0, 0);
+
+		public SKRotationScaleMatrix (float scos, float ssin, float tx, float ty)
+		{
+			fSCos = scos;
+			fSSin = ssin;
+			fTX = tx;
+			fTY = ty;
+		}
+
+		public readonly SKMatrix ToMatrix () =>
+			new SKMatrix (fSCos, -fSSin, fTX, fSSin, fSCos, fTY, 0, 0, 1);
+
+		public static SKRotationScaleMatrix FromDegrees (float scale, float degrees, float tx, float ty, float anchorX, float anchorY) =>
+			FromRadians (scale, degrees * SKMatrix.DegreesToRadians, tx, ty, anchorX, anchorY);
+
+		public static SKRotationScaleMatrix FromRadians (float scale, float radians, float tx, float ty, float anchorX, float anchorY)
+		{
+			var s = (float)Math.Sin (radians) * scale;
+			var c = (float)Math.Cos (radians) * scale;
+			var x = tx + -c * anchorX + s * anchorY;
+			var y = ty + -s * anchorX - c * anchorY;
+
+			return new SKRotationScaleMatrix (c, s, x, y);
+		}
+
+		public static SKRotationScaleMatrix CreateIdentity () =>
+			new SKRotationScaleMatrix (1, 0, 0, 0);
+
+		public static SKRotationScaleMatrix CreateTranslation (float x, float y) =>
+			new SKRotationScaleMatrix (1, 0, x, y);
+
+		public static SKRotationScaleMatrix CreateScale (float s) =>
+			new SKRotationScaleMatrix (s, 0, 0, 0);
+
+		public static SKRotationScaleMatrix CreateRotation (float radians, float anchorX, float anchorY) =>
+			FromRadians (1, radians, 0, 0, anchorX, anchorY);
+
+		public static SKRotationScaleMatrix CreateRotationDegrees (float degrees, float anchorX, float anchorY) =>
+			FromDegrees (1, degrees, 0, 0, anchorX, anchorY);
+	}
+}

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -3618,10 +3618,10 @@ namespace SkiaSharp
 			set => fFormat = value;
 		}
 
-		public bool Equals (GRGlFramebufferInfo obj) =>
+		public readonly bool Equals (GRGlFramebufferInfo obj) =>
 			fFBOID == obj.fFBOID && fFormat == obj.fFormat;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is GRGlFramebufferInfo f && Equals (f);
 
 		public static bool operator == (GRGlFramebufferInfo left, GRGlFramebufferInfo right) =>
@@ -3630,7 +3630,7 @@ namespace SkiaSharp
 		public static bool operator != (GRGlFramebufferInfo left, GRGlFramebufferInfo right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fFBOID);
@@ -3664,10 +3664,10 @@ namespace SkiaSharp
 			set => fFormat = value;
 		}
 
-		public bool Equals (GRGlTextureInfo obj) =>
+		public readonly bool Equals (GRGlTextureInfo obj) =>
 			fTarget == obj.fTarget && fID == obj.fID && fFormat == obj.fFormat;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is GRGlTextureInfo f && Equals (f);
 
 		public static bool operator == (GRGlTextureInfo left, GRGlTextureInfo right) =>
@@ -3676,7 +3676,7 @@ namespace SkiaSharp
 		public static bool operator != (GRGlTextureInfo left, GRGlTextureInfo right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fTarget);
@@ -3725,10 +3725,10 @@ namespace SkiaSharp
 			set => fDisposalMethod = value;
 		}
 
-		public bool Equals (SKCodecFrameInfo obj) =>
+		public readonly bool Equals (SKCodecFrameInfo obj) =>
 			fRequiredFrame == obj.fRequiredFrame && fDuration == obj.fDuration && fFullyReceived == obj.fFullyReceived && fAlphaType == obj.fAlphaType && fDisposalMethod == obj.fDisposalMethod;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKCodecFrameInfo f && Equals (f);
 
 		public static bool operator == (SKCodecFrameInfo left, SKCodecFrameInfo right) =>
@@ -3737,7 +3737,7 @@ namespace SkiaSharp
 		public static bool operator != (SKCodecFrameInfo left, SKCodecFrameInfo right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fRequiredFrame);
@@ -3768,10 +3768,10 @@ namespace SkiaSharp
 		// public sk_transfer_function_behavior_t fPremulBehavior
 		public SKTransferFunctionBehavior fPremulBehavior;
 
-		public bool Equals (SKCodecOptionsInternal obj) =>
+		public readonly bool Equals (SKCodecOptionsInternal obj) =>
 			fZeroInitialized == obj.fZeroInitialized && fSubset == obj.fSubset && fFrameIndex == obj.fFrameIndex && fPriorFrame == obj.fPriorFrame && fPremulBehavior == obj.fPremulBehavior;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKCodecOptionsInternal f && Equals (f);
 
 		public static bool operator == (SKCodecOptionsInternal left, SKCodecOptionsInternal right) =>
@@ -3780,7 +3780,7 @@ namespace SkiaSharp
 		public static bool operator != (SKCodecOptionsInternal left, SKCodecOptionsInternal right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fZeroInitialized);
@@ -3812,10 +3812,10 @@ namespace SkiaSharp
 		private readonly Single fA;
 		public readonly Single Alpha => fA;
 
-		public bool Equals (SKColorF obj) =>
+		public readonly bool Equals (SKColorF obj) =>
 			fR == obj.fR && fG == obj.fG && fB == obj.fB && fA == obj.fA;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKColorF f && Equals (f);
 
 		public static bool operator == (SKColorF left, SKColorF right) =>
@@ -3824,7 +3824,7 @@ namespace SkiaSharp
 		public static bool operator != (SKColorF left, SKColorF right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fR);
@@ -3888,10 +3888,10 @@ namespace SkiaSharp
 			set => fF = value;
 		}
 
-		public bool Equals (SKColorSpaceTransferFn obj) =>
+		public readonly bool Equals (SKColorSpaceTransferFn obj) =>
 			fG == obj.fG && fA == obj.fA && fB == obj.fB && fC == obj.fC && fD == obj.fD && fE == obj.fE && fF == obj.fF;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKColorSpaceTransferFn f && Equals (f);
 
 		public static bool operator == (SKColorSpaceTransferFn left, SKColorSpaceTransferFn right) =>
@@ -3900,7 +3900,7 @@ namespace SkiaSharp
 		public static bool operator != (SKColorSpaceTransferFn left, SKColorSpaceTransferFn right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fG);
@@ -3974,10 +3974,10 @@ namespace SkiaSharp
 			set => fWY = value;
 		}
 
-		public bool Equals (SKColorSpacePrimaries obj) =>
+		public readonly bool Equals (SKColorSpacePrimaries obj) =>
 			fRX == obj.fRX && fRY == obj.fRY && fGX == obj.fGX && fGY == obj.fGY && fBX == obj.fBX && fBY == obj.fBY && fWX == obj.fWX && fWY == obj.fWY;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKColorSpacePrimaries f && Equals (f);
 
 		public static bool operator == (SKColorSpacePrimaries left, SKColorSpacePrimaries right) =>
@@ -3986,7 +3986,7 @@ namespace SkiaSharp
 		public static bool operator != (SKColorSpacePrimaries left, SKColorSpacePrimaries right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fRX);
@@ -4038,10 +4038,10 @@ namespace SkiaSharp
 		// public int fEncodingQuality
 		public Int32 fEncodingQuality;
 
-		public bool Equals (SKDocumentPdfMetadataInternal obj) =>
+		public readonly bool Equals (SKDocumentPdfMetadataInternal obj) =>
 			fTitle == obj.fTitle && fAuthor == obj.fAuthor && fSubject == obj.fSubject && fKeywords == obj.fKeywords && fCreator == obj.fCreator && fProducer == obj.fProducer && fCreation == obj.fCreation && fModified == obj.fModified && fRasterDPI == obj.fRasterDPI && fPDFA == obj.fPDFA && fEncodingQuality == obj.fEncodingQuality;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKDocumentPdfMetadataInternal f && Equals (f);
 
 		public static bool operator == (SKDocumentPdfMetadataInternal left, SKDocumentPdfMetadataInternal right) =>
@@ -4050,7 +4050,7 @@ namespace SkiaSharp
 		public static bool operator != (SKDocumentPdfMetadataInternal left, SKDocumentPdfMetadataInternal right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fTitle);
@@ -4120,10 +4120,10 @@ namespace SkiaSharp
 		// public float fStrikeoutPosition
 		private Single fStrikeoutPosition;
 
-		public bool Equals (SKFontMetrics obj) =>
+		public readonly bool Equals (SKFontMetrics obj) =>
 			fFlags == obj.fFlags && fTop == obj.fTop && fAscent == obj.fAscent && fDescent == obj.fDescent && fBottom == obj.fBottom && fLeading == obj.fLeading && fAvgCharWidth == obj.fAvgCharWidth && fMaxCharWidth == obj.fMaxCharWidth && fXMin == obj.fXMin && fXMax == obj.fXMax && fXHeight == obj.fXHeight && fCapHeight == obj.fCapHeight && fUnderlineThickness == obj.fUnderlineThickness && fUnderlinePosition == obj.fUnderlinePosition && fStrikeoutThickness == obj.fStrikeoutThickness && fStrikeoutPosition == obj.fStrikeoutPosition;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKFontMetrics f && Equals (f);
 
 		public static bool operator == (SKFontMetrics left, SKFontMetrics right) =>
@@ -4132,7 +4132,7 @@ namespace SkiaSharp
 		public static bool operator != (SKFontMetrics left, SKFontMetrics right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fFlags);
@@ -4180,10 +4180,10 @@ namespace SkiaSharp
 			set => fContrast = value;
 		}
 
-		public bool Equals (SKHighContrastConfig obj) =>
+		public readonly bool Equals (SKHighContrastConfig obj) =>
 			fGrayscale == obj.fGrayscale && fInvertStyle == obj.fInvertStyle && fContrast == obj.fContrast;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKHighContrastConfig f && Equals (f);
 
 		public static bool operator == (SKHighContrastConfig left, SKHighContrastConfig right) =>
@@ -4192,7 +4192,7 @@ namespace SkiaSharp
 		public static bool operator != (SKHighContrastConfig left, SKHighContrastConfig right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fGrayscale);
@@ -4221,10 +4221,10 @@ namespace SkiaSharp
 		// public sk_alphatype_t alphaType
 		public SKAlphaType alphaType;
 
-		public bool Equals (SKImageInfoNative obj) =>
+		public readonly bool Equals (SKImageInfoNative obj) =>
 			colorspace == obj.colorspace && width == obj.width && height == obj.height && colorType == obj.colorType && alphaType == obj.alphaType;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKImageInfoNative f && Equals (f);
 
 		public static bool operator == (SKImageInfoNative left, SKImageInfoNative right) =>
@@ -4233,7 +4233,7 @@ namespace SkiaSharp
 		public static bool operator != (SKImageInfoNative left, SKImageInfoNative right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (colorspace);
@@ -4263,10 +4263,10 @@ namespace SkiaSharp
 			set => y = value;
 		}
 
-		public bool Equals (SKPointI obj) =>
+		public readonly bool Equals (SKPointI obj) =>
 			x == obj.x && y == obj.y;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKPointI f && Equals (f);
 
 		public static bool operator == (SKPointI left, SKPointI right) =>
@@ -4275,7 +4275,7 @@ namespace SkiaSharp
 		public static bool operator != (SKPointI left, SKPointI right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (x);
@@ -4316,10 +4316,10 @@ namespace SkiaSharp
 			set => bottom = value;
 		}
 
-		public bool Equals (SKRectI obj) =>
+		public readonly bool Equals (SKRectI obj) =>
 			left == obj.left && top == obj.top && right == obj.right && bottom == obj.bottom;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKRectI f && Equals (f);
 
 		public static bool operator == (SKRectI left, SKRectI right) =>
@@ -4328,7 +4328,7 @@ namespace SkiaSharp
 		public static bool operator != (SKRectI left, SKRectI right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (left);
@@ -4357,10 +4357,10 @@ namespace SkiaSharp
 			set => h = value;
 		}
 
-		public bool Equals (SKSizeI obj) =>
+		public readonly bool Equals (SKSizeI obj) =>
 			w == obj.w && h == obj.h;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKSizeI f && Equals (f);
 
 		public static bool operator == (SKSizeI left, SKSizeI right) =>
@@ -4369,7 +4369,7 @@ namespace SkiaSharp
 		public static bool operator != (SKSizeI left, SKSizeI right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (w);
@@ -4410,10 +4410,10 @@ namespace SkiaSharp
 			set => fBlendBehavior = value;
 		}
 
-		public bool Equals (SKJpegEncoderOptions obj) =>
+		public readonly bool Equals (SKJpegEncoderOptions obj) =>
 			fQuality == obj.fQuality && fDownsample == obj.fDownsample && fAlphaOption == obj.fAlphaOption && fBlendBehavior == obj.fBlendBehavior;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKJpegEncoderOptions f && Equals (f);
 
 		public static bool operator == (SKJpegEncoderOptions left, SKJpegEncoderOptions right) =>
@@ -4422,7 +4422,7 @@ namespace SkiaSharp
 		public static bool operator != (SKJpegEncoderOptions left, SKJpegEncoderOptions right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fQuality);
@@ -4458,10 +4458,10 @@ namespace SkiaSharp
 		// public const sk_color_t* fColors
 		public UInt32* fColors;
 
-		public bool Equals (SKLatticeInternal obj) =>
+		public readonly bool Equals (SKLatticeInternal obj) =>
 			fXDivs == obj.fXDivs && fYDivs == obj.fYDivs && fRectTypes == obj.fRectTypes && fXCount == obj.fXCount && fYCount == obj.fYCount && fBounds == obj.fBounds && fColors == obj.fColors;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKLatticeInternal f && Equals (f);
 
 		public static bool operator == (SKLatticeInternal left, SKLatticeInternal right) =>
@@ -4470,7 +4470,7 @@ namespace SkiaSharp
 		public static bool operator != (SKLatticeInternal left, SKLatticeInternal right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fXDivs);
@@ -4500,10 +4500,10 @@ namespace SkiaSharp
 		// public sk_manageddrawable_destroy_proc fDestroy
 		public SKManagedDrawableDestroyProxyDelegate fDestroy;
 
-		public bool Equals (SKManagedDrawableDelegates obj) =>
+		public readonly bool Equals (SKManagedDrawableDelegates obj) =>
 			fDraw == obj.fDraw && fGetBounds == obj.fGetBounds && fNewPictureSnapshot == obj.fNewPictureSnapshot && fDestroy == obj.fDestroy;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKManagedDrawableDelegates f && Equals (f);
 
 		public static bool operator == (SKManagedDrawableDelegates left, SKManagedDrawableDelegates right) =>
@@ -4512,7 +4512,7 @@ namespace SkiaSharp
 		public static bool operator != (SKManagedDrawableDelegates left, SKManagedDrawableDelegates right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fDraw);
@@ -4566,10 +4566,10 @@ namespace SkiaSharp
 		// public sk_managedstream_destroy_proc fDestroy
 		public SKManagedStreamDestroyProxyDelegate fDestroy;
 
-		public bool Equals (SKManagedStreamDelegates obj) =>
+		public readonly bool Equals (SKManagedStreamDelegates obj) =>
 			fRead == obj.fRead && fPeek == obj.fPeek && fIsAtEnd == obj.fIsAtEnd && fHasPosition == obj.fHasPosition && fHasLength == obj.fHasLength && fRewind == obj.fRewind && fGetPosition == obj.fGetPosition && fSeek == obj.fSeek && fMove == obj.fMove && fGetLength == obj.fGetLength && fDuplicate == obj.fDuplicate && fFork == obj.fFork && fDestroy == obj.fDestroy;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKManagedStreamDelegates f && Equals (f);
 
 		public static bool operator == (SKManagedStreamDelegates left, SKManagedStreamDelegates right) =>
@@ -4578,7 +4578,7 @@ namespace SkiaSharp
 		public static bool operator != (SKManagedStreamDelegates left, SKManagedStreamDelegates right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fRead);
@@ -4614,10 +4614,10 @@ namespace SkiaSharp
 		// public sk_managedwstream_destroy_proc fDestroy
 		public SKManagedWStreamDestroyProxyDelegate fDestroy;
 
-		public bool Equals (SKManagedWStreamDelegates obj) =>
+		public readonly bool Equals (SKManagedWStreamDelegates obj) =>
 			fWrite == obj.fWrite && fFlush == obj.fFlush && fBytesWritten == obj.fBytesWritten && fDestroy == obj.fDestroy;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKManagedWStreamDelegates f && Equals (f);
 
 		public static bool operator == (SKManagedWStreamDelegates left, SKManagedWStreamDelegates right) =>
@@ -4626,7 +4626,7 @@ namespace SkiaSharp
 		public static bool operator != (SKManagedWStreamDelegates left, SKManagedWStreamDelegates right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fWrite);
@@ -4653,10 +4653,10 @@ namespace SkiaSharp
 		// public sk_mask_format_t fFormat
 		private SKMaskFormat fFormat;
 
-		public bool Equals (SKMask obj) =>
+		public readonly bool Equals (SKMask obj) =>
 			fImage == obj.fImage && fBounds == obj.fBounds && fRowBytes == obj.fRowBytes && fFormat == obj.fFormat;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKMask f && Equals (f);
 
 		public static bool operator == (SKMask left, SKMask right) =>
@@ -4665,7 +4665,7 @@ namespace SkiaSharp
 		public static bool operator != (SKMask left, SKMask right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fImage);
@@ -4743,10 +4743,10 @@ namespace SkiaSharp
 			set => persp2 = value;
 		}
 
-		public bool Equals (SKMatrix obj) =>
+		public readonly bool Equals (SKMatrix obj) =>
 			scaleX == obj.scaleX && skewX == obj.skewX && transX == obj.transX && skewY == obj.skewY && scaleY == obj.scaleY && transY == obj.transY && persp0 == obj.persp0 && persp1 == obj.persp1 && persp2 == obj.persp2;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKMatrix f && Equals (f);
 
 		public static bool operator == (SKMatrix left, SKMatrix right) =>
@@ -4755,7 +4755,7 @@ namespace SkiaSharp
 		public static bool operator != (SKMatrix left, SKMatrix right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (scaleX);
@@ -4787,10 +4787,10 @@ namespace SkiaSharp
 		// public void* fComments
 		private void* fComments;
 
-		public bool Equals (SKPngEncoderOptions obj) =>
+		public readonly bool Equals (SKPngEncoderOptions obj) =>
 			fFilterFlags == obj.fFilterFlags && fZLibLevel == obj.fZLibLevel && fUnpremulBehavior == obj.fUnpremulBehavior && fComments == obj.fComments;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKPngEncoderOptions f && Equals (f);
 
 		public static bool operator == (SKPngEncoderOptions left, SKPngEncoderOptions right) =>
@@ -4799,7 +4799,7 @@ namespace SkiaSharp
 		public static bool operator != (SKPngEncoderOptions left, SKPngEncoderOptions right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fFilterFlags);
@@ -4828,10 +4828,10 @@ namespace SkiaSharp
 			set => y = value;
 		}
 
-		public bool Equals (SKPoint obj) =>
+		public readonly bool Equals (SKPoint obj) =>
 			x == obj.x && y == obj.y;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKPoint f && Equals (f);
 
 		public static bool operator == (SKPoint left, SKPoint right) =>
@@ -4840,7 +4840,7 @@ namespace SkiaSharp
 		public static bool operator != (SKPoint left, SKPoint right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (x);
@@ -4874,10 +4874,10 @@ namespace SkiaSharp
 			set => z = value;
 		}
 
-		public bool Equals (SKPoint3 obj) =>
+		public readonly bool Equals (SKPoint3 obj) =>
 			x == obj.x && y == obj.y && z == obj.z;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKPoint3 f && Equals (f);
 
 		public static bool operator == (SKPoint3 left, SKPoint3 right) =>
@@ -4886,7 +4886,7 @@ namespace SkiaSharp
 		public static bool operator != (SKPoint3 left, SKPoint3 right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (x);
@@ -4928,10 +4928,10 @@ namespace SkiaSharp
 			set => bottom = value;
 		}
 
-		public bool Equals (SKRect obj) =>
+		public readonly bool Equals (SKRect obj) =>
 			left == obj.left && top == obj.top && right == obj.right && bottom == obj.bottom;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKRect f && Equals (f);
 
 		public static bool operator == (SKRect left, SKRect right) =>
@@ -4940,7 +4940,7 @@ namespace SkiaSharp
 		public static bool operator != (SKRect left, SKRect right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (left);
@@ -4983,10 +4983,10 @@ namespace SkiaSharp
 			set => fTY = value;
 		}
 
-		public bool Equals (SKRotationScaleMatrix obj) =>
+		public readonly bool Equals (SKRotationScaleMatrix obj) =>
 			fSCos == obj.fSCos && fSSin == obj.fSSin && fTX == obj.fTX && fTY == obj.fTY;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKRotationScaleMatrix f && Equals (f);
 
 		public static bool operator == (SKRotationScaleMatrix left, SKRotationScaleMatrix right) =>
@@ -4995,7 +4995,7 @@ namespace SkiaSharp
 		public static bool operator != (SKRotationScaleMatrix left, SKRotationScaleMatrix right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fSCos);
@@ -5024,10 +5024,10 @@ namespace SkiaSharp
 			set => h = value;
 		}
 
-		public bool Equals (SKSize obj) =>
+		public readonly bool Equals (SKSize obj) =>
 			w == obj.w && h == obj.h;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKSize f && Equals (f);
 
 		public static bool operator == (SKSize left, SKSize right) =>
@@ -5036,7 +5036,7 @@ namespace SkiaSharp
 		public static bool operator != (SKSize left, SKSize right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (w);
@@ -5061,10 +5061,10 @@ namespace SkiaSharp
 		// public void* clusters
 		public void* clusters;
 
-		public bool Equals (SKRunBufferInternal obj) =>
+		public readonly bool Equals (SKRunBufferInternal obj) =>
 			glyphs == obj.glyphs && pos == obj.pos && utf8text == obj.utf8text && clusters == obj.clusters;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKRunBufferInternal f && Equals (f);
 
 		public static bool operator == (SKRunBufferInternal left, SKRunBufferInternal right) =>
@@ -5073,7 +5073,7 @@ namespace SkiaSharp
 		public static bool operator != (SKRunBufferInternal left, SKRunBufferInternal right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (glyphs);
@@ -5112,10 +5112,10 @@ namespace SkiaSharp
 		// public uint8_t fSecond
 		public Byte fSecond;
 
-		public bool Equals (SKTimeDateTimeInternal obj) =>
+		public readonly bool Equals (SKTimeDateTimeInternal obj) =>
 			fTimeZoneMinutes == obj.fTimeZoneMinutes && fYear == obj.fYear && fMonth == obj.fMonth && fDayOfWeek == obj.fDayOfWeek && fDay == obj.fDay && fHour == obj.fHour && fMinute == obj.fMinute && fSecond == obj.fSecond;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKTimeDateTimeInternal f && Equals (f);
 
 		public static bool operator == (SKTimeDateTimeInternal left, SKTimeDateTimeInternal right) =>
@@ -5124,7 +5124,7 @@ namespace SkiaSharp
 		public static bool operator != (SKTimeDateTimeInternal left, SKTimeDateTimeInternal right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fTimeZoneMinutes);
@@ -5164,10 +5164,10 @@ namespace SkiaSharp
 			set => fUnpremulBehavior = value;
 		}
 
-		public bool Equals (SKWebpEncoderOptions obj) =>
+		public readonly bool Equals (SKWebpEncoderOptions obj) =>
 			fCompression == obj.fCompression && fQuality == obj.fQuality && fUnpremulBehavior == obj.fUnpremulBehavior;
 
-		public override bool Equals (object obj) =>
+		public readonly override bool Equals (object obj) =>
 			obj is SKWebpEncoderOptions f && Equals (f);
 
 		public static bool operator == (SKWebpEncoderOptions left, SKWebpEncoderOptions right) =>
@@ -5176,7 +5176,7 @@ namespace SkiaSharp
 		public static bool operator != (SKWebpEncoderOptions left, SKWebpEncoderOptions right) =>
 			!left.Equals (right);
 
-		public override int GetHashCode ()
+		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
 			hash.Add (fCompression);

--- a/binding/HarfBuzzSharp.Shared/Blob.cs
+++ b/binding/HarfBuzzSharp.Shared/Blob.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 
 namespace HarfBuzzSharp
@@ -14,7 +15,8 @@ namespace HarfBuzzSharp
 		{
 		}
 
-		[Obsolete ("Use Blob(IntPtr, int, MemoryMode, ReleaseDelegate releaseDelegate) instead.")]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Obsolete ("Use Blob(IntPtr, int, MemoryMode, ReleaseDelegate) instead.")]
 		public Blob (IntPtr data, uint length, MemoryMode mode, object userData, BlobReleaseDelegate releaseDelegate)
 			: this (data, (int)length, mode, () => releaseDelegate?.Invoke (userData))
 		{

--- a/binding/HarfBuzzSharp.Shared/DelegateProxies.cs
+++ b/binding/HarfBuzzSharp.Shared/DelegateProxies.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,6 +11,7 @@ namespace HarfBuzzSharp
 
 	public delegate Blob GetTableDelegate (Face face, Tag tag);
 
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete ("Use ReleaseDelegate instead.")]
 	public delegate void BlobReleaseDelegate (object context);
 

--- a/cake/UpdateDocs.cake
+++ b/cake/UpdateDocs.cake
@@ -368,6 +368,31 @@ Task ("docs-format-docs")
             .Where (e => !e.Elements ().Any ())
             .Remove ();
 
+        // special case for Android resources: don't process
+        if (xdoc.Root.Name == "Type") {
+            var nameAttr = xdoc.Root.Attribute ("FullName")?.Value;
+            if (nameAttr == "SkiaSharp.Views.Android.Resource" || nameAttr?.StartsWith ("SkiaSharp.Views.Android.Resource+") == true) {
+                DeleteFile (file);
+                continue;
+            }
+        }
+        if (xdoc.Root.Name == "Overview") {
+            foreach (var type in xdoc.Root.Descendants ("Type").ToArray ()) {
+                var nameAttr = type.Attribute ("Name")?.Value;
+                if (nameAttr == "Resource" || nameAttr?.StartsWith ("Resource+") == true) {
+                    type.Remove ();
+                }
+            }
+        }
+        if (xdoc.Root.Name == "Framework") {
+            foreach (var type in xdoc.Root.Descendants ("Type").ToArray ()) {
+                var nameAttr = type.Attribute ("Name")?.Value;
+                if (nameAttr == "SkiaSharp.Views.Android.Resource" || nameAttr?.StartsWith ("SkiaSharp.Views.Android.Resource/") == true) {
+                    type.Remove ();
+                }
+            }
+        }
+
         // count the types without docs
         var typesWithDocs = xdoc.Root
             .Elements ("Docs");

--- a/cake/UtilsManaged.cake
+++ b/cake/UtilsManaged.cake
@@ -113,6 +113,8 @@ IEnumerable<(DirectoryPath path, string platform)> GetPlatformDirectories(Direct
             yield return (dir, "watchos");
         else if (d.StartsWith("tizen"))
             yield return (dir, "tizen");
+        else if (d.StartsWith("netcoreapp"))
+            ; // skip this one for now
         else
             throw new Exception($"Unknown platform '{d}' found at '{dir}'.");
     }
@@ -163,7 +165,9 @@ async Task<NuGetDiff> CreateNuGetDiffAsync()
     await AddDep("Xamarin.Forms", "tizen40");
     await AddDep("Xamarin.Forms", "uap10.0");
     await AddDep("Xamarin.Forms.Platform.WPF", "net45");
+    await AddDep("Xamarin.Forms.Platform.GTK", "net45");
     await AddDep("GtkSharp", "netstandard2.0");
+    await AddDep("GdkSharp", "netstandard2.0");
     await AddDep("GLibSharp", "netstandard2.0");
     await AddDep("AtkSharp", "netstandard2.0");
     await AddDep("System.Memory", "netstandard2.0");

--- a/changelogs/SkiaSharp.HarfBuzz/1.68.2/SkiaSharp.HarfBuzz.md
+++ b/changelogs/SkiaSharp.HarfBuzz/1.68.2/SkiaSharp.HarfBuzz.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.HarfBuzz.dll
+
+## SkiaSharp.HarfBuzz.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views.Desktop.Common/1.68.2/SkiaSharp.Views.Desktop.Common.md
+++ b/changelogs/SkiaSharp.Views.Desktop.Common/1.68.2/SkiaSharp.Views.Desktop.Common.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.Desktop.Common.dll
+
+## SkiaSharp.Views.Desktop.Common.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views.Forms.GTK/1.68.2/SkiaSharp.Views.Forms.md
+++ b/changelogs/SkiaSharp.Views.Forms.GTK/1.68.2/SkiaSharp.Views.Forms.md
@@ -49,6 +49,20 @@ public interface ISKCanvasViewController : Xamarin.Forms.IElementController, Xam
 }
 ```
 
+#### New Type: SkiaSharp.Views.Forms.ISKGLViewController
+
+```csharp
+public interface ISKGLViewController : Xamarin.Forms.IElementController, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController {
+	// events
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.SKSize>> GetCanvasSize;
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.GRContext>> GetGRContext;
+	public event System.EventHandler SurfaceInvalidated;
+	// methods
+	public virtual void OnPaintSurface (SKPaintGLSurfaceEventArgs e);
+	public virtual void OnTouch (SKTouchEventArgs e);
+}
+```
+
 #### New Type: SkiaSharp.Views.Forms.SKBitmapImageSource
 
 ```csharp
@@ -117,7 +131,7 @@ public abstract class SKCanvasViewRendererBase`2 : Xamarin.Forms.Platform.GTK.Vi
 #### New Type: SkiaSharp.Views.Forms.SKGLView
 
 ```csharp
-public class SKGLView : Xamarin.Forms.View, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IAnimatable, Xamarin.Forms.IElementController, Xamarin.Forms.ITabStopElement, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.IGestureController, Xamarin.Forms.Internals.INameScope, Xamarin.Forms.Internals.INavigationProxy {
+public class SKGLView : Xamarin.Forms.View, ISKGLViewController, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IAnimatable, Xamarin.Forms.IElementController, Xamarin.Forms.ITabStopElement, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.IGestureController, Xamarin.Forms.Internals.INameScope, Xamarin.Forms.Internals.INavigationProxy {
 	// constructors
 	public SKGLView ();
 	// fields

--- a/changelogs/SkiaSharp.Views.Forms.GTK/1.68.2/SkiaSharp.Views.Forms.md
+++ b/changelogs/SkiaSharp.Views.Forms.GTK/1.68.2/SkiaSharp.Views.Forms.md
@@ -1,0 +1,300 @@
+# API diff: SkiaSharp.Views.Forms.dll
+
+## SkiaSharp.Views.Forms.dll
+
+> Assembly Version Changed: 1.68.0.0 vs 0.0.0.0
+
+### New Namespace SkiaSharp.Views.Forms
+
+#### New Type: SkiaSharp.Views.Forms.Extensions
+
+```csharp
+public static class Extensions {
+	// methods
+	public static Xamarin.Forms.Color ToFormsColor (this SkiaSharp.SKColor color);
+	public static Xamarin.Forms.Point ToFormsPoint (this SkiaSharp.SKPoint point);
+	public static Xamarin.Forms.Point ToFormsPoint (this SkiaSharp.SKPointI point);
+	public static Xamarin.Forms.Rectangle ToFormsRect (this SkiaSharp.SKRect rect);
+	public static Xamarin.Forms.Rectangle ToFormsRect (this SkiaSharp.SKRectI rect);
+	public static Xamarin.Forms.Size ToFormsSize (this SkiaSharp.SKSize size);
+	public static Xamarin.Forms.Size ToFormsSize (this SkiaSharp.SKSizeI size);
+	public static SkiaSharp.SKColor ToSKColor (this Xamarin.Forms.Color color);
+	public static SkiaSharp.SKPoint ToSKPoint (this Xamarin.Forms.Point point);
+	public static SkiaSharp.SKRect ToSKRect (this Xamarin.Forms.Rectangle rect);
+	public static SkiaSharp.SKSize ToSKSize (this Xamarin.Forms.Size size);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.GetPropertyValueEventArgs`1
+
+```csharp
+public class GetPropertyValueEventArgs`1 : System.EventArgs {
+	// constructors
+	public GetPropertyValueEventArgs`1 ();
+	// properties
+	public T Value { get; set; }
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.ISKCanvasViewController
+
+```csharp
+public interface ISKCanvasViewController : Xamarin.Forms.IElementController, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController {
+	// events
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.SKSize>> GetCanvasSize;
+	public event System.EventHandler SurfaceInvalidated;
+	// methods
+	public virtual void OnPaintSurface (SKPaintSurfaceEventArgs e);
+	public virtual void OnTouch (SKTouchEventArgs e);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKBitmapImageSource
+
+```csharp
+public sealed class SKBitmapImageSource : Xamarin.Forms.ImageSource, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.INameScope {
+	// constructors
+	public SKBitmapImageSource ();
+	// fields
+	public static Xamarin.Forms.BindableProperty BitmapProperty;
+	// properties
+	public SkiaSharp.SKBitmap Bitmap { get; set; }
+	// methods
+	public override System.Threading.Tasks.Task<bool> Cancel ();
+	protected override void OnPropertyChanged (string propertyName);
+	public static SKBitmapImageSource op_Implicit (SkiaSharp.SKBitmap bitmap);
+	public static SkiaSharp.SKBitmap op_Implicit (SKBitmapImageSource source);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKCanvasView
+
+```csharp
+public class SKCanvasView : Xamarin.Forms.View, ISKCanvasViewController, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IAnimatable, Xamarin.Forms.IElementController, Xamarin.Forms.ITabStopElement, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.IGestureController, Xamarin.Forms.Internals.INameScope, Xamarin.Forms.Internals.INavigationProxy {
+	// constructors
+	public SKCanvasView ();
+	// fields
+	public static Xamarin.Forms.BindableProperty EnableTouchEventsProperty;
+	public static Xamarin.Forms.BindableProperty IgnorePixelScalingProperty;
+	// properties
+	public SkiaSharp.SKSize CanvasSize { get; }
+	public bool EnableTouchEvents { get; set; }
+	public bool IgnorePixelScaling { get; set; }
+	// events
+	public event System.EventHandler<SKPaintSurfaceEventArgs> PaintSurface;
+	public event System.EventHandler<SKTouchEventArgs> Touch;
+	// methods
+	public void InvalidateSurface ();
+	protected override Xamarin.Forms.SizeRequest OnMeasure (double widthConstraint, double heightConstraint);
+	protected virtual void OnPaintSurface (SKPaintSurfaceEventArgs e);
+	protected virtual void OnTouch (SKTouchEventArgs e);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKCanvasViewRenderer
+
+```csharp
+public class SKCanvasViewRenderer : SkiaSharp.Views.Forms.SKCanvasViewRendererBase`2[SkiaSharp.Views.Forms.SKCanvasView,SkiaSharp.Views.Gtk.SKWidget], Atk.Implementor, GLib.IWrapper, System.Collections.IEnumerable, System.IDisposable, Xamarin.Forms.IEffectControlProvider, Xamarin.Forms.IRegisterable, Xamarin.Forms.Platform.GTK.IVisualElementRenderer, Xamarin.Forms.Platform.GTK.IVisualNativeElementRenderer {
+	// constructors
+	public SKCanvasViewRenderer ();
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKCanvasViewRendererBase`2
+
+```csharp
+public abstract class SKCanvasViewRendererBase`2 : Xamarin.Forms.Platform.GTK.ViewRenderer`2[TFormsView,TNativeView], Atk.Implementor, GLib.IWrapper, System.Collections.IEnumerable, System.IDisposable, Xamarin.Forms.IEffectControlProvider, Xamarin.Forms.IRegisterable, Xamarin.Forms.Platform.GTK.IVisualElementRenderer, Xamarin.Forms.Platform.GTK.IVisualNativeElementRenderer {
+	// constructors
+	protected SKCanvasViewRendererBase`2 ();
+	// methods
+	protected virtual TNativeView CreateNativeControl ();
+	protected override void Dispose (bool disposing);
+	protected override void OnElementChanged (Xamarin.Forms.Platform.GTK.ElementChangedEventArgs<TFormsView> e);
+	protected override void OnElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKGLView
+
+```csharp
+public class SKGLView : Xamarin.Forms.View, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IAnimatable, Xamarin.Forms.IElementController, Xamarin.Forms.ITabStopElement, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.IGestureController, Xamarin.Forms.Internals.INameScope, Xamarin.Forms.Internals.INavigationProxy {
+	// constructors
+	public SKGLView ();
+	// fields
+	public static Xamarin.Forms.BindableProperty EnableTouchEventsProperty;
+	public static Xamarin.Forms.BindableProperty HasRenderLoopProperty;
+	// properties
+	public SkiaSharp.SKSize CanvasSize { get; }
+	public bool EnableTouchEvents { get; set; }
+	public SkiaSharp.GRContext GRContext { get; }
+	public bool HasRenderLoop { get; set; }
+	// events
+	public event System.EventHandler<SKPaintGLSurfaceEventArgs> PaintSurface;
+	public event System.EventHandler<SKTouchEventArgs> Touch;
+	// methods
+	public void InvalidateSurface ();
+	protected override Xamarin.Forms.SizeRequest OnMeasure (double widthConstraint, double heightConstraint);
+	protected virtual void OnPaintSurface (SKPaintGLSurfaceEventArgs e);
+	protected virtual void OnTouch (SKTouchEventArgs e);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKImageImageSource
+
+```csharp
+public sealed class SKImageImageSource : Xamarin.Forms.ImageSource, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.INameScope {
+	// constructors
+	public SKImageImageSource ();
+	// fields
+	public static Xamarin.Forms.BindableProperty ImageProperty;
+	// properties
+	public SkiaSharp.SKImage Image { get; set; }
+	// methods
+	public override System.Threading.Tasks.Task<bool> Cancel ();
+	protected override void OnPropertyChanged (string propertyName);
+	public static SKImageImageSource op_Implicit (SkiaSharp.SKImage image);
+	public static SkiaSharp.SKImage op_Implicit (SKImageImageSource source);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKImageSourceHandler
+
+```csharp
+public sealed class SKImageSourceHandler : Xamarin.Forms.IRegisterable, Xamarin.Forms.Platform.GTK.Renderers.IImageSourceHandler {
+	// constructors
+	public SKImageSourceHandler ();
+	// methods
+	public virtual System.Threading.Tasks.Task<Gdk.Pixbuf> LoadImageAsync (Xamarin.Forms.ImageSource imagesource, System.Threading.CancellationToken cancelationToken, float scale);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKMouseButton
+
+```csharp
+[Serializable]
+public enum SKMouseButton {
+	Left = 1,
+	Middle = 2,
+	Right = 3,
+	Unknown = 0,
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKPaintGLSurfaceEventArgs
+
+```csharp
+public class SKPaintGLSurfaceEventArgs : System.EventArgs {
+	// constructors
+	public SKPaintGLSurfaceEventArgs (SkiaSharp.SKSurface surface, SkiaSharp.GRBackendRenderTarget renderTarget);
+
+	[Obsolete ("Use SKPaintGLSurfaceEventArgs(SKSurface, GRBackendRenderTarget, SKColorType, GRSurfaceOrigin) instead.")]
+public SKPaintGLSurfaceEventArgs (SkiaSharp.SKSurface surface, SkiaSharp.GRBackendRenderTargetDesc renderTarget);
+	public SKPaintGLSurfaceEventArgs (SkiaSharp.SKSurface surface, SkiaSharp.GRBackendRenderTarget renderTarget, SkiaSharp.GRSurfaceOrigin origin, SkiaSharp.SKColorType colorType);
+	// properties
+	public SkiaSharp.GRBackendRenderTarget BackendRenderTarget { get; }
+	public SkiaSharp.SKColorType ColorType { get; }
+	public SkiaSharp.GRSurfaceOrigin Origin { get; }
+
+	[Obsolete ("Use BackendRenderTarget instead.")]
+public SkiaSharp.GRBackendRenderTargetDesc RenderTarget { get; }
+	public SkiaSharp.SKSurface Surface { get; }
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKPaintSurfaceEventArgs
+
+```csharp
+public class SKPaintSurfaceEventArgs : System.EventArgs {
+	// constructors
+	public SKPaintSurfaceEventArgs (SkiaSharp.SKSurface surface, SkiaSharp.SKImageInfo info);
+	// properties
+	public SkiaSharp.SKImageInfo Info { get; }
+	public SkiaSharp.SKSurface Surface { get; }
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKPictureImageSource
+
+```csharp
+public sealed class SKPictureImageSource : Xamarin.Forms.ImageSource, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.INameScope {
+	// constructors
+	public SKPictureImageSource ();
+	// fields
+	public static Xamarin.Forms.BindableProperty DimensionsProperty;
+	public static Xamarin.Forms.BindableProperty PictureProperty;
+	// properties
+	public SkiaSharp.SKSizeI Dimensions { get; set; }
+	public SkiaSharp.SKPicture Picture { get; set; }
+	// methods
+	public override System.Threading.Tasks.Task<bool> Cancel ();
+	protected override void OnPropertyChanged (string propertyName);
+	public static SkiaSharp.SKPicture op_Explicit (SKPictureImageSource source);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKPixmapImageSource
+
+```csharp
+public sealed class SKPixmapImageSource : Xamarin.Forms.ImageSource, System.ComponentModel.INotifyPropertyChanged, Xamarin.Forms.IElementController, Xamarin.Forms.Internals.IDynamicResourceHandler, Xamarin.Forms.Internals.INameScope {
+	// constructors
+	public SKPixmapImageSource ();
+	// fields
+	public static Xamarin.Forms.BindableProperty PixmapProperty;
+	// properties
+	public SkiaSharp.SKPixmap Pixmap { get; set; }
+	// methods
+	public override System.Threading.Tasks.Task<bool> Cancel ();
+	protected override void OnPropertyChanged (string propertyName);
+	public static SKPixmapImageSource op_Implicit (SkiaSharp.SKPixmap pixmap);
+	public static SkiaSharp.SKPixmap op_Implicit (SKPixmapImageSource source);
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKTouchAction
+
+```csharp
+[Serializable]
+public enum SKTouchAction {
+	Cancelled = 4,
+	Entered = 0,
+	Exited = 5,
+	Moved = 2,
+	Pressed = 1,
+	Released = 3,
+	WheelChanged = 6,
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKTouchDeviceType
+
+```csharp
+[Serializable]
+public enum SKTouchDeviceType {
+	Mouse = 1,
+	Pen = 2,
+	Touch = 0,
+}
+```
+
+#### New Type: SkiaSharp.Views.Forms.SKTouchEventArgs
+
+```csharp
+public class SKTouchEventArgs : System.EventArgs {
+	// constructors
+	public SKTouchEventArgs (long id, SKTouchAction type, SkiaSharp.SKPoint location, bool inContact);
+	public SKTouchEventArgs (long id, SKTouchAction type, SKMouseButton mouseButton, SKTouchDeviceType deviceType, SkiaSharp.SKPoint location, bool inContact);
+	public SKTouchEventArgs (long id, SKTouchAction type, SKMouseButton mouseButton, SKTouchDeviceType deviceType, SkiaSharp.SKPoint location, bool inContact, int wheelDelta);
+	// properties
+	public SKTouchAction ActionType { get; }
+	public SKTouchDeviceType DeviceType { get; }
+	public bool Handled { get; set; }
+	public long Id { get; }
+	public bool InContact { get; }
+	public SkiaSharp.SKPoint Location { get; }
+	public SKMouseButton MouseButton { get; }
+	public int WheelDelta { get; }
+	// methods
+	public override string ToString ();
+}
+```
+

--- a/changelogs/SkiaSharp.Views.Forms.WPF/1.68.2/SkiaSharp.Views.Forms.md
+++ b/changelogs/SkiaSharp.Views.Forms.WPF/1.68.2/SkiaSharp.Views.Forms.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.Forms.dll
+
+## SkiaSharp.Views.Forms.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views.Forms.WPF/1.68.2/SkiaSharp.Views.Forms.md
+++ b/changelogs/SkiaSharp.Views.Forms.WPF/1.68.2/SkiaSharp.Views.Forms.md
@@ -2,4 +2,29 @@
 
 ## SkiaSharp.Views.Forms.dll
 
-> No changes.
+### Namespace SkiaSharp.Views.Forms
+
+#### Type Changed: SkiaSharp.Views.Forms.SKGLView
+
+Added interface:
+
+```csharp
+ISKGLViewController
+```
+
+
+#### New Type: SkiaSharp.Views.Forms.ISKGLViewController
+
+```csharp
+public interface ISKGLViewController : Xamarin.Forms.IElementController, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController {
+	// events
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.SKSize>> GetCanvasSize;
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.GRContext>> GetGRContext;
+	public event System.EventHandler SurfaceInvalidated;
+	// methods
+	public virtual void OnPaintSurface (SKPaintGLSurfaceEventArgs e);
+	public virtual void OnTouch (SKTouchEventArgs e);
+}
+```
+
+

--- a/changelogs/SkiaSharp.Views.Forms/1.68.2/SkiaSharp.Views.Forms.md
+++ b/changelogs/SkiaSharp.Views.Forms/1.68.2/SkiaSharp.Views.Forms.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.Forms.dll
+
+## SkiaSharp.Views.Forms.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views.Forms/1.68.2/SkiaSharp.Views.Forms.md
+++ b/changelogs/SkiaSharp.Views.Forms/1.68.2/SkiaSharp.Views.Forms.md
@@ -2,4 +2,29 @@
 
 ## SkiaSharp.Views.Forms.dll
 
-> No changes.
+### Namespace SkiaSharp.Views.Forms
+
+#### Type Changed: SkiaSharp.Views.Forms.SKGLView
+
+Added interface:
+
+```csharp
+ISKGLViewController
+```
+
+
+#### New Type: SkiaSharp.Views.Forms.ISKGLViewController
+
+```csharp
+public interface ISKGLViewController : Xamarin.Forms.IElementController, Xamarin.Forms.IViewController, Xamarin.Forms.IVisualElementController {
+	// events
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.SKSize>> GetCanvasSize;
+	public event System.EventHandler<SkiaSharp.Views.Forms.GetPropertyValueEventArgs<SkiaSharp.GRContext>> GetGRContext;
+	public event System.EventHandler SurfaceInvalidated;
+	// methods
+	public virtual void OnPaintSurface (SKPaintGLSurfaceEventArgs e);
+	public virtual void OnTouch (SKTouchEventArgs e);
+}
+```
+
+

--- a/changelogs/SkiaSharp.Views.Gtk2/1.68.2/SkiaSharp.Views.Gtk.md
+++ b/changelogs/SkiaSharp.Views.Gtk2/1.68.2/SkiaSharp.Views.Gtk.md
@@ -1,0 +1,30 @@
+# API diff: SkiaSharp.Views.Gtk.dll
+
+## SkiaSharp.Views.Gtk.dll
+
+### Namespace SkiaSharp.Views.Gtk
+
+#### New Type: SkiaSharp.Views.Gtk.GTKExtensions
+
+```csharp
+public static class GTKExtensions {
+	// methods
+	public static Gdk.Color ToColor (this SkiaSharp.SKColor color);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKBitmap skiaBitmap);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKImage skiaImage);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKPixmap pixmap);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKPicture picture, SkiaSharp.SKSizeI dimensions);
+	public static Gdk.Point ToPoint (this SkiaSharp.SKPointI point);
+	public static Gdk.Rectangle ToRect (this SkiaSharp.SKRectI rect);
+	public static SkiaSharp.SKBitmap ToSKBitmap (this Gdk.Pixbuf pixbuf);
+	public static SkiaSharp.SKColor ToSKColor (this Gdk.Color color);
+	public static SkiaSharp.SKImage ToSKImage (this Gdk.Pixbuf pixbuf);
+	public static void ToSKPixmap (this Gdk.Pixbuf pixbuf, SkiaSharp.SKPixmap pixmap);
+	public static SkiaSharp.SKPointI ToSKPointI (this Gdk.Point point);
+	public static SkiaSharp.SKRectI ToSKRectI (this Gdk.Rectangle rect);
+	public static SkiaSharp.SKSizeI ToSKSizeI (this Gdk.Size size);
+	public static Gdk.Size ToSize (this SkiaSharp.SKSizeI size);
+}
+```
+
+

--- a/changelogs/SkiaSharp.Views.Gtk3/1.68.2/SkiaSharp.Views.Gtk3.md
+++ b/changelogs/SkiaSharp.Views.Gtk3/1.68.2/SkiaSharp.Views.Gtk3.md
@@ -1,0 +1,30 @@
+# API diff: SkiaSharp.Views.Gtk3.dll
+
+## SkiaSharp.Views.Gtk3.dll
+
+### Namespace SkiaSharp.Views.Gtk
+
+#### New Type: SkiaSharp.Views.Gtk.GTKExtensions
+
+```csharp
+public static class GTKExtensions {
+	// methods
+	public static Gdk.Color ToColor (this SkiaSharp.SKColor color);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKBitmap skiaBitmap);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKImage skiaImage);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKPixmap pixmap);
+	public static Gdk.Pixbuf ToPixbuf (this SkiaSharp.SKPicture picture, SkiaSharp.SKSizeI dimensions);
+	public static Gdk.Point ToPoint (this SkiaSharp.SKPointI point);
+	public static Gdk.Rectangle ToRect (this SkiaSharp.SKRectI rect);
+	public static SkiaSharp.SKBitmap ToSKBitmap (this Gdk.Pixbuf pixbuf);
+	public static SkiaSharp.SKColor ToSKColor (this Gdk.Color color);
+	public static SkiaSharp.SKImage ToSKImage (this Gdk.Pixbuf pixbuf);
+	public static void ToSKPixmap (this Gdk.Pixbuf pixbuf, SkiaSharp.SKPixmap pixmap);
+	public static SkiaSharp.SKPointI ToSKPointI (this Gdk.Point point);
+	public static SkiaSharp.SKRectI ToSKRectI (this Gdk.Rectangle rect);
+	public static SkiaSharp.SKSizeI ToSKSizeI (this Gdk.Size size);
+	public static Gdk.Size ToSize (this SkiaSharp.SKSizeI size);
+}
+```
+
+

--- a/changelogs/SkiaSharp.Views.WPF/1.68.2/SkiaSharp.Views.WPF.md
+++ b/changelogs/SkiaSharp.Views.WPF/1.68.2/SkiaSharp.Views.WPF.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.WPF.dll
+
+## SkiaSharp.Views.WPF.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views.WindowsForms/1.68.2/SkiaSharp.Views.WindowsForms.md
+++ b/changelogs/SkiaSharp.Views.WindowsForms/1.68.2/SkiaSharp.Views.WindowsForms.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.WindowsForms.dll
+
+## SkiaSharp.Views.WindowsForms.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Android.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Android.md
@@ -1,0 +1,20 @@
+# API diff: SkiaSharp.Views.Android.dll
+
+## SkiaSharp.Views.Android.dll
+
+### Namespace SkiaSharp.Views.Android
+
+#### New Type: SkiaSharp.Views.Android.Resource
+
+```csharp
+public class Resource {
+	// constructors
+	public Resource ();
+
+	// inner types
+	public class Attribute {
+	}
+}
+```
+
+

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Desktop.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Desktop.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.Desktop.dll
+
+## SkiaSharp.Views.Desktop.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Mac.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Mac.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.Mac.dll
+
+## SkiaSharp.Views.Mac.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Tizen.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.Tizen.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.Tizen.dll
+
+## SkiaSharp.Views.Tizen.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.UWP.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.UWP.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.UWP.dll
+
+## SkiaSharp.Views.UWP.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.iOS.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.iOS.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.iOS.dll
+
+## SkiaSharp.Views.iOS.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.tvOS.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.tvOS.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.tvOS.dll
+
+## SkiaSharp.Views.tvOS.dll
+
+> No changes.

--- a/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.watchOS.md
+++ b/changelogs/SkiaSharp.Views/1.68.2/SkiaSharp.Views.watchOS.md
@@ -1,0 +1,5 @@
+# API diff: SkiaSharp.Views.watchOS.dll
+
+## SkiaSharp.Views.watchOS.dll
+
+> No changes.

--- a/changelogs/SkiaSharp/1.68.2/SkiaSharp.breaking.md
+++ b/changelogs/SkiaSharp/1.68.2/SkiaSharp.breaking.md
@@ -1,0 +1,51 @@
+# API diff: SkiaSharp.dll
+
+## SkiaSharp.dll
+
+### Namespace SkiaSharp
+
+#### Type Changed: SkiaSharp.SKColor
+
+Modified methods:
+
+```diff
+-public override bool Equals (object other)
++public override bool Equals (object obj)
+```
+
+
+#### Type Changed: SkiaSharp.SKPMColor
+
+Modified methods:
+
+```diff
+-public override bool Equals (object other)
++public override bool Equals (object obj)
+```
+
+
+#### Type Changed: SkiaSharp.SKSize
+
+Modified methods:
+
+```diff
+-public bool op_Equality (SKSize sz1, SKSize sz2---right---)
++public bool op_Equality (SKSize left, SKSize +++sz2+++right)
+-public bool op_Inequality (SKSize sz1, SKSize sz2---right---)
++public bool op_Inequality (SKSize left, SKSize +++sz2+++right)
+```
+
+
+#### Type Changed: SkiaSharp.SKSizeI
+
+Modified methods:
+
+```diff
+-public bool op_Equality (SKSizeI sz1, SKSizeI sz2---right---)
++public bool op_Equality (SKSizeI left, SKSizeI +++sz2+++right)
+-public bool op_Inequality (SKSizeI sz1, SKSizeI sz2---right---)
++public bool op_Inequality (SKSizeI left, SKSizeI +++sz2+++right)
+```
+
+
+

--- a/changelogs/SkiaSharp/1.68.2/SkiaSharp.md
+++ b/changelogs/SkiaSharp/1.68.2/SkiaSharp.md
@@ -144,16 +144,9 @@ Added methods:
 ```csharp
 public void DrawArc (SKRect oval, float startAngle, float sweepAngle, bool useCenter, SKPaint paint);
 public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKPaint paint);
-public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKBlendMode mode, SKPaint paint);
-public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKRect cullRect, SKPaint paint);
-public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKBlendMode mode, SKRect cullRect, SKPaint paint);
 public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKPaint paint);
 public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKRect cullRect, SKPaint paint);
-public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPaint paint);
-public void DrawPatch (SKPoint[] cubics, SKPoint[] texCoords, SKPaint paint);
-public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKBlendMode mode, SKPaint paint);
 public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKPaint paint);
-public void DrawPatch (SKPoint[] cubics, SKPoint[] texCoords, SKBlendMode mode, SKPaint paint);
 public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKBlendMode mode, SKPaint paint);
 public void DrawRoundRectDifference (SKRoundRect outer, SKRoundRect inner, SKPaint paint);
 ```

--- a/changelogs/SkiaSharp/1.68.2/SkiaSharp.md
+++ b/changelogs/SkiaSharp/1.68.2/SkiaSharp.md
@@ -1,0 +1,834 @@
+# API diff: SkiaSharp.dll
+
+## SkiaSharp.dll
+
+### Namespace SkiaSharp
+
+#### Type Changed: SkiaSharp.GRBackendRenderTargetDesc
+
+Added interface:
+
+```csharp
+System.IEquatable<GRBackendRenderTargetDesc>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (GRBackendRenderTargetDesc obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (GRBackendRenderTargetDesc left, GRBackendRenderTargetDesc right);
+public static bool op_Inequality (GRBackendRenderTargetDesc left, GRBackendRenderTargetDesc right);
+```
+
+
+#### Type Changed: SkiaSharp.GRBackendTextureDesc
+
+Added interface:
+
+```csharp
+System.IEquatable<GRBackendTextureDesc>
+```
+
+Added properties:
+
+```csharp
+public SKRectI Rect { get; }
+public SKSizeI Size { get; }
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (GRBackendTextureDesc obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (GRBackendTextureDesc left, GRBackendTextureDesc right);
+public static bool op_Inequality (GRBackendTextureDesc left, GRBackendTextureDesc right);
+```
+
+
+#### Type Changed: SkiaSharp.GRGlBackendTextureDesc
+
+Added interface:
+
+```csharp
+System.IEquatable<GRGlBackendTextureDesc>
+```
+
+Added properties:
+
+```csharp
+public SKRectI Rect { get; }
+public SKSizeI Size { get; }
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (GRGlBackendTextureDesc obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (GRGlBackendTextureDesc left, GRGlBackendTextureDesc right);
+public static bool op_Inequality (GRGlBackendTextureDesc left, GRGlBackendTextureDesc right);
+```
+
+
+#### Type Changed: SkiaSharp.GRGlFramebufferInfo
+
+Added interface:
+
+```csharp
+System.IEquatable<GRGlFramebufferInfo>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (GRGlFramebufferInfo obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (GRGlFramebufferInfo left, GRGlFramebufferInfo right);
+public static bool op_Inequality (GRGlFramebufferInfo left, GRGlFramebufferInfo right);
+```
+
+
+#### Type Changed: SkiaSharp.GRGlTextureInfo
+
+Added constructor:
+
+```csharp
+public GRGlTextureInfo (uint target, uint id);
+```
+
+Added interface:
+
+```csharp
+System.IEquatable<GRGlTextureInfo>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (GRGlTextureInfo obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (GRGlTextureInfo left, GRGlTextureInfo right);
+public static bool op_Inequality (GRGlTextureInfo left, GRGlTextureInfo right);
+```
+
+
+#### Type Changed: SkiaSharp.SKBitmap
+
+Added methods:
+
+```csharp
+public SKShader ToShader ();
+public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy);
+public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix);
+```
+
+
+#### Type Changed: SkiaSharp.SKCanvas
+
+Added properties:
+
+```csharp
+public bool IsClipEmpty { get; }
+public bool IsClipRect { get; }
+```
+
+Added methods:
+
+```csharp
+public void DrawArc (SKRect oval, float startAngle, float sweepAngle, bool useCenter, SKPaint paint);
+public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKPaint paint);
+public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKBlendMode mode, SKPaint paint);
+public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKRect cullRect, SKPaint paint);
+public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKBlendMode mode, SKRect cullRect, SKPaint paint);
+public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKPaint paint);
+public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKRect cullRect, SKPaint paint);
+public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPaint paint);
+public void DrawPatch (SKPoint[] cubics, SKPoint[] texCoords, SKPaint paint);
+public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKBlendMode mode, SKPaint paint);
+public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKPaint paint);
+public void DrawPatch (SKPoint[] cubics, SKPoint[] texCoords, SKBlendMode mode, SKPaint paint);
+public void DrawPatch (SKPoint[] cubics, SKColor[] colors, SKPoint[] texCoords, SKBlendMode mode, SKPaint paint);
+public void DrawRoundRectDifference (SKRoundRect outer, SKRoundRect inner, SKPaint paint);
+```
+
+
+#### Type Changed: SkiaSharp.SKCodecFrameInfo
+
+Added interface:
+
+```csharp
+System.IEquatable<SKCodecFrameInfo>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKCodecFrameInfo obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKCodecFrameInfo left, SKCodecFrameInfo right);
+public static bool op_Inequality (SKCodecFrameInfo left, SKCodecFrameInfo right);
+```
+
+
+#### Type Changed: SkiaSharp.SKCodecOptions
+
+Added interface:
+
+```csharp
+System.IEquatable<SKCodecOptions>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKCodecOptions obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKCodecOptions left, SKCodecOptions right);
+public static bool op_Inequality (SKCodecOptions left, SKCodecOptions right);
+```
+
+
+#### Type Changed: SkiaSharp.SKColor
+
+Added interface:
+
+```csharp
+System.IEquatable<SKColor>
+```
+
+Modified methods:
+
+```diff
+-public override bool Equals (object other)
++public override bool Equals (object obj)
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKColor obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKColorSpacePrimaries
+
+Added interface:
+
+```csharp
+System.IEquatable<SKColorSpacePrimaries>
+```
+
+Added field:
+
+```csharp
+public static SKColorSpacePrimaries Empty;
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKColorSpacePrimaries obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKColorSpacePrimaries left, SKColorSpacePrimaries right);
+public static bool op_Inequality (SKColorSpacePrimaries left, SKColorSpacePrimaries right);
+```
+
+
+#### Type Changed: SkiaSharp.SKColorSpaceTransferFn
+
+Added interface:
+
+```csharp
+System.IEquatable<SKColorSpaceTransferFn>
+```
+
+Added field:
+
+```csharp
+public static SKColorSpaceTransferFn Empty;
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKColorSpaceTransferFn obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKColorSpaceTransferFn left, SKColorSpaceTransferFn right);
+public static bool op_Inequality (SKColorSpaceTransferFn left, SKColorSpaceTransferFn right);
+```
+
+
+#### Type Changed: SkiaSharp.SKDocumentPdfMetadata
+
+Added interface:
+
+```csharp
+System.IEquatable<SKDocumentPdfMetadata>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKDocumentPdfMetadata obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKDocumentPdfMetadata left, SKDocumentPdfMetadata right);
+public static bool op_Inequality (SKDocumentPdfMetadata left, SKDocumentPdfMetadata right);
+```
+
+
+#### Type Changed: SkiaSharp.SKFontMetrics
+
+Added interface:
+
+```csharp
+System.IEquatable<SKFontMetrics>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKFontMetrics obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKFontMetrics left, SKFontMetrics right);
+public static bool op_Inequality (SKFontMetrics left, SKFontMetrics right);
+```
+
+
+#### Type Changed: SkiaSharp.SKHighContrastConfig
+
+Added interface:
+
+```csharp
+System.IEquatable<SKHighContrastConfig>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKHighContrastConfig obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKHighContrastConfig left, SKHighContrastConfig right);
+public static bool op_Inequality (SKHighContrastConfig left, SKHighContrastConfig right);
+```
+
+
+#### Type Changed: SkiaSharp.SKImage
+
+Added method:
+
+```csharp
+public SKShader ToShader ();
+```
+
+
+#### Type Changed: SkiaSharp.SKImageInfo
+
+Added interface:
+
+```csharp
+System.IEquatable<SKImageInfo>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKImageInfo obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKImageInfo left, SKImageInfo right);
+public static bool op_Inequality (SKImageInfo left, SKImageInfo right);
+```
+
+
+#### Type Changed: SkiaSharp.SKJpegEncoderOptions
+
+Added interface:
+
+```csharp
+System.IEquatable<SKJpegEncoderOptions>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKJpegEncoderOptions obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKJpegEncoderOptions left, SKJpegEncoderOptions right);
+public static bool op_Inequality (SKJpegEncoderOptions left, SKJpegEncoderOptions right);
+```
+
+
+#### Type Changed: SkiaSharp.SKLattice
+
+Added interface:
+
+```csharp
+System.IEquatable<SKLattice>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKLattice obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKLattice left, SKLattice right);
+public static bool op_Inequality (SKLattice left, SKLattice right);
+```
+
+
+#### Type Changed: SkiaSharp.SKMask
+
+Added interface:
+
+```csharp
+System.IEquatable<SKMask>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKMask obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKMask left, SKMask right);
+public static bool op_Inequality (SKMask left, SKMask right);
+```
+
+
+#### Type Changed: SkiaSharp.SKMatrix
+
+Added interface:
+
+```csharp
+System.IEquatable<SKMatrix>
+```
+
+Added fields:
+
+```csharp
+public static SKMatrix Empty;
+public static SKMatrix Identity;
+```
+
+Added property:
+
+```csharp
+public bool IsInvertible { get; }
+```
+
+Obsoleted methods:
+
+```diff
+ [Obsolete ("Use MapRect(SKRect) instead.")]
+ public static void MapRect (ref SKMatrix matrix, out SKRect dest, ref SKRect source);
+ [Obsolete ("Use PostConcat(SKMatrix) instead.")]
+ public static void PostConcat (ref SKMatrix target, SKMatrix matrix);
+ [Obsolete ("Use PostConcat(SKMatrix) instead.")]
+ public static void PostConcat (ref SKMatrix target, ref SKMatrix matrix);
+ [Obsolete ("Use PreConcat(SKMatrix) instead.")]
+ public static void PreConcat (ref SKMatrix target, SKMatrix matrix);
+ [Obsolete ("Use PreConcat(SKMatrix) instead.")]
+ public static void PreConcat (ref SKMatrix target, ref SKMatrix matrix);
+ [Obsolete ("Use CreateRotation(float) instead.")]
+ public static void Rotate (ref SKMatrix matrix, float radians);
+ [Obsolete ("Use CreateRotation(float, float, float) instead.")]
+ public static void Rotate (ref SKMatrix matrix, float radians, float pivotx, float pivoty);
+ [Obsolete ("Use CreateRotationDegrees(float) instead.")]
+ public static void RotateDegrees (ref SKMatrix matrix, float degrees);
+ [Obsolete ("Use CreateRotationDegrees(float, float, float) instead.")]
+ public static void RotateDegrees (ref SKMatrix matrix, float degrees, float pivotx, float pivoty);
+ [Obsolete ()]
+ public void SetScaleTranslate (float sx, float sy, float tx, float ty);
+```
+
+Added methods:
+
+```csharp
+public static SKMatrix Concat (SKMatrix first, SKMatrix second);
+public static SKMatrix CreateIdentity ();
+public static SKMatrix CreateRotation (float radians);
+public static SKMatrix CreateRotation (float radians, float pivotX, float pivotY);
+public static SKMatrix CreateRotationDegrees (float degrees);
+public static SKMatrix CreateRotationDegrees (float degrees, float pivotX, float pivotY);
+public static SKMatrix CreateScale (float x, float y);
+public static SKMatrix CreateScale (float x, float y, float pivotX, float pivotY);
+public static SKMatrix CreateSkew (float x, float y);
+public static SKMatrix CreateTranslation (float x, float y);
+public virtual bool Equals (SKMatrix obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public SKMatrix Invert ();
+public SKMatrix PostConcat (SKMatrix matrix);
+public SKMatrix PreConcat (SKMatrix matrix);
+public static bool op_Equality (SKMatrix left, SKMatrix right);
+public static bool op_Inequality (SKMatrix left, SKMatrix right);
+```
+
+
+#### Type Changed: SkiaSharp.SKMatrix44
+
+Added property:
+
+```csharp
+public bool IsInvertible { get; }
+```
+
+Added methods:
+
+```csharp
+public static SKMatrix44 CreateTranslation (float x, float y, float z);
+public static SKMatrix44 op_Implicit (SKMatrix matrix);
+```
+
+
+#### Type Changed: SkiaSharp.SKPMColor
+
+Added interface:
+
+```csharp
+System.IEquatable<SKPMColor>
+```
+
+Modified methods:
+
+```diff
+-public override bool Equals (object other)
++public override bool Equals (object obj)
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKPMColor obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKPicture
+
+Added methods:
+
+```csharp
+public SKShader ToShader ();
+public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy);
+public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKRect tile);
+public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix, SKRect tile);
+```
+
+
+#### Type Changed: SkiaSharp.SKPixmap
+
+Added methods:
+
+```csharp
+public bool Erase (SKColorF color);
+public bool Erase (SKColorF color, SKRectI subset);
+```
+
+
+#### Type Changed: SkiaSharp.SKPngEncoderOptions
+
+Added interface:
+
+```csharp
+System.IEquatable<SKPngEncoderOptions>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKPngEncoderOptions obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKPngEncoderOptions left, SKPngEncoderOptions right);
+public static bool op_Inequality (SKPngEncoderOptions left, SKPngEncoderOptions right);
+```
+
+
+#### Type Changed: SkiaSharp.SKPoint
+
+Added interface:
+
+```csharp
+System.IEquatable<SKPoint>
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKPoint obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKPoint3
+
+Added interface:
+
+```csharp
+System.IEquatable<SKPoint3>
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKPoint3 obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKPointI
+
+Added interface:
+
+```csharp
+System.IEquatable<SKPointI>
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKPointI obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKRect
+
+Added interface:
+
+```csharp
+System.IEquatable<SKRect>
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKRect obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKRectI
+
+Added interface:
+
+```csharp
+System.IEquatable<SKRectI>
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKRectI obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKRoundRect
+
+Added constructor:
+
+```csharp
+public SKRoundRect (SKRect rect, float radius);
+```
+
+
+#### Type Changed: SkiaSharp.SKShader
+
+Added methods:
+
+```csharp
+public static SKShader CreateBitmap (SKBitmap src);
+public static SKShader CreateColor (SKColorF color, SKColorSpace colorspace);
+public static SKShader CreateImage (SKImage src);
+public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy);
+public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix);
+public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode mode);
+public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode);
+public static SKShader CreateLinearGradient (SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix);
+public static SKShader CreatePerlinNoiseFractalNoise (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKSizeI tileSize);
+public static SKShader CreatePerlinNoiseImprovedNoise (float baseFrequencyX, float baseFrequencyY, int numOctaves, float z);
+public static SKShader CreatePerlinNoiseTurbulence (float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, SKSizeI tileSize);
+public static SKShader CreatePicture (SKPicture src);
+public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode mode);
+public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode);
+public static SKShader CreateRadialGradient (SKPoint center, float radius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix);
+public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace);
+public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos);
+public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKMatrix localMatrix);
+public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode tileMode, float startAngle, float endAngle);
+public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle);
+public static SKShader CreateSweepGradient (SKPoint center, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode tileMode, float startAngle, float endAngle, SKMatrix localMatrix);
+public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorspace, SKShaderTileMode mode);
+public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode);
+public static SKShader CreateTwoPointConicalGradient (SKPoint start, float startRadius, SKPoint end, float endRadius, SKColorF[] colors, SKColorSpace colorspace, float[] colorPos, SKShaderTileMode mode, SKMatrix localMatrix);
+public SKShader WithColorFilter (SKColorFilter filter);
+public SKShader WithLocalMatrix (SKMatrix localMatrix);
+```
+
+
+#### Type Changed: SkiaSharp.SKSize
+
+Added interface:
+
+```csharp
+System.IEquatable<SKSize>
+```
+
+Modified methods:
+
+```diff
+-public bool op_Equality (SKSize sz1, SKSize sz2---right---)
++public bool op_Equality (SKSize left, SKSize +++sz2+++right)
+-public bool op_Inequality (SKSize sz1, SKSize sz2---right---)
++public bool op_Inequality (SKSize left, SKSize +++sz2+++right)
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKSize obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKSizeI
+
+Added interface:
+
+```csharp
+System.IEquatable<SKSizeI>
+```
+
+Modified methods:
+
+```diff
+-public bool op_Equality (SKSizeI sz1, SKSizeI sz2---right---)
++public bool op_Equality (SKSizeI left, SKSizeI +++sz2+++right)
+-public bool op_Inequality (SKSizeI sz1, SKSizeI sz2---right---)
++public bool op_Inequality (SKSizeI left, SKSizeI +++sz2+++right)
+```
+
+Added method:
+
+```csharp
+public virtual bool Equals (SKSizeI obj);
+```
+
+
+#### Type Changed: SkiaSharp.SKSurfaceProps
+
+Added interface:
+
+```csharp
+System.IEquatable<SKSurfaceProps>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKSurfaceProps obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKSurfaceProps left, SKSurfaceProps right);
+public static bool op_Inequality (SKSurfaceProps left, SKSurfaceProps right);
+```
+
+
+#### Type Changed: SkiaSharp.SKWebpEncoderOptions
+
+Added interface:
+
+```csharp
+System.IEquatable<SKWebpEncoderOptions>
+```
+
+Added methods:
+
+```csharp
+public virtual bool Equals (SKWebpEncoderOptions obj);
+public override bool Equals (object obj);
+public override int GetHashCode ();
+public static bool op_Equality (SKWebpEncoderOptions left, SKWebpEncoderOptions right);
+public static bool op_Inequality (SKWebpEncoderOptions left, SKWebpEncoderOptions right);
+```
+
+
+#### New Type: SkiaSharp.SKColorF
+
+```csharp
+public struct SKColorF, System.IEquatable<SKColorF> {
+	// constructors
+	public SKColorF (float red, float green, float blue);
+	public SKColorF (float red, float green, float blue, float alpha);
+	// fields
+	public static SKColorF Empty;
+	// properties
+	public float Alpha { get; }
+	public float Blue { get; }
+	public float Green { get; }
+	public float Hue { get; }
+	public float Red { get; }
+	// methods
+	public SKColorF Clamp ();
+	public virtual bool Equals (SKColorF obj);
+	public override bool Equals (object obj);
+	public static SKColorF FromHsl (float h, float s, float l, float a);
+	public static SKColorF FromHsv (float h, float s, float v, float a);
+	public override int GetHashCode ();
+	public void ToHsl (out float h, out float s, out float l);
+	public void ToHsv (out float h, out float s, out float v);
+	public override string ToString ();
+	public SKColorF WithAlpha (float alpha);
+	public SKColorF WithBlue (float blue);
+	public SKColorF WithGreen (float green);
+	public SKColorF WithRed (float red);
+	public static bool op_Equality (SKColorF left, SKColorF right);
+	public static SKColor op_Explicit (SKColorF color);
+	public static SKColorF op_Implicit (SKColor color);
+	public static bool op_Inequality (SKColorF left, SKColorF right);
+}
+```
+
+#### New Type: SkiaSharp.SKRotationScaleMatrix
+
+```csharp
+public struct SKRotationScaleMatrix, System.IEquatable<SKRotationScaleMatrix> {
+	// constructors
+	public SKRotationScaleMatrix (float scos, float ssin, float tx, float ty);
+	// fields
+	public static SKRotationScaleMatrix Empty;
+	public static SKRotationScaleMatrix Identity;
+	// properties
+	public float SCos { get; set; }
+	public float SSin { get; set; }
+	public float TX { get; set; }
+	public float TY { get; set; }
+	// methods
+	public static SKRotationScaleMatrix CreateIdentity ();
+	public static SKRotationScaleMatrix CreateRotation (float radians, float anchorX, float anchorY);
+	public static SKRotationScaleMatrix CreateRotationDegrees (float degrees, float anchorX, float anchorY);
+	public static SKRotationScaleMatrix CreateScale (float s);
+	public static SKRotationScaleMatrix CreateTranslation (float x, float y);
+	public virtual bool Equals (SKRotationScaleMatrix obj);
+	public override bool Equals (object obj);
+	public static SKRotationScaleMatrix FromDegrees (float scale, float degrees, float tx, float ty, float anchorX, float anchorY);
+	public static SKRotationScaleMatrix FromRadians (float scale, float radians, float tx, float ty, float anchorX, float anchorY);
+	public override int GetHashCode ();
+	public SKMatrix ToMatrix ();
+	public static bool op_Equality (SKRotationScaleMatrix left, SKRotationScaleMatrix right);
+	public static bool op_Inequality (SKRotationScaleMatrix left, SKRotationScaleMatrix right);
+}
+```
+
+

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -24,8 +24,8 @@ variables:
   VM_IMAGE_LINUX: Hosted Ubuntu 1604
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
-  # To speed up builds when debugging DevOps
-  DOWNLOAD_EXTERNALS: '3439836'
+  # # To speed up builds when debugging DevOps
+  # DOWNLOAD_EXTERNALS: ''
 
 resources:
   repositories:

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -24,8 +24,8 @@ variables:
   VM_IMAGE_LINUX: Hosted Ubuntu 1604
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
-  # # To speed up builds when debugging DevOps
-  # DOWNLOAD_EXTERNALS: ''
+  # To speed up builds when debugging DevOps
+  DOWNLOAD_EXTERNALS: '3439836'
 
 resources:
   repositories:

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -19,15 +19,15 @@ parameters:
   docker: ''                                    # the Docker image to build and use
 
 jobs:
-# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-#   - template: azure-templates-download.yml
-#     parameters:
-#       name: ${{ parameters.name }}
-#       displayName: ${{ parameters.displayName }}
-#       vmImage: ${{ parameters.vmImage }}
-#       condition: ${{ parameters.condition }}
+- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+  - template: azure-templates-download.yml
+    parameters:
+      name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      vmImage: ${{ parameters.vmImage }}
+      condition: ${{ parameters.condition }}
 
-# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -19,15 +19,15 @@ parameters:
   docker: ''                                    # the Docker image to build and use
 
 jobs:
-- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-  - template: azure-templates-download.yml
-    parameters:
-      name: ${{ parameters.name }}
-      displayName: ${{ parameters.displayName }}
-      vmImage: ${{ parameters.vmImage }}
-      condition: ${{ parameters.condition }}
+# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+#   - template: azure-templates-download.yml
+#     parameters:
+#       name: ${{ parameters.name }}
+#       displayName: ${{ parameters.displayName }}
+#       vmImage: ${{ parameters.vmImage }}
+#       condition: ${{ parameters.condition }}
 
-- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKCanvasViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKCanvasViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Content;
 using Xamarin.Forms;
 
@@ -16,6 +17,7 @@ namespace SkiaSharp.Views.Forms
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use SKCanvasViewRenderer(Context) instead.")]
 		public SKCanvasViewRenderer()
 			: base()

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKGLViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKGLViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Content;
 using Android.Opengl;
 using Xamarin.Forms;
@@ -17,6 +18,7 @@ namespace SkiaSharp.Views.Forms
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use SKGLViewRenderer(Context) instead.")]
 		public SKGLViewRenderer()
 			: base()

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Native.Shared/SKCanvasViewRendererBase.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Native.Shared/SKCanvasViewRendererBase.cs
@@ -54,6 +54,7 @@ namespace SkiaSharp.Views.Forms
 #endif
 
 #if __ANDROID__
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use SKCanvasViewRendererBase(Context) instead.")]
 #endif
 		protected SKCanvasViewRendererBase()

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Native.Shared/SKGLViewRendererBase.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Native.Shared/SKGLViewRendererBase.cs
@@ -55,6 +55,7 @@ namespace SkiaSharp.Views.Forms
 #endif
 
 #if __ANDROID__
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use SKGLViewRendererBase(Context) instead.")]
 #endif
 		protected SKGLViewRendererBase()

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKGLView.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKGLView.cs
@@ -114,7 +114,7 @@ namespace SkiaSharp.Views.Forms
 		}
 	}
 
-	internal interface ISKGLViewController : IViewController
+	public interface ISKGLViewController : IViewController
 	{
 		// the native listens to this event
 		event EventHandler SurfaceInvalidated;

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKPaintGLSurfaceEventArgs.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKPaintGLSurfaceEventArgs.cs
@@ -1,12 +1,15 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SkiaSharp.Views.Forms
 {
 	public class SKPaintGLSurfaceEventArgs : EventArgs
 	{
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		private GRBackendRenderTargetDesc? rtDesc;
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use SKPaintGLSurfaceEventArgs(SKSurface, GRBackendRenderTarget, SKColorType, GRSurfaceOrigin) instead.")]
 		public SKPaintGLSurfaceEventArgs(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{
@@ -32,6 +35,7 @@ namespace SkiaSharp.Views.Forms
 
 		public SKSurface Surface { get; private set; }
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use BackendRenderTarget instead.")]
 		public GRBackendRenderTargetDesc RenderTarget
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKCanvasView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Content;
 using Android.Graphics;
 using Android.Runtime;
@@ -136,6 +137,7 @@ namespace SkiaSharp.Views.Android
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintSurfaceEventArgs) instead.")]
 		protected virtual void OnDraw(SKSurface surface, SKImageInfo info)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Content;
 using Android.Opengl;
 using Android.Util;
@@ -9,6 +10,7 @@ namespace SkiaSharp.Views.Android
 	{
 		private SKGLSurfaceViewRenderer renderer;
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		private ISKRenderer skRenderer;
 
@@ -44,12 +46,14 @@ namespace SkiaSharp.Views.Android
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use PaintSurface instead.")]
 		public virtual void SetRenderer(ISKRenderer renderer)
 		{
 			skRenderer = renderer;
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use SKGLSurfaceView.PaintSurface instead.")]
 		public interface ISKRenderer
 		{
@@ -70,6 +74,7 @@ namespace SkiaSharp.Views.Android
 				surfaceView.OnPaintSurface(e);
 			}
 
+			[EditorBrowsable (EditorBrowsableState.Never)]
 			[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 			protected override void OnDrawFrame(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 			{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Opengl;
 using Javax.Microedition.Khronos.Opengles;
 
@@ -25,6 +26,7 @@ namespace SkiaSharp.Views.Android
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 		protected virtual void OnDrawFrame(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Content;
 using Android.Opengl;
 using Android.Util;
@@ -9,6 +10,7 @@ namespace SkiaSharp.Views.Android
 	{
 		private SKGLTextureViewRenderer renderer;
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		private ISKRenderer skRenderer;
 
@@ -44,12 +46,14 @@ namespace SkiaSharp.Views.Android
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use PaintSurface instead.")]
 		public virtual void SetRenderer(ISKRenderer renderer)
 		{
 			skRenderer = renderer;
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use SKGLTextureView.PaintSurface instead.")]
 		public interface ISKRenderer
 		{
@@ -70,6 +74,7 @@ namespace SkiaSharp.Views.Android
 				textureView.OnPaintSurface(e);
 			}
 
+			[EditorBrowsable (EditorBrowsableState.Never)]
 			[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 			protected override void OnDrawFrame(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 			{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Opengl;
 using Javax.Microedition.Khronos.Opengles;
 
@@ -25,6 +26,7 @@ namespace SkiaSharp.Views.Android
 		{
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 		protected virtual void OnDrawFrame(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/ISKCanvasLayerDelegate.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/ISKCanvasLayerDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 #if __TVOS__
 namespace SkiaSharp.Views.tvOS
@@ -10,6 +11,7 @@ namespace SkiaSharp.Views.iOS
 namespace SkiaSharp.Views.Mac
 #endif
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete("Use SKCanvasLayer.PaintSurface instead.")]
 	public interface ISKCanvasLayerDelegate
 	{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/ISKGLLayerDelegate.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/ISKGLLayerDelegate.cs
@@ -1,5 +1,6 @@
 ﻿#if !__WATCHOS__
 using System;
+using System.ComponentModel;
 
 #if __TVOS__
 namespace SkiaSharp.Views.tvOS
@@ -9,6 +10,7 @@ namespace SkiaSharp.Views.iOS
 namespace SkiaSharp.Views.Mac
 #endif
 {
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	[Obsolete("Use SKGLLayer.PaintSurface instead.")]
 	public interface ISKGLLayerDelegate
 	{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCanvasLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCanvasLayer.cs
@@ -1,6 +1,7 @@
 ﻿#if !__WATCHOS__
 
 using System;
+using System.ComponentModel;
 using CoreAnimation;
 using CoreGraphics;
 
@@ -25,6 +26,7 @@ namespace SkiaSharp.Views.Mac
 			NeedsDisplayOnBoundsChange = true;
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use PaintSurface instead.")]
 		public ISKCanvasLayerDelegate SKDelegate { get; set; }
 
@@ -69,6 +71,7 @@ namespace SkiaSharp.Views.Mac
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, SKImageInfo info)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
@@ -112,6 +112,7 @@ namespace SkiaSharp.Views.iOS
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, SKImageInfo info)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLLayer.cs
@@ -1,6 +1,7 @@
 ﻿#if !__WATCHOS__
 
 using System;
+using System.ComponentModel;
 using CoreAnimation;
 using CoreGraphics;
 using OpenGLES;
@@ -30,6 +31,7 @@ namespace SkiaSharp.Views.iOS
 			Opaque = true;
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use PaintSurface instead.")]
 		public ISKGLLayerDelegate SKDelegate { get; set; }
 
@@ -110,6 +112,7 @@ namespace SkiaSharp.Views.iOS
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
@@ -138,6 +138,7 @@ namespace SkiaSharp.Views.iOS
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SkiaSharp.Views.Gtk3.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SkiaSharp.Views.Gtk3.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\SkiaSharp.Views.Desktop.Common\SkiaSharp.Views.Desktop.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SkiaSharp.Views.Gtk\GTKExtensions.cs" Link="GTKExtensions.cs" />
     <Compile Include="..\SkiaSharp.Views.Shared\Properties\SkiaSharpViewsAssemblyInfo.cs" Link="Properties\SkiaSharpViewsAssemblyInfo.cs" />
   </ItemGroup>
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKCanvasView.cs
@@ -63,6 +63,7 @@ namespace SkiaSharp.Views.Mac
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, SKImageInfo info)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLLayer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using CoreAnimation;
 using CoreVideo;
 using OpenGL;
@@ -21,6 +22,7 @@ namespace SkiaSharp.Views.Mac
 			NeedsDisplayOnBoundsChange = true;
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use PaintSurface instead.")]
 		public ISKGLLayerDelegate SKDelegate { get; set; }
 
@@ -35,6 +37,7 @@ namespace SkiaSharp.Views.Mac
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLView.cs
@@ -128,6 +128,7 @@ namespace SkiaSharp.Views.Mac
 			PaintSurface?.Invoke(this, e);
 		}
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use OnPaintSurface(SKPaintGLSurfaceEventArgs) instead.")]
 		public virtual void DrawInSurface(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Shared/SKPaintGLSurfaceEventArgs.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Shared/SKPaintGLSurfaceEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿#if !__WATCHOS__
 using System;
+using System.ComponentModel;
 
 #if __ANDROID__
 namespace SkiaSharp.Views.Android
@@ -19,9 +20,11 @@ namespace SkiaSharp.Views.Tizen
 {
 	public class SKPaintGLSurfaceEventArgs : EventArgs
 	{
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete]
 		private GRBackendRenderTargetDesc? rtDesc;
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use SKPaintGLSurfaceEventArgs(SKSurface, GRBackendRenderTarget, SKColorType, GRSurfaceOrigin) instead.")]
 		public SKPaintGLSurfaceEventArgs(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{
@@ -47,6 +50,7 @@ namespace SkiaSharp.Views.Tizen
 
 		public SKSurface Surface { get; private set; }
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete("Use BackendRenderTarget instead.")]
 		public GRBackendRenderTargetDesc RenderTarget
 		{

--- a/tests/Tests/SKCanvasTest.cs
+++ b/tests/Tests/SKCanvasTest.cs
@@ -128,7 +128,7 @@ namespace SkiaSharp.Tests
 			var sprites = new[] { SKRect.Empty, SKRect.Empty };
 			var transforms = new[] { SKRotationScaleMatrix.Empty };
 
-			Assert.Throws<ArgumentException>("transforms", () => canvas.DrawAtlas(img, sprites, transforms, SKBlendMode.Src, paint));
+			Assert.Throws<ArgumentException>("transforms", () => canvas.DrawAtlas(img, sprites, transforms, paint));
 		}
 
 		[SkippableFact]
@@ -161,7 +161,7 @@ namespace SkiaSharp.Tests
 				Shader = baboon.ToShader(),
 			};
 
-			canvas.DrawPatch(cubics, tex, paint);
+			canvas.DrawPatch(cubics, null, tex, paint);
 		}
 
 		[SkippableFact]

--- a/tests/Tests/SKColorSpaceTest.cs
+++ b/tests/Tests/SKColorSpaceTest.cs
@@ -206,6 +206,10 @@ namespace SkiaSharp.Tests
 			};
 			AssertMatrix(toXYZ, colorspace.ToXyzD50());
 
+			var matrix = new SKMatrix44();
+			Assert.True(colorspace.ToXyzD50(matrix));
+			AssertMatrix(toXYZ, matrix);
+
 			var fromXYZ = new[]
 			{
 				1.96253f, -0.61068f, -0.34137f, 0f,

--- a/tests/Tests/SKMatrixTests.cs
+++ b/tests/Tests/SKMatrixTests.cs
@@ -158,9 +158,8 @@ namespace SkiaSharp.Tests
 		{
 			var a = SKMatrix.MakeTranslation(10, 20);
 			var b = SKMatrix.MakeTranslation(5, 7);
-			var c = new SKMatrix();
 
-			SKMatrix.Concat(ref c, ref a, ref b);
+			var c = SKMatrix.Concat(a, b);
 			
 			Assert.Equal(SKMatrix.MakeTranslation(15, 27).Values, c.Values);
 		}
@@ -171,9 +170,9 @@ namespace SkiaSharp.Tests
 			var a = SKMatrix.MakeTranslation(10, 20);
 			var b = SKMatrix.MakeTranslation(5, 7);
 
-			SKMatrix.PreConcat(ref a, ref b);
+			var c = a.PreConcat(b);
 			
-			Assert.Equal(SKMatrix.MakeTranslation(15, 27).Values, a.Values);
+			Assert.Equal(SKMatrix.MakeTranslation(15, 27).Values, c.Values);
 		}
 
 		[SkippableFact]
@@ -182,16 +181,16 @@ namespace SkiaSharp.Tests
 			var a = SKMatrix.MakeTranslation(10, 20);
 			var b = SKMatrix.MakeTranslation(5, 7);
 
-			SKMatrix.PostConcat(ref a, ref b);
+			var c = a.PostConcat(b);
 			
-			Assert.Equal(SKMatrix.MakeTranslation(15, 27).Values, a.Values);
+			Assert.Equal(SKMatrix.MakeTranslation(15, 27).Values, c.Values);
 		}
 
 		[SkippableFact]
 		public void SKRotationScaleMatrixTranslationToMatrixIsCorrect()
 		{
 			var m = SKMatrix.MakeTranslation(5, 7);
-			var rsm = SKRotationScaleMatrix.CreateTranslate(5, 7).ToMatrix();
+			var rsm = SKRotationScaleMatrix.CreateTranslation(5, 7).ToMatrix();
 
 			Assert.Equal(m.Values, rsm.Values);
 		}

--- a/utils/SkiaSharpGenerator/Generate/Generator.cs
+++ b/utils/SkiaSharpGenerator/Generate/Generator.cs
@@ -361,12 +361,12 @@ namespace SkiaSharpGenerator
 					{
 						equalityFields.Add($"{f} == obj.{f}");
 					}
-					writer.WriteLine($"\t\tpublic bool Equals ({name} obj) =>");
+					writer.WriteLine($"\t\tpublic readonly bool Equals ({name} obj) =>");
 					writer.WriteLine($"\t\t\t{string.Join(" && ", equalityFields)};");
 					writer.WriteLine();
 
 					// Equals
-					writer.WriteLine($"\t\tpublic override bool Equals (object obj) =>");
+					writer.WriteLine($"\t\tpublic readonly override bool Equals (object obj) =>");
 					writer.WriteLine($"\t\t\tobj is {name} f && Equals (f);");
 					writer.WriteLine();
 
@@ -379,7 +379,7 @@ namespace SkiaSharpGenerator
 					writer.WriteLine();
 
 					// GetHashCode
-					writer.WriteLine($"\t\tpublic override int GetHashCode ()");
+					writer.WriteLine($"\t\tpublic readonly override int GetHashCode ()");
 					writer.WriteLine($"\t\t{{");
 					writer.WriteLine($"\t\t\tvar hash = new HashCode ();");
 					foreach (var f in allFields)


### PR DESCRIPTION
**Description of Change**

- Make more members readonly
- the generator now makes the equality members readonly
- split the SKMatrix file into SKMatrix44, SKRotationScaleMatrix, SK3dView
- split the SKColorSpace structs/classes into a separate file
- reworked/renamed all the poorly designed SKMatrix (and related) members to be actually useful

**Bugs Fixed**

 - Fixes https://github.com/mono/SkiaSharp/issues/399

**API Changes**

 - TODO

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
