### PR TITLE
Add version numbers to native libraries

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -28,6 +28,9 @@ Xamarin.Forms                                   reference   4.4.0.991757
 libSkiaSharp            soname      80.0.0
 HarfBuzz                soname      0.20601.0
 
+# native suffix
+libSkiaSharp            suffix      _80_0
+
 # SkiaSharp.dll
 SkiaSharp               assembly    2.80.0.0
 SkiaSharp               file        2.80.0.0

--- a/binding/Binding/SkiaApi.cs
+++ b/binding/Binding/SkiaApi.cs
@@ -19,7 +19,7 @@ namespace SkiaSharp
 #elif __TIZEN__
 		private const string SKIA = "libSkiaSharp.so";
 #else
-		private const string SKIA = "libSkiaSharp";
+		private const string SKIA = "libSkiaSharp" + VersionConstants.NativeSuffix;
 #endif
 
 #if USE_DELEGATES

--- a/native/linux/build.cake
+++ b/native/linux/build.cake
@@ -36,11 +36,13 @@ Task("libSkiaSharp")
 
         var soname = GetVersion("libSkiaSharp", "soname");
         var map = MakeAbsolute((FilePath)"libSkiaSharp/libSkiaSharp.map");
+        var suffix = GetVersion("libSkiaSharp", "suffix");
 
         GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
             $"target_os='linux' " +
             $"target_cpu='{arch}' " +
             $"is_official_build=true " +
+            $"skiasharp_suffix='{suffix}'" +
             $"skia_enable_gpu={(SUPPORT_GPU ? "true" : "false")} " +
             $"skia_enable_tools=false " +
             $"skia_use_icu=false " +
@@ -61,9 +63,9 @@ Task("libSkiaSharp")
 
         var outDir = OUTPUT_PATH.Combine($"{VARIANT}/{dir}");
         EnsureDirectoryExists(outDir);
-        var so = SKIA_PATH.CombineWithFilePath($"out/{VARIANT}/{arch}/libSkiaSharp.so.{soname}");
+        var so = SKIA_PATH.CombineWithFilePath($"out/{VARIANT}/{arch}/libSkiaSharp{suffix}.so.{soname}");
         CopyFileToDirectory(so, outDir);
-        CopyFile(so, outDir.CombineWithFilePath("libSkiaSharp.so"));
+        CopyFile(so, outDir.CombineWithFilePath($"libSkiaSharp{suffix}.so"));
     }
 });
 

--- a/native/linuxnodeps/build.cake
+++ b/native/linuxnodeps/build.cake
@@ -15,7 +15,8 @@ Task("libSkiaSharp")
         { "gnArgs", "skia_use_fontconfig=false" },
     });
 
-    RunProcess("ldd", OUTPUT_PATH.CombineWithFilePath($"x64/libSkiaSharp.so").FullPath, out var stdout);
+    var suffix = GetVersion("libSkiaSharp", "suffix");
+    RunProcess("ldd", OUTPUT_PATH.CombineWithFilePath($"x64/libSkiaSharp{suffix}.so").FullPath, out var stdout);
 
     if (stdout.Any(o => o.Contains("fontconfig")))
         throw new Exception("libSkiaSharp.so contained a dependency on fontconfig.");

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -24,11 +24,13 @@ Task("libSkiaSharp")
         if (Skip(arch)) return;
 
         var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
+        var suffix = GetVersion("libSkiaSharp", "suffix");
 
         GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
             $"target_os='win'" +
             $"target_cpu='{skiaArch}' " +
             $"is_official_build=true " +
+            $"skiasharp_suffix='{suffix}'" +
             $"skia_enable_fontmgr_win_gdi=false " +
             $"skia_enable_tools=false " +
             $"skia_use_dng_sdk=true " +
@@ -48,8 +50,8 @@ Task("libSkiaSharp")
 
         var outDir = OUTPUT_PATH.Combine($"{VARIANT}/{dir}");
         EnsureDirectoryExists(outDir);
-        CopyFileToDirectory(SKIA_PATH.CombineWithFilePath($"out/{VARIANT}/{arch}/libSkiaSharp.dll"), outDir);
-        CopyFileToDirectory(SKIA_PATH.CombineWithFilePath($"out/{VARIANT}/{arch}/libSkiaSharp.pdb"), outDir);
+        CopyFileToDirectory(SKIA_PATH.CombineWithFilePath($"out/{VARIANT}/{arch}/libSkiaSharp{suffix}.dll"), outDir);
+        CopyFileToDirectory(SKIA_PATH.CombineWithFilePath($"out/{VARIANT}/{arch}/libSkiaSharp{suffix}.pdb"), outDir);
     }
 });
 

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -75,12 +75,22 @@
       <_VersionPackagingGroup>$(PackagingGroup.Split('.')[0])</_VersionPackagingGroup>
       <_VersionAssemblyPattern>^$(_VersionPackagingGroup)\s*assembly\s*(.*)$</_VersionAssemblyPattern>
       <_VersionFilePattern>^$(_VersionPackagingGroup)\s*file\s*(.*)$</_VersionFilePattern>
+      <_NativeSuffixPattern>^lib$(_VersionPackagingGroup)\s*suffix\s*(.*)$</_NativeSuffixPattern>
       <_VersionAssemblyMatch>$([System.Text.RegularExpressions.Regex]::Match($(_VersionTxtContents), $(_VersionAssemblyPattern), System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Multiline).Groups[1].Value.Trim())</_VersionAssemblyMatch>
       <_VersionFileMatch>$([System.Text.RegularExpressions.Regex]::Match($(_VersionTxtContents), $(_VersionFilePattern), System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Multiline).Groups[1].Value.Trim())</_VersionFileMatch>
+      <_NativeSuffixMatch>$([System.Text.RegularExpressions.Regex]::Match($(_VersionTxtContents), $(_NativeSuffixPattern), System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Multiline).Groups[1].Value.Trim())</_NativeSuffixMatch>
       <_VersionGeneratedContents>
 [assembly: System.Reflection.AssemblyVersion("$(_VersionAssemblyMatch)")]
 [assembly: System.Reflection.AssemblyFileVersion("$(_VersionFileMatch)")]
 [assembly: System.Reflection.AssemblyInformationalVersion("$(_VersionFileMatch)$(_VersionGitSha)")]
+
+internal partial class VersionConstants {
+    public const string AssemblyVersion = "$(_VersionAssemblyMatch)"%3B
+    public const string AssemblyFileVersion = "$(_VersionFileMatch)"%3B
+    public const string AssemblyInformationalVersion = "$(_VersionFileMatch)$(_VersionGitSha)"%3B
+    public const string GitSha = "$(_VersionGitSha)"%3B
+    public const string NativeSuffix = "$(_NativeSuffixMatch)"%3B
+}
       </_VersionGeneratedContents>
     </PropertyGroup>
     <WriteLinesToFile Condition=" !Exists('$(_VersionSourceFile)') or '$([System.IO.File]::ReadAllText($(_VersionSourceFile)).Trim())' != '$(_VersionGeneratedContents.Trim())' "


### PR DESCRIPTION
**Description of Change**

Add a "suffix" to library names:

`libSkiaSharp_<milestone>_<skiasharp>.<ext>`

For example for 1.68.3:

`libSkiaSharp_68_3.dll`

And for 2.80.0:

`libSkiaSharp_80_0.dll`

This will avoid the cases when older versions are used with newer apps and causing crashes.

The reason for the 2 numbers only is the way SkiaSharp is versioned:

`<major-change-indicator>.<skia-version>.<skiasharp-version>.<bug-or-packaging-fix>`

So...
- Going from `1.*` to `2.*` is nothing special - except we may have re-written the library (which we haven't actually done because we like backwards compatibility)
- Going from `*.1` to `*.2` means that Google's code is new - and may have behavioral changes (which usually doesn't happen - except for bug fixes)
- Going from `*.*.1` to `*.*.2` means that we did a new API or changed some interop code (and thus ABI breaking)
- Going form `*.*.*.1` to `*.*.*.2` means that there may have been a docs/packaging/managed-only change (and the native library is still the same version)