### PR TITLE
Option to disable automatic resizing of the canvas

### DIFF
--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/Internal/SizeWatcherInterop.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/Internal/SizeWatcherInterop.cs
@@ -17,11 +17,13 @@ namespace SkiaSharp.Views.Blazor.Internal
 
 		private DotNetObjectReference<FloatFloatActionHelper>? callbackReference;
 
+		/// <summary>
+		/// Imports the SizeWatcher script, but doesn't start observing.
+		/// </summary>
 		public static async Task<SizeWatcherInterop> ImportAsync(IJSRuntime js, ElementReference element, Action<SKSize> callback)
 		{
 			var interop = new SizeWatcherInterop(js, element, callback);
 			await interop.ImportAsync();
-			interop.Start();
 			return interop;
 		}
 

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
@@ -57,6 +57,12 @@ namespace SkiaSharp.Views.Blazor
 			}
 		}
 
+		/// <summary>
+		/// If true (default), the canvas will be automatically resized to fit the client width and height. 
+		/// </summary>
+		[Parameter]
+		public bool AutoResize { get; set; } = true;
+
 		[Parameter(CaptureUnmatchedValues = true)]
 		public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 
@@ -67,7 +73,7 @@ namespace SkiaSharp.Views.Blazor
 				interop = await SKHtmlCanvasInterop.ImportAsync(JS, htmlCanvas, OnRenderFrame);
 				interop.InitRaster();
 
-				sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
+				if (AutoResize) sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
 				dpiWatcher = await DpiWatcherInterop.ImportAsync(JS, OnDpiChanged);
 			}
 		}
@@ -167,7 +173,7 @@ namespace SkiaSharp.Views.Blazor
 		public void Dispose()
 		{
 			dpiWatcher.Unsubscribe(OnDpiChanged);
-			sizeWatcher.Dispose();
+			sizeWatcher?.Dispose();
 			interop.Dispose();
 
 			FreeBitmap();

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
@@ -15,6 +15,7 @@ namespace SkiaSharp.Views.Blazor
 		private DpiWatcherInterop dpiWatcher = null!;
 		private ElementReference htmlCanvas;
 
+		private bool autoResize;
 		private SKSizeI pixelSize;
 		private byte[]? pixels;
 		private GCHandle pixelsHandle;
@@ -61,7 +62,21 @@ namespace SkiaSharp.Views.Blazor
 		/// If true (default), the canvas will be automatically resized to fit the client width and height. 
 		/// </summary>
 		[Parameter]
-		public bool AutoResize { get; set; } = true;
+		public bool AutoResize
+		{
+			get => autoResize;
+			set
+			{
+				if (autoResize != value)
+				{
+					if (!autoResize && value) sizeWatcher.Start();
+					if (autoResize && !value) sizeWatcher.Stop();
+
+					autoResize = value;
+					Invalidate();
+				}
+			}
+		} = true;
 
 		[Parameter(CaptureUnmatchedValues = true)]
 		public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
@@ -73,7 +88,7 @@ namespace SkiaSharp.Views.Blazor
 				interop = await SKHtmlCanvasInterop.ImportAsync(JS, htmlCanvas, OnRenderFrame);
 				interop.InitRaster();
 
-				if (AutoResize) sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
+				await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
 				dpiWatcher = await DpiWatcherInterop.ImportAsync(JS, OnDpiChanged);
 			}
 		}

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
@@ -19,6 +19,7 @@ namespace SkiaSharp.Views.Blazor
 		private const SKColorType colorType = SKColorType.Rgba8888;
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
+		private bool autoResize;
 		private GRContext? context;
 		private GRGlInterface? glInterface;
 		private GRBackendRenderTarget? renderTarget;
@@ -37,7 +38,21 @@ namespace SkiaSharp.Views.Blazor
 		/// If true (default), the canvas will be automatically resized to fit the client width and height. 
 		/// </summary>
 		[Parameter]
-		public bool AutoResize { get; set; } = true;
+		public bool AutoResize
+		{
+			get => autoResize;
+			set
+			{
+				if (autoResize != value)
+				{
+					if (!autoResize && value) sizeWatcher.Start();
+					if (autoResize && !value) sizeWatcher.Stop();
+
+					autoResize = value;
+					Invalidate();
+				}
+			}
+		} = true;
 
 		[Parameter]
 		public Action<SKPaintGLSurfaceEventArgs>? OnPaintSurface { get; set; }
@@ -80,7 +95,7 @@ namespace SkiaSharp.Views.Blazor
 				interop = await SKHtmlCanvasInterop.ImportAsync(JS, htmlCanvas, OnRenderFrame);
 				jsGLInfo = interop.InitGL();
 
-				if (AutoResize) sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
+				sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
 				dpiWatcher = await DpiWatcherInterop.ImportAsync(JS, OnDpiChanged);
 			}
 		}

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
@@ -33,6 +33,12 @@ namespace SkiaSharp.Views.Blazor
 		[Inject]
 		IJSRuntime JS { get; set; } = null!;
 
+		/// <summary>
+		/// If true (default), the canvas will be automatically resized to fit the client width and height. 
+		/// </summary>
+		[Parameter]
+		public bool AutoResize { get; set; } = true;
+
 		[Parameter]
 		public Action<SKPaintGLSurfaceEventArgs>? OnPaintSurface { get; set; }
 
@@ -74,7 +80,7 @@ namespace SkiaSharp.Views.Blazor
 				interop = await SKHtmlCanvasInterop.ImportAsync(JS, htmlCanvas, OnRenderFrame);
 				jsGLInfo = interop.InitGL();
 
-				sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
+				if (AutoResize) sizeWatcher = await SizeWatcherInterop.ImportAsync(JS, htmlCanvas, OnSizeChanged);
 				dpiWatcher = await DpiWatcherInterop.ImportAsync(JS, OnDpiChanged);
 			}
 		}
@@ -141,12 +147,12 @@ namespace SkiaSharp.Views.Blazor
 					canvas.Save();
 				}
 
-				// start drawing
-				OnPaintSurface?.Invoke(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, info.WithSize(userVisibleSize), info));
-			}
+			// start drawing
+			OnPaintSurface?.Invoke(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, info.WithSize(userVisibleSize), info));
+		}
 
-			// update the control
-			canvas?.Flush();
+		// update the control
+		canvas?.Flush();
 			context.Flush();
 		}
 
@@ -186,7 +192,7 @@ namespace SkiaSharp.Views.Blazor
 		public void Dispose()
 		{
 			dpiWatcher.Unsubscribe(OnDpiChanged);
-			sizeWatcher.Dispose();
+			sizeWatcher?.Dispose();
 			interop.Dispose();
 		}
 	}

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
@@ -147,12 +147,12 @@ namespace SkiaSharp.Views.Blazor
 					canvas.Save();
 				}
 
-			// start drawing
-			OnPaintSurface?.Invoke(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, info.WithSize(userVisibleSize), info));
-		}
+				// start drawing
+				OnPaintSurface?.Invoke(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, info.WithSize(userVisibleSize), info));
+			}
 
-		// update the control
-		canvas?.Flush();
+			// update the control
+			canvas?.Flush();
 			context.Flush();
 		}
 


### PR DESCRIPTION
At the moment it's not possible to disable automatic resizing of the canvas. Besides that there is a bug in the automatic resizing, I don't want the functionality at all for my project.

I added parameter 'AutoResize' to SKGLView and SKCanvasView (which is true by default). When it is disabled, the SizeWatcherInterop won't be used.

See issue:
https://github.com/mono/SkiaSharp/issues/1896

Added: 
 
```
/// <summary>
/// If true (default), the canvas will be automatically resized to fit the client width and height. 
/// </summary>
[Parameter]
public bool AutoResize { get; set; } = true;
```