### PR TITLE
iOS requires that the view have a background

### DIFF
--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Handlers/SKCanvasView/SKCanvasViewHandler.iOS.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Handlers/SKCanvasView/SKCanvasViewHandler.iOS.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Maui.Handlers;
 using SkiaSharp.Views.iOS;
 using SkiaSharp.Views.Maui.Platform;
+using UIKit;
 
 namespace SkiaSharp.Views.Maui.Handlers
 {
@@ -9,7 +10,7 @@ namespace SkiaSharp.Views.Maui.Handlers
 		private SKSizeI lastCanvasSize;
 		private SKTouchHandler? touchHandler;
 
-		protected override SKCanvasView CreateNativeView() => new SKCanvasView();
+		protected override SKCanvasView CreateNativeView() => new SKCanvasView { BackgroundColor = UIColor.Clear };
 
 		protected override void ConnectHandler(SKCanvasView nativeView)
 		{


### PR DESCRIPTION
**Description of Change**

If there is no color set, then iOS can't clear it. As a result, the canvas is clear, but then it draws that clear canvas onto whatever there was before. And what was there before was the canvas so it keeps stacking things up.

This PR make sure that we let iOS know that it has to clear the underlying surface with transparent.

**Bugs Fixed**

An issue where the canvas never really cleared.

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
