### PR TITLE
Angle WPF

### DIFF
--- a/samples/Gallery/WPF/SkiaSharpSample.sln
+++ b/samples/Gallery/WPF/SkiaSharpSample.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.HarfBuzz", "..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Views.Desktop.Common", "..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.Desktop.Common\SkiaSharp.Views.Desktop.Common.csproj", "{D52BB2A5-9B68-4A89-B221-2A4EC7DA01F9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Views.WindowsForms", "..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.WindowsForms\SkiaSharp.Views.WindowsForms.csproj", "{A1334727-7CC6-43AC-A617-EEFE2174F454}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +25,18 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x64.ActiveCfg = Debug|x64
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x64.Build.0 = Debug|x64
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x86.ActiveCfg = Debug|x86
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x86.Build.0 = Debug|x86
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x64.ActiveCfg = Release|x64
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x64.Build.0 = Release|x64
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x86.ActiveCfg = Release|x86
+		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x86.Build.0 = Release|x86
 		{EB1BBDCC-FB07-40D5-8B9E-0079E2C2F2DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB1BBDCC-FB07-40D5-8B9E-0079E2C2F2DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB1BBDCC-FB07-40D5-8B9E-0079E2C2F2DF}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -63,18 +73,6 @@ Global
 		{2AE5D8C5-EAC6-4515-89F2-A4994B41C925}.Release|x64.Build.0 = Release|Any CPU
 		{2AE5D8C5-EAC6-4515-89F2-A4994B41C925}.Release|x86.ActiveCfg = Release|Any CPU
 		{2AE5D8C5-EAC6-4515-89F2-A4994B41C925}.Release|x86.Build.0 = Release|Any CPU
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x64.ActiveCfg = Debug|x64
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x64.Build.0 = Debug|x64
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x86.ActiveCfg = Debug|x86
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Debug|x86.Build.0 = Debug|x86
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x64.ActiveCfg = Release|x64
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x64.Build.0 = Release|x64
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x86.ActiveCfg = Release|x86
-		{74178C7C-19A0-45E6-8EFB-F4DB7EE37C6F}.Release|x86.Build.0 = Release|x86
 		{156FADFB-602E-4658-A235-D4D24CD46F09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{156FADFB-602E-4658-A235-D4D24CD46F09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{156FADFB-602E-4658-A235-D4D24CD46F09}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -99,18 +97,6 @@ Global
 		{D52BB2A5-9B68-4A89-B221-2A4EC7DA01F9}.Release|x64.Build.0 = Release|Any CPU
 		{D52BB2A5-9B68-4A89-B221-2A4EC7DA01F9}.Release|x86.ActiveCfg = Release|Any CPU
 		{D52BB2A5-9B68-4A89-B221-2A4EC7DA01F9}.Release|x86.Build.0 = Release|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Debug|x64.Build.0 = Debug|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Debug|x86.Build.0 = Debug|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Release|x64.ActiveCfg = Release|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Release|x64.Build.0 = Release|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Release|x86.ActiveCfg = Release|Any CPU
-		{A1334727-7CC6-43AC-A617-EEFE2174F454}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/Gallery/WPF/SkiaSharpSample/MainWindow.xaml
+++ b/samples/Gallery/WPF/SkiaSharpSample/MainWindow.xaml
@@ -3,8 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:views="clr-namespace:SkiaSharp.Views.WPF;assembly=SkiaSharp.Views.WPF"
-        xmlns:local="clr-namespace:SkiaSharpSample"
+        xmlns:wpf="clr-namespace:SkiaSharp.Views.WPF;assembly=SkiaSharp.Views.WPF"
         mc:Ignorable="d"
         Title="SkiaSharp for WPF" Height="350" Width="525" Icon="icon.ico">
     <DockPanel>
@@ -16,17 +15,9 @@
                 <MenuItem Header="Toggle Samples Slideshow" Click="OnToggleSlideshow" />
                 <Separator />
             </MenuItem>
-            <MenuItem Header="_Tools">
-                <MenuItem Header="Configure Backend">
-                    <MenuItem Header="Memory" Click="OnBackendChanged" Tag="Memory" />
-                    <MenuItem Header="OpenGL" Click="OnBackendChanged" Tag="OpenGL" />
-                    <MenuItem Header="Vulkan" Click="OnBackendChanged" Tag="Vulkan" />
-                </MenuItem>
-            </MenuItem>
         </Menu>
         <Grid>
-            <views:SKElement x:Name="canvas" PaintSurface="OnPaintCanvas" MouseLeftButtonUp="OnSampleClicked" />
-            <WindowsFormsHost x:Name="glhost" Initialized="OnGLControlHost" Visibility="Collapsed" />
+            <wpf:SKElement x:Name="canvas" PaintSurface="OnPaintCanvas" MouseLeftButtonUp="OnSampleClicked" />
         </Grid>
     </DockPanel>
 </Window>

--- a/samples/Gallery/WPF/SkiaSharpSample/MainWindow.xaml.cs
+++ b/samples/Gallery/WPF/SkiaSharpSample/MainWindow.xaml.cs
@@ -86,11 +86,9 @@ namespace SkiaSharpSample
 			switch (backend)
 			{
 				case SampleBackends.Memory:
-					glhost.Visibility = Visibility.Collapsed;
 					canvas.Visibility = Visibility.Visible;
 					break;
 				case SampleBackends.OpenGL:
-					glhost.Visibility = Visibility.Visible;
 					canvas.Visibility = Visibility.Collapsed;
 					break;
 				default:
@@ -148,22 +146,6 @@ namespace SkiaSharpSample
 			}
 		}
 
-		private void OnGLControlHost(object sender, EventArgs e)
-		{
-			var glControl = new SKGLControl();
-			glControl.PaintSurface += OnPaintGL;
-			glControl.Dock = System.Windows.Forms.DockStyle.Fill;
-			glControl.Click += OnSampleClicked;
-
-			var host = (WindowsFormsHost)sender;
-			host.Child = glControl;
-		}
-
-		private void OnPaintGL(object sender, SKPaintGLSurfaceEventArgs e)
-		{
-			OnPaintSurface(e.Surface.Canvas, e.BackendRenderTarget.Width, e.BackendRenderTarget.Height);
-		}
-
 		private void OnPaintCanvas(object sender, SKPaintSurfaceEventArgs e)
 		{
 			OnPaintSurface(e.Surface.Canvas, e.Info.Width, e.Info.Height);
@@ -202,7 +184,6 @@ namespace SkiaSharpSample
 		private void OnRefreshRequested(object sender, EventArgs e)
 		{
 			canvas.InvalidateVisual();
-			glhost.Child?.Invalidate();
 		}
 
 		private void OnPaintSurface(SKCanvas canvas, int width, int height)

--- a/samples/Gallery/WPF/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Gallery/WPF/SkiaSharpSample/SkiaSharpSample.csproj
@@ -97,7 +97,7 @@
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK" Version="3.2.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
     <ProjectReference Include="..\..\..\..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj">
       <Project>{2ae5d8c5-eac6-4515-89f2-a4994b41c925}</Project>
@@ -114,10 +114,6 @@
     <ProjectReference Include="..\..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.Desktop.Common\SkiaSharp.Views.Desktop.Common.csproj">
       <Project>{d52bb2a5-9b68-4a89-b221-2a4ec7da01f9}</Project>
       <Name>SkiaSharp.Views.Desktop.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.WindowsForms\SkiaSharp.Views.WindowsForms.csproj">
-      <Project>{a1334727-7cc6-43ac-a617-eefe2174f454}</Project>
-      <Name>SkiaSharp.Views.WindowsForms</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\..\source\SkiaSharp.Views\SkiaSharp.Views.WPF\SkiaSharp.Views.WPF.csproj">
       <Project>{743cf830-d458-41a9-865a-f85126562015}</Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/FallbackContext.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/FallbackContext.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenTK;
+using SkiaSharp.Views.WPF.Angle;
+using SkiaSharp.Views.WPF.OutputImage;
+
+namespace SkiaSharp.Views.WPF
+{
+	internal class FallbackContext
+    {
+	    private GameWindow? _gameWindow;
+	    private D3DAngleInterop? _angleInterop;
+	    private bool _initialized;
+
+		public GRContext? GrContext { get; private set; }
+
+	    public bool IsGpuRendering => GrContext != null;
+
+	    public int SampleCount { get; private set; }
+	    public int StencilBits { get; private set; }
+	    public GLMode Mode { get; private set; }
+	    public SKColorType ColorType { get; private set; }
+
+		public void TryInitialize()
+		{
+			if (_initialized)
+			{
+				return;
+			}
+			_initialized = true;
+
+			TryInitializeAngleContext();
+
+			if (GrContext == null)
+			{
+				TryInitializeOpenGLContext();
+			}
+
+			if (GrContext == null)
+			{
+				Mode = GLMode.CPU;
+				ColorType = SKColorType.Bgra8888;
+			}
+		}
+
+		private void TryInitializeAngleContext()
+		{
+			try
+			{
+				_angleInterop = new D3DAngleInterop();
+				var glInterface = GRGlInterface.CreateNativeAngleInterface();
+				GrContext = GRContext.CreateGl(glInterface);
+
+				SampleCount = OpenTK.Graphics.ES20.GL.GetInteger(OpenTK.Graphics.ES20.GetPName.Samples);
+				StencilBits = OpenTK.Graphics.ES20.GL.GetInteger(OpenTK.Graphics.ES20.GetPName.StencilBits);
+				var maxSamples = GrContext.GetMaxSurfaceSampleCount(SKColorType.Rgba8888);
+				if (SampleCount > maxSamples)
+					SampleCount = maxSamples;
+
+				GC.SuppressFinalize(GrContext);
+				Mode = GLMode.Angle;
+				ColorType = SKColorType.Rgba8888;
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+			}
+		}
+
+		private void TryInitializeOpenGLContext()
+		{
+			try
+			{
+				_gameWindow = new GameWindow();
+				_gameWindow.MakeCurrent();
+				GrContext = GRContext.CreateGl();
+
+				SampleCount = OpenTK.Graphics.OpenGL.GL.GetInteger(OpenTK.Graphics.OpenGL.GetPName.Samples);
+				StencilBits = OpenTK.Graphics.OpenGL.GL.GetInteger(OpenTK.Graphics.OpenGL.GetPName.StencilBits);
+				var maxSamples = GrContext.GetMaxSurfaceSampleCount(SKColorType.Bgra8888);
+				if (SampleCount > maxSamples)
+					SampleCount = maxSamples;
+
+				GC.SuppressFinalize(GrContext);
+				Mode = GLMode.OpenGL;
+				ColorType = SKColorType.Bgra8888;
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+			}
+		}
+
+		public SKSurface CreateSurface(SKImageInfo info)
+		{
+			if (IsGpuRendering)
+			{
+				return SKSurface.Create(GrContext, false, info, 1, GRSurfaceOrigin.TopLeft);
+			}
+			return SKSurface.Create(info);
+		}
+
+		public IOutputImage CreateOutputImage(SizeWithDpi size)
+		{
+			if (Mode == GLMode.Angle)
+			{
+				return new AngleImage(size, _angleInterop);
+			}
+
+			//openGL and CPU will work over CpuImage (WriteableBitmap)
+			return new CpuImage(size);
+		}
+
+		public void Dispose()
+		{
+			GrContext?.Dispose();
+			GrContext = null;
+			_gameWindow?.Dispose();
+			_gameWindow = null;
+		}
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/GLMode.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/GLMode.cs
@@ -1,0 +1,10 @@
+﻿namespace SkiaSharp.Views.WPF
+{
+	public enum GLMode : byte
+	{
+		NotInitialized = 0,
+		Angle = 1,
+		OpenGL = 2,
+		CPU = 3,
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/GLMode.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/GLMode.cs
@@ -4,7 +4,6 @@
 	{
 		NotInitialized = 0,
 		Angle = 1,
-		OpenGL = 2,
-		CPU = 3,
+		CPU = 2,
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3D9Interop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3D9Interop.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using SharpDX.Direct3D9;
+
+namespace SkiaSharp.Views.WPF.Angle
+{
+	internal class D3D9Interop
+	{
+		private bool _disposed;
+		private Texture? _texture;
+		private readonly Direct3DEx _d3dEx;
+		private readonly DeviceEx _deviceEx;
+
+		public D3D9Interop()
+		{
+			_d3dEx = new Direct3DEx();
+			_deviceEx = MakeDevice();
+		}
+
+		/// <summary>
+		///     Creates a new Direct3D9 Ex device, required for efficient
+		///     hardware-accelerated in Windows Vista and later.
+		/// </summary>
+		/// <returns></returns>
+		private DeviceEx MakeDevice() =>
+			new DeviceEx(_d3dEx, 0,
+				DeviceType.Hardware,
+				IntPtr.Zero,
+				CreateFlags.HardwareVertexProcessing
+				| CreateFlags.Multithreaded
+				| CreateFlags.FpuPreserve,
+				new PresentParameters
+				{
+					Windowed = true,
+					SwapEffect = SwapEffect.Discard,
+					PresentationInterval = PresentInterval.Immediate,
+
+					// The device back buffer is not used.
+					BackBufferFormat = Format.Unknown,
+					BackBufferWidth = 1,
+					BackBufferHeight = 1,
+
+					// Use dummy window handle.
+					DeviceWindowHandle = IntPtr.Zero
+				});
+
+		/// <summary>
+		///     Creates a new Direct3D9 texture that uses the same memory as the
+		///     passed in DirectX11-texture.
+		/// </summary>
+		public Texture CreateNewSharedTexture(IntPtr sharedHandle, int width, int height)
+		{
+			if (_disposed)
+			{
+				throw new ObjectDisposedException(GetType().FullName);
+			}
+			if (sharedHandle == IntPtr.Zero)
+			{
+				throw new ArgumentException(
+					"Unable to access resource. The texture needs to be created as a shared resource.", "render_target");
+			}
+
+			_texture?.Dispose();
+			_texture = new Texture(_deviceEx,
+				width,
+				height,
+				1, Usage.RenderTarget, Format.A8R8G8B8,
+				Pool.Default, ref sharedHandle);
+			return _texture;
+		}
+
+		~D3D9Interop()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		private void Dispose(bool disposeManaged)
+		{
+			if (_disposed)
+				return;
+
+			if (disposeManaged)
+			{
+				_texture?.Dispose();
+				_deviceEx?.Dispose();
+				_d3dEx?.Dispose();
+			}
+			_disposed = true;
+		}
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3D9Interop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3D9Interop.cs
@@ -5,15 +5,15 @@ namespace SkiaSharp.Views.WPF.Angle
 {
 	internal class D3D9Interop
 	{
-		private bool _disposed;
-		private Texture? _texture;
-		private readonly Direct3DEx _d3dEx;
-		private readonly DeviceEx _deviceEx;
+		private bool disposed;
+		private Texture? texture;
+		private readonly Direct3DEx d3dEx;
+		private readonly DeviceEx deviceEx;
 
 		public D3D9Interop()
 		{
-			_d3dEx = new Direct3DEx();
-			_deviceEx = MakeDevice();
+			d3dEx = new Direct3DEx();
+			deviceEx = MakeDevice();
 		}
 
 		/// <summary>
@@ -22,7 +22,7 @@ namespace SkiaSharp.Views.WPF.Angle
 		/// </summary>
 		/// <returns></returns>
 		private DeviceEx MakeDevice() =>
-			new DeviceEx(_d3dEx, 0,
+			new DeviceEx(d3dEx, 0,
 				DeviceType.Hardware,
 				IntPtr.Zero,
 				CreateFlags.HardwareVertexProcessing
@@ -49,7 +49,7 @@ namespace SkiaSharp.Views.WPF.Angle
 		/// </summary>
 		public Texture CreateNewSharedTexture(IntPtr sharedHandle, int width, int height)
 		{
-			if (_disposed)
+			if (disposed)
 			{
 				throw new ObjectDisposedException(GetType().FullName);
 			}
@@ -59,13 +59,13 @@ namespace SkiaSharp.Views.WPF.Angle
 					"Unable to access resource. The texture needs to be created as a shared resource.", "render_target");
 			}
 
-			_texture?.Dispose();
-			_texture = new Texture(_deviceEx,
+			texture?.Dispose();
+			texture = new Texture(deviceEx,
 				width,
 				height,
 				1, Usage.RenderTarget, Format.A8R8G8B8,
 				Pool.Default, ref sharedHandle);
-			return _texture;
+			return texture;
 		}
 
 		~D3D9Interop()
@@ -81,16 +81,16 @@ namespace SkiaSharp.Views.WPF.Angle
 
 		private void Dispose(bool disposeManaged)
 		{
-			if (_disposed)
+			if (disposed)
 				return;
 
 			if (disposeManaged)
 			{
-				_texture?.Dispose();
-				_deviceEx?.Dispose();
-				_d3dEx?.Dispose();
+				texture?.Dispose();
+				deviceEx?.Dispose();
+				d3dEx?.Dispose();
 			}
-			_disposed = true;
+			disposed = true;
 		}
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Interop;
+using OpenTK.Graphics;
+using OpenTK.Platform;
+using OpenTK.Platform.Egl;
+
+namespace SkiaSharp.Views.WPF.Angle
+{
+	/// <summary>
+	/// GLES 2.0 and ANGLE context initialization over DirectX 9
+	/// </summary>
+    internal class D3DAngleInterop : IDisposable
+    {
+        private readonly Window _window;
+        private readonly GraphicsContext _context;
+        private readonly IAngleWindowInfo _windowInfo;
+        private readonly D3D9Interop _d3d9Interop;
+
+        public D3DAngleInterop()
+        {
+            _d3d9Interop = new D3D9Interop();
+            _window = new Window();
+
+			var handle = new WindowInteropHelper(_window).Handle;
+			var basicWindowInfo = Utilities.CreateWindowsWindowInfo(handle);
+            _windowInfo = Utilities.CreateAngleWindowInfo(basicWindowInfo);
+
+            _context = new GraphicsContext(
+                new GraphicsMode(32, 24), _windowInfo, 2, 0,
+                GraphicsContextFlags.Embedded | GraphicsContextFlags.Offscreen | GraphicsContextFlags.AngleD3D9);
+            _context.MakeCurrent(_windowInfo);
+            _context.LoadAll();
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+            _d3d9Interop.Dispose();
+        }
+
+        public IntPtr GetD3DSharedHandleForSurface(IntPtr eglSurface, int width, int height)
+        {
+            var ptr = _windowInfo.QuerySurfacePointer(eglSurface);
+            var texture = _d3d9Interop.CreateNewSharedTexture(ptr, width, height);
+            return texture.GetSurfaceLevel(0).NativePointer;
+        }
+
+        public void EnsureContext() => _context.MakeCurrent(_windowInfo);
+
+        public void MakeCurrent(IntPtr surface) => _windowInfo.MakeCurrent(surface);
+
+        public IntPtr CreateOffscreenSurface(int width, int height) => _windowInfo.CreateSurface(width, height);
+
+        public void DestroyOffscreenSurface(ref IntPtr surface) => _windowInfo.DestroySurface(ref surface);
+    }
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Windows;
-using System.Windows.Interop;
+using System.Windows.Forms;
 using OpenTK.Graphics;
 using OpenTK.Platform;
 using OpenTK.Platform.Egl;
@@ -12,7 +11,7 @@ namespace SkiaSharp.Views.WPF.Angle
 	/// </summary>
     internal class D3DAngleInterop : IDisposable
     {
-        private readonly Window _window;
+        private readonly Control _control;
         private readonly GraphicsContext _context;
         private readonly IAngleWindowInfo _windowInfo;
         private readonly D3D9Interop _d3d9Interop;
@@ -20,10 +19,9 @@ namespace SkiaSharp.Views.WPF.Angle
         public D3DAngleInterop()
         {
             _d3d9Interop = new D3D9Interop();
-            _window = new Window();
+            _control = new Control();
 
-			var handle = new WindowInteropHelper(_window).Handle;
-			var basicWindowInfo = Utilities.CreateWindowsWindowInfo(handle);
+			var basicWindowInfo = Utilities.CreateWindowsWindowInfo(_control.Handle);
             _windowInfo = Utilities.CreateAngleWindowInfo(basicWindowInfo);
 
             _context = new GraphicsContext(

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
@@ -15,8 +15,9 @@ namespace SkiaSharp.Views.WPF.Angle
         private readonly GraphicsContext context;
         private readonly IAngleWindowInfo windowInfo;
         private readonly D3D9Interop d3d9Interop;
+        private bool disposed;
 
-        public D3DAngleInterop()
+		public D3DAngleInterop()
         {
             d3d9Interop = new D3D9Interop();
             control = new Control();
@@ -29,12 +30,6 @@ namespace SkiaSharp.Views.WPF.Angle
                 GraphicsContextFlags.Embedded | GraphicsContextFlags.Offscreen | GraphicsContextFlags.AngleD3D9);
             context.MakeCurrent(windowInfo);
             context.LoadAll();
-        }
-
-        public void Dispose()
-        {
-            context.Dispose();
-            d3d9Interop.Dispose();
         }
 
         public IntPtr GetD3DSharedHandleForSurface(IntPtr eglSurface, int width, int height)
@@ -51,5 +46,29 @@ namespace SkiaSharp.Views.WPF.Angle
         public IntPtr CreateOffscreenSurface(int width, int height) => windowInfo.CreateSurface(width, height);
 
         public void DestroyOffscreenSurface(ref IntPtr surface) => windowInfo.DestroySurface(ref surface);
-    }
+
+        ~D3DAngleInterop()
+        {
+	        Dispose(false);
+        }
+
+        public void Dispose()
+        {
+	        Dispose(true);
+	        GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposeManaged)
+        {
+	        if (disposed)
+		        return;
+
+	        if (disposeManaged)
+			{
+				context.Dispose();
+				d3d9Interop.Dispose();
+			}
+	        disposed = true;
+        }
+	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/Interop/D3DAngleInterop.cs
@@ -11,45 +11,45 @@ namespace SkiaSharp.Views.WPF.Angle
 	/// </summary>
     internal class D3DAngleInterop : IDisposable
     {
-        private readonly Control _control;
-        private readonly GraphicsContext _context;
-        private readonly IAngleWindowInfo _windowInfo;
-        private readonly D3D9Interop _d3d9Interop;
+        private readonly Control control;
+        private readonly GraphicsContext context;
+        private readonly IAngleWindowInfo windowInfo;
+        private readonly D3D9Interop d3d9Interop;
 
         public D3DAngleInterop()
         {
-            _d3d9Interop = new D3D9Interop();
-            _control = new Control();
+            d3d9Interop = new D3D9Interop();
+            control = new Control();
 
-			var basicWindowInfo = Utilities.CreateWindowsWindowInfo(_control.Handle);
-            _windowInfo = Utilities.CreateAngleWindowInfo(basicWindowInfo);
+			var basicWindowInfo = Utilities.CreateWindowsWindowInfo(control.Handle);
+            windowInfo = Utilities.CreateAngleWindowInfo(basicWindowInfo);
 
-            _context = new GraphicsContext(
-                new GraphicsMode(32, 24), _windowInfo, 2, 0,
+            context = new GraphicsContext(
+                new GraphicsMode(32, 24), windowInfo, 2, 0,
                 GraphicsContextFlags.Embedded | GraphicsContextFlags.Offscreen | GraphicsContextFlags.AngleD3D9);
-            _context.MakeCurrent(_windowInfo);
-            _context.LoadAll();
+            context.MakeCurrent(windowInfo);
+            context.LoadAll();
         }
 
         public void Dispose()
         {
-            _context.Dispose();
-            _d3d9Interop.Dispose();
+            context.Dispose();
+            d3d9Interop.Dispose();
         }
 
         public IntPtr GetD3DSharedHandleForSurface(IntPtr eglSurface, int width, int height)
         {
-            var ptr = _windowInfo.QuerySurfacePointer(eglSurface);
-            var texture = _d3d9Interop.CreateNewSharedTexture(ptr, width, height);
+            var ptr = windowInfo.QuerySurfacePointer(eglSurface);
+            var texture = d3d9Interop.CreateNewSharedTexture(ptr, width, height);
             return texture.GetSurfaceLevel(0).NativePointer;
         }
 
-        public void EnsureContext() => _context.MakeCurrent(_windowInfo);
+        public void EnsureContext() => context.MakeCurrent(windowInfo);
 
-        public void MakeCurrent(IntPtr surface) => _windowInfo.MakeCurrent(surface);
+        public void MakeCurrent(IntPtr surface) => windowInfo.MakeCurrent(surface);
 
-        public IntPtr CreateOffscreenSurface(int width, int height) => _windowInfo.CreateSurface(width, height);
+        public IntPtr CreateOffscreenSurface(int width, int height) => windowInfo.CreateSurface(width, height);
 
-        public void DestroyOffscreenSurface(ref IntPtr surface) => _windowInfo.DestroySurface(ref surface);
+        public void DestroyOffscreenSurface(ref IntPtr surface) => windowInfo.DestroySurface(ref surface);
     }
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/AngleImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/AngleImage.cs
@@ -47,10 +47,7 @@ namespace SkiaSharp.Views.WPF.OutputImage
 			image.Unlock();
 		}
 
-		public SKSurface CreateSurface(WaterfallContext context)
-		{
-			return SKSurface.Create(context.GrContext, renderTarget, GRSurfaceOrigin.TopLeft, context.ColorType);
-		}
+		public SKSurface CreateSurface() => SKSurface.Create(context.GrContext, renderTarget, GRSurfaceOrigin.TopLeft, context.ColorType);
 
 		public void TryResize(SizeWithDpi size)
 		{
@@ -84,7 +81,12 @@ namespace SkiaSharp.Views.WPF.OutputImage
 				SetSharedSurfaceToD3DImage();
 			}
 
+			UpdateBackendRenderTarget();
+		}
 
+		private void UpdateBackendRenderTarget()
+		{
+			renderTarget?.Dispose();
 			var glInfo = new GRGlFramebufferInfo(
 				fboId: 0,
 				format: context.ColorType.ToGlSizedFormat());

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/AngleImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/AngleImage.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using SkiaSharp.Views.WPF.Angle;
+
+namespace SkiaSharp.Views.WPF.OutputImage
+{
+	internal class AngleImage : IOutputImage
+	{
+		private static readonly Duration LockTimeout = new Duration(TimeSpan.FromMilliseconds(2000));
+		private readonly D3DAngleInterop _angleInterop;
+		private IntPtr _d3dSurface;
+		private IntPtr _eglSurface;
+		private D3DImage _image;
+		private Int32Rect _rect;
+		private bool _isBackBufferSet;
+
+		public SizeWithDpi Size { get; private set; }
+
+		public AngleImage(SizeWithDpi size, D3DAngleInterop angleInterop)
+		{
+			_angleInterop = angleInterop;
+			TryResize(size);
+		}
+
+		public ImageSource Source => _image;
+
+		public bool TryLock()
+		{
+			if (!_isBackBufferSet ||
+			    _image == null ||
+			    !_image.IsFrontBufferAvailable)
+			{
+				return false;
+			}
+
+			return _image.TryLock(LockTimeout);
+		}
+
+		public void Unlock()
+		{
+			_image.AddDirtyRect(_rect);
+			_image.Unlock();
+		}
+
+		public SKSurface CreateSurface(FallbackContext context)
+		{
+			var glInfo = new GRGlFramebufferInfo(
+				fboId: 0,
+				format: context.ColorType.ToGlSizedFormat());
+			var renderTarget = new GRBackendRenderTarget(
+				width: Size.Width,
+				height: Size.Height,
+				sampleCount: context.SampleCount,
+				stencilBits: context.StencilBits,
+				glInfo: glInfo);
+			return SKSurface.Create(context.GrContext, renderTarget, GRSurfaceOrigin.TopLeft, context.ColorType);
+		}
+
+		public void TryResize(SizeWithDpi size)
+		{
+			if (Size.Equals(size))
+			{
+				return;
+			}
+
+			if (Size.DpiX != size.DpiX ||
+			    Size.DpiY != size.DpiY)
+			{
+				_image = new D3DImage(size.DpiX, size.DpiX);
+				_isBackBufferSet = false;
+			}
+
+			Size = size;
+
+			_angleInterop.EnsureContext();
+
+			if (_eglSurface != IntPtr.Zero)
+			{
+				_angleInterop.DestroyOffscreenSurface(ref _eglSurface);
+			}
+
+			_eglSurface = _angleInterop.CreateOffscreenSurface(size.Width, size.Height);
+			_angleInterop.MakeCurrent(_eglSurface);
+
+			_d3dSurface = _angleInterop.GetD3DSharedHandleForSurface(_eglSurface, size.Width, size.Height);
+			if (_d3dSurface != IntPtr.Zero)
+			{
+				SetSharedSurfaceToD3DImage();
+			}
+		}
+
+		private void SetSharedSurfaceToD3DImage()
+		{
+			if (_image == null)
+			{
+				return;
+			}
+			if (_image.TryLock(LockTimeout))
+			{
+				_image.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _d3dSurface, true);
+				_isBackBufferSet = true;
+				_rect = new Int32Rect(0, 0, _image.PixelWidth, _image.PixelHeight);
+				_image.AddDirtyRect(_rect);
+			}
+			_image.Unlock();
+		}
+
+		public void MakeCurrent() => _angleInterop.MakeCurrent(_eglSurface);
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
@@ -21,22 +21,9 @@ namespace SkiaSharp.Views.WPF.OutputImage
 	    public ImageSource Source => image;
 
 	    public SKSurface CreateSurface(WaterfallContext context)
-	    {
-		    if (context.GrContext == null)
-		    {
-				return SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, context.ColorType), image.BackBuffer);
-		    }
-		    var glInfo = new GRGlFramebufferInfo(
-			    fboId: 0,
-			    format: context.ColorType.ToGlSizedFormat());
-		    var renderTarget = new GRBackendRenderTarget(
-			    width: Size.Width,
-			    height: Size.Height,
-			    sampleCount: context.SampleCount,
-			    stencilBits: context.StencilBits,
-			    glInfo: glInfo);
-		    return SKSurface.Create(context.GrContext, renderTarget, GRSurfaceOrigin.TopLeft, context.ColorType);
-	    }
+		{
+			return SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, context.ColorType), image.BackBuffer);
+		}
 
 		public void TryResize(SizeWithDpi size)
 		{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
@@ -20,7 +20,7 @@ namespace SkiaSharp.Views.WPF.OutputImage
 
 	    public ImageSource Source => _image;
 
-	    public SKSurface CreateSurface(FallbackContext context)
+	    public SKSurface CreateSurface(WaterfallContext context)
 	    {
 		    if (context.GrContext == null)
 		    {

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace SkiaSharp.Views.WPF.OutputImage
+{
+    internal class CpuImage : IOutputImage
+	{
+		private static readonly Duration LockTimeout = new Duration(TimeSpan.FromMilliseconds(2000));
+		private WriteableBitmap _image;
+		private Int32Rect _rect;
+
+		public SizeWithDpi Size { get; private set; }
+
+		public CpuImage(SizeWithDpi size)
+	    {
+			TryResize(size);
+		}
+
+	    public ImageSource Source => _image;
+
+	    public SKSurface CreateSurface(FallbackContext context)
+	    {
+		    if (context.GrContext == null)
+		    {
+				return SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, context.ColorType), _image.BackBuffer);
+		    }
+		    var glInfo = new GRGlFramebufferInfo(
+			    fboId: 0,
+			    format: context.ColorType.ToGlSizedFormat());
+		    var renderTarget = new GRBackendRenderTarget(
+			    width: Size.Width,
+			    height: Size.Height,
+			    sampleCount: context.SampleCount,
+			    stencilBits: context.StencilBits,
+			    glInfo: glInfo);
+		    return SKSurface.Create(context.GrContext, renderTarget, GRSurfaceOrigin.TopLeft, context.ColorType);
+	    }
+
+		public void TryResize(SizeWithDpi size)
+		{
+			if (Size.Equals(size))
+			{
+				return;
+			}
+
+			Size = size;
+			_image = new WriteableBitmap(size.Width, size.Height, size.DpiX, size.DpiY, PixelFormats.Pbgra32, null);
+			_rect = new Int32Rect(0, 0, size.Width, size.Height);
+		}
+
+	    public bool TryLock() => _image.TryLock(LockTimeout);
+
+	    public void Unlock()
+		{
+			_image.AddDirtyRect(_rect);
+			_image.Unlock();
+		}
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
@@ -10,20 +10,27 @@ namespace SkiaSharp.Views.WPF.OutputImage
 		private static readonly Duration LockTimeout = new Duration(TimeSpan.FromMilliseconds(2000));
 		private WriteableBitmap image;
 		private Int32Rect rect;
+		private SKColorType colorType;
 
 		public SizeWithDpi Size { get; private set; }
 
-		public CpuImage(SizeWithDpi size)
-	    {
+		public CpuImage(SizeWithDpi size, SKColorType colorType)
+		{
+			this.colorType = colorType;
 			TryResize(size);
 		}
 
 	    public ImageSource Source => image;
 
-	    public SKSurface CreateSurface(WaterfallContext context)
-		{
-			return SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, context.ColorType), image.BackBuffer);
-		}
+	    public SKSurface CreateSurface() => SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, colorType), image.BackBuffer);
+
+	    public bool TryLock() => image.TryLock(LockTimeout);
+
+	    public void Unlock()
+	    {
+		    image.AddDirtyRect(rect);
+		    image.Unlock();
+	    }
 
 		public void TryResize(SizeWithDpi size)
 		{
@@ -35,14 +42,6 @@ namespace SkiaSharp.Views.WPF.OutputImage
 			Size = size;
 			image = new WriteableBitmap(size.Width, size.Height, size.DpiX, size.DpiY, PixelFormats.Pbgra32, null);
 			rect = new Int32Rect(0, 0, size.Width, size.Height);
-		}
-
-	    public bool TryLock() => image.TryLock(LockTimeout);
-
-	    public void Unlock()
-		{
-			image.AddDirtyRect(rect);
-			image.Unlock();
 		}
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/CpuImage.cs
@@ -8,8 +8,8 @@ namespace SkiaSharp.Views.WPF.OutputImage
     internal class CpuImage : IOutputImage
 	{
 		private static readonly Duration LockTimeout = new Duration(TimeSpan.FromMilliseconds(2000));
-		private WriteableBitmap _image;
-		private Int32Rect _rect;
+		private WriteableBitmap image;
+		private Int32Rect rect;
 
 		public SizeWithDpi Size { get; private set; }
 
@@ -18,13 +18,13 @@ namespace SkiaSharp.Views.WPF.OutputImage
 			TryResize(size);
 		}
 
-	    public ImageSource Source => _image;
+	    public ImageSource Source => image;
 
 	    public SKSurface CreateSurface(WaterfallContext context)
 	    {
 		    if (context.GrContext == null)
 		    {
-				return SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, context.ColorType), _image.BackBuffer);
+				return SKSurface.Create(new SKImageInfo(Size.Width, Size.Height, context.ColorType), image.BackBuffer);
 		    }
 		    var glInfo = new GRGlFramebufferInfo(
 			    fboId: 0,
@@ -46,16 +46,16 @@ namespace SkiaSharp.Views.WPF.OutputImage
 			}
 
 			Size = size;
-			_image = new WriteableBitmap(size.Width, size.Height, size.DpiX, size.DpiY, PixelFormats.Pbgra32, null);
-			_rect = new Int32Rect(0, 0, size.Width, size.Height);
+			image = new WriteableBitmap(size.Width, size.Height, size.DpiX, size.DpiY, PixelFormats.Pbgra32, null);
+			rect = new Int32Rect(0, 0, size.Width, size.Height);
 		}
 
-	    public bool TryLock() => _image.TryLock(LockTimeout);
+	    public bool TryLock() => image.TryLock(LockTimeout);
 
 	    public void Unlock()
 		{
-			_image.AddDirtyRect(_rect);
-			_image.Unlock();
+			image.AddDirtyRect(rect);
+			image.Unlock();
 		}
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/IOutputImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/IOutputImage.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Windows.Media;
-using SkiaSharp.Views.WPF.OutputImage;
+﻿using System.Windows.Media;
 
-namespace SkiaSharp.Views.WPF
+namespace SkiaSharp.Views.WPF.OutputImage
 {
 	internal interface IOutputImage
 	{
@@ -15,6 +13,6 @@ namespace SkiaSharp.Views.WPF
 		bool TryLock();
 		void Unlock();
 
-		SKSurface CreateSurface(FallbackContext context);
+		SKSurface CreateSurface(WaterfallContext context);
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/IOutputImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/IOutputImage.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Windows.Media;
+using SkiaSharp.Views.WPF.OutputImage;
+
+namespace SkiaSharp.Views.WPF
+{
+	internal interface IOutputImage
+	{
+		ImageSource Source { get; }
+
+		public SizeWithDpi Size { get; }
+
+		void TryResize(SizeWithDpi size);
+
+		bool TryLock();
+		void Unlock();
+
+		SKSurface CreateSurface(FallbackContext context);
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/IOutputImage.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/IOutputImage.cs
@@ -13,6 +13,6 @@ namespace SkiaSharp.Views.WPF.OutputImage
 		bool TryLock();
 		void Unlock();
 
-		SKSurface CreateSurface(WaterfallContext context);
+		SKSurface CreateSurface();
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/SizeWithDpi.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/OutputImage/SizeWithDpi.cs
@@ -1,0 +1,37 @@
+﻿namespace SkiaSharp.Views.WPF.OutputImage
+{
+    internal struct SizeWithDpi
+    {
+		public static SizeWithDpi Empty = new SizeWithDpi(0, 0);
+
+	    public int Width;
+	    public int Height;
+	    public double DpiX;
+	    public double DpiY;
+
+	    public SizeWithDpi(int width, int height, double dpiX = 96.0, double dpiY = 96.0)
+	    {
+		    Width = width;
+		    Height = height;
+		    DpiX = dpiX;
+		    DpiY = dpiY;
+	    }
+
+        public override bool Equals(object obj)
+        {
+            return obj is SizeWithDpi dpi &&
+                   Width == dpi.Width &&
+                   Height == dpi.Height &&
+                   DpiX == dpi.DpiX &&
+                   DpiY == dpi.DpiY;
+        }
+
+        public bool Equals(SizeWithDpi dpi)
+        {
+	        return Width == dpi.Width &&
+	               Height == dpi.Height &&
+	               DpiX == dpi.DpiX &&
+	               DpiY == dpi.DpiY;
+        }
+	}
+}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using SkiaSharp.Views.Desktop;
 using SkiaSharp.Views.WPF.OutputImage;
 
@@ -16,9 +12,8 @@ namespace SkiaSharp.Views.WPF
 	[DefaultProperty("Name")]
 	public class SKElement : FrameworkElement
 	{
-		private static FallbackContext context;
+		private static WaterfallContext context;
 		private readonly bool designMode;
-		private double dpiX, dpiY;
 
 		private IOutputImage image;
 		private bool ignorePixelScaling;
@@ -75,7 +70,8 @@ namespace SkiaSharp.Views.WPF
 
 			if (context == null)
 			{
-				context = new FallbackContext();
+				context = new WaterfallContext();
+				context.Initialize();
 			}
 
 			if (image == null)
@@ -90,8 +86,6 @@ namespace SkiaSharp.Views.WPF
 
 			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
 
-			context.TryInitialize();
-			image = context.CreateOutputImage(CreateSize());
 			// draw on the bitmap
 			if (image.TryLock())
 			{
@@ -100,6 +94,9 @@ namespace SkiaSharp.Views.WPF
 					OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info));
 				}
 			}
+
+			context.GrContext?.Flush();
+			OpenTK.Graphics.ES20.GL.Flush();
 
 			image.Unlock();
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
@@ -95,8 +95,11 @@ namespace SkiaSharp.Views.WPF
 				}
 			}
 
-			context.GrContext?.Flush();
-			OpenTK.Graphics.ES20.GL.Flush();
+			if (context.IsGpuRendering)
+			{
+				context.GrContext?.Flush();
+				OpenTK.Graphics.ES20.GL.Flush();
+			}
 
 			image.Unlock();
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp3.0</TargetFrameworks>
     <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>SkiaSharp.Views.WPF</RootNamespace>
     <AssemblyName>SkiaSharp.Views.WPF</AssemblyName>
     <PackagingGroup>SkiaSharp.Views.WPF</PackagingGroup>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -21,6 +21,7 @@
     <Compile Include="..\SkiaSharp.Views.Shared\Properties\SkiaSharpViewsAssemblyInfo.cs" Link="Properties\SkiaSharpViewsAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2020091801" />
     <PackageReference Include="OpenTK" Version="3.2.0" />
     <PackageReference Include="SharpDX.Direct3D9" Version="4.2.0" />
   </ItemGroup>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SkiaSharp.Views.WPF.csproj
@@ -19,4 +19,8 @@
   <ItemGroup>
     <Compile Include="..\SkiaSharp.Views.Shared\Properties\SkiaSharpViewsAssemblyInfo.cs" Link="Properties\SkiaSharpViewsAssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTK" Version="3.2.0" />
+    <PackageReference Include="SharpDX.Direct3D9" Version="4.2.0" />
+  </ItemGroup>
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WaterfallContext.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WaterfallContext.cs
@@ -12,7 +12,8 @@ namespace SkiaSharp.Views.WPF
 	/// ANGLE can be not itialized if ANGLE libs are missing or GPU device is missing.
 	/// </summary>
 	internal class WaterfallContext
-    {
+	{
+		private bool disposed;
 	    private GameWindow? gameWindow;
 	    private D3DAngleInterop? angleInterop;
 
@@ -68,15 +69,32 @@ namespace SkiaSharp.Views.WPF
 			}
 
 			//openGL and CPU will work over CpuImage (WriteableBitmap)
-			return new CpuImage(size);
+			return new CpuImage(size, ColorType);
+		}
+
+		~WaterfallContext()
+		{
+			Dispose(false);
 		}
 
 		public void Dispose()
 		{
-			GrContext?.Dispose();
-			GrContext = null;
-			gameWindow?.Dispose();
-			gameWindow = null;
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		private void Dispose(bool disposeManaged)
+		{
+			if (disposed)
+				return;
+
+			if (disposeManaged)
+			{
+				angleInterop?.Dispose();
+				gameWindow?.Dispose();
+				GrContext?.Dispose();
+			}
+			disposed = true;
 		}
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WaterfallContext.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WaterfallContext.cs
@@ -15,8 +15,8 @@ namespace SkiaSharp.Views.WPF
 	/// </summary>
 	internal class WaterfallContext
     {
-	    private GameWindow? _gameWindow;
-	    private D3DAngleInterop? _angleInterop;
+	    private GameWindow? gameWindow;
+	    private D3DAngleInterop? angleInterop;
 
 		public GRContext? GrContext { get; private set; }
 
@@ -47,7 +47,7 @@ namespace SkiaSharp.Views.WPF
 		{
 			try
 			{
-				_angleInterop = new D3DAngleInterop();
+				angleInterop = new D3DAngleInterop();
 				var glInterface = GRGlInterface.CreateNativeAngleInterface();
 				GrContext = GRContext.CreateGl(glInterface);
 
@@ -71,8 +71,8 @@ namespace SkiaSharp.Views.WPF
 		{
 			try
 			{
-				_gameWindow = new GameWindow();
-				_gameWindow.MakeCurrent();
+				gameWindow = new GameWindow();
+				gameWindow.MakeCurrent();
 				GrContext = GRContext.CreateGl();
 
 				SampleCount = OpenTK.Graphics.OpenGL.GL.GetInteger(OpenTK.Graphics.OpenGL.GetPName.Samples);
@@ -104,7 +104,7 @@ namespace SkiaSharp.Views.WPF
 		{
 			if (Mode == GLMode.Angle)
 			{
-				return new AngleImage(size, _angleInterop, this);
+				return new AngleImage(size, angleInterop, this);
 			}
 
 			//openGL and CPU will work over CpuImage (WriteableBitmap)
@@ -115,8 +115,8 @@ namespace SkiaSharp.Views.WPF
 		{
 			GrContext?.Dispose();
 			GrContext = null;
-			_gameWindow?.Dispose();
-			_gameWindow = null;
+			gameWindow?.Dispose();
+			gameWindow = null;
 		}
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WaterfallContext.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WaterfallContext.cs
@@ -1,20 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using OpenTK;
 using SkiaSharp.Views.WPF.Angle;
 using SkiaSharp.Views.WPF.OutputImage;
 
 namespace SkiaSharp.Views.WPF
 {
-	internal class FallbackContext
+	/// <summary>
+	/// Tryes to initialize ANGLE, then OpenGL, then uses CPU rendering.
+	///
+	/// ANGLE can be unitialized if ANGLE libs are missing or GPU device is missing.
+	/// OpenGL can initialize if ANGLE is not initialized by missing ANGLE libs, but there is GPU device exists.
+	/// CPU will be used if two choises above is failed.
+	/// </summary>
+	internal class WaterfallContext
     {
 	    private GameWindow? _gameWindow;
 	    private D3DAngleInterop? _angleInterop;
-	    private bool _initialized;
 
 		public GRContext? GrContext { get; private set; }
 
@@ -25,14 +27,8 @@ namespace SkiaSharp.Views.WPF
 	    public GLMode Mode { get; private set; }
 	    public SKColorType ColorType { get; private set; }
 
-		public void TryInitialize()
+		public void Initialize()
 		{
-			if (_initialized)
-			{
-				return;
-			}
-			_initialized = true;
-
 			TryInitializeAngleContext();
 
 			if (GrContext == null)
@@ -108,7 +104,7 @@ namespace SkiaSharp.Views.WPF
 		{
 			if (Mode == GLMode.Angle)
 			{
-				return new AngleImage(size, _angleInterop);
+				return new AngleImage(size, _angleInterop, this);
 			}
 
 			//openGL and CPU will work over CpuImage (WriteableBitmap)


### PR DESCRIPTION
**Description of Change**

I've added working ANGLE approach to the SkiaSharp.Views.WPF that enables GPU rendering with minimum performance overhead on transferring draw calls between OpenGL and DirectX.

This version of code is a minimum working example that's have minimum changes to the SKElement code. I've decided to do so to make PR as simple as I can, so it will be easy to understand the code and make some changes to it, if we will need some. 

[WARNING]
ANGLE libs are attached by Avalonia nuget package, but it has an issue, somehow it do not copy angle libs to the connected projects output, like WPF sample. So to make ANGLE working you need to copy libs manually. We need to ask and make an update to Avalonia nuget package or make SkiaSharp ANGLE libs package that supports dlls copying to connected projects.

If this PR will be merged I will continue the work and add support of rendering in specific thread, and other tweaks.

**Bugs Added**

* Window hang on any DEVICE_LOST. Device lost can be triggered by PC sleep/hybernate or by directX command line call.

- Related to issue #

**API Changes**

Added: 
 
- `GLMode SKElement.Mode { get; }`
- `GRContext SKElement.GRContext { get; }`
- `void SKElement.StopRenderAndDisposeAllUnmanagedResources()`

**Behavioral Changes**

* My code do not support multiple instances of SKElement. I don't know if we need to make this feature.
* I've removed openGL/WindowsFormsHost approach because it's bad and don't needed anymore (from my perspective)
* My code do not support backend switch. Do I need to implement it?

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
- [ ] Angle Libs nuget issue is resolved
