### PR TITLE
Make SKElement.OnRender do nothing if there is no PresentationSource

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs
@@ -51,7 +51,7 @@ namespace SkiaSharp.Views.WPF
 			if (designMode)
 				return;
 
-			if (Visibility != Visibility.Visible)
+			if (Visibility != Visibility.Visible || PresentationSource.FromVisual(this) == null)
 				return;
 
 			var size = CreateSize(out var scaleX, out var scaleY);


### PR DESCRIPTION
**Description of Change**

Avoid NRE in SKElement when PresentationSource.FromVisual(this) returns null.

No tests as I do not know of a simple way to reproduce the underlying issue.

**Bugs Fixed**


- Fixes #1605

**API Changes**

None

**Behavioral Changes**

None

**PR Checklist**

- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
