### PR TITLE
Improve triggering of touch event and introduce Eraser device

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Android.Views;
 
 namespace SkiaSharp.Views.Forms
@@ -19,9 +20,11 @@ namespace SkiaSharp.Views.Forms
 			if (view != null)
 			{
 				view.Touch -= OnTouch;
+				view.GenericMotion -= OnGenericMotion;
 				if (enableTouchEvents)
 				{
 					view.Touch += OnTouch;
+					view.GenericMotion += OnGenericMotion;
 				}
 			}
 		}
@@ -42,43 +45,31 @@ namespace SkiaSharp.Views.Forms
 				return;
 
 			var evt = e.Event;
-			var pointer = evt.ActionIndex;
-
-			var id = evt.GetPointerId(pointer);
-			var coords = scalePixels(evt.GetX(pointer), evt.GetY(pointer));
-
-			var toolType = evt.GetToolType(pointer);
-
-			var deviceType = GetDeviceType(toolType);
-
-			var pressure = evt.GetPressure(pointer);
-
-			var button = GetButton(evt, toolType);
+			var count = evt.PointerCount;
 
 			switch (evt.ActionMasked)
 			{
 				case MotionEventActions.Down:
 				case MotionEventActions.PointerDown:
 					{
-						var args = new SKTouchEventArgs(id, SKTouchAction.Pressed, button, deviceType, coords, true, 0, pressure);
+						for (var pointer = 0; pointer < count; pointer++)
+						{
+							var args = CreateTouchEventArgs(SKTouchAction.Pressed, true, evt, pointer);
 
-						onTouchAction(args);
-						e.Handled = args.Handled;
+							onTouchAction(args);
+							e.Handled |= args.Handled;
+						}
 						break;
 					}
 
 				case MotionEventActions.Move:
 					{
-						var count = evt.PointerCount;
-						for (pointer = 0; pointer < count; pointer++)
+						for (var pointer = 0; pointer < count; pointer++)
 						{
-							id = evt.GetPointerId(pointer);
-							coords = scalePixels(evt.GetX(pointer), evt.GetY(pointer));
-
-							var args = new SKTouchEventArgs(id, SKTouchAction.Moved, button, deviceType, coords, true, 0, pressure);
+							var args = CreateTouchEventArgs(SKTouchAction.Moved, true, evt, pointer);
 
 							onTouchAction(args);
-							e.Handled = e.Handled || args.Handled;
+							e.Handled |= args.Handled;
 						}
 						break;
 					}
@@ -86,16 +77,96 @@ namespace SkiaSharp.Views.Forms
 				case MotionEventActions.Up:
 				case MotionEventActions.PointerUp:
 					{
-						var args = new SKTouchEventArgs(id, SKTouchAction.Released, button, deviceType, coords, false, 0, pressure);
+						for (var pointer = 0; pointer < count; pointer++)
+						{
+							var args = CreateTouchEventArgs(SKTouchAction.Released, false, evt, pointer);
 
-						onTouchAction(args);
-						e.Handled = args.Handled;
+							onTouchAction(args);
+							e.Handled |= args.Handled;
+						}
 						break;
 					}
 
 				case MotionEventActions.Cancel:
 					{
-						var args = new SKTouchEventArgs(id, SKTouchAction.Cancelled, button, deviceType, coords, false, 0, pressure);
+						for (var pointer = 0; pointer < count; pointer++)
+						{
+							var args = CreateTouchEventArgs(SKTouchAction.Cancelled, false, evt, pointer);
+
+							onTouchAction(args);
+							e.Handled |= args.Handled;
+						}
+						break;
+					}
+			}
+		}
+
+		private void OnGenericMotion(object sender, View.GenericMotionEventArgs e)
+		{
+			if (onTouchAction == null || scalePixels == null)
+				return;
+
+			if (!e.Event.IsFromSource(InputSourceType.Mouse))
+				return;
+
+			var evt = e.Event;
+			var pointer = evt.ActionIndex;
+
+			var id = evt.GetPointerId(pointer);
+			var coords = scalePixels(evt.GetX(pointer), evt.GetY(pointer));
+
+			var toolType = evt.GetToolType(pointer);
+			var deviceType = GetDeviceType(toolType);
+			var button = GetButton(evt.ActionButton, toolType);
+			var inContact = button != SKMouseButton.Unknown;
+
+			switch (evt.Action)
+			{
+				case MotionEventActions.ButtonPress:
+					{
+						var args = new SKTouchEventArgs(id, SKTouchAction.Pressed, button, deviceType, coords, inContact);
+
+						onTouchAction(args);
+						e.Handled = args.Handled;
+						break;
+					}
+				case MotionEventActions.ButtonRelease:
+					{
+						var args = new SKTouchEventArgs(id, SKTouchAction.Released, button, deviceType, coords, inContact);
+
+						onTouchAction(args);
+						e.Handled = args.Handled;
+						break;
+					}
+				case MotionEventActions.HoverEnter:
+					{
+						var args = new SKTouchEventArgs(id, SKTouchAction.Entered, button, deviceType, coords, inContact);
+
+						onTouchAction(args);
+						e.Handled = args.Handled;
+						break;
+					}
+				case MotionEventActions.HoverExit:
+					{
+						var args = new SKTouchEventArgs(id, SKTouchAction.Exited, button, deviceType, coords, inContact);
+
+						onTouchAction(args);
+						e.Handled = args.Handled;
+						break;
+					}
+				case MotionEventActions.HoverMove:
+					{
+						var args = new SKTouchEventArgs(id, SKTouchAction.Moved, button, deviceType, coords, inContact);
+
+						onTouchAction(args);
+						e.Handled = args.Handled;
+						break;
+					}
+				case MotionEventActions.Scroll:
+					{
+						var axisValue = evt.GetAxisValue(Axis.Vscroll, pointer);
+						var wheelDelta = axisValue.Equals(0) ? 0 : axisValue > 0 ? 1 : -1;
+						var args = new SKTouchEventArgs(id, SKTouchAction.WheelChanged, button, deviceType, coords, inContact, wheelDelta);
 
 						onTouchAction(args);
 						e.Handled = args.Handled;
@@ -104,17 +175,45 @@ namespace SkiaSharp.Views.Forms
 			}
 		}
 
-		private static SKMouseButton GetButton(MotionEvent evt, MotionEventToolType toolType)
+		private SKTouchEventArgs CreateTouchEventArgs(SKTouchAction actionType, bool inContact, MotionEvent evt, int pointerIndex)
+		{
+			var id = evt.GetPointerId(pointerIndex);
+			var toolType = evt.GetToolType(pointerIndex);
+			var button = GetButton(evt.ButtonState, toolType);
+			var coords = scalePixels(evt.GetX(pointerIndex), evt.GetY(pointerIndex));
+			var deviceType = GetDeviceType(toolType);
+			var pressure = evt.GetPressure(pointerIndex);
+
+			return new SKTouchEventArgs(id, actionType, button, deviceType, coords, inContact, 0, pressure);
+		}
+
+		private static SKMouseButton GetButton(MotionEventButtonState buttonState, MotionEventToolType toolType)
 		{
 			var button = SKMouseButton.Left;
 
-			if (toolType == MotionEventToolType.Eraser)
+			if (buttonState.HasFlag(MotionEventButtonState.StylusPrimary))
+			{
+				button = SKMouseButton.Left;
+			}
+			else if (buttonState.HasFlag(MotionEventButtonState.Primary))
+			{
+				button = SKMouseButton.Left;
+			}
+			else if (buttonState.HasFlag(MotionEventButtonState.StylusSecondary))
+			{
+				button = SKMouseButton.Right;
+			}
+			else if (buttonState.HasFlag(MotionEventButtonState.Secondary))
+			{
+				button = SKMouseButton.Right;
+			}
+			else if (buttonState.HasFlag(MotionEventButtonState.Tertiary))
 			{
 				button = SKMouseButton.Middle;
 			}
-			else if (evt.ButtonState.HasFlag(MotionEventButtonState.StylusSecondary))
+			else if (toolType == MotionEventToolType.Mouse)
 			{
-				button = SKMouseButton.Right;
+				button = SKMouseButton.Unknown;
 			}
 
 			return button;
@@ -126,7 +225,7 @@ namespace SkiaSharp.Views.Forms
 				MotionEventToolType.Unknown => SKTouchDeviceType.Touch,
 				MotionEventToolType.Finger => SKTouchDeviceType.Touch,
 				MotionEventToolType.Stylus => SKTouchDeviceType.Pen,
-				MotionEventToolType.Eraser => SKTouchDeviceType.Pen,
+				MotionEventToolType.Eraser => SKTouchDeviceType.Eraser,
 				MotionEventToolType.Mouse => SKTouchDeviceType.Mouse,
 				_ => SKTouchDeviceType.Touch,
 			};

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SKTouchHandler.cs
@@ -116,8 +116,9 @@ namespace SkiaSharp.Views.Forms
 			cgPoint.Y = View.Bounds.Height - cgPoint.Y;
 
 			var point = scalePixels(cgPoint.X, cgPoint.Y);
+			var wheelDelta = (int)mouseEvent.ScrollingDeltaY;
 
-			var args = new SKTouchEventArgs(id, actionType, mouse, device, point, inContact);
+			var args = new SKTouchEventArgs(id, actionType, mouse, device, point, inContact, wheelDelta, mouseEvent.Pressure);
 			onTouchAction(args);
 			return args.Handled;
 		}

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKTouchEventArgs.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKTouchEventArgs.cs
@@ -9,6 +9,11 @@ namespace SkiaSharp.Views.Forms
 		{
 		}
 
+		public SKTouchEventArgs(long id, SKTouchAction type, SKPoint location, bool inContact, float pressure)
+			: this(id, type, SKMouseButton.Left, SKTouchDeviceType.Touch, location, inContact, 0, pressure)
+		{
+		}
+
 		public SKTouchEventArgs(long id, SKTouchAction type, SKMouseButton mouseButton, SKTouchDeviceType deviceType, SKPoint location, bool inContact)
 			: this(id, type, mouseButton, deviceType, location, inContact, 0, 1)
 		{
@@ -70,7 +75,8 @@ namespace SkiaSharp.Views.Forms
 	{
 		Touch,
 		Mouse,
-		Pen
+		Pen,
+		Eraser
 	}
 
 	public enum SKMouseButton

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SKTouchHandler.cs
@@ -86,6 +86,7 @@ namespace SkiaSharp.Views.Forms
 
 			public void OnStarted()
 			{
+				// TODO: id is always increasing
 				++currentId;
 				PostEvent(SKTouchAction.Pressed);
 			}
@@ -112,7 +113,7 @@ namespace SkiaSharp.Views.Forms
 
 				var p = handler.gestureLayer.EvasCanvas.Pointer;
 				var coords = handler.scalePixels(p.X, p.Y);
-				var inContact = (action == SKTouchAction.Pressed || action == SKTouchAction.Moved) ? true : false;
+				var inContact = action == SKTouchAction.Pressed || action == SKTouchAction.Moved;
 
 				handler.onTouchAction(new SKTouchEventArgs(currentId, action, coords, inContact));
 			}

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.UWP/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.UWP/SKTouchHandler.cs
@@ -110,22 +110,27 @@ namespace SkiaSharp.Views.Forms
 			var skPoint = scalePixels(windowsPoint.X, windowsPoint.Y);
 
 			var mouse = GetMouseButton(pointerPoint);
-			var device = GetTouchDevice(evt);
+			var device = GetTouchDevice(evt, pointerPoint);
 
 			var wheelDelta = pointerPoint?.Properties?.MouseWheelDelta ?? 0;
+			var pressure = pointerPoint?.Properties?.Pressure ?? 1;
 
-			var args = new SKTouchEventArgs(id, touchActionType, mouse, device, skPoint, evt.Pointer.IsInContact, wheelDelta);
+			var args = new SKTouchEventArgs(id, touchActionType, mouse, device, skPoint, evt.Pointer.IsInContact, wheelDelta, pressure);
 			onTouchAction(args);
 			return args.Handled;
 		}
 
-		private static SKTouchDeviceType GetTouchDevice(PointerRoutedEventArgs evt)
+		private static SKTouchDeviceType GetTouchDevice(PointerRoutedEventArgs evt, PointerPoint pointerPoint)
 		{
 			var device = SKTouchDeviceType.Touch;
 			switch (evt.Pointer.PointerDeviceType)
 			{
 				case PointerDeviceType.Pen:
-					device = SKTouchDeviceType.Pen;
+					var isEraser = false;
+					isEraser |= pointerPoint?.Properties?.IsInverted == true;
+					isEraser |= pointerPoint?.Properties?.IsEraser == true;
+
+					device = isEraser ? SKTouchDeviceType.Eraser : SKTouchDeviceType.Pen;
 					break;
 				case PointerDeviceType.Mouse:
 					device = SKTouchDeviceType.Mouse;

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerElement.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.WPF/SKTouchHandlerElement.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 
@@ -18,8 +17,6 @@ namespace SkiaSharp.Views.Forms
 
 		public void SetEnabled(FrameworkElement view, bool enableTouchEvents)
 		{
-			// TODO: touch and stylus
-
 			if (view != null)
 			{
 				// mouse
@@ -30,6 +27,23 @@ namespace SkiaSharp.Views.Forms
 				view.MouseUp -= OnMouseReleased;
 				view.MouseWheel -= OnMouseWheel;
 
+				// touch
+				view.TouchEnter -= OnTouchEntered;
+				view.TouchLeave -= OnTouchExited;
+				view.TouchDown -= OnTouchPressed;
+				view.TouchMove -= OnTouchMoved;
+				view.TouchUp -= OnTouchReleased;
+
+				// stylus
+				view.StylusEnter -= OnStylusEntered;
+				view.StylusLeave -= OnStylusExited;
+				view.StylusDown -= OnStylusPressed;
+				view.StylusMove -= OnStylusMoved;
+				view.StylusInAirMove -= OnStylusInAirMoved;
+				view.StylusUp -= OnStylusReleased;
+				view.StylusButtonDown -= OnStylusButtonPressed;
+				view.StylusButtonUp -= OnStylusButtonReleased;
+
 				if (enableTouchEvents)
 				{
 					// mouse
@@ -39,6 +53,23 @@ namespace SkiaSharp.Views.Forms
 					view.MouseMove += OnMouseMoved;
 					view.MouseUp += OnMouseReleased;
 					view.MouseWheel += OnMouseWheel;
+
+					// touch
+					view.TouchEnter += OnTouchEntered;
+					view.TouchLeave += OnTouchExited;
+					view.TouchDown += OnTouchPressed;
+					view.TouchMove += OnTouchMoved;
+					view.TouchUp += OnTouchReleased;
+
+					// stylus
+					view.StylusEnter += OnStylusEntered;
+					view.StylusLeave += OnStylusExited;
+					view.StylusDown += OnStylusPressed;
+					view.StylusMove += OnStylusMoved;
+					view.StylusInAirMove += OnStylusInAirMoved;
+					view.StylusUp += OnStylusReleased;
+					view.StylusButtonDown += OnStylusButtonPressed;
+					view.StylusButtonUp += OnStylusButtonReleased;
 				}
 			}
 		}
@@ -53,14 +84,32 @@ namespace SkiaSharp.Views.Forms
 			scalePixels = null;
 		}
 
-		// mouse events
-
 		private void OnMouseEntered(object sender, MouseEventArgs e)
 		{
 			e.Handled = CommonHandler(sender, SKTouchAction.Entered, e);
 		}
 
+		private void OnTouchEntered(object sender, TouchEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Entered, e);
+		}
+
+		private void OnStylusEntered(object sender, StylusEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Entered, e);
+		}
+
 		private void OnMouseExited(object sender, MouseEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Exited, e);
+		}
+
+		private void OnTouchExited(object sender, TouchEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Exited, e);
+		}
+
+		private void OnStylusExited(object sender, StylusEventArgs e)
 		{
 			e.Handled = CommonHandler(sender, SKTouchAction.Exited, e);
 		}
@@ -76,7 +125,37 @@ namespace SkiaSharp.Views.Forms
 			}
 		}
 
+		private void OnTouchPressed(object sender, TouchEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Pressed, e);
+		}
+
+		private void OnStylusPressed(object sender, StylusDownEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Pressed, e);
+		}
+
+		private void OnStylusButtonPressed(object sender, StylusButtonEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Pressed, e);
+		}
+
 		private void OnMouseMoved(object sender, MouseEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Moved, e);
+		}
+
+		private void OnTouchMoved(object sender, TouchEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Moved, e);
+		}
+
+		private void OnStylusMoved(object sender, StylusEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Moved, e);
+		}
+
+		private void OnStylusInAirMoved(object sender, StylusEventArgs e)
 		{
 			e.Handled = CommonHandler(sender, SKTouchAction.Moved, e);
 		}
@@ -87,6 +166,21 @@ namespace SkiaSharp.Views.Forms
 
 			var view = sender as FrameworkElement;
 			view.ReleaseMouseCapture();
+		}
+
+		private void OnTouchReleased(object sender, TouchEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Released, e);
+		}
+
+		private void OnStylusReleased(object sender, StylusEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Released, e);
+		}
+
+		private void OnStylusButtonReleased(object sender, StylusButtonEventArgs e)
+		{
+			e.Handled = CommonHandler(sender, SKTouchAction.Released, e);
 		}
 
 		private void OnMouseWheel(object sender, MouseWheelEventArgs e)
@@ -108,7 +202,7 @@ namespace SkiaSharp.Views.Forms
 				return false;
 
 			var id = GetId(evt);
-			var action = GetTouchAction(touchActionType, view, evt);
+			var action = touchActionType;
 			var mouse = GetMouseButton(evt);
 			var device = GetTouchDevice(evt);
 			var windowsPoint = GetPosition(evt, view);
@@ -142,28 +236,6 @@ namespace SkiaSharp.Views.Forms
 			}
 
 			return inContact;
-		}
-
-		private SKTouchAction GetTouchAction(SKTouchAction touchActionType, FrameworkElement view, InputEventArgs evt)
-		{
-			if (evt is TouchEventArgs touchEvent)
-			{
-				var action = touchEvent.GetTouchPoint(view).Action;
-				switch (action)
-				{
-					case TouchAction.Down:
-						touchActionType = SKTouchAction.Pressed;
-						break;
-					case TouchAction.Move:
-						touchActionType = SKTouchAction.Moved;
-						break;
-					case TouchAction.Up:
-						touchActionType = SKTouchAction.Released;
-						break;
-				}
-			}
-
-			return touchActionType;
 		}
 
 		private Point GetPosition(InputEventArgs evt, FrameworkElement view)
@@ -211,14 +283,14 @@ namespace SkiaSharp.Views.Forms
 			var device = SKTouchDeviceType.Mouse;
 			switch (evt)
 			{
-				case MouseEventArgs mouse:
+				case MouseEventArgs _:
 					device = SKTouchDeviceType.Mouse;
 					break;
 				case TouchEventArgs touch:
 					device = SKTouchDeviceType.Touch;
 					break;
 				case StylusEventArgs stylus:
-					device = SKTouchDeviceType.Pen;
+					device = stylus.Inverted ? SKTouchDeviceType.Eraser : SKTouchDeviceType.Pen;
 					break;
 			}
 			return device;
@@ -265,8 +337,23 @@ namespace SkiaSharp.Views.Forms
 
 				case StylusEventArgs stylus:
 					{
-						System.Diagnostics.Debug.WriteLine(string.Join(", ", stylus.StylusDevice.StylusButtons.Select(b => b.Name)));
-						mouse = stylus.InAir ? SKMouseButton.Unknown : SKMouseButton.Left;
+						var buttonsCount = stylus.StylusDevice.StylusButtons.Count;
+						var isPrimaryPressed = false;
+						var isSecondaryPressed = false;
+						var isTertiaryPressed = false;
+						if (buttonsCount > 0)
+							isPrimaryPressed = stylus.StylusDevice.StylusButtons[0].StylusButtonState == StylusButtonState.Down;
+						if (buttonsCount > 1)
+							isSecondaryPressed = stylus.StylusDevice.StylusButtons[1].StylusButtonState == StylusButtonState.Down;
+						if (buttonsCount > 2)
+							isTertiaryPressed = stylus.StylusDevice.StylusButtons[2].StylusButtonState == StylusButtonState.Down;
+
+						if (isPrimaryPressed)
+							mouse = SKMouseButton.Left;
+						else if (isSecondaryPressed)
+							mouse = SKMouseButton.Right;
+						else if (isTertiaryPressed)
+							mouse = SKMouseButton.Middle;
 					}
 					break;
 			}

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.iOS/SKTouchHandler.cs
@@ -102,7 +102,7 @@ namespace SkiaSharp.Views.Forms
 			var cgPoint = touch.LocationInView(View);
 			var point = scalePixels(cgPoint.X, cgPoint.Y);
 
-			var args = new SKTouchEventArgs(id, actionType, point, inContact);
+			var args = new SKTouchEventArgs(id, actionType, point, inContact, (float)touch.Force);
 			onTouchAction(args);
 			return args.Handled;
 		}


### PR DESCRIPTION
**Description of Changes**

- Capture touch pressure for Mac, UWP and iOS.
- Capture wheel delta for Mac.
- Support touch and stylus on WPF platform.
- Support mouse on Android platform.
- Introduce Eraser device.
- Add a TO-DO for Tizen where device ID is buggy.

**API Changes**

Added: 
 
- `Eraser` member for `SKTouchDeviceType` enum.
- Constructor `.ctor(long, SKTouchAction, SKPoint, bool, float)` for `SKTouchEventArgs` for `SKTouchEventArgs` class.

**Behavioral Changes**

- Android triggers `Pressed`, `Up` and `Cancel` events for all pointers instead of triggering just for `Moved` event.
- When Stylus pen is inverted trigger touch event as Eraser device.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
