### PR TITLE
Update OpenTK

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -9,8 +9,8 @@ Xamarin.Forms.Platform.WPF                      release     4.5.0.725
 Xamarin.Forms.Platform.GTK                      release     4.5.0.725
 Tizen.NET                                       release     4.0.0
 Tizen.NET.Sdk                                   release     1.0.9
-OpenTK                                          release     3.0.1
-OpenTK.GLControl                                release     3.0.1
+OpenTK                                          release     3.1.0
+OpenTK.GLControl                                release     3.1.0
 MSBuild.Sdk.Extras                              release     2.0.54
 Cake                                            release     0.38.4
 GtkSharp                                        release     3.22.24.37

--- a/nuget/SkiaSharp.Views.Forms.GTK.nuspec
+++ b/nuget/SkiaSharp.Views.Forms.GTK.nuspec
@@ -34,7 +34,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
         <dependency id="SkiaSharp.Views.Desktop.Common" version="1.0.0" />
         <dependency id="SkiaSharp.Views.Gtk2" version="1.0.0" />
         <dependency id="SkiaSharp.Views.Forms" version="1.0.0" />
-        <dependency id="OpenTK" version="3.0.1" />
+        <dependency id="OpenTK" version="3.1.0" />
       </group>
     </dependencies>
 

--- a/nuget/SkiaSharp.Views.Forms.WPF.nuspec
+++ b/nuget/SkiaSharp.Views.Forms.WPF.nuspec
@@ -35,8 +35,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
         <dependency id="SkiaSharp.Views.WindowsForms" version="1.0.0" />
         <dependency id="SkiaSharp.Views.WPF" version="1.0.0" />
         <dependency id="SkiaSharp.Views.Forms" version="1.0.0" />
-        <dependency id="OpenTK" version="3.0.1" />
-        <dependency id="OpenTK.GLControl" version="3.0.1" />
+        <dependency id="OpenTK" version="3.1.0" />
+        <dependency id="OpenTK.GLControl" version="3.1.0" />
       </group>
     </dependencies>
 

--- a/nuget/SkiaSharp.Views.WindowsForms.nuspec
+++ b/nuget/SkiaSharp.Views.WindowsForms.nuspec
@@ -30,14 +30,14 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="net462">
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views.Desktop.Common" version="1.0.0" />
-        <dependency id="OpenTK" version="3.0.1" />
-        <dependency id="OpenTK.GLControl" version="3.0.1" />
+        <dependency id="OpenTK" version="3.1.0" />
+        <dependency id="OpenTK.GLControl" version="3.1.0" />
       </group>
       <group targetFramework="netcoreapp3.0">
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SkiaSharp.Views.Desktop.Common" version="1.0.0" />
-        <dependency id="OpenTK" version="3.0.1" />
-        <dependency id="OpenTK.GLControl" version="3.0.1" />
+        <dependency id="OpenTK" version="3.1.0" />
+        <dependency id="OpenTK.GLControl" version="3.1.0" />
       </group>
     </dependencies>
 

--- a/samples/Basic/Desktop/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/Desktop/SkiaSharpSample/SkiaSharpSample.csproj
@@ -51,8 +51,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.0.1" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.0.1" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp\SkiaSharp.csproj">
       <Project>{eb1bbdcc-fb07-40d5-8b9e-0079e2c2f2df}</Project>
       <Name>SkiaSharp</Name>

--- a/samples/Basic/WPF/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/WPF/SkiaSharpSample/SkiaSharpSample.csproj
@@ -54,8 +54,8 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.0.1" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.0.1" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
     <ProjectReference Include="..\..\..\..\binding\SkiaSharp\SkiaSharp.csproj">
       <Project>{eb1bbdcc-fb07-40d5-8b9e-0079e2c2f2df}</Project>
       <Name>SkiaSharp</Name>

--- a/samples/Gallery/Desktop/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Gallery/Desktop/SkiaSharpSample/SkiaSharpSample.csproj
@@ -89,8 +89,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.0.1" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.0.1" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj">
       <Project>{2ae5d8c5-eac6-4515-89f2-a4994b41c925}</Project>
       <Name>HarfBuzzSharp</Name>

--- a/samples/Gallery/WPF/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Gallery/WPF/SkiaSharpSample/SkiaSharpSample.csproj
@@ -97,8 +97,8 @@
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.0.1" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.0.1" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj">
       <Project>{2ae5d8c5-eac6-4515-89f2-a4994b41c925}</Project>
       <Name>HarfBuzzSharp</Name>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SkiaSharp.Views.WindowsForms.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WindowsForms/SkiaSharp.Views.WindowsForms.csproj
@@ -8,8 +8,8 @@
     <DefineConstants>$(DefineConstants);__DESKTOP__;__WINFORMS__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.0.1" NoWarn="NU1701" />
-    <PackageReference Include="OpenTK.GLControl" Version="3.0.1" NoWarn="NU1701" />
+    <PackageReference Include="OpenTK" Version="3.1.0" NoWarn="NU1701" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" NoWarn="NU1701" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
**Description of Change**

It appears the v3.0.1 of OpenTK is not correctly strong named. However, v3.1.0 is. 

**Bugs Fixed**

- Fixes #1479

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
