### PR TITLE
Prevent the GC from collecting "this" and "pixels"

### DIFF
--- a/binding/Binding/SKImage.cs
+++ b/binding/Binding/SKImage.cs
@@ -569,7 +569,9 @@ namespace SkiaSharp
 		public bool ReadPixels (SKImageInfo dstInfo, IntPtr dstPixels, int dstRowBytes, int srcX, int srcY, SKImageCachingHint cachingHint)
 		{
 			var cinfo = SKImageInfoNative.FromManaged (ref dstInfo);
-			return SkiaApi.sk_image_read_pixels (Handle, &cinfo, (void*)dstPixels, (IntPtr)dstRowBytes, srcX, srcY, cachingHint);
+			var result = SkiaApi.sk_image_read_pixels (Handle, &cinfo, (void*)dstPixels, (IntPtr)dstRowBytes, srcX, srcY, cachingHint);
+			GC.KeepAlive (this);
+			return result;
 		}
 
 		public bool ReadPixels (SKPixmap pixmap) =>
@@ -583,7 +585,9 @@ namespace SkiaSharp
 			if (pixmap == null)
 				throw new ArgumentNullException (nameof (pixmap));
 
-			return SkiaApi.sk_image_read_pixels_into_pixmap (Handle, pixmap.Handle, srcX, srcY, cachingHint);
+			var result = SkiaApi.sk_image_read_pixels_into_pixmap (Handle, pixmap.Handle, srcX, srcY, cachingHint);
+			GC.KeepAlive (this);
+			return result;
 		}
 
 		// ScalePixels

--- a/binding/Binding/SKPixmap.cs
+++ b/binding/Binding/SKPixmap.cs
@@ -210,7 +210,9 @@ namespace SkiaSharp
 
 		public bool ReadPixels (SKPixmap pixmap)
 		{
-			return ReadPixels (pixmap.Info, pixmap.GetPixels (), pixmap.RowBytes, 0, 0, SKTransferFunctionBehavior.Respect);
+			var result = ReadPixels (pixmap.Info, pixmap.GetPixels (), pixmap.RowBytes, 0, 0, SKTransferFunctionBehavior.Respect);
+			GC.KeepAlive (this);
+			return result;
 		}
 
 		// Encode

--- a/binding/Binding/SKPixmap.cs
+++ b/binding/Binding/SKPixmap.cs
@@ -210,9 +210,7 @@ namespace SkiaSharp
 
 		public bool ReadPixels (SKPixmap pixmap)
 		{
-			var result = ReadPixels (pixmap.Info, pixmap.GetPixels (), pixmap.RowBytes, 0, 0, SKTransferFunctionBehavior.Respect);
-			GC.KeepAlive (this);
-			return result;
+			return ReadPixels (pixmap.Info, pixmap.GetPixels (), pixmap.RowBytes, 0, 0, SKTransferFunctionBehavior.Respect);
 		}
 
 		// Encode

--- a/binding/Binding/SKSurface.cs
+++ b/binding/Binding/SKSurface.cs
@@ -346,7 +346,9 @@ namespace SkiaSharp
 		public bool ReadPixels (SKImageInfo dstInfo, IntPtr dstPixels, int dstRowBytes, int srcX, int srcY)
 		{
 			var cinfo = SKImageInfoNative.FromManaged (ref dstInfo);
-			return SkiaApi.sk_surface_read_pixels (Handle, &cinfo, (void*)dstPixels, (IntPtr)dstRowBytes, srcX, srcY);
+			var result = SkiaApi.sk_surface_read_pixels (Handle, &cinfo, (void*)dstPixels, (IntPtr)dstRowBytes, srcX, srcY);
+			GC.KeepAlive (this);
+			return result;
 		}
 
 		internal static SKSurface GetObject (IntPtr handle) =>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/AndroidExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/AndroidExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Android.Graphics;
+﻿using System;
+using Android.Graphics;
 
 namespace SkiaSharp.Views.Android
 {
@@ -130,7 +131,9 @@ namespace SkiaSharp.Views.Android
 		{
 			using (var pixmap = skiaBitmap.PeekPixels())
 			{
-				return pixmap.ToBitmap();
+				var bmp = pixmap.ToBitmap();
+				GC.KeepAlive(skiaBitmap);
+				return bmp;
 			}
 		}
 
@@ -183,7 +186,9 @@ namespace SkiaSharp.Views.Android
 		{
 			using (var pixmap = skiaImage.PeekPixels())
 			{
-				return pixmap.ToBitmap();
+				var bmp = pixmap.ToBitmap();
+				GC.KeepAlive(skiaImage);
+				return bmp;
 			}
 		}
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
@@ -176,6 +176,7 @@ namespace SkiaSharp.Views.Mac
 					provider,
 					null, false, CGColorRenderingIntent.Default);
 			}
+			GC.KeepAlive(skiaBitmap);
 			return cgImage;
 		}
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Gtk/GTKExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Gtk/GTKExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Gdk;
 
+using GC = System.GC;
+
 namespace SkiaSharp.Views.Gtk
 {
 	public static class GTKExtensions
@@ -91,9 +93,12 @@ namespace SkiaSharp.Views.Gtk
 
 		public static Pixbuf ToPixbuf(this SKBitmap skiaBitmap)
 		{
-			using (var image = SKImage.FromPixels(skiaBitmap.PeekPixels()))
+			using (var pixmap = skiaBitmap.PeekPixels())
+			using (var image = SKImage.FromPixels(pixmap))
 			{
-				return image.ToPixbuf();
+				var pixbuf = image.ToPixbuf();
+				GC.KeepAlive(skiaBitmap);
+				return pixbuf;
 			}
 		}
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Shared/Extensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Shared/Extensions.cs
@@ -137,9 +137,12 @@ namespace SkiaSharp.Views.Tizen
 
 		public static System.Drawing.Bitmap ToBitmap(this SKBitmap skiaBitmap)
 		{
-			using (var image = SKImage.FromPixels(skiaBitmap.PeekPixels()))
+			using (var pixmap = skiaBitmap.PeekPixels())
+			using (var image = SKImage.FromPixels(pixmap))
 			{
-				return image.ToBitmap();
+				var bmp = image.ToBitmap();
+				GC.KeepAlive(skiaBitmap);
+				return bmp;
 			}
 		}
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/UWPExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/UWPExtensions.cs
@@ -96,9 +96,12 @@ namespace SkiaSharp.Views.UWP
 
 		public static WriteableBitmap ToWriteableBitmap(this SKBitmap skiaBitmap)
 		{
-			using (var image = SKImage.FromPixels(skiaBitmap.PeekPixels()))
+			using (var pixmap = skiaBitmap.PeekPixels())
+			using (var image = SKImage.FromPixels(pixmap))
 			{
-				return image.ToWriteableBitmap();
+				var wb = image.ToWriteableBitmap();
+				GC.KeepAlive(skiaBitmap);
+				return wb;
 			}
 		}
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WPFExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WPFExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -85,9 +86,12 @@ namespace SkiaSharp.Views.WPF
 
 		public static WriteableBitmap ToWriteableBitmap(this SKBitmap skiaBitmap)
 		{
-			using (var image = SKImage.FromPixels(skiaBitmap.PeekPixels()))
+			using (var pixmap = skiaBitmap.PeekPixels())
+			using (var image = SKImage.FromPixels(pixmap))
 			{
-				return image.ToWriteableBitmap();
+				var wb = image.ToWriteableBitmap();
+				GC.KeepAlive(skiaBitmap);
+				return wb;
 			}
 		}
 


### PR DESCRIPTION
**Description of Change**

Prevent the GC from collecting `this` and some cases where we no longer reference the object, just pixel data.

Reading pixels takes long enough that the GC will collect the object. Use GC.KeepAlive to prevent this.

Often the cause is that we go `SKImage` -> `SKPixmap`. This basically tells the GC that the bitmap is free, but in actual fact it is not - the pixmap is just a pointer to the pixel data.

**Bugs Fixed**

- Related to issue #1244

**API Changes**

None.

**Behavioral Changes**

Preserve `this`.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
