### PR TITLE
Create a NuGet containing just the native/nugets

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -32,7 +32,6 @@ var SKIP_EXTERNALS = Argument ("skipexternals", "")
 var PACK_ALL_PLATFORMS = Argument ("packall", Argument ("PackAllPlatforms", false));
 var BUILD_ALL_PLATFORMS = Argument ("buildall", Argument ("BuildAllPlatforms", false));
 var PRINT_ALL_ENV_VARS = Argument ("printAllEnvVars", false);
-var AZURE_BUILD_ID = Argument ("azureBuildId", "");
 var UNSUPPORTED_TESTS = Argument ("unsupportedTests", "");
 var THROW_ON_TEST_FAILURE = Argument ("throwOnTestFailure", true);
 var NUGET_DIFF_PRERELEASE = Argument ("nugetDiffPrerelease", false);
@@ -54,8 +53,7 @@ var BUILD_NUMBER = EnvironmentVariable ("BUILD_NUMBER") ?? "0";
 var GIT_SHA = Argument ("gitSha", EnvironmentVariable ("GIT_SHA") ?? "");
 var GIT_BRANCH_NAME = Argument ("gitbranch", EnvironmentVariable ("GIT_BRANCH_NAME") ?? "");
 
-var AZURE_BUILD_SUCCESS = "https://dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_apis/build/builds?statusFilter=completed&resultFilter=succeeded&definitions=4&branchName=refs/heads/master&$top=1&api-version=5.1";
-var AZURE_BUILD_URL = "https://dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_apis/build/builds/{0}/artifacts?artifactName={1}&%24format=zip&api-version=5.1";
+var PREVIEW_FEED_URL = "https://nugetized.blob.core.windows.net/skiasharp-eap/flatcontainer/{0}/{1}/{0}.{1}.nupkg"; // 0=id, 1=version
 
 var TRACKED_NUGETS = new Dictionary<string, Version> {
     { "SkiaSharp",                                     new Version (1, 57, 0) },
@@ -89,20 +87,6 @@ foreach (var arg in CAKE_ARGUMENTS) {
 #load "cake/externals.cake"
 #load "cake/UpdateDocs.cake"
 #load "cake/samples.cake"
-
-Task ("determine-last-successful-build")
-    .WithCriteria (string.IsNullOrEmpty (AZURE_BUILD_ID))
-    .Does (() =>
-{
-    Warning ("A build ID (--azureBuildId=<ID>) was not specified, using the last successful build.");
-
-    var successUrl = string.Format(AZURE_BUILD_SUCCESS);
-    var json = ParseJson (FileReadText (DownloadFile (successUrl)));
-
-    AZURE_BUILD_ID = (string)json ["value"] [0] ["id"];
-
-    Information ($"Using last successful build ID {AZURE_BUILD_ID}");
-});
 
 Task ("__________________________________")
     .Description ("__________________________________________________");

--- a/build.cake
+++ b/build.cake
@@ -47,7 +47,7 @@ var MDocPath = Context.Tools.Resolve ("mdoc.exe");
 
 DirectoryPath DOCS_PATH = MakeAbsolute(ROOT_PATH.Combine("docs/SkiaSharpAPI"));
 
-var PREVIEW_LABEL = EnvironmentVariable ("PREVIEW_LABEL") ?? "preview";
+var PREVIEW_LABEL = Argument ("previewLabel", EnvironmentVariable ("PREVIEW_LABEL") ?? "preview");
 var FEATURE_NAME = EnvironmentVariable ("FEATURE_NAME") ?? "";
 var BUILD_NUMBER = EnvironmentVariable ("BUILD_NUMBER") ?? "0";
 var GIT_SHA = Argument ("gitSha", EnvironmentVariable ("GIT_SHA") ?? "");
@@ -556,13 +556,19 @@ Task ("nuget")
             var metadata = xdoc.Root.Element ("metadata");
             var version = metadata.Element ("version");
 
-            version.Value = "0.0.0-commit." + GIT_SHA;
-            xdoc.Save (nuspec);
-            PackageNuGet (nuspec, OUTPUT_NUGETS_PATH, true);
+            if (!string.IsNullOrEmpty (PREVIEW_LABEL) && PREVIEW_LABEL.StartsWith ("pr.")) {
+                version.Value = "0.0.0-" + PREVIEW_LABEL;
+                xdoc.Save (nuspec);
+                PackageNuGet (nuspec, OUTPUT_NUGETS_PATH, true);
+            } else {
+                version.Value = "0.0.0-commit." + GIT_SHA;
+                xdoc.Save (nuspec);
+                PackageNuGet (nuspec, OUTPUT_NUGETS_PATH, true);
 
-            version.Value = "0.0.0-branch." + GIT_BRANCH_NAME.Replace ("/", ".");
-            xdoc.Save (nuspec);
-            PackageNuGet (nuspec, OUTPUT_NUGETS_PATH, true);
+                version.Value = "0.0.0-branch." + GIT_BRANCH_NAME.Replace ("/", ".");
+                xdoc.Save (nuspec);
+                PackageNuGet (nuspec, OUTPUT_NUGETS_PATH, true);
+            }
 
             DeleteFiles ($"./output/{pair.Value}/*.nuspec");
         }

--- a/cake/UpdateDocs.cake
+++ b/cake/UpdateDocs.cake
@@ -37,23 +37,20 @@ void CopyChangelogs (DirectoryPath diffRoot, string id, string version)
     }
 }
 
-Task ("docs-download-build-artifact")
-    .IsDependentOn ("determine-last-successful-build")
+Task ("docs-download-output")
     .Does (() =>
 {
-    var url = string.Format(AZURE_BUILD_URL, AZURE_BUILD_ID, "nuget");
-
     EnsureDirectoryExists ("./output");
     CleanDirectories ("./output");
+    EnsureDirectoryExists ("./output/temp");
 
-    DownloadFile(url, "./output/nuget.zip");
-});
+    var url = GetDownloadUrl ("_nugets");
+    DownloadFile (url, "./output/temp/nugets.nupkg");
 
-Task ("docs-expand-build-artifact")
-    .Does (() =>
-{
-    Unzip ("./output/nuget.zip", "./output");
-    MoveDirectory ("./output/nuget", OUTPUT_NUGETS_PATH);
+    Unzip ("./output/temp/nugets.nupkg", "./output/temp");
+    MoveDirectory ("./output/temp/tools", OUTPUT_NUGETS_PATH);
+
+    DeleteDirectory("./output/temp", new DeleteDirectorySettings { Recursive = true, Force = true });
 
     foreach (var id in TRACKED_NUGETS.Keys) {
         var version = GetVersion (id);
@@ -62,10 +59,6 @@ Task ("docs-expand-build-artifact")
         Unzip ($"{OUTPUT_NUGETS_PATH}/{name}", $"./output/{id}/nuget");
     }
 });
-
-Task ("docs-download-output")
-    .IsDependentOn ("docs-download-build-artifact")
-    .IsDependentOn ("docs-expand-build-artifact");
 
 Task ("docs-api-diff")
     .Does (async () =>

--- a/cake/UtilsManaged.cake
+++ b/cake/UtilsManaged.cake
@@ -220,3 +220,14 @@ async Task<NuGetDiff> CreateNuGetDiffAsync()
         comparer.SearchPaths.Add(System.IO.Path.Combine(root, "lib", platform));
     }
 }
+
+string GetDownloadUrl(string id)
+{
+    var version = "0.0.0-branch.master";
+    if (!string.IsNullOrEmpty (GIT_SHA))
+        version = "0.0.0-commit." + GIT_SHA.ToLower ();
+    if (!string.IsNullOrEmpty (GIT_BRANCH_NAME))
+        version = "0.0.0-branch." + GIT_BRANCH_NAME.Replace ("/", ".").ToLower ();
+
+    return string.Format (PREVIEW_FEED_URL, "skiasharp.harfbuzz", version);
+}

--- a/cake/UtilsManaged.cake
+++ b/cake/UtilsManaged.cake
@@ -1,7 +1,7 @@
-void PackageNuGet(FilePath nuspecPath, DirectoryPath outputPath)
+void PackageNuGet(FilePath nuspecPath, DirectoryPath outputPath, bool allowDefaultExcludes = false)
 {
     EnsureDirectoryExists(outputPath);
-    NuGetPack(nuspecPath, new NuGetPackSettings {
+    var settings = new NuGetPackSettings {
         OutputDirectory = MakeAbsolute(outputPath),
         BasePath = nuspecPath.GetDirectory(),
         ToolPath = NuGetToolPath,
@@ -11,7 +11,11 @@ void PackageNuGet(FilePath nuspecPath, DirectoryPath outputPath)
             // NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
             { "NoWarn", "NU5048,NU5105,NU5125" }
         },
-    });
+    };
+    if (allowDefaultExcludes) {
+        settings.ArgumentCustomization = args => args.Append("-NoDefaultExcludes");
+    }
+    NuGetPack(nuspecPath, settings);
 }
 
 void RunTests(FilePath testAssembly, bool is32)

--- a/cake/UtilsManaged.cake
+++ b/cake/UtilsManaged.cake
@@ -223,11 +223,15 @@ async Task<NuGetDiff> CreateNuGetDiffAsync()
 
 string GetDownloadUrl(string id)
 {
-    var version = "0.0.0-branch.master";
-    if (!string.IsNullOrEmpty (GIT_SHA))
-        version = "0.0.0-commit." + GIT_SHA.ToLower ();
-    if (!string.IsNullOrEmpty (GIT_BRANCH_NAME))
-        version = "0.0.0-branch." + GIT_BRANCH_NAME.Replace ("/", ".").ToLower ();
+    var version = "0.0.0-";
+    if (!string.IsNullOrEmpty (PREVIEW_LABEL) && PREVIEW_LABEL.StartsWith ("pr."))
+        version += PREVIEW_LABEL.ToLower ();
+    else if (!string.IsNullOrEmpty (GIT_SHA))
+        version += "commit." + GIT_SHA.ToLower ();
+    else if (!string.IsNullOrEmpty (GIT_BRANCH_NAME))
+        version += "branch." + GIT_BRANCH_NAME.Replace ("/", ".").ToLower ();
+    else
+        version += "branch.master";
 
     return string.Format (PREVIEW_FEED_URL, "skiasharp.harfbuzz", version);
 }

--- a/cake/externals.cake
+++ b/cake/externals.cake
@@ -25,19 +25,19 @@ Task("externals-osx")
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Task("externals-download")
-    .IsDependentOn("determine-last-successful-build")
     .Does(() =>
 {
-    var artifactName = "native";
-    var artifactFilename = $"{artifactName}.zip";
-    var url = string.Format(AZURE_BUILD_URL, AZURE_BUILD_ID, artifactName);
+    EnsureDirectoryExists ("./output");
+    CleanDirectories ("./output");
+    EnsureDirectoryExists ("./output/temp");
 
-    var outputPath = "./output";
-    EnsureDirectoryExists(outputPath);
-    CleanDirectories(outputPath);
+    var url = GetDownloadUrl ("_nativeassets");
+    DownloadFile (url, "./output/temp/nativeassets.nupkg");
 
-    DownloadFile(url, $"{outputPath}/{artifactFilename}");
-    Unzip($"{outputPath}/{artifactFilename}", outputPath);
+    Unzip ("./output/temp/nativeassets.nupkg", "./output/temp");
+    MoveDirectory ("./output/temp/tools", "./output/native");
+
+    DeleteDirectory("./output/temp", new DeleteDirectorySettings { Recursive = true, Force = true });
 });
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/nuget/_NativeAssets.nuspec
+++ b/nuget/_NativeAssets.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+
+    <id>_NativeAssets</id>
+    <title>Build Native Assets</title>
+    <version>1.0.0</version>
+    <description>All the native assets from the build</description>
+    <summary>All the native assets from the build</summary>
+    <authors>Microsoft</authors>
+
+  </metadata>
+  <files>
+
+    <file src="*/**" target="tools/" />
+
+  </files>
+</package>

--- a/nuget/_NuGets.nuspec
+++ b/nuget/_NuGets.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+
+    <id>_NuGets</id>
+    <title>Build NuGets</title>
+    <version>1.0.0</version>
+    <description>All the NuGet packages from the build</description>
+    <summary>All the NuGet packages from the build</summary>
+    <authors>Microsoft</authors>
+
+  </metadata>
+  <files>
+
+    <file src="*.nupkg" exclude="_*;*-*" target="tools/" />
+
+  </files>
+</package>

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -15,7 +15,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: ''                            # the build number to download externals from
+  buildExternals: '3945260'                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -26,16 +26,16 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
 
 jobs:
-# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-#   - template: azure-templates-download.yml
-#     parameters:
-#       name: ${{ parameters.name }}
-#       displayName: ${{ parameters.displayName }}
-#       vmImage: ${{ parameters.vmImage }}
-#       condition: ${{ parameters.condition }}
-#       buildExternals: ${{ parameters.buildExternals }}
+- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+  - template: azure-templates-download.yml
+    parameters:
+      name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      vmImage: ${{ parameters.vmImage }}
+      condition: ${{ parameters.condition }}
+      buildExternals: ${{ parameters.buildExternals }}
 
-# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -15,7 +15,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: '3945260'                            # the build number to download externals from
+  buildExternals: ''                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -26,16 +26,16 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
 
 jobs:
-- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-  - template: azure-templates-download.yml
-    parameters:
-      name: ${{ parameters.name }}
-      displayName: ${{ parameters.displayName }}
-      vmImage: ${{ parameters.vmImage }}
-      condition: ${{ parameters.condition }}
-      buildExternals: ${{ parameters.buildExternals }}
+# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+#   - template: azure-templates-download.yml
+#     parameters:
+#       name: ${{ parameters.name }}
+#       displayName: ${{ parameters.displayName }}
+#       vmImage: ${{ parameters.vmImage }}
+#       condition: ${{ parameters.condition }}
+#       buildExternals: ${{ parameters.buildExternals }}
 
-- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120


### PR DESCRIPTION
**Description of Change**

Create a NuGet containing just the native/nugets. This package can then be uploaded to the preview feed and downloaded by anyone.

The most common use case is the NuGets for generating docs or the native bits so that they don't have to built.

**Bugs Fixed**

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
