### PR TITLE
Improve the experience with the SKTextBlobBuilder

### DIFF
--- a/binding/Binding/SKRunBuffer.cs
+++ b/binding/Binding/SKRunBuffer.cs
@@ -19,13 +19,13 @@ namespace SkiaSharp
 		public int TextSize { get; }
 
 		public Span<ushort> GetGlyphSpan () =>
-			new Span<ushort> (internalBuffer.glyphs, Size);
+			new Span<ushort> (internalBuffer.glyphs, internalBuffer.glyphs == null ? 0 : Size);
 
 		public Span<byte> GetTextSpan () =>
-			new Span<byte> (internalBuffer.utf8text, TextSize);
+			new Span<byte> (internalBuffer.utf8text, internalBuffer.utf8text == null ? 0 : TextSize);
 
 		public Span<uint> GetClusterSpan () =>
-			new Span<uint> (internalBuffer.clusters, Size);
+			new Span<uint> (internalBuffer.clusters, internalBuffer.clusters == null ? 0 : Size);
 
 		public void SetGlyphs (ReadOnlySpan<ushort> glyphs) =>
 			glyphs.CopyTo (GetGlyphSpan ());
@@ -45,7 +45,7 @@ namespace SkiaSharp
 		}
 
 		public Span<float> GetPositionSpan () =>
-			new Span<float> (internalBuffer.pos, Size);
+			new Span<float> (internalBuffer.pos, internalBuffer.pos == null ? 0 : Size);
 
 		public void SetPositions (ReadOnlySpan<float> positions) =>
 			positions.CopyTo (GetPositionSpan ());
@@ -59,7 +59,7 @@ namespace SkiaSharp
 		}
 
 		public Span<SKPoint> GetPositionSpan () =>
-			new Span<SKPoint> (internalBuffer.pos, Size);
+			new Span<SKPoint> (internalBuffer.pos, internalBuffer.pos == null ? 0 : Size);
 
 		public void SetPositions (ReadOnlySpan<SKPoint> positions) =>
 			positions.CopyTo (GetPositionSpan ());

--- a/binding/Binding/SKTextBlob.cs
+++ b/binding/Binding/SKTextBlob.cs
@@ -258,7 +258,11 @@ namespace SkiaSharp
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
 
-			using (var lang = new SKString ()) {
+			var originalEncoding = font.TextEncoding;
+			try {
+				font.TextEncoding = SKTextEncoding.GlyphId;
+
+				using var lang = new SKString ();
 				SKRunBufferInternal runbuffer;
 				if (bounds is SKRect b) {
 					SkiaApi.sk_textblob_builder_alloc_run_text (Handle, font.Handle, count, x, y, textByteCount, lang.Handle, &b, &runbuffer);
@@ -267,6 +271,9 @@ namespace SkiaSharp
 				}
 
 				return new SKRunBuffer (runbuffer, count, textByteCount);
+
+			} finally {
+				font.TextEncoding = originalEncoding;
 			}
 		}
 
@@ -286,7 +293,11 @@ namespace SkiaSharp
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
 
-			using (var lang = new SKString ()) {
+			var originalEncoding = font.TextEncoding;
+			try {
+				font.TextEncoding = SKTextEncoding.GlyphId;
+
+				using var lang = new SKString ();
 				SKRunBufferInternal runbuffer;
 				if (bounds is SKRect b) {
 					SkiaApi.sk_textblob_builder_alloc_run_text_pos_h (Handle, font.Handle, count, y, textByteCount, lang.Handle, &b, &runbuffer);
@@ -295,6 +306,8 @@ namespace SkiaSharp
 				}
 
 				return new SKHorizontalRunBuffer (runbuffer, count, textByteCount);
+			} finally {
+				font.TextEncoding = originalEncoding;
 			}
 		}
 
@@ -314,7 +327,11 @@ namespace SkiaSharp
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
 
-			using (var lang = new SKString ()) {
+			var originalEncoding = font.TextEncoding;
+			try {
+				font.TextEncoding = SKTextEncoding.GlyphId;
+
+				using var lang = new SKString ();
 				SKRunBufferInternal runbuffer;
 				if (bounds is SKRect b) {
 					SkiaApi.sk_textblob_builder_alloc_run_text_pos (Handle, font.Handle, count, textByteCount, lang.Handle, &b, &runbuffer);
@@ -323,6 +340,8 @@ namespace SkiaSharp
 				}
 
 				return new SKPositionedRunBuffer (runbuffer, count, textByteCount);
+			} finally {
+				font.TextEncoding = originalEncoding;
 			}
 		}
 	}

--- a/tests/Tests/SKTextBlobTest.cs
+++ b/tests/Tests/SKTextBlobTest.cs
@@ -17,6 +17,23 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void NonGlyphTextEncodingDoesNotThrow()
+		{
+			using var paint = new SKPaint { TextEncoding = SKTextEncoding.Utf16 };
+
+			using var builder = new SKTextBlobBuilder();
+
+			var run = builder.AllocateRun(paint, 100, 0, 0, 50);
+			Assert.Equal(100, run.GetGlyphSpan().Length);
+			Assert.Equal(50, run.GetTextSpan().Length);
+
+			using var blob = builder.Build();
+			Assert.NotNull(blob);
+
+			Assert.Equal(SKTextEncoding.Utf16, paint.TextEncoding);
+		}
+
+		[SkippableFact]
 		public void TestExplicitBounds()
 		{
 			var builder = new SKTextBlobBuilder();


### PR DESCRIPTION
**Description of Change**

When the paint encoding is anything but GlyphId, the underlying allocation fails. This results in not only strange behaviour, but also invalid data. The run buffer is given a size, but nothing was allocated. This does 2 things:

- if a buffer is null, override the size
- if the encoding is not glyph, then change it temporarily

**Bugs Fixed**

- Fixes #1151

**API Changes**

None.

**Behavioral Changes**

Instead of throwing an unexpected exception when trying to USE the run buffer, the allocation will now succeed. And, if the each buffer on the run is null, then don't return a `Span<T>` that is not null.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
