### PR TITLE
[FEATURE] Passing --configuration=debug to the bootstrapper should generate a debug build

### DIFF
--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -25,11 +25,12 @@ Task("libSkiaSharp")
         if (Skip(arch)) return;
 
         var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
+        var official = CONFIGURATION.Equals("debug", StringComparison.OrdinalIgnoreCase) ? "false" : "true";
 
         GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
             $"target_os='win'" +
             $"target_cpu='{skiaArch}' " +
-            $"is_official_build=true " +
+            $"is_official_build={official} " +
             $"skia_enable_fontmgr_win_gdi=false " +
             $"skia_enable_tools=false " +
             $"skia_use_dng_sdk=true " +


### PR DESCRIPTION
**Description of Change**

Passing `--configuration=debug` to the bootstrapper now generates a debug build

**Bugs Fixed**

- Related to issue #1402 

**API Changes**

none

**Behavioral Changes**

Passing `--configuration=debug` to the bootstrapper now generates a debug build

**PR Checklist**

- [n] Has tests (if omitted, state reason in description)
- [y] Rebased on top of master at time of PR
- [y] Changes adhere to coding standard
- [n] Updated documentation
