### PR TITLE
Correctly dispose (again) the managed/native object relationship

### DIFF
--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -271,11 +271,11 @@ namespace SkiaSharp
 			if (Interlocked.CompareExchange (ref isDisposed, 1, 0) != 0)
 				return;
 
-			if (Handle != IntPtr.Zero && OwnsHandle)
-				DisposeNative ();
-
 			if (disposing)
 				DisposeManaged ();
+
+			if (Handle != IntPtr.Zero && OwnsHandle)
+				DisposeNative ();
 
 			Handle = IntPtr.Zero;
 		}

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -63,11 +63,22 @@ namespace SkiaSharp
 			}
 		}
 
+		protected override void DisposeUnownedManaged ()
+		{
+			if (ownedObjects != null) {
+				foreach (var child in ownedObjects) {
+					if (child.Value is SKObject c && !c.OwnsHandle)
+						c.DisposeInternal ();
+				}
+			}
+		}
+
 		protected override void DisposeManaged ()
 		{
 			if (ownedObjects != null) {
 				foreach (var child in ownedObjects) {
-					child.Value?.DisposeInternal ();
+					if (child.Value is SKObject c && c.OwnsHandle)
+						c.DisposeInternal ();
 				}
 				ownedObjects.Clear ();
 			}
@@ -256,6 +267,11 @@ namespace SkiaSharp
 
 		protected internal bool IsDisposed => isDisposed == 1;
 
+		protected virtual void DisposeUnownedManaged ()
+		{
+			// dispose of any managed resources that are not actually owned
+		}
+
 		protected virtual void DisposeManaged ()
 		{
 			// dispose of any managed resources
@@ -271,11 +287,17 @@ namespace SkiaSharp
 			if (Interlocked.CompareExchange (ref isDisposed, 1, 0) != 0)
 				return;
 
+			// dispose any objects that are owned/created by native code
 			if (disposing)
-				DisposeManaged ();
+				DisposeUnownedManaged ();
 
+			// destroy the native object
 			if (Handle != IntPtr.Zero && OwnsHandle)
 				DisposeNative ();
+
+			// dispose any remaining managed-created objects
+			if (disposing)
+				DisposeManaged ();
 
 			Handle = IntPtr.Zero;
 		}

--- a/tests/Tests/SKObjectTest.cs
+++ b/tests/Tests/SKObjectTest.cs
@@ -484,5 +484,100 @@ namespace SkiaSharp.Tests
 			public static DelayedDestructionObject GetObject(IntPtr handle, bool owns = true) =>
 				GetOrAddObject(handle, owns, (h, o) => new DelayedDestructionObject(h, o));
 		}
+
+		[SkippableFact]
+		public void ManagedObjectsAreDisposedBeforeNative()
+		{
+			var parent1 = ParentChildWorld.GetParent("Root");
+			var child1 = parent1.Child;
+
+			parent1.Dispose();
+
+			var managedParent = ParentChildWorld.DisposeManagedParent;
+			var managedChild = ParentChildWorld.DisposeManagedChild;
+
+			var nativeParent = ParentChildWorld.DisposeNativeParent;
+			var nativeChild = ParentChildWorld.DisposeNativeChild;
+
+			Assert.True(child1.IsDisposed);
+			Assert.True(parent1.IsDisposed);
+
+			Assert.Equal("DisposeManaged", managedParent.State);
+			Assert.Equal("DisposeManaged", managedChild.State);
+
+			Assert.Equal("DisposeManaged", nativeParent.State);
+			Assert.Equal("DisposeManaged", nativeChild.State);
+
+			managedParent.Dispose();
+			nativeParent.Dispose();
+		}
+
+		private static class ParentChildWorld
+		{
+			public static readonly IntPtr ParentHandle = GetNextPtr();
+			public static readonly IntPtr ChildHandle = GetNextPtr();
+
+			public static ParentObject GetParent(string state) =>
+				SKObject.GetOrAddObject(ParentHandle, (h, o) => new ParentObject(state, h, o));
+
+			public static ParentObject DisposeManagedParent;
+			public static ChildObject DisposeManagedChild;
+
+			public static ParentObject DisposeNativeParent;
+			public static ChildObject DisposeNativeChild;
+		}
+
+		private class ParentObject : SKObject
+		{
+			public ParentObject(string state, IntPtr handle, bool owns)
+				: base(handle, owns)
+			{
+				State = state;
+			}
+
+			public ChildObject Child =>
+				OwnedBy(GetOrAddObject(ParentChildWorld.ChildHandle, false, (h, o) => new ChildObject(State, h, o)), this);
+
+			public string State { get; }
+
+			protected override void DisposeManaged()
+			{
+				base.DisposeManaged();
+
+				if (State == "Root")
+				{
+					ParentChildWorld.DisposeManagedParent = ParentChildWorld.GetParent("DisposeManaged");
+					ParentChildWorld.DisposeManagedChild = ParentChildWorld.DisposeManagedParent.Child;
+				}
+			}
+
+			protected override void DisposeNative()
+			{
+				base.DisposeNative();
+
+				if (State == "Root")
+				{
+					ParentChildWorld.DisposeNativeParent = ParentChildWorld.GetParent("DisposeNative");
+					ParentChildWorld.DisposeNativeChild = ParentChildWorld.DisposeNativeParent.Child;
+				}
+			}
+
+			public override string ToString() =>
+				$"Parent: {State}";
+		}
+
+		private class ChildObject : SKObject
+		{
+			public ChildObject(string state, IntPtr handle, bool owns)
+				: base(handle, owns)
+			{
+				State = state;
+			}
+
+			public string State { get; }
+
+			public override string ToString() =>
+				$"Child: {State}";
+		}
 	}
 }

--- a/tests/Tests/SKObjectTest.cs
+++ b/tests/Tests/SKObjectTest.cs
@@ -493,6 +493,9 @@ namespace SkiaSharp.Tests
 
 			parent1.Dispose();
 
+			var unownedParent = ParentChildWorld.DisposeUnownedManagedParent;
+			var unownedChild =  ParentChildWorld.DisposeUnownedManagedChild;
+
 			var managedParent = ParentChildWorld.DisposeManagedParent;
 			var managedChild = ParentChildWorld.DisposeManagedChild;
 
@@ -502,12 +505,16 @@ namespace SkiaSharp.Tests
 			Assert.True(child1.IsDisposed);
 			Assert.True(parent1.IsDisposed);
 
-			Assert.Equal("DisposeManaged", managedParent.State);
-			Assert.Equal("DisposeManaged", managedChild.State);
+			Assert.Equal("DisposeUnownedManaged", unownedParent.State);
+			Assert.Equal("DisposeUnownedManaged", unownedChild.State);
 
-			Assert.Equal("DisposeManaged", nativeParent.State);
-			Assert.Equal("DisposeManaged", nativeChild.State);
+			Assert.Equal("DisposeUnownedManaged", managedParent.State);
+			Assert.Equal("DisposeUnownedManaged", managedChild.State);
 
+			Assert.Equal("DisposeUnownedManaged", nativeParent.State);
+			Assert.Equal("DisposeUnownedManaged", nativeChild.State);
+
+			unownedParent.Dispose();
 			managedParent.Dispose();
 			nativeParent.Dispose();
 		}
@@ -525,6 +532,9 @@ namespace SkiaSharp.Tests
 
 			public static ParentObject DisposeNativeParent;
 			public static ChildObject DisposeNativeChild;
+
+			public static ParentObject DisposeUnownedManagedParent;
+			public static ChildObject DisposeUnownedManagedChild;
 		}
 
 		private class ParentObject : SKObject
@@ -539,6 +549,17 @@ namespace SkiaSharp.Tests
 				OwnedBy(GetOrAddObject(ParentChildWorld.ChildHandle, false, (h, o) => new ChildObject(State, h, o)), this);
 
 			public string State { get; }
+
+			protected override void DisposeUnownedManaged()
+			{
+				base.DisposeUnownedManaged();
+
+				if (State == "Root")
+				{
+					ParentChildWorld.DisposeUnownedManagedParent = ParentChildWorld.GetParent("DisposeUnownedManaged");
+					ParentChildWorld.DisposeUnownedManagedChild = ParentChildWorld.DisposeUnownedManagedParent.Child;
+				}
+			}
 
 			protected override void DisposeManaged()
 			{


### PR DESCRIPTION
**Description of Change**

This PR fine tunes the disposal steps of a co-owned object pair. There are a few scenarios:

1. A managed creates and owns an underlying native instance. (`SKBitmap`)  
   When the managed object is disposed, destroy the native object.
2. A native object creates a child native object that is managed on the native side. (`SKSurface` controls `SKCanvas`)  
  When then the managed object destroys the native surface, the native canvas is also destroyed. There may be a case where a brand new native canvas is constructed in the same place - before the managed canvas is disposed. We have to make sure that e dispose the managed object before we destroy the native object.
3. A native object "creates" a managed object that is managed from the native side. (`SKSvgCanvas` controls `SKManagedStream`)  
  The managed object creates the native object, but the native object owns the managed object. This means that even when the managed object is disposed, the action is "ignored" and proxied to the native destructor - which will then call back into managed code to dispose the managed object. This is because the native canvas may flush or write closing data into the managed stream.

Scenarios 2 and 3 cause an issue: In one case, the managed `SKCanvas` needs to be destroyed before destroying the native `SkSurface`. On the other hand, the native `SKSvgCanvas` needs to be destroyed before destroying the managed `SKManagedStream`. So which goes first?

The answer is in the ownership of the handle: In scenario 1, the surface owns its handle and the canvas - which does _not_ own its handle. In scenario 2, the canvas owns its handle and the stream - which _does_ own its handle.

This shows that we need to first dispose all the "reference-only" objects - or the ones that do _not_ own their handle. Then dispose the native object. Finally, clean up any managed objects.

**Bugs Fixed**

- Fixes #1343

**API Changes**

None.

**Behavioral Changes**

See description...

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
