### PR TITLE
Add snapshots with bounds

### DIFF
--- a/binding/Binding/SKSurface.cs
+++ b/binding/Binding/SKSurface.cs
@@ -312,6 +312,9 @@ namespace SkiaSharp
 		public SKImage Snapshot () =>
 			SKImage.GetObject (SkiaApi.sk_surface_new_image_snapshot (Handle));
 
+		public SKImage Snapshot (SKRectI bounds) =>
+			SKImage.GetObject (SkiaApi.sk_surface_new_image_snapshot_with_crop (Handle, &bounds));
+
 		public void Draw (SKCanvas canvas, float x, float y, SKPaint paint)
 		{
 			if (canvas == null)

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -11073,6 +11073,20 @@ namespace SkiaSharp
 			(sk_surface_new_image_snapshot_delegate ??= GetSymbol<Delegates.sk_surface_new_image_snapshot> ("sk_surface_new_image_snapshot")).Invoke (param0);
 		#endif
 
+		// sk_image_t* sk_surface_new_image_snapshot_with_crop(sk_surface_t* surface, const sk_irect_t* bounds)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_image_t sk_surface_new_image_snapshot_with_crop (sk_surface_t surface, SKRectI* bounds);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_image_t sk_surface_new_image_snapshot_with_crop (sk_surface_t surface, SKRectI* bounds);
+		}
+		private static Delegates.sk_surface_new_image_snapshot_with_crop sk_surface_new_image_snapshot_with_crop_delegate;
+		internal static sk_image_t sk_surface_new_image_snapshot_with_crop (sk_surface_t surface, SKRectI* bounds) =>
+			(sk_surface_new_image_snapshot_with_crop_delegate ??= GetSymbol<Delegates.sk_surface_new_image_snapshot_with_crop> ("sk_surface_new_image_snapshot_with_crop")).Invoke (surface, bounds);
+		#endif
+
 		// sk_surface_t* sk_surface_new_null(int width, int height)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]

--- a/tests/Tests/SKSurfaceTest.cs
+++ b/tests/Tests/SKSurfaceTest.cs
@@ -162,6 +162,95 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[SkippableFact]
+		public void Snapshot()
+		{
+			var info = new SKImageInfo(100, 100);
+			using var surface = SKSurface.Create(info);
+			Assert.NotNull(surface);
+
+			var image = surface.Snapshot();
+			Assert.NotNull(image);
+
+			Assert.Equal(info.Width, image.Width);
+			Assert.Equal(info.Height, image.Height);
+		}
+
+		[SkippableFact]
+		public void SnapshotReturnsSameInstance()
+		{
+			var info = new SKImageInfo(100, 100);
+			using var surface = SKSurface.Create(info);
+			Assert.NotNull(surface);
+
+			var image1 = surface.Snapshot();
+			Assert.NotNull(image1);
+			var image2 = surface.Snapshot();
+			Assert.NotNull(image2);
+
+			Assert.Equal(image1, image2);
+		}
+
+		[SkippableFact]
+		public void SnapshotWithBoundsReturnsSameInstance()
+		{
+			var info = new SKImageInfo(100, 100);
+			using var surface = SKSurface.Create(info);
+			Assert.NotNull(surface);
+
+			var image1 = surface.Snapshot();
+			Assert.NotNull(image1);
+			var image2 = surface.Snapshot(info.Rect);
+			Assert.NotNull(image2);
+
+			Assert.Equal(image1, image2);
+		}
+
+		[SkippableFact]
+		public void SnapshotWithBoundsReturnsDifferentInstance()
+		{
+			var info = new SKImageInfo(100, 100);
+			using var surface = SKSurface.Create(info);
+			Assert.NotNull(surface);
+
+			var image1 = surface.Snapshot();
+			Assert.NotNull(image1);
+			var image2 = surface.Snapshot(new SKRectI(10, 10, 90, 90));
+			Assert.NotNull(image2);
+
+			Assert.NotEqual(image1, image2);
+		}
+
+		[SkippableFact]
+		public void SnapshotWithSameBoundsReturnsSameInstance()
+		{
+			var info = new SKImageInfo(100, 100);
+			using var surface = SKSurface.Create(info);
+			Assert.NotNull(surface);
+
+			var image1 = surface.Snapshot(new SKRectI(10, 10, 90, 90));
+			Assert.NotNull(image1);
+			var image2 = surface.Snapshot(new SKRectI(10, 10, 90, 90));
+			Assert.NotNull(image2);
+
+			Assert.NotEqual(image1, image2);
+		}
+
+		[SkippableFact]
+		public void SnapshotWithDifferentBoundsReturnsDifferentInstance()
+		{
+			var info = new SKImageInfo(100, 100);
+			using var surface = SKSurface.Create(info);
+			Assert.NotNull(surface);
+
+			var image1 = surface.Snapshot(new SKRectI(10, 20, 90, 90));
+			Assert.NotNull(image1);
+			var image2 = surface.Snapshot(new SKRectI(10, 10, 80, 90));
+			Assert.NotNull(image2);
+
+			Assert.NotEqual(image1, image2);
+		}
+
 		[Obsolete]
 		[SkippableFact]
 		public void SimpleSurfaceWithPropsIsCorrect()


### PR DESCRIPTION
**Description of Change**

Add an overload to `SKSurface.Snapshot()` that takes a bounds rect.

**Bugs Fixed**

- Related to issue #1334
