### PR TITLE
Support VS 2013 because it is easy to do so

### DIFF
--- a/binding/HarfBuzzSharp/nuget/build/net462/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/net462/HarfBuzzSharp.targets
@@ -7,57 +7,65 @@
         <_AppIsFullMac Condition=" '$(XamarinMacFrameworkRoot)' != '' and '$(TargetFrameworkIdentifier)' != 'Xamarin.Mac' and '$(UseXamMacFullFramework)' == 'True' and ('$(OutputType)' == 'Exe' or '$(IsAppExtension)' == 'True') ">True</_AppIsFullMac>
     </PropertyGroup>
 
-    <!-- get the preferred architecture -->
-    <PropertyGroup>
-        <!-- handle VS 2017 live unit testing -->
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(BuildingForLiveUnitTesting)' == 'true' and '$(PlatformTarget)' == '' ">x86</PreferredNativeHarfBuzzSharp>   
-
-        <!-- handle x86/x64 specifically -->
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and ( '$(PlatformTarget)' == 'x64' or '$(PlatformTarget)' == 'x86' ) ">$(PlatformTarget)</PreferredNativeHarfBuzzSharp> 
-        <!-- handle Any CPU, considering Prefer32Bit - but only on Windows as macOS and Linux ignore this flag -->
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(OS)' != 'Unix' and '$(Prefer32Bit)' == 'False' ">x64</PreferredNativeHarfBuzzSharp>  
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(OS)' != 'Unix' and '$(Prefer32Bit)' == 'True' ">x86</PreferredNativeHarfBuzzSharp> 
-        <!-- fall back to x64 on 64-bit machines -->
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(MSBuildRuntimeType)' != 'Core' and '$([System.Environment]::Is64BitOperatingSystem)' == 'True' ">x64</PreferredNativeHarfBuzzSharp> 
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' and '$(MSBuildRuntimeType)' == 'Core' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' ">x64</PreferredNativeHarfBuzzSharp> 
-        <!-- fall back to x86 -->
-        <PreferredNativeHarfBuzzSharp Condition=" '$(PreferredNativeHarfBuzzSharp)' == '' ">x86</PreferredNativeHarfBuzzSharp>
-    </PropertyGroup>
-
     <!-- handle the case where this is a Xamarin.Mac Full app/extension -->
     <ItemGroup Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' != 'False' and '$(_AppIsFullMac)' == 'True' ">
-        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libHarfBuzzSharp*.dylib" Kind="Dynamic" Visible="false" />
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libHarfBuzzSharp*.dylib">
+            <Kind>Dynamic</Kind>
+            <Visible>False</Visible>
+        </NativeReference>
     </ItemGroup>
 
     <!-- copy the native files to the output directory -->
     <ItemGroup Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' != 'False' and '$(_AppIsFullMac)' != 'True' ">
 
-        <!-- preferred -->
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(PreferredNativeHarfBuzzSharp)\native\libHarfBuzzSharp*.dll" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-$(PreferredNativeHarfBuzzSharp)\native\libHarfBuzzSharp*.so" />
-
         <!-- Windows -->
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\libHarfBuzzSharp*.dll" Dir="x86\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\libHarfBuzzSharp*.dll" Dir="x64\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\libHarfBuzzSharp*.dll" Dir="arm64\" />
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\libHarfBuzzSharp*.dll">
+            <Dir>x86\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\libHarfBuzzSharp*.dll">
+            <Dir>x64\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\libHarfBuzzSharp*.dll">
+            <Dir>arm64\</Dir>
+        </_NativeHarfBuzzSharpFile>
 
         <!-- Linux -->
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libHarfBuzzSharp*.so" Dir="x86\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libHarfBuzzSharp*.so" Dir="x64\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libHarfBuzzSharp*.so" Dir="arm\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libHarfBuzzSharp*.so" Dir="arm64\" />
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libHarfBuzzSharp*.so">
+            <Dir>x86\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libHarfBuzzSharp*.so">
+            <Dir>x64\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libHarfBuzzSharp*.so">
+            <Dir>arm\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libHarfBuzzSharp*.so">
+            <Dir>arm64\</Dir>
+        </_NativeHarfBuzzSharpFile>
 
         <!-- Linux: Musl -->
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x86\native\libHarfBuzzSharp*.so" Dir="x86\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x64\native\libHarfBuzzSharp*.so" Dir="x64\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm\native\libHarfBuzzSharp*.so" Dir="arm\" />
-        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm64\native\libHarfBuzzSharp*.so" Dir="arm64\" />
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x86\native\libHarfBuzzSharp*.so">
+            <Dir>x86\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x64\native\libHarfBuzzSharp*.so">
+            <Dir>x64\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm\native\libHarfBuzzSharp*.so">
+            <Dir>arm\</Dir>
+        </_NativeHarfBuzzSharpFile>
+        <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm64\native\libHarfBuzzSharp*.so">
+            <Dir>arm64\</Dir>
+        </_NativeHarfBuzzSharpFile>
 
         <!-- macOS -->
         <_NativeHarfBuzzSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libHarfBuzzSharp*.dylib" />
 
         <!-- include everything -->
-        <Content Include="@(_NativeHarfBuzzSharpFile)" Link="%(Dir)%(Filename)%(Extension)" Visible="False" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="@(_NativeHarfBuzzSharpFile)">
+            <Link>%(Dir)%(Filename)%(Extension)</Link>
+            <Visible>False</Visible>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
 
     </ItemGroup>
 

--- a/binding/SkiaSharp/nuget/build/net462/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/net462/SkiaSharp.targets
@@ -9,34 +9,63 @@
 
     <!-- handle the case where this is a Xamarin.Mac Full app/extension -->
     <ItemGroup Condition=" '$(ShouldIncludeNativeSkiaSharp)' != 'False' and '$(_AppIsFullMac)' == 'True' ">
-        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libSkiaSharp*.dylib" Kind="Dynamic" Visible="false" />
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libSkiaSharp*.dylib">
+            <Kind>Dynamic</Kind>
+            <Visible>False</Visible>
+        </NativeReference>
     </ItemGroup>
 
     <!-- copy the native files to the output directory -->
     <ItemGroup Condition=" '$(ShouldIncludeNativeSkiaSharp)' != 'False' and '$(_AppIsFullMac)' != 'True' ">
 
         <!-- Windows -->
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\libSkiaSharp*.dll" Dir="x86\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\libSkiaSharp*.dll" Dir="x64\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\libSkiaSharp*.dll" Dir="arm64\" />
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\libSkiaSharp*.dll">
+            <Dir>x86\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\libSkiaSharp*.dll">
+            <Dir>x64\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\libSkiaSharp*.dll">
+            <Dir>arm64\</Dir>
+        </_NativeSkiaSharpFile>
 
         <!-- Linux -->
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libSkiaSharp*.so" Dir="x86\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libSkiaSharp*.so" Dir="x64\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libSkiaSharp*.so" Dir="arm\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libSkiaSharp*.so" Dir="arm64\" />
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libSkiaSharp*.so">
+            <Dir>x86\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libSkiaSharp*.so">
+            <Dir>x64\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libSkiaSharp*.so">
+            <Dir>arm\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libSkiaSharp*.so">
+            <Dir>arm64\</Dir>
+        </_NativeSkiaSharpFile>
 
         <!-- Linux: Musl -->
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x86\native\libSkiaSharp*.so" Dir="x86\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x64\native\libSkiaSharp*.so" Dir="x64\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm\native\libSkiaSharp*.so" Dir="arm\" />
-        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm64\native\libSkiaSharp*.so" Dir="arm64\" />
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x86\native\libSkiaSharp*.so">
+            <Dir>x86\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x64\native\libSkiaSharp*.so">
+            <Dir>x64\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm\native\libSkiaSharp*.so">
+            <Dir>arm\</Dir>
+        </_NativeSkiaSharpFile>
+        <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm64\native\libSkiaSharp*.so">
+            <Dir>arm64\</Dir>
+        </_NativeSkiaSharpFile>
 
         <!-- macOS -->
         <_NativeSkiaSharpFile Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libSkiaSharp*.dylib" />
 
         <!-- include everything -->
-        <Content Include="@(_NativeSkiaSharpFile)" Link="%(Dir)%(Filename)%(Extension)" Visible="False" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="@(_NativeSkiaSharpFile)">
+            <Link>%(Dir)%(Filename)%(Extension)</Link>
+            <Visible>False</Visible>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
 
     </ItemGroup>
 


### PR DESCRIPTION
**Description of Change**

The older VS versions do not support the "everything as attributes" system, so go back to the older sub-element style. This is minimal effort to support older VS and more friendly neighborhood devs.

**Bugs Fixed**

- Fixes #1532 

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
