### PR TITLE
Fix issue when creating SKData from a non-seekable stream

### DIFF
--- a/binding/Binding/SKData.cs
+++ b/binding/Binding/SKData.cs
@@ -97,7 +97,15 @@ namespace SkiaSharp
 		{
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
-			return Create (stream, stream.Length);
+			if (stream.CanSeek) {
+				return Create (stream, stream.Length);
+			} else {
+				using var memory = new SKDynamicMemoryWStream ();
+				using (var managed = new SKManagedStream (stream)) {
+					managed.CopyTo (memory);
+				}
+				return memory.DetachAsData ();
+			}
 		}
 
 		public static SKData Create (Stream stream, int length)

--- a/tests/Tests/SKDataTest.cs
+++ b/tests/Tests/SKDataTest.cs
@@ -133,6 +133,16 @@ namespace SkiaSharp.Tests
 			Assert.True(released, "The SKDataReleaseDelegate was not called.");
 		}
 
+		[SkippableFact]
+		public void CanCreateFromNonSeekable()
+		{
+			using var stream = File.OpenRead(Path.Combine(PathToImages, "baboon.png"));
+			using var nonSeekable = new NonSeekableReadOnlyStream(stream);
+			using var data = SKData.Create(nonSeekable);
+
+			Assert.NotNull(data);
+		}
+
 		[SkippableFact(Skip = "Doesn't work as it relies on memory being overwritten by an external process.")]
 		public void DataDisposedReturnsInvalidStream()
 		{


### PR DESCRIPTION
**Description of Change**

`SKData.Create(Stream)` throws when the stream is non-seekable. This is because we need the length before we can allocate memory. And, we can't get the length.

So, we create a copy of the stream, get the length and then allocate the memory. 

> It is a double copy, but that is unfortunately what we need to do.

**Bugs Fixed**

None.

**API Changes**

None.