### PR TITLE
[android] don't include .so files in class libraries

### DIFF
--- a/binding/SkiaSharp/nuget/build/monoandroid/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/monoandroid/SkiaSharp.targets
@@ -3,7 +3,8 @@
 
     <!-- if ShouldIncludeNativeSkiaSharp == False then don't include the native libSkiaSharp -->
     <PropertyGroup>
-        <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">True</ShouldIncludeNativeSkiaSharp>
+        <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' and '$(AndroidApplication)' == 'True' ">True</ShouldIncludeNativeSkiaSharp>
+        <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">False</ShouldIncludeNativeSkiaSharp>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(ShouldIncludeNativeSkiaSharp)' != 'False' ">


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5776
Fixes: https://github.com/xamarin/xamarin-android/issues/6545

If you do:

1. File -> New Xamarin.Android class library
2. Add `<PackageReference Include="SkiaSharp" Version="2.80.3" />`

You end up with 13MB `.dll` file with C# code inside! The class
library is redistributing the SkiaSharp native libraries.

`$(ShouldIncludeNativeSkiaSharp)` should default to `False` for class
libraries.

To test this change, I manually edited:

    %userprofile%\.nuget\packages\skiasharp\2.80.3\build\monoandroid1.0\SkiaSharp.targets
    %userprofile%\.nuget\packages\skiasharp\2.80.3\buildTransitive\monoandroid1.0\SkiaSharp.targets

Now my class library is 76,800 bytes.

When consuming this class library in an Android application project,
everything should still work as expected. However, the application
will need to reference SkiaSharp -- which is actually ideal.

**API Changes**

None

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
