### PR TITLE
Ensure that the assemblies are in fact signed

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -28,26 +28,26 @@ HarfBuzz                soname      0.20601.0
 
 # SkiaSharp.dll
 SkiaSharp               assembly    1.68.0.0
-SkiaSharp               file        1.68.2.0
+SkiaSharp               file        1.68.2.1
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        2.6.1.2
+HarfBuzzSharp           file        2.6.1.3
 
 # nuget versions
-SkiaSharp                                       nuget       1.68.2
-SkiaSharp.NativeAssets.Linux                    nuget       1.68.2
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       1.68.2
-SkiaSharp.NativeAssets.NanoServer               nuget       1.68.2
-SkiaSharp.Views                                 nuget       1.68.2
-SkiaSharp.Views.Desktop.Common                  nuget       1.68.2
-SkiaSharp.Views.Gtk2                            nuget       1.68.2
-SkiaSharp.Views.Gtk3                            nuget       1.68.2
-SkiaSharp.Views.WindowsForms                    nuget       1.68.2
-SkiaSharp.Views.WPF                             nuget       1.68.2
-SkiaSharp.Views.Forms                           nuget       1.68.2
-SkiaSharp.Views.Forms.WPF                       nuget       1.68.2
-SkiaSharp.Views.Forms.GTK                       nuget       1.68.2
-SkiaSharp.HarfBuzz                              nuget       1.68.2
-HarfBuzzSharp                                   nuget       2.6.1.2
-HarfBuzzSharp.NativeAssets.Linux                nuget       2.6.1.2
+SkiaSharp                                       nuget       1.68.2.1
+SkiaSharp.NativeAssets.Linux                    nuget       1.68.2.1
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       1.68.2.1
+SkiaSharp.NativeAssets.NanoServer               nuget       1.68.2.1
+SkiaSharp.Views                                 nuget       1.68.2.1
+SkiaSharp.Views.Desktop.Common                  nuget       1.68.2.1
+SkiaSharp.Views.Gtk2                            nuget       1.68.2.1
+SkiaSharp.Views.Gtk3                            nuget       1.68.2.1
+SkiaSharp.Views.WindowsForms                    nuget       1.68.2.1
+SkiaSharp.Views.WPF                             nuget       1.68.2.1
+SkiaSharp.Views.Forms                           nuget       1.68.2.1
+SkiaSharp.Views.Forms.WPF                       nuget       1.68.2.1
+SkiaSharp.Views.Forms.GTK                       nuget       1.68.2.1
+SkiaSharp.HarfBuzz                              nuget       1.68.2.1
+HarfBuzzSharp                                   nuget       2.6.1.3
+HarfBuzzSharp.NativeAssets.Linux                nuget       2.6.1.3

--- a/build.cake
+++ b/build.cake
@@ -119,7 +119,8 @@ Task ("libs")
             platform = ".Linux";
         }
     }
-    RunMSBuild ($"./source/SkiaSharpSource{platform}.sln");
+    RunMSBuild ($"./source/SkiaSharpSource{platform}.sln",
+        bl: $"./output/binlogs/libs{platform}.binlog");
 
     // assemble the mdoc docs
     EnsureDirectoryExists ("./output/docs/mdoc/");
@@ -142,7 +143,9 @@ Task ("tests")
 
     void RunDesktopTest (string arch)
     {
-        RunMSBuild ("./tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.sln", platform: arch == "AnyCPU" ? "Any CPU" : arch);
+        RunMSBuild ("./tests/SkiaSharp.Desktop.Tests/SkiaSharp.Desktop.Tests.sln",
+            platform: arch == "AnyCPU" ? "Any CPU" : arch,
+            bl: $"./output/binlogs/tests-desktop.{arch}.binlog");
         try {
             RunTests ($"./tests/SkiaSharp.Desktop.Tests/bin/{arch}/{CONFIGURATION}/SkiaSharp.Tests.dll", arch == "x86");
         } catch {
@@ -164,7 +167,8 @@ Task ("tests")
     }
 
     // .NET Core
-    RunMSBuild ("./tests/SkiaSharp.NetCore.Tests/SkiaSharp.NetCore.Tests.sln");
+    RunMSBuild ("./tests/SkiaSharp.NetCore.Tests/SkiaSharp.NetCore.Tests.sln",
+        bl: $"./output/binlogs/tests-netcore.binlog");
     try {
         RunNetCoreTests ("./tests/SkiaSharp.NetCore.Tests/SkiaSharp.NetCore.Tests.csproj");
     } catch {

--- a/cake/UpdateDocs.cake
+++ b/cake/UpdateDocs.cake
@@ -76,6 +76,7 @@ Task ("docs-api-diff")
 
     // pretty version
     var diffDir = "./output/api-diff";
+    EnsureDirectoryExists (diffDir);
     CleanDirectories (diffDir);
 
     Information ($"Creating comparer...");

--- a/cake/msbuild.cake
+++ b/cake/msbuild.cake
@@ -6,7 +6,8 @@ void RunMSBuild(
     string platform = "Any CPU",
     string platformTarget = null,
     bool restore = true,
-    bool restoreOnly = false)
+    bool restoreOnly = false,
+    string bl = null)
 {
     var nugetSources = new [] { OUTPUT_NUGETS_PATH.FullPath, "https://api.nuget.org/v3/index.json" };
 
@@ -16,6 +17,13 @@ void RunMSBuild(
         c.Configuration = CONFIGURATION;
         c.Verbosity = VERBOSITY;
         c.MaxCpuCount = 0;
+
+        if (!string.IsNullOrEmpty(bl)) {
+            c.BinaryLogger = new MSBuildBinaryLogSettings {
+                Enabled = true,
+                FileName = bl,
+            };
+        }
 
         if (!string.IsNullOrEmpty(MSBUILD_EXE)) {
             c.ToolPath = MSBUILD_EXE;

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
   - patch/*
 
 variables:
-  SKIASHARP_VERSION: 1.68.2
+  SKIASHARP_VERSION: 1.68.2.1
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -14,21 +14,21 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: '3688818'                            # the build number to download externals from
+  buildExternals: ''                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
 
 jobs:
-- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-  - template: azure-templates-download.yml
-    parameters:
-      name: ${{ parameters.name }}
-      displayName: ${{ parameters.displayName }}
-      vmImage: ${{ parameters.vmImage }}
-      condition: ${{ parameters.condition }}
-      buildExternals: ${{ parameters.buildExternals }}
+# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+#   - template: azure-templates-download.yml
+#     parameters:
+#       name: ${{ parameters.name }}
+#       displayName: ${{ parameters.displayName }}
+#       vmImage: ${{ parameters.vmImage }}
+#       condition: ${{ parameters.condition }}
+#       buildExternals: ${{ parameters.buildExternals }}
 
-- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -14,21 +14,21 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: ''                            # the build number to download externals from
+  buildExternals: '3688818'                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
 
 jobs:
-# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-#   - template: azure-templates-download.yml
-#     parameters:
-#       name: ${{ parameters.name }}
-#       displayName: ${{ parameters.displayName }}
-#       vmImage: ${{ parameters.vmImage }}
-#       condition: ${{ parameters.condition }}
-#       buildExternals: ${{ parameters.buildExternals }}
+- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+  - template: azure-templates-download.yml
+    parameters:
+      name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      vmImage: ${{ parameters.vmImage }}
+      condition: ${{ parameters.condition }}
+      buildExternals: ${{ parameters.buildExternals }}
 
-# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -6,6 +6,10 @@
     <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/bin/mono') ">/usr/bin/mono</_ManagedExeLauncher>
     <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And '$(_ManagedExeLauncher)' == '' ">mono</_ManagedExeLauncher>
 
+    <_SnExePath Condition=" '$(OS)' == 'Windows_NT' And '$(_SnExePath)' == '' and '$(WindowsSDK_ExecutablePath_x86)' != '' ">$(WindowsSDK_ExecutablePath_x86)sn.exe</_SnExePath>
+    <_SnExePath Condition=" '$(OS)' == 'Windows_NT' And '$(_SnExePath)' == '' and '$(WindowsSDK_ExecutablePath_x64)' != '' ">$(WindowsSDK_ExecutablePath_x64)sn.exe</_SnExePath>
+    <_SnExePath Condition=" '$(_SnExePath)' == '' ">sn</_SnExePath>
+
     <PublicSign Condition=" '$(PublicSign)' == '' and '$(SignAssembly)' == 'true' ">true</PublicSign>
     <KeyFileName Condition=" '$(KeyFileName)' == '' ">mono.snk</KeyFileName>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\$(KeyFileName)</AssemblyOriginatorKeyFile>
@@ -91,7 +95,7 @@
     ===================================================================================================================
   -->
   <Target Name="_SignAssembly" AfterTargets="CoreCompile" DependsOnTargets="_RedirectMovedTypes" Condition=" '$(SignAssembly)' == 'true' ">
-    <Exec Command="sn -q -R @(IntermediateAssembly -> '&quot;%(Identity)&quot;') &quot;$(AssemblyOriginatorKeyFile)&quot;" />
+    <Exec Command="&quot;$(_SnExePath)&quot; -q -R @(IntermediateAssembly -> '&quot;%(Identity)&quot;') &quot;$(AssemblyOriginatorKeyFile)&quot;" />
   </Target>
 
   <!--
@@ -102,7 +106,7 @@
     ===================================================================================================================
   -->
   <Target Name="_SignAssemblyVerify" AfterTargets="Build" Condition=" '$(SignAssembly)' == 'true' and '$(Configuration)' == 'Release' and '$(TargetPath)' != '' ">
-    <Exec Command="sn -vf &quot;$(TargetPath)&quot;" />
+    <Exec Command="&quot;$(_SnExePath)&quot; -vf &quot;$(TargetPath)&quot;" />
   </Target>
 
   <!--

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -7,6 +7,7 @@
     <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' and '$(_ManagedExeLauncher)' == '' ">mono</_ManagedExeLauncher>
 
     <_SnExePath Condition=" '$(OS)' == 'Windows_NT' and '$(_SnExePath)' == '' and Exists('$(SDK40ToolsPath)sn.exe') ">$(SDK40ToolsPath)sn.exe</_SnExePath>
+    <_SnExePath Condition=" '$(OS)' == 'Windows_NT' and '$(_SnExePath)' == '' and Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe') ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe</_SnExePath>
     <_SnExePath Condition=" '$(_SnExePath)' == '' ">sn</_SnExePath>
 
     <PublicSign Condition=" '$(PublicSign)' == '' and '$(SignAssembly)' == 'true' ">true</PublicSign>

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -1,13 +1,12 @@
 <Project>
 
   <PropertyGroup>
-    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/Mono.framework/Versions/Current/bin/mono') ">/Library/Frameworks/Mono.framework/Versions/Current/bin/mono</_ManagedExeLauncher>
-    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/local/bin/mono') ">/usr/local/bin/mono</_ManagedExeLauncher>
-    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/bin/mono') ">/usr/bin/mono</_ManagedExeLauncher>
-    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And '$(_ManagedExeLauncher)' == '' ">mono</_ManagedExeLauncher>
+    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' and Exists('/Library/Frameworks/Mono.framework/Versions/Current/bin/mono') ">/Library/Frameworks/Mono.framework/Versions/Current/bin/mono</_ManagedExeLauncher>
+    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' and Exists('/usr/local/bin/mono') ">/usr/local/bin/mono</_ManagedExeLauncher>
+    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' and Exists('/usr/bin/mono') ">/usr/bin/mono</_ManagedExeLauncher>
+    <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' and '$(_ManagedExeLauncher)' == '' ">mono</_ManagedExeLauncher>
 
-    <_SnExePath Condition=" '$(OS)' == 'Windows_NT' And '$(_SnExePath)' == '' and '$(WindowsSDK_ExecutablePath_x86)' != '' ">$(WindowsSDK_ExecutablePath_x86)sn.exe</_SnExePath>
-    <_SnExePath Condition=" '$(OS)' == 'Windows_NT' And '$(_SnExePath)' == '' and '$(WindowsSDK_ExecutablePath_x64)' != '' ">$(WindowsSDK_ExecutablePath_x64)sn.exe</_SnExePath>
+    <_SnExePath Condition=" '$(OS)' == 'Windows_NT' and '$(_SnExePath)' == '' and Exists('$(SDK40ToolsPath)sn.exe') ">$(SDK40ToolsPath)sn.exe</_SnExePath>
     <_SnExePath Condition=" '$(_SnExePath)' == '' ">sn</_SnExePath>
 
     <PublicSign Condition=" '$(PublicSign)' == '' and '$(SignAssembly)' == 'true' ">true</PublicSign>

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -6,7 +6,7 @@
     <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/bin/mono') ">/usr/bin/mono</_ManagedExeLauncher>
     <_ManagedExeLauncher Condition=" '$(OS)' != 'Windows_NT' And '$(_ManagedExeLauncher)' == '' ">mono</_ManagedExeLauncher>
 
-    <PublicSign Condition=" '$(PublicSign)' == '' and '$(SignAssembly)' == 'true' and '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublicSign Condition=" '$(PublicSign)' == '' and '$(SignAssembly)' == 'true' ">true</PublicSign>
     <KeyFileName Condition=" '$(KeyFileName)' == '' ">mono.snk</KeyFileName>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\$(KeyFileName)</AssemblyOriginatorKeyFile>
 
@@ -90,8 +90,19 @@
     Sign the assembly using sn.
     ===================================================================================================================
   -->
-  <Target Name="_SignAssembly" AfterTargets="CoreCompile" Condition=" '$(IsWindows)' != 'true' and '$(SignAssembly)' == 'true' ">
+  <Target Name="_SignAssembly" AfterTargets="CoreCompile" DependsOnTargets="_RedirectMovedTypes" Condition=" '$(SignAssembly)' == 'true' ">
     <Exec Command="sn -q -R @(IntermediateAssembly -> '&quot;%(Identity)&quot;') &quot;$(AssemblyOriginatorKeyFile)&quot;" />
+  </Target>
+
+  <!--
+    ===================================================================================================================
+    _SignAssemblyVerify
+
+    Verify that the output assembly is signed correctly for release.
+    ===================================================================================================================
+  -->
+  <Target Name="_SignAssemblyVerify" AfterTargets="Build" Condition=" '$(SignAssembly)' == 'true' and '$(Configuration)' == 'Release' and '$(TargetPath)' != '' ">
+    <Exec Command="sn -vf &quot;$(TargetPath)&quot;" />
   </Target>
 
   <!--


### PR DESCRIPTION
**Description of Change**

Ensure that the assemblies are in fact signed.

Since the addition of the `Xamarin.Build.TypeRedirector` NuGet package to fix up the VS2017 and VS2019 issues, the assembly is modified AFTER the signing, so that breaks it. This PR now specifies that the signing task depends on the redirection task.

Type redirector issues:
 - https://github.com/xamarin/xamarin-macios/issues/5273
 - https://github.com/xamarin/XamarinComponents/pull/764

**Bugs Fixed**

- Fixes #1267

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
