### PR TITLE
Add Alpine Native Libraries

### DIFF
--- a/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
+++ b/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
@@ -31,7 +31,7 @@
           Condition=" Exists('..\..\output\native\nanoserver\x64\libHarfBuzzSharp.dll') or '$(IsWindows)' == 'true' " />
     <None Include="..\..\output\native\linuxnodeps\x64\libHarfBuzzSharp.so" Link="nuget\runtimes\linuxnodeps-x64\native\libHarfBuzzSharp.so"
           Condition=" Exists('..\..\output\native\linuxnodeps\x64\libHarfBuzzSharp.so') or '$(IsLinux)' == 'true' " />
-    <None Include="..\..\output\native\alpine\x64\libHarfBuzzSharp.so" Link="nuget\runtimes\alpine-x64\native\libHarfBuzzSharp.so"
+    <None Include="..\..\output\native\alpine\x64\libHarfBuzzSharp.so" Link="nuget\runtimes\linux-musl-x64\native\libHarfBuzzSharp.so"
           Condition=" Exists('..\..\output\native\alpine\x64\libHarfBuzzSharp.so') or '$(IsLinux)' == 'true' " />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
+++ b/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
@@ -31,6 +31,8 @@
           Condition=" Exists('..\..\output\native\nanoserver\x64\libHarfBuzzSharp.dll') or '$(IsWindows)' == 'true' " />
     <None Include="..\..\output\native\linuxnodeps\x64\libHarfBuzzSharp.so" Link="nuget\runtimes\linuxnodeps-x64\native\libHarfBuzzSharp.so"
           Condition=" Exists('..\..\output\native\linuxnodeps\x64\libHarfBuzzSharp.so') or '$(IsLinux)' == 'true' " />
+    <None Include="..\..\output\native\alpine\x64\libHarfBuzzSharp.so" Link="nuget\runtimes\alpine-x64\native\libHarfBuzzSharp.so"
+          Condition=" Exists('..\..\output\native\alpine\x64\libHarfBuzzSharp.so') or '$(IsLinux)' == 'true' " />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <None Include="nuget\build\net45\HarfBuzzSharp.targets" Link="nuget\build\$(TargetFramework)\HarfBuzzSharp.targets" />

--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -30,6 +30,8 @@
           Condition=" Exists('..\..\output\native\nanoserver\x64\libSkiaSharp.dll') or '$(IsWindows)' == 'true' " />
     <None Include="..\..\output\native\linuxnodeps\x64\libSkiaSharp.so" Link="nuget\runtimes\linuxnodeps-x64\native\libSkiaSharp.so"
           Condition=" Exists('..\..\output\native\linuxnodeps\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
+    <None Include="..\..\output\native\alpine\x64\libSkiaSharp.so" Link="nuget\runtimes\alpine-x64\native\libSkiaSharp.so"
+          Condition=" Exists('..\..\output\native\alpine\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <None Include="nuget\build\net45\SkiaSharp.targets" Link="nuget\build\$(TargetFramework)\SkiaSharp.targets" />

--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -32,6 +32,8 @@
           Condition=" Exists('..\..\output\native\linuxnodeps\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
     <None Include="..\..\output\native\alpine\x64\libSkiaSharp.so" Link="nuget\runtimes\linux-musl-x64\native\libSkiaSharp.so"
           Condition=" Exists('..\..\output\native\alpine\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
+    <None Include="..\..\output\native\alpinenodeps\x64\libSkiaSharp.so" Link="nuget\runtimes\linuxnodeps-musl-x64\native\libSkiaSharp.so"
+          Condition=" Exists('..\..\output\native\alpinenodeps\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <None Include="nuget\build\net45\SkiaSharp.targets" Link="nuget\build\$(TargetFramework)\SkiaSharp.targets" />

--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -30,7 +30,7 @@
           Condition=" Exists('..\..\output\native\nanoserver\x64\libSkiaSharp.dll') or '$(IsWindows)' == 'true' " />
     <None Include="..\..\output\native\linuxnodeps\x64\libSkiaSharp.so" Link="nuget\runtimes\linuxnodeps-x64\native\libSkiaSharp.so"
           Condition=" Exists('..\..\output\native\linuxnodeps\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
-    <None Include="..\..\output\native\alpine\x64\libSkiaSharp.so" Link="nuget\runtimes\alpine-x64\native\libSkiaSharp.so"
+    <None Include="..\..\output\native\alpine\x64\libSkiaSharp.so" Link="nuget\runtimes\linux-musl-x64\native\libSkiaSharp.so"
           Condition=" Exists('..\..\output\native\alpine\x64\libSkiaSharp.so') or '$(IsLinux)' == 'true' " />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/cake/native-shared.cake
+++ b/cake/native-shared.cake
@@ -61,7 +61,7 @@ void GnNinja(DirectoryPath outDir, string target, string skiaArgs)
 
     // build native skia
     RunProcess(NINJA_EXE, new ProcessSettings {
-        Arguments = $"{target} -C out/{outDir}",
+        Arguments = $"-C out/{outDir} {target}",
         WorkingDirectory = SKIA_PATH.FullPath,
     });
 }

--- a/native/linuxnodeps/build.cake
+++ b/native/linuxnodeps/build.cake
@@ -3,12 +3,14 @@ DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native/linuxn
 
 #load "../../cake/shared.cake"
 
+string VARIANT = BUILD_VARIANT ?? "linuxnodeps";
+
 Task("libSkiaSharp")
     .WithCriteria(IsRunningOnLinux())
     .Does(() =>
 {
     RunCake("../linux/build.cake", "libSkiaSharp", new Dictionary<string, string> {
-        { "variant", "linuxnodeps" },
+        { "variant", VARIANT },
         { "gnArgs", "skia_use_fontconfig=false" },
     });
 
@@ -23,7 +25,7 @@ Task("libHarfBuzzSharp")
     .Does(() =>
 {
     RunCake("../linux/build.cake", "libHarfBuzzSharp", new Dictionary<string, string> {
-        { "variant", "linuxnodeps" },
+        { "variant", VARIANT },
     });
 
     RunProcess("ldd", OUTPUT_PATH.CombineWithFilePath($"x64/libHarfBuzzSharp.so").FullPath, out var stdout);

--- a/native/linuxnodeps/build.cake
+++ b/native/linuxnodeps/build.cake
@@ -1,9 +1,10 @@
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
-DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native/linuxnodeps"));
+DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native"));
 
 #load "../../cake/shared.cake"
 
 var BUILD_VARIANT = Argument("variant", EnvironmentVariable("BUILD_VARIANT") ?? "linuxnodeps");
+OUTPUT_PATH.Combine(BUILD_VARIANT);
 
 Task("libSkiaSharp")
     .WithCriteria(IsRunningOnLinux())

--- a/native/linuxnodeps/build.cake
+++ b/native/linuxnodeps/build.cake
@@ -4,7 +4,7 @@ DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native"));
 #load "../../cake/shared.cake"
 
 var BUILD_VARIANT = Argument("variant", EnvironmentVariable("BUILD_VARIANT") ?? "linuxnodeps");
-OUTPUT_PATH.Combine(BUILD_VARIANT);
+OUTPUT_PATH = OUTPUT_PATH.Combine(BUILD_VARIANT);
 
 Task("libSkiaSharp")
     .WithCriteria(IsRunningOnLinux())

--- a/native/linuxnodeps/build.cake
+++ b/native/linuxnodeps/build.cake
@@ -3,14 +3,14 @@ DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native/linuxn
 
 #load "../../cake/shared.cake"
 
-string VARIANT = BUILD_VARIANT ?? "linuxnodeps";
+var BUILD_VARIANT = Argument("variant", EnvironmentVariable("BUILD_VARIANT") ?? "linuxnodeps");
 
 Task("libSkiaSharp")
     .WithCriteria(IsRunningOnLinux())
     .Does(() =>
 {
     RunCake("../linux/build.cake", "libSkiaSharp", new Dictionary<string, string> {
-        { "variant", VARIANT },
+        { "variant", BUILD_VARIANT },
         { "gnArgs", "skia_use_fontconfig=false" },
     });
 
@@ -25,7 +25,7 @@ Task("libHarfBuzzSharp")
     .Does(() =>
 {
     RunCake("../linux/build.cake", "libHarfBuzzSharp", new Dictionary<string, string> {
-        { "variant", VARIANT },
+        { "variant", BUILD_VARIANT },
     });
 
     RunProcess("ldd", OUTPUT_PATH.CombineWithFilePath($"x64/libHarfBuzzSharp.so").FullPath, out var stdout);

--- a/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
+++ b/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
@@ -44,7 +44,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- harfbuzz.dll and other native files -->
     <file platform="linux" src="runtimes/linux-x64/native/libHarfBuzzSharp.so" />
-    <file platform="linux" src="runtimes/alpine-x64/native/libHarfBuzzSharp.so" />
+    <file platform="linux" src="runtimes/linux-musl-x64/native/libHarfBuzzSharp.so" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/net45/_._" />

--- a/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
+++ b/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
@@ -44,6 +44,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- harfbuzz.dll and other native files -->
     <file platform="linux" src="runtimes/linux-x64/native/libHarfBuzzSharp.so" />
+    <file platform="linux" src="runtimes/alpine-x64/native/libHarfBuzzSharp.so" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/net45/_._" />

--- a/nuget/SkiaSharp.NativeAssets.Linux.NoDependencies.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.NoDependencies.nuspec
@@ -57,6 +57,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="linux" src="runtimes/linuxnodeps-x64/native/libSkiaSharp.so" target="runtimes/linux-x64/native/libSkiaSharp.so" />
+    <file platform="linux" src="runtimes/linuxnodeps-musl-x64/native/libSkiaSharp.so" target="runtimes/linux-musl-x64/native/libSkiaSharp.so" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/net45/_._" />

--- a/nuget/SkiaSharp.NativeAssets.Linux.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.nuspec
@@ -45,6 +45,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="linux" src="runtimes/linux-x64/native/libSkiaSharp.so" />
+    <file platform="linux" src="runtimes/alpine-x64/native/libSkiaSharp.so" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/net45/_._" />

--- a/nuget/SkiaSharp.NativeAssets.Linux.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.nuspec
@@ -45,7 +45,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="linux" src="runtimes/linux-x64/native/libSkiaSharp.so" />
-    <file platform="linux" src="runtimes/alpine-x64/native/libSkiaSharp.so" />
+    <file platform="linux" src="runtimes/linux-musl-x64/native/libSkiaSharp.so" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/net45/_._" />

--- a/scripts/Docker/alpine/amd64/Dockerfile
+++ b/scripts/Docker/alpine/amd64/Dockerfile
@@ -1,0 +1,8 @@
+FROM amd64/alpine:3.9
+
+RUN apk add --no-cache bash curl ca-certificates python git build-base ninja fontconfig-dev
+RUN apk add --no-cache samurai --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache mono clang gn --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN cert-sync /etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /work

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -252,7 +252,7 @@ stages:
       - template: azure-templates-bootstrapper.yml # Build Native Linux [Alpine] (Linux)
         parameters:
           name: native_linux_alpine_linux
-          displayName: Build Native Linux [Alpinr] (Linux)
+          displayName: Build Native Linux [Alpine] (Linux)
           vmImage: $(VM_IMAGE_LINUX)
           docker: scripts/Docker/alpine/amd64
           target: externals-linux

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -249,6 +249,14 @@ stages:
           docker: scripts/Docker/ubuntu16/amd64
           target: externals-linuxnodeps
           additionalArgs: --buildarch=x64
+      - template: azure-templates-bootstrapper.yml # Build Native Linux [Alpine] (Linux)
+        parameters:
+          name: native_linux_alpine_linux
+          displayName: Build Native Linux [Alpinr] (Linux)
+          vmImage: $(VM_IMAGE_LINUX)
+          docker: scripts/Docker/alpine/amd64
+          target: externals-linux
+          additionalArgs: --buildarch=x64 --gn=gn --ninja=ninja --variant=alpine
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Linux)
         parameters:
           name: native_tizen_linux
@@ -316,6 +324,7 @@ stages:
           requiredArtifacts:
             - native_linux_linux
             - native_linux_nodependencies_linux
+            - native_linux_alpine_linux
             - native_tizen_linux
 
   - stage: package
@@ -454,6 +463,7 @@ stages:
           requiredArtifacts:
             - native_linux_linux
             - native_linux_nodependencies_linux
+            - native_linux_alpine_linux
           postBuildSteps:
             - task: PublishTestResults@2
               displayName: Publish the Mono test results
@@ -469,6 +479,7 @@ stages:
                 testResultsFormat: xUnit
                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
                 testRunTitle: 'Linux .NET Core Tests'
+      # TODO: add tests for linux alpine
       # TODO: add tests for linux no dependencies
       # TODO: add tests for windows nano server
 

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -257,6 +257,14 @@ stages:
           docker: scripts/Docker/alpine/amd64
           target: externals-linux
           additionalArgs: --buildarch=x64 --gn=gn --ninja=ninja --variant=alpine
+      - template: azure-templates-bootstrapper.yml # Build Native Linux [Alpine, No Dependencies] (Linux)
+        parameters:
+          name: native_linux_alpinenodependencies_linux
+          displayName: Build Native Linux [Alpine, No Dependencies] (Linux)
+          vmImage: $(VM_IMAGE_LINUX)
+          docker: scripts/Docker/alpine/amd64
+          target: externals-linuxnodeps
+          additionalArgs: --buildarch=x64 --gn=gn --ninja=ninja --variant=alpinenodeps
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Linux)
         parameters:
           name: native_tizen_linux
@@ -324,6 +332,7 @@ stages:
           requiredArtifacts:
             - native_linux_linux
             - native_linux_nodependencies_linux
+            - native_linux_alpinenodependencies_linux
             - native_linux_alpine_linux
             - native_tizen_linux
 
@@ -463,6 +472,7 @@ stages:
           requiredArtifacts:
             - native_linux_linux
             - native_linux_nodependencies_linux
+            - native_linux_alpinenodependencies_linux
             - native_linux_alpine_linux
           postBuildSteps:
             - task: PublishTestResults@2

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -44,7 +44,7 @@ jobs:
       - template: azure-templates-variables.yml
 
       # install any packages on linux
-      - ${{ if endsWith(parameters.name, '_linux') }}:
+      - ${{ if and(eq(parameters.docker, ''), endsWith(parameters.name, '_linux')) }}:
         - bash: |
             sudo apt update
             sudo apt install -y ${{ parameters.packages }}
@@ -52,7 +52,7 @@ jobs:
           condition: ne('${{ parameters.packages }}', '')
 
       # make sure mono/msbuild is the correct version
-      - ${{ if endsWith(parameters.name, '_linux') }}:
+      - ${{ if and(eq(parameters.docker, ''), endsWith(parameters.name, '_linux')) }}:
         - bash: |
             sudo apt remove -y mono-complete msbuild
             sudo apt autoremove -y

--- a/utils/NativeLibraryMiniTest/Program.cs
+++ b/utils/NativeLibraryMiniTest/Program.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Runtime.InteropServices;
+
+using sk_bitmap_t = System.IntPtr;
+using sk_colorspace_t = System.IntPtr;
+using sk_pixmap_t = System.IntPtr;
+using sk_wstream_t = System.IntPtr;
+using sk_wstream_filestream_t = System.IntPtr;
+
+namespace NativeLibraryMiniTest {
+    unsafe class Program {
+        const string SKIA = "libSkiaSharp.so";
+
+        static int Main(string[] args) {
+            Console.WriteLine("Starting test...");
+
+            Console.WriteLine("Color type test...");
+            Console.WriteLine($"sk_colortype_get_default_8888() = {sk_colortype_get_default_8888()}");
+
+            Console.WriteLine("Bitmap create and save test...");
+            var bmp = sk_bitmap_new();
+            var info = new sk_imageinfo_t {
+                width = 100,
+                height = 100,
+                colorType = sk_colortype_get_default_8888(),
+                alphaType = sk_alphatype_t.Premul,
+            };
+            sk_bitmap_try_alloc_pixels_with_flags(bmp, &info, 0);
+            sk_bitmap_erase(bmp, 0xFFFF0000);
+            var pix = sk_pixmap_new();
+            sk_bitmap_peek_pixels(bmp, pix);
+            var stream = sk_filewstream_new("output.png");
+            var opt = new sk_pngencoder_options_t {
+                fFilterFlags = 248,
+                fZLibLevel = 6,
+            };
+            sk_pngencoder_encode(stream, pix, &opt);
+            sk_filewstream_destroy(stream);
+            sk_pixmap_destructor(pix);
+            sk_bitmap_destructor(bmp);
+
+            Console.WriteLine("Test complete.");
+            return 0;
+        }
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern sk_colortype_t sk_colortype_get_default_8888();
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern sk_bitmap_t sk_bitmap_new();
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        static extern bool sk_bitmap_try_alloc_pixels_with_flags(sk_bitmap_t cbitmap, sk_imageinfo_t* requestedInfo, uint flags);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern void sk_bitmap_erase(sk_bitmap_t cbitmap, uint color);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        static extern bool sk_bitmap_peek_pixels(sk_bitmap_t cbitmap, sk_pixmap_t cpixmap);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        static extern bool sk_pngencoder_encode(sk_wstream_t dst, sk_pixmap_t src, void* options);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern void sk_bitmap_destructor(sk_bitmap_t cbitmap);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern sk_pixmap_t sk_pixmap_new();
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern void sk_pixmap_destructor(sk_pixmap_t cpixmap);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern sk_wstream_filestream_t sk_filewstream_new([MarshalAs(UnmanagedType.LPStr)] string path);
+
+        [DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+        static extern void sk_filewstream_destroy(sk_wstream_filestream_t cstream);
+
+        [StructLayout(LayoutKind.Sequential)]
+        unsafe partial struct sk_imageinfo_t {
+            public sk_colorspace_t colorspace;
+            public int width;
+            public int height;
+            public sk_colortype_t colorType;
+            public sk_alphatype_t alphaType;
+        }
+
+        enum sk_colortype_t {
+            Unknown = 0,
+            Rgba8888 = 4,
+            Bgra8888 = 6,
+        }
+
+        enum sk_alphatype_t {
+            Unknown = 0,
+            Opaque = 1,
+            Premul = 2,
+            Unpremul = 3,
+        }
+
+        [StructLayout (LayoutKind.Sequential)]
+        struct sk_pngencoder_options_t {
+            public int fFilterFlags;
+            public int fZLibLevel;
+            public void* fComments;
+        }
+    }
+}

--- a/utils/NativeLibraryMiniTest/build.sh
+++ b/utils/NativeLibraryMiniTest/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+mkdir -p utils/NativeLibraryMiniTest/bin
+csc /out:utils/NativeLibraryMiniTest/bin/Program.exe /unsafe utils/NativeLibraryMiniTest/Program.cs
+cp output/native/linux/x64/libSkiaSharp.so utils/NativeLibraryMiniTest/bin/
+
+(cd utils/NativeLibraryMiniTest/bin && mono Program.exe)


### PR DESCRIPTION
**Description of Change**

Adding a build for Alpine linux.

Builds on Alpine 3.9, tested all the way back to Alpine 3.7.

**Bugs Fixed**

- Related to #453

**API Changes**

None.

**Behavioral Changes**

The *.NativeAssets.Linux NuGet packages will now have an Alpine linux binary.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
