### PR TITLE
[Blazor] prevent infinite loop in SKCanvasView

### DIFF
--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
@@ -157,7 +157,7 @@ namespace SkiaSharp.Views.Blazor
 
 		private void OnSizeChanged(SKSize newSize)
 		{
-			if (Math.Round(canvasSize.Width * dpi) == newSize.Width && Math.Round(canvasSize.Height * dpi) == newSize.Height)
+			if ((int)(canvasSize.Width * dpi) == newSize.Width && (int)(canvasSize.Height * dpi) == newSize.Height)
 				return;
 			canvasSize = newSize;
 

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
@@ -157,6 +157,8 @@ namespace SkiaSharp.Views.Blazor
 
 		private void OnSizeChanged(SKSize newSize)
 		{
+			if (Math.Round(canvasSize.Width * dpi) == newSize.Width && Math.Round(canvasSize.Height * dpi) == newSize.Height)
+				return;
 			canvasSize = newSize;
 
 			Invalidate();


### PR DESCRIPTION
**Description of Change**

Prevents infinite resize loop - i don't know if this is the most elegant solution, but it works.

Added the following line to `OnSizeChanged` Event of Blazor `SKCanvasView`
```csharp
if (Math.Round(canvasSize.Width * dpi) == newSize.Width && Math.Round(canvasSize.Height * dpi) == newSize.Height)
    return;
```
If  Monitor scaling is applied in Windows Settings App, the view keeps multiplying the canvas size with the DPI (in my case being 1.25 for 125% scaling) in the `Invalidate`-Method. 
The Canvas will be resized to the new size which results in the `SizeWatcherInterop` to fire its `OnSizeChanged` Event which will set `canvasSize` to `newSize` and calls `Invalidate` again to start infinite loop, also mentioned here:
https://github.com/mono/SkiaSharp/issues/1838#issuecomment-991914840

**Bugs Fixed**
https://github.com/mono/SkiaSharp/issues/1838

- Related to issue #1838

**API Changes**
None

**Behavioral Changes**
None

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
