### PR TITLE
Update externals for new gn and add helper script

### DIFF
--- a/scripts/Docker/alpine/amd64/.dockerignore
+++ b/scripts/Docker/alpine/amd64/.dockerignore
@@ -1,0 +1,1 @@
+build-local.sh

--- a/scripts/Docker/alpine/amd64/build-local.sh
+++ b/scripts/Docker/alpine/amd64/build-local.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+(cd $DIR && docker build --tag skiasharp-alpine .)
+(cd $DIR/../../../../ && docker run --rm --name skiasharp-alpine --volume $(pwd):/work skiasharp-alpine /bin/bash ./bootstrapper.sh -t externals-linux -c Release --buildarch=x64 --variant=alpine)


### PR DESCRIPTION
**Description of Change**

It appears that an updated gn is stricter when it comes to visibility. The upstream repo also has made this change.

Also, I have added a script to help builds locally.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
