### PR TITLE
Update all the build tools

### DIFF
--- a/cake/msbuild.cake
+++ b/cake/msbuild.cake
@@ -17,6 +17,12 @@ void RunMSBuild(
         c.Verbosity = VERBOSITY;
         c.MaxCpuCount = 0;
 
+        if (!string.IsNullOrEmpty(MSBUILD_EXE)) {
+            c.ToolPath = MSBUILD_EXE;
+        } else if (IsRunningOnWindows() && !string.IsNullOrEmpty(VS_INSTALL)) {
+            c.ToolPath = ((DirectoryPath)VS_INSTALL).CombineWithFilePath("MSBuild/Current/Bin/MSBuild.exe");
+        }
+
         c.NoLogo = VERBOSITY == Verbosity.Minimal;
 
         if (restoreOnly) {

--- a/cake/native-shared.cake
+++ b/cake/native-shared.cake
@@ -43,6 +43,13 @@ void GnNinja(DirectoryPath outDir, string target, string skiaArgs)
     var quote = IsRunningOnWindows() || isCore ? "\"" : "'";
     var innerQuote = IsRunningOnWindows() || isCore ? "\\\"" : "\"";
 
+    // override win_vc with the command line args
+    if (!string.IsNullOrEmpty(VS_INSTALL)) {
+        DirectoryPath win_vc = VS_INSTALL;
+        win_vc = win_vc.Combine("VC");
+        skiaArgs += $" win_vc='{win_vc}' ";
+    }
+
     // generate native skia build files
     RunProcess(SKIA_PATH.CombineWithFilePath($"bin/gn{exe}"), new ProcessSettings {
         Arguments = $"gen out/{outDir} --args={quote}{skiaArgs.Replace("'", innerQuote)}{quote}",

--- a/cake/shared.cake
+++ b/cake/shared.cake
@@ -5,6 +5,9 @@ var TARGET = Argument("t", Argument("target", "Default"));
 var VERBOSITY = Argument("v", Argument("verbosity", Verbosity.Normal));
 var CONFIGURATION = Argument("c", Argument("configuration", "Release"));
 
+var VS_INSTALL = Argument("vsinstall", EnvironmentVariable("VS_INSTALL"));
+var MSBUILD_EXE = Argument("msbuild", EnvironmentVariable("MSBUILD_EXE"));
+
 var CAKE_ARGUMENTS = (IReadOnlyDictionary<string, string>)Context.Arguments
     .GetType()
     .GetProperty("Arguments")

--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -26,7 +26,7 @@ Task("libSkiaSharp")
             $"skia_use_system_expat=false skia_use_system_freetype2=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false " +
             $"extra_cflags=[ '-DSKIA_C_DLL' ] " +
             $"ndk='{ANDROID_NDK_HOME}' " +
-            $"ndk_api={(skiaArch == "x64" || skiaArch == "arm64" ? 21 : 9)}");
+            $"ndk_api={(skiaArch == "x64" || skiaArch == "arm64" ? 21 : 16)}");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);

--- a/native/android/libHarfBuzzSharp/jni/Application.mk
+++ b/native/android/libHarfBuzzSharp/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
-APP_PLATFORM := android-9
+APP_PLATFORM := android-16
 NDK_TOOLCHAIN_VERSION := clang
 APP_STL := c++_static
 APP_OPTIM := release

--- a/native/uwp/SkiaSharp.Views.Interop.UWP/SkiaSharp.Views.Interop.UWP.vcxproj
+++ b/native/uwp/SkiaSharp.Views.Interop.UWP/SkiaSharp.Views.Interop.UWP.vcxproj
@@ -42,35 +42,35 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/native/uwp/libHarfBuzzSharp/libHarfBuzzSharp.vcxproj
+++ b/native/uwp/libHarfBuzzSharp/libHarfBuzzSharp.vcxproj
@@ -241,35 +241,35 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/native/windows/libHarfBuzzSharp/libHarfBuzzSharp.vcxproj
+++ b/native/windows/libHarfBuzzSharp/libHarfBuzzSharp.vcxproj
@@ -222,32 +222,32 @@
     <ProjectGuid>{AFE6308E-9F79-4F9D-85BF-B68E8DEE2F13}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libHarfBuzzSharp</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -21,7 +21,6 @@ variables:
   XCODE_VERSION: 11.3
   DOTNET_VERSION: 3.0.x
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS_NATIVE: Hosted VS2017
   VM_IMAGE_WINDOWS: Hosted Windows 2019 with VS2019
   VM_IMAGE_MAC: Hosted macOS
   VM_IMAGE_LINUX: Hosted Ubuntu 1604
@@ -57,35 +56,35 @@ stages:
         parameters:
           name: native_android_x86_windows
           displayName: Build Native Android|x86 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=x86
       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (Windows)
         parameters:
           name: native_android_x64_windows
           displayName: Build Native Android|x64 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=x64
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (Windows)
         parameters:
           name: native_android_arm_windows
           displayName: Build Native Android|arm (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=arm
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (Windows)
         parameters:
           name: native_android_arm64_windows
           displayName: Build Native Android|arm64 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=arm64
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Windows)
         parameters:
           name: native_tizen_windows
           displayName: Build Native Tizen (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-tizen
           condition: false # TODO: TIZEN INSTALL BUGS
       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x86 (Windows)
@@ -121,28 +120,28 @@ stages:
         parameters:
           name: native_uwp_x86_windows
           displayName: Build Native UWP|x86 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
       - template: azure-templates-bootstrapper.yml # Build Native UWP|x64 (Windows)
         parameters:
           name: native_uwp_x64_windows
           displayName: Build Native UWP|x64 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm (Windows)
         parameters:
           name: native_uwp_arm_windows
           displayName: Build Native UWP|arm (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm64 (Windows)
         parameters:
           name: native_uwp_arm64_windows
           displayName: Build Native UWP|arm64 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
           condition: false # TODO: NOT YET SUPPORTED
@@ -150,21 +149,21 @@ stages:
         parameters:
           name: native_win32_x86_windows
           displayName: Build Native Win32|x86 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x86
       - template: azure-templates-bootstrapper.yml # Build Native Win32|x64 (Windows)
         parameters:
           name: native_win32_x64_windows
           displayName: Build Native Win32|x64 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x64
       - template: azure-templates-bootstrapper.yml # Build Native NanoServer|x64 (Windows)
         parameters:
           name: native_win32_x64_nanoserver_windows
           displayName: Build Native NanoServer|x64 (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
           preBuildSteps:
@@ -358,7 +357,7 @@ stages:
         parameters:
           name: api_diff_windows
           displayName: API Diff
-          vmImage: $(VM_IMAGE_WINDOWS_NATIVE)
+          vmImage: Hosted VS2017
           target: docs-api-diff
           shouldPublish: false
           requiredArtifacts:
@@ -558,7 +557,7 @@ stages:
             name: native_checks_windows
             displayName: Run Code Checks
             # condition: and(always(), eq('refs/heads/master', variables['Build.SourceBranch']))
-            vmImage: $(VM_IMAGE_WINDOWS)
+            vmImage: Hosted VS2017
             target: git-sync-deps
             shouldPublish: false
             postBuildSteps:

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -283,12 +283,6 @@ stages:
             - native_win32_x86_windows
             - native_win32_x64_windows
             - native_win32_x64_nanoserver_windows
-          preBuildSteps:
-            - pwsh: |
-                $uri = 'https://go.microsoft.com/fwlink/p/?LinkId=619296'
-                .\scripts\download-file.ps1 -Uri $uri -OutFile sdksetup.exe
-                .\sdksetup.exe /norestart /quiet | Out-Null
-              displayName: Install the Windows 10 SDK 10.0.10240
       - template: azure-templates-bootstrapper.yml # Build Managed (macOS)
         parameters:
           name: managed_macos

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -96,6 +96,13 @@ jobs:
           displayName: Switch to the latest Xamarin SDK
         - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XCODE_VERSION).app;sudo xcode-select --switch /Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer
           displayName: Switch to the latest Xcode
+      # install the older Windows SDKs
+      - ${{ if endsWith(parameters.name, '_windows') }}:
+        - pwsh: |
+            $uri = 'https://go.microsoft.com/fwlink/p/?LinkId=619296'
+            .\scripts\download-file.ps1 -Uri $uri -OutFile sdksetup.exe
+            .\sdksetup.exe /norestart /quiet | Out-Null
+          displayName: Install the Windows 10 SDK 10.0.10240
       # download artifacts
       - ${{ each dep in parameters.requiredArtifacts }}:
         - task: DownloadBuildArtifacts@0

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -38,9 +38,11 @@ jobs:
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     steps:
+      # prepare
       - checkout: self
         submodules: recursive
       - template: azure-templates-variables.yml
+
       # install any packages on linux
       - ${{ if endsWith(parameters.name, '_linux') }}:
         - bash: |
@@ -48,6 +50,7 @@ jobs:
             sudo apt install -y ${{ parameters.packages }}
           displayName: Install additional package dependencies
           condition: ne('${{ parameters.packages }}', '')
+
       # make sure mono/msbuild is the correct version
       - ${{ if endsWith(parameters.name, '_linux') }}:
         - bash: |
@@ -60,12 +63,10 @@ jobs:
             sudo apt install -y mono-complete msbuild
             mono --version
           displayName: Install Mono and MSBuild
-      # install tizen
-      - ${{ if contains(parameters.name, '_tizen_') }}:
-        - pwsh: .\scripts\install-openjdk.ps1
-          displayName: Install the OpenJDK
-        - pwsh: .\scripts\install-tizen.ps1
-          displayName: Install the Tizen SDK
+      - ${{ if endsWith(parameters.name, '_macos') }}:
+        - bash: sudo $(Agent.HomeDirectory)/scripts/select-xamarin-sdk.sh $(MONO_VERSION_MACOS)
+          displayName: Switch to the latest Xamarin SDK
+
       # install extra bits for the native builds
       - ${{ if startsWith(parameters.name, 'native_') }}:
         # switch to Python 2.7
@@ -74,14 +75,22 @@ jobs:
           inputs:
             versionSpec: '2.7'
             architecture: 'x64'
-        # install android ndk
-        - ${{ if contains(parameters.name, '_android_') }}:
-          - pwsh: .\scripts\install-android-ndk.ps1
-            displayName: Install the Android NDK
-        # install llvm
-        - ${{ if endsWith(parameters.name, '_windows') }}:
-          - pwsh: .\scripts\install-llvm.ps1
-            displayName: Install LLVM
+        - ${{ if not(contains(parameters.name, '_checks_')) }}:
+          # install android ndk
+          - ${{ if contains(parameters.name, '_android_') }}:
+            - pwsh: .\scripts\install-android-ndk.ps1
+              displayName: Install the Android NDK
+          # install tizen
+          - ${{ if contains(parameters.name, '_tizen_') }}:
+            - pwsh: .\scripts\install-openjdk.ps1
+              displayName: Install the OpenJDK
+            - pwsh: .\scripts\install-tizen.ps1
+              displayName: Install the Tizen SDK
+          # install llvm
+          - ${{ if contains(parameters.name, '_win32_') }}:
+            - pwsh: .\scripts\install-llvm.ps1
+              displayName: Install LLVM
+
       # install extra bits for the manged builds
       - ${{ if not(startsWith(parameters.name, 'native_')) }}:
         - task: UseDotNet@2
@@ -90,20 +99,23 @@ jobs:
             version: $(DOTNET_VERSION)
             performMultiLevelLookup: true
           displayName: Install the correct version of .NET Core
-      # switch to the correct mono version on mac
+
+      # install the mac tools
       - ${{ if endsWith(parameters.name, '_macos') }}:
-        - bash: sudo $(Agent.HomeDirectory)/scripts/select-xamarin-sdk.sh $(MONO_VERSION_MACOS)
-          displayName: Switch to the latest Xamarin SDK
         - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XCODE_VERSION).app;sudo xcode-select --switch /Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer
           displayName: Switch to the latest Xcode
+
+      # install the Windows tools
       - ${{ if endsWith(parameters.name, '_windows') }}:
-        # install the older Windows SDKs
-        - ${{ if or(startsWith(parameters.name, 'native_'), startsWith(parameters.name, 'managed_')) }}:
-          - pwsh: |
-              $uri = 'https://go.microsoft.com/fwlink/p/?LinkId=619296'
-              .\scripts\download-file.ps1 -Uri $uri -OutFile sdksetup.exe
-              .\sdksetup.exe /norestart /quiet | Out-Null
-            displayName: Install the Windows 10 SDK 10.0.10240
+        - ${{ if not(contains(parameters.name, '_checks_')) }}:
+          # install the older Windows SDKs
+          - ${{ if or(startsWith(parameters.name, 'native_'), startsWith(parameters.name, 'managed_')) }}:
+            - pwsh: |
+                $uri = 'https://go.microsoft.com/fwlink/p/?LinkId=619296'
+                .\scripts\download-file.ps1 -Uri $uri -OutFile sdksetup.exe
+                .\sdksetup.exe /norestart /quiet | Out-Null
+              displayName: Install the Windows 10 SDK 10.0.10240
+
       # download artifacts
       - ${{ each dep in parameters.requiredArtifacts }}:
         - task: DownloadBuildArtifacts@0
@@ -116,8 +128,10 @@ jobs:
             Get-ChildItem '.\download-temp\${{ dep }}\' | Copy-Item -Destination '.\output\' -Recurse -Force
             Remove-Item '.\download-temp\${{ dep }}\' -Recurse -Force
           displayName: Move the ${{ dep }} artifacts to the output directory
+
       # pre-build steps
       - ${{ parameters.preBuildSteps }}
+
       # build
       - ${{ if eq(parameters.docker, '') }}:
         - ${{ if endsWith(parameters.name, '_windows') }}:
@@ -137,8 +151,10 @@ jobs:
           displayName: Build the Docker image for ${{ parameters.docker }}
         - bash: docker run --rm --name skiasharp --volume $(pwd):/work skiasharp /bin/bash scripts/retry-command.sh ${{ parameters.retryCount }} ./bootstrapper.sh -t ${{ parameters.target }} -v ${{ parameters.verbosity }} -c ${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}
           displayName: Run the bootstrapper for ${{ parameters.target }} using the Docker image
+
       # post-build steps
       - ${{ parameters.postBuildSteps }}
+
       # publish artifacts
       - task: PublishBuildArtifacts@1
         displayName: Publish the ${{ parameters.name }} artifacts

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -96,13 +96,14 @@ jobs:
           displayName: Switch to the latest Xamarin SDK
         - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XCODE_VERSION).app;sudo xcode-select --switch /Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer
           displayName: Switch to the latest Xcode
-      # install the older Windows SDKs
       - ${{ if endsWith(parameters.name, '_windows') }}:
-        - pwsh: |
-            $uri = 'https://go.microsoft.com/fwlink/p/?LinkId=619296'
-            .\scripts\download-file.ps1 -Uri $uri -OutFile sdksetup.exe
-            .\sdksetup.exe /norestart /quiet | Out-Null
-          displayName: Install the Windows 10 SDK 10.0.10240
+        # install the older Windows SDKs
+        - ${{ if or(startsWith(parameters.name, 'native_'), startsWith(parameters.name, 'managed_')) }}:
+          - pwsh: |
+              $uri = 'https://go.microsoft.com/fwlink/p/?LinkId=619296'
+              .\scripts\download-file.ps1 -Uri $uri -OutFile sdksetup.exe
+              .\sdksetup.exe /norestart /quiet | Out-Null
+            displayName: Install the Windows 10 SDK 10.0.10240
       # download artifacts
       - ${{ each dep in parameters.requiredArtifacts }}:
         - task: DownloadBuildArtifacts@0

--- a/scripts/install-android-ndk.ps1
+++ b/scripts/install-android-ndk.ps1
@@ -1,5 +1,5 @@
 Param(
-    [string] $Version = "r15c",
+    [string] $Version = "r19c",
     [string] $InstallDestination = $null
 )
 

--- a/scripts/install-llvm.ps1
+++ b/scripts/install-llvm.ps1
@@ -1,5 +1,5 @@
 Param(
-    [string] $Version = "9.0.1"
+    [string] $Version = "9.0.0"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/install-llvm.ps1
+++ b/scripts/install-llvm.ps1
@@ -1,5 +1,5 @@
 Param(
-    [string] $Version = "9.0.0"
+    [string] $Version = "9.0.1"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/install-openjdk.ps1
+++ b/scripts/install-openjdk.ps1
@@ -6,16 +6,16 @@ $ErrorActionPreference = 'Stop'
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
-$version = "12.0.2"
+$version = "13.0.2"
 if ($IsMacOS) {
     $ext = "tar.gz"
-    $url = "https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_osx-x64_bin.tar.gz"
+    $url = "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_osx-x64_bin.tar.gz"
 } elseif ($IsLinux) {
     $ext = "tar.gz"
-    $url = "https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz"
+    $url = "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_osx-x64_bin.tar.gz"
 } else {
     $ext = "zip"
-    $url = "https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_windows-x64_bin.zip"
+    $url = "https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_windows-x64_bin.zip"
 }
 
 $jdk = Join-Path "$HOME" "openjdk"

--- a/scripts/install-tizen.ps1
+++ b/scripts/install-tizen.ps1
@@ -3,7 +3,7 @@
 #  - https://developercommunity.visualstudio.com/content/problem/661596/the-updated-path-doesnt-kick-in.html
 
 Param(
-    [string] $Version = "3.5",
+    [string] $Version = "3.6",
     [string] $InstallDestination = $null
 )
 


### PR DESCRIPTION
**Description of Change**

Update all the build tools:
- Windows builds to use the v14.2 compilers
- Android to use the r19c (min Android API level 16)
- OpenJDK 13.0.2
- Tizen Studio 3.6
- Build on VS 2019
- Added build args to support preview/any VS installs

**Bugs Fixed**

None.

_I am secretly hoping that this will fix an issue that is preventing #1117 from building. I JUST set up a brand new machine and everything builds..._

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
