### PR TITLE
Force a single CPU on macOS/Linux

### DIFF
--- a/cake/msbuild.cake
+++ b/cake/msbuild.cake
@@ -59,7 +59,11 @@ void RunMSBuild(
     MSBuild(solution, c => {
         c.Configuration = configuration ?? CONFIGURATION;
         c.Verbosity = VERBOSITY;
-        c.MaxCpuCount = 0;
+
+        if (IsRunningOnWindows())
+            c.MaxCpuCount = 0;
+        else
+            c.MaxCpuCount = 1;
 
         var relativeSolution = MakeAbsolute(ROOT_PATH).GetRelativePath(MakeAbsolute(solution));
         var blPath = ROOT_PATH.Combine("output/logs/binlogs").CombineWithFilePath(relativeSolution + ".binlog");


### PR DESCRIPTION
**Description of Change**

Try resolve the intermittent build fails when using multiple threads on macOS/Linux.

**Bugs Fixed**

- Related to issue https://github.com/actions/virtual-environments/issues/4948

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
