### PR TITLE
[Android.Views] Refresh the surface when recreated

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/GLTextureView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/GLTextureView.cs
@@ -144,12 +144,13 @@ namespace SkiaSharp.Views.Android
 
 		public void OnSurfaceTextureUpdated(SurfaceTexture surface)
 		{
-			//mGLThread.RequestRender();
+			//glThread.RequestRender();
 		}
 
 		public void OnSurfaceTextureAvailable(SurfaceTexture surface, int width, int height)
 		{
 			glThread.OnSurfaceCreated();
+			glThread.RequestRender();
 		}
 
 		public bool OnSurfaceTextureDestroyed(SurfaceTexture surface)


### PR DESCRIPTION
**Description of Change**

Make sure to request a redraw when the surface is created. This is not an issue when there is an update thread running.

**Bugs Fixed**

- Fixes #1232

**API Changes**

None.

**Behavioral Changes**

Fixes the issue 

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
