### PR TITLE
ci: [WebAssembly] Enable emscripten Uno bootstrapper multiversioning

### DIFF
--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -81,7 +81,7 @@ Task("libSkiaSharp")
     var oFiles = GetFiles($"{mergeDir}/*.o");
     RunProcess(AR, $"-crs {a} {string.Join(" ", oFiles)}");
 
-    var outDir = OUTPUT_PATH.Combine($"wasm");
+    var outDir = OUTPUT_PATH.Combine($"wasm", "libSkiaSharp.a", Environment.GetEnvironmentVariable("EMSCRIPTEN_VERSION"));
     EnsureDirectoryExists(outDir);
     CopyFileToDirectory(a, outDir);
 });
@@ -98,7 +98,7 @@ Task("libHarfBuzzSharp")
         COMPILERS +
         ADDITIONAL_GN_ARGS);
 
-    var outDir = OUTPUT_PATH.Combine($"wasm");
+    var outDir = OUTPUT_PATH.Combine($"wasm", "libHarfBuzzSharp.a", Environment.GetEnvironmentVariable("EMSCRIPTEN_VERSION"));
     EnsureDirectoryExists(outDir);
     var so = SKIA_PATH.CombineWithFilePath($"out/wasm/libHarfBuzzSharp.a");
     CopyFileToDirectory(so, outDir);

--- a/nuget/HarfBuzzSharp.NativeAssets.WebAssembly.nuspec
+++ b/nuget/HarfBuzzSharp.NativeAssets.WebAssembly.nuspec
@@ -36,7 +36,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="build/wasm/HarfBuzzSharp.targets" target="buildTransitive/netstandard1.0/HarfBuzzSharp.NativeAssets.WebAssembly.targets" />
 
     <!-- libHarfBuzzSharp.a and other native files -->
-    <file src="build/wasm/libHarfBuzzSharp.a" target="build/netstandard1.0/libHarfBuzzSharp.a" />
+    <file src="build/wasm/**/*.a" target="build/netstandard1.0" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/netstandard1.0/_._" />

--- a/nuget/SkiaSharp.NativeAssets.WebAssembly.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.WebAssembly.nuspec
@@ -37,7 +37,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="build/wasm/SkiaSharp.targets" target="buildTransitive/netstandard1.0/SkiaSharp.NativeAssets.WebAssembly.targets" />
 
     <!-- libSkiaSharp.a and other native files -->
-    <file src="build/wasm/libSkiaSharp.a" target="build/netstandard1.0/libSkiaSharp.a" />
+    <file src="build/wasm/**/*.a" target="build/netstandard1.0" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/netstandard1.0/_._" />

--- a/scripts/Docker/wasm/Dockerfile
+++ b/scripts/Docker/wasm/Dockerfile
@@ -1,7 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.201-bionic
 
-ARG EMSCRIPTEN_VERSION=1.40.0
-
 RUN apt-get update \
     && apt-get install -y apt-transport-https curl wget python python3 git make \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
@@ -10,10 +8,10 @@ RUN apt-get update \
     && apt-get install -y mono-devel  \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --branch ${EMSCRIPTEN_VERSION} https://github.com/emscripten-core/emsdk ~/emsdk && \
+RUN git clone --branch $EMSCRIPTEN_VERSION https://github.com/emscripten-core/emsdk ~/emsdk && \
     cd ~/emsdk && \
-    ./emsdk install ${EMSCRIPTEN_VERSION} && \
-    ./emsdk activate ${EMSCRIPTEN_VERSION}
+    ./emsdk install $EMSCRIPTEN_VERSION} && \
+    ./emsdk activate $EMSCRIPTEN_VERSION
 
 # Workaround for https://github.com/dotnet/sdk/issues/11108
 RUN cd /usr/share/dotnet/sdk/3.1.201/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets && \

--- a/scripts/Docker/wasm/build-local.sh
+++ b/scripts/Docker/wasm/build-local.sh
@@ -3,5 +3,5 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-(cd $DIR && docker build --tag skiasharp-wasm .)
+(cd $DIR && docker build --tag skiasharp-wasm --build-arg EMSCRIPTEN_VERSION="$EMSCRIPTEN_VERSION" .)
 (cd $DIR/../../../ && docker run --rm --name skiasharp-wasm --volume $(pwd):/work skiasharp-wasm /bin/bash ./bootstrapper.sh -t externals-wasm)

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -33,7 +33,6 @@ variables:
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
   ENABLE_CODE_COVERAGE: true
-  EMSCRIPTEN_VERSION: 1.40.0
 
 resources:
   repositories:
@@ -296,6 +295,28 @@ stages:
   - stage: native_wasm
     displayName: Native WASM
     dependsOn: prepare
+    strategy:
+        matrix:
+          1_39_11:
+            EMSCRIPTEN_VERSION: 1.39.11
+
+          1_40_0:
+            EMSCRIPTEN_VERSION: 1.40.0
+
+          2_0_5:
+            EMSCRIPTEN_VERSION: 2.0.5
+
+          2_0_6:
+            EMSCRIPTEN_VERSION: 2.0.6
+
+          2_0_9:
+            EMSCRIPTEN_VERSION: 2.0.9
+
+          2_0_11:
+            EMSCRIPTEN_VERSION: 2.0.11
+
+          2_0_12:
+            EMSCRIPTEN_VERSION: 2.0.12
     jobs:
       - template: azure-templates-bootstrapper.yml # Build Native WASM (Linux)
         parameters:
@@ -304,6 +325,7 @@ stages:
           vmImage: $(VM_IMAGE_LINUX)
           docker: scripts/Docker/wasm
           target: externals-wasm
+          dockerArgs: --build-arg EMSCRIPTEN_VERSION=$(EMSCRIPTEN_VERSION)
 
   - stage: managed
     displayName: Build Managed


### PR DESCRIPTION
**Description of Change**

Adds support for emscripten multi-versioning based on the `Uno.Wasm.Bootstrap` specification here: https://github.com/unoplatform/Uno.Wasm.Bootstrap#static-linking-multi-version-support.

This enables `SkiaSharp.NativeAssets.WebAssembly` to be backward compatible with known versions of emscripten, letting the Uno bootstrapper choose the most appropriate version for the dotnet runtime being used.

- Related to issue #

**API Changes**

none

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
