### PR TITLE
Attempt to use the local ChromeDriver first

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -36,6 +36,7 @@ var UNSUPPORTED_TESTS = Argument ("unsupportedTests", "");
 var THROW_ON_TEST_FAILURE = Argument ("throwOnTestFailure", true);
 var NUGET_DIFF_PRERELEASE = Argument ("nugetDiffPrerelease", false);
 var COVERAGE = Argument ("coverage", false);
+var CHROMEWEBDRIVER = Argument ("chromedriver", EnvironmentVariable ("CHROMEWEBDRIVER"));
 
 var PLATFORM_SUPPORTS_VULKAN_TESTS = (IsRunningOnWindows () || IsRunningOnLinux ()).ToString ();
 var SUPPORT_VULKAN_VAR = Argument ("supportVulkan", EnvironmentVariable ("SUPPORT_VULKAN") ?? PLATFORM_SUPPORTS_VULKAN_TESTS);
@@ -325,7 +326,10 @@ Task ("tests-wasm")
             Arguments = "server.py",
             WorkingDirectory = pubDir,
         });
-        DotNetCoreRun("./utils/WasmTestRunner/WasmTestRunner.csproj", "http://localhost:8000/ -o ./tests/SkiaSharp.Wasm.Tests/TestResults/");
+        DotNetCoreRun("./utils/WasmTestRunner/WasmTestRunner.csproj",
+            "http://localhost:8000/ " +
+            "-o ./tests/SkiaSharp.Wasm.Tests/TestResults/ " +
+            (string.IsNullOrEmpty(CHROMEWEBDRIVER) ? "" : $"-d {CHROMEWEBDRIVER}"));
     } catch {
         failedTests++;
     } finally {

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -678,7 +678,7 @@ stages:
           vmImage: $(VM_IMAGE_LINUX)
           packages: $(MANAGED_LINUX_PACKAGES) ninja-build
           target: tests-wasm
-          additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false
+          additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
           shouldPublish: false
           requiredArtifacts:
             - native_wasm_linux

--- a/utils/WasmTestRunner/Program.cs
+++ b/utils/WasmTestRunner/Program.cs
@@ -14,6 +14,8 @@ namespace WasmTestRunner
 		private const string DefaultUrl = "http://localhost:5000/";
 		private const string ResultsFileName = "TestResults.xml";
 
+		public static string ChromeDriverPath { get; set; }
+
 		public static string OutputPath { get; set; } = Directory.GetCurrentDirectory();
 
 		public static int Timeout { get; set; } = 30;
@@ -30,6 +32,7 @@ namespace WasmTestRunner
 		{
 			var p = new OptionSet
 			{
+				{ "d|driver=", "the path to the ChromeDriver executable. Default is use the local version.", v => ChromeDriverPath = v },
 				{ "o|output=", "the path to the test results file. Default is the current directory.", v => OutputPath = v },
 				{ "t|timeout=", "the number of seconds to wait before timing out. Default is 30.", (int v) => Timeout = v },
 				{ "no-headless", "do not use a headless browser.", v => UseHeadless = false },
@@ -105,7 +108,9 @@ namespace WasmTestRunner
 
 			options.AddArgument("window-size=1024x768");
 
-			using var service = ChromeDriverService.CreateDefaultService();
+			using var service = string.IsNullOrEmpty(ChromeDriverPath)
+				? ChromeDriverService.CreateDefaultService()
+				: ChromeDriverService.CreateDefaultService(ChromeDriverPath);
 			using var driver = new ChromeDriver(service, options);
 
 			driver.Url = Url;


### PR DESCRIPTION
**Description of Change**

Every so often, the ChromeDriver goes out of date and requires an update to the NuGet. Instead of always relying on the package, check the local bot for it and use that as it will always be in sync.

