### PR TITLE
Ensure that VS is installed correctly

### DIFF
--- a/scripts/install-vs.ps1
+++ b/scripts/install-vs.ps1
@@ -4,20 +4,38 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 
-Write-Host "Downloading Visual Studio..."
+$startTime = Get-Date
+
+Write-Host "Downloading Visual Studio Installer..."
+Invoke-WebRequest -UseBasicParsing `
+    -Uri "https://aka.ms/vs/install/latest/vs_setup.exe" `
+    -OutFile "$env:TEMP\dd_vs_setup.exe"
+
+Write-Host "Updating the Visual Studio Installer..."
+$exitCode = & "$env:TEMP\dd_vs_setup.exe" --update --quiet --wait | Out-Null
+
+Write-Host "Exit code: $exitCode"
+
+Write-Host "Downloading Visual Studio ($Version)..."
 Invoke-WebRequest -UseBasicParsing `
     -Uri "https://aka.ms/vs/$Version/vs_community.exe" `
-    -OutFile vs_community.exe
+    -OutFile "$env:TEMP\dd_vs_community.exe"
 
 Write-Host "Installing Visual Studio..."
-./vs_community.exe --passive --norestart --wait `
+$exitCode = & "$env:TEMP\dd_vs_community.exe" --quiet --norestart --wait `
   --add Microsoft.VisualStudio.Workload.NetCrossPlat `
   --add Microsoft.VisualStudio.Workload.NetCoreTools `
   --add Microsoft.VisualStudio.Workload.ManagedDesktop `
   --add Microsoft.VisualStudio.Workload.Universal `
   | Out-Null
 
-Remove-Item vs_community.exe
+Write-Host "Exit code: $exitCode"
+
+$vsLogs = 'output\vs-logs'
+New-Item -ItemType Directory -Force -Path "$vsLogs" | Out-Null
+Get-ChildItem "$env:TEMP\dd_*" |
+  Where-Object { $_.CreationTime -gt $startTime } |
+  Copy-Item -Destination "$vsLogs"
 
 $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 


### PR DESCRIPTION
**Description of Change**

In some cases, the preview VS installer is older than the currently installed installer. As a result, the installer thinks it is already up to date.

This PR makes sure to always pull the latest installer, and then update to the very latest. This somehow makes the old installer install...