### PR TITLE
Handle a crash when the Apple views are 0x0 or 1x1

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
@@ -101,6 +101,10 @@ namespace SkiaSharp.Views.iOS
 				context = GRContext.CreateGl(glInterface);
 			}
 
+			// it was not possible to access the context, so wait for a redraw
+			if (context == null)
+				return;	
+
 			// get the new surface size
 			var newSize = new SKSizeI((int)DrawableWidth, (int)DrawableHeight);
 


### PR DESCRIPTION
**Description of Change**

Sometimes in Xamarin.Forms, the view is added to the hierarchy at a 1x1 or invisible. This results in the view trying to draw, but actually not a valid GL context yet.

Detect this when the GRContext cannot be created and wait for the next render. We are not losing any data, because the view is hidden or 1x1. 
