### PR TITLE
Allow to create Angle GRGlInterface from non UWP environment

### DIFF
--- a/binding/Binding/GRGlInterface.cs
+++ b/binding/Binding/GRGlInterface.cs
@@ -29,7 +29,7 @@ namespace SkiaSharp
 			return GetObject (SkiaApi.gr_glinterface_create_native_interface ());
 		}
 
-		private static GRGlInterface CreateAngle ()
+		public static GRGlInterface CreateAngle ()
 		{
 			if (PlatformConfiguration.IsWindows) {
 				return CreateAngle (AngleLoader.GetProc);


### PR DESCRIPTION
Allow to create Angle `GRGlInterface` from non UWP environment (WPF for an instance) from a new non deprecated `Create()` API. Another option will be making `AngleLoader` public to use a `CreateAngle (GRGlGetProcedureAddressDelegate get)`.

Now we are using a deprecated method, but I want to be sure that in the next releases we will be able to init Angle without reflection :) :
```C#
GrContext = GRContext.CreateGl(GRGlInterface.CreateNativeAngleInterface());
```

What I want:
```C#
GrContext = GRContext.CreateAngle();
```

basic `Create()` call will make an `openGL` `GRContext`.