### PR TITLE
Queue the redraw for iOS and macOS

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SKGLViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SKGLViewRenderer.cs
@@ -46,7 +46,7 @@ namespace SkiaSharp.Views.Forms
 			if (oneShot)
 			{
 				var nativeView = Control;
-				nativeView?.Display();
+				nativeView?.BeginInvokeOnMainThread(() => nativeView?.Display());
 				return;
 			}
 
@@ -58,7 +58,7 @@ namespace SkiaSharp.Views.Forms
 				var formsView = Element;
 
 				// redraw the view
-				nativeView?.Display();
+				nativeView?.BeginInvokeOnMainThread(() => nativeView?.Display());
 
 				// stop the render loop if this was a one-shot, or the views are disposed
 				if (nativeView == null || formsView == null || !formsView.HasRenderLoop)

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKGLViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKGLViewRenderer.cs
@@ -55,7 +55,7 @@ namespace SkiaSharp.Views.Forms
 			if (oneShot)
 			{
 				var nativeView = Control;
-				nativeView?.Display();
+				nativeView?.BeginInvokeOnMainThread(() => nativeView?.Display());
 				return;
 			}
 


### PR DESCRIPTION
**Description of Change**

macOS and iOS draw immediately, so rather queue the redraw. Not only does this fix the stack overflow, but is now more consistent with the other platforms.

This also just fixes it for macOS and the render loop. Unlike iOS, macOS does not start the `CVDisplayLink` the same way as the `CADisplayLink`. As a result, the callback is on the background thread.

**Bugs Fixed**

- Fixes #1074

**API Changes**

None.

**Behavioral Changes**

This technically a breaking change for macOS in that the draw is now on the main thread. But, the loop never worked, and the one shot caused a stack overflow.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
