### PR TITLE
Added device type to touch events (touch, mouse, pen)

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
@@ -36,6 +36,36 @@ namespace SkiaSharp.Views.Forms
 			scalePixels = null;
 		}
 
+		private static SKTouchDeviceType GetDeviceType(MotionEventToolType toolType)
+		{
+			SKTouchDeviceType deviceType = SKTouchDeviceType.Touch;
+
+			switch (toolType)
+			{
+				case MotionEventToolType.Eraser:
+					deviceType = SKTouchDeviceType.Pen;
+					break;
+
+				case MotionEventToolType.Finger:
+					deviceType = SKTouchDeviceType.Touch;
+					break;
+
+				case MotionEventToolType.Mouse:
+					deviceType = SKTouchDeviceType.Mouse;
+					break;
+
+				case MotionEventToolType.Stylus:
+					deviceType = SKTouchDeviceType.Pen;
+					break;
+
+				case MotionEventToolType.Unknown:
+					deviceType = SKTouchDeviceType.Touch;
+					break;
+			}
+
+			return deviceType;
+		}
+
 		private void OnTouch(object sender, View.TouchEventArgs e)
 		{
 			if (onTouchAction == null || scalePixels == null)
@@ -47,12 +77,17 @@ namespace SkiaSharp.Views.Forms
 			var id = evt.GetPointerId(pointer);
 			var coords = scalePixels(evt.GetX(pointer), evt.GetY(pointer));
 
+			var toolType = evt.GetToolType(id);
+
+			var deviceType = GetDeviceType(toolType);
+
 			switch (evt.ActionMasked)
 			{
 				case MotionEventActions.Down:
 				case MotionEventActions.PointerDown:
 					{
-						var args = new SKTouchEventArgs(id, SKTouchAction.Pressed, coords, true);
+						var args = new SKTouchEventArgs(id, SKTouchAction.Pressed, SKMouseButton.Left, deviceType, coords, true);
+
 						onTouchAction(args);
 						e.Handled = args.Handled;
 						break;
@@ -66,7 +101,7 @@ namespace SkiaSharp.Views.Forms
 							id = evt.GetPointerId(pointer);
 							coords = scalePixels(evt.GetX(pointer), evt.GetY(pointer));
 
-							var args = new SKTouchEventArgs(id, SKTouchAction.Moved, coords, true);
+							var args = new SKTouchEventArgs(id, SKTouchAction.Moved, SKMouseButton.Left, deviceType, coords, true);
 							onTouchAction(args);
 							e.Handled = e.Handled || args.Handled;
 						}
@@ -76,7 +111,7 @@ namespace SkiaSharp.Views.Forms
 				case MotionEventActions.Up:
 				case MotionEventActions.PointerUp:
 					{
-						var args = new SKTouchEventArgs(id, SKTouchAction.Released, coords, false);
+						var args = new SKTouchEventArgs(id, SKTouchAction.Released, SKMouseButton.Left, deviceType, coords, false);
 						onTouchAction(args);
 						e.Handled = args.Handled;
 						break;
@@ -84,7 +119,7 @@ namespace SkiaSharp.Views.Forms
 
 				case MotionEventActions.Cancel:
 					{
-						var args = new SKTouchEventArgs(id, SKTouchAction.Cancelled, coords, false);
+						var args = new SKTouchEventArgs(id, SKTouchAction.Cancelled, SKMouseButton.Left, deviceType, coords, false);
 						onTouchAction(args);
 						e.Handled = args.Handled;
 						break;

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
@@ -36,36 +36,6 @@ namespace SkiaSharp.Views.Forms
 			scalePixels = null;
 		}
 
-		private static SKTouchDeviceType GetDeviceType(MotionEventToolType toolType)
-		{
-			SKTouchDeviceType deviceType = SKTouchDeviceType.Touch;
-
-			switch (toolType)
-			{
-				case MotionEventToolType.Eraser:
-					deviceType = SKTouchDeviceType.Pen;
-					break;
-
-				case MotionEventToolType.Finger:
-					deviceType = SKTouchDeviceType.Touch;
-					break;
-
-				case MotionEventToolType.Mouse:
-					deviceType = SKTouchDeviceType.Mouse;
-					break;
-
-				case MotionEventToolType.Stylus:
-					deviceType = SKTouchDeviceType.Pen;
-					break;
-
-				case MotionEventToolType.Unknown:
-					deviceType = SKTouchDeviceType.Touch;
-					break;
-			}
-
-			return deviceType;
-		}
-
 		private void OnTouch(object sender, View.TouchEventArgs e)
 		{
 			if (onTouchAction == null || scalePixels == null)
@@ -78,7 +48,6 @@ namespace SkiaSharp.Views.Forms
 			var coords = scalePixels(evt.GetX(pointer), evt.GetY(pointer));
 
 			var toolType = evt.GetToolType(id);
-
 			var deviceType = GetDeviceType(toolType);
 
 			switch (evt.ActionMasked)
@@ -126,5 +95,16 @@ namespace SkiaSharp.Views.Forms
 					}
 			}
 		}
+
+		private static SKTouchDeviceType GetDeviceType(MotionEventToolType toolType) =>
+			toolType switch
+			{
+				MotionEventToolType.Unknown => SKTouchDeviceType.Touch,
+				MotionEventToolType.Finger => SKTouchDeviceType.Touch,
+				MotionEventToolType.Stylus => SKTouchDeviceType.Pen,
+				MotionEventToolType.Eraser => SKTouchDeviceType.Pen,
+				MotionEventToolType.Mouse => SKTouchDeviceType.Mouse,
+				_ => SKTouchDeviceType.Touch,
+			};
 	}
 }


### PR DESCRIPTION
**Description of Change**

Added motion event tool type to touch device type mappings
**Bugs Fixed**

- Fixes #1186

**API Changes**

None

**Behavioral Changes**
Touch events will now be the correct type: touch, pen, mouse.  Previously they were all touch.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
