### PR TITLE
Free up space by deleting samples as they build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -424,9 +424,6 @@ Task ("samples")
 
             RunNuGetRestorePackagesConfig (sln);
             RunMSBuild (sln, platform: buildPlatform);
-
-            // delete the built sample
-            CleanDirectories (sln.GetDirectory ().FullPath);
         }
     }
 
@@ -460,6 +457,10 @@ Task ("samples")
     }
 
     foreach (var sln in solutions) {
+        // might have been deleted due to a platform build and cleanup
+        if (!FileExists (sln))
+            continue;
+
         var name = sln.GetFilenameWithoutExtension ();
         var slnPlatform = name.GetExtension ();
 
@@ -469,6 +470,8 @@ Task ("samples")
             if (!variants.Any ()) {
                 // there is no platform variant
                 BuildSample (sln);
+                // delete the built sample
+                CleanDirectories (sln.GetDirectory ().FullPath);
             } else {
                 // skip as there is a platform variant
             }
@@ -481,6 +484,8 @@ Task ("samples")
                 (isWin && slnPlatform == ".windows");
             if (shouldBuild) {
                 BuildSample (sln);
+                // delete the built sample
+                CleanDirectories (sln.GetDirectory ().FullPath);
             } else {
                 // skip this as this is not the correct platform
             }

--- a/build.cake
+++ b/build.cake
@@ -424,6 +424,9 @@ Task ("samples")
 
             RunNuGetRestorePackagesConfig (sln);
             RunMSBuild (sln, platform: buildPlatform);
+
+            // delete the built sample
+            CleanDirectories (sln.GetDirectory ().FullPath);
         }
     }
 
@@ -482,9 +485,6 @@ Task ("samples")
                 // skip this as this is not the correct platform
             }
         }
-
-        // delete the build sample
-        CleanDirectories (sln.GetDirectory ().FullPath);
     }
 
     CleanDirectory ("./output/samples/");

--- a/build.cake
+++ b/build.cake
@@ -450,6 +450,12 @@ Task ("samples")
 
     // build solutions locally
     var solutions = GetFiles ("./output/samples/**/*.sln");
+
+    Information ("Solutions found:");
+    foreach (var sln in solutions) {
+        Information ("    " + sln);
+    }
+
     foreach (var sln in solutions) {
         var name = sln.GetFilenameWithoutExtension ();
         var slnPlatform = name.GetExtension ();
@@ -476,6 +482,9 @@ Task ("samples")
                 // skip this as this is not the correct platform
             }
         }
+
+        // delete the build sample
+        CleanDirectories (sln.GetDirectory ().FullPath);
     }
 
     CleanDirectory ("./output/samples/");

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: ''                            # the build number to download externals from
+  buildExternals: '4876692'                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -29,17 +29,17 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
 
 jobs:
-# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-#   - template: azure-templates-download.yml
-#     parameters:
-#       name: ${{ parameters.name }}
-#       displayName: ${{ parameters.displayName }}
-#       vmImage: ${{ parameters.vmImage }}
-#       condition: ${{ parameters.condition }}
-#       postBuildSteps: ${{ parameters.postBuildSteps }}
-#       buildExternals: ${{ parameters.buildExternals }}
+- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+  - template: azure-templates-download.yml
+    parameters:
+      name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      vmImage: ${{ parameters.vmImage }}
+      condition: ${{ parameters.condition }}
+      postBuildSteps: ${{ parameters.postBuildSteps }}
+      buildExternals: ${{ parameters.buildExternals }}
 
-# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: '4876692'                            # the build number to download externals from
+  buildExternals: ''                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -29,17 +29,17 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
 
 jobs:
-- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-  - template: azure-templates-download.yml
-    parameters:
-      name: ${{ parameters.name }}
-      displayName: ${{ parameters.displayName }}
-      vmImage: ${{ parameters.vmImage }}
-      condition: ${{ parameters.condition }}
-      postBuildSteps: ${{ parameters.postBuildSteps }}
-      buildExternals: ${{ parameters.buildExternals }}
+# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+#   - template: azure-templates-download.yml
+#     parameters:
+#       name: ${{ parameters.name }}
+#       displayName: ${{ parameters.displayName }}
+#       vmImage: ${{ parameters.vmImage }}
+#       condition: ${{ parameters.condition }}
+#       postBuildSteps: ${{ parameters.postBuildSteps }}
+#       buildExternals: ${{ parameters.buildExternals }}
 
-- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120


### PR DESCRIPTION
**Description of Change**

Free up space be deleting samples as we go. Seems CI runs out of disk space with all the stuff we install and all the bits the compiler generates.