### PR TITLE
Re-work views to avoid incorrect disposal

### DIFF
--- a/binding/Binding/SKSurface.cs
+++ b/binding/Binding/SKSurface.cs
@@ -293,7 +293,7 @@ namespace SkiaSharp
 		//
 
 		public SKCanvas Canvas =>
-			GetObject<SKCanvas> (SkiaApi.sk_surface_get_canvas (Handle), false);
+			GetObject<SKCanvas> (SkiaApi.sk_surface_get_canvas (Handle), false, unrefExisting: false);
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use SurfaceProperties instead.")]

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
@@ -13,12 +13,15 @@ namespace SkiaSharp.Views.Android
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
 		private GRContext context;
+		private GRGlFramebufferInfo glInfo;
 		private GRBackendRenderTarget renderTarget;
 		private SKSurface surface;
-		private int surfaceWidth;
-		private int surfaceHeight;
+		private SKCanvas canvas;
 
-		public SKSize CanvasSize => renderTarget.Size;
+		private SKSizeI lastSize;
+		private SKSizeI newSize;
+
+		public SKSize CanvasSize => lastSize;
 
 		public GRContext GRContext => context;
 
@@ -44,10 +47,12 @@ namespace SkiaSharp.Views.Android
 			}
 
 			// manage the drawing surface
-			if (renderTarget == null || surface == null || renderTarget.Width != surfaceWidth || renderTarget.Height != surfaceHeight)
+			if (renderTarget == null || lastSize != newSize || !renderTarget.IsValid)
 			{
 				// create or update the dimensions
-				renderTarget?.Dispose();
+				lastSize = newSize;
+
+				// read the info from the buffer
 				var buffer = new int[3];
 				GLES20.GlGetIntegerv(GLES20.GlFramebufferBinding, buffer, 0);
 				GLES20.GlGetIntegerv(GLES20.GlStencilBits, buffer, 1);
@@ -56,18 +61,29 @@ namespace SkiaSharp.Views.Android
 				var maxSamples = context.GetMaxSurfaceSampleCount(colorType);
 				if (samples > maxSamples)
 					samples = maxSamples;
-				var glInfo = new GRGlFramebufferInfo((uint)buffer[0], colorType.ToGlSizedFormat());
-				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, buffer[1], glInfo);
+				glInfo = new GRGlFramebufferInfo((uint)buffer[0], colorType.ToGlSizedFormat());
 
-				// create the surface
+				// destroy the old surface
 				surface?.Dispose();
-				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				surface = null;
+				canvas = null;
+
+				// re-create the render target
+				renderTarget?.Dispose();
+				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, buffer[1], glInfo);
 			}
 
-			using (new SKAutoCanvasRestore(surface.Canvas, true))
+			// create the surface
+			if (surface == null)
+			{
+				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				canvas = surface.Canvas;
+			}
+
+			using (new SKAutoCanvasRestore(canvas, true))
 			{
 				// start drawing
-				var e = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType);
+				var e = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo);
 				OnPaintSurface(e);
 #pragma warning disable CS0618 // Type or member is obsolete
 				OnDrawFrame(e.Surface, e.RenderTarget);
@@ -75,7 +91,7 @@ namespace SkiaSharp.Views.Android
 			}
 
 			// flush the SkiaSharp contents to GL
-			surface.Canvas.Flush();
+			canvas.Flush();
 			context.Flush();
 		}
 
@@ -83,8 +99,8 @@ namespace SkiaSharp.Views.Android
 		{
 			GLES20.GlViewport(0, 0, width, height);
 
-			surfaceWidth = width;
-			surfaceHeight = height;
+			// get the new surface size
+			newSize = new SKSizeI(width, height);
 		}
 
 		public void OnSurfaceCreated(IGL10 gl, EGLConfig config)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLSurfaceViewRenderer.cs
@@ -70,7 +70,7 @@ namespace SkiaSharp.Views.Android
 
 				// re-create the render target
 				renderTarget?.Dispose();
-				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, buffer[1], glInfo);
+				renderTarget = new GRBackendRenderTarget(newSize.Width, newSize.Height, samples, buffer[1], glInfo);
 			}
 
 			// create the surface

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
@@ -13,12 +13,15 @@ namespace SkiaSharp.Views.Android
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
 		private GRContext context;
+		private GRGlFramebufferInfo glInfo;
 		private GRBackendRenderTarget renderTarget;
 		private SKSurface surface;
-		private int surfaceWidth;
-		private int surfaceHeight;
+		private SKCanvas canvas;
 
-		public SKSize CanvasSize => renderTarget.Size;
+		private SKSizeI lastSize;
+		private SKSizeI newSize;
+
+		public SKSize CanvasSize => lastSize;
 
 		public GRContext GRContext => context;
 
@@ -44,10 +47,12 @@ namespace SkiaSharp.Views.Android
 			}
 
 			// manage the drawing surface
-			if (renderTarget == null || surface == null || renderTarget.Width != surfaceWidth || renderTarget.Height != surfaceHeight)
+			if (renderTarget == null || lastSize != newSize || !renderTarget.IsValid)
 			{
 				// create or update the dimensions
-				renderTarget?.Dispose();
+				lastSize = newSize;
+
+				// read the info from the buffer
 				var buffer = new int[3];
 				GLES20.GlGetIntegerv(GLES20.GlFramebufferBinding, buffer, 0);
 				GLES20.GlGetIntegerv(GLES20.GlStencilBits, buffer, 1);
@@ -56,18 +61,29 @@ namespace SkiaSharp.Views.Android
 				var maxSamples = context.GetMaxSurfaceSampleCount(colorType);
 				if (samples > maxSamples)
 					samples = maxSamples;
-				var glInfo = new GRGlFramebufferInfo((uint)buffer[0], colorType.ToGlSizedFormat());
-				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, buffer[1], glInfo);
+				glInfo = new GRGlFramebufferInfo((uint)buffer[0], colorType.ToGlSizedFormat());
 
-				// create the surface
+				// destroy the old surface
 				surface?.Dispose();
-				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				surface = null;
+				canvas = null;
+
+				// re-create the render target
+				renderTarget?.Dispose();
+				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, buffer[1], glInfo);
 			}
 
-			using (new SKAutoCanvasRestore(surface.Canvas, true))
+			// create the surface
+			if (surface == null)
+			{
+				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				canvas = surface.Canvas;
+			}
+
+			using (new SKAutoCanvasRestore(canvas, true))
 			{
 				// start drawing
-				var e = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType);
+				var e = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo);
 				OnPaintSurface(e);
 #pragma warning disable CS0618 // Type or member is obsolete
 				OnDrawFrame(e.Surface, e.RenderTarget);
@@ -75,7 +91,7 @@ namespace SkiaSharp.Views.Android
 			}
 
 			// flush the SkiaSharp contents to GL
-			surface.Canvas.Flush();
+			canvas.Flush();
 			context.Flush();
 		}
 
@@ -83,8 +99,8 @@ namespace SkiaSharp.Views.Android
 		{
 			GLES20.GlViewport(0, 0, width, height);
 
-			surfaceWidth = width;
-			surfaceHeight = height;
+			// get the new surface size
+			newSize = new SKSizeI(width, height);
 		}
 
 		public void OnSurfaceCreated(IGL10 gl, EGLConfig config)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/SKGLTextureViewRenderer.cs
@@ -70,7 +70,7 @@ namespace SkiaSharp.Views.Android
 
 				// re-create the render target
 				renderTarget?.Dispose();
-				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, buffer[1], glInfo);
+				renderTarget = new GRBackendRenderTarget(newSize.Width, newSize.Height, samples, buffer[1], glInfo);
 			}
 
 			// create the surface

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLLayer.cs
@@ -13,8 +13,12 @@ namespace SkiaSharp.Views.Mac
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
 		private GRContext context;
+		private GRGlFramebufferInfo glInfo;
 		private GRBackendRenderTarget renderTarget;
 		private SKSurface surface;
+		private SKCanvas canvas;
+
+		private SKSizeI lastSize;
 
 		public SKGLLayer()
 		{
@@ -26,7 +30,7 @@ namespace SkiaSharp.Views.Mac
 		[Obsolete("Use PaintSurface instead.")]
 		public ISKGLLayerDelegate SKDelegate { get; set; }
 
-		public SKSize CanvasSize => renderTarget.Size;
+		public SKSize CanvasSize => lastSize;
 
 		public GRContext GRContext => context;
 
@@ -57,28 +61,42 @@ namespace SkiaSharp.Views.Mac
 			// manage the drawing surface
 			var surfaceWidth = (int)(Bounds.Width * ContentsScale);
 			var surfaceHeight = (int)(Bounds.Height * ContentsScale);
-			if (renderTarget == null || surface == null || renderTarget.Width != surfaceWidth || renderTarget.Height != surfaceHeight)
+			var newSize = new SKSizeI(surfaceWidth, surfaceHeight);
+			if (renderTarget == null || lastSize != newSize || !renderTarget.IsValid)
 			{
 				// create or update the dimensions
-				renderTarget?.Dispose();
+				lastSize = newSize;
+
+				// read the info from the buffer
 				Gles.glGetIntegerv(Gles.GL_FRAMEBUFFER_BINDING, out var framebuffer);
 				Gles.glGetIntegerv(Gles.GL_STENCIL_BITS, out var stencil);
 				Gles.glGetIntegerv(Gles.GL_SAMPLES, out var samples);
 				var maxSamples = context.GetMaxSurfaceSampleCount(colorType);
 				if (samples > maxSamples)
 					samples = maxSamples;
-				var glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
-				renderTarget = new GRBackendRenderTarget(surfaceWidth, surfaceHeight, samples, stencil, glInfo);
+				glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
 
-				// create the surface
+				// destroy the old surface
 				surface?.Dispose();
-				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				surface = null;
+				canvas = null;
+
+				// re-create the render target
+				renderTarget?.Dispose();
+				renderTarget = new GRBackendRenderTarget(newSize.Width, newSize.Height, samples, stencil, glInfo);
 			}
 
-			using (new SKAutoCanvasRestore(surface.Canvas, true))
+			// create the surface
+			if (surface == null)
+			{
+				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				canvas = surface.Canvas;
+			}
+
+			using (new SKAutoCanvasRestore(canvas, true))
 			{
 				// start drawing
-				var e = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType);
+				var e = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo);
 				OnPaintSurface(e);
 #pragma warning disable CS0618 // Type or member is obsolete
 				DrawInSurface(e.Surface, e.RenderTarget);
@@ -87,7 +105,7 @@ namespace SkiaSharp.Views.Mac
 			}
 
 			// flush the SkiaSharp context to the GL context
-			surface.Canvas.Flush();
+			canvas.Flush();
 			context.Flush();
 
 			base.DrawInCGLContext(glContext, pixelFormat, timeInterval, ref timeStamp);

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Shared/SKPaintGLSurfaceEventArgs.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Shared/SKPaintGLSurfaceEventArgs.cs
@@ -20,11 +20,11 @@ namespace SkiaSharp.Views.Tizen
 {
 	public class SKPaintGLSurfaceEventArgs : EventArgs
 	{
-		[EditorBrowsable (EditorBrowsableState.Never)]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete]
 		private GRBackendRenderTargetDesc? rtDesc;
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete("Use SKPaintGLSurfaceEventArgs(SKSurface, GRBackendRenderTarget, SKColorType, GRSurfaceOrigin) instead.")]
 		public SKPaintGLSurfaceEventArgs(SKSurface surface, GRBackendRenderTargetDesc renderTarget)
 		{
@@ -48,37 +48,35 @@ namespace SkiaSharp.Views.Tizen
 			Origin = origin;
 		}
 
+		internal SKPaintGLSurfaceEventArgs(SKSurface surface, GRBackendRenderTarget renderTarget, GRSurfaceOrigin origin, SKColorType colorType, GRGlFramebufferInfo glInfo)
+		{
+			Surface = surface;
+			BackendRenderTarget = renderTarget;
+			ColorType = colorType;
+			Origin = origin;
+#pragma warning disable CS0612 // Type or member is obsolete
+			rtDesc = CreateDesc(glInfo);
+#pragma warning restore CS0612 // Type or member is obsolete
+		}
+
 		public SKSurface Surface { get; private set; }
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete("Use BackendRenderTarget instead.")]
-		public GRBackendRenderTargetDesc RenderTarget
-		{
-			get
+		public GRBackendRenderTargetDesc RenderTarget => rtDesc ??= CreateDesc(BackendRenderTarget.GetGlFramebufferInfo());
+
+		[Obsolete]
+		private GRBackendRenderTargetDesc CreateDesc(GRGlFramebufferInfo glInfo) =>
+			new GRBackendRenderTargetDesc
 			{
-				if (!rtDesc.HasValue)
-				{
-					var rth = IntPtr.Zero;
-					if (BackendRenderTarget.GetGlFramebufferInfo(out var glInfo))
-					{
-						rth = (IntPtr)glInfo.FramebufferObjectId;
-					}
-
-					rtDesc = new GRBackendRenderTargetDesc
-					{
-						Width = BackendRenderTarget.Width,
-						Height = BackendRenderTarget.Height,
-						RenderTargetHandle = rth,
-						SampleCount = BackendRenderTarget.SampleCount,
-						StencilBits = BackendRenderTarget.StencilBits,
-						Config = ColorType.ToPixelConfig(),
-						Origin = Origin,
-					};
-				}
-
-				return rtDesc.Value;
-			}
-		}
+				Width = BackendRenderTarget.Width,
+				Height = BackendRenderTarget.Height,
+				RenderTargetHandle = (IntPtr)glInfo.FramebufferObjectId,
+				SampleCount = BackendRenderTarget.SampleCount,
+				StencilBits = BackendRenderTarget.StencilBits,
+				Config = ColorType.ToPixelConfig(),
+				Origin = Origin,
+			};
 
 		public GRBackendRenderTarget BackendRenderTarget { get; private set; }
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Shared/SKPaintGLSurfaceEventArgs.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Shared/SKPaintGLSurfaceEventArgs.cs
@@ -48,7 +48,7 @@ namespace SkiaSharp.Views.Tizen
 			Origin = origin;
 		}
 
-		internal SKPaintGLSurfaceEventArgs(SKSurface surface, GRBackendRenderTarget renderTarget, GRSurfaceOrigin origin, SKColorType colorType, GRGlFramebufferInfo glInfo)
+		public SKPaintGLSurfaceEventArgs(SKSurface surface, GRBackendRenderTarget renderTarget, GRSurfaceOrigin origin, SKColorType colorType, GRGlFramebufferInfo glInfo)
 		{
 			Surface = surface;
 			BackendRenderTarget = renderTarget;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKGLSurfaceView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKGLSurfaceView.cs
@@ -19,8 +19,10 @@ namespace SkiaSharp.Views.Tizen
 		private IntPtr glSurface;
 
 		private GRContext context;
+		private GRGlFramebufferInfo glInfo;
 		private GRBackendRenderTarget renderTarget;
 		private SKSurface surface;
+		private SKCanvas canvas;
 		private SKSizeI surfaceSize;
 
 		public SKGLSurfaceView(EvasObject parent)
@@ -90,14 +92,14 @@ namespace SkiaSharp.Views.Tizen
 
 				if (surface != null && renderTarget != null && context != null)
 				{
-					using (new SKAutoCanvasRestore(surface.Canvas, true))
+					using (new SKAutoCanvasRestore(canvas, true))
 					{
 						// draw using SkiaSharp
-						OnDrawFrame(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType));
+						OnDrawFrame(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo));
 					}
 
 					// flush the SkiaSharp contents to GL
-					surface.Canvas.Flush();
+					canvas.Flush();
 					context.Flush();
 				}
 			}
@@ -149,12 +151,13 @@ namespace SkiaSharp.Views.Tizen
 				var maxSamples = context.GetMaxSurfaceSampleCount(colorType);
 				if (samples > maxSamples)
 					samples = maxSamples;
-				var glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
+				glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
 				renderTarget = new GRBackendRenderTarget(surfaceSize.Width, surfaceSize.Height, samples, stencil, glInfo);
 
 				// create the surface
 				surface?.Dispose();
 				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				canvas = surface.Canvas;
 			}
 		}
 
@@ -163,6 +166,7 @@ namespace SkiaSharp.Views.Tizen
 			if (glSurface != IntPtr.Zero)
 			{
 				// dispose the unmanaged memory
+				canvas = null;
 				surface?.Dispose();
 				surface = null;
 				renderTarget?.Dispose();

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
@@ -17,8 +17,12 @@ namespace SkiaSharp.Views.Desktop
 		private bool designMode;
 
 		private GRContext grContext;
+		private GRGlFramebufferInfo glInfo;
 		private GRBackendRenderTarget renderTarget;
 		private SKSurface surface;
+		private SKCanvas canvas;
+
+		private SKSizeI lastSize;
 
 		public SKGLControl()
 			: base(new GraphicsMode(new ColorFormat(8, 8, 8, 8), 24, 8))
@@ -49,7 +53,7 @@ namespace SkiaSharp.Views.Desktop
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public SKSize CanvasSize => new SKSize(renderTarget.Width, renderTarget.Height);
+		public SKSize CanvasSize => lastSize;
 
 		[Bindable(false)]
 		[Browsable(false)]
@@ -79,33 +83,48 @@ namespace SkiaSharp.Views.Desktop
 				grContext = GRContext.Create(GRBackend.OpenGL, glInterface);
 			}
 
+			// get the new surface size
+			var newSize = new SKSizeI(Width, Height);
+
 			// manage the drawing surface
-			if (renderTarget == null || surface == null || renderTarget.Width != Width || renderTarget.Height != Height)
+			if (renderTarget == null || lastSize != newSize || !renderTarget.IsValid)
 			{
 				// create or update the dimensions
-				renderTarget?.Dispose();
+				lastSize = newSize;
+
 				GL.GetInteger(GetPName.FramebufferBinding, out var framebuffer);
 				GL.GetInteger(GetPName.StencilBits, out var stencil);
 				GL.GetInteger(GetPName.Samples, out var samples);
 				var maxSamples = grContext.GetMaxSurfaceSampleCount(colorType);
 				if (samples > maxSamples)
 					samples = maxSamples;
-				var glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
-				renderTarget = new GRBackendRenderTarget(Width, Height, samples, stencil, glInfo);
+				glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
 
-				// create the surface
+				// destroy the old surface
 				surface?.Dispose();
-				surface = SKSurface.Create(grContext, renderTarget, surfaceOrigin, colorType);
+				surface = null;
+				canvas = null;
+
+				// re-create the render target
+				renderTarget?.Dispose();
+				renderTarget = new GRBackendRenderTarget(newSize.Width, newSize.Height, samples, stencil, glInfo);
 			}
 
-			using (new SKAutoCanvasRestore(surface.Canvas, true))
+			// create the surface
+			if (surface == null)
+			{
+				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				canvas = surface.Canvas;
+			}
+
+			using (new SKAutoCanvasRestore(canvas, true))
 			{
 				// start drawing
-				OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType));
+				OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo));
 			}
 
 			// update the control
-			surface.Canvas.Flush();
+			canvas.Flush();
 			SwapBuffers();
 		}
 
@@ -120,6 +139,7 @@ namespace SkiaSharp.Views.Desktop
 			base.Dispose(disposing);
 
 			// clean up
+			canvas = null;
 			surface?.Dispose();
 			surface = null;
 			renderTarget?.Dispose();

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SKGLControl.cs
@@ -113,7 +113,7 @@ namespace SkiaSharp.Views.Desktop
 			// create the surface
 			if (surface == null)
 			{
-				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
+				surface = SKSurface.Create(grContext, renderTarget, surfaceOrigin, colorType);
 				canvas = surface.Canvas;
 			}
 


### PR DESCRIPTION
**Description of Change**

In some instances, the managed canvas is being collected at the same time the new one is being created. This causes the the app to crash for some reason. The technically should not happen as the canvas is still valid - and we can see this when we set the canvas as a class field.

But, for now, just work around the issue by adding the canvas as a field.

In addition, do more granular construction of the GL objects, and then also reduce the amount of interop in the render loop.

**Bugs Fixed**

- Fixes #1121 
- Fixes #910
- Fixes #1173
- Fixes #1168
- Fixes #1144

**API Changes**

None.

**Behavioral Changes**

Some fixes for crashes.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
