### PR TITLE
Merge filter factory overloads now accept null arguments

### DIFF
--- a/binding/Binding/SKImageFilter.cs
+++ b/binding/Binding/SKImageFilter.cs
@@ -168,7 +168,7 @@ namespace SkiaSharp
 			var handles = new IntPtr[filters.Length];
 			for (int i = 0; i < filters.Length; i++)
 			{
-				handles[i] = filters[i].Handle;
+				handles[i] = filters[i]?.Handle ?? IntPtr.Zero;
 			}
 			fixed (IntPtr* h = handles) {
 				return GetObject<SKImageFilter> (SkiaApi.sk_imagefilter_new_merge (h, filters.Length, cropRect == null ? IntPtr.Zero : cropRect.Handle));

--- a/tests/Tests/SKImageFilterTest.cs
+++ b/tests/Tests/SKImageFilterTest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace SkiaSharp.Tests
+{
+	public class SKImageFilterTest : SKTest
+	{
+		[SkippableFact]
+		public void MergeFilterAcceptsSourceGraphicInputs()
+		{
+			var filter = SKImageFilter.CreateMerge(new SKImageFilter[] {null});
+			Assert.NotNull(filter);
+		}
+	}
+}


### PR DESCRIPTION
**Description**

`SKImageFilter.CreateMerge` overloads now accept null for the image filter input argments

Since null  refers to the source graphics being drawn, passing null must be allowed. 

Added unit test

**Bugs Fixed**

`SKImageFilter.CreateMerge` doesn't throw `NullReferenceException` anymore.

- Related to issue #1163 

**API Changes**

None.

**Behavioral Changes**

`SKImageFilter.CreateMerge` doesn't throw `NullReferenceException` anymore.

**PR Checklist**

- [y] Has tests (if omitted, state reason in description)
- [n] Rebased on top of master at time of PR
- [?] Changes adhere to coding standard
- [n] Updated documentation

