### PR TITLE
Make the GL views a "zero allocation draw"

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
@@ -88,12 +88,15 @@ namespace SkiaSharp.Views.UWP
 				lastPaintEventArgs = null;
 			}
 
-			// start drawing
+			// create or recreate the event args
 			if (!reusePaintEventArgsInstance || lastPaintEventArgs == null)
 				lastPaintEventArgs = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo);
 
+			// reset the draw matrix just in case
+			canvas.RestoreToCount(1);
+
+			// start drawing
 			OnPaintSurface(lastPaintEventArgs);
-			canvas.RestoreToCount(0);
 
 			// update the control
 			canvas.Flush();

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKSwapChainPanel.cs
@@ -18,6 +18,9 @@ namespace SkiaSharp.Views.UWP
 
 		private SKSizeI lastSize;
 
+		private SKPaintGLSurfaceEventArgs lastPaintEventArgs;
+		private bool reusePaintEventArgsInstance = true;
+
 		public SKSwapChainPanel()
 		{
 		}
@@ -80,13 +83,17 @@ namespace SkiaSharp.Views.UWP
 			{
 				surface = SKSurface.Create(context, renderTarget, surfaceOrigin, colorType);
 				canvas = surface.Canvas;
+
+				// reset the args
+				lastPaintEventArgs = null;
 			}
 
-			using (new SKAutoCanvasRestore(canvas, true))
-			{
-				// start drawing
-				OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo));
-			}
+			// start drawing
+			if (!reusePaintEventArgsInstance || lastPaintEventArgs == null)
+				lastPaintEventArgs = new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo);
+
+			OnPaintSurface(lastPaintEventArgs);
+			canvas.RestoreToCount(0);
 
 			// update the control
 			canvas.Flush();
@@ -97,6 +104,7 @@ namespace SkiaSharp.Views.UWP
 		{
 			base.OnDestroyingContext();
 
+			lastPaintEventArgs = null;
 			lastSize = default;
 
 			canvas?.Dispose();


### PR DESCRIPTION
**Description of Change**

Reduce the allocations in a draw loop of the GL views. 

Or at least see what we can do and provide options.

**Bugs Fixed**

- Fixes #1251 

**API Changes**

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

**Behavioral Changes**

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
