### PR TITLE
Revert the code for SKMatrix.SetScaleTranslate

### DIFF
--- a/binding/Binding/SKMatrix.cs
+++ b/binding/Binding/SKMatrix.cs
@@ -288,8 +288,20 @@ namespace SkiaSharp
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[Obsolete ("Use CreateScaleTranslation(float, float, float, float) instead.")]
-		public void SetScaleTranslate (float sx, float sy, float tx, float ty) =>
-			CreateScaleTranslation (sx, sy, tx, ty);
+		public void SetScaleTranslate (float sx, float sy, float tx, float ty)
+		{
+			scaleX = sx;
+			skewX = 0;
+			transX = tx;
+
+			skewY = 0;
+			scaleY = sy;
+			transY = ty;
+
+			persp0 = 0;
+			persp1 = 0;
+			persp2 = 1;
+		}
 
 		// Rotate
 

--- a/tests/Tests/SKMatrixTests.cs
+++ b/tests/Tests/SKMatrixTests.cs
@@ -227,5 +227,20 @@ namespace SkiaSharp.Tests
 			Assert.Equal(10, newPoint.X, PRECISION);
 			Assert.Equal(40, newPoint.Y, PRECISION);
 		}
+
+		[Obsolete]
+		[SkippableFact]
+		public void SetScaleTranslateWorksCorrectly()
+		{
+			var tempMatrix = SKMatrix.MakeIdentity();
+
+			tempMatrix.Values = new float[] { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+
+			SKMatrix.RotateDegrees(ref tempMatrix, 0);
+
+			tempMatrix.SetScaleTranslate(1.2f, 1.0f, 0, 0);
+
+			Assert.Equal(1.2f, tempMatrix.Values[0]);
+		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Revert the incorrect code for `SKMatrix.SetScaleTranslate`

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1451

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
