### PR TITLE
Allow building just a single external

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,9 @@ DirectoryPath ROOT_PATH = MakeAbsolute(Directory("."));
 #load "cake/native-shared.cake"
 
 var SKIP_EXTERNALS = Argument ("skipexternals", "")
-    .ToLower ().Split (new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+    .ToLower ().Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+var JUST_EXTERNALS = Argument ("justexternals", "")
+    .ToLower ().Split (new [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 var PACK_ALL_PLATFORMS = Argument ("packall", Argument ("PackAllPlatforms", false));
 var BUILD_ALL_PLATFORMS = Argument ("buildall", Argument ("BuildAllPlatforms", false));
 var PRINT_ALL_ENV_VARS = Argument ("printAllEnvVars", false);

--- a/cake/externals.cake
+++ b/cake/externals.cake
@@ -84,5 +84,8 @@ bool ShouldBuildExternal(string platform)
     if (SKIP_EXTERNALS.Contains(platform))
         return false;
 
+    if (JUST_EXTERNALS.Length > 0)
+        return JUST_EXTERNALS.Contains(platform);
+
     return true;
 }


### PR DESCRIPTION
**Description of Change**

Passing `-justExternals=windows` to the bootstrapper just builds that external.

**Bugs Fixed**

- Related to issue #1403 

This also replaces the `,` separator with `;` for `--skipExternals`, since `,` didn't work at all, at least on Windows. See note in issue #1403. Maybe I should have created another issue for that 😉 

**API Changes**

none

**Behavioral Changes**

Passing multiple externals to `--skipExternals` separated by semicolons now works.

**PR Checklist**

- [n] Has tests (if omitted, state reason in description)
- [y] Rebased on top of master at time of PR
- [y] Changes adhere to coding standard
- [n] Updated documentation
