### PR TITLE
[WASM] Add CanvasSize to SkiaSharp.Views.Blazor Views

### DIFF
--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKCanvasView.razor.cs
@@ -23,6 +23,8 @@ namespace SkiaSharp.Views.Blazor
 		private SKSize canvasSize;
 		private bool enableRenderLoop;
 
+		public SKSize CanvasSize => canvasSize;
+
 		[Inject]
 		IJSRuntime JS { get; set; } = null!;
 

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/SKGLView.razor.cs
@@ -30,6 +30,8 @@ namespace SkiaSharp.Views.Blazor
 		private double dpi;
 		private SKSize canvasSize;
 
+		public SKSize CanvasSize => canvasSize;
+
 		[Inject]
 		IJSRuntime JS { get; set; } = null!;
 


### PR DESCRIPTION
**Description of Change**
Fixes #1911 and #1888 :
Added CanvasSize to Both (`SKCanvasView.razor.cs` and `SKGLView.razor.cs`) Views
```csharp
public SKSize CanvasSize => canvasSize;
```

See also similar contribution: https://github.com/mono/SkiaSharp/pull/1832 & https://github.com/mono/SkiaSharp/issues/1831
<!-- Describe your changes here.  -->

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Related to issue #1911 

**API Changes**
Added: 
File: `SKCanvasView.razor.cs` and `SKGLView.razor.cs`
```csharp
public SKSize CanvasSize => canvasSize;
```

**Behavioral Changes**
none
<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
