### PR TITLE
First version of high quality image downsampler

### DIFF
--- a/binding/Binding.Resampler/FilterKernel.cs
+++ b/binding/Binding.Resampler/FilterKernel.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Numerics;
+
+namespace SkiaSharp
+{
+	internal sealed class FilterKernel
+	{
+		private readonly int stride;
+		private readonly float[] weights;
+		private readonly int[] offsets;
+		private readonly int[] counts;
+
+		public FilterKernel (SKSamplingFilterFunction filterFunction, int filterRadius, int srcLength, int dstLength, double outputShift, double outputLength, bool superSampling, bool wrapAtEdges)
+		{
+			double srcScaleFactor = outputLength / srcLength;
+			double dstScaleFactor = srcLength / outputLength;
+			double srcKernelRadius = filterRadius * dstScaleFactor;
+
+			// https://en.wikipedia.org/wiki/Lanczos_resampling
+			stride = 2 + (int)Math.Ceiling (2 * srcKernelRadius);
+			weights = new float[dstLength * stride];
+			offsets = new int[dstLength];
+			counts = new int[dstLength];
+
+			// To detect indices out of range, and for better cache locality, we allocate this on the stack
+			Span<float> localWeights = stackalloc float[stride];
+
+			int dstMax = dstLength - 1;
+
+			float startCoverage = (float)(1 - outputShift);
+			float endCoverage = (float)(1 - (dstLength - outputShift - outputLength));
+
+			for (int dstPixel = 0; dstPixel <= dstMax; dstPixel++) {
+				var alpha = dstPixel == 0 ? startCoverage
+					: dstPixel == dstMax ? endCoverage
+					: 1;
+
+				if (Math.Abs (dstScaleFactor - 1) < 1e-6) {
+					// No scaling needed
+					offsets[dstPixel] = dstPixel;
+					counts[dstPixel] = 1;
+					weights[dstPixel * stride] = alpha;
+				} else {
+					var srcMid = (dstPixel - outputShift) * dstScaleFactor;
+					int srcMin = (int)Math.Floor (srcMid - srcKernelRadius);
+					int srcMax = (int)Math.Ceiling (srcMid + srcKernelRadius);
+					var srcClampedMin = Math.Max (0, srcMin);
+					var srcClampedMax = Math.Min (srcLength - 1, srcMax);
+					var count = srcClampedMax - srcClampedMin + 1;
+					var last = count - 1;
+
+					offsets[dstPixel] = srcClampedMin;
+					counts[dstPixel] = count;
+
+					var weightsOffset = dstPixel * stride;
+
+					if (filterRadius == 0) {
+						// Do a simple box filter.
+						var weight = alpha / count;
+						for (int i = 0; i < count; i++) {
+							weights[weightsOffset + i] = weight;
+						}
+					} else {
+						// Use a Lanczos filter.
+						float sum = 0;
+
+						// Compute the weight of each source pixel.
+						// A source pixel can occur multiple times due to edge wrapping and super-sampling!
+						for (int srcPixel = srcMin; srcPixel <= srcMax; ++srcPixel) {
+							var weight = (float)filterFunction ((srcPixel - srcMid) * srcScaleFactor, filterRadius);
+							int index = GetWeightIndex (srcPixel - srcClampedMin, last, wrapAtEdges);
+							localWeights[index] += weight;
+							sum += weight;
+						}
+
+						if (superSampling) {
+							// Also include (s0 + s1)/2 source pixels (simple bi-linear interpolation)
+							// TODO: Also use Lanczos for super sampling?
+							for (int srcPixel = srcMin; srcPixel < srcMax; ++srcPixel) {
+								var weight = (float)filterFunction ((srcPixel - srcMid + 0.5f) * srcScaleFactor, filterRadius);
+								int index0 = GetWeightIndex (srcPixel - srcClampedMin, last, wrapAtEdges);
+								int index1 = GetWeightIndex (srcPixel - srcClampedMin + 1, last, wrapAtEdges);
+								sum += weight;
+								weight *= 0.5f;
+								localWeights[index0] += weight;
+								localWeights[index1] += weight;
+							}
+						}
+
+						//Debug.Assert(Math.Abs(localWeights.ToArray().Sum() - sum) < 0.001f);
+						float normalize = alpha / sum;
+						for (int i = 0; i < count; i++) {
+							weights[weightsOffset + i] = localWeights[i] * normalize;
+							localWeights[i] = 0;
+						}
+					}
+				}
+			}
+		}
+
+		private int GetWeightIndex (int offset, int last, bool wrap)
+		{
+			// Wrap around the edges, but always clamp if needed.
+			if (offset < 0)
+				return wrap ? Math.Min (-offset, last) : 0;
+
+			if (offset > last)
+				return wrap ? Math.Max (2 * last - offset, 0) : last;
+
+			return offset;
+		}
+
+		public void Convolve (
+			ReadOnlySpan<Vector4> srcColors,
+			int srcOffset,
+			Span<Vector4> dstColors,
+			int dstOffset,
+			int dstStride,
+			int dstCount)
+		{
+			Span<float> weights = this.weights;
+
+			for (int i = 0; i < dstCount; ++i) {
+				var offset = offsets[i];
+				var count = counts[i];
+				var srcGroup = srcColors.Slice (srcOffset + offset, count);
+				var srcWeights = weights.Slice (i * stride, count);
+				var dots = DotProducts (srcGroup, srcWeights);
+				dstColors[dstOffset + i * dstStride] = dots;
+			}
+		}
+
+		private static Vector4 DotProducts (ReadOnlySpan<Vector4> values, ReadOnlySpan<float> weights)
+		{
+			// NOTE: Benchmarking showed that neither an unsafe context,
+			// nor unrolling the loop matters, at least not in .NET Core 3.1
+			var dots = Vector4.Zero;
+			for (int i = 0; i < values.Length; ++i) {
+				dots += values[i] * weights[i];
+			}
+			return dots;
+		}
+	}
+}

--- a/binding/Binding.Resampler/ImageResampler.cs
+++ b/binding/Binding.Resampler/ImageResampler.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Numerics;
+using System.Threading.Tasks;
+
+namespace SkiaSharp
+{
+	public static class ImageResampler
+	{
+		public static SKBitmap ResampledBy (this SKBitmap srcBitmap,
+			float scaleFactor, SKImageSamplingOptions options = null)
+		{
+			using var srcPixmap = srcBitmap.PeekPixels ();
+			return ResampledBy (srcPixmap, scaleFactor, options);
+		}
+
+		public static SKBitmap ResampledBy (this SKBitmap srcBitmap,
+			float widthFactor, float heightFactor, SKImageSamplingOptions options = null)
+		{
+			using var srcPixmap = srcBitmap.PeekPixels ();
+			return ResampledBy (srcPixmap, widthFactor, heightFactor, options);
+		}
+
+		public static SKBitmap ResampledTo (this SKBitmap srcBitmap,
+			float outputWidth, float outputHeight, SKImageSamplingOptions options = null)
+		{
+			using var srcPixmap = srcBitmap.PeekPixels ();
+			return ResampledTo(srcPixmap, outputWidth, outputHeight, options);
+		}
+
+		public static SKBitmap ResampledBy (this SKPixmap srcPixmap, float scaleFactor, SKImageSamplingOptions options = null)
+			=> ResampledTo (srcPixmap, srcPixmap.Width * scaleFactor, srcPixmap.Height * scaleFactor, options);
+
+		public static SKBitmap ResampledBy (this SKPixmap srcPixmap, float widthFactor, float heightFactor, SKImageSamplingOptions options = null)
+			=> ResampledTo (srcPixmap, srcPixmap.Width * widthFactor, srcPixmap.Height * heightFactor, options);
+
+		public static SKBitmap ResampledTo (this SKPixmap srcPixmap, float outputWidth, float outputHeight, SKImageSamplingOptions options = null)
+		{
+			var filterRadius = options?.FilterRadius ?? 3;
+			var outputLeft = options?.OutputOffset.X ?? 0;
+			var outputTop = options?.OutputOffset.Y ?? 0;
+			var superSample = options?.SuperSample ?? true;
+			var parallelOptions = options?.ParallelOptions;
+			var wrapAtEdges = options?.WrapAtEdges ?? false;
+			var filterFunc = options?.FilterFunc ?? SKSamplingFilterFunctions.Lanczos;
+			var outputColorType = options?.OutputColorType ?? srcPixmap.ColorType;
+			var outputColorSpace = options?.OutputColorSpace ?? srcPixmap.ColorSpace ?? SKColorSpace.CreateSrgb ();
+
+			// Validate arguments
+			if (float.IsInfinity (filterRadius) || float.IsNaN (filterRadius) || filterRadius < 0 || filterRadius > 9)
+				throw new ArgumentOutOfRangeException (nameof (filterRadius));
+
+			if (float.IsInfinity (outputWidth) || float.IsNaN (outputWidth) || outputWidth <= 0)
+				throw new ArgumentOutOfRangeException (nameof (outputWidth));
+
+			if (float.IsInfinity (outputHeight) || float.IsNaN (outputHeight) || outputHeight <= 0)
+				throw new ArgumentOutOfRangeException (nameof (outputHeight));
+
+			if (srcPixmap == null)
+				throw new ArgumentNullException (nameof (srcPixmap));
+
+			var srcWidth = srcPixmap.Width;
+			var srcHeight = srcPixmap.Height;
+
+			if (outputWidth >= srcWidth && outputHeight >= srcHeight) {
+				// We need to up-sample in both dimensions
+				return new Sampler (outputLeft, outputTop, outputWidth, outputHeight, outputColorType, outputColorSpace, filterRadius).Up (srcPixmap);
+			}
+
+			if (outputWidth >= srcWidth) {
+				// Up-sample horizontally, down-sample vertically
+				using var tmpBitmap = new Sampler (outputLeft, 0, outputWidth, srcHeight, outputColorType, outputColorSpace, filterRadius).Up (srcPixmap);
+				using var tmpPixels = tmpBitmap.PeekPixels ();
+				return new Sampler (0, outputTop, tmpBitmap.Width, outputHeight, outputColorType, outputColorSpace, filterRadius)
+					.Down (tmpPixels, filterFunc, superSample, parallelOptions, wrapAtEdges);
+			}
+
+			if (outputWidth >= srcWidth) {
+				// Up-sample vertically, down-sample horizontally
+				using var tmpBitmap = new Sampler (0, outputTop, srcWidth, outputHeight, outputColorType, outputColorSpace, filterRadius).Up (srcPixmap);
+				using var tmpPixels = tmpBitmap.PeekPixels ();
+				return new Sampler (outputLeft, 0, outputWidth, tmpBitmap.Height, outputColorType, outputColorSpace, filterRadius)
+					.Down (tmpPixels, filterFunc, superSample, parallelOptions, wrapAtEdges);
+			}
+
+			// Down-sample in both dimensions.
+			return new Sampler (outputLeft, outputTop, outputWidth, outputHeight, outputColorType, outputColorSpace, filterRadius)
+				.Down (srcPixmap, filterFunc, superSample, parallelOptions, wrapAtEdges);
+		}
+
+		internal readonly struct Sampler
+		{
+			public readonly float OutputFracX;
+			public readonly float OutputFracY;
+			public readonly float OutputWidth;
+			public readonly float OutputHeight;
+			public readonly SKColorType OutputColorType;
+			public readonly SKColorSpace OutputColorSpace;
+			public readonly int FilterRadius;
+			public readonly int DstWidth;
+			public readonly int DstHeight;
+
+			public Sampler (
+				float outputLeft,
+				float outputTop,
+				float outputWidth,
+				float outputHeight,
+				SKColorType outputColorType,
+				SKColorSpace outputColorSpace,
+				int filterRadius)
+			{
+				var outputRight = outputLeft + outputWidth;
+				var outputBottom = outputTop + outputHeight;
+
+				var dstLeft = (int)Math.Floor (outputLeft);
+				var dstTop = (int)Math.Floor (outputTop);
+
+				OutputWidth = outputWidth;
+				OutputHeight = outputHeight;
+
+				OutputColorType = outputColorType;
+				OutputColorSpace = outputColorSpace;
+
+				FilterRadius = filterRadius;
+
+				DstWidth = (int)(Math.Ceiling (outputRight) - dstLeft);
+				DstHeight = (int)(Math.Ceiling (outputBottom) - dstTop);
+
+				OutputFracX = outputLeft - dstLeft;
+				OutputFracY = outputTop - dstTop;
+			}
+
+			public SKBitmap Down (SKPixmap srcPixmap, SKSamplingFilterFunction filterFunc,
+				bool superSample, ParallelOptions? parallelOptions, bool wrapAtEdges)
+			{
+				var srcWidth = srcPixmap.Width;
+				var srcHeight = srcPixmap.Height;
+
+				// We need to down-sample the source pixmap.
+				//
+				// Outline of algorithm:
+				// - scale the rows of the source image horizontally to the columns of temporary transposed bitmap of size (srcHeight, dstWidth)
+				// - scale the rows of the transposed bitmap to the columns of the output bitmap of size (dstWidth, dstHeight)
+				//
+				// Temporary buffers are used to convert to and from a 32-bit float linear color space, needed to correctly average the colors
+				var linearColorSpace = SKColorSpace.CreateSrgbLinear ();
+
+				// Create temporary transposed bitmap in 32-bit linear sRGB space
+				// We need pre-multiplied alpha to correctly average transparent pixels:
+				// https://entropymine.com/imageworsener/resizealpha/
+				var tmpWidth = srcHeight;
+				var tmpHeight = DstWidth;
+				var tmpImgInfo = new SKImageInfo (tmpWidth, tmpHeight, SKColorType.RgbaF32, SKAlphaType.Premul, linearColorSpace);
+				using var tmpBitmap = new SKBitmap (tmpImgInfo);
+				using var tmpPixmap = tmpBitmap.PeekPixels ();
+
+				// Create a row bitmap, using Skia to convert the input to 32-bit linear sRGB space.
+				var linRowInfo = new SKImageInfo (srcWidth, 1, SKColorType.RgbaF32, SKAlphaType.Premul, linearColorSpace);
+
+				// Create a column bitmap in 32-bit linear sRGB space, using Skia to convert the output color type and space.
+				var linColInfo = new SKImageInfo (1, DstHeight, SKColorType.RgbaF32, SKAlphaType.Premul, linearColorSpace);
+
+				// Create the filter kernels
+				var horScalingKernel = new FilterKernel (filterFunc, FilterRadius, srcWidth, DstWidth, OutputFracX, OutputWidth, superSample, wrapAtEdges);
+				var verScalingKernel = new FilterKernel (filterFunc, FilterRadius, srcHeight, DstHeight, OutputFracY, OutputHeight, superSample, wrapAtEdges);
+
+				// Create the output image bitmap
+				var dstImgInfo = new SKImageInfo (DstWidth, DstHeight, OutputColorType, SKAlphaType.Premul, OutputColorSpace);
+
+				var dstBitmap = new SKBitmap (dstImgInfo);
+
+				try {
+					SKBitmap ProcessRow (int srcRowTmpCol, SKBitmap rowBitmap)
+					{
+						// Convert to 32-bit linear colors
+						using var rowPixmap = rowBitmap.PeekPixels ();
+						srcPixmap.ReadPixels (rowPixmap, 0, srcRowTmpCol);
+
+						// Convolve to the temporary transposed bitmap
+						var tmpSpan = tmpPixmap.GetPixelSpan<Vector4> ();
+						var rowSpan = rowPixmap.GetPixelSpan<Vector4> ();
+
+						horScalingKernel.Convolve (rowSpan, 0,
+							tmpSpan, srcRowTmpCol, tmpWidth, tmpHeight);
+
+						return rowBitmap;
+					};
+
+					SKBitmap ProcessColumn (int tmpRowDstCol, SKBitmap colBitmap)
+					{
+						var tmpSpan = tmpPixmap.GetPixelSpan<Vector4> ();
+
+						using var colPixmap = colBitmap.PeekPixels ();
+						var colSpan = colPixmap.GetPixelSpan<Vector4> ();
+
+						// Convolve to the destination column
+						verScalingKernel.Convolve (
+							tmpSpan, tmpRowDstCol * tmpWidth,
+							colSpan, 0, 1, colSpan.Length);
+
+						// Convert to output colors.
+						colPixmap.ReadPixels (dstImgInfo, dstBitmap.GetAddress (tmpRowDstCol, 0), dstBitmap.RowBytes);
+
+						return colBitmap;
+					}
+
+					var parForOptions = parallelOptions ?? new ParallelOptions { MaxDegreeOfParallelism = 1 };
+
+					// Horizontal scaling pass, convolving each row in the source bitmap to a column in the temp transposed bitmap
+					Parallel.For (0, srcHeight, parForOptions,
+						() => new SKBitmap (linRowInfo),
+						(srcRowTmpCol, state, linRowBitmap) => ProcessRow (srcRowTmpCol, linRowBitmap),
+						linRowBitmap => linRowBitmap?.Dispose ());
+
+					// Vertical scaling pass, convolving each row in the temp transposed bitmap to a column in the destination bitmap
+					Parallel.For (0, DstWidth, parForOptions,
+						() => new SKBitmap (linColInfo),
+						(tmpRowDstCol, state, linColBitmap) => ProcessColumn (tmpRowDstCol, linColBitmap),
+						linColBitmap => linColBitmap?.Dispose ());
+				} catch {
+					// If any exception occurs, dispose the dstBitmap
+					dstBitmap.Dispose ();
+					throw;
+				}
+
+				return dstBitmap;
+			}
+
+			public SKBitmap Up (SKPixmap srcPixmap)
+			{
+				// NOTE: We currently just use Skia for up-sampling. IMHO this always looks bad anyway, whatever alg is picked...
+				var outBitmap = new SKBitmap (
+					new SKImageInfo (DstWidth, DstHeight, OutputColorType, SKAlphaType.Premul, OutputColorSpace));
+
+				// NOTE: We use DrawBitmap to deal with fractional output sizes.
+				using var inImage = SKImage.FromPixels (srcPixmap);
+
+				var filterQuality = FilterRadius <= 0 ? SKFilterQuality.Low
+					: FilterRadius == 1 ? SKFilterQuality.Medium
+					: SKFilterQuality.High;
+
+				using var paint = new SKPaint { FilterQuality = filterQuality };
+				using var canvas = new SKCanvas (outBitmap);
+				canvas.DrawImage (inImage, SKRect.Create (OutputFracX, OutputFracY, OutputWidth, OutputHeight), paint);
+				return outBitmap;
+			}
+		}
+	}
+}

--- a/binding/Binding.Resampler/SKImageSamplingOptions.cs
+++ b/binding/Binding.Resampler/SKImageSamplingOptions.cs
@@ -1,0 +1,61 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+
+namespace SkiaSharp
+{
+	public delegate double SKSamplingFilterFunction(double x, int r);
+
+	public sealed class SKImageSamplingOptions
+	{
+		/// <summary>
+		/// The color type of the output image. By default the color type of the input is used.
+		/// </summary>
+		/// <remarks>
+		/// For high quality rendering, you can use <see cref="SKColorType.RgbaF16"/>
+		/// </remarks>
+		/// <seealso cref="OutputColorSpace"/>
+		public SKColorType? OutputColorType;
+
+		/// <summary>
+		/// The color space of the output image. By default the color space of the input is used.
+		/// </summary>
+		/// <remarks>
+		/// For high quality rendering, you should use <see cref="SKColorSpace.CreateSrgbLinear()"/>
+		/// </remarks>
+		/// <seealso cref="OutputColorType"/>
+		public SKColorSpace? OutputColorSpace;
+
+		/// <summary>
+		/// The (fractional) offset of the resampled output image.
+		/// Only the fractional part is used, the integer part is ignored.
+		/// This allows shifting the output with sub-pixel precision.
+		/// </summary>
+		public SKPoint OutputOffset { get; set; }
+
+		/// <summary>
+		/// The filter function to use.
+		/// </summary>
+		public SKSamplingFilterFunction FilterFunc { get; set; } = SKSamplingFilterFunctions.Lanczos;
+
+		/// <summary>
+		/// The radius (half the width) of the sampling filter. 
+		/// </summary>
+		public int FilterRadius { get; set; } = 3;
+
+		/// <summary>
+		/// Sample interpolated source pixels too? Enabled by default since this is cheap and removes more aliasing.
+		/// </summary>
+		public bool SuperSample { get; set; } = true;
+
+		/// <summary>
+		/// When sampling outside of the source image,
+		/// wrap around the nearest edge, or just clamp (the default)?
+		/// </summary>
+		public bool WrapAtEdges { get; set; }
+
+		/// <summary>
+		/// Re-sample in parallel?
+		/// </summary>
+		public ParallelOptions? ParallelOptions { get; set; }
+	}
+}

--- a/binding/Binding.Resampler/SKSamplingFilterFunctions.cs
+++ b/binding/Binding.Resampler/SKSamplingFilterFunctions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace SkiaSharp
+{
+	public static class SKSamplingFilterFunctions
+	{
+		public static readonly SKSamplingFilterFunction Lanczos = (t, a) =>
+		{
+			t = Math.Abs(t);
+			return t < a ? Sinc(t) * Sinc(t / a) : 0.0;
+		};
+
+		private static double Sinc(double x)
+		{
+			x *= Math.PI;
+
+			return x < 0.01 && (x > -0.01)
+				? 1.0 + x * x * (-1.0 / 6.0 + x * x * 1.0 / 120.0)
+				: Math.Sin(x) / x;
+		}
+
+	}
+}

--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -16,6 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\output\native\windows\x64\libSkiaSharp.dll" Link="nuget\runtimes\win-x64\native\libSkiaSharp.dll"
@@ -35,6 +37,7 @@
     <None Include="nuget\build\net45\SkiaSharp.targets" Link="nuget\build\$(TargetFramework)\SkiaSharp.targets" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Binding.Resampler\**\*.cs" Link="Resampler/%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="..\Binding\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>

--- a/samples/Gallery/Shared/SampleCategories.cs
+++ b/samples/Gallery/Shared/SampleCategories.cs
@@ -19,5 +19,6 @@ namespace SkiaSharpSample
 		PathEffects = 1 << 10,
 		SVG = 1 << 11,
 		Documents = 1 << 12,
+		Xtras = 1 << 13,
 	}
 }

--- a/samples/Gallery/Shared/Samples/ImageResamplingSample.cs
+++ b/samples/Gallery/Shared/Samples/ImageResamplingSample.cs
@@ -1,0 +1,75 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using SkiaSharp;
+
+namespace SkiaSharpSample.Samples
+{
+	[Preserve(AllMembers = true)]
+	public class ImageResamplingSample : AnimatedSampleBase
+	{
+		private bool useSkiaNative = false;
+
+		[Preserve]
+		public ImageResamplingSample()
+		{
+		}
+
+		public override string Title => "Image Resampling";
+
+		public override SampleCategories Category => SampleCategories.Xtras;
+
+		protected override void OnDrawSample(SKCanvas canvas, int width, int height)
+		{
+			canvas.Clear(SKColors.Black);
+
+			using (var stream = new SKManagedStream(SampleMedia.Images.Baboon))
+			using (var bitmap = SKBitmap.Decode(stream))
+			using (var hardPaint = new SKPaint
+			{
+				FilterQuality = SKFilterQuality.None,
+				IsAntialias = false
+			})
+			using (var softPaint = new SKPaint
+			{
+				TextSize = 16,
+				Color = SKColors.White,
+				IsAntialias = true,
+				Style = SKPaintStyle.Fill,
+				FilterQuality = SKFilterQuality.High,
+				TextAlign = SKTextAlign.Center
+			})
+			{
+				var dstWidth = width * 0.75f;
+				var dstHeight = height * 0.75f;
+				var dstRect = SKRect.Create((width - dstWidth) / 2f, 20 + (height - dstHeight - 20) / 2f, dstWidth, dstHeight);
+
+				if (useSkiaNative)
+				{
+					canvas.DrawBitmap(bitmap, dstRect, softPaint);
+					canvas.DrawText("Skia resize", width / 2f, 20, softPaint);
+				}
+				else
+				{
+					var options = new SKImageSamplingOptions
+					{
+						OutputOffset = dstRect.Location,
+						ParallelOptions = new ParallelOptions()
+					};
+
+					using (var resampled = bitmap.ResampledTo(dstRect.Width, dstRect.Height, options))
+					{
+						// Make sure to convert the positions to integers to avoid Skia doing another sub-pixel resize!
+						canvas.DrawBitmap(resampled, (int)dstRect.Left, (int)dstRect.Top, hardPaint);
+						canvas.DrawText("SkiaSharp resample", width / 2f, 20, softPaint);
+					}
+				}
+			}
+		}
+
+		protected override async Task OnUpdate(CancellationToken token)
+		{
+			await Task.Delay(1000, token);
+			useSkiaNative = !useSkiaNative;
+		}
+	}
+}


### PR DESCRIPTION
**Description of Change**

- Currently uses Skia for upsampling (IMHO upsampling always looks blurry anyway)
- Not optimized yet, just uses `Vector4` from the `System.Numerics` package.  
   - Most of the time is actually spent in Skia's color type conversion...
   - I have optimized AVX2 code ready that short circuits the most common case (speedup x5), but I first wanted to share a "minimal" working example, without unsafe pointers, to get feedback
- The code currently always uses a `Parallel.For`, but by default only uses a single thread. 
- Since Skia native doesn't have this resampler, I decided to use extensions methods, and put the code in a separate directory.
- The `outputWidth` and `outputHeight` are `float`s, to allow fractional sizes (just like `SKCanvas.DrawImage`  can draw into a fractional rectangle). 
- The `SKImageSamplingOptions.OutputOffset` allows to control the sub-pixel offsets, if needed, and allows setting other options.
- `SKCanvas.DrawResampledBitmap(bitmap, sourceRect, targetRect, options, paint)` and overloads could be a handy method too, I didn't add this yet.
- I added an example in the gallery. The baboon image is actually a good image, clearly showing the difference in quality between Skia's native hybrid box-resampler/resizer and this Lanczos based resampler.
- Currently always uses a Lanczos filter (good average filter), but allows to provide external ones.
- [To improve quality](https://github.com/avaneev/avir), the image is first upscaled `x2`, but this is completely integrated in the filter weights, so has zero overhead. 
- I haven't done any testing on ARM devices yet (not sure how to do this). 
- I was able to run all unit tests, but I didn't add any yet. The existing APIs don't change at all.
- I struggled a lot to verify the results. I reported some bugs to Skia regarding PNG image encoding bugs. Thanks for the GIMP tip, that one always worked correctly.
- I should add a lot more comments about how this all works ;-)


**Bugs Fixed**

Skia's default image resizing can be blurry.

- Related to issue ##1127 

**API Changes**

Added: 

- `public static SKBitmap ResampledBy (this SKBitmap srcBitmap, float scaleFactor, SKImageSamplingOptions options = null)`
- `public static SKBitmap ResampledBy (this SKBitmap srcBitmap, float widthFactor, float heightFactor, SKImageSamplingOptions options = null)`
- `public static SKBitmap ResampledTo (this SKBitmap srcBitmap, float outputWidth, float outputHeight, SKImageSamplingOptions options = null)`
- `public static SKBitmap ResampledBy (this SKPixmap srcPixmap, float scaleFactor, SKImageSamplingOptions options = null)`
- `public static SKBitmap ResampledBy (this SKPixmap srcPixmap, float widthFactor, float heightFactor, SKImageSamplingOptions options = null)`
- `public static SKBitmap ResampledTo (this SKPixmap srcPixmap, float outputWidth, float outputHeight, SKImageSamplingOptions options = null)`

**Behavioral Changes**

None

**PR Checklist**

- [n] Has tests (if omitted, state reason in description) -> Added sample (should add many unit tests some day)
- [y] Rebased on top of `develop` at time of PR
- [y] Changes adhere to coding standard -> formatted according to `.editorconfig`
- [n] Updated documentation -> Not yet, until we agree on API, if this PR is accepted at all ;-)


