### PR TITLE
Null out the field when disposing.

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
@@ -130,6 +130,7 @@ namespace SkiaSharp.Views.iOS
 			base.Dispose(disposing);
 
 			drawable?.Dispose();
+			drawable = null;
 		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Null out the field when disposing.

Not sure why iOS is drawing a disposed object, but just be safe.

**Bugs Fixed**

-  Fixes #960

**API Changes**

None.

**Behavioral Changes**

None visible... maybe fewer crashes?

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
