### PR TITLE
[macOS] Use NeedsDisplay instead of Display

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SKGLViewRenderer.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Mac/SKGLViewRenderer.cs
@@ -44,7 +44,11 @@ namespace SkiaSharp.Views.Forms
 			if (oneShot)
 			{
 				var nativeView = Control;
-				nativeView?.BeginInvokeOnMainThread(() => nativeView?.Display());
+				nativeView?.BeginInvokeOnMainThread(() =>
+				{
+					if (nativeView != null)
+						nativeView.NeedsDisplay = true;
+				});
 				return;
 			}
 
@@ -56,7 +60,11 @@ namespace SkiaSharp.Views.Forms
 				var formsView = Element;
 
 				// redraw the view
-				nativeView?.BeginInvokeOnMainThread(() => nativeView?.Display());
+				nativeView?.BeginInvokeOnMainThread(() =>
+				{
+					if (nativeView != null)
+						nativeView.NeedsDisplay = true;
+				});
 
 				// stop the render loop if this was a one-shot, or the views are disposed
 				if (nativeView == null || formsView == null || !formsView.HasRenderLoop)

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Mac/SKSwapChainPanel.macOS.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Mac/SKSwapChainPanel.macOS.cs
@@ -69,7 +69,11 @@ namespace SkiaSharp.Views.UWP
 			displayLink.SetOutputCallback(delegate
 			{
 				// redraw the view
-				glView?.BeginInvokeOnMainThread(() => glView?.Display());
+				glView?.BeginInvokeOnMainThread(() =>
+				{
+					if (glView != null)
+						glView.NeedsDisplay = true;
+				});
 
 				// stop the render loop if it has been disabled or the views are disposed
 				if (glView == null || !EnableRenderLoop)


### PR DESCRIPTION
**Description of Change**

Use NeedsDisplay instead of Display to prevent the double paint.

**Bugs Fixed**

 - Fixes #1467

**API Changes**

None.

**Behavioral Changes**

No longer a double paint.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
