### PR TITLE
Ensure that SKMatrix.IsInvertible does not crash

### DIFF
--- a/tests/Tests/SKMatrixTests.cs
+++ b/tests/Tests/SKMatrixTests.cs
@@ -189,6 +189,17 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void IsInvertibleIsTrueForInvertableMatrix()
+		{
+			var matrix = new SKMatrix(
+				1, 2, 3,
+				0, 1, 4,
+				5, 6, 1);
+
+			Assert.True(matrix.IsInvertible);
+		}
+
+		[SkippableFact]
 		public void InverseOfMatrixIsCorrect()
 		{
 			var rowMajor = new float[] {


### PR DESCRIPTION
**Description of Change**

Ensure that SKMatrix.IsInvertible does not crash.

**Bugs Fixed**

 - Fixes #1526

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
