### PR TITLE
Swap the buffers after a resize

### DIFF
--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -114,14 +114,16 @@ Task("ANGLE")
     {
         if (Skip(arch)) return;
 
+        var d = CONFIGURATION.ToLower() == "release" ? "" : "debug/";
+
         RunProcess (vcpkg, $"install angle:{arch}-uwp");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/bin/libEGL.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/bin/libEGL.pdb"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/bin/libGLESv2.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/bin/libGLESv2.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libEGL.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libEGL.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libGLESv2.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libGLESv2.pdb"), outDir);
     }
 });
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/AngleSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/AngleSwapChainPanel.cs
@@ -150,8 +150,8 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnCompositionChanged(SwapChainPanel sender, object args)
 		{
-
 			pendingSizeChange = true;
+
 			ContentsScale = CompositionScaleX;
 
 			DestroyRenderSurface();
@@ -194,6 +194,8 @@ namespace SkiaSharp.Views.UWP
 			if (designMode || !isLoaded || !isVisible || glesContext?.HasSurface != true)
 				return;
 
+			glesContext.MakeCurrent();
+
 			if (pendingSizeChange)
 			{
 				pendingSizeChange = false;
@@ -202,7 +204,6 @@ namespace SkiaSharp.Views.UWP
 					glesContext.SwapBuffers();
 			}
 
-			glesContext.MakeCurrent();
 			glesContext.GetSurfaceDimensions(out var panelWidth, out var panelHeight);
 			glesContext.SetViewportSize(panelWidth, panelHeight);
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/AngleSwapChainPanel.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/AngleSwapChainPanel.cs
@@ -33,6 +33,8 @@ namespace SkiaSharp.Views.UWP
 
 		private bool enableRenderLoop;
 
+		private bool pendingSizeChange = false;
+
 		public AngleSwapChainPanel()
 		{
 			glesContext = null;
@@ -148,6 +150,8 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnCompositionChanged(SwapChainPanel sender, object args)
 		{
+
+			pendingSizeChange = true;
 			ContentsScale = CompositionScaleX;
 
 			DestroyRenderSurface();
@@ -157,6 +161,8 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnSizeChanged(object sender, SizeChangedEventArgs e)
 		{
+			pendingSizeChange = true;
+
 			EnsureRenderSurface();
 			Invalidate();
 		}
@@ -187,6 +193,14 @@ namespace SkiaSharp.Views.UWP
 		{
 			if (designMode || !isLoaded || !isVisible || glesContext?.HasSurface != true)
 				return;
+
+			if (pendingSizeChange)
+			{
+				pendingSizeChange = false;
+
+				if (!EnableRenderLoop)
+					glesContext.SwapBuffers();
+			}
 
 			glesContext.MakeCurrent();
 			glesContext.GetSurfaceDimensions(out var panelWidth, out var panelHeight);


### PR DESCRIPTION
**Description of Change**

This swaps to the next buffer which is the new, correct size. When the size or scale changes, the new size is added to a "pending" variable and only gets pushed on the next frame. For render loop views, this is no problem, but for refresh-when-dirty views, we need to force the update by requesting the new buffer before drawing.

**Bugs Fixed**

- Fixes #1377
- Fixes #914
- Fixes #722

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
