### PR TITLE
Add bindings for the serialization of SKPicture

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -31,10 +31,10 @@ Xamarin.Forms                                   reference   4.4.0.991757
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs
 libSkiaSharp            milestone   80
-libSkiaSharp            increment   2
+libSkiaSharp            increment   3
 
 # native sonames
-libSkiaSharp            soname      80.2.0
+libSkiaSharp            soname      80.3.0
 HarfBuzz                soname      0.20601.0
 
 # SkiaSharp.dll

--- a/binding/Binding/SKPicture.cs
+++ b/binding/Binding/SKPicture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace SkiaSharp
 {
@@ -23,6 +24,28 @@ namespace SkiaSharp
 			}
 		}
 
+		// Serialize
+
+		public SKData Serialize () =>
+			SKData.GetObject (SkiaApi.sk_picture_serialize_to_data (Handle));
+
+		public void Serialize (Stream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException (nameof (stream));
+
+			using var managed = new SKManagedWStream (stream);
+			Serialize (managed);
+		}
+
+		public void Serialize (SKWStream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException (nameof (stream));
+
+			SkiaApi.sk_picture_serialize_to_stream (Handle, stream.Handle);
+		}
+
 		// ToShader
 
 		public SKShader ToShader () =>
@@ -36,6 +59,54 @@ namespace SkiaSharp
 
 		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix, SKRect tile) =>
 			SKShader.GetObject (SkiaApi.sk_picture_make_shader (Handle, tmx, tmy, &localMatrix, &tile));
+
+		// Deserialize
+
+		public static SKPicture Deserialize (IntPtr data, int length)
+		{
+			if (data == IntPtr.Zero)
+				throw new ArgumentNullException (nameof (data));
+
+			if (length == 0)
+				return null;
+
+			return GetObject (SkiaApi.sk_picture_deserialize_from_memory ((void*)data, (IntPtr)length));
+		}
+
+		public static SKPicture Deserialize (ReadOnlySpan<byte> data)
+		{
+			if (data.Length == 0)
+				return null;
+
+			fixed (void* ptr = data) {
+				return GetObject (SkiaApi.sk_picture_deserialize_from_memory (ptr, (IntPtr)data.Length));
+			}
+		}
+
+		public static SKPicture Deserialize (SKData data)
+		{
+			if (data == null)
+				throw new ArgumentNullException (nameof (data));
+
+			return GetObject (SkiaApi.sk_picture_deserialize_from_data (data.Handle));
+		}
+
+		public static SKPicture Deserialize (Stream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException (nameof (stream));
+
+			using var managed = new SKManagedStream (stream);
+			return Deserialize (managed);
+		}
+
+		public static SKPicture Deserialize (SKStream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException (nameof (stream));
+
+			return GetObject (SkiaApi.sk_picture_deserialize_from_stream (stream.Handle));
+		}
 
 		//
 

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -8695,6 +8695,48 @@ namespace SkiaSharp
 
 		#region sk_picture.h
 
+		// sk_picture_t* sk_picture_deserialize_from_data(sk_data_t* data)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_picture_t sk_picture_deserialize_from_data (sk_data_t data);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_picture_t sk_picture_deserialize_from_data (sk_data_t data);
+		}
+		private static Delegates.sk_picture_deserialize_from_data sk_picture_deserialize_from_data_delegate;
+		internal static sk_picture_t sk_picture_deserialize_from_data (sk_data_t data) =>
+			(sk_picture_deserialize_from_data_delegate ??= GetSymbol<Delegates.sk_picture_deserialize_from_data> ("sk_picture_deserialize_from_data")).Invoke (data);
+		#endif
+
+		// sk_picture_t* sk_picture_deserialize_from_memory(void* buffer, size_t length)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_picture_t sk_picture_deserialize_from_memory (void* buffer, /* size_t */ IntPtr length);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_picture_t sk_picture_deserialize_from_memory (void* buffer, /* size_t */ IntPtr length);
+		}
+		private static Delegates.sk_picture_deserialize_from_memory sk_picture_deserialize_from_memory_delegate;
+		internal static sk_picture_t sk_picture_deserialize_from_memory (void* buffer, /* size_t */ IntPtr length) =>
+			(sk_picture_deserialize_from_memory_delegate ??= GetSymbol<Delegates.sk_picture_deserialize_from_memory> ("sk_picture_deserialize_from_memory")).Invoke (buffer, length);
+		#endif
+
+		// sk_picture_t* sk_picture_deserialize_from_stream(sk_stream_t* stream)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_picture_t sk_picture_deserialize_from_stream (sk_stream_t stream);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_picture_t sk_picture_deserialize_from_stream (sk_stream_t stream);
+		}
+		private static Delegates.sk_picture_deserialize_from_stream sk_picture_deserialize_from_stream_delegate;
+		internal static sk_picture_t sk_picture_deserialize_from_stream (sk_stream_t stream) =>
+			(sk_picture_deserialize_from_stream_delegate ??= GetSymbol<Delegates.sk_picture_deserialize_from_stream> ("sk_picture_deserialize_from_stream")).Invoke (stream);
+		#endif
+
 		// void sk_picture_get_cull_rect(sk_picture_t*, sk_rect_t*)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -8833,6 +8875,34 @@ namespace SkiaSharp
 		private static Delegates.sk_picture_ref sk_picture_ref_delegate;
 		internal static void sk_picture_ref (sk_picture_t param0) =>
 			(sk_picture_ref_delegate ??= GetSymbol<Delegates.sk_picture_ref> ("sk_picture_ref")).Invoke (param0);
+		#endif
+
+		// sk_data_t* sk_picture_serialize_to_data(const sk_picture_t* picture)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_data_t sk_picture_serialize_to_data (sk_picture_t picture);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_data_t sk_picture_serialize_to_data (sk_picture_t picture);
+		}
+		private static Delegates.sk_picture_serialize_to_data sk_picture_serialize_to_data_delegate;
+		internal static sk_data_t sk_picture_serialize_to_data (sk_picture_t picture) =>
+			(sk_picture_serialize_to_data_delegate ??= GetSymbol<Delegates.sk_picture_serialize_to_data> ("sk_picture_serialize_to_data")).Invoke (picture);
+		#endif
+
+		// void sk_picture_serialize_to_stream(const sk_picture_t* picture, sk_wstream_t* stream)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_picture_serialize_to_stream (sk_picture_t picture, sk_wstream_t stream);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_picture_serialize_to_stream (sk_picture_t picture, sk_wstream_t stream);
+		}
+		private static Delegates.sk_picture_serialize_to_stream sk_picture_serialize_to_stream_delegate;
+		internal static void sk_picture_serialize_to_stream (sk_picture_t picture, sk_wstream_t stream) =>
+			(sk_picture_serialize_to_stream_delegate ??= GetSymbol<Delegates.sk_picture_serialize_to_stream> ("sk_picture_serialize_to_stream")).Invoke (picture, stream);
 		#endif
 
 		// void sk_picture_unref(sk_picture_t*)

--- a/tests/Tests/SKPictureTest.cs
+++ b/tests/Tests/SKPictureTest.cs
@@ -19,7 +19,7 @@ namespace SkiaSharp.Tests
 
 			var span = data.AsSpan();
 			Assert.True(span.Length > 8);
-			Assert.Equal(MagicBytes, span[0..8].ToArray());
+			Assert.Equal(MagicBytes, span.Slice(0, 8).ToArray());
 		}
 
 		[SkippableFact]
@@ -31,7 +31,7 @@ namespace SkiaSharp.Tests
 			picture.Serialize(stream);
 
 			Assert.True(stream.Length > 8);
-			Assert.Equal(MagicBytes, stream.ToArray()[0..8]);
+			Assert.Equal(MagicBytes, stream.ToArray().AsSpan(0, 8).ToArray());
 		}
 
 		[SkippableFact]

--- a/tests/Tests/SKPictureTest.cs
+++ b/tests/Tests/SKPictureTest.cs
@@ -1,0 +1,70 @@
+﻿using System.IO;
+using Xunit;
+
+namespace SkiaSharp.Tests
+{
+	public class SKPictureTest : SKTest
+	{
+		private static readonly byte[] MagicBytes = {
+			(byte)'s', (byte)'k', (byte)'i', (byte)'a', (byte)'p', (byte)'i', (byte)'c', (byte)'t'
+		};
+
+		[SkippableFact]
+		public void CanSerializeToData()
+		{
+			using var picture = CreateTestPicture();
+
+			using var data = picture.Serialize();
+			Assert.NotNull(data);
+
+			var span = data.AsSpan();
+			Assert.True(span.Length > 8);
+			Assert.Equal(MagicBytes, span[0..8].ToArray());
+		}
+
+		[SkippableFact]
+		public void CanSerializeToStream()
+		{
+			using var picture = CreateTestPicture();
+
+			using var stream = new MemoryStream();
+			picture.Serialize(stream);
+
+			Assert.True(stream.Length > 8);
+			Assert.Equal(MagicBytes, stream.ToArray()[0..8]);
+		}
+
+		[SkippableFact]
+		public void CanDeserializeFromData()
+		{
+			using var picture = CreateTestPicture();
+			using var data = picture.Serialize();
+
+			using var bmp = new SKBitmap(40, 40);
+			using var cnv = new SKCanvas(bmp);
+
+			using var deserialized = SKPicture.Deserialize(data);
+			Assert.Equal(SKRect.Create(0, 0, 40, 40), deserialized.CullRect);
+			cnv.DrawPicture(deserialized);
+
+			ValidateTestBitmap(bmp);
+		}
+
+		[SkippableFact]
+		public void CanDeserializeFromStream()
+		{
+			using var picture = CreateTestPicture();
+			using var data = picture.Serialize();
+			using var stream = new MemoryStream(data.ToArray());
+
+			using var bmp = new SKBitmap(40, 40);
+			using var cnv = new SKCanvas(bmp);
+
+			using var deserialized = SKPicture.Deserialize(stream);
+			Assert.Equal(SKRect.Create(0, 0, 40, 40), deserialized.CullRect);
+			cnv.DrawPicture(deserialized);
+
+			ValidateTestBitmap(bmp);
+		}
+	}
+}

--- a/tests/Tests/SKTest.cs
+++ b/tests/Tests/SKTest.cs
@@ -75,26 +75,43 @@ namespace SkiaSharp.Tests
 			bmp.Erase(SKColors.Transparent);
 
 			using (var canvas = new SKCanvas(bmp))
-			using (var paint = new SKPaint())
 			{
-
-				var x = bmp.Width / 2;
-				var y = bmp.Height / 2;
-
-				paint.Color = SKColors.Red.WithAlpha(alpha);
-				canvas.DrawRect(SKRect.Create(0, 0, x, y), paint);
-
-				paint.Color = SKColors.Green.WithAlpha(alpha);
-				canvas.DrawRect(SKRect.Create(x, 0, x, y), paint);
-
-				paint.Color = SKColors.Blue.WithAlpha(alpha);
-				canvas.DrawRect(SKRect.Create(0, y, x, y), paint);
-
-				paint.Color = SKColors.Yellow.WithAlpha(alpha);
-				canvas.DrawRect(SKRect.Create(x, y, x, y), paint);
+				DrawTestBitmap(canvas, 40, 40, alpha);
 			}
 
 			return bmp;
+		}
+
+		protected static SKPicture CreateTestPicture(byte alpha = 255)
+		{
+			using var recorder = new SKPictureRecorder();
+			using var canvas = recorder.BeginRecording(SKRect.Create(0, 0, 40, 40));
+
+			DrawTestBitmap(canvas, 40, 40, alpha);
+
+			return recorder.EndRecording();
+		}
+
+		private static void DrawTestBitmap(SKCanvas canvas, int width, int height, byte alpha = 255)
+		{
+			using var paint = new SKPaint();
+
+			var x = width / 2;
+			var y = height / 2;
+
+			canvas.Clear(SKColors.Transparent);
+
+			paint.Color = SKColors.Red.WithAlpha(alpha);
+			canvas.DrawRect(SKRect.Create(0, 0, x, y), paint);
+
+			paint.Color = SKColors.Green.WithAlpha(alpha);
+			canvas.DrawRect(SKRect.Create(x, 0, x, y), paint);
+
+			paint.Color = SKColors.Blue.WithAlpha(alpha);
+			canvas.DrawRect(SKRect.Create(0, y, x, y), paint);
+
+			paint.Color = SKColors.Yellow.WithAlpha(alpha);
+			canvas.DrawRect(SKRect.Create(x, y, x, y), paint);
 		}
 
 		protected static void ValidateTestBitmap(SKBitmap bmp, byte alpha = 255)


### PR DESCRIPTION
**Description of Change**

Add bindings for the serialization of SKPicture.

**Bugs Fixed**

- Fixes #880 

**API Changes**

```csharp
class SKPicture {
    public SKData Serialize ();
    public void Serialize (Stream stream);
    public void Serialize (SKWStream stream);

    public static SKPicture Deserialize (IntPtr data, int length);
    public static SKPicture Deserialize (ReadOnlySpan<byte> data);
    public static SKPicture Deserialize (SKData data);
    public static SKPicture Deserialize (Stream stream);
    public static SKPicture Deserialize (SKStream stream);
}
```

**Behavioral Changes**

New APIs that do not change behaviour of existing functionality.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
