### PR TITLE
Fix NRE in .NET Maui SKCanvasView

### DIFF
--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/SKCanvasView.HandlerImpl.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/SKCanvasView.HandlerImpl.cs
@@ -22,7 +22,7 @@ namespace SkiaSharp.Views.Maui.Controls
 
 			void OnSurfaceInvalidated(object? sender, EventArgs e)
 			{
-				Handler.UpdateValue(nameof(ISKCanvasView.InvalidateSurface));
+				Handler?.UpdateValue(nameof(ISKCanvasView.InvalidateSurface));
 			}
 		}
 


### PR DESCRIPTION
**Description of Change**

protect null Handlers in .NET Maui SKCanvasView when invalidate the surface.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
