### PR TITLE
Fix the Mac Catalyst build task Inputs/Outputs

### DIFF
--- a/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.Local.targets
+++ b/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.Local.targets
@@ -6,7 +6,8 @@
         <_HarfBuzzSharpExpandNativeReferencesPath>obj\$(Configuration)\$(TargetFramework)\harfbuzzsharpextract\</_HarfBuzzSharpExpandNativeReferencesPath>
     </PropertyGroup>
 
-    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_HarfBuzzSharpExpandNativeReferencesStamp)') ">
+    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' "
+            Inputs="$(MSBuildThisFileFullPath)" Outputs="$(_HarfBuzzSharpExpandNativeReferencesStamp)">
 
         <RemoveDir Directories="$(_HarfBuzzSharpExpandNativeReferencesPath)" />
         <MakeDir Directories="$(_HarfBuzzSharpExpandNativeReferencesPath)" />

--- a/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/maccatalyst/HarfBuzzSharp.targets
@@ -7,7 +7,8 @@
     </PropertyGroup>
 
     <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_HarfBuzzSharpExpandNativeReferencesStamp)') ">
+    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' "
+            Inputs="$(MSBuildThisFileFullPath)" Outputs="$(_HarfBuzzSharpExpandNativeReferencesStamp)">
 
         <ItemGroup>
             <_HarfBuzzSharpPossibleNativeFramework

--- a/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.Local.targets
+++ b/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.Local.targets
@@ -6,7 +6,8 @@
         <_SkiaSharpExpandNativeReferencesPath>obj\$(Configuration)\$(TargetFramework)\skiasharpextract\</_SkiaSharpExpandNativeReferencesPath>
     </PropertyGroup>
 
-    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_SkiaSharpExpandNativeReferencesStamp)') ">
+    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' "
+            Inputs="$(MSBuildThisFileFullPath)" Outputs="$(_SkiaSharpExpandNativeReferencesStamp)">
 
         <RemoveDir Directories="$(_SkiaSharpExpandNativeReferencesPath)" />
         <MakeDir Directories="$(_SkiaSharpExpandNativeReferencesPath)" />

--- a/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/maccatalyst/SkiaSharp.targets
@@ -7,7 +7,8 @@
     </PropertyGroup>
 
     <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' and !Exists('$(_SkiaSharpExpandNativeReferencesStamp)') ">
+    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences" Condition=" '$(OS)' == 'Unix' "
+            Inputs="$(MSBuildThisFileFullPath)" Outputs="$(_SkiaSharpExpandNativeReferencesStamp)">
 
         <ItemGroup>
             <_SkiaSharpPossibleNativeFramework


### PR DESCRIPTION
**Description of Change**

This PR correctly handles the incremental builds of the mac catalyst targets. Previously, the entire task was skipped if the stamp file existed.

However, if for some reason the native file in the bin folder was deleted, then the task never ran again. This is because technically the target was ready, we just need to re-create the items. So to do this we set the targets file as the import and the stamp as the output. Then, MSBuild will do its thing and ensure that no _tasks_ run, just the properties and items are set.

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes an issue where deleting the Frameworks folder (or items in it) in the .app in the bin folder would cause an error. 

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
