### PR TITLE
Add Mac Catalyst support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ SkiaSharp provides cross-platform bindings for:
 
  - .NET Standard 1.3
  - .NET Core
+ - .NET 6
  - Tizen
- - Xamarin.Android
- - Xamarin.iOS
- - Xamarin.tvOS
- - Xamarin.watchOS
- - Xamarin.Mac
+ - Android
+ - iOS
+ - tvOS
+ - watchOS
+ - macOS
+ - Mac Catalyst
  - Windows Classic Desktop (Windows.Forms / WPF)
  - Windows UWP (Desktop / Mobile / Xbox / HoloLens)
  - Web Assembly (WASM)

--- a/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
+++ b/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-maccatalyst'))">
     <!-- Mac Catalyst -->
-    <None Include="nuget\build\maccatalyst\HarfBuzzSharp.targets" Link="nuget\build\net6.0-maccatalyst\SkiaSHarfBuzzSharpharp.targets" />
+    <None Include="nuget\build\maccatalyst\HarfBuzzSharp.targets" Link="nuget\build\net6.0-maccatalyst\HarfBuzzSharp.targets" />
     <None Include="nuget\build\maccatalyst\HarfBuzzSharp.Local.targets" Link="nuget\build\net6.0-maccatalyst\HarfBuzzSharp.Local.targets" />
     <None Include="..\..\output\native\maccatalyst\libHarfBuzzSharp*.framework.zip" Link="nuget\runtimes\maccatalyst\native\%(Filename)%(Extension)" />
   </ItemGroup>

--- a/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
+++ b/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
@@ -61,32 +61,30 @@
     <None Include="..\..\output\native\android\armeabi-v7a\libHarfBuzzSharp*" Link="nuget\runtimes\android-arm\native\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\android\arm64-v8a\libHarfBuzzSharp*" Link="nuget\runtimes\android-arm64\native\%(Filename)%(Extension)" />
     <None Include="nuget\build\android\HarfBuzzSharp.targets" Link="nuget\build\net6.0-android\HarfBuzzSharp.targets" />
-    <None Include="nuget\build\monoandroid\HarfBuzzSharp.targets" Link="nuget\build\net6.0-android\HarfBuzzSharp.Local.targets" />
+    <None Include="nuget\build\android\HarfBuzzSharp.Local.targets" Link="nuget\build\net6.0-android\HarfBuzzSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <!-- iOS -->
     <None Include="..\..\output\native\ios\libHarfBuzzSharp.framework\**" Link="nuget\runtimes\ios\native\libHarfBuzzSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="nuget\build\ios\HarfBuzzSharp.targets" Link="nuget\build\net6.0-ios\HarfBuzzSharp.targets" />
-    <None Include="nuget\build\xamarinios\HarfBuzzSharp.targets" Link="nuget\build\net6.0-ios\HarfBuzzSharp.Local.targets" />
+    <None Include="nuget\build\ios\HarfBuzzSharp.Local.targets" Link="nuget\build\net6.0-ios\HarfBuzzSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-maccatalyst'))">
     <!-- Mac Catalyst -->
-    <None Include="..\..\output\native\maccatalyst\libHarfBuzzSharp.framework\**" Link="nuget\runtimes\maccatalyst\native\libHarfBuzzSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Include="nuget\build\maccatalyst\HarfBuzzSharp.targets" Link="nuget\build\net6.0-maccatalyst\SkiaSHarfBuzzSharpharp.targets" />
+    <None Include="nuget\build\maccatalyst\HarfBuzzSharp.Local.targets" Link="nuget\build\net6.0-maccatalyst\HarfBuzzSharp.Local.targets" />
+    <None Include="..\..\output\native\maccatalyst\libHarfBuzzSharp*.framework.zip" Link="nuget\runtimes\maccatalyst\native\%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-tvos'))">
     <!-- tvOS -->
     <None Include="..\..\output\native\tvos\libHarfBuzzSharp.framework\**" Link="nuget\runtimes\tvos\native\libHarfBuzzSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="nuget\build\tvos\HarfBuzzSharp.targets" Link="nuget\build\net6.0-tvos\HarfBuzzSharp.targets" />
-    <None Include="nuget\build\xamarintvos\HarfBuzzSharp.targets" Link="nuget\build\net6.0-tvos\HarfBuzzSharp.Local.targets" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('-watchos'))">
-    <!-- watchOS -->
-    <None Include="..\..\output\native\watchos\libHarfBuzzSharp.framework\**" Link="nuget\runtimes\watchos\native\libHarfBuzzSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Include="nuget\build\tvos\HarfBuzzSharp.Local.targets" Link="nuget\build\net6.0-tvos\HarfBuzzSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-macos'))">
     <!-- macOS -->
     <None Include="nuget\build\macos\HarfBuzzSharp.targets" Link="nuget\build\net6.0-macos\HarfBuzzSharp.targets" />
-    <None Include="nuget\build\xamarinmac\HarfBuzzSharp.targets" Link="nuget\build\net6.0-macos\HarfBuzzSharp.Local.targets" />
+    <None Include="nuget\build\macos\HarfBuzzSharp.Local.targets" Link="nuget\build\net6.0-macos\HarfBuzzSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />

--- a/binding/HarfBuzzSharp/nuget/build/android/HarfBuzzSharp.Local.targets
+++ b/binding/HarfBuzzSharp/nuget/build/android/HarfBuzzSharp.Local.targets
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-x86\native\libHarfBuzzSharp.so" Abi="x86" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-x64\native\libHarfBuzzSharp.so" Abi="x86_64" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-arm\native\libHarfBuzzSharp.so" Abi="armeabi-v7a" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-arm64\native\libHarfBuzzSharp.so" Abi="arm64-v8a" />
+    </ItemGroup>
+
+</Project>

--- a/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.Local.targets
+++ b/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.Local.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libHarfBuzzSharp.framework" Kind="Framework" />
+    </ItemGroup>
+
+</Project>

--- a/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.targets
@@ -14,7 +14,7 @@
                     '%(ResolvedFileToPublish.PathInPackage)' != ''">
                     <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
                     <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-                </_PossibleNativeFramework>
+            </_PossibleNativeFramework>
             <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
                 <Kind>Framework</Kind>
                 <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>

--- a/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.Local.targets
+++ b/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.Local.targets
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <_HarfBuzzSharpExpandNativeReferencesStamp>obj\$(Configuration)\$(TargetFramework)\harfbuzzsharpextract.stamp</_HarfBuzzSharpExpandNativeReferencesStamp>
+        <_HarfBuzzSharpExpandNativeReferencesPath>obj\$(Configuration)\$(TargetFramework)\harfbuzzsharpextract\</_HarfBuzzSharpExpandNativeReferencesPath>
+    </PropertyGroup>
+
+    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_HarfBuzzSharpExpandNativeReferencesStamp)') ">
+
+        <RemoveDir Directories="$(_HarfBuzzSharpExpandNativeReferencesPath)" />
+        <MakeDir Directories="$(_HarfBuzzSharpExpandNativeReferencesPath)" />
+        <Exec Command="unzip -d $(_HarfBuzzSharpExpandNativeReferencesPath) $(MSBuildThisFileDirectory)..\..\runtimes\maccatalyst\native\libHarfBuzzSharp.framework.zip" />
+
+        <ItemGroup>
+            <NativeReference Include="$(_HarfBuzzSharpExpandNativeReferencesPath)libHarfBuzzSharp.framework" Kind="Framework" />
+        </ItemGroup>
+
+        <Touch Files="$(_HarfBuzzSharpExpandNativeReferencesStamp)" AlwaysCreate="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(_HarfBuzzSharpExpandNativeReferencesPath)\**" />
+            <FileWrites Include="$(_HarfBuzzSharpExpandNativeReferencesStamp)" />
+        </ItemGroup>
+
+    </Target>
+
+    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/12369 -->
+    <Target Name="_HarfBuzzSharpCollectFrameworksFixes" AfterTargets="_CollectFrameworks" Condition=" '$(OS)' == 'Unix' ">
+        <PropertyGroup>
+            <_HarfBuzzSharpNativeAssetPath>$(_FrameworksDirectory)\libHarfBuzzSharp.framework\libHarfBuzzSharp</_HarfBuzzSharpNativeAssetPath>
+            <_HarfBuzzSharpIsSymlink Condition="$([MSBuild]::BitwiseAnd(1024, $([System.IO.File]::GetAttributes('$(_HarfBuzzSharpNativeAssetPath)')))) == '1024'">true</_HarfBuzzSharpIsSymlink>
+        </PropertyGroup>
+        <RemoveDir Directories="$(_FrameworksDirectory)\libHarfBuzzSharp.framework" Condition="'$(_HarfBuzzSharpIsSymlink)' != 'true'" />
+        <Exec Command="cp -R $(_HarfBuzzSharpExpandNativeReferencesPath)libHarfBuzzSharp.framework $(_FrameworksDirectory)/libHarfBuzzSharp.framework" Condition="'$(_HarfBuzzSharpIsSymlink)' != 'true'" />
+    </Target>
+
+</Project>

--- a/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.targets
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <_HarfBuzzSharpExpandNativeReferencesStamp>$(IntermediateOutputPath)harfbuzzsharpextract.stamp</_HarfBuzzSharpExpandNativeReferencesStamp>
+        <_HarfBuzzSharpExpandNativeReferencesPath>$(IntermediateOutputPath)harfbuzzsharpextract\</_HarfBuzzSharpExpandNativeReferencesPath>
+    </PropertyGroup>
+
+    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
+    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_HarfBuzzSharpExpandNativeReferencesStamp)') ">
+
+        <ItemGroup>
+            <_HarfBuzzSharpPossibleNativeFramework
+                Include="@(ResolvedFileToPublish)"
+                Condition="
+                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
+                    '%(ResolvedFileToPublish.Filename)' == 'libHarfBuzzSharp.framework' and
+                    '%(ResolvedFileToPublish.Extension)' == '.zip' and
+                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
+                    '%(ResolvedFileToPublish.PathInPackage)' != ''">
+                <ExtractPath>$(_HarfBuzzSharpExpandNativeReferencesPath)</ExtractPath>
+                <DirectoryName>$(_HarfBuzzSharpExpandNativeReferencesPath)%(ResolvedFileToPublish.Filename)</DirectoryName>
+            </_HarfBuzzSharpPossibleNativeFramework>
+        </ItemGroup>
+
+        <RemoveDir Directories="$(_HarfBuzzSharpExpandNativeReferencesPath)" />
+
+        <MakeDir Directories="%(_HarfBuzzSharpPossibleNativeFramework.ExtractPath)" />
+        <Exec Command="unzip -d %(_HarfBuzzSharpPossibleNativeFramework.ExtractPath) %(_HarfBuzzSharpPossibleNativeFramework.FullPath)" />
+
+        <ItemGroup>
+            <NativeReference Include="%(_HarfBuzzSharpPossibleNativeFramework.DirectoryName)">
+                <Kind>Framework</Kind>
+                <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>
+                <NuGetPackageVersion>%(NuGetPackageVersion)</NuGetPackageVersion>
+                <AssetType>%(AssetType)</AssetType>
+                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_HarfBuzzSharpPossibleNativeFramework.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
+            </NativeReference>
+        </ItemGroup>
+
+        <Touch Files="$(_HarfBuzzSharpExpandNativeReferencesStamp)" AlwaysCreate="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(_HarfBuzzSharpExpandNativeReferencesPath)\**" />
+            <FileWrites Include="$(_HarfBuzzSharpExpandNativeReferencesStamp)" />
+            <_PossibleNativeFramework Remove="@(_PossibleNativeFramework)" />
+        </ItemGroup>
+
+    </Target>
+
+    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/12369 -->
+    <Target Name="_HarfBuzzSharpCollectFrameworksFixes" AfterTargets="_CollectFrameworks" Condition=" '$(OS)' == 'Unix' ">
+        <PropertyGroup>
+            <_HarfBuzzSharpNativeAssetPath>$(_FrameworksDirectory)\libHarfBuzzSharp.framework\libHarfBuzzSharp</_HarfBuzzSharpNativeAssetPath>
+            <_HarfBuzzSharpIsSymlink Condition="$([MSBuild]::BitwiseAnd(1024, $([System.IO.File]::GetAttributes('$(_HarfBuzzSharpNativeAssetPath)')))) == '1024'">true</_HarfBuzzSharpIsSymlink>
+        </PropertyGroup>
+        <RemoveDir Directories="$(_FrameworksDirectory)\libHarfBuzzSharp.framework" Condition="'$(_HarfBuzzSharpIsSymlink)' != 'true'" />
+        <Exec Command="cp -R $(_HarfBuzzSharpExpandNativeReferencesPath)libHarfBuzzSharp.framework $(_FrameworksDirectory)/libHarfBuzzSharp.framework" Condition="'$(_HarfBuzzSharpIsSymlink)' != 'true'" />
+    </Target>
+
+</Project>

--- a/binding/HarfBuzzSharp/nuget/build/macos/HarfBuzzSharp.Local.targets
+++ b/binding/HarfBuzzSharp/nuget/build/macos/HarfBuzzSharp.Local.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libHarfBuzzSharp.framework" Kind="Framework" />
+    </ItemGroup>
+
+</Project>

--- a/binding/HarfBuzzSharp/nuget/build/tvos/HarfBuzzSharp.Local.targets
+++ b/binding/HarfBuzzSharp/nuget/build/tvos/HarfBuzzSharp.Local.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\tvos\native\libHarfBuzzSharp.framework" Kind="Framework" />
+    </ItemGroup>
+
+</Project>

--- a/binding/HarfBuzzSharp/nuget/build/tvos/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/tvos/HarfBuzzSharp.targets
@@ -14,7 +14,7 @@
                     '%(ResolvedFileToPublish.PathInPackage)' != ''">
                     <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
                     <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-                </_PossibleNativeFramework>
+            </_PossibleNativeFramework>
             <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
                 <Kind>Framework</Kind>
                 <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>

--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -60,32 +60,30 @@
     <None Include="..\..\output\native\android\armeabi-v7a\libSkiaSharp*" Link="nuget\runtimes\android-arm\native\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\android\arm64-v8a\libSkiaSharp*" Link="nuget\runtimes\android-arm64\native\%(Filename)%(Extension)" />
     <None Include="nuget\build\android\SkiaSharp.targets" Link="nuget\build\net6.0-android\SkiaSharp.targets" />
-    <None Include="nuget\build\monoandroid\SkiaSharp.targets" Link="nuget\build\net6.0-android\SkiaSharp.Local.targets" />
+    <None Include="nuget\build\android\SkiaSharp.Local.targets" Link="nuget\build\net6.0-android\SkiaSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <!-- iOS -->
     <None Include="..\..\output\native\ios\libSkiaSharp.framework\**" Link="nuget\runtimes\ios\native\libSkiaSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="nuget\build\ios\SkiaSharp.targets" Link="nuget\build\net6.0-ios\SkiaSharp.targets" />
-    <None Include="nuget\build\xamarinios\SkiaSharp.targets" Link="nuget\build\net6.0-ios\SkiaSharp.Local.targets" />
+    <None Include="nuget\build\ios\SkiaSharp.Local.targets" Link="nuget\build\net6.0-ios\SkiaSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-maccatalyst'))">
     <!-- Mac Catalyst -->
-    <None Include="..\..\output\native\maccatalyst\libSkiaSharp.framework\**" Link="nuget\runtimes\maccatalyst\native\libSkiaSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Include="nuget\build\maccatalyst\SkiaSharp.targets" Link="nuget\build\net6.0-maccatalyst\SkiaSharp.targets" />
+    <None Include="nuget\build\maccatalyst\SkiaSharp.Local.targets" Link="nuget\build\net6.0-maccatalyst\SkiaSharp.Local.targets" />
+    <None Include="..\..\output\native\maccatalyst\libSkiaSharp*.framework.zip" Link="nuget\runtimes\maccatalyst\native\%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-tvos'))">
     <!-- tvOS -->
     <None Include="..\..\output\native\tvos\libSkiaSharp.framework\**" Link="nuget\runtimes\tvos\native\libSkiaSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="nuget\build\tvos\SkiaSharp.targets" Link="nuget\build\net6.0-tvos\SkiaSharp.targets" />
-    <None Include="nuget\build\xamarintvos\SkiaSharp.targets" Link="nuget\build\net6.0-tvos\SkiaSharp.Local.targets" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('-watchos'))">
-    <!-- watchOS -->
-    <None Include="..\..\output\native\watchos\libSkiaSharp.framework\**" Link="nuget\runtimes\watchos\native\libSkiaSharp.framework\%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Include="nuget\build\tvos\SkiaSharp.Local.targets" Link="nuget\build\net6.0-tvos\SkiaSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-macos'))">
     <!-- macOS -->
     <None Include="nuget\build\macos\SkiaSharp.targets" Link="nuget\build\net6.0-macos\SkiaSharp.targets" />
-    <None Include="nuget\build\xamarinmac\SkiaSharp.targets" Link="nuget\build\net6.0-macos\SkiaSharp.Local.targets" />
+    <None Include="nuget\build\macos\SkiaSharp.Local.targets" Link="nuget\build\net6.0-macos\SkiaSharp.Local.targets" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Binding.Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />

--- a/binding/SkiaSharp/nuget/build/android/SkiaSharp.Local.targets
+++ b/binding/SkiaSharp/nuget/build/android/SkiaSharp.Local.targets
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-x86\native\libSkiaSharp.so" Abi="x86" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-x64\native\libSkiaSharp.so" Abi="x86_64" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-arm\native\libSkiaSharp.so" Abi="armeabi-v7a" />
+        <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\runtimes\android-arm64\native\libSkiaSharp.so" Abi="arm64-v8a" />
+    </ItemGroup>
+
+</Project>

--- a/binding/SkiaSharp/nuget/build/ios/SkiaSharp.Local.targets
+++ b/binding/SkiaSharp/nuget/build/ios/SkiaSharp.Local.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libSkiaSharp.framework" Kind="Framework" />
+    </ItemGroup>
+
+</Project>

--- a/binding/SkiaSharp/nuget/build/ios/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/ios/SkiaSharp.targets
@@ -14,7 +14,7 @@
                     '%(ResolvedFileToPublish.PathInPackage)' != ''">
                     <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
                     <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-                </_PossibleNativeFramework>
+            </_PossibleNativeFramework>
             <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
                 <Kind>Framework</Kind>
                 <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>

--- a/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.Local.targets
+++ b/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.Local.targets
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <_SkiaSharpExpandNativeReferencesStamp>obj\$(Configuration)\$(TargetFramework)\skiasharpextract.stamp</_SkiaSharpExpandNativeReferencesStamp>
+        <_SkiaSharpExpandNativeReferencesPath>obj\$(Configuration)\$(TargetFramework)\skiasharpextract\</_SkiaSharpExpandNativeReferencesPath>
+    </PropertyGroup>
+
+    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_SkiaSharpExpandNativeReferencesStamp)') ">
+
+        <RemoveDir Directories="$(_SkiaSharpExpandNativeReferencesPath)" />
+        <MakeDir Directories="$(_SkiaSharpExpandNativeReferencesPath)" />
+        <Exec Command="unzip -d $(_SkiaSharpExpandNativeReferencesPath) $(MSBuildThisFileDirectory)..\..\runtimes\maccatalyst\native\libSkiaSharp.framework.zip" />
+
+        <ItemGroup>
+            <NativeReference Include="$(_SkiaSharpExpandNativeReferencesPath)libSkiaSharp.framework" Kind="Framework" />
+        </ItemGroup>
+
+        <Touch Files="$(_SkiaSharpExpandNativeReferencesStamp)" AlwaysCreate="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(_SkiaSharpExpandNativeReferencesPath)\**" />
+            <FileWrites Include="$(_SkiaSharpExpandNativeReferencesStamp)" />
+        </ItemGroup>
+
+    </Target>
+
+    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/12369 -->
+    <Target Name="_SkiaSharpCollectFrameworksFixes" AfterTargets="_CollectFrameworks" Condition=" '$(OS)' == 'Unix' ">
+        <PropertyGroup>
+            <_SkiaSharpNativeAssetPath>$(_FrameworksDirectory)\libSkiaSharp.framework\libSkiaSharp</_SkiaSharpNativeAssetPath>
+            <_SkiaSharpIsSymlink Condition="$([MSBuild]::BitwiseAnd(1024, $([System.IO.File]::GetAttributes('$(_SkiaSharpNativeAssetPath)')))) == '1024'">true</_SkiaSharpIsSymlink>
+        </PropertyGroup>
+        <RemoveDir Directories="$(_FrameworksDirectory)\libSkiaSharp.framework" Condition="'$(_SkiaSharpIsSymlink)' != 'true'" />
+        <Exec Command="cp -R $(_SkiaSharpExpandNativeReferencesPath)libSkiaSharp.framework $(_FrameworksDirectory)/libSkiaSharp.framework" Condition="'$(_SkiaSharpIsSymlink)' != 'true'" />
+    </Target>
+
+</Project>

--- a/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.targets
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <_SkiaSharpExpandNativeReferencesStamp>$(IntermediateOutputPath)skiasharpextract.stamp</_SkiaSharpExpandNativeReferencesStamp>
+        <_SkiaSharpExpandNativeReferencesPath>$(IntermediateOutputPath)skiasharpextract\</_SkiaSharpExpandNativeReferencesPath>
+    </PropertyGroup>
+
+    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
+    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_SkiaSharpExpandNativeReferencesStamp)') ">
+
+        <ItemGroup>
+            <_SkiaSharpPossibleNativeFramework
+                Include="@(ResolvedFileToPublish)"
+                Condition="
+                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
+                    '%(ResolvedFileToPublish.Filename)' == 'libSkiaSharp.framework' and
+                    '%(ResolvedFileToPublish.Extension)' == '.zip' and
+                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
+                    '%(ResolvedFileToPublish.PathInPackage)' != ''">
+                <ExtractPath>$(_SkiaSharpExpandNativeReferencesPath)</ExtractPath>
+                <DirectoryName>$(_SkiaSharpExpandNativeReferencesPath)%(ResolvedFileToPublish.Filename)</DirectoryName>
+            </_SkiaSharpPossibleNativeFramework>
+        </ItemGroup>
+
+        <RemoveDir Directories="$(_SkiaSharpExpandNativeReferencesPath)" />
+
+        <MakeDir Directories="%(_SkiaSharpPossibleNativeFramework.ExtractPath)" />
+        <Exec Command="unzip -d %(_SkiaSharpPossibleNativeFramework.ExtractPath) %(_SkiaSharpPossibleNativeFramework.FullPath)" />
+
+        <ItemGroup>
+            <NativeReference Include="%(_SkiaSharpPossibleNativeFramework.DirectoryName)">
+                <Kind>Framework</Kind>
+                <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>
+                <NuGetPackageVersion>%(NuGetPackageVersion)</NuGetPackageVersion>
+                <AssetType>%(AssetType)</AssetType>
+                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_SkiaSharpPossibleNativeFramework.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
+            </NativeReference>
+        </ItemGroup>
+
+        <Touch Files="$(_SkiaSharpExpandNativeReferencesStamp)" AlwaysCreate="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(_SkiaSharpExpandNativeReferencesPath)\**" />
+            <FileWrites Include="$(_SkiaSharpExpandNativeReferencesStamp)" />
+            <_PossibleNativeFramework Remove="@(_PossibleNativeFramework)" />
+        </ItemGroup>
+
+    </Target>
+
+    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/12369 -->
+    <Target Name="_SkiaSharpCollectFrameworksFixes" AfterTargets="_CollectFrameworks" Condition=" '$(OS)' == 'Unix' ">
+        <PropertyGroup>
+            <_SkiaSharpNativeAssetPath>$(_FrameworksDirectory)\libSkiaSharp.framework\libSkiaSharp</_SkiaSharpNativeAssetPath>
+            <_SkiaSharpIsSymlink Condition="$([MSBuild]::BitwiseAnd(1024, $([System.IO.File]::GetAttributes('$(_SkiaSharpNativeAssetPath)')))) == '1024'">true</_SkiaSharpIsSymlink>
+        </PropertyGroup>
+        <RemoveDir Directories="$(_FrameworksDirectory)\libSkiaSharp.framework" Condition="'$(_SkiaSharpIsSymlink)' != 'true'" />
+        <Exec Command="cp -R $(_SkiaSharpExpandNativeReferencesPath)libSkiaSharp.framework $(_FrameworksDirectory)/libSkiaSharp.framework" Condition="'$(_SkiaSharpIsSymlink)' != 'true'" />
+    </Target>
+
+</Project>

--- a/binding/SkiaSharp/nuget/build/macos/SkiaSharp.Local.targets
+++ b/binding/SkiaSharp/nuget/build/macos/SkiaSharp.Local.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libSkiaSharp.dylib" Kind="Dynamic" />
+    </ItemGroup>
+
+</Project>

--- a/binding/SkiaSharp/nuget/build/tvos/SkiaSharp.Local.targets
+++ b/binding/SkiaSharp/nuget/build/tvos/SkiaSharp.Local.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\tvos\native\libSkiaSharp.framework" Kind="Framework" />
+    </ItemGroup>
+
+</Project>

--- a/binding/SkiaSharp/nuget/build/tvos/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/tvos/SkiaSharp.targets
@@ -14,7 +14,7 @@
                     '%(ResolvedFileToPublish.PathInPackage)' != ''">
                     <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
                     <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-                </_PossibleNativeFramework>
+            </_PossibleNativeFramework>
             <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
                 <Kind>Framework</Kind>
                 <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>

--- a/cake/xcode.cake
+++ b/cake/xcode.cake
@@ -108,6 +108,8 @@ void CreateFatVersionedFramework(DirectoryPath archives)
     RunLipo($"{archives}.framework/Versions/A/{libName}", binaries);
 
     StripSign($"{archives}.framework");
+
+    RunZip($"{archives}.framework");
 }
 
 void SafeCopy(DirectoryPath src, DirectoryPath dst)
@@ -115,4 +117,16 @@ void SafeCopy(DirectoryPath src, DirectoryPath dst)
     EnsureDirectoryExists(dst);
     DeleteDirectory(dst, new DeleteDirectorySettings { Recursive = true, Force = true });
     RunProcess("cp", $"-R {src} {dst}");
+}
+
+void RunZip(DirectoryPath src)
+{
+    var dir = src.Combine("..");
+    var dst = (FilePath)(src.FullPath + ".zip");
+    if (FileExists(dst))
+        DeleteFile(dst);
+    RunProcess("zip", new ProcessSettings {
+        Arguments = $"-yr {dst} {src.GetDirectoryName()}",
+        WorkingDirectory = dir.FullPath,
+    });
 }

--- a/nuget/HarfbuzzSharp.nuspec
+++ b/nuget/HarfbuzzSharp.nuspec
@@ -130,6 +130,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="build/net6.0-macos/HarfBuzzSharp.targets" target="buildTransitive/net6.0-macos10.15/HarfBuzzSharp.targets" />
     <file src="build/tizen40/HarfBuzzSharp.targets" />
     <file src="build/tizen40/HarfBuzzSharp.targets" target="buildTransitive/tizen40/HarfBuzzSharp.targets" />
+    <file src="build/net6.0-maccatalyst/HarfBuzzSharp.targets" target="build/net6.0-maccatalyst13.5/HarfBuzzSharp.targets" />
+    <file src="build/net6.0-maccatalyst/HarfBuzzSharp.targets" target="buildTransitive/net6.0-maccatalyst13.5/HarfBuzzSharp.targets" />
 
     <!-- libHarfBuzzSharp.dll and other native files -->
     <!-- win -->
@@ -154,7 +156,7 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- ios -->
     <file platform="macos" src="runtimes/ios/native/libHarfBuzzSharp.framework/**/*" target="runtimes/ios/native/libHarfBuzzSharp.framework" />
     <!-- maccatalyst -->
-    <!-- <file platform="macos" src="runtimes/maccatalyst/native/libHarfBuzzSharp.framework/**/*" target="runtimes/maccatalyst/native/libHarfBuzzSharp.framework" /> -->
+    <file platform="macos" src="runtimes/maccatalyst/native/libHarfBuzzSharp.framework.zip" />
     <!-- tvos -->
     <file platform="macos" src="runtimes/tvos/native/libHarfBuzzSharp.framework/**/*" target="runtimes/tvos/native/libHarfBuzzSharp.framework" />
     <!-- watchos -->

--- a/nuget/SkiaSharp.NativeAssets.MacCatalyst.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.MacCatalyst.nuspec
@@ -36,11 +36,11 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
   <files>
 
     <!-- the build bits -->
-    <!-- <file src="build/net6.0-macos/SkiaSharp.targets" target="build/net6.0-macos10.15/SkiaSharp.NativeAssets.macOS.targets" /> -->
-    <!-- <file src="build/net6.0-macos/SkiaSharp.targets" target="buildTransitive/net6.0-macos10.15/SkiaSharp.NativeAssets.macOS.targets" /> -->
+    <file src="build/net6.0-maccatalyst/HarfBuzzSharp.targets" target="build/net6.0-maccatalyst13.5/HarfBuzzSharp.targets" />
+    <file src="build/net6.0-maccatalyst/HarfBuzzSharp.targets" target="buildTransitive/net6.0-maccatalyst13.5/HarfBuzzSharp.targets" />
 
     <!-- libSkiaSharp.dll and other native files -->
-    <!-- <file platform="macos" src="runtimes/maccatalyst/native/libSkiaSharp.framework/**/*" target="runtimes/maccatalyst/native/libSkiaSharp.framework" /> -->
+    <file platform="macos" src="runtimes/maccatalyst/native/libSkiaSharp.framework.zip" target="runtimes/maccatalyst/native/libSkiaSharp.framework.zip" />
 
     <!-- placeholders -->
     <file src="_._" target="lib/net6.0-maccatalyst13.5/_._" />

--- a/samples/Basic/Maui/SkiaSharpSample/SkiaSharpSample.csproj
+++ b/samples/Basic/Maui/SkiaSharpSample/SkiaSharpSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-ios;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>net6.0-ios;net6.0-maccatalyst;net6.0-android</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SingleProject>true</SingleProject>
     <RootNamespace>SkiaSharpSample</RootNamespace>

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -73,6 +73,7 @@ stages:
           target: externals-android
           additionalArgs: --buildarch=x86
           installWindowsSdk: false
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (Win)
         parameters:
           name: native_android_x64_windows
@@ -81,6 +82,7 @@ stages:
           target: externals-android
           additionalArgs: --buildarch=x64
           installWindowsSdk: false
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (Win)
         parameters:
           name: native_android_arm_windows
@@ -89,6 +91,7 @@ stages:
           target: externals-android
           additionalArgs: --buildarch=arm
           installWindowsSdk: false
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (Win)
         parameters:
           name: native_android_arm64_windows
@@ -97,6 +100,7 @@ stages:
           target: externals-android
           additionalArgs: --buildarch=arm64
           installWindowsSdk: false
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Win)
         parameters:
           name: native_tizen_windows
@@ -104,6 +108,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-tizen
           installWindowsSdk: false
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x86 (Win)
         parameters:
           name: native_uwp_angle_x86_windows
@@ -111,6 +116,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x64 (Win)
         parameters:
           name: native_uwp_angle_x64_windows
@@ -118,6 +124,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm (Win)
         parameters:
           name: native_uwp_angle_arm_windows
@@ -125,6 +132,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm64 (Win)
         parameters:
           name: native_uwp_angle_arm64_windows
@@ -132,6 +140,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native UWP|x86 (Win)
         parameters:
           name: native_uwp_x86_windows
@@ -139,6 +148,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native UWP|x64 (Win)
         parameters:
           name: native_uwp_x64_windows
@@ -146,6 +156,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm (Win)
         parameters:
           name: native_uwp_arm_windows
@@ -153,6 +164,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm64 (Win)
         parameters:
           name: native_uwp_arm64_windows
@@ -160,6 +172,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Win32|x86 (Win)
         parameters:
           name: native_win32_x86_windows
@@ -167,6 +180,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x86
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Win32|x64 (Win)
         parameters:
           name: native_win32_x64_windows
@@ -174,6 +188,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x64
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Win32|arm64 (Win)
         parameters:
           name: native_win32_arm64_windows
@@ -181,6 +196,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=arm64
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native NanoServer|x64 (Win)
         parameters:
           name: native_win32_x64_nanoserver_windows
@@ -188,6 +204,7 @@ stages:
           vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
+          artifactName: native
           tools:
             - nano-api-scan
 
@@ -229,30 +246,35 @@ stages:
           displayName: iOS
           vmImage: $(VM_IMAGE_MAC)
           target: externals-ios
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
         parameters:
           name: native_maccatalyst_macos
           displayName: Mac Catalyst
           vmImage: $(VM_IMAGE_MAC)
           target: externals-maccatalyst
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
         parameters:
           name: native_macos_macos
           displayName: macOS
           vmImage: $(VM_IMAGE_MAC)
           target: externals-macos
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
         parameters:
           name: native_tvos_macos
           displayName: tvOS
           vmImage: $(VM_IMAGE_MAC)
           target: externals-tvos
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
         parameters:
           name: native_watchos_macos
           displayName: watchOS
           vmImage: $(VM_IMAGE_MAC)
           target: externals-watchos
+          artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
         parameters:
           name: native_tizen_macos
@@ -267,6 +289,7 @@ stages:
     jobs:
       - template: azure-templates-linux-matrix.yml # Build Native Linux (Linux)
         parameters:
+          artifactName: native
           builds:
             - name: ''
             - name: nodeps
@@ -300,6 +323,7 @@ stages:
     jobs:
       - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
         parameters:
+          artifactName: native
           emscripten:
             - 2.0.5
             - 2.0.6
@@ -324,24 +348,8 @@ stages:
           target: libs
           additionalArgs: --skipExternals="all"
           requiredArtifacts:
-            - native_android_x86_windows
-            - native_android_x64_windows
-            - native_android_arm_windows
-            - native_android_arm64_windows
-            - native_tizen_windows
-            - native_uwp_angle_x86_windows
-            - native_uwp_angle_x64_windows
-            - native_uwp_angle_arm_windows
-            - native_uwp_angle_arm64_windows
-            - native_uwp_x86_windows
-            - native_uwp_x64_windows
-            - native_uwp_arm_windows
-            - native_uwp_arm64_windows
-            - native_win32_x86_windows
-            - native_win32_x64_windows
-            - native_win32_arm64_windows
-            - native_win32_x64_nanoserver_windows
-            - native_wasm_linux
+            - native
+          artifactName: managed
       - template: azure-templates-bootstrapper.yml # Build Managed (macOS)
         parameters:
           name: managed_macos
@@ -350,18 +358,8 @@ stages:
           target: libs
           additionalArgs: --skipExternals="all"
           requiredArtifacts:
-            - native_android_x86_macos
-            - native_android_x64_macos
-            - native_android_arm_macos
-            - native_android_arm64_macos
-            - native_ios_macos
-            - native_maccatalyst_macos
-            - native_macos_macos
-            # - native_tizen_macos
-            - native_tizen_windows
-            - native_tvos_macos
-            - native_watchos_macos
-            - native_wasm_linux
+            - native
+          artifactName: managed
       - template: azure-templates-bootstrapper.yml # Build Managed (Linux)
         parameters:
           name: managed_linux
@@ -371,17 +369,8 @@ stages:
           target: libs
           additionalArgs: --skipExternals="all"
           requiredArtifacts:
-            - native_linux_x64_linux
-            - native_linux_arm_linux
-            - native_linux_arm64_linux
-            - native_linux_x64_nodeps_linux
-            - native_linux_arm_nodeps_linux
-            - native_linux_arm64_nodeps_linux
-            - native_linux_x64_alpine_linux
-            - native_linux_x64_alpine_nodeps_linux
-            # - native_tizen_linux
-            - native_tizen_windows
-            - native_wasm_linux
+            - native
+          artifactName: managed
 
   - stage: package
     displayName: Package NuGets
@@ -396,17 +385,9 @@ stages:
           additionalArgs: --packall=true --skipbuild=true
           installWindowsSdk: false
           installDotNet: false
-          shouldPublish: true
           requiredArtifacts:
-            - managed_linux
-            - managed_macos
-            - managed_windows
+            - managed
           postBuildSteps:
-            - task: PublishBuildArtifacts@1
-              displayName: Publish the native artifacts
-              inputs:
-                artifactName: native
-                pathToPublish: 'output/native'
             - task: PublishBuildArtifacts@1
               displayName: Publish the nuget artifacts
               inputs:

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -217,12 +217,12 @@ jobs:
         inputs:
           artifactName: ${{ parameters.name }}
           pathToPublish: 'output'
-      - task: PublishBuildArtifacts@1
-        displayName: Publish the combined ${{ coalesce(parameters.artifactName, parameters.name) }} artifacts
-        condition: ne(parameters.artifactName, '')
-        inputs:
-          artifactName: ${{ coalesce(parameters.artifactName, parameters.name) }}
-          pathToPublish: 'output'
+      - ${{ if ne(parameters.artifactName, '') }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Publish the combined ${{ parameters.artifactName }} artifacts
+          inputs:
+            artifactName: ${{ parameters.artifactName }}
+            pathToPublish: 'output'
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - task: ComponentGovernanceComponentDetection@0
           displayName: Run component detection

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: '5063341'                            # the build number to download externals from
+  buildExternals: ''                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -29,17 +29,17 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
 
 jobs:
-- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-  - template: azure-templates-download.yml
-    parameters:
-      name: ${{ parameters.name }}
-      displayName: ${{ parameters.displayName }}
-      vmImage: ${{ parameters.vmImage }}
-      condition: ${{ parameters.condition }}
-      postBuildSteps: ${{ parameters.postBuildSteps }}
-      buildExternals: ${{ parameters.buildExternals }}
+# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+#   - template: azure-templates-download.yml
+#     parameters:
+#       name: ${{ parameters.name }}
+#       displayName: ${{ parameters.displayName }}
+#       vmImage: ${{ parameters.vmImage }}
+#       condition: ${{ parameters.condition }}
+#       postBuildSteps: ${{ parameters.postBuildSteps }}
+#       buildExternals: ${{ parameters.buildExternals }}
 
-- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: ''                            # the build number to download externals from
+  buildExternals: '5063341'                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -29,17 +29,17 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
 
 jobs:
-# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-#   - template: azure-templates-download.yml
-#     parameters:
-#       name: ${{ parameters.name }}
-#       displayName: ${{ parameters.displayName }}
-#       vmImage: ${{ parameters.vmImage }}
-#       condition: ${{ parameters.condition }}
-#       postBuildSteps: ${{ parameters.postBuildSteps }}
-#       buildExternals: ${{ parameters.buildExternals }}
+- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+  - template: azure-templates-download.yml
+    parameters:
+      name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      vmImage: ${{ parameters.vmImage }}
+      condition: ${{ parameters.condition }}
+      postBuildSteps: ${{ parameters.postBuildSteps }}
+      buildExternals: ${{ parameters.buildExternals }}
 
-# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: ''                            # the build number to download externals from
+  buildExternals: '5067956'                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -27,19 +27,20 @@ parameters:
   installDotNet: true                           # whether or not to install the dotnet SDK
   installLlvm: true                             # whether or not to install the LLVM compiler
   installEmsdk: false                           # whether or not to install the Emscripten SDK
+  artifactName: ''                              # the name of the artifact to merge this run into
 
 jobs:
-# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-#   - template: azure-templates-download.yml
-#     parameters:
-#       name: ${{ parameters.name }}
-#       displayName: ${{ parameters.displayName }}
-#       vmImage: ${{ parameters.vmImage }}
-#       condition: ${{ parameters.condition }}
-#       postBuildSteps: ${{ parameters.postBuildSteps }}
-#       buildExternals: ${{ parameters.buildExternals }}
+- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+  - template: azure-templates-download.yml
+    parameters:
+      name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      vmImage: ${{ parameters.vmImage }}
+      condition: ${{ parameters.condition }}
+      postBuildSteps: ${{ parameters.postBuildSteps }}
+      buildExternals: ${{ parameters.buildExternals }}
 
-# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120
@@ -215,6 +216,12 @@ jobs:
         condition: or(${{ parameters.shouldPublish }}, failed())
         inputs:
           artifactName: ${{ parameters.name }}
+          pathToPublish: 'output'
+      - task: PublishBuildArtifacts@1
+        displayName: Publish the combined ${{ coalesce(parameters.artifactName, parameters.name) }} artifacts
+        condition: ne(parameters.artifactName, '')
+        inputs:
+          artifactName: ${{ coalesce(parameters.artifactName, parameters.name) }}
           pathToPublish: 'output'
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - task: ComponentGovernanceComponentDetection@0

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  buildExternals: '5067956'                            # the build number to download externals from
+  buildExternals: ''                            # the build number to download externals from
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -30,18 +30,18 @@ parameters:
   artifactName: ''                              # the name of the artifact to merge this run into
 
 jobs:
-- ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
-  - template: azure-templates-download.yml
-    parameters:
-      name: ${{ parameters.name }}
-      displayName: ${{ parameters.displayName }}
-      vmImage: ${{ parameters.vmImage }}
-      condition: ${{ parameters.condition }}
-      postBuildSteps: ${{ parameters.postBuildSteps }}
-      buildExternals: ${{ parameters.buildExternals }}
-      artifactName: ${{ parameters.artifactName }}
+# - ${{ if and(ne(parameters.buildExternals, ''), startsWith(parameters.name, 'native_')) }}:
+#   - template: azure-templates-download.yml
+#     parameters:
+#       name: ${{ parameters.name }}
+#       displayName: ${{ parameters.displayName }}
+#       vmImage: ${{ parameters.vmImage }}
+#       condition: ${{ parameters.condition }}
+#       postBuildSteps: ${{ parameters.postBuildSteps }}
+#       buildExternals: ${{ parameters.buildExternals }}
+#       artifactName: ${{ parameters.artifactName }}
 
-- ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
+# - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -39,6 +39,7 @@ jobs:
       condition: ${{ parameters.condition }}
       postBuildSteps: ${{ parameters.postBuildSteps }}
       buildExternals: ${{ parameters.buildExternals }}
+      artifactName: ${{ parameters.artifactName }}
 
 - ${{ if or(eq(parameters.buildExternals, ''), not(startsWith(parameters.name, 'native_'))) }}:
   - job: ${{ parameters.name }}

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -36,10 +36,10 @@ jobs:
         inputs:
           artifactName: ${{ parameters.name }}
           pathToPublish: 'output'
-      - task: PublishBuildArtifacts@1
-        displayName: Publish the combined ${{ coalesce(parameters.artifactName, parameters.name) }} artifacts
-        condition: ne(parameters.artifactName, '')
-        inputs:
-          artifactName: ${{ coalesce(parameters.artifactName, parameters.name) }}
-          pathToPublish: 'output'
+      - ${{ if ne(parameters.artifactName, '') }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Publish the combined ${{ parameters.artifactName }} artifacts
+          inputs:
+            artifactName: ${{ parameters.artifactName }}
+            pathToPublish: 'output'
       - ${{ parameters.postBuildSteps }}

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -5,6 +5,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   buildExternals: ''                            # the build number to download externals from
   postBuildSteps: []                            # any additional steps to run after the build
+  artifactName: ''                              # the name of the artifact to merge this run into
 
 jobs:
   - job: ${{ parameters.name }}
@@ -34,5 +35,11 @@ jobs:
         displayName: Publish the ${{ parameters.name }} artifacts
         inputs:
           artifactName: ${{ parameters.name }}
+          pathToPublish: 'output'
+      - task: PublishBuildArtifacts@1
+        displayName: Publish the combined ${{ coalesce(parameters.artifactName, parameters.name) }} artifacts
+        condition: ne(parameters.artifactName, '')
+        inputs:
+          artifactName: ${{ coalesce(parameters.artifactName, parameters.name) }}
           pathToPublish: 'output'
       - ${{ parameters.postBuildSteps }}

--- a/scripts/azure-templates-linux-matrix.yml
+++ b/scripts/azure-templates-linux-matrix.yml
@@ -1,4 +1,5 @@
 parameters:
+  artifactName: ''                              # the name of the artifact to merge this run into
   builds:
     - name: ''
       desc: ''
@@ -25,3 +26,4 @@ jobs:
           dockerArgs: ${{ item.dockerArgs }}
           target: ${{ coalesce(item.target, 'externals-linux') }}
           additionalArgs: --buildarch=${{ item.arch }} --variant=${{ coalesce(item.variant, 'linux') }}${{ build.name }} --gnArgs="\"${{ build.gnArgs }} ${{ item.gnArgs }}\"" ${{ build.additionalArgs }} ${{ item.additionalArgs }}
+          artifactName: ${{ parameters.artifactName }}

--- a/scripts/azure-templates-wasm-matrix.yml
+++ b/scripts/azure-templates-wasm-matrix.yml
@@ -1,4 +1,5 @@
 parameters:
+  artifactName: ''                              # the name of the artifact to merge this run into
   emscripten: [ ]
 
 jobs:
@@ -12,9 +13,4 @@ jobs:
         target: externals-wasm
         dockerArgs: --build-arg EMSCRIPTEN_VERSION=${{ version }}
         additionalArgs: --emscriptenVersion=${{ version }}
-        postBuildSteps:
-          - task: PublishBuildArtifacts@1
-            displayName: Publish the native_wasm_linux artifacts
-            inputs:
-              artifactName: native_wasm_linux
-              pathToPublish: 'output'
+        artifactName: ${{ parameters.artifactName }}


### PR DESCRIPTION
**Description of Change**

This PR adds the Mac Catalyst native component to the packages.

Previously this was having issues with the fact that the native framework has symlinks and .NET does not know how to handle that. It would end up duplicating files and then Xcode would not understand.

There are currently 2 issues that still affect this, and thus targets are required to patch it up a bit:
 - https://github.com/xamarin/xamarin-macios/issues/11667
 - https://github.com/xamarin/xamarin-macios/issues/12369

**Bugs Fixed**

 - None

**API Changes**

None

**Behavioral Changes**

Code that would throw at runtime now does not.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
