### PR TITLE
SKTypeface does not count bytes but glyphs

### DIFF
--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -287,10 +287,10 @@ namespace SkiaSharp
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CountGlyphs(IntPtr, int, SKTextEncoding) instead.")]
 		public int CountGlyphs (IntPtr str, int strLen, SKEncoding encoding) =>
-			GetFont ().CountGlyphs (str, strLen, encoding.ToTextEncoding ());
+			CountGlyphs (str, strLen, encoding.ToTextEncoding ());
 
 		public int CountGlyphs (IntPtr str, int strLen, SKTextEncoding encoding) =>
-			GetFont ().CountGlyphs (str, strLen, encoding);
+			GetFont ().CountGlyphs (str, strLen * encoding.GetCharacterByteSize (), encoding);
 
 		// GetGlyph (int)
 
@@ -386,7 +386,7 @@ namespace SkiaSharp
 		public ushort[] GetGlyphs (IntPtr text, int length, SKTextEncoding encoding)
 		{
 			using var font = ToFont ();
-			return font.GetGlyphs (text, length, encoding);
+			return font.GetGlyphs (text, length * encoding.GetCharacterByteSize (), encoding);
 		}
 
 		// ContainsGlyph
@@ -406,10 +406,10 @@ namespace SkiaSharp
 			GetFont ().ContainsGlyphs (text);
 
 		public bool ContainsGlyphs (ReadOnlySpan<byte> text, SKTextEncoding encoding) =>
-			GetFont ().ContainsGlyphs (text, encoding);
+			ContainsGlyphs (text, encoding);
 
 		public bool ContainsGlyphs (IntPtr text, int length, SKTextEncoding encoding) =>
-			GetFont ().ContainsGlyphs (text, length, encoding);
+			GetFont ().ContainsGlyphs (text, length * encoding.GetCharacterByteSize (), encoding);
 
 		// GetFont
 

--- a/binding/Binding/Util.cs
+++ b/binding/Binding/Util.cs
@@ -90,6 +90,17 @@ namespace SkiaSharp
 				_ => throw new ArgumentOutOfRangeException (nameof (encoding), $"Encoding {encoding} is not supported.")
 			};
 
+		// GetCharacterByteSize
+
+		internal static int GetCharacterByteSize (this SKTextEncoding encoding) =>
+			encoding switch
+			{
+				SKTextEncoding.Utf8 => 1,
+				SKTextEncoding.Utf16 => 2,
+				SKTextEncoding.Utf32 => 4,
+				_ => throw new ArgumentOutOfRangeException (nameof (encoding), $"Encoding {encoding} is not supported.")
+			};
+
 		// GetUnicodeCharacterCode
 
 		public static int GetUnicodeCharacterCode (string character, SKTextEncoding encoding)

--- a/tests/Tests/SKFontTest.cs
+++ b/tests/Tests/SKFontTest.cs
@@ -32,6 +32,23 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public unsafe void UnicharCountReturnsCorrectCount()
+		{
+			var text = new uint[] { 79 };
+			var count = text.Length * sizeof(uint);
+
+			using var font = new SKFont();
+
+			fixed (uint* t = text)
+			{
+				Assert.Equal(1, font.CountGlyphs((IntPtr)t, count, SKTextEncoding.Utf32));
+
+				var glyphs = font.GetGlyphs((IntPtr)t, count, SKTextEncoding.Utf32);
+				Assert.Single(glyphs);
+			}
+		}
+
+		[SkippableFact]
 		public void CountGlyphsReturnsTheCorrectNumberOfGlyphsForEmtptyString()
 		{
 			using var font = new SKFont();

--- a/tests/Tests/SKTypefaceTest.cs
+++ b/tests/Tests/SKTypefaceTest.cs
@@ -196,6 +196,23 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public unsafe void UnicharCountReturnsCorrectCount()
+		{
+			var text = new uint[] { 79 };
+			var count = text.Length;
+
+			var typeface = SKTypeface.Default;
+
+			fixed (uint* t = text)
+			{
+				Assert.Equal(1, typeface.CountGlyphs((IntPtr)t, count, SKTextEncoding.Utf32));
+
+				var glyphs = typeface.GetGlyphs((IntPtr)t, count, SKTextEncoding.Utf32);
+				Assert.Single(glyphs);
+			}
+		}
+
+		[SkippableFact]
 		public void PlainGlyphsReturnsTheCorrectNumberOfCharacters()
 		{
 			const string text = "Hello World!";


### PR DESCRIPTION
**Description of Change**

Historically, SkTypeface.charsToGlyphs assumed the data was already in glyphs. So a UTF32 data array would pass the number of glyphs. Since that method was removed, we switched to SkFont.textToGlyphs. This worked in bytes. As a result, we need to make sure we convert from glyph count to byte count when we use it.

**Bugs Fixed**

- Fixes #1398

**API Changes**

None.

**Behavioral Changes**

`SKTypeface.GetGlyphs` now correctly passes the byte size to the font.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
