### PR TITLE
Make the SKFont's public API glyph-only and the others types use it under the hood

### DIFF
--- a/binding/Binding/SKFont.cs
+++ b/binding/Binding/SKFont.cs
@@ -262,7 +262,7 @@ namespace SkiaSharp
 			return SkiaApi.sk_font_text_to_glyphs (Handle, text, (IntPtr)length, encoding, null, 0);
 		}
 
-		// MeasureText
+		// MeasureText (text)
 
 		internal float MeasureText (string text, SKPaint paint = null) =>
 			MeasureText (text.AsSpan (), paint);
@@ -316,6 +316,23 @@ namespace SkiaSharp
 				return 0;
 
 			return SkiaApi.sk_font_measure_text (Handle, text, (IntPtr)length, encoding, bounds, paint?.Handle ?? IntPtr.Zero);
+		}
+
+		// MeasureText (glyphs)
+
+		public float MeasureText (ReadOnlySpan<ushort> glyphs, SKPaint paint = null)
+		{
+			fixed (ushort* gp = glyphs) {
+				return MeasureText (gp, glyphs.Length * 2, SKTextEncoding.GlyphId, null, paint);
+			}
+		}
+
+		public float MeasureText (ReadOnlySpan<ushort> glyphs, out SKRect bounds, SKPaint paint = null)
+		{
+			fixed (ushort* gp = glyphs)
+			fixed (SKRect* b = &bounds) {
+				return MeasureText (gp, glyphs.Length * 2, SKTextEncoding.GlyphId, b, paint);
+			}
 		}
 
 		// BreakText

--- a/binding/Binding/SKFont.cs
+++ b/binding/Binding/SKFont.cs
@@ -826,7 +826,7 @@ namespace SkiaSharp
 
 		// GetTextPathOnPath (glyphs)
 
-		public SKPath GetTextPathOnPath (ReadOnlySpan<ushort> glyphs, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
+		internal SKPath GetTextPathOnPath (ReadOnlySpan<ushort> glyphs, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
 		{
 			if (path == null)
 				throw new ArgumentNullException (nameof (path));
@@ -843,7 +843,7 @@ namespace SkiaSharp
 			return GetTextPathOnPath (glyphs, glyphWidths, glyphOffsets, path, textAlign);
 		}
 
-		public SKPath GetTextPathOnPath (ReadOnlySpan<ushort> glyphs, ReadOnlySpan<float> glyphWidths, ReadOnlySpan<SKPoint> glyphPositions, SKPath path, SKTextAlign textAlign = SKTextAlign.Left)
+		internal SKPath GetTextPathOnPath (ReadOnlySpan<ushort> glyphs, ReadOnlySpan<float> glyphWidths, ReadOnlySpan<SKPoint> glyphPositions, SKPath path, SKTextAlign textAlign = SKTextAlign.Left)
 		{
 			if (glyphs.Length != glyphWidths.Length)
 				throw new ArgumentException ("The number of glyphs and glyph widths must be the same.");

--- a/binding/Binding/SKFont.cs
+++ b/binding/Binding/SKFont.cs
@@ -120,7 +120,7 @@ namespace SkiaSharp
 
 		// GetGlyphs
 
-		public ushort[] GetGlyphs (ReadOnlySpan<int> codepoints)
+		internal ushort[] GetGlyphs (ReadOnlySpan<int> codepoints)
 		{
 			var glyphs = new ushort[codepoints.Length];
 			GetGlyphs (codepoints, glyphs);
@@ -143,24 +143,24 @@ namespace SkiaSharp
 
 		// GetGlyphs
 
-		public ushort[] GetGlyphs (string text) =>
+		internal ushort[] GetGlyphs (string text) =>
 			GetGlyphs (text.AsSpan ());
 
-		public ushort[] GetGlyphs (ReadOnlySpan<char> text)
+		internal ushort[] GetGlyphs (ReadOnlySpan<char> text)
 		{
 			fixed (void* t = text) {
 				return GetGlyphs (t, text.Length * 2, SKTextEncoding.Utf16);
 			}
 		}
 
-		public ushort[] GetGlyphs (ReadOnlySpan<byte> text, SKTextEncoding encoding)
+		internal ushort[] GetGlyphs (ReadOnlySpan<byte> text, SKTextEncoding encoding)
 		{
 			fixed (void* t = text) {
 				return GetGlyphs (t, text.Length, encoding);
 			}
 		}
 
-		public ushort[] GetGlyphs (IntPtr text, int length, SKTextEncoding encoding) =>
+		internal ushort[] GetGlyphs (IntPtr text, int length, SKTextEncoding encoding) =>
 			GetGlyphs ((void*)text, length, encoding);
 
 		public void GetGlyphs (string text, Span<ushort> glyphs) =>
@@ -264,30 +264,30 @@ namespace SkiaSharp
 
 		// MeasureText
 
-		public float MeasureText (string text, SKPaint paint = null) =>
+		internal float MeasureText (string text, SKPaint paint = null) =>
 			MeasureText (text.AsSpan (), paint);
 
-		public float MeasureText (ReadOnlySpan<char> text, SKPaint paint = null)
+		internal float MeasureText (ReadOnlySpan<char> text, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				return MeasureText (t, text.Length * 2, SKTextEncoding.Utf16, null, paint);
 			}
 		}
 
-		public float MeasureText (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPaint paint = null)
+		internal float MeasureText (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				return MeasureText (t, text.Length, encoding, null, paint);
 			}
 		}
 
-		public float MeasureText (IntPtr text, int length, SKTextEncoding encoding, SKPaint paint = null) =>
+		internal float MeasureText (IntPtr text, int length, SKTextEncoding encoding, SKPaint paint = null) =>
 			MeasureText ((void*)text, length, encoding, null, paint);
 
-		public float MeasureText (string text, out SKRect bounds, SKPaint paint = null) =>
+		internal float MeasureText (string text, out SKRect bounds, SKPaint paint = null) =>
 			MeasureText (text.AsSpan (), out bounds, paint);
 
-		public float MeasureText (ReadOnlySpan<char> text, out SKRect bounds, SKPaint paint = null)
+		internal float MeasureText (ReadOnlySpan<char> text, out SKRect bounds, SKPaint paint = null)
 		{
 			fixed (void* t = text)
 			fixed (SKRect* b = &bounds) {
@@ -295,7 +295,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public float MeasureText (ReadOnlySpan<byte> text, SKTextEncoding encoding, out SKRect bounds, SKPaint paint = null)
+		internal float MeasureText (ReadOnlySpan<byte> text, SKTextEncoding encoding, out SKRect bounds, SKPaint paint = null)
 		{
 			fixed (void* t = text)
 			fixed (SKRect* b = &bounds) {
@@ -303,7 +303,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public float MeasureText (IntPtr text, int length, SKTextEncoding encoding, out SKRect bounds, SKPaint paint = null)
+		internal float MeasureText (IntPtr text, int length, SKTextEncoding encoding, out SKRect bounds, SKPaint paint = null)
 		{
 			fixed (SKRect* b = &bounds) {
 				return MeasureText ((void*)text, length, encoding, b, paint);
@@ -320,10 +320,10 @@ namespace SkiaSharp
 
 		// BreakText
 
-		public int BreakText (string text, float maxWidth, out float measuredWidth, SKPaint paint = null) =>
+		internal int BreakText (string text, float maxWidth, out float measuredWidth, SKPaint paint = null) =>
 			BreakText (text.AsSpan (), maxWidth, out measuredWidth, paint);
 
-		public int BreakText (ReadOnlySpan<char> text, float maxWidth, out float measuredWidth, SKPaint paint = null)
+		internal int BreakText (ReadOnlySpan<char> text, float maxWidth, out float measuredWidth, SKPaint paint = null)
 		{
 			fixed (void* t = text)
 			fixed (float* mw = &measuredWidth) {
@@ -332,7 +332,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public int BreakText (ReadOnlySpan<byte> text, SKTextEncoding encoding, float maxWidth, out float measuredWidth, SKPaint paint = null)
+		internal int BreakText (ReadOnlySpan<byte> text, SKTextEncoding encoding, float maxWidth, out float measuredWidth, SKPaint paint = null)
 		{
 			fixed (void* t = text)
 			fixed (float* mw = &measuredWidth) {
@@ -340,7 +340,7 @@ namespace SkiaSharp
 			}
 		}
 
-		public int BreakText (IntPtr text, int length, SKTextEncoding encoding, float maxWidth, out float measuredWidth, SKPaint paint = null)
+		internal int BreakText (IntPtr text, int length, SKTextEncoding encoding, float maxWidth, out float measuredWidth, SKPaint paint = null)
 		{
 			fixed (float* mw = &measuredWidth) {
 				return BreakText ((void*)text, length, encoding, maxWidth, mw, paint);
@@ -357,44 +357,44 @@ namespace SkiaSharp
 
 		// GetGlyphPositions (text)
 
-		public SKPoint[] GetGlyphPositions (string text, SKPoint origin = default) =>
+		internal SKPoint[] GetGlyphPositions (string text, SKPoint origin = default) =>
 			GetGlyphPositions (text.AsSpan (), origin);
 
-		public SKPoint[] GetGlyphPositions (ReadOnlySpan<char> text, SKPoint origin = default)
+		internal SKPoint[] GetGlyphPositions (ReadOnlySpan<char> text, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return GetGlyphPositions (t, text.Length * 2, SKTextEncoding.Utf16, origin);
 			}
 		}
 
-		public SKPoint[] GetGlyphPositions (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPoint origin = default)
+		internal SKPoint[] GetGlyphPositions (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return GetGlyphPositions (t, text.Length, encoding, origin);
 			}
 		}
 
-		public SKPoint[] GetGlyphPositions (IntPtr text, int length, SKTextEncoding encoding, SKPoint origin = default) =>
+		internal SKPoint[] GetGlyphPositions (IntPtr text, int length, SKTextEncoding encoding, SKPoint origin = default) =>
 			GetGlyphPositions ((void*)text, length, encoding, origin);
 
-		public void GetGlyphPositions (string text, Span<SKPoint> offsets, SKPoint origin = default) =>
+		internal void GetGlyphPositions (string text, Span<SKPoint> offsets, SKPoint origin = default) =>
 			GetGlyphPositions (text.AsSpan (), offsets, origin);
 
-		public void GetGlyphPositions (ReadOnlySpan<char> text, Span<SKPoint> offsets, SKPoint origin = default)
+		internal void GetGlyphPositions (ReadOnlySpan<char> text, Span<SKPoint> offsets, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				GetGlyphPositions (t, text.Length * 2, SKTextEncoding.Utf16, offsets, origin);
 			}
 		}
 
-		public void GetGlyphPositions (ReadOnlySpan<byte> text, SKTextEncoding encoding, Span<SKPoint> offsets, SKPoint origin = default)
+		internal void GetGlyphPositions (ReadOnlySpan<byte> text, SKTextEncoding encoding, Span<SKPoint> offsets, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				GetGlyphPositions (t, text.Length, encoding, offsets, origin);
 			}
 		}
 
-		public void GetGlyphPositions (IntPtr text, int length, SKTextEncoding encoding, Span<SKPoint> offsets, SKPoint origin = default) =>
+		internal void GetGlyphPositions (IntPtr text, int length, SKTextEncoding encoding, Span<SKPoint> offsets, SKPoint origin = default) =>
 			GetGlyphPositions ((void*)text, length, encoding, offsets, origin);
 
 		internal SKPoint[] GetGlyphPositions (void* text, int length, SKTextEncoding encoding, SKPoint origin)
@@ -427,7 +427,7 @@ namespace SkiaSharp
 
 		// GetGlyphPositions (glyphs)
 
-		public SKPoint[] GetGlyphPositions (ReadOnlySpan<ushort> glyphs, SKPoint origin = default)
+		internal SKPoint[] GetGlyphPositions (ReadOnlySpan<ushort> glyphs, SKPoint origin = default)
 		{
 			var positions = new SKPoint[glyphs.Length];
 			GetGlyphPositions (glyphs, positions, origin);
@@ -447,44 +447,44 @@ namespace SkiaSharp
 
 		// GetGlyphOffsets (text)
 
-		public float[] GetGlyphOffsets (string text, float origin = 0f) =>
+		internal float[] GetGlyphOffsets (string text, float origin = 0f) =>
 			GetGlyphOffsets (text.AsSpan (), origin);
 
-		public float[] GetGlyphOffsets (ReadOnlySpan<char> text, float origin = 0f)
+		internal float[] GetGlyphOffsets (ReadOnlySpan<char> text, float origin = 0f)
 		{
 			fixed (void* t = text) {
 				return GetGlyphOffsets (t, text.Length * 2, SKTextEncoding.Utf16, origin);
 			}
 		}
 
-		public float[] GetGlyphOffsets (ReadOnlySpan<byte> text, SKTextEncoding encoding, float origin = 0f)
+		internal float[] GetGlyphOffsets (ReadOnlySpan<byte> text, SKTextEncoding encoding, float origin = 0f)
 		{
 			fixed (void* t = text) {
 				return GetGlyphOffsets (t, text.Length, encoding, origin);
 			}
 		}
 
-		public float[] GetGlyphOffsets (IntPtr text, int length, SKTextEncoding encoding, float origin = 0f) =>
+		internal float[] GetGlyphOffsets (IntPtr text, int length, SKTextEncoding encoding, float origin = 0f) =>
 			GetGlyphOffsets ((void*)text, length, encoding, origin);
 
-		public void GetGlyphOffsets (string text, Span<float> offsets, float origin = 0f) =>
+		internal void GetGlyphOffsets (string text, Span<float> offsets, float origin = 0f) =>
 			GetGlyphOffsets (text.AsSpan (), offsets, origin);
 
-		public void GetGlyphOffsets (ReadOnlySpan<char> text, Span<float> offsets, float origin = 0f)
+		internal void GetGlyphOffsets (ReadOnlySpan<char> text, Span<float> offsets, float origin = 0f)
 		{
 			fixed (void* t = text) {
 				GetGlyphOffsets (t, text.Length * 2, SKTextEncoding.Utf16, offsets, origin);
 			}
 		}
 
-		public void GetGlyphOffsets (ReadOnlySpan<byte> text, SKTextEncoding encoding, Span<float> offsets, float origin = 0f)
+		internal void GetGlyphOffsets (ReadOnlySpan<byte> text, SKTextEncoding encoding, Span<float> offsets, float origin = 0f)
 		{
 			fixed (void* t = text) {
 				GetGlyphOffsets (t, text.Length, encoding, offsets, origin);
 			}
 		}
 
-		public void GetGlyphOffsets (IntPtr text, int length, SKTextEncoding encoding, Span<float> offsets, float origin = 0f) =>
+		internal void GetGlyphOffsets (IntPtr text, int length, SKTextEncoding encoding, Span<float> offsets, float origin = 0f) =>
 			GetGlyphOffsets ((void*)text, length, encoding, offsets, origin);
 
 		internal float[] GetGlyphOffsets (void* text, int length, SKTextEncoding encoding, float origin)
@@ -517,7 +517,7 @@ namespace SkiaSharp
 
 		// GetGlyphOffsets (glyphs)
 
-		public float[] GetGlyphOffsets (ReadOnlySpan<ushort> glyphs, float origin = 0f)
+		internal float[] GetGlyphOffsets (ReadOnlySpan<ushort> glyphs, float origin = 0f)
 		{
 			var offsets = new float[glyphs.Length];
 			GetGlyphOffsets (glyphs, offsets, origin);
@@ -537,64 +537,64 @@ namespace SkiaSharp
 
 		// GetGlyphWidths (text)
 
-		public float[] GetGlyphWidths (string text, SKPaint paint = null) =>
+		internal float[] GetGlyphWidths (string text, SKPaint paint = null) =>
 			GetGlyphWidths (text.AsSpan (), paint);
 
-		public float[] GetGlyphWidths (ReadOnlySpan<char> text, SKPaint paint = null)
+		internal float[] GetGlyphWidths (ReadOnlySpan<char> text, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				return GetGlyphWidths (t, text.Length * 2, SKTextEncoding.Utf16, paint);
 			}
 		}
 
-		public float[] GetGlyphWidths (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPaint paint = null)
+		internal float[] GetGlyphWidths (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				return GetGlyphWidths (t, text.Length, encoding, paint);
 			}
 		}
 
-		public float[] GetGlyphWidths (IntPtr text, int length, SKTextEncoding encoding, SKPaint paint = null) =>
+		internal float[] GetGlyphWidths (IntPtr text, int length, SKTextEncoding encoding, SKPaint paint = null) =>
 			GetGlyphWidths ((void*)text, length, encoding, paint);
 
-		public float[] GetGlyphWidths (string text, out SKRect[] bounds, SKPaint paint = null) =>
+		internal float[] GetGlyphWidths (string text, out SKRect[] bounds, SKPaint paint = null) =>
 			GetGlyphWidths (text.AsSpan (), out bounds, paint);
 
-		public float[] GetGlyphWidths (ReadOnlySpan<char> text, out SKRect[] bounds, SKPaint paint = null)
+		internal float[] GetGlyphWidths (ReadOnlySpan<char> text, out SKRect[] bounds, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				return GetGlyphWidths (t, text.Length * 2, SKTextEncoding.Utf16, out bounds, paint);
 			}
 		}
 
-		public float[] GetGlyphWidths (ReadOnlySpan<byte> text, SKTextEncoding encoding, out SKRect[] bounds, SKPaint paint = null)
+		internal float[] GetGlyphWidths (ReadOnlySpan<byte> text, SKTextEncoding encoding, out SKRect[] bounds, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				return GetGlyphWidths (t, text.Length, encoding, out bounds, paint);
 			}
 		}
 
-		public float[] GetGlyphWidths (IntPtr text, int length, SKTextEncoding encoding, out SKRect[] bounds, SKPaint paint = null) =>
+		internal float[] GetGlyphWidths (IntPtr text, int length, SKTextEncoding encoding, out SKRect[] bounds, SKPaint paint = null) =>
 			GetGlyphWidths ((void*)text, length, encoding, out bounds, paint);
 
-		public void GetGlyphWidths (string text, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null) =>
+		internal void GetGlyphWidths (string text, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null) =>
 			GetGlyphWidths (text.AsSpan (), widths, bounds, paint);
 
-		public void GetGlyphWidths (ReadOnlySpan<char> text, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null)
+		internal void GetGlyphWidths (ReadOnlySpan<char> text, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				GetGlyphWidths (t, text.Length * 2, SKTextEncoding.Utf16, widths, bounds, paint);
 			}
 		}
 
-		public void GetGlyphWidths (ReadOnlySpan<byte> text, SKTextEncoding encoding, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null)
+		internal void GetGlyphWidths (ReadOnlySpan<byte> text, SKTextEncoding encoding, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null)
 		{
 			fixed (void* t = text) {
 				GetGlyphWidths (t, text.Length, encoding, widths, bounds, paint);
 			}
 		}
 
-		public void GetGlyphWidths (IntPtr text, int length, SKTextEncoding encoding, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null) =>
+		internal void GetGlyphWidths (IntPtr text, int length, SKTextEncoding encoding, Span<float> widths, Span<SKRect> bounds, SKPaint paint = null) =>
 			GetGlyphWidths ((void*)text, length, encoding, widths, bounds, paint);
 
 		internal float[] GetGlyphWidths (void* text, int length, SKTextEncoding encoding, SKPaint paint)
@@ -652,14 +652,14 @@ namespace SkiaSharp
 
 		// GetGlyphWidths (glyphs)
 
-		public float[] GetGlyphWidths (ReadOnlySpan<ushort> glyphs, SKPaint paint = null)
+		internal float[] GetGlyphWidths (ReadOnlySpan<ushort> glyphs, SKPaint paint = null)
 		{
 			var widths = new float[glyphs.Length];
 			GetGlyphWidths (glyphs, widths, Span<SKRect>.Empty, paint);
 			return widths;
 		}
 
-		public float[] GetGlyphWidths (ReadOnlySpan<ushort> glyphs, out SKRect[] bounds, SKPaint paint = null)
+		internal float[] GetGlyphWidths (ReadOnlySpan<ushort> glyphs, out SKRect[] bounds, SKPaint paint = null)
 		{
 			var widths = new float[glyphs.Length];
 			bounds = new SKRect[glyphs.Length];
@@ -692,24 +692,24 @@ namespace SkiaSharp
 
 		// GetTextPath (text)
 
-		public SKPath GetTextPath (string text, SKPoint origin = default) =>
+		internal SKPath GetTextPath (string text, SKPoint origin = default) =>
 			GetTextPath (text.AsSpan (), origin);
 
-		public SKPath GetTextPath (ReadOnlySpan<char> text, SKPoint origin = default)
+		internal SKPath GetTextPath (ReadOnlySpan<char> text, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return GetTextPath (t, text.Length * 2, SKTextEncoding.Utf16, origin);
 			}
 		}
 
-		public SKPath GetTextPath (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPoint origin = default)
+		internal SKPath GetTextPath (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return GetTextPath (t, text.Length, encoding, origin);
 			}
 		}
 
-		public SKPath GetTextPath (IntPtr text, int length, SKTextEncoding encoding, SKPoint origin = default) =>
+		internal SKPath GetTextPath (IntPtr text, int length, SKTextEncoding encoding, SKPoint origin = default) =>
 			GetTextPath ((void*)text, length, encoding, origin);
 
 		internal SKPath GetTextPath (void* text, int length, SKTextEncoding encoding, SKPoint origin)
@@ -724,24 +724,24 @@ namespace SkiaSharp
 
 		// GetTextPath (positioned)
 
-		public SKPath GetTextPath (string text, ReadOnlySpan<SKPoint> positions) =>
+		internal SKPath GetTextPath (string text, ReadOnlySpan<SKPoint> positions) =>
 			GetTextPath (text.AsSpan (), positions);
 
-		public SKPath GetTextPath (ReadOnlySpan<char> text, ReadOnlySpan<SKPoint> positions)
+		internal SKPath GetTextPath (ReadOnlySpan<char> text, ReadOnlySpan<SKPoint> positions)
 		{
 			fixed (void* t = text) {
 				return GetTextPath (t, text.Length * 2, SKTextEncoding.Utf16, positions);
 			}
 		}
 
-		public SKPath GetTextPath (ReadOnlySpan<byte> text, SKTextEncoding encoding, ReadOnlySpan<SKPoint> positions)
+		internal SKPath GetTextPath (ReadOnlySpan<byte> text, SKTextEncoding encoding, ReadOnlySpan<SKPoint> positions)
 		{
 			fixed (void* t = text) {
 				return GetTextPath (t, text.Length, encoding, positions);
 			}
 		}
 
-		public SKPath GetTextPath (IntPtr text, int length, SKTextEncoding encoding, ReadOnlySpan<SKPoint> positions) =>
+		internal SKPath GetTextPath (IntPtr text, int length, SKTextEncoding encoding, ReadOnlySpan<SKPoint> positions) =>
 			GetTextPath ((void*)text, length, encoding, positions);
 
 		internal SKPath GetTextPath (void* text, int length, SKTextEncoding encoding, ReadOnlySpan<SKPoint> positions)
@@ -772,24 +772,24 @@ namespace SkiaSharp
 
 		// GetTextPathOnPath (text)
 
-		public SKPath GetTextPathOnPath (string text, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
+		internal SKPath GetTextPathOnPath (string text, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
 			GetTextPathOnPath (text.AsSpan (), path, textAlign, origin);
 
-		public SKPath GetTextPathOnPath (ReadOnlySpan<char> text, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
+		internal SKPath GetTextPathOnPath (ReadOnlySpan<char> text, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return GetTextPathOnPath (t, text.Length * 2, SKTextEncoding.Utf16, path, textAlign, origin);
 			}
 		}
 
-		public SKPath GetTextPathOnPath (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
+		internal SKPath GetTextPathOnPath (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return GetTextPathOnPath (t, text.Length, encoding, path, textAlign, origin);
 			}
 		}
 
-		public SKPath GetTextPathOnPath (IntPtr text, int length, SKTextEncoding encoding, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
+		internal SKPath GetTextPathOnPath (IntPtr text, int length, SKTextEncoding encoding, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
 			GetTextPathOnPath ((void*)text, length, encoding, path, textAlign, origin);
 
 		internal SKPath GetTextPathOnPath (void* text, int length, SKTextEncoding encoding, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -243,7 +243,13 @@ namespace SkiaSharp
 		public float MeasureText (string text) =>
 			GetFont ().MeasureText (text, this);
 
+		public float MeasureText (ReadOnlySpan<char> text) =>
+			GetFont ().MeasureText (text, this);
+
 		public float MeasureText (byte[] text) =>
+			GetFont ().MeasureText (text, TextEncoding, this);
+
+		public float MeasureText (ReadOnlySpan<byte> text) =>
 			GetFont ().MeasureText (text, TextEncoding, this);
 
 		public float MeasureText (IntPtr buffer, int length) =>
@@ -255,7 +261,13 @@ namespace SkiaSharp
 		public float MeasureText (string text, ref SKRect bounds) =>
 			GetFont ().MeasureText (text, out bounds, this);
 
+		public float MeasureText (ReadOnlySpan<char> text, ref SKRect bounds) =>
+			GetFont ().MeasureText (text, out bounds, this);
+
 		public float MeasureText (byte[] text, ref SKRect bounds) =>
+			GetFont ().MeasureText (text, TextEncoding, out bounds, this);
+
+		public float MeasureText (ReadOnlySpan<byte> text, ref SKRect bounds) =>
 			GetFont ().MeasureText (text, TextEncoding, out bounds, this);
 
 		public float MeasureText (IntPtr buffer, int length, ref SKRect bounds) =>
@@ -290,16 +302,29 @@ namespace SkiaSharp
 			return charsRead;
 		}
 
+		public long BreakText (ReadOnlySpan<char> text, float maxWidth) =>
+			GetFont ().BreakText (text, maxWidth, out _, this);
+
+		public long BreakText (ReadOnlySpan<char> text, float maxWidth, out float measuredWidth) =>
+			GetFont ().BreakText (text, maxWidth, out measuredWidth, this);
+
 		public long BreakText (byte[] text, float maxWidth) =>
 			GetFont ().BreakText (text, TextEncoding, maxWidth, out _, this);
 
-		public long BreakText (byte[] text, float maxWidth, out float measuredWidth)
-		{
-			return GetFont ().BreakText (text, TextEncoding, maxWidth, out measuredWidth, this);
-		}
+		public long BreakText (byte[] text, float maxWidth, out float measuredWidth) =>
+			GetFont ().BreakText (text, TextEncoding, maxWidth, out measuredWidth, this);
+
+		public long BreakText (ReadOnlySpan<byte> text, float maxWidth) =>
+			GetFont ().BreakText (text, TextEncoding, maxWidth, out _, this);
+
+		public long BreakText (ReadOnlySpan<byte> text, float maxWidth, out float measuredWidth) =>
+			GetFont ().BreakText (text, TextEncoding, maxWidth, out measuredWidth, this);
 
 		public long BreakText (IntPtr buffer, int length, float maxWidth) =>
 			GetFont ().BreakText (buffer, length, TextEncoding, maxWidth, out _, this);
+
+		public long BreakText (IntPtr buffer, int length, float maxWidth, out float measuredWidth) =>
+			GetFont ().BreakText (buffer, length, TextEncoding, maxWidth, out measuredWidth, this);
 
 		public long BreakText (IntPtr buffer, IntPtr length, float maxWidth) =>
 			GetFont ().BreakText (buffer, (int)length, TextEncoding, maxWidth, out _, this);
@@ -307,17 +332,18 @@ namespace SkiaSharp
 		public long BreakText (IntPtr buffer, IntPtr length, float maxWidth, out float measuredWidth) =>
 			GetFont ().BreakText (buffer, (int)length, TextEncoding, maxWidth, out measuredWidth, this);
 
-		public long BreakText (IntPtr buffer, int length, float maxWidth, out float measuredWidth)
-		{
-			return GetFont ().BreakText (buffer, length, TextEncoding, maxWidth, out measuredWidth, this);
-		}
-
 		// GetTextPath
 
 		public SKPath GetTextPath (string text, float x, float y) =>
 			GetFont ().GetTextPath (text, new SKPoint (x, y));
 
+		public SKPath GetTextPath (ReadOnlySpan<char> text, float x, float y) =>
+			GetFont ().GetTextPath (text, new SKPoint (x, y));
+
 		public SKPath GetTextPath (byte[] text, float x, float y) =>
+			GetFont ().GetTextPath (text, TextEncoding, new SKPoint (x, y));
+
+		public SKPath GetTextPath (ReadOnlySpan<byte> text, float x, float y) =>
 			GetFont ().GetTextPath (text, TextEncoding, new SKPoint (x, y));
 
 		public SKPath GetTextPath (IntPtr buffer, int length, float x, float y) =>
@@ -326,23 +352,21 @@ namespace SkiaSharp
 		public SKPath GetTextPath (IntPtr buffer, IntPtr length, float x, float y) =>
 			GetFont ().GetTextPath (buffer, (int)length, TextEncoding, new SKPoint (x, y));
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete]
 		public SKPath GetTextPath (string text, SKPoint[] points) =>
 			GetFont ().GetTextPath (text, points);
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete]
+		public SKPath GetTextPath (ReadOnlySpan<char> text, SKPoint[] points) =>
+			GetFont ().GetTextPath (text, points);
+
 		public SKPath GetTextPath (byte[] text, SKPoint[] points) =>
 			GetFont ().GetTextPath (text, TextEncoding, points);
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete]
+		public SKPath GetTextPath (ReadOnlySpan<byte> text, SKPoint[] points) =>
+			GetFont ().GetTextPath (text, TextEncoding, points);
+
 		public SKPath GetTextPath (IntPtr buffer, int length, SKPoint[] points) =>
 			GetFont ().GetTextPath (buffer, length, TextEncoding, points);
 
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete]
 		public SKPath GetTextPath (IntPtr buffer, IntPtr length, SKPoint[] points) =>
 			GetFont ().GetTextPath (buffer, (int)length, TextEncoding, points);
 
@@ -409,7 +433,13 @@ namespace SkiaSharp
 		public int CountGlyphs (string text) =>
 			GetFont ().CountGlyphs (text);
 
+		public int CountGlyphs (ReadOnlySpan<char> text) =>
+			GetFont ().CountGlyphs (text);
+
 		public int CountGlyphs (byte[] text) =>
+			GetFont ().CountGlyphs (text, TextEncoding);
+
+		public int CountGlyphs (ReadOnlySpan<byte> text) =>
 			GetFont ().CountGlyphs (text, TextEncoding);
 
 		public int CountGlyphs (IntPtr text, int length) =>
@@ -423,7 +453,13 @@ namespace SkiaSharp
 		public ushort[] GetGlyphs (string text) =>
 			GetFont ().GetGlyphs (text);
 
+		public ushort[] GetGlyphs (ReadOnlySpan<char> text) =>
+			GetFont ().GetGlyphs (text);
+
 		public ushort[] GetGlyphs (byte[] text) =>
+			GetFont ().GetGlyphs (text, TextEncoding);
+
+		public ushort[] GetGlyphs (ReadOnlySpan<byte> text) =>
 			GetFont ().GetGlyphs (text, TextEncoding);
 
 		public ushort[] GetGlyphs (IntPtr text, int length) =>
@@ -437,7 +473,13 @@ namespace SkiaSharp
 		public bool ContainsGlyphs (string text) =>
 			GetFont ().ContainsGlyphs (text);
 
+		public bool ContainsGlyphs (ReadOnlySpan<char> text) =>
+			GetFont ().ContainsGlyphs (text);
+
 		public bool ContainsGlyphs (byte[] text) =>
+			GetFont ().ContainsGlyphs (text, TextEncoding);
+
+		public bool ContainsGlyphs (ReadOnlySpan<byte> text) =>
 			GetFont ().ContainsGlyphs (text, TextEncoding);
 
 		public bool ContainsGlyphs (IntPtr text, int length) =>
@@ -446,12 +488,46 @@ namespace SkiaSharp
 		public bool ContainsGlyphs (IntPtr text, IntPtr length) =>
 			GetFont ().ContainsGlyphs (text, (int)length, TextEncoding);
 
+		// GetGlyphPositions
+
+		public SKPoint[] GetGlyphPositions (string text, SKPoint origin = default) =>
+			GetFont ().GetGlyphPositions (text, origin);
+
+		public SKPoint[] GetGlyphPositions (ReadOnlySpan<char> text, SKPoint origin = default) =>
+			GetFont ().GetGlyphPositions (text, origin);
+
+		public SKPoint[] GetGlyphPositions (ReadOnlySpan<byte> text, SKPoint origin = default) =>
+			GetFont ().GetGlyphPositions (text, TextEncoding, origin);
+
+		public SKPoint[] GetGlyphPositions (IntPtr text, int length, SKPoint origin = default) =>
+			GetFont ().GetGlyphPositions (text, length, TextEncoding, origin);
+
+		// GetGlyphOffsets
+
+		public float[] GetGlyphOffsets (string text, float origin = 0f) =>
+			GetFont ().GetGlyphOffsets (text, origin);
+
+		public float[] GetGlyphOffsets (ReadOnlySpan<char> text, float origin = 0f) =>
+			GetFont ().GetGlyphOffsets (text, origin);
+
+		public float[] GetGlyphOffsets (ReadOnlySpan<byte> text, float origin = 0f) =>
+			GetFont ().GetGlyphOffsets (text, TextEncoding, origin);
+
+		public float[] GetGlyphOffsets (IntPtr text, int length, float origin = 0f) =>
+			GetFont ().GetGlyphOffsets (text, length, TextEncoding, origin);
+
 		// GetGlyphWidths
 
 		public float[] GetGlyphWidths (string text) =>
 			GetFont ().GetGlyphWidths (text, this);
 
+		public float[] GetGlyphWidths (ReadOnlySpan<char> text) =>
+			GetFont ().GetGlyphWidths (text, this);
+
 		public float[] GetGlyphWidths (byte[] text) =>
+			GetFont ().GetGlyphWidths (text, TextEncoding, this);
+
+		public float[] GetGlyphWidths (ReadOnlySpan<byte> text) =>
 			GetFont ().GetGlyphWidths (text, TextEncoding, this);
 
 		public float[] GetGlyphWidths (IntPtr text, int length) =>
@@ -463,7 +539,13 @@ namespace SkiaSharp
 		public float[] GetGlyphWidths (string text, out SKRect[] bounds) =>
 			GetFont ().GetGlyphWidths (text, out bounds, this);
 
+		public float[] GetGlyphWidths (ReadOnlySpan<char> text, out SKRect[] bounds) =>
+			GetFont ().GetGlyphWidths (text, out bounds, this);
+
 		public float[] GetGlyphWidths (byte[] text, out SKRect[] bounds) =>
+			GetFont ().GetGlyphWidths (text, TextEncoding, out bounds, this);
+
+		public float[] GetGlyphWidths (ReadOnlySpan<byte> text, out SKRect[] bounds) =>
 			GetFont ().GetGlyphWidths (text, TextEncoding, out bounds, this);
 
 		public float[] GetGlyphWidths (IntPtr text, int length, out SKRect[] bounds) =>
@@ -474,7 +556,10 @@ namespace SkiaSharp
 
 		// GetTextIntercepts
 
-		public float[] GetTextIntercepts (string text, float x, float y, float upperBounds, float lowerBounds)
+		public float[] GetTextIntercepts (string text, float x, float y, float upperBounds, float lowerBounds) =>
+			GetTextIntercepts (text.AsSpan (), x, y, upperBounds, lowerBounds);
+
+		public float[] GetTextIntercepts (ReadOnlySpan<char> text, float x, float y, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -483,7 +568,10 @@ namespace SkiaSharp
 			return blob.GetIntercepts (upperBounds, lowerBounds, this);
 		}
 
-		public float[] GetTextIntercepts (byte[] text, float x, float y, float upperBounds, float lowerBounds)
+		public float[] GetTextIntercepts (byte[] text, float x, float y, float upperBounds, float lowerBounds) =>
+			GetTextIntercepts (text.AsSpan (), x, y, upperBounds, lowerBounds);
+
+		public float[] GetTextIntercepts (ReadOnlySpan<byte> text, float x, float y, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -516,7 +604,10 @@ namespace SkiaSharp
 
 		// GetPositionedTextIntercepts
 
-		public float[] GetPositionedTextIntercepts (string text, SKPoint[] positions, float upperBounds, float lowerBounds)
+		public float[] GetPositionedTextIntercepts (string text, SKPoint[] positions, float upperBounds, float lowerBounds) =>
+			GetPositionedTextIntercepts (text.AsSpan (), positions, upperBounds, lowerBounds);
+
+		public float[] GetPositionedTextIntercepts (ReadOnlySpan<char> text, SKPoint[] positions, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -525,7 +616,10 @@ namespace SkiaSharp
 			return blob.GetIntercepts (upperBounds, lowerBounds, this);
 		}
 
-		public float[] GetPositionedTextIntercepts (byte[] text, SKPoint[] positions, float upperBounds, float lowerBounds)
+		public float[] GetPositionedTextIntercepts (byte[] text, SKPoint[] positions, float upperBounds, float lowerBounds) =>
+			GetPositionedTextIntercepts (text.AsSpan (), positions, upperBounds, lowerBounds);
+
+		public float[] GetPositionedTextIntercepts (ReadOnlySpan<byte> text, SKPoint[] positions, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -536,7 +630,6 @@ namespace SkiaSharp
 
 		public float[] GetPositionedTextIntercepts (IntPtr text, int length, SKPoint[] positions, float upperBounds, float lowerBounds) =>
 			GetPositionedTextIntercepts (text, (IntPtr)length, positions, upperBounds, lowerBounds);
-
 
 		public float[] GetPositionedTextIntercepts (IntPtr text, IntPtr length, SKPoint[] positions, float upperBounds, float lowerBounds)
 		{
@@ -549,7 +642,10 @@ namespace SkiaSharp
 
 		// GetHorizontalTextIntercepts
 
-		public float[] GetHorizontalTextIntercepts (string text, float[] xpositions, float y, float upperBounds, float lowerBounds)
+		public float[] GetHorizontalTextIntercepts (string text, float[] xpositions, float y, float upperBounds, float lowerBounds) =>
+			GetHorizontalTextIntercepts (text.AsSpan (), xpositions, y, upperBounds, lowerBounds);
+
+		public float[] GetHorizontalTextIntercepts (ReadOnlySpan<char> text, float[] xpositions, float y, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -558,7 +654,10 @@ namespace SkiaSharp
 			return blob.GetIntercepts (upperBounds, lowerBounds, this);
 		}
 
-		public float[] GetHorizontalTextIntercepts (byte[] text, float[] xpositions, float y, float upperBounds, float lowerBounds)
+		public float[] GetHorizontalTextIntercepts (byte[] text, float[] xpositions, float y, float upperBounds, float lowerBounds) =>
+			GetHorizontalTextIntercepts (text.AsSpan (), xpositions, y, upperBounds, lowerBounds);
+
+		public float[] GetHorizontalTextIntercepts (ReadOnlySpan<byte> text, float[] xpositions, float y, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -585,7 +684,7 @@ namespace SkiaSharp
 			SKFont.GetObject (SkiaApi.sk_compatpaint_make_font (Handle));
 
 		internal SKFont GetFont () =>
-			OwnedBy (font ??= SKFont.GetObject (SkiaApi.sk_compatpaint_get_font (Handle), false), this);
+			font ??= OwnedBy (SKFont.GetObject (SkiaApi.sk_compatpaint_get_font (Handle), false), this);
 
 		//
 

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -367,6 +367,9 @@ namespace SkiaSharp
 		public SKPath GetTextPath (IntPtr buffer, int length, SKPoint[] points) =>
 			GetFont ().GetTextPath (buffer, length, TextEncoding, points);
 
+		public SKPath GetTextPath (IntPtr buffer, int length, ReadOnlySpan<SKPoint> points) =>
+			GetFont ().GetTextPath (buffer, length, TextEncoding, points);
+
 		public SKPath GetTextPath (IntPtr buffer, IntPtr length, SKPoint[] points) =>
 			GetFont ().GetTextPath (buffer, (int)length, TextEncoding, points);
 

--- a/binding/Binding/SKPaint.cs
+++ b/binding/Binding/SKPaint.cs
@@ -355,13 +355,13 @@ namespace SkiaSharp
 		public SKPath GetTextPath (string text, SKPoint[] points) =>
 			GetFont ().GetTextPath (text, points);
 
-		public SKPath GetTextPath (ReadOnlySpan<char> text, SKPoint[] points) =>
+		public SKPath GetTextPath (ReadOnlySpan<char> text, ReadOnlySpan<SKPoint> points) =>
 			GetFont ().GetTextPath (text, points);
 
 		public SKPath GetTextPath (byte[] text, SKPoint[] points) =>
 			GetFont ().GetTextPath (text, TextEncoding, points);
 
-		public SKPath GetTextPath (ReadOnlySpan<byte> text, SKPoint[] points) =>
+		public SKPath GetTextPath (ReadOnlySpan<byte> text, ReadOnlySpan<SKPoint> points) =>
 			GetFont ().GetTextPath (text, TextEncoding, points);
 
 		public SKPath GetTextPath (IntPtr buffer, int length, SKPoint[] points) =>
@@ -607,7 +607,7 @@ namespace SkiaSharp
 		public float[] GetPositionedTextIntercepts (string text, SKPoint[] positions, float upperBounds, float lowerBounds) =>
 			GetPositionedTextIntercepts (text.AsSpan (), positions, upperBounds, lowerBounds);
 
-		public float[] GetPositionedTextIntercepts (ReadOnlySpan<char> text, SKPoint[] positions, float upperBounds, float lowerBounds)
+		public float[] GetPositionedTextIntercepts (ReadOnlySpan<char> text, ReadOnlySpan<SKPoint> positions, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -619,7 +619,7 @@ namespace SkiaSharp
 		public float[] GetPositionedTextIntercepts (byte[] text, SKPoint[] positions, float upperBounds, float lowerBounds) =>
 			GetPositionedTextIntercepts (text.AsSpan (), positions, upperBounds, lowerBounds);
 
-		public float[] GetPositionedTextIntercepts (ReadOnlySpan<byte> text, SKPoint[] positions, float upperBounds, float lowerBounds)
+		public float[] GetPositionedTextIntercepts (ReadOnlySpan<byte> text, ReadOnlySpan<SKPoint> positions, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -645,7 +645,7 @@ namespace SkiaSharp
 		public float[] GetHorizontalTextIntercepts (string text, float[] xpositions, float y, float upperBounds, float lowerBounds) =>
 			GetHorizontalTextIntercepts (text.AsSpan (), xpositions, y, upperBounds, lowerBounds);
 
-		public float[] GetHorizontalTextIntercepts (ReadOnlySpan<char> text, float[] xpositions, float y, float upperBounds, float lowerBounds)
+		public float[] GetHorizontalTextIntercepts (ReadOnlySpan<char> text, ReadOnlySpan<float> xpositions, float y, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));
@@ -657,7 +657,7 @@ namespace SkiaSharp
 		public float[] GetHorizontalTextIntercepts (byte[] text, float[] xpositions, float y, float upperBounds, float lowerBounds) =>
 			GetHorizontalTextIntercepts (text.AsSpan (), xpositions, y, upperBounds, lowerBounds);
 
-		public float[] GetHorizontalTextIntercepts (ReadOnlySpan<byte> text, float[] xpositions, float y, float upperBounds, float lowerBounds)
+		public float[] GetHorizontalTextIntercepts (ReadOnlySpan<byte> text, ReadOnlySpan<float> xpositions, float y, float upperBounds, float lowerBounds)
 		{
 			if (text == null)
 				throw new ArgumentNullException (nameof (text));

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -19,6 +19,8 @@ namespace SkiaSharp
 	{
 		private static readonly SKTypeface defaultTypeface;
 
+		private SKFont font;
+
 		static SKTypeface ()
 		{
 			defaultTypeface = new SKTypefaceStatic (SkiaApi.sk_typeface_ref_default ());
@@ -252,74 +254,53 @@ namespace SkiaSharp
 		// CountGlyphs (string/char)
 
 		public int CountGlyphs (string str) =>
-			CountGlyphs (str.AsSpan ());
+			GetFont ().CountGlyphs (str);
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CountGlyphs(string) instead.")]
 		public int CountGlyphs (string str, SKEncoding encoding) =>
-			CountGlyphs (str.AsSpan ());
+			GetFont ().CountGlyphs (str);
 
-		public int CountGlyphs (ReadOnlySpan<char> str)
-		{
-			using var font = ToFont ();
-			return font.CountGlyphs (str);
-		}
+		public int CountGlyphs (ReadOnlySpan<char> str) =>
+			GetFont ().CountGlyphs (str);
 
 		// CountGlyphs (byte[])
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CountGlyphs(byte[], SKTextEncoding) instead.")]
 		public int CountGlyphs (byte[] str, SKEncoding encoding) =>
-			CountGlyphs (str.AsSpan (), encoding.ToTextEncoding ());
+			GetFont ().CountGlyphs (str, encoding.ToTextEncoding ());
 
 		public int CountGlyphs (byte[] str, SKTextEncoding encoding) =>
-			CountGlyphs (str.AsSpan (), encoding);
+			GetFont ().CountGlyphs (str, encoding);
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CountGlyphs(ReadOnlySpan<byte>, SKTextEncoding) instead.")]
 		public int CountGlyphs (ReadOnlySpan<byte> str, SKEncoding encoding) =>
-			CountGlyphs (str, encoding.ToTextEncoding ());
+			GetFont ().CountGlyphs (str, encoding.ToTextEncoding ());
 
-		public int CountGlyphs (ReadOnlySpan<byte> str, SKTextEncoding encoding)
-		{
-			using var font = ToFont ();
-			return font.CountGlyphs (str, encoding);
-		}
+		public int CountGlyphs (ReadOnlySpan<byte> str, SKTextEncoding encoding) =>
+			GetFont ().CountGlyphs (str, encoding);
 
 		// CountGlyphs (IntPtr)
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use CountGlyphs(ReadOnlySpan<byte>, SKTextEncoding) instead.")]
+		[Obsolete ("Use CountGlyphs(IntPtr, int, SKTextEncoding) instead.")]
 		public int CountGlyphs (IntPtr str, int strLen, SKEncoding encoding) =>
-			CountGlyphs (str, strLen, encoding.ToTextEncoding ());
+			GetFont ().CountGlyphs (str, strLen, encoding.ToTextEncoding ());
 
-		public int CountGlyphs (IntPtr str, int strLen, SKTextEncoding encoding)
-		{
-			using var font = ToFont ();
-			return font.CountGlyphs (str, strLen, encoding);
-		}
+		public int CountGlyphs (IntPtr str, int strLen, SKTextEncoding encoding) =>
+			GetFont ().CountGlyphs (str, strLen, encoding);
 
 		// GetGlyph (int)
 
 		public ushort GetGlyph (int codepoint) =>
-			SkiaApi.sk_typeface_unichar_to_glyph (Handle, codepoint);
+			GetFont ().GetGlyph (codepoint);
 
 		// GetGlyphs (int)
 
-		public ushort[] GetGlyphs (ReadOnlySpan<int> codepoints)
-		{
-			var glyphs = new ushort[codepoints.Length];
-			GetGlyphs (codepoints, glyphs);
-			return glyphs;
-		}
-
-		public void GetGlyphs (ReadOnlySpan<int> codepoints, Span<ushort> glyphs)
-		{
-			fixed (int* up = codepoints)
-			fixed (ushort* gp = glyphs) {
-				SkiaApi.sk_typeface_unichars_to_glyphs (Handle, up, codepoints.Length, gp);
-			}
-		}
+		public ushort[] GetGlyphs (ReadOnlySpan<int> codepoints) =>
+			GetFont ().GetGlyphs (codepoints);
 
 		// GetGlyphs (string/char, out)
 
@@ -361,7 +342,7 @@ namespace SkiaSharp
 			return glyphs.Length;
 		}
 
-		// GetGlyphs (string/char, out)
+		// GetGlyphs (string/char)
 
 		public ushort[] GetGlyphs (string text) =>
 			GetGlyphs (text.AsSpan ());
@@ -377,7 +358,7 @@ namespace SkiaSharp
 			return font.GetGlyphs (text);
 		}
 
-		// GetGlyphs (byte[], out)
+		// GetGlyphs (byte[])
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GetGlyphs(ReadOnlySpan<byte>, SKTextEncoding) instead.")]
@@ -395,6 +376,8 @@ namespace SkiaSharp
 			return font.GetGlyphs (text, encoding);
 		}
 
+		// GetGlyphs (IntPtr)
+
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use GetGlyphs(IntPtr, int, SKTextEncoding) instead.")]
 		public ushort[] GetGlyphs (IntPtr text, int length, SKEncoding encoding) =>
@@ -409,27 +392,29 @@ namespace SkiaSharp
 		// ContainsGlyph
 
 		public bool ContainsGlyph (int codepoint) =>
-			GetGlyph (codepoint) != 0;
+			GetFont ().ContainsGlyph (codepoint);
 
 		// ContainsGlyphs
 
 		public bool ContainsGlyphs (ReadOnlySpan<int> codepoints) =>
-			ContainsGlyphs (GetGlyphs (codepoints));
+			GetFont ().ContainsGlyphs (codepoints);
 
 		public bool ContainsGlyphs (string text) =>
-			ContainsGlyphs (GetGlyphs (text));
+			GetFont ().ContainsGlyphs (text);
 
 		public bool ContainsGlyphs (ReadOnlySpan<char> text) =>
-			ContainsGlyphs (GetGlyphs (text));
+			GetFont ().ContainsGlyphs (text);
 
 		public bool ContainsGlyphs (ReadOnlySpan<byte> text, SKTextEncoding encoding) =>
-			ContainsGlyphs (GetGlyphs (text, encoding));
+			GetFont ().ContainsGlyphs (text, encoding);
 
 		public bool ContainsGlyphs (IntPtr text, int length, SKTextEncoding encoding) =>
-			ContainsGlyphs (GetGlyphs (text, length, encoding));
+			GetFont ().ContainsGlyphs (text, length, encoding);
 
-		private bool ContainsGlyphs (ushort[] glyphs) =>
-			Array.IndexOf (glyphs, 0) != -1;
+		// GetFont
+
+		internal SKFont GetFont () =>
+			font ??= OwnedBy (new SKFont (this), this);
 
 		// ToFont
 

--- a/tests/Tests/SKFontTest.cs
+++ b/tests/Tests/SKFontTest.cs
@@ -139,6 +139,31 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void MeasureTextMeasuresTheTextForGlyphs()
+		{
+			var font = new SKFont();
+			var expectedWidth = font.MeasureText("Hello World!");
+
+			var glyphs = font.GetGlyphs("Hello World!");
+			var width = font.MeasureText(glyphs);
+
+			Assert.Equal(expectedWidth, width);
+		}
+
+		[SkippableFact]
+		public void MeasureTextReturnsTheBoundsForGlyphs()
+		{
+			var font = new SKFont();
+			var expectedWidth = font.MeasureText("Hello World!", out var expectedBounds);
+
+			var glyphs = font.GetGlyphs("Hello World!");
+			var width = font.MeasureText(glyphs, out var bounds);
+
+			Assert.Equal(expectedWidth, width);
+			Assert.Equal(expectedBounds, bounds);
+		}
+
+		[SkippableFact]
 		public void MeasureTextSucceedsForEmtptyString()
 		{
 			var font = new SKFont();


### PR DESCRIPTION
**Description of Change**

Make `SKFont` glyph-only:

- hide the `SKFont` members that take strings/bytes
- hide the overloads that return arrays (promote the use of the "out span")
- expose string/byte members on `SKPaint`, and only expose the returning array (for consistency)
- use a single instance of `SKFont` for `SKTypeface` glyph members

The whole reason for this PR is to help define or direct type usage:

- `SKFont`  
   - This type is very low level and just works with glyphs and unicode (`ushort` and `int`).
   - To keep all the text members together, the other overloads are also defined, but are internal.
   - For now, only the overloads that take an "outwards span" are exposed: `void Get(ReadOnlySpan<T> input, Span<T> output)`
- `SKPaint`  
   - This type is for use with a canvas, so only exposes the string (and sadly, due to bad choices the byte arrays).
   - All members just redirect to the underlying `SKFont` internal members.
   - For now, only the overloads that return an array are exposed: `T[] Get(ReadOnlySpan<T> input)`
- `SKTypeface`
  - This type is used to get glyph information (in addition to the other members): count, get and contains
  - All members just redirect to an underlying `SKFont`
   - For now, only the overloads that return an array are exposed: `T[] Get(ReadOnlySpan<T> input)`

Typically, the members on `SKPaint` and `SKTypeface` should not really be used as the string logic is dumb and only really understands Latin text. However, it is useful still. The members on `SKFont` are all the things you would use when doing text shaping. And, that API strongly encourages the use of array pools or other non-allocating operations.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
