### PR TITLE
Use the correct MacCatalyst targets file name

### DIFF
--- a/nuget/HarfBuzzSharp.NativeAssets.WebAssembly.nuspec
+++ b/nuget/HarfBuzzSharp.NativeAssets.WebAssembly.nuspec
@@ -26,6 +26,11 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
 
+    <dependencies>
+      <group targetFramework="netstandard1.0">
+      </group>
+    </dependencies>
+
   </metadata>
   <files>
 

--- a/nuget/SkiaSharp.NativeAssets.MacCatalyst.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.MacCatalyst.nuspec
@@ -36,8 +36,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
   <files>
 
     <!-- the build bits -->
-    <file src="build/net6.0-maccatalyst/SkiaSharp.targets" target="build/net6.0-maccatalyst13.5/SkiaSharp.targets" />
-    <file src="build/net6.0-maccatalyst/SkiaSharp.targets" target="buildTransitive/net6.0-maccatalyst13.5/SkiaSharp.targets" />
+    <file src="build/net6.0-maccatalyst/SkiaSharp.targets" target="build/net6.0-maccatalyst13.5/SkiaSharp.NativeAssets.MacCatalyst.targets" />
+    <file src="build/net6.0-maccatalyst/SkiaSharp.targets" target="buildTransitive/net6.0-maccatalyst13.5/SkiaSharp.NativeAssets.MacCatalyst.targets" />
 
     <!-- libSkiaSharp.dll and other native files -->
     <file platform="macos" src="runtimes/maccatalyst/native/libSkiaSharp.framework.zip" target="runtimes/maccatalyst/native/libSkiaSharp.framework.zip" />

--- a/nuget/SkiaSharp.NativeAssets.WebAssembly.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.WebAssembly.nuspec
@@ -27,6 +27,11 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
 
+    <dependencies>
+      <group targetFramework="netstandard1.0">
+      </group>
+    </dependencies>
+
   </metadata>
   <files>
 


### PR DESCRIPTION
**Description of Change**

The file name of the .targets file for the SkiaSharp.NativeAssets.MacCatalyst package was not renamed to match the package ID and thus never got imported.

This is a bug in the PR #1760 

**Bugs Fixed**

 - The .targets file for maccatalyst are not imported.

**API Changes**
None.

**Behavioral Changes**

Mac Catalyst compilation now works.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
