### PR TITLE
Prevent double load issue.

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
@@ -26,6 +26,9 @@ namespace SkiaSharp.Views.UWP
 		private bool ignorePixelScaling;
 		private bool isVisible = true;
 
+		// workaround for https://github.com/mono/SkiaSharp/issues/1118
+		private int loadUnloadCounter = 0;
+
 		public SKXamlCanvas()
 		{
 			if (designMode)
@@ -89,6 +92,10 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
+			loadUnloadCounter++;
+			if (loadUnloadCounter != 1)
+				return;
+
 			var display = DisplayInformation.GetForCurrentView();
 			display.DpiChanged += OnDpiChanged;
 
@@ -97,6 +104,10 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
+			loadUnloadCounter--;
+			if (loadUnloadCounter != 0)
+				return;
+
 			var display = DisplayInformation.GetForCurrentView();
 			display.DpiChanged -= OnDpiChanged;
 
@@ -145,7 +156,7 @@ namespace SkiaSharp.Views.UWP
 			var dpi = Dpi;
 			return new SKSizeI((int)(w * dpi), (int)(h * dpi));
 
-			bool IsPositive(double value)
+			static bool IsPositive(double value)
 			{
 				return !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
 			}


### PR DESCRIPTION
**Description of Change**

For some reason, some controls (such as the `ScrollViewer`'s `LeftHeader`, `TopHeader` and `TopLeftHeader`) are loaded twice.
We work around this by just adding a counter.
This will also fix any other controls that are a bit weird.

**Bugs Fixed**

- Fixes #1118

**API Changes**

None.

**Behavioral Changes**

Any code that relied on the `ScrollViewer`'s `LeftHeader`, `TopHeader` and `TopLeftHeader` loading twice and then unloading once will not work as expected. The control still loads twice, but the second (and subsequent) loads are ignored. Similarly, all unloads, except the load, will be ignore.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
