### PR TITLE
Explicitly request GL ES 3.x in case we have it

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/Interop/Evas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/Interop/Evas.cs
@@ -18,6 +18,9 @@ namespace SkiaSharp.Views.Tizen.Interop
 		internal static extern IntPtr evas_gl_context_create(IntPtr evas_gl, IntPtr share_ctx);
 
 		[DllImport(Libraries.Evas)]
+		internal static extern IntPtr evas_gl_context_version_create(IntPtr evas_gl, IntPtr share_ctx, GLContextVersion version);
+
+		[DllImport(Libraries.Evas)]
 		internal static extern void evas_gl_context_destroy(IntPtr evas_gl, IntPtr ctx);
 
 		[DllImport(Libraries.Evas)]
@@ -39,6 +42,14 @@ namespace SkiaSharp.Views.Tizen.Interop
 		[DllImport(Libraries.Evas)]
 		[return: MarshalAs(UnmanagedType.U1)]
 		internal static extern bool evas_gl_make_current(IntPtr evas_gl, IntPtr surf, IntPtr ctx);
+
+		internal enum GLContextVersion
+		{
+			EVAS_GL_GLES_1_X = 1,  // OpenGL-ES 1.x
+			EVAS_GL_GLES_2_X = 2,  // OpenGL-ES 2.x (default)
+			EVAS_GL_GLES_3_X = 3,  // OpenGL-ES 3.x (since 2.4)
+			EVAS_GL_DEBUG = 0x1000 // Enable debug mode on this context (see GL_KHR_debug) (since 4.0)
+		}
 
 		internal struct Config
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKGLSurfaceView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKGLSurfaceView.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using ElmSharp;
 using SkiaSharp.Views.GlesInterop;
 using SkiaSharp.Views.Tizen.Interop;
+using Tizen;
 
 namespace SkiaSharp.Views.Tizen
 {
@@ -61,8 +62,22 @@ namespace SkiaSharp.Views.Tizen
 				glConfigPtr = Marshal.AllocHGlobal(Marshal.SizeOf(glConfig));
 				Marshal.StructureToPtr(glConfig, glConfigPtr, false);
 
-				// initialize the context
-				glContext = Evas.evas_gl_context_create(glEvas, IntPtr.Zero);
+				// try initialize the context with Open GL ES 3.x first
+				glContext = Evas.evas_gl_context_version_create(glEvas, IntPtr.Zero, Evas.GLContextVersion.EVAS_GL_GLES_3_X);
+
+				// if we could not get 3.x, try 2.x
+				if (glContext == IntPtr.Zero)
+				{
+					Log.Debug("SKGLSurfaceView", "OpenGL ES 3.x was not available, trying 2.x.");
+					glContext = Evas.evas_gl_context_version_create(glEvas, IntPtr.Zero, Evas.GLContextVersion.EVAS_GL_GLES_2_X);
+				}
+
+				// if that is not available, the default
+				if (glContext == IntPtr.Zero)
+				{
+					Log.Debug("SKGLSurfaceView", "OpenGL ES 2.x was not available, trying the default.");
+					glContext = Evas.evas_gl_context_create(glEvas, IntPtr.Zero);
+				}
 			}
 		}
 
@@ -139,9 +154,15 @@ namespace SkiaSharp.Views.Tizen
 				Gles.glViewport(0, 0, surfaceSize.Width, surfaceSize.Height);
 
 				// create the interface using the function pointers provided by the EFL
-				var glInterface = GRGlInterface.CreateEvas(glEvas);
+				var glInterface = GRGlInterface.CreateEvas(glEvas, glContext);
+				if (glInterface == null)
+					Log.Error("SKGLSurfaceView", "Unable to create GRGlInterface.");
+				if (!glInterface.Validate())
+					Log.Error("SKGLSurfaceView", "The created GRGlInterface was not valid.");
 				context?.Dispose();
 				context = GRContext.CreateGl(glInterface);
+				if (context == null)
+					Log.Error("SKGLSurfaceView", "Unable to create the GRContext.");
 
 				// create the render target
 				renderTarget?.Dispose();


### PR DESCRIPTION
**Description of Change**

This actually "hides" an "issue" with the GL process. If we use the "default" APIs, then it explicitly requests a OpenGL ES 2.0 context. Then SkiaSharp will ask the API what version - which is actually 3.1 (at least on my watch), so then skia tries to set up a 3.x context, but only has the 2.x API.

We _could_ override/intercept the `glGetString(GL_VERSION)` call, but that is work. Also, we want new things. So, we first request a 3.x, then 2.x and _then_ get the default. Since 3.x came with Tizen 4.0+, we should _always_ be getting a 3.x context. Not only do we avoid this issue, but also get a newer context.

**Bugs Fixed**

 - `SKGLView` crashes on the watch.

**API Changes**


```csharp
public static GRGlInterface CreateEvas (IntPtr evas, IntPtr evasGlContext);
```

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
