### PR TITLE
Improve the hot path of the path iterators

### DIFF
--- a/benchmarks/SkiaSharp.Benchmarks/Program.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/Program.cs
@@ -1,4 +1,6 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 
@@ -8,7 +10,9 @@ namespace SkiaSharp.Benchmarks
 	[SimpleJob(RuntimeMoniker.Mono)]
 	[SimpleJob(RuntimeMoniker.Net472)]
 	[SimpleJob(RuntimeMoniker.NetCoreApp31)]
-	public class Benchmark
+	[SimpleJob(RuntimeMoniker.NetCoreApp50)]
+	[MemoryDiagnoser]
+	public unsafe class Benchmark
 	{
 		public Benchmark()
 		{

--- a/benchmarks/SkiaSharp.Benchmarks/SkiaSharp.Benchmarks.csproj
+++ b/benchmarks/SkiaSharp.Benchmarks/SkiaSharp.Benchmarks.csproj
@@ -9,7 +9,7 @@
     <SkipCopyToOutputDirectory>true</SkipCopyToOutputDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj" />

--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -537,8 +537,16 @@ namespace SkiaSharp
 					throw new ArgumentException ("Must be an array of four elements.", nameof (points));
 
 				fixed (SKPoint* p = points) {
-					return SkiaApi.sk_path_iter_next (Handle, p);
+					return Next(p);
 				}
+			}
+
+			public SKPathVerb Next (SKPoint* points)
+			{
+				if (points == null)
+					throw new ArgumentNullException (nameof (points));
+
+				return SkiaApi.sk_path_iter_next (Handle, points);
 			}
 
 			public float ConicWeight () =>
@@ -576,9 +584,18 @@ namespace SkiaSharp
 					throw new ArgumentNullException (nameof (points));
 				if (points.Length != 4)
 					throw new ArgumentException ("Must be an array of four elements.", nameof (points));
+
 				fixed (SKPoint* p = points) {
-					return SkiaApi.sk_path_rawiter_next (Handle, p);
+					return Next (p);
 				}
+			}
+
+			public SKPathVerb Next (SKPoint* points)
+			{
+				if (points == null)
+					throw new ArgumentNullException (nameof (points));
+
+				return SkiaApi.sk_path_rawiter_next (Handle, points);
 			}
 
 			public float ConicWeight () =>


### PR DESCRIPTION

**Description of Change**

Expose the raw pointers for the Next method so consumers can opt into a much more performant run.

Benchmark code: https://gist.github.com/mattleibow/7f7f554d8717caa065970081b8ffd115

![image](https://user-images.githubusercontent.com/1096616/113015848-38377f00-917e-11eb-902e-4e70c2f1249a.png)


**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Related to issue #

**API Changes**

```csharp
SKPathVerb SKPath.Iterator.Next(SKPoint* points);
SKPathVerb SKPath.RawIterator.Next(SKPoint* points);
```

**Behavioral Changes**

None.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
