### PR TITLE
Make sure to not dispose system fonts

### DIFF
--- a/binding/Binding/SKColorSpace.cs
+++ b/binding/Binding/SKColorSpace.cs
@@ -182,14 +182,9 @@ namespace SkiaSharp
 		private sealed class SKColorSpaceStatic : SKColorSpace
 		{
 			internal SKColorSpaceStatic (IntPtr x)
-				: base (x, false)
+				: base (x, true)
 			{
 				IgnorePublicDispose = true;
-			}
-
-			protected override void Dispose (bool disposing)
-			{
-				// do not dispose
 			}
 		}
 	}

--- a/binding/Binding/SKData.cs
+++ b/binding/Binding/SKData.cs
@@ -14,11 +14,11 @@ namespace SkiaSharp
 		// improvement in Copy performance.
 		internal const int CopyBufferSize = 81920;
 
-		private static readonly Lazy<SKData> empty;
+		private static readonly SKData empty;
 
 		static SKData()
 		{
-			empty = new Lazy<SKData> (() => new SKDataStatic (SkiaApi.sk_data_new_empty ()));
+			empty = new SKDataStatic (SkiaApi.sk_data_new_empty ());
 		}
 
 		internal static void EnsureStaticInstanceAreInitialized ()
@@ -40,7 +40,7 @@ namespace SkiaSharp
 
 		void ISKNonVirtualReferenceCounted.UnreferenceNative () => SkiaApi.sk_data_unref (Handle);
 
-		public static SKData Empty => empty.Value;
+		public static SKData Empty => empty;
 
 		// CreateCopy
 
@@ -279,17 +279,14 @@ namespace SkiaSharp
 			}
 		}
 
+		//
+
 		private sealed class SKDataStatic : SKData
 		{
 			internal SKDataStatic (IntPtr x)
-				: base (x, false)
+				: base (x, true)
 			{
 				IgnorePublicDispose = true;
-			}
-
-			protected override void Dispose (bool disposing)
-			{
-				// do not dispose
 			}
 		}
 	}

--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -71,7 +71,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = SKTypeface.GetObject (SkiaApi.sk_fontmgr_match_family_style (Handle, familyName, style.Handle));
-			tf?.PreventUserDisposal ();
+			tf?.PreventPublicDisposal ();
 			return tf;
 		}
 
@@ -83,7 +83,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = SKTypeface.GetObject (SkiaApi.sk_fontmgr_match_face_style (Handle, face.Handle, style.Handle));
-			tf?.PreventUserDisposal ();
+			tf?.PreventPublicDisposal ();
 			return tf;
 		}
 
@@ -184,7 +184,7 @@ namespace SkiaSharp
 				familyName = string.Empty;
 
 			var tf = SKTypeface.GetObject (SkiaApi.sk_fontmgr_match_family_style_character (Handle, familyName, style.Handle, bcp47, bcp47?.Length ?? 0, character));
-			tf?.PreventUserDisposal ();
+			tf?.PreventPublicDisposal ();
 			return tf;
 		}
 

--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -71,7 +71,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_family_style (Handle, familyName, style.Handle));
-			tf.IgnorePublicDispose = true;
+			tf?.PreventUserDisposal ();
 			return tf;
 		}
 
@@ -83,7 +83,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_face_style (Handle, face.Handle, style.Handle));
-			tf.IgnorePublicDispose = true;
+			tf?.PreventUserDisposal ();
 			return tf;
 		}
 
@@ -184,7 +184,7 @@ namespace SkiaSharp
 				familyName = string.Empty;
 
 			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_family_style_character (Handle, familyName, style.Handle, bcp47, bcp47?.Length ?? 0, character));
-			tf.IgnorePublicDispose = true;
+			tf?.PreventUserDisposal ();
 			return tf;
 		}
 

--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -7,11 +7,11 @@ namespace SkiaSharp
 {
 	public unsafe class SKFontManager : SKObject, ISKReferenceCounted
 	{
-		private static readonly Lazy<SKFontManager> defaultManager;
+		private static readonly SKFontManager defaultManager;
 
-		static SKFontManager()
+		static SKFontManager ()
 		{
-			defaultManager = new Lazy<SKFontManager> (() => new SKFontManagerStatic (SkiaApi.sk_fontmgr_ref_default ()));
+			defaultManager = new SKFontManagerStatic (SkiaApi.sk_fontmgr_ref_default ());
 		}
 
 		internal static void EnsureStaticInstanceAreInitialized ()
@@ -29,7 +29,7 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public static SKFontManager Default => defaultManager.Value;
+		public static SKFontManager Default => defaultManager;
 
 		public int FontFamilyCount => SkiaApi.sk_fontmgr_count_families (Handle);
 
@@ -62,12 +62,17 @@ namespace SkiaSharp
 			return GetObject<SKFontStyleSet> (SkiaApi.sk_fontmgr_match_family (Handle, familyName));
 		}
 
+		public SKTypeface MatchFamily (string familyName) =>
+			MatchFamily (familyName, SKFontStyle.Normal);
+
 		public SKTypeface MatchFamily (string familyName, SKFontStyle style)
 		{
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
 
-			return GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_family_style (Handle, familyName, style.Handle));
+			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_family_style (Handle, familyName, style.Handle));
+			tf.IgnorePublicDispose = true;
+			return tf;
 		}
 
 		public SKTypeface MatchTypeface (SKTypeface face, SKFontStyle style)
@@ -77,7 +82,9 @@ namespace SkiaSharp
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
 
-			return GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_face_style (Handle, face.Handle, style.Handle));
+			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_face_style (Handle, face.Handle, style.Handle));
+			tf.IgnorePublicDispose = true;
+			return tf;
 		}
 
 		public SKTypeface CreateTypeface (string path, int index = 0)
@@ -176,7 +183,9 @@ namespace SkiaSharp
 			if (familyName == null)
 				familyName = string.Empty;
 
-			return GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_family_style_character (Handle, familyName, style.Handle, bcp47, bcp47?.Length ?? 0, character));
+			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontmgr_match_family_style_character (Handle, familyName, style.Handle, bcp47, bcp47?.Length ?? 0, character));
+			tf.IgnorePublicDispose = true;
+			return tf;
 		}
 
 		public static SKFontManager CreateDefault ()
@@ -184,17 +193,14 @@ namespace SkiaSharp
 			return GetObject<SKFontManager> (SkiaApi.sk_fontmgr_create_default ());
 		}
 
+		//
+
 		private sealed class SKFontManagerStatic : SKFontManager
 		{
 			internal SKFontManagerStatic (IntPtr x)
-				: base (x, false)
+				: base (x, true)
 			{
 				IgnorePublicDispose = true;
-			}
-
-			protected override void Dispose (bool disposing)
-			{
-				// do not dispose
 			}
 		}
 	}

--- a/binding/Binding/SKFontStyle.cs
+++ b/binding/Binding/SKFontStyle.cs
@@ -4,17 +4,17 @@ namespace SkiaSharp
 {
 	public class SKFontStyle : SKObject
 	{
-		private static readonly Lazy<SKFontStyle> normal;
-		private static readonly Lazy<SKFontStyle> bold;
-		private static readonly Lazy<SKFontStyle> italic;
-		private static readonly Lazy<SKFontStyle> boldItalic;
+		private static readonly SKFontStyle normal;
+		private static readonly SKFontStyle bold;
+		private static readonly SKFontStyle italic;
+		private static readonly SKFontStyle boldItalic;
 
-		static SKFontStyle()
+		static SKFontStyle ()
 		{
-			normal = new Lazy<SKFontStyle> (() => new SKFontStyleStatic (SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright));
-			bold = new Lazy<SKFontStyle> (() => new SKFontStyleStatic (SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright));
-			italic = new Lazy<SKFontStyle> (() => new SKFontStyleStatic (SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Italic));
-			boldItalic = new Lazy<SKFontStyle> (() => new SKFontStyleStatic (SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Italic));
+			normal = new SKFontStyleStatic (SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+			bold = new SKFontStyleStatic (SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+			italic = new SKFontStyleStatic (SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Italic);
+			boldItalic = new SKFontStyleStatic (SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Italic);
 		}
 
 		[Preserve]
@@ -50,13 +50,15 @@ namespace SkiaSharp
 
 		public SKFontStyleSlant Slant => SkiaApi.sk_fontstyle_get_slant (Handle);
 
-		public static SKFontStyle Normal => normal.Value;
+		public static SKFontStyle Normal => normal;
 
-		public static SKFontStyle Bold => bold.Value;
+		public static SKFontStyle Bold => bold;
 
-		public static SKFontStyle Italic => italic.Value;
+		public static SKFontStyle Italic => italic;
 
-		public static SKFontStyle BoldItalic => boldItalic.Value;
+		public static SKFontStyle BoldItalic => boldItalic;
+
+		//
 
 		private sealed class SKFontStyleStatic : SKFontStyle
 		{
@@ -64,11 +66,6 @@ namespace SkiaSharp
 				: base (weight, width, slant)
 			{
 				IgnorePublicDispose = true;
-			}
-
-			protected override void Dispose (bool disposing)
-			{
-				// do not dispose
 			}
 		}
 	}

--- a/binding/Binding/SKFontStyleSet.cs
+++ b/binding/Binding/SKFontStyleSet.cs
@@ -38,7 +38,7 @@ namespace SkiaSharp
 				throw new ArgumentOutOfRangeException ($"Index was out of range. Must be non-negative and less than the size of the set.", nameof (index));
 
 			var tf = SKTypeface.GetObject (SkiaApi.sk_fontstyleset_create_typeface (Handle, index));
-			tf?.PreventUserDisposal ();
+			tf?.PreventPublicDisposal ();
 			return tf;
 		}
 
@@ -48,7 +48,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = SKTypeface.GetObject (SkiaApi.sk_fontstyleset_match_style (Handle, style.Handle));
-			tf?.PreventUserDisposal ();
+			tf?.PreventPublicDisposal ();
 			return tf;
 		}
 

--- a/binding/Binding/SKFontStyleSet.cs
+++ b/binding/Binding/SKFontStyleSet.cs
@@ -37,7 +37,9 @@ namespace SkiaSharp
 			if (index < 0 || index >= Count)
 				throw new ArgumentOutOfRangeException ($"Index was out of range. Must be non-negative and less than the size of the set.", nameof (index));
 
-			return GetObject<SKTypeface> (SkiaApi.sk_fontstyleset_create_typeface (Handle, index));
+			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontstyleset_create_typeface (Handle, index));
+			tf.IgnorePublicDispose = true;
+			return tf;
 		}
 
 		public SKTypeface CreateTypeface (SKFontStyle style)
@@ -45,7 +47,9 @@ namespace SkiaSharp
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
 
-			return GetObject<SKTypeface> (SkiaApi.sk_fontstyleset_match_style (Handle, style.Handle));
+			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontstyleset_match_style (Handle, style.Handle));
+			tf.IgnorePublicDispose = true;
+			return tf;
 		}
 
 		public IEnumerator<SKFontStyle> GetEnumerator () => GetStyles ().GetEnumerator ();

--- a/binding/Binding/SKFontStyleSet.cs
+++ b/binding/Binding/SKFontStyleSet.cs
@@ -38,7 +38,7 @@ namespace SkiaSharp
 				throw new ArgumentOutOfRangeException ($"Index was out of range. Must be non-negative and less than the size of the set.", nameof (index));
 
 			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontstyleset_create_typeface (Handle, index));
-			tf.IgnorePublicDispose = true;
+			tf?.PreventUserDisposal ();
 			return tf;
 		}
 
@@ -48,7 +48,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = GetObject<SKTypeface> (SkiaApi.sk_fontstyleset_match_style (Handle, style.Handle));
-			tf.IgnorePublicDispose = true;
+			tf?.PreventUserDisposal ();
 			return tf;
 		}
 

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -127,6 +127,12 @@ namespace SkiaSharp
 			return HandleDictionary.GetInstance<TSkiaObject> (handle, out instance);
 		}
 
+		// indicate that the user cannot dispose the object
+		internal void PreventUserDisposal ()
+		{
+			IgnorePublicDispose = true;
+		}
+
 		// indicate that the ownership of this object is now in the hands of
 		// the native object
 		internal void RevokeOwnership (SKObject newOwner)

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -239,7 +239,7 @@ namespace SkiaSharp
 
 		protected internal virtual bool OwnsHandle { get; protected set; }
 
-		protected internal bool IgnorePublicDispose { get; protected set; }
+		protected internal bool IgnorePublicDispose { get; set; }
 
 		protected internal bool IsDisposed => isDisposed == 1;
 

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -136,7 +136,7 @@ namespace SkiaSharp
 		}
 
 		// indicate that the user cannot dispose the object
-		internal void PreventUserDisposal ()
+		internal void PreventPublicDisposal ()
 		{
 			IgnorePublicDispose = true;
 		}

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -76,7 +76,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = GetObject<SKTypeface> (SkiaApi.sk_typeface_create_from_name_with_font_style (familyName, style.Handle));
-			tf.IgnorePublicDispose = true;
+			tf?.PreventUserDisposal ();
 			return tf;
 		}
 

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -76,7 +76,7 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (style));
 
 			var tf = GetObject (SkiaApi.sk_typeface_create_from_name_with_font_style (familyName, style.Handle));
-			tf?.PreventUserDisposal ();
+			tf?.PreventPublicDisposal ();
 			return tf;
 		}
 

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -17,11 +17,11 @@ namespace SkiaSharp
 
 	public unsafe class SKTypeface : SKObject, ISKReferenceCounted
 	{
-		private static readonly Lazy<SKTypeface> defaultTypeface;
+		private static readonly SKTypeface defaultTypeface;
 
 		static SKTypeface ()
 		{
-			defaultTypeface = new Lazy<SKTypeface> (() => new SKTypefaceStatic (SkiaApi.sk_typeface_ref_default ()));
+			defaultTypeface = new SKTypefaceStatic (SkiaApi.sk_typeface_ref_default ());
 		}
 
 		internal static void EnsureStaticInstanceAreInitialized ()
@@ -41,7 +41,7 @@ namespace SkiaSharp
 		protected override void Dispose (bool disposing) =>
 			base.Dispose (disposing);
 
-		public static SKTypeface Default => defaultTypeface.Value;
+		public static SKTypeface Default => defaultTypeface;
 
 		public static SKTypeface CreateDefault ()
 		{
@@ -75,7 +75,9 @@ namespace SkiaSharp
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
 
-			return GetObject<SKTypeface> (SkiaApi.sk_typeface_create_from_name_with_font_style (familyName, style.Handle));
+			var tf = GetObject<SKTypeface> (SkiaApi.sk_typeface_create_from_name_with_font_style (familyName, style.Handle));
+			tf.IgnorePublicDispose = true;
+			return tf;
 		}
 
 		public static SKTypeface FromFamilyName (string familyName, SKFontStyleWeight weight, SKFontStyleWidth width, SKFontStyleSlant slant)
@@ -444,14 +446,9 @@ namespace SkiaSharp
 		private sealed class SKTypefaceStatic : SKTypeface
 		{
 			internal SKTypefaceStatic (IntPtr x)
-				: base (x, false)
+				: base (x, true)
 			{
 				IgnorePublicDispose = true;
-			}
-
-			protected override void Dispose (bool disposing)
-			{
-				// do not dispose
 			}
 		}
 	}

--- a/tests/Tests/SKDataTest.cs
+++ b/tests/Tests/SKDataTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
-using System.IO;
 
 namespace SkiaSharp.Tests
 {
@@ -17,6 +17,15 @@ namespace SkiaSharp.Tests
 
 			empty.Dispose();
 			Assert.True(SKObject.GetInstance<SKData>(empty.Handle, out _));
+		}
+
+		[SkippableFact]
+		public void EmptyAndZeroLengthSameObject()
+		{
+			var empty = SKData.Empty;
+			var zero = SKData.Create(0);
+
+			Assert.Same(empty, zero);
 		}
 
 		[SkippableFact]
@@ -65,7 +74,8 @@ namespace SkiaSharp.Tests
 		{
 			bool released = false;
 
-			var onRelease = new SKDataReleaseDelegate((addr, ctx) => {
+			var onRelease = new SKDataReleaseDelegate((addr, ctx) =>
+			{
 				Marshal.FreeCoTaskMem(addr);
 				released = true;
 				Assert.Equal("RELEASING!", ctx);
@@ -73,7 +83,8 @@ namespace SkiaSharp.Tests
 
 			var memory = Marshal.AllocCoTaskMem(10);
 
-			using (var data = SKData.Create(memory, 10, onRelease, "RELEASING!")) {
+			using (var data = SKData.Create(memory, 10, onRelease, "RELEASING!"))
+			{
 				Assert.Equal(memory, data.Data);
 				Assert.Equal(10, data.Size);
 			}

--- a/tests/Tests/SKFontManagerTest.cs
+++ b/tests/Tests/SKFontManagerTest.cs
@@ -256,6 +256,8 @@ namespace SkiaSharp.Tests
 		[SkippableFact]
 		public unsafe void FromTypefaceReturnsSameObject()
 		{
+			VerifySupportsMatchingTypefaces();
+
 			var fonts = SKFontManager.Default;
 
 			var tf = SKTypeface.FromFamilyName(DefaultFontFamily);

--- a/tests/Tests/SKFontManagerTest.cs
+++ b/tests/Tests/SKFontManagerTest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Xunit;
 using System.IO;
+using Xunit;
 
 namespace SkiaSharp.Tests
 {
@@ -116,7 +116,6 @@ namespace SkiaSharp.Tests
 			}
 		}
 
-
 		[SkippableFact]
 		public void CanReadNonASCIIFile()
 		{
@@ -211,6 +210,139 @@ namespace SkiaSharp.Tests
 			fonts.Dispose();
 			fonts = SKFontManager.Default;
 			Assert.NotNull(fonts);
+		}
+
+		[SkippableFact]
+		public unsafe void FromPathReturnsDifferentObject()
+		{
+			var fonts = SKFontManager.Default;
+
+			var path = Path.Combine(PathToFonts, "Roboto2-Regular_NoEmbed.ttf");
+
+			using var tf1 = fonts.CreateTypeface(path);
+			using var tf2 = fonts.CreateTypeface(path);
+
+			Assert.NotSame(tf1, tf2);
+		}
+
+		[SkippableFact]
+		public unsafe void FromStreamReturnsDifferentObject()
+		{
+			var fonts = SKFontManager.Default;
+
+			using var stream1 = File.OpenRead(Path.Combine(PathToFonts, "Roboto2-Regular_NoEmbed.ttf"));
+			using var tf1 = fonts.CreateTypeface(stream1);
+
+			using var stream2 = File.OpenRead(Path.Combine(PathToFonts, "Roboto2-Regular_NoEmbed.ttf"));
+			using var tf2 = fonts.CreateTypeface(stream2);
+
+			Assert.NotSame(tf1, tf2);
+		}
+
+		[SkippableFact]
+		public unsafe void FromDataReturnsDifferentObject()
+		{
+			var fonts = SKFontManager.Default;
+
+			using var data = SKData.Create(Path.Combine(PathToFonts, "Roboto2-Regular_NoEmbed.ttf"));
+
+			using var tf1 = fonts.CreateTypeface(data);
+			using var tf2 = fonts.CreateTypeface(data);
+
+			Assert.NotSame(tf1, tf2);
+		}
+
+		[Obsolete]
+		[SkippableFact]
+		public unsafe void FromTypefaceReturnsSameObject()
+		{
+			var fonts = SKFontManager.Default;
+
+			var tf = SKTypeface.FromFamilyName(DefaultFontFamily);
+
+			var tf1 = fonts.MatchTypeface(tf, SKFontStyle.Normal);
+			var tf2 = fonts.MatchTypeface(tf, SKFontStyle.Normal);
+
+			Assert.Same(tf, tf1);
+			Assert.Same(tf1, tf2);
+		}
+
+		[SkippableFact]
+		public unsafe void FromFamilyReturnsSameObject()
+		{
+			var fonts = SKFontManager.Default;
+
+			var tf1 = fonts.MatchFamily(DefaultFontFamily, SKFontStyle.Normal);
+			var tf2 = fonts.MatchFamily(DefaultFontFamily, SKFontStyle.Normal);
+
+			Assert.Same(tf1, tf2);
+		}
+
+		[SkippableFact]
+		public unsafe void FromFamilyDisposeDoesNotDispose()
+		{
+			var fonts = SKFontManager.Default;
+
+			var tf1 = fonts.MatchFamily(DefaultFontFamily, SKFontStyle.Normal);
+			var tf2 = fonts.MatchFamily(DefaultFontFamily, SKFontStyle.Normal);
+
+			Assert.Same(tf1, tf2);
+
+			tf1.Dispose();
+
+			Assert.NotEqual(IntPtr.Zero, tf1.Handle);
+			Assert.False(tf1.IsDisposed);
+		}
+
+		[SkippableFact]
+		public unsafe void TypefaceAndFontManagerReturnsSameObject()
+		{
+			var fonts = SKFontManager.Default;
+
+			var tf1 = fonts.MatchFamily("Times New Roman");
+			var tf2 = SKTypeface.FromFamilyName("Times New Roman");
+
+			Assert.Same(tf1, tf2);
+		}
+
+		[SkippableFact]
+		public unsafe void GCStillCollectsTypeface()
+		{
+			if (!IsWindows)
+				throw new SkipException("Test designed for Windows.");
+
+			var handle = DoWork();
+
+			CollectGarbage();
+
+			Assert.False(SKObject.GetInstance<SKTypeface>(handle, out _));
+
+			static IntPtr DoWork()
+			{
+				var fonts = SKFontManager.Default;
+
+				var tf1 = fonts.MatchFamily("Times New Roman", SKFontStyle.Normal);
+				var tf2 = fonts.MatchFamily("Times New Roman", SKFontStyle.Normal);
+				Assert.Same(tf1, tf2);
+
+				var tf3 = fonts.CreateTypeface(@"C:\Windows\Fonts\times.ttf");
+				Assert.NotSame(tf1, tf3);
+
+				tf1.Dispose();
+				tf2.Dispose();
+				tf3.Dispose();
+
+				Assert.NotEqual(IntPtr.Zero, tf1.Handle);
+				Assert.False(tf1.IsDisposed);
+
+				Assert.NotEqual(IntPtr.Zero, tf2.Handle);
+				Assert.False(tf2.IsDisposed);
+
+				Assert.Equal(IntPtr.Zero, tf3.Handle);
+				Assert.True(tf3.IsDisposed);
+
+				return tf1.Handle;
+			}
 		}
 	}
 }

--- a/tests/Tests/SKFontStyleSetTest.cs
+++ b/tests/Tests/SKFontStyleSetTest.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace SkiaSharp.Tests
 {
@@ -99,6 +100,48 @@ namespace SkiaSharp.Tests
 			}
 
 			Assert.Equal(set.Count, count);
+		}
+
+		[SkippableFact]
+		public void CreateTypefaceReturnsSameTypeface()
+		{
+			var fonts = SKFontManager.Default;
+			var set = fonts.GetFontStyles(DefaultFontFamily);
+
+			var tf1 = set.CreateTypeface(SKFontStyle.Normal);
+			var tf2 = set.CreateTypeface(SKFontStyle.Normal);
+
+			Assert.Same(tf1, tf2);
+		}
+
+		[SkippableFact]
+		public unsafe void CreateTypefaceDisposeDoesNotDispose()
+		{
+			var fonts = SKFontManager.Default;
+			var set = fonts.GetFontStyles(DefaultFontFamily);
+
+			var tf1 = set.CreateTypeface(SKFontStyle.Normal);
+			var tf2 = set.CreateTypeface(SKFontStyle.Normal);
+
+			Assert.Same(tf1, tf2);
+
+			tf1.Dispose();
+
+			Assert.NotEqual(IntPtr.Zero, tf1.Handle);
+			Assert.False(tf1.IsDisposed);
+		}
+
+		[SkippableFact]
+		public void StyleReturnsSameTypeface()
+		{
+			var fonts = SKFontManager.Default;
+
+			var set = fonts.GetFontStyles(DefaultFontFamily);
+			var tf1 = set.CreateTypeface(SKFontStyle.Normal);
+
+			var tf2 = fonts.MatchFamily(DefaultFontFamily, SKFontStyle.Normal);
+
+			Assert.Same(tf1, tf2);
 		}
 	}
 }

--- a/tests/Tests/SKShaperTest.cs
+++ b/tests/Tests/SKShaperTest.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using HarfBuzzSharp;
 using SkiaSharp.Tests;
 using Xunit;
@@ -102,53 +99,6 @@ namespace SkiaSharp.HarfBuzz.Tests
 				var data = Marshal.AllocCoTaskMem(size);
 				skiaTypeface.TryGetTableData(tag, 0, size, data);
 				return new Blob(data, size, MemoryMode.Writeable, () => Marshal.FreeCoTaskMem(data));
-			}
-		}
-
-		[SkippableFact]
-		public void TestMultiThreadCrash()
-		{
-			const int count = 20000;
-			var threads = new List<Thread>();
-
-			for (var i = 0; i < count; i++)
-			{
-				var t = new Thread(new ParameterizedThreadStart(Work));
-				t.TrySetApartmentState(Thread.CurrentThread.GetApartmentState());
-				t.Name = i.ToString();
-				t.Start(i);
-				threads.Add(t);
-			}
-
-			for (var i = 0; i < count; i++)
-			{
-				threads[i].Join();
-			}
-
-			static void Work(object state)
-			{
-				var text = $"Some wonderful text goes here {state}.";
-				var typeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold);
-				//using (var typeface = SkiaSharp.SKTypeface.FromFamilyName("Arial", SkiaSharp.SKFontStyle.Bold))
-				//{
-
-				using var paint = new SKPaint();
-
-				SKShaper.Result result;
-				using (var shaper = new SKShaper(typeface))
-				{
-					result = shaper.Shape(text, 75, 75, paint);
-				}
-
-				var imageInfo = new SKImageInfo(128, 128);
-				using var bitmap = new SKBitmap(imageInfo);
-				using var canvas = new SKCanvas(bitmap);
-
-				var bytes = result.Codepoints.Select(cp => BitConverter.GetBytes((ushort)cp)).SelectMany(b => b).ToArray();
-				paint.TextEncoding = SKTextEncoding.GlyphId;
-
-				canvas.DrawPositionedText(bytes, result.Points, paint);
-				//}
 			}
 		}
 	}

--- a/tests/Tests/SKTypefaceTest.cs
+++ b/tests/Tests/SKTypefaceTest.cs
@@ -486,6 +486,8 @@ namespace SkiaSharp.Tests
 		[SkippableFact]
 		public unsafe void FromTypefaceReturnsSameObject()
 		{
+			VerifySupportsMatchingTypefaces();
+
 			var tf = SKTypeface.FromFamilyName(DefaultFontFamily);
 
 			var tf1 = SKTypeface.FromTypeface(tf, SKTypefaceStyle.Normal);


### PR DESCRIPTION
**Description of Change**

Make sure to not dispose system fonts.

`SKFontManager` and `SKTypeface` return a cached/singleton for system fonts. Do not dispose these because they may be in use in other parts of drawing code.

Because it is actually reference counted on the native side, we can allow the GC to collect it still. When the GC is working, this means that there are no more managed references and a disposal of the managed object will do nothing bad.

**Bugs Fixed**

- Fixes #1220

**API Changes**

`SKFontManager.SKTypeface MatchFamily (string familyName);`

**Behavioral Changes**

System fonts are no longer disposed.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
