### PR TITLE
IsAntialias should also control the Edging

### DIFF
--- a/tests/Tests/SKPaintTest.cs
+++ b/tests/Tests/SKPaintTest.cs
@@ -554,5 +554,92 @@ namespace SkiaSharp.Tests
 
 			Assert.NotNull(paint.GetTextPath("", 0, 0));
 		}
+
+		[SkippableTheory]
+		[InlineData(true, true, SKFontEdging.SubpixelAntialias)]
+		[InlineData(false, true, SKFontEdging.Alias)]
+		[InlineData(true, false, SKFontEdging.Antialias)]
+		[InlineData(false, false, SKFontEdging.Alias)]
+		public void UpdatingPropertiesIsAntialiasLcdRenderText(bool isAntialias, bool lcd, SKFontEdging newEdging)
+		{
+			var paint = new SKPaint();
+
+			paint.IsAntialias = isAntialias;
+			paint.LcdRenderText = lcd;
+
+			Assert.Equal(newEdging, paint.GetFont().Edging);
+		}
+
+		[SkippableTheory]
+		[InlineData(true, true, SKFontEdging.SubpixelAntialias)]
+		[InlineData(false, true, SKFontEdging.Alias)]
+		[InlineData(true, false, SKFontEdging.Antialias)]
+		[InlineData(false, false, SKFontEdging.Alias)]
+		public void UpdatingPropertiesLcdRenderTextIsAntialias(bool isAntialias, bool lcd, SKFontEdging newEdging)
+		{
+			var paint = new SKPaint();
+
+			paint.LcdRenderText = lcd;
+			paint.IsAntialias = isAntialias;
+
+			Assert.Equal(newEdging, paint.GetFont().Edging);
+		}
+
+		[SkippableFact]
+		public void PaintWithSubpixelEdgingIsPreserved()
+		{
+			var font = new SKFont();
+			font.Edging = SKFontEdging.SubpixelAntialias;
+
+			var paint = new SKPaint(font);
+
+			Assert.True(paint.LcdRenderText);
+			Assert.False(paint.IsAntialias);
+			Assert.Equal(SKFontEdging.Alias, paint.GetFont().Edging);
+
+			paint.IsAntialias = true;
+
+			Assert.True(paint.LcdRenderText);
+			Assert.True(paint.IsAntialias);
+			Assert.Equal(SKFontEdging.SubpixelAntialias, paint.GetFont().Edging);
+		}
+
+		[SkippableFact]
+		public void PaintWithAntialiasEdgingIsPreserved()
+		{
+			var font = new SKFont();
+			font.Edging = SKFontEdging.Antialias;
+
+			var paint = new SKPaint(font);
+
+			Assert.False(paint.LcdRenderText);
+			Assert.False(paint.IsAntialias);
+			Assert.Equal(SKFontEdging.Alias, paint.GetFont().Edging);
+
+			paint.IsAntialias = true;
+
+			Assert.False(paint.LcdRenderText);
+			Assert.True(paint.IsAntialias);
+			Assert.Equal(SKFontEdging.Antialias, paint.GetFont().Edging);
+		}
+
+		[SkippableFact]
+		public void PaintWithAliasEdgingIsPreserved()
+		{
+			var font = new SKFont();
+			font.Edging = SKFontEdging.Alias;
+
+			var paint = new SKPaint(font);
+
+			Assert.False(paint.LcdRenderText);
+			Assert.False(paint.IsAntialias);
+			Assert.Equal(SKFontEdging.Alias, paint.GetFont().Edging);
+
+			paint.IsAntialias = true;
+
+			Assert.False(paint.LcdRenderText);
+			Assert.True(paint.IsAntialias);
+			Assert.Equal(SKFontEdging.Antialias, paint.GetFont().Edging);
+		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

@mattleibow

This is for compatibility and consistency. Before 2.80, the anti-aliasing flag would also affect the font edging. After 2.80, the properties were separate and now we have to make sure the paint updates the edging based on what the anti-aliasing and LCD rendering indicate.

**Bugs Fixed**

| 1.68.x | 2.80.x | PR |
| :-: | :-: | :-: |
| ![image](https://user-images.githubusercontent.com/1096616/132564635-8b0e485c-fd23-4415-a0d9-54930120d3f8.png) | ![image](https://user-images.githubusercontent.com/1096616/132564872-bf859b47-a694-415a-80d8-3b681831581f.png) | ![image](https://user-images.githubusercontent.com/1096616/132564945-cf215985-825d-4074-88da-33e66f5b0c57.png) |

```csharp
cnv.Clear(SKColors.White);

var paint = new SKPaint();
paint.TextSize = 40;

paint.IsAntialias = false;
paint.LcdRenderText = false;
cnv.DrawText("Hello World!", 20, 50, paint);

paint.IsAntialias = true;
paint.LcdRenderText = false;
cnv.DrawText("Hello World!", 20, 100, paint);

paint.IsAntialias = false;
paint.LcdRenderText = true;
cnv.DrawText("Hello World!", 20, 150, paint);

paint.IsAntialias = true;
paint.LcdRenderText = true;
cnv.DrawText("Hello World!", 20, 200, paint);
```

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
