### PR TITLE
[android] eliminate lots of fields in Resource.designer.cs

### DIFF
--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls.Compatibility/SkiaSharp.Views.Maui.Controls.Compatibility.csproj
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls.Compatibility/SkiaSharp.Views.Maui.Controls.Compatibility.csproj
@@ -10,6 +10,7 @@
     <DefineConstants>$(DefineConstants);__MAUI__</DefineConstants>
     <PackagingPlatform Condition="$(TargetFramework.Contains('-windows'))">net6.0-windows</PackagingPlatform>
     <UseMaui>true</UseMaui>
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/SkiaSharp.Views.Maui.Controls.csproj
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/SkiaSharp.Views.Maui.Controls.csproj
@@ -10,6 +10,7 @@
     <DefineConstants>$(DefineConstants);__MAUI__</DefineConstants>
     <PackagingPlatform Condition="$(TargetFramework.Contains('-windows'))">net6.0-windows</PackagingPlatform>
     <UseMaui>true</UseMaui>
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/SkiaSharp.Views.Maui.Core.csproj
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/SkiaSharp.Views.Maui.Core.csproj
@@ -11,6 +11,7 @@
     <DefineConstants>$(DefineConstants);__MAUI__</DefineConstants>
     <PackagingPlatform Condition="$(TargetFramework.Contains('-windows'))">net6.0-windows</PackagingPlatform>
     <UseMauiCore>true</UseMauiCore>
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />


### PR DESCRIPTION
**Description of Change**

Context: https://github.com/jonathanpeppers/CustomResourceDesigner
Context: https://github.com/xamarin/xamarin-android/issues/6310

We found a case where a .NET MAUI app that included SkiaSharp and
Telerik controls was setting ~90,000 fields at startup in the
`Resource.designer.cs` file via the `UpdateIdValues()` method.

This also would happen in any Xamarin.Android class library:

* Include AndroidX & Google Material
* Include at least one `@(AndroidResource)` and use the ID from C#
* `Resource.designer.cs` has 2,700+ fields

So SkiaSharp is not unique to the problem here...

Reviewing the SkiaSharp fields, I found:

    source\SkiaSharp.Views.Maui\SkiaSharp.Views.Maui.Controls\obj\Debug\net6.0-android\Resource.designer.cs
    5335 fields
    source\SkiaSharp.Views.Maui\SkiaSharp.Views.Maui.Core\obj\Debug\net6.0-android\Resource.designer.cs
    5313 fields
    source\SkiaSharp.Views.Maui\SkiaSharp.Views.Maui.Controls.Compatibility\obj\Debug\net6.0-android\Resource.designer.cs
    5335 fields

We can simply set `$(AndroidGenerateResourceDesigner)` to `false` in
these projects, as they do not use any of the fields. This will
prevent .NET 6 apps using these libraries from setting 16,005 fields
at startup.

I also did a spot check on `SkiaSharp.Views.Android`, but it's OK --
it only has 3 fields:

    public class Resource
    {
        public class Attribute
        {
            public static int ignorePixelScaling;
            //...
        }
        public class Styleable
        {
            public static int[] SKCanvasView;
            public static int SKCanvasView_ignorePixelScaling;
            //...
        }
        //...
    }

We are working on a long-term solution for this issue in
Xamarin.Android, but we can do a simple workaround in SkiaSharp for
now.

**Bugs Fixed**

n/a

**API Changes**

None

**Behavioral Changes**

If the three projects require usage of `Resource.designer.cs` in the future, we could follow the pattern here:

https://github.com/jonathanpeppers/CustomResourceDesigner

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
