### PR TITLE
Passing null as path arg to SkPathMeasure ctor throws now

### DIFF
--- a/binding/Binding/SKPathMeasure.cs
+++ b/binding/Binding/SKPathMeasure.cs
@@ -5,29 +5,27 @@ namespace SkiaSharp
 	public unsafe class SKPathMeasure : SKObject
 	{
 		[Preserve]
-		internal SKPathMeasure (IntPtr handle, bool owns)
+		private SKPathMeasure (IntPtr handle, bool owns)
 			: base (handle, owns)
 		{
+			if (handle == IntPtr.Zero) {
+				throw new InvalidOperationException ("Unable to create a new SKPathMeasure instance.");
+			}
 		}
 
 		public SKPathMeasure ()
 			: this (SkiaApi.sk_pathmeasure_new (), true)
 		{
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SKPathMeasure instance.");
-			}
 		}
 
 		public SKPathMeasure (SKPath path, bool forceClosed = false, float resScale = 1)
-			: this (SkiaApi.sk_pathmeasure_new_with_path (path == null ? IntPtr.Zero : path.Handle, forceClosed, resScale), true)
+			: this (SkiaApi.sk_pathmeasure_new_with_path (
+				path?.Handle ?? throw new ArgumentNullException (nameof (path)),
+				forceClosed,
+				resScale),
+			true)
 		{
-			if (Handle == IntPtr.Zero) {
-				throw new InvalidOperationException ("Unable to create a new SKPathMeasure instance.");
-			}
 		}
-
-		protected override void Dispose (bool disposing) =>
-			base.Dispose (disposing);
 
 		protected override void DisposeNative () =>
 			SkiaApi.sk_pathmeasure_destroy (Handle);

--- a/tests/Tests/SKPathMeasureTest.cs
+++ b/tests/Tests/SKPathMeasureTest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Xunit;
+
+namespace SkiaSharp.Tests
+{
+	public class SKPathMeasureTest : SKTest
+	{
+		[SkippableFact]
+		public void ConstructorThrowsOnNullPathArgument()
+		{
+			Assert.Throws<ArgumentNullException>(() => new SKPathMeasure(null));
+		}
+	}
+}


### PR DESCRIPTION
**Description of Change**

Passing `null` for the `path` argument of the `SkPathMeasure` constructor now throws an `ArgumentNullException`

Plus some small tweaks (could do without them, but couldn't resist :wink:)

**Bugs Fixed**

- Related to issue #1187 

**API Changes**

None

**Behavioral Changes**

None

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [?] Changes adhere to coding standard
- [n] Updated documentation

**Notes**

Note that I was unable to run all unit tests, even before applying my changes, `dotnet test` always seems to hang at some point, or randomly crash some tests with access violations. This didn't happen last week. I lost a couple of hours trying to figure out why, but eventually I threw in the towel... 

This was the output before it hangs
```
[xUnit.net 00:00:01.25]     SkiaSharp.Tests.SKDataTest.DataDisposedReturnsInvalidStream [SKIP]
  ! SkiaSharp.Tests.SKDataTest.DataDisposedReturnsInvalidStream [1ms]
[xUnit.net 00:00:01.27]     SkiaSharp.Tests.SKBitmapTest.ImageScalingMultipleThreadsTest [SKIP]
  ! SkiaSharp.Tests.SKBitmapTest.ImageScalingMultipleThreadsTest [1ms]
[xUnit.net 00:00:01.59]     SkiaSharp.Tests.SKPaintTest.DrawTransparentImageWithHighFilterQualityWithUnpremul [SKIP]
  ! SkiaSharp.Tests.SKPaintTest.DrawTransparentImageWithHighFilterQualityWithUnpremul [1ms]
[xUnit.net 00:00:04.18]     SkiaSharp.Tests.SKCodecTest.DownloadedStream [SKIP]
  ! SkiaSharp.Tests.SKCodecTest.DownloadedStream [1ms]
```

Attaching the VS2019 debugger revealed that `SKImageTest::TextureImageIsValidOnContext()` hangs, the last managed call was `Wgl.wglChoosePixelFormatARB`. This might be a display driver issue, but I have the latest one. I have 32 hyperthreads, so maybe some tests are not 100% isolated...

