### PR TITLE
Build using the older gcc 6.2 and new llvm 10 compiler

### DIFF
--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -34,7 +34,7 @@ Task("libSkiaSharp")
            $"skia_use_system_libpng=false " +
            $"skia_use_system_libwebp=false " +
            $"skia_use_system_zlib=true " +
-           $"extra_cflags=[ '-DSKIA_C_DLL', '-DXML_DEV_URANDOM' ] " +
+           $"extra_cflags=[ '-DSKIA_C_DLL', '-DXML_DEV_URANDOM', '-DSK_NO_MAKE_SHARED_PTR' ] " +
            $"ncli='{TIZEN_STUDIO_HOME}' " +
            $"ncli_version='4.0'");
 

--- a/native/tizen/libSkiaSharp/project_def.prop
+++ b/native/tizen/libSkiaSharp/project_def.prop
@@ -25,6 +25,7 @@ USER_DEFS = NDEBUG                                        \
             SK_ENCODE_WEBP                                \
             SK_GAMMA_APPLY_TO_A8                          \
             SK_GL                                         \
+            SK_NO_MAKE_SHARED_PTR                         \
             SK_R32_SHIFT=16                               \
             SK_SUPPORT_PDF                                \
             SK_USE_LIBGIFCODEC                            \

--- a/scripts/install-tizen.ps1
+++ b/scripts/install-tizen.ps1
@@ -63,31 +63,31 @@ if ($IsMacOS -or $IsLinux) {
     & "$packMan" install --no-java-check --accept-license "$packages"
 }
 
-# function Swap-Tool {
-#     param ([string] $OldName, [string] $NewName)
-#
-#     $tsTools = Join-Path "$ts" "tools"
-#     $llvm40 = Join-Path $tsTools $OldName
-#     $llvm40OLD = Join-Path $tsTools "$OldName-OLD"
-#     $llvm10 = Join-Path $tsTools $NewName
-#     if (!(Test-Path $llvm40OLD)) {
-#         Copy-Item $llvm40 $llvm40OLD -Recurse -Force
-#     }
-#     if (Test-Path $llvm40) {
-#         Remove-Item $llvm40 -Recurse -Force
-#     }
-#     Copy-Item $llvm10 $llvm40 -Recurse -Force
-# }
-#
-# # Upgrade LLVM 4 to LLVM 10 by literally replacing the folder
-# if ($UpgradeLLVM) {
-#     Write-Host "Upgrading LLVM and GCC in place..."
-#     Swap-Tool "llvm-4.0.0" "llvm-10"
-#     Swap-Tool "aarch64-linux-gnu-gcc-6.2" "aarch64-linux-gnu-gcc-9.2"
-#     Swap-Tool "arm-linux-gnueabi-gcc-6.2" "arm-linux-gnueabi-gcc-9.2"
-#     Swap-Tool "i586-linux-gnueabi-gcc-6.2" "i586-linux-gnueabi-gcc-9.2"
-#     Swap-Tool "x86_64-linux-gnu-gcc-6.2" "x86_64-linux-gnu-gcc-9.2"
-# }
+function Swap-Tool {
+    param ([string] $OldName, [string] $NewName)
+
+    $tsTools = Join-Path "$ts" "tools"
+    $llvm40 = Join-Path $tsTools $OldName
+    $llvm40OLD = Join-Path $tsTools "$OldName-OLD"
+    $llvm10 = Join-Path $tsTools $NewName
+    if (!(Test-Path $llvm40OLD)) {
+        Copy-Item $llvm40 $llvm40OLD -Recurse -Force
+    }
+    if (Test-Path $llvm40) {
+        Remove-Item $llvm40 -Recurse -Force
+    }
+    Copy-Item $llvm10 $llvm40 -Recurse -Force
+}
+
+# Upgrade LLVM 4 to LLVM 10 by literally replacing the folder
+if ($UpgradeLLVM) {
+    Write-Host "Upgrading LLVM and GCC in place..."
+    Swap-Tool "llvm-4.0.0" "llvm-10"
+    # Swap-Tool "aarch64-linux-gnu-gcc-6.2" "aarch64-linux-gnu-gcc-9.2"
+    # Swap-Tool "arm-linux-gnueabi-gcc-6.2" "arm-linux-gnueabi-gcc-9.2"
+    # Swap-Tool "i586-linux-gnueabi-gcc-6.2" "i586-linux-gnueabi-gcc-9.2"
+    # Swap-Tool "x86_64-linux-gnu-gcc-6.2" "x86_64-linux-gnu-gcc-9.2"
+}
 
 # make sure that Tizen Studio is in TIZEN_STUDIO_HOME
 Write-Host "##vso[task.setvariable variable=TIZEN_STUDIO_HOME;]$ts";

--- a/scripts/install-tizen.ps1
+++ b/scripts/install-tizen.ps1
@@ -63,31 +63,31 @@ if ($IsMacOS -or $IsLinux) {
     & "$packMan" install --no-java-check --accept-license "$packages"
 }
 
-function Swap-Tool {
-    param ([string] $OldName, [string] $NewName)
-
-    $tsTools = Join-Path "$ts" "tools"
-    $llvm40 = Join-Path $tsTools $OldName
-    $llvm40OLD = Join-Path $tsTools "$OldName-OLD"
-    $llvm10 = Join-Path $tsTools $NewName
-    if (!(Test-Path $llvm40OLD)) {
-        Copy-Item $llvm40 $llvm40OLD -Recurse -Force
-    }
-    if (Test-Path $llvm40) {
-        Remove-Item $llvm40 -Recurse -Force
-    }
-    Copy-Item $llvm10 $llvm40 -Recurse -Force
-}
-
-# Upgrade LLVM 4 to LLVM 10 by literally replacing the folder
-if ($UpgradeLLVM) {
-    Write-Host "Upgrading LLVM and GCC in place..."
-    Swap-Tool "llvm-4.0.0" "llvm-10"
-    Swap-Tool "aarch64-linux-gnu-gcc-6.2" "aarch64-linux-gnu-gcc-9.2"
-    Swap-Tool "arm-linux-gnueabi-gcc-6.2" "arm-linux-gnueabi-gcc-9.2"
-    Swap-Tool "i586-linux-gnueabi-gcc-6.2" "i586-linux-gnueabi-gcc-9.2"
-    Swap-Tool "x86_64-linux-gnu-gcc-6.2" "x86_64-linux-gnu-gcc-9.2"
-}
+# function Swap-Tool {
+#     param ([string] $OldName, [string] $NewName)
+#
+#     $tsTools = Join-Path "$ts" "tools"
+#     $llvm40 = Join-Path $tsTools $OldName
+#     $llvm40OLD = Join-Path $tsTools "$OldName-OLD"
+#     $llvm10 = Join-Path $tsTools $NewName
+#     if (!(Test-Path $llvm40OLD)) {
+#         Copy-Item $llvm40 $llvm40OLD -Recurse -Force
+#     }
+#     if (Test-Path $llvm40) {
+#         Remove-Item $llvm40 -Recurse -Force
+#     }
+#     Copy-Item $llvm10 $llvm40 -Recurse -Force
+# }
+#
+# # Upgrade LLVM 4 to LLVM 10 by literally replacing the folder
+# if ($UpgradeLLVM) {
+#     Write-Host "Upgrading LLVM and GCC in place..."
+#     Swap-Tool "llvm-4.0.0" "llvm-10"
+#     Swap-Tool "aarch64-linux-gnu-gcc-6.2" "aarch64-linux-gnu-gcc-9.2"
+#     Swap-Tool "arm-linux-gnueabi-gcc-6.2" "arm-linux-gnueabi-gcc-9.2"
+#     Swap-Tool "i586-linux-gnueabi-gcc-6.2" "i586-linux-gnueabi-gcc-9.2"
+#     Swap-Tool "x86_64-linux-gnu-gcc-6.2" "x86_64-linux-gnu-gcc-9.2"
+# }
 
 # make sure that Tizen Studio is in TIZEN_STUDIO_HOME
 Write-Host "##vso[task.setvariable variable=TIZEN_STUDIO_HOME;]$ts";


### PR DESCRIPTION
**Description of Change**

Previously I had used the new compiler AND new GCC to use the new features, however, it seems this may not have actually been working or we got lucky.

After upgrading to skia m88, I notice that the Tizen apps are no longer running. I think either m80 just did not make use of certain symbols in the newer glibc. However, with m88, this is now happening. It might have been a bit deceiving because the app may have launched and rendered content because libSkiaSharp is actually bundled on the Tizen device - at least my watch has it.

The new approach is to use the new compilers still, but the old GCC and work around the features needed in the code.

The even better solution would be to have 2 versions of the library built for different versions of Tizen. However, that is for a new PR.

**Bugs Fixed**

 - The libSkiaSharp.so not being loaded because it depended on a newer glibc

**API Changes**

None.

**Behavioral Changes**

Should not be as this was the compiler we were using previously, however, there may be some slight perf decreases if there were any optimizations done in headers. 

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
