### PR TITLE
Can't share encoded data if we have any modifiers

### DIFF
--- a/tests/Tests/SKImageTest.cs
+++ b/tests/Tests/SKImageTest.cs
@@ -819,6 +819,37 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[SkippableTheory]
+		[InlineData(0f, 0f, 0f, 0f)]
+		[InlineData(0f, 0f, 1f, 1f)]
+		[InlineData(0.5f, 0.5f, 1f, 1f)]
+		public void SubsetEncodesSubset(float xRatio, float yRatio, float wRatio, float hRatio)
+		{
+			var path = Path.Combine(PathToImages, "baboon.jpg");
+			using var image = SKImage.FromEncodedData(path);
+			var width = image.Width;
+			var height = image.Height;
+
+			var rect = new SKRectI(0, 0, width, height);
+			var subset = image;
+			if (xRatio != 0 || yRatio != 0 || wRatio != 0 || hRatio != 0)
+			{
+				var floatingRect = new SKRect(width * xRatio, height * yRatio, width * wRatio, height * hRatio);
+				rect = SKRectI.Round(floatingRect);
+				subset = image.Subset(rect);
+			}
+
+			using var encoded = subset.Encode();
+			using var img2 = SKImage.FromEncodedData(encoded);
+
+			Assert.Equal(rect.Width, img2.Width);
+			Assert.Equal(rect.Height, img2.Height);
+
+			var subsetPixels = subset.ToRasterImage(true).PeekPixels().GetPixelSpan();
+			var img2Pixels = img2.ToRasterImage(true).PeekPixels().GetPixelSpan();
+			Assert.Equal(subsetPixels.ToArray(), img2Pixels.ToArray());
+		}
+
 		[Obsolete]
 		[SkippableFact]
 		public void EncodeWithSimpleSerializer()

--- a/tests/Tests/SKTest.cs
+++ b/tests/Tests/SKTest.cs
@@ -51,6 +51,24 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		protected static void SaveImage(SKImage img, string filename = "output.png")
+		{
+			using (var bitmap = new SKBitmap(img.Width, img.Height))
+			using (var canvas = new SKCanvas(bitmap))
+			{
+				canvas.Clear(SKColors.Transparent);
+				canvas.DrawImage(img, 0, 0);
+				canvas.Flush();
+
+				using (var stream = File.OpenWrite(Path.Combine(PathToImages, filename)))
+				using (var image = SKImage.FromBitmap(bitmap))
+				using (var data = image.Encode())
+				{
+					data.SaveTo(stream);
+				}
+			}
+		}
+
 		protected static SKBitmap CreateTestBitmap(byte alpha = 255)
 		{
 			var bmp = new SKBitmap(40, 40);


### PR DESCRIPTION
**Description of Change**

 - Can't share encoded data if we have any modifiers
 - Add some tests for this

**Bugs Fixed**

- Fixes #465 

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
