### PR TITLE
Run nightly builds to ensure always green

### DIFF
--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -19,6 +19,12 @@ steps:
     displayName: Use a special preview label for PRs
     condition: eq(variables['Build.Reason'], 'PullRequest')
   - pwsh: |
+      $nightly = "nightly"
+      Write-Host "Preview label: $nightly"
+      Write-Host "##vso[task.setvariable variable=PREVIEW_LABEL]$nightly"
+    displayName: Use a special preview label for scheduled
+    condition: eq(variables['Build.Reason'], 'Schedule')
+  - pwsh: |
       $label = ""
       if ($env:BUILD_REASON -ne "PullRequest") {
         $label = "+" + $env:BUILD_SOURCEBRANCHNAME


### PR DESCRIPTION
**Description of Change**

Run some nightly builds to ensure CI is always green when it is needed. Things might be getting out of date and we want to catch it.
