### PR TITLE
Make sure the view is still in the hierarchy

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerElement.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerElement.cs
@@ -103,6 +103,10 @@ namespace SkiaSharp.Views.Forms
 
 			var view = sender as FrameworkElement;
 
+			// bail out if this view is not part the view hierarchy anymore
+			if (PresentationSource.FromVisual(view) == null)
+				return false;
+
 			var id = GetId(evt);
 			var action = GetTouchAction(touchActionType, view, evt);
 			var mouse = GetMouseButton(evt);


### PR DESCRIPTION
**Description of Change**

Make sure the view is still in the hierarchy
In the case of virtualized list views, the control may no longer be in screen, so we have to ignore touch events.

**Bugs Fixed**

- Fixes #978

**API Changes**

None.

**Behavioral Changes**

Bug fix.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
