### PR TITLE
Reshape SKGLView when Window.BackingScaleFactor changes (#1853)

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Mac/SKGLView.cs
@@ -158,8 +158,28 @@ namespace SkiaSharp.Views.Mac
 
 		public event EventHandler<SKPaintGLSurfaceEventArgs> PaintSurface;
 
+		private nfloat lastBackingScaleFactor = 0;
+
 		protected virtual void OnPaintSurface(SKPaintGLSurfaceEventArgs e)
 		{
+			// Track if the scale of the display has changed and if so force the SKGLView to reshape itself.
+			// If this is not done, the output will scale correctly when the window is dragged from a non-retina to a retina display.
+			if (lastBackingScaleFactor != Window.BackingScaleFactor)
+			{
+				bool isFirstPaint = lastBackingScaleFactor == 0;
+				lastBackingScaleFactor = Window.BackingScaleFactor;
+				if (!isFirstPaint)
+				{
+					Reshape();
+					// A redraw will also be necessary. Invoke later or the request will be ignored
+					Invoke(() => {
+						NeedsDisplay = true;
+					}, 0);
+					// do not call proceed at the wrong scale
+					return;
+				}
+			}
+
 			PaintSurface?.Invoke(this, e);
 		}
 


### PR DESCRIPTION
**Description of Change**

Reshape SKGLView when Window.BackingScaleFactor changes, ensuring that the output is displayed at the proper scale. If it is possible to create a test for this type of visual change, I don't know how.

**Bugs Fixed**

[BUG] macOS: When display scale changes SKGLView does not adjust appropriately

https://github.com/mono/SkiaSharp/issues/1853

**API Changes**

None

**Behavioral Changes**

None

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
