### PR TITLE
Sometimes we can't return float, for some reason

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -31,7 +31,7 @@ Xamarin.Forms                                   reference   4.4.0.991757
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs
 libSkiaSharp            milestone   80
-libSkiaSharp            increment   0
+libSkiaSharp            increment   1
 
 # native sonames
 libSkiaSharp            soname      80.0.0

--- a/binding/Binding/SKFont.cs
+++ b/binding/Binding/SKFont.cs
@@ -315,7 +315,9 @@ namespace SkiaSharp
 			if (!ValidateTextArgs (text, length, encoding))
 				return 0;
 
-			return SkiaApi.sk_font_measure_text (Handle, text, (IntPtr)length, encoding, bounds, paint?.Handle ?? IntPtr.Zero);
+			float measuredWidth;
+			SkiaApi.sk_font_measure_text_no_return (Handle, text, (IntPtr)length, encoding, bounds, paint?.Handle ?? IntPtr.Zero, &measuredWidth);
+			return measuredWidth;
 		}
 
 		// MeasureText (glyphs)

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -3945,6 +3945,20 @@ namespace SkiaSharp
 			(sk_font_measure_text_delegate ??= GetSymbol<Delegates.sk_font_measure_text> ("sk_font_measure_text")).Invoke (font, text, byteLength, encoding, bounds, paint);
 		#endif
 
+		// void sk_font_measure_text_no_return(const sk_font_t* font, const void* text, size_t byteLength, sk_text_encoding_t encoding, sk_rect_t* bounds, const sk_paint_t* paint, float* measuredWidth)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_font_measure_text_no_return (sk_font_t font, void* text, /* size_t */ IntPtr byteLength, SKTextEncoding encoding, SKRect* bounds, sk_paint_t paint, Single* measuredWidth);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_font_measure_text_no_return (sk_font_t font, void* text, /* size_t */ IntPtr byteLength, SKTextEncoding encoding, SKRect* bounds, sk_paint_t paint, Single* measuredWidth);
+		}
+		private static Delegates.sk_font_measure_text_no_return sk_font_measure_text_no_return_delegate;
+		internal static void sk_font_measure_text_no_return (sk_font_t font, void* text, /* size_t */ IntPtr byteLength, SKTextEncoding encoding, SKRect* bounds, sk_paint_t paint, Single* measuredWidth) =>
+			(sk_font_measure_text_no_return_delegate ??= GetSymbol<Delegates.sk_font_measure_text_no_return> ("sk_font_measure_text_no_return")).Invoke (font, text, byteLength, encoding, bounds, paint, measuredWidth);
+		#endif
+
 		// sk_font_t* sk_font_new()
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
**Description of Change**

Sometimes we can't return float, for some reason. There appears to be some bug or something on net472 + x86 + Marshal. It works in all other instances.

This is also very hard to test, because you need to be using VS and have the debugger attached... I blame the debugger for breaking things.

**Bugs Fixed**

- Fixes #1409

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
