### PR TITLE
No need to allocate on disposal

### DIFF
--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -71,7 +71,9 @@ namespace SkiaSharp
 				}
 				dic.Clear ();
 			}
-			KeepAliveObjects?.Clear ();
+			if (keepAliveObjects is ConcurrentDictionary<IntPtr, SKObject> ka) {
+				ka.Clear ();
+			}
 		}
 
 		protected override void DisposeNative ()

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -65,15 +65,13 @@ namespace SkiaSharp
 
 		protected override void DisposeManaged ()
 		{
-			if (ownedObjects is ConcurrentDictionary<IntPtr, SKObject> dic) {
-				foreach (var child in dic) {
-					child.Value.DisposeInternal ();
+			if (ownedObjects != null) {
+				foreach (var child in ownedObjects) {
+					child.Value?.DisposeInternal ();
 				}
-				dic.Clear ();
+				ownedObjects.Clear ();
 			}
-			if (keepAliveObjects is ConcurrentDictionary<IntPtr, SKObject> ka) {
-				ka.Clear ();
-			}
+			keepAliveObjects?.Clear ();
 		}
 
 		protected override void DisposeNative ()


### PR DESCRIPTION
**Description of Change**

No need to allocate on disposal. The lazy property must not be used, but rather the field.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
