### PR TITLE
SkiaSharpSample project now default startup project in the WPF SkiaSharpSample solution

### DIFF
--- a/samples/Gallery/WPF/SkiaSharpSample.sln
+++ b/samples/Gallery/WPF/SkiaSharpSample.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29027.242
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharpSample", "SkiaSharpSample\SkiaSharpSample.csproj", "{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp", "..\..\..\binding\SkiaSharp\SkiaSharp.csproj", "{EB1BBDCC-FB07-40D5-8B9E-0079E2C2F2DF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Views.WPF", "..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.WPF\SkiaSharp.Views.WPF.csproj", "{743CF830-D458-41A9-865A-F85126562015}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HarfBuzzSharp", "..\..\..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj", "{2AE5D8C5-EAC6-4515-89F2-A4994B41C925}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaSharpSample", "SkiaSharpSample\SkiaSharpSample.csproj", "{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.HarfBuzz", "..\..\..\source\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz.csproj", "{156FADFB-602E-4658-A235-D4D24CD46F09}"
 EndProject


### PR DESCRIPTION
**Description of Change**

In the `samples\Gallery\WPF\SkiaSharpSample.sln` solution, I made the `SkiaSharpSample` project the default startup project by listing it first in the sln file.

**API Changes**

None

**Behavioral Changes**

No runtime changes.

This change improves the development experience.  When first cloning the repo or after deleting the `samples\Gallery\WPF\.vs` folder and then opening `samples\Gallery\WPF\SkiaSharpSample.sln` with Visual Studio, the default startup project will now be the `SkiaSharpSample` project.  This is an improvement because it is the only project that can be started.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [NA] Updated documentation
