### PR TITLE
Never dispose the native statics

### DIFF
--- a/binding/Binding/SKColorSpace.cs
+++ b/binding/Binding/SKColorSpace.cs
@@ -265,10 +265,11 @@ namespace SkiaSharp
 		private sealed class SKColorSpaceStatic : SKColorSpace
 		{
 			internal SKColorSpaceStatic (IntPtr x)
-				: base (x, true)
+				: base (x, false)
 			{
-				IgnorePublicDispose = true;
 			}
+
+			protected override void Dispose (bool disposing) { }
 		}
 	}
 }

--- a/binding/Binding/SKData.cs
+++ b/binding/Binding/SKData.cs
@@ -301,10 +301,11 @@ namespace SkiaSharp
 		private sealed class SKDataStatic : SKData
 		{
 			internal SKDataStatic (IntPtr x)
-				: base (x, true)
+				: base (x, false)
 			{
-				IgnorePublicDispose = true;
 			}
+
+			protected override void Dispose (bool disposing) { }
 		}
 	}
 }

--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -202,10 +202,11 @@ namespace SkiaSharp
 		private sealed class SKFontManagerStatic : SKFontManager
 		{
 			internal SKFontManagerStatic (IntPtr x)
-				: base (x, true)
+				: base (x, false)
 			{
-				IgnorePublicDispose = true;
 			}
+
+			protected override void Dispose (bool disposing) { }
 		}
 	}
 }

--- a/binding/Binding/SKFontStyle.cs
+++ b/binding/Binding/SKFontStyle.cs
@@ -67,8 +67,9 @@ namespace SkiaSharp
 			internal SKFontStyleStatic (SKFontStyleWeight weight, SKFontStyleWidth width, SKFontStyleSlant slant)
 				: base (weight, width, slant)
 			{
-				IgnorePublicDispose = true;
 			}
+
+			protected override void Dispose (bool disposing) { }
 		}
 	}
 }

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -458,10 +458,11 @@ namespace SkiaSharp
 		private sealed class SKTypefaceStatic : SKTypeface
 		{
 			internal SKTypefaceStatic (IntPtr x)
-				: base (x, true)
+				: base (x, false)
 			{
-				IgnorePublicDispose = true;
 			}
+
+			protected override void Dispose (bool disposing) { }
 		}
 	}
 }

--- a/build.cake
+++ b/build.cake
@@ -204,6 +204,8 @@ Task ("tests-netfx")
 
     void RunDesktopTest (string arch)
     {
+        if (Skip(arch)) return;
+
         RunMSBuild ("./tests/SkiaSharp.Desktop.Tests.sln", platform: arch == "AnyCPU" ? "Any CPU" : arch);
 
         // SkiaSharp.Tests.dll

--- a/tests/Tests/ApiTests.cs
+++ b/tests/Tests/ApiTests.cs
@@ -52,6 +52,7 @@ namespace SkiaSharp.Tests
 		public static IEnumerable<object[]> InteropDelegatesData =>
 			InteropDelegates.Select(m => new object[] { m });
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableFact]
 		public void DelegateTypesAreValid()
 		{
@@ -59,6 +60,7 @@ namespace SkiaSharp.Tests
 			Assert.NotEmpty(del);
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableTheory]
 		[MemberData(nameof(InteropDelegatesData))]
 		public void DelegateTypesHaveAttributes(Type delegateType)
@@ -66,6 +68,7 @@ namespace SkiaSharp.Tests
 			Assert.NotNull(delegateType.GetCustomAttribute<UnmanagedFunctionPointerAttribute>());
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableTheory]
 		[MemberData(nameof(InteropMembersData))]
 		public void ApiTypesAreNotInvalid(MethodInfo method, string delegateName)
@@ -89,6 +92,7 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableTheory]
 		[MemberData(nameof(InteropMembersData))]
 		public void ApiReturnTypesArePrimitives(MethodInfo method, string delegateName)
@@ -115,6 +119,7 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableTheory]
 		[MemberData(nameof(InteropMembersData))]
 		public void ApiTypesAreMarshalledCorrectly(MethodInfo method, string delegateName)
@@ -187,6 +192,7 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableTheory]
 		// too old
 		[InlineData("80.0", "0.0", "[80.0, 81.0)")]
@@ -230,24 +236,28 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableFact]
 		public void TestLibraryVersions()
 		{
 			Assert.True(SkiaSharpVersion.CheckNativeLibraryCompatible());
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableFact]
 		public void TestLibraryVersionsDoesNotThrow()
 		{
 			SkiaSharpVersion.CheckNativeLibraryCompatible(true);
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableFact]
 		public void TestVersionsString()
 		{
 			Assert.Equal(SkiaSharpVersion.Native.ToString(2), SkiaSharpVersion.NativeString);
 		}
 
+		[Trait(CategoryKey, ApiCategory)]
 		[SkippableFact]
 		public void PlatformConfigurationIsMuslOverrideCanBeFoundViaReflection()
 		{

--- a/tests/Tests/BaseTest.cs
+++ b/tests/Tests/BaseTest.cs
@@ -7,6 +7,7 @@ namespace SkiaSharp.Tests
 	{
 		protected const string CategoryKey = "Category";
 
+		protected const string ApiCategory = "API";
 		protected const string GpuCategory = "GPU";
 		protected const string MatchCharacterCategory = "MatchCharacter";
 


### PR DESCRIPTION
**Description of Change**

When the AppDomain is unloaded, the runtime will try to dispose all instances, including ones on static fields. This might never happen in a single app, however, during test runs or potentially IDE integrations, the AppDomain is unloaded, the instances are collected and then SkiaSharp statics try to dispose of the native statics.

I originally had code to prevent the user from disposing the instances, however, the GC still runs and is still able to collect. So, for these few instances we mark it that we do not own the handles (which we don't) and then never even try clean up the instances. The GC will get to it.

**Bugs Fixed**

 - Potential crashes when AppDomains are unloaded.
 - Appears in #1817 when we get a GC collection out of expected order.

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
