### PR TITLE
Move the WASM view into a separate package

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -20,7 +20,7 @@ AtkSharp                                        release     3.22.24.37
 System.Memory                                   release     4.5.3
 System.IO.UnmanagedMemoryStream                 release     4.3.0
 SharpVk                                         release     0.4.2
-Uno.UI                                          release     2.0.532
+Uno.UI                                          release     2.4.4
 
 # additional references used by the tooling
 OpenTK.GLControl                                reference   1.1.2349.61993
@@ -61,6 +61,7 @@ SkiaSharp.Views.Forms                           nuget       2.80.2
 SkiaSharp.Views.Forms.WPF                       nuget       2.80.2
 SkiaSharp.Views.Forms.GTK                       nuget       2.80.2
 SkiaSharp.Views.Uno                             nuget       2.80.2
+SkiaSharp.Views.Uno.WebAssembly                 nuget       2.80.2
 SkiaSharp.HarfBuzz                              nuget       2.80.2
 SkiaSharp.Vulkan.SharpVk                        nuget       2.80.2
 HarfBuzzSharp                                   nuget       2.6.1.6

--- a/build.cake
+++ b/build.cake
@@ -71,6 +71,7 @@ var TRACKED_NUGETS = new Dictionary<string, Version> {
     { "SkiaSharp.Views.Forms.WPF",                     new Version (1, 57, 0) },
     { "SkiaSharp.Views.Forms.GTK",                     new Version (1, 57, 0) },
     { "SkiaSharp.Views.Uno",                           new Version (1, 57, 0) },
+    { "SkiaSharp.Views.Uno.WebAssembly",               new Version (1, 57, 0) },
     { "HarfBuzzSharp",                                 new Version (1, 0, 0) },
     { "HarfBuzzSharp.NativeAssets.Linux",              new Version (1, 0, 0) },
     { "SkiaSharp.HarfBuzz",                            new Version (1, 57, 0) },

--- a/cake/UpdateDocs.cake
+++ b/cake/UpdateDocs.cake
@@ -199,8 +199,8 @@ Task ("docs-update-frameworks")
     // generate the temp frameworks.xml
     var xFrameworks = new XElement ("Frameworks");
     foreach (var id in TRACKED_NUGETS.Keys) {
-        // skip doc generatgion for Uno, this is the same as UWP and it is not needed
-        if (id == "SkiaSharp.Views.Uno")
+        // skip doc generation for Uno, this is the same as UWP and it is not needed
+        if (id.StartsWith ("SkiaSharp.Views.Uno"))
             continue;
 
         // get the versions

--- a/nuget/SkiaSharp.Views.Uno.WebAssembly.nuspec
+++ b/nuget/SkiaSharp.Views.Uno.WebAssembly.nuspec
@@ -3,7 +3,7 @@
   <metadata>
 
     <!-- package -->
-    <id>SkiaSharp.Views.Uno</id>
+    <id>SkiaSharp.Views.Uno.WebAssembly</id>
     <title>SkiaSharp for Uno Platform</title>
     <version>1.0.0</version>
     <description>
@@ -28,23 +28,9 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <dependencies>
       <group targetFramework="netstandard2.0">
-      </group>
-      <group targetFramework="monoandroid1.0">
         <dependency id="Uno.UI" version="2.4.4" />
         <dependency id="SkiaSharp" version="1.0.0" />
-      </group>
-      <group targetFramework="xamarinios1.0">
-        <dependency id="Uno.UI" version="2.4.4" />
-        <dependency id="SkiaSharp" version="1.0.0" />
-      </group>
-      <group targetFramework="xamarinmac2.0">
-        <dependency id="Uno.UI" version="2.4.4" />
-        <dependency id="SkiaSharp" version="1.0.0" />
-      </group>
-      <group targetFramework="uap10.0">
-        <dependency id="Uno.UI" version="2.4.4" />
-        <dependency id="SkiaSharp" version="1.0.0" />
-        <dependency id="SkiaSharp.Views" version="1.0.0" />
+        <dependency id="SkiaSharp.NativeAssets.WebAssembly" version="1.0.0" />
       </group>
     </dependencies>
 
@@ -52,14 +38,11 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
   <files>
 
     <!-- SkiaSharp.Views.UWP.dll -->
-    <file src="lib/netstandard2.0/_._" />
-    <file platform="macos,windows" src="lib/monoandroid1.0/SkiaSharp.Views.UWP.dll" />
-    <file platform="macos,windows" src="lib/monoandroid1.0/SkiaSharp.Views.UWP.xml" />
-    <file platform="macos" src="lib/xamarinios1.0/SkiaSharp.Views.UWP.dll" />
-    <file platform="macos" src="lib/xamarinios1.0/SkiaSharp.Views.UWP.xml" />
-    <file platform="macos" src="lib/xamarinmac2.0/SkiaSharp.Views.UWP.dll" />
-    <file platform="macos" src="lib/xamarinmac2.0/SkiaSharp.Views.UWP.xml" />
-    <file src="_._" target="lib/uap10.0/_._" />
+    <file src="lib/netstandard2.0/SkiaSharp.Views.UWP.dll" />
+    <file src="lib/netstandard2.0/SkiaSharp.Views.UWP.xml" />
+
+    <!-- the build bits -->
+    <file src="build/netstandard2.0/SkiaSharp.Views.Uno.WebAssembly.targets" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/samples/Basic/Uno/SkiaSharpSample.Android/SkiaSharpSample.Android.csproj
+++ b/samples/Basic/Uno/SkiaSharpSample.Android/SkiaSharpSample.Android.csproj
@@ -56,8 +56,8 @@
     <Reference Include="Mono.Android.Export" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.4.0" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/samples/Basic/Uno/SkiaSharpSample.Wasm/SkiaSharpSample.Wasm.csproj
+++ b/samples/Basic/Uno/SkiaSharpSample.Wasm/SkiaSharpSample.Wasm.csproj
@@ -24,11 +24,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Uno.UI" Version="2.4.4" />
-  </ItemGroup>
-  <!-- workaround for https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/253 -->
-  <ItemGroup Condition=" '$(WasmShellForceDisableWSL)' != 'true' ">
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.9" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.9" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.12" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />
@@ -40,5 +37,5 @@
     <EmbeddedResource Include="WasmScripts\*.js" />
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
-  <Import Project="..\..\..\..\output\SkiaSharp.Views.Uno\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets" Condition="Exists('..\..\..\..\output\SkiaSharp.Views.Uno\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets')" />
+  <Import Project="..\..\..\..\output\SkiaSharp.Views.Uno.WebAssembly\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.WebAssembly.targets" Condition="Exists('..\..\..\..\output\SkiaSharp.Views.Uno.WebAssembly\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.WebAssembly.targets')" />
 </Project>

--- a/samples/Basic/Uno/SkiaSharpSample.iOS/SkiaSharpSample.iOS.csproj
+++ b/samples/Basic/Uno/SkiaSharpSample.iOS/SkiaSharpSample.iOS.csproj
@@ -95,8 +95,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.4.0" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/samples/Basic/Uno/SkiaSharpSample.macOS/SkiaSharpSample.macOS.csproj
+++ b/samples/Basic/Uno/SkiaSharpSample.macOS/SkiaSharpSample.macOS.csproj
@@ -41,8 +41,8 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.4.0" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/samples/Gallery/Uno/SkiaSharpSample.Android/SkiaSharpSample.Android.csproj
+++ b/samples/Gallery/Uno/SkiaSharpSample.Android/SkiaSharpSample.Android.csproj
@@ -57,8 +57,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials" Version="1.5.1" />
-    <PackageReference Include="Uno.UI" Version="2.4.0" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />

--- a/samples/Gallery/Uno/SkiaSharpSample.Wasm/SkiaSharpSample.Wasm.csproj
+++ b/samples/Gallery/Uno/SkiaSharpSample.Wasm/SkiaSharpSample.Wasm.csproj
@@ -24,11 +24,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Uno.UI" Version="2.4.4" />
-  </ItemGroup>
-  <!-- workaround for https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/253 -->
-  <ItemGroup Condition=" '$(WasmShellForceDisableWSL)' != 'true' ">
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.9" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.9" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.12" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />
@@ -40,5 +38,5 @@
     <EmbeddedResource Include="WasmScripts\*.js" />
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
-  <Import Project="..\..\..\..\output\SkiaSharp.Views.Uno\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets" Condition="Exists('..\..\..\..\output\SkiaSharp.Views.Uno\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets')" />
+  <Import Project="..\..\..\..\output\SkiaSharp.Views.Uno.WebAssembly\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.WebAssembly.targets" Condition="Exists('..\..\..\..\output\SkiaSharp.Views.Uno.WebAssembly\nuget\build\netstandard2.0\SkiaSharp.Views.Uno.WebAssembly.targets')" />
 </Project>

--- a/samples/Gallery/Uno/SkiaSharpSample.iOS/SkiaSharpSample.iOS.csproj
+++ b/samples/Gallery/Uno/SkiaSharpSample.iOS/SkiaSharpSample.iOS.csproj
@@ -101,8 +101,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials" Version="1.5.1" />
-    <PackageReference Include="Uno.UI" Version="2.4.0" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/samples/Gallery/Uno/SkiaSharpSample.macOS/SkiaSharpSample.macOS.csproj
+++ b/samples/Gallery/Uno/SkiaSharpSample.macOS/SkiaSharpSample.macOS.csproj
@@ -42,8 +42,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials" Version="1.5.1" />
-    <PackageReference Include="Uno.UI" Version="2.4.0" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.4.4" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
   </ItemGroup>

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Android/SkiaSharp.Views.Uno.Android.csproj
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Android/SkiaSharp.Views.Uno.Android.csproj
@@ -8,7 +8,7 @@
     <PackagingPlatform>monoandroid1.0</PackagingPlatform>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.532" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.Android\SkiaSharp.Android.csproj" />

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Mac/SkiaSharp.Views.Uno.Mac.csproj
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Mac/SkiaSharp.Views.Uno.Mac.csproj
@@ -8,7 +8,7 @@
     <DefineConstants>$(DefineConstants);__MACOS__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.532" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.OSX\SkiaSharp.OSX.csproj" />

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SkiaSharp.Views.Uno.Wasm.csproj
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SkiaSharp.Views.Uno.Wasm.csproj
@@ -4,17 +4,18 @@
     <RootNamespace>SkiaSharp.Views.UWP</RootNamespace>
     <AssemblyName>SkiaSharp.Views.UWP</AssemblyName>
     <SignAssembly>false</SignAssembly>
-    <PackagingGroup>SkiaSharp.Views.Uno</PackagingGroup>
+    <PackagingGroup>SkiaSharp.Views.Uno.WebAssembly</PackagingGroup>
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.532" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets" Link="nuget\build\$(PackagingPlatform)\SkiaSharp.Views.Uno.targets" />
+    <None Remove="nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets" />
+    <None Include="nuget\build\netstandard2.0\SkiaSharp.Views.Uno.targets" Link="nuget\build\$(PackagingPlatform)\SkiaSharp.Views.Uno.WebAssembly.targets" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SkiaSharp.Views\SkiaSharp.Views.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.iOS/SkiaSharp.Views.Uno.iOS.csproj
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.iOS/SkiaSharp.Views.Uno.iOS.csproj
@@ -7,7 +7,7 @@
     <PackagingGroup>SkiaSharp.Views.Uno</PackagingGroup>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="2.0.532" />
+    <PackageReference Include="Uno.UI" Version="2.4.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp.iOS\SkiaSharp.iOS.csproj" />

--- a/tests/SkiaSharp.Wasm.Tests/SkiaSharp.Wasm.Tests.csproj
+++ b/tests/SkiaSharp.Wasm.Tests/SkiaSharp.Wasm.Tests.csproj
@@ -16,8 +16,8 @@
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.9" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.9" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.12" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.12" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />

--- a/utils/NativeLibraryMiniTest/wasm/NativeLibraryMiniTest.csproj
+++ b/utils/NativeLibraryMiniTest/wasm/NativeLibraryMiniTest.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.9" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.9" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.4.0-dev.12" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.4.0-dev.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Description of Change**

Move the WASM view into a separate package: `SkiaSharp.Views.Uno.WebAssembly`
- v3 of Uno will do this, so better to do it now and not break people later
- update to the latest v2 for now
- update the bootstrapper

**Bugs Fixed**

- Related to issue #1420 
- Related to issue #1396 
- Related to issue #1333 

**API Changes**

None.

**Behavioral Changes**

The WASM controls for Uno are now in a new package: `SkiaSharp.Views.Uno.WebAssembly`

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
