### PR TITLE
SKCanvas.DrawTextOnPath can throw NullReferenceException

### DIFF
--- a/binding/Binding/SKFont.cs
+++ b/binding/Binding/SKFont.cs
@@ -876,9 +876,10 @@ namespace SkiaSharp
 				if (x1 >= 0 && x0 <= contourLength) {
 					var glyphId = glyphs[index];
 					var glyphPath = glyphPathCache.GetPath (glyphId);
-
-					var transformation = SKMatrix.CreateTranslation (x0, glyphOffset.Y);
-					MorphPath (textPath, glyphPath, pathMeasure, transformation);
+					if (glyphPath != null) {
+						var transformation = SKMatrix.CreateTranslation (x0, glyphOffset.Y);
+						MorphPath (textPath, glyphPath, pathMeasure, transformation);
+					}
 				}
 			}
 
@@ -991,7 +992,7 @@ namespace SkiaSharp
 			public void Dispose ()
 			{
 				foreach (var path in Values) {
-					path.Dispose ();
+					path?.Dispose ();
 				}
 				Clear ();
 			}


### PR DESCRIPTION
**Description of Change**

`SKFont.GetGlyphPath` (native code `SkFont::getPath`) can return `null`.

I didn't take that into account.

**Bugs Fixed**

- Related to issue #1408 

I still don't know why `DrawTextOnPath` fails on iOS, but the code should handle the `null` case anyway. Hard for me to debug without an iOS device.

**API Changes**

None

**Behavioral Changes**

`DrawTextOnPath` doesn't throw a `NullReferenceException` when `SKFont.GetGlyphPath` returns `null`

**PR Checklist**

- [n] Has tests (if omitted, state reason in description)
- [y] Rebased on top of master at time of PR
- [y] Changes adhere to coding standard
- [n] Updated documentation

I wasn't able to write a unit test, because I couldn't find a single font for which `SKFont.GetGlyphPath` returns `null`.

However, I could include the test, but that is only usefull if the unit tests also run on iOS...

