### PR TITLE
Make sure the OpenGL context is "current" before drawing on it

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
@@ -70,6 +70,8 @@ namespace SkiaSharp.Views.Desktop
 
 			base.OnPaint(e);
 
+			MakeCurrent();
+
 			// create the contexts if not done already
 			if (grContext == null)
 			{


### PR DESCRIPTION
**Description of Change**

If there are multiple `SKGLControls` drawing at the same time, there is the chance that one view may draw on another view. Or cause issues. This is because OpenGL is basically a thread-static library, and can only have a single "current" context per thread. By calling `MakeCurrent`, we are letting OpenGL know that _this_ view is drawing and all operations are here. The next view that wants to draw then also lets OpenGL know that it wants to do some work and the OpenGL can "shift" over to that one.

**Bugs Fixed**

- Fixes #920

**API Changes**

None.

**Behavioral Changes**

When multiple `SKGLControls` are created, there is some cross-talk. This PR makes sure that each view requests control over all operations.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
