### PR TITLE
Release the skia objects when the view is unloaded

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/AngleSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/AngleSwapChainPanel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SkiaSharp.Views.GlesInterop;
 using Windows.ApplicationModel;
 using Windows.Foundation;
 using Windows.System.Threading;
@@ -6,7 +7,6 @@ using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
-using SkiaSharp.Views.GlesInterop;
 
 namespace SkiaSharp.Views.UWP
 {
@@ -103,6 +103,10 @@ namespace SkiaSharp.Views.UWP
 		{
 		}
 
+		protected virtual void OnDestroyingContext()
+		{
+		}
+
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
 			glesContext = new GlesContext();
@@ -118,6 +122,8 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
+			OnDestroyingContext();
+
 			CompositionScaleChanged -= OnCompositionChanged;
 			SizeChanged -= OnSizeChanged;
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using SkiaSharp.Views.GlesInterop;
 using Windows.Foundation;
-using Windows.UI.Xaml;
 
 namespace SkiaSharp.Views.UWP
 {
@@ -21,7 +20,6 @@ namespace SkiaSharp.Views.UWP
 
 		public SKSwapChainPanel()
 		{
-			Unloaded += OnUnloaded;
 		}
 
 		public SKSize CanvasSize => lastSize;
@@ -95,18 +93,27 @@ namespace SkiaSharp.Views.UWP
 			context.Flush();
 		}
 
-		private void OnUnloaded(object sender, RoutedEventArgs e)
+		protected override void OnDestroyingContext()
 		{
+			base.OnDestroyingContext();
+
 			lastSize = default;
+
 			canvas?.Dispose();
 			canvas = null;
+
 			surface?.Dispose();
 			surface = null;
+
 			renderTarget?.Dispose();
 			renderTarget = null;
+
 			glInfo = default;
+
+			context?.AbandonContext(true);
 			context?.Dispose();
 			context = null;
+
 			glInterface?.Dispose();
 			glInterface = null;
 		}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using Windows.Foundation;
 using SkiaSharp.Views.GlesInterop;
+using Windows.Foundation;
+using Windows.UI.Xaml;
 
 namespace SkiaSharp.Views.UWP
 {
@@ -20,6 +21,7 @@ namespace SkiaSharp.Views.UWP
 
 		public SKSwapChainPanel()
 		{
+			Unloaded += OnUnloaded;
 		}
 
 		public SKSize CanvasSize => lastSize;
@@ -91,6 +93,22 @@ namespace SkiaSharp.Views.UWP
 			// update the control
 			canvas.Flush();
 			context.Flush();
+		}
+
+		private void OnUnloaded(object sender, RoutedEventArgs e)
+		{
+			lastSize = default;
+			canvas?.Dispose();
+			canvas = null;
+			surface?.Dispose();
+			surface = null;
+			renderTarget?.Dispose();
+			renderTarget = null;
+			glInfo = default;
+			context?.Dispose();
+			context = null;
+			glInterface?.Dispose();
+			glInterface = null;
 		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Release the skia objects when the view is unloaded.

This was originally changed in 8039d0d0bbb135e8013be121cddf8716e7b8ce96 for the AngleSwapChainPanel view. But, this was not also extended to include the skia objects in SKSwapChainPanel.

Nothing needs to be re-created because it is all done in the first paint operation.

**Bugs Fixed**

- Fixes #1155
- Related to #705

**API Changes**

None.

**Behavioral Changes**

Draws correctly when unloaded and re loaded.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
