### PR TITLE
fix: [Uno] Rely on build defined property to detect WebAssembly

### DIFF
--- a/binding/HarfBuzzSharp/nuget/build/wasm/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/wasm/HarfBuzzSharp.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(WasmHead)' == 'True'">
+    <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
         <Content Include="$(HarfBuzzSharpStaticLibraryPath)" Visible="false" />
     </ItemGroup>
 

--- a/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(WasmHead)' == 'True'">
+    <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
         <Content Include="$(SkiaSharpStaticLibraryPath)" Visible="false" />
     </ItemGroup>
 


### PR DESCRIPTION
**Description of Change**

WasmHead was only defined in projects from templates and is not reliable.

**Bugs Fixed**

Support for Uno 3.x recent templates.

- Related to issue #

**API Changes**

None

**Behavioral Changes**

None
**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
