### PR TITLE
Make use of the newer/better/faster/more-er 1ES build agents

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -60,9 +60,9 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ')) }}:
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-')) }}:
             name: ${{ variables.VM_IMAGE_LINUX }}
         steps:
           - checkout: none
@@ -744,9 +744,9 @@ stages:
       - job: coverage_reports                      # Coverage Reports
         displayName: Coverage Reports
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ')) }}:
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-')) }}:
             name: ${{ variables.VM_IMAGE_LINUX }}
         dependsOn:
           - tests_netcore_windows

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -38,6 +38,7 @@ variables:
   VM_IMAGE_WINDOWS: 'Azure Pipelines windows-2022'
   VM_IMAGE_MAC: 'Azure Pipelines macOS-10.15'
   VM_IMAGE_LINUX: 'Azure Pipelines ubuntu-18.04'
+  VM_IMAGE_AZURE_PREFIX: 'Azure Pipelines '
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -60,9 +61,9 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure Pipelines', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines')) }}:
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, variables.VM_IMAGE_AZURE_PREFIX) }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, variables.VM_IMAGE_AZURE_PREFIX, '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, variables.VM_IMAGE_AZURE_PREFIX)) }}:
             name: ${{ variables.VM_IMAGE_LINUX }}
         steps:
           - checkout: none

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -44,6 +44,9 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
+  VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
+  VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
+  VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
           name: native_android_x86_windows
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-android
           additionalArgs: --buildarch=x86
           installWindowsSdk: false
@@ -95,7 +95,7 @@ stages:
           name: native_android_x64_windows
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-android
           additionalArgs: --buildarch=x64
           installWindowsSdk: false
@@ -105,7 +105,7 @@ stages:
           name: native_android_arm_windows
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-android
           additionalArgs: --buildarch=arm
           installWindowsSdk: false
@@ -115,7 +115,7 @@ stages:
           name: native_android_arm64_windows
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-android
           additionalArgs: --buildarch=arm64
           installWindowsSdk: false
@@ -125,7 +125,7 @@ stages:
           name: native_tizen_windows
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-tizen
           installWindowsSdk: false
           artifactName: native
@@ -134,7 +134,7 @@ stages:
           name: native_uwp_angle_x86_windows
           displayName: ANGLE x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
           artifactName: native
@@ -143,7 +143,7 @@ stages:
           name: native_uwp_angle_x64_windows
           displayName: ANGLE x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
           artifactName: native
@@ -152,7 +152,7 @@ stages:
           name: native_uwp_angle_arm_windows
           displayName: ANGLE arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
           artifactName: native
@@ -161,7 +161,7 @@ stages:
           name: native_uwp_angle_arm64_windows
           displayName: ANGLE arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
           artifactName: native
@@ -170,7 +170,7 @@ stages:
           name: native_uwp_x86_windows
           displayName: UWP x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
           artifactName: native
@@ -179,7 +179,7 @@ stages:
           name: native_uwp_x64_windows
           displayName: UWP x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
           artifactName: native
@@ -188,7 +188,7 @@ stages:
           name: native_uwp_arm_windows
           displayName: UWP arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
           artifactName: native
@@ -197,7 +197,7 @@ stages:
           name: native_uwp_arm64_windows
           displayName: UWP arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
           artifactName: native
@@ -206,7 +206,7 @@ stages:
           name: native_win32_x86_windows
           displayName: Win32 x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-windows
           additionalArgs: --buildarch=x86
           artifactName: native
@@ -215,7 +215,7 @@ stages:
           name: native_win32_x64_windows
           displayName: Win32 x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-windows
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -224,7 +224,7 @@ stages:
           name: native_win32_arm64_windows
           displayName: Win32 arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-windows
           additionalArgs: --buildarch=arm64
           artifactName: native
@@ -233,7 +233,7 @@ stages:
           name: native_win32_x64_nanoserver_windows
           displayName: Nano Server x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -249,7 +249,7 @@ stages:
           name: native_android_x86_macos
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=x86
       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
@@ -257,7 +257,7 @@ stages:
           name: native_android_x64_macos
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=x64
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
@@ -265,7 +265,7 @@ stages:
           name: native_android_arm_macos
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=arm
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
@@ -273,7 +273,7 @@ stages:
           name: native_android_arm64_macos
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=arm64
       - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
@@ -281,7 +281,7 @@ stages:
           name: native_ios_macos
           displayName: iOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-ios
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
@@ -289,7 +289,7 @@ stages:
           name: native_maccatalyst_macos
           displayName: Mac Catalyst
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-maccatalyst
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
@@ -297,7 +297,7 @@ stages:
           name: native_macos_macos
           displayName: macOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-macos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
@@ -305,7 +305,7 @@ stages:
           name: native_tvos_macos
           displayName: tvOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-tvos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
@@ -313,7 +313,7 @@ stages:
           name: native_watchos_macos
           displayName: watchOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-watchos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
@@ -321,7 +321,7 @@ stages:
           name: native_tizen_macos
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-tizen
           condition: false # TODO: TIZEN INSTALL BUGS
 
@@ -357,7 +357,7 @@ stages:
           name: native_tizen_linux
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(TIZEN_LINUX_PACKAGES)
           target: externals-tizen
 
@@ -389,7 +389,7 @@ stages:
         parameters:
           name: managed_windows
           displayName: Managed (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: libs
           additionalArgs: --skipExternals="all"
           installPreviewVs: true
@@ -403,7 +403,7 @@ stages:
         parameters:
           name: managed_macos
           displayName: Managed (macOS)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: libs
           additionalArgs: --skipExternals="all"
           requiredArtifacts:
@@ -416,7 +416,7 @@ stages:
         parameters:
           name: managed_linux
           displayName: Managed (Linux)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: libs
           additionalArgs: --skipExternals="all"
@@ -435,7 +435,7 @@ stages:
         parameters:
           name: package_windows
           displayName: Package NuGets
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: nuget
           additionalArgs: --packall=true --skipbuild=true
           installWindowsSdk: false
@@ -479,7 +479,7 @@ stages:
         parameters:
           name: api_diff_windows
           displayName: API Diff
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: docs-api-diff
           additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
           shouldPublish: false
@@ -523,7 +523,7 @@ stages:
         parameters:
           name: tests_netfx_windows
           displayName: Windows (.NET Framework)
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           installPreviewVs: true
@@ -544,7 +544,7 @@ stages:
         parameters:
           name: tests_netcore_windows
           displayName: Windows (.NET Core)
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           installWindowsSdk: false
@@ -571,7 +571,7 @@ stages:
         parameters:
           name: tests_netfx_macos
           displayName: macOS (.NET Framework)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -589,7 +589,7 @@ stages:
         parameters:
           name: tests_netcore_macos
           displayName: macOS (.NET Core)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -614,7 +614,7 @@ stages:
         parameters:
           name: tests_android_macos
           displayName: Android (macOS)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-android
           additionalArgs: --device=android-emulator-32_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -650,7 +650,7 @@ stages:
         parameters:
           name: tests_ios_macos
           displayName: iOS (macOS)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-ios
           additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -682,7 +682,7 @@ stages:
         parameters:
           name: tests_netfx_linux
           displayName: Linux (.NET Framework)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -701,7 +701,7 @@ stages:
         parameters:
           name: tests_netcore_linux
           displayName: Linux (.NET Core)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -727,7 +727,7 @@ stages:
         parameters:
           name: tests_wasm_linux
           displayName: WASM (Linux)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES) ninja-build
           target: tests-wasm
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
@@ -790,7 +790,7 @@ stages:
         parameters:
           name: samples_windows
           displayName: Windows
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
           target: samples
           installPreviewVs: true
           requiredArtifactsMap:
@@ -803,7 +803,7 @@ stages:
         parameters:
           name: samples_macos
           displayName: macOS
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: samples
           shouldPublish: false
           requiredArtifactsMap:
@@ -815,7 +815,7 @@ stages:
         parameters:
           name: samples_linux
           displayName: Linux
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: samples
           shouldPublish: false
@@ -835,7 +835,7 @@ stages:
             name: native_checks_windows
             displayName: Run Code Checks
             condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
-            vmImage: $(VM_IMAGE_WINDOWS)
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
             target: git-sync-deps
             installWindowsSdk: false
             installDotNet: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -44,9 +44,6 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
-  VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
-  VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -88,7 +85,7 @@ stages:
           name: native_android_x86_windows
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-android
           additionalArgs: --buildarch=x86
           installWindowsSdk: false
@@ -98,7 +95,7 @@ stages:
           name: native_android_x64_windows
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-android
           additionalArgs: --buildarch=x64
           installWindowsSdk: false
@@ -108,7 +105,7 @@ stages:
           name: native_android_arm_windows
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-android
           additionalArgs: --buildarch=arm
           installWindowsSdk: false
@@ -118,7 +115,7 @@ stages:
           name: native_android_arm64_windows
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-android
           additionalArgs: --buildarch=arm64
           installWindowsSdk: false
@@ -128,7 +125,7 @@ stages:
           name: native_tizen_windows
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-tizen
           installWindowsSdk: false
           artifactName: native
@@ -137,7 +134,7 @@ stages:
           name: native_uwp_angle_x86_windows
           displayName: ANGLE x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
           artifactName: native
@@ -146,7 +143,7 @@ stages:
           name: native_uwp_angle_x64_windows
           displayName: ANGLE x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
           artifactName: native
@@ -155,7 +152,7 @@ stages:
           name: native_uwp_angle_arm_windows
           displayName: ANGLE arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
           artifactName: native
@@ -164,7 +161,7 @@ stages:
           name: native_uwp_angle_arm64_windows
           displayName: ANGLE arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
           artifactName: native
@@ -173,7 +170,7 @@ stages:
           name: native_uwp_x86_windows
           displayName: UWP x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
           artifactName: native
@@ -182,7 +179,7 @@ stages:
           name: native_uwp_x64_windows
           displayName: UWP x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
           artifactName: native
@@ -191,7 +188,7 @@ stages:
           name: native_uwp_arm_windows
           displayName: UWP arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
           artifactName: native
@@ -200,7 +197,7 @@ stages:
           name: native_uwp_arm64_windows
           displayName: UWP arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
           artifactName: native
@@ -209,7 +206,7 @@ stages:
           name: native_win32_x86_windows
           displayName: Win32 x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-windows
           additionalArgs: --buildarch=x86
           artifactName: native
@@ -218,7 +215,7 @@ stages:
           name: native_win32_x64_windows
           displayName: Win32 x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-windows
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -227,7 +224,7 @@ stages:
           name: native_win32_arm64_windows
           displayName: Win32 arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-windows
           additionalArgs: --buildarch=arm64
           artifactName: native
@@ -236,7 +233,7 @@ stages:
           name: native_win32_x64_nanoserver_windows
           displayName: Nano Server x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -252,7 +249,7 @@ stages:
           name: native_android_x86_macos
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=x86
       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
@@ -260,7 +257,7 @@ stages:
           name: native_android_x64_macos
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=x64
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
@@ -268,7 +265,7 @@ stages:
           name: native_android_arm_macos
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=arm
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
@@ -276,7 +273,7 @@ stages:
           name: native_android_arm64_macos
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-android
           additionalArgs: --buildarch=arm64
       - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
@@ -284,7 +281,7 @@ stages:
           name: native_ios_macos
           displayName: iOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-ios
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
@@ -292,7 +289,7 @@ stages:
           name: native_maccatalyst_macos
           displayName: Mac Catalyst
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-maccatalyst
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
@@ -300,7 +297,7 @@ stages:
           name: native_macos_macos
           displayName: macOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-macos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
@@ -308,7 +305,7 @@ stages:
           name: native_tvos_macos
           displayName: tvOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-tvos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
@@ -316,7 +313,7 @@ stages:
           name: native_watchos_macos
           displayName: watchOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-watchos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
@@ -324,7 +321,7 @@ stages:
           name: native_tizen_macos
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: externals-tizen
           condition: false # TODO: TIZEN INSTALL BUGS
 
@@ -360,7 +357,7 @@ stages:
           name: native_tizen_linux
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(TIZEN_LINUX_PACKAGES)
           target: externals-tizen
 
@@ -392,7 +389,7 @@ stages:
         parameters:
           name: managed_windows
           displayName: Managed (Windows)
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: libs
           additionalArgs: --skipExternals="all"
           installPreviewVs: true
@@ -406,7 +403,7 @@ stages:
         parameters:
           name: managed_macos
           displayName: Managed (macOS)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: libs
           additionalArgs: --skipExternals="all"
           requiredArtifacts:
@@ -419,7 +416,7 @@ stages:
         parameters:
           name: managed_linux
           displayName: Managed (Linux)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: libs
           additionalArgs: --skipExternals="all"
@@ -438,7 +435,7 @@ stages:
         parameters:
           name: package_windows
           displayName: Package NuGets
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: nuget
           additionalArgs: --packall=true --skipbuild=true
           installWindowsSdk: false
@@ -482,7 +479,7 @@ stages:
         parameters:
           name: api_diff_windows
           displayName: API Diff
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: docs-api-diff
           additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
           shouldPublish: false
@@ -526,7 +523,7 @@ stages:
         parameters:
           name: tests_netfx_windows
           displayName: Windows (.NET Framework)
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           installPreviewVs: true
@@ -547,7 +544,7 @@ stages:
         parameters:
           name: tests_netcore_windows
           displayName: Windows (.NET Core)
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           installWindowsSdk: false
@@ -574,7 +571,7 @@ stages:
         parameters:
           name: tests_netfx_macos
           displayName: macOS (.NET Framework)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -592,7 +589,7 @@ stages:
         parameters:
           name: tests_netcore_macos
           displayName: macOS (.NET Core)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -617,7 +614,7 @@ stages:
         parameters:
           name: tests_android_macos
           displayName: Android (macOS)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-android
           additionalArgs: --device=android-emulator-32_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -653,7 +650,7 @@ stages:
         parameters:
           name: tests_ios_macos
           displayName: iOS (macOS)
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: tests-ios
           additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -685,7 +682,7 @@ stages:
         parameters:
           name: tests_netfx_linux
           displayName: Linux (.NET Framework)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -704,7 +701,7 @@ stages:
         parameters:
           name: tests_netcore_linux
           displayName: Linux (.NET Core)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -730,7 +727,7 @@ stages:
         parameters:
           name: tests_wasm_linux
           displayName: WASM (Linux)
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES) ninja-build
           target: tests-wasm
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
@@ -793,7 +790,7 @@ stages:
         parameters:
           name: samples_windows
           displayName: Windows
-          vmImage: $(VM_IMAGE_WINDOWS)
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
           target: samples
           installPreviewVs: true
           requiredArtifactsMap:
@@ -806,7 +803,7 @@ stages:
         parameters:
           name: samples_macos
           displayName: macOS
-          vmImage: $(VM_IMAGE_MAC)
+          vmImage: ${{ parameters.VM_IMAGE_MAC }}
           target: samples
           shouldPublish: false
           requiredArtifactsMap:
@@ -818,7 +815,7 @@ stages:
         parameters:
           name: samples_linux
           displayName: Linux
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           packages: $(MANAGED_LINUX_PACKAGES)
           target: samples
           shouldPublish: false
@@ -838,7 +835,7 @@ stages:
             name: native_checks_windows
             displayName: Run Code Checks
             condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
-            vmImage: $(VM_IMAGE_WINDOWS)
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: git-sync-deps
             installWindowsSdk: false
             installDotNet: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -13,6 +13,15 @@ parameters:
     displayName: 'The specific native artifacts to use for this build.'
     type: number
     default: 0
+  - name: VM_IMAGE_WINDOWS
+    type: string
+    default: 'Azure-Pipelines-windows-2022'
+  - name: VM_IMAGE_MAC
+    type: string
+    default: 'Azure-Pipelines-macOS-10.15'
+  - name: VM_IMAGE_LINUX
+    type: string
+    default: 'Azure-Pipelines-ubuntu-18.04'
 
 variables:
   SKIASHARP_VERSION: 2.88.0
@@ -35,9 +44,6 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: 'Azure-Pipelines-windows-2022'
-  VM_IMAGE_MAC: 'Azure-Pipelines-macOS-10.15'
-  VM_IMAGE_LINUX: 'Azure-Pipelines-ubuntu-18.04'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -60,10 +66,10 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-')) }}:
-            name: ${{ variables.VM_IMAGE_LINUX }}
+          ${{ if startsWith(parameters.VM_IMAGE_LINUX, 'Azure-Pipelines-') }}:
+            vmImage: ${{ replace(parameters.VM_IMAGE_LINUX, 'Azure-Pipelines-', '') }}
+          ${{ if not(startsWith(parameters.VM_IMAGE_LINUX, 'Azure-Pipelines-')) }}:
+            name: ${{ parameters.VM_IMAGE_LINUX }}
         steps:
           - checkout: none
           - template: azure-templates-variables.yml
@@ -744,10 +750,10 @@ stages:
       - job: coverage_reports                      # Coverage Reports
         displayName: Coverage Reports
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines-')) }}:
-            name: ${{ variables.VM_IMAGE_LINUX }}
+          ${{ if startsWith(parameters.VM_IMAGE_LINUX, 'Azure-Pipelines-') }}:
+            vmImage: ${{ replace(parameters.VM_IMAGE_LINUX, 'Azure-Pipelines-', '') }}
+          ${{ if not(startsWith(parameters.VM_IMAGE_LINUX, 'Azure-Pipelines-')) }}:
+            name: ${{ parameters.VM_IMAGE_LINUX }}
         dependsOn:
           - tests_netcore_windows
           - tests_netcore_macos

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -35,9 +35,9 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: windows-2022
-  VM_IMAGE_MAC: macOS-10.15
-  VM_IMAGE_LINUX: ubuntu-18.04
+  VM_IMAGE_WINDOWS: 'Hosted VS2019'
+  VM_IMAGE_MAC: 'Hosted macOS'
+  VM_IMAGE_LINUX: 'Hosted Ubuntu 1804'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -35,9 +35,9 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: 'Hosted VS2019'
-  VM_IMAGE_MAC: 'Hosted macOS'
-  VM_IMAGE_LINUX: 'Hosted Ubuntu 1804'
+  VM_IMAGE_WINDOWS: 'Azure Pipelines windows-2022'
+  VM_IMAGE_MAC: 'Azure Pipelines macOS-10.15'
+  VM_IMAGE_LINUX: 'Azure Pipelines ubuntu-18.04'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -16,6 +16,9 @@ parameters:
   - name: VM_IMAGE_WINDOWS
     type: string
     default: 'Azure-Pipelines-windows-2022'
+  - name: VM_IMAGE_WINDOWS_NATIVE
+    type: string
+    default: 'Azure-Pipelines-windows-2019'
   - name: VM_IMAGE_MAC
     type: string
     default: 'Azure-Pipelines-macOS-10.15'
@@ -85,7 +88,7 @@ stages:
           name: native_android_x86_windows
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-android
           additionalArgs: --buildarch=x86
           installWindowsSdk: false
@@ -95,7 +98,7 @@ stages:
           name: native_android_x64_windows
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-android
           additionalArgs: --buildarch=x64
           installWindowsSdk: false
@@ -105,7 +108,7 @@ stages:
           name: native_android_arm_windows
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-android
           additionalArgs: --buildarch=arm
           installWindowsSdk: false
@@ -115,7 +118,7 @@ stages:
           name: native_android_arm64_windows
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-android
           additionalArgs: --buildarch=arm64
           installWindowsSdk: false
@@ -125,7 +128,7 @@ stages:
           name: native_tizen_windows
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-tizen
           installWindowsSdk: false
           artifactName: native
@@ -134,7 +137,7 @@ stages:
           name: native_uwp_angle_x86_windows
           displayName: ANGLE x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
           artifactName: native
@@ -143,7 +146,7 @@ stages:
           name: native_uwp_angle_x64_windows
           displayName: ANGLE x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
           artifactName: native
@@ -152,7 +155,7 @@ stages:
           name: native_uwp_angle_arm_windows
           displayName: ANGLE arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
           artifactName: native
@@ -161,7 +164,7 @@ stages:
           name: native_uwp_angle_arm64_windows
           displayName: ANGLE arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
           artifactName: native
@@ -170,7 +173,7 @@ stages:
           name: native_uwp_x86_windows
           displayName: UWP x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
           artifactName: native
@@ -179,7 +182,7 @@ stages:
           name: native_uwp_x64_windows
           displayName: UWP x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
           artifactName: native
@@ -188,7 +191,7 @@ stages:
           name: native_uwp_arm_windows
           displayName: UWP arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
           artifactName: native
@@ -197,7 +200,7 @@ stages:
           name: native_uwp_arm64_windows
           displayName: UWP arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
           artifactName: native
@@ -206,7 +209,7 @@ stages:
           name: native_win32_x86_windows
           displayName: Win32 x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-windows
           additionalArgs: --buildarch=x86
           artifactName: native
@@ -215,7 +218,7 @@ stages:
           name: native_win32_x64_windows
           displayName: Win32 x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-windows
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -224,7 +227,7 @@ stages:
           name: native_win32_arm64_windows
           displayName: Win32 arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-windows
           additionalArgs: --buildarch=arm64
           artifactName: native
@@ -233,7 +236,7 @@ stages:
           name: native_win32_x64_nanoserver_windows
           displayName: Nano Server x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+          vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE}}
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
           artifactName: native

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
           name: native_android_x86_windows
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=x86
           installWindowsSdk: false
@@ -95,7 +95,7 @@ stages:
           name: native_android_x64_windows
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=x64
           installWindowsSdk: false
@@ -105,7 +105,7 @@ stages:
           name: native_android_arm_windows
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=arm
           installWindowsSdk: false
@@ -115,7 +115,7 @@ stages:
           name: native_android_arm64_windows
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=arm64
           installWindowsSdk: false
@@ -125,7 +125,7 @@ stages:
           name: native_tizen_windows
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-tizen
           installWindowsSdk: false
           artifactName: native
@@ -134,7 +134,7 @@ stages:
           name: native_uwp_angle_x86_windows
           displayName: ANGLE x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
           artifactName: native
@@ -143,7 +143,7 @@ stages:
           name: native_uwp_angle_x64_windows
           displayName: ANGLE x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
           artifactName: native
@@ -152,7 +152,7 @@ stages:
           name: native_uwp_angle_arm_windows
           displayName: ANGLE arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
           artifactName: native
@@ -161,7 +161,7 @@ stages:
           name: native_uwp_angle_arm64_windows
           displayName: ANGLE arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
           artifactName: native
@@ -170,7 +170,7 @@ stages:
           name: native_uwp_x86_windows
           displayName: UWP x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
           artifactName: native
@@ -179,7 +179,7 @@ stages:
           name: native_uwp_x64_windows
           displayName: UWP x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
           artifactName: native
@@ -188,7 +188,7 @@ stages:
           name: native_uwp_arm_windows
           displayName: UWP arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
           artifactName: native
@@ -197,7 +197,7 @@ stages:
           name: native_uwp_arm64_windows
           displayName: UWP arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
           artifactName: native
@@ -206,7 +206,7 @@ stages:
           name: native_win32_x86_windows
           displayName: Win32 x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x86
           artifactName: native
@@ -215,7 +215,7 @@ stages:
           name: native_win32_x64_windows
           displayName: Win32 x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -224,7 +224,7 @@ stages:
           name: native_win32_arm64_windows
           displayName: Win32 arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=arm64
           artifactName: native
@@ -233,7 +233,7 @@ stages:
           name: native_win32_x64_nanoserver_windows
           displayName: Nano Server x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -249,7 +249,7 @@ stages:
           name: native_android_x86_macos
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-android
           additionalArgs: --buildarch=x86
       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
@@ -257,7 +257,7 @@ stages:
           name: native_android_x64_macos
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-android
           additionalArgs: --buildarch=x64
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
@@ -265,7 +265,7 @@ stages:
           name: native_android_arm_macos
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-android
           additionalArgs: --buildarch=arm
       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
@@ -273,7 +273,7 @@ stages:
           name: native_android_arm64_macos
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-android
           additionalArgs: --buildarch=arm64
       - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
@@ -281,7 +281,7 @@ stages:
           name: native_ios_macos
           displayName: iOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-ios
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
@@ -289,7 +289,7 @@ stages:
           name: native_maccatalyst_macos
           displayName: Mac Catalyst
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-maccatalyst
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
@@ -297,7 +297,7 @@ stages:
           name: native_macos_macos
           displayName: macOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-macos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
@@ -305,7 +305,7 @@ stages:
           name: native_tvos_macos
           displayName: tvOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-tvos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
@@ -313,7 +313,7 @@ stages:
           name: native_watchos_macos
           displayName: watchOS
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-watchos
           artifactName: native
       - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
@@ -321,7 +321,7 @@ stages:
           name: native_tizen_macos
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: externals-tizen
           condition: false # TODO: TIZEN INSTALL BUGS
 
@@ -357,7 +357,7 @@ stages:
           name: native_tizen_linux
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           packages: $(TIZEN_LINUX_PACKAGES)
           target: externals-tizen
 
@@ -389,7 +389,7 @@ stages:
         parameters:
           name: managed_windows
           displayName: Managed (Windows)
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: libs
           additionalArgs: --skipExternals="all"
           installPreviewVs: true
@@ -403,7 +403,7 @@ stages:
         parameters:
           name: managed_macos
           displayName: Managed (macOS)
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: libs
           additionalArgs: --skipExternals="all"
           requiredArtifacts:
@@ -416,7 +416,7 @@ stages:
         parameters:
           name: managed_linux
           displayName: Managed (Linux)
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           packages: $(MANAGED_LINUX_PACKAGES)
           target: libs
           additionalArgs: --skipExternals="all"
@@ -435,7 +435,7 @@ stages:
         parameters:
           name: package_windows
           displayName: Package NuGets
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: nuget
           additionalArgs: --packall=true --skipbuild=true
           installWindowsSdk: false
@@ -479,7 +479,7 @@ stages:
         parameters:
           name: api_diff_windows
           displayName: API Diff
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: docs-api-diff
           additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
           shouldPublish: false
@@ -523,7 +523,7 @@ stages:
         parameters:
           name: tests_netfx_windows
           displayName: Windows (.NET Framework)
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           installPreviewVs: true
@@ -544,7 +544,7 @@ stages:
         parameters:
           name: tests_netcore_windows
           displayName: Windows (.NET Core)
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           installWindowsSdk: false
@@ -571,7 +571,7 @@ stages:
         parameters:
           name: tests_netfx_macos
           displayName: macOS (.NET Framework)
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -589,7 +589,7 @@ stages:
         parameters:
           name: tests_netcore_macos
           displayName: macOS (.NET Core)
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -614,7 +614,7 @@ stages:
         parameters:
           name: tests_android_macos
           displayName: Android (macOS)
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: tests-android
           additionalArgs: --device=android-emulator-32_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -650,7 +650,7 @@ stages:
         parameters:
           name: tests_ios_macos
           displayName: iOS (macOS)
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: tests-ios
           additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
           shouldPublish: false
@@ -682,7 +682,7 @@ stages:
         parameters:
           name: tests_netfx_linux
           displayName: Linux (.NET Framework)
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           packages: $(MANAGED_LINUX_PACKAGES)
           target: tests-netfx
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -701,7 +701,7 @@ stages:
         parameters:
           name: tests_netcore_linux
           displayName: Linux (.NET Core)
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           packages: $(MANAGED_LINUX_PACKAGES)
           target: tests-netcore
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -727,7 +727,7 @@ stages:
         parameters:
           name: tests_wasm_linux
           displayName: WASM (Linux)
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           packages: $(MANAGED_LINUX_PACKAGES) ninja-build
           target: tests-wasm
           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
@@ -790,7 +790,7 @@ stages:
         parameters:
           name: samples_windows
           displayName: Windows
-          vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: samples
           installPreviewVs: true
           requiredArtifactsMap:
@@ -803,7 +803,7 @@ stages:
         parameters:
           name: samples_macos
           displayName: macOS
-          vmImage: ${{ parameters.VM_IMAGE_MAC }}
+          vmImage: $(VM_IMAGE_MAC)
           target: samples
           shouldPublish: false
           requiredArtifactsMap:
@@ -815,7 +815,7 @@ stages:
         parameters:
           name: samples_linux
           displayName: Linux
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           packages: $(MANAGED_LINUX_PACKAGES)
           target: samples
           shouldPublish: false
@@ -835,7 +835,7 @@ stages:
             name: native_checks_windows
             displayName: Run Code Checks
             condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS }}
+            vmImage: $(VM_IMAGE_WINDOWS)
             target: git-sync-deps
             installWindowsSdk: false
             installDotNet: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -36,7 +36,6 @@ variables:
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
   VM_IMAGE_WINDOWS: windows-2022
-  VM_IMAGE_WINDOWS_PREVIOUS: windows-2019
   VM_IMAGE_MAC: macOS-10.15
   VM_IMAGE_LINUX: ubuntu-18.04
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -77,7 +76,7 @@ stages:
           name: native_android_x86_windows
           displayName: Android x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=x86
           installWindowsSdk: false
@@ -87,7 +86,7 @@ stages:
           name: native_android_x64_windows
           displayName: Android x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=x64
           installWindowsSdk: false
@@ -97,7 +96,7 @@ stages:
           name: native_android_arm_windows
           displayName: Android arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=arm
           installWindowsSdk: false
@@ -107,7 +106,7 @@ stages:
           name: native_android_arm64_windows
           displayName: Android arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-android
           additionalArgs: --buildarch=arm64
           installWindowsSdk: false
@@ -117,7 +116,7 @@ stages:
           name: native_tizen_windows
           displayName: Tizen
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-tizen
           installWindowsSdk: false
           artifactName: native
@@ -126,7 +125,7 @@ stages:
           name: native_uwp_angle_x86_windows
           displayName: ANGLE x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
           artifactName: native
@@ -135,7 +134,7 @@ stages:
           name: native_uwp_angle_x64_windows
           displayName: ANGLE x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
           artifactName: native
@@ -144,7 +143,7 @@ stages:
           name: native_uwp_angle_arm_windows
           displayName: ANGLE arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
           artifactName: native
@@ -153,7 +152,7 @@ stages:
           name: native_uwp_angle_arm64_windows
           displayName: ANGLE arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: ANGLE
           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
           artifactName: native
@@ -162,7 +161,7 @@ stages:
           name: native_uwp_x86_windows
           displayName: UWP x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x86 --skipAngle=true
           artifactName: native
@@ -171,7 +170,7 @@ stages:
           name: native_uwp_x64_windows
           displayName: UWP x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=x64 --skipAngle=true
           artifactName: native
@@ -180,7 +179,7 @@ stages:
           name: native_uwp_arm_windows
           displayName: UWP arm
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm --skipAngle=true
           artifactName: native
@@ -189,7 +188,7 @@ stages:
           name: native_uwp_arm64_windows
           displayName: UWP arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-uwp
           additionalArgs: --buildarch=arm64 --skipAngle=true
           artifactName: native
@@ -198,7 +197,7 @@ stages:
           name: native_win32_x86_windows
           displayName: Win32 x86
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x86
           artifactName: native
@@ -207,7 +206,7 @@ stages:
           name: native_win32_x64_windows
           displayName: Win32 x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -216,7 +215,7 @@ stages:
           name: native_win32_arm64_windows
           displayName: Win32 arm64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-windows
           additionalArgs: --buildarch=arm64
           artifactName: native
@@ -225,7 +224,7 @@ stages:
           name: native_win32_x64_nanoserver_windows
           displayName: Nano Server x64
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: externals-nanoserver
           additionalArgs: --buildarch=x64
           artifactName: native
@@ -471,7 +470,7 @@ stages:
         parameters:
           name: api_diff_windows
           displayName: API Diff
-          vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+          vmImage: $(VM_IMAGE_WINDOWS)
           target: docs-api-diff
           additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
           shouldPublish: false
@@ -824,7 +823,7 @@ stages:
             name: native_checks_windows
             displayName: Run Code Checks
             condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
-            vmImage: $(VM_IMAGE_WINDOWS_PREVIOUS)
+            vmImage: $(VM_IMAGE_WINDOWS)
             target: git-sync-deps
             installWindowsSdk: false
             installDotNet: false

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -35,9 +35,9 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: 'Azure Pipelines windows-2022'
-  VM_IMAGE_MAC: 'Azure Pipelines macOS-10.15'
-  VM_IMAGE_LINUX: 'Azure Pipelines ubuntu-18.04'
+  VM_IMAGE_WINDOWS: 'Azure-Pipelines-windows-2022'
+  VM_IMAGE_MAC: 'Azure-Pipelines-macOS-10.15'
+  VM_IMAGE_LINUX: 'Azure-Pipelines-ubuntu-18.04'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -60,9 +60,9 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure Pipelines ', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ')) }}:
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ')) }}:
             name: ${{ variables.VM_IMAGE_LINUX }}
         steps:
           - checkout: none
@@ -744,9 +744,9 @@ stages:
       - job: coverage_reports                      # Coverage Reports
         displayName: Coverage Reports
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ') }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure Pipelines ', '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ')) }}:
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure-Pipelines- ')) }}:
             name: ${{ variables.VM_IMAGE_LINUX }}
         dependsOn:
           - tests_netcore_windows

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -744,7 +744,10 @@ stages:
       - job: coverage_reports                      # Coverage Reports
         displayName: Coverage Reports
         pool:
-          vmImage: $(VM_IMAGE_LINUX)
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure Pipelines ', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ')) }}:
+            name: ${{ variables.VM_IMAGE_LINUX }}
         dependsOn:
           - tests_netcore_windows
           - tests_netcore_macos

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -333,6 +333,7 @@ stages:
         parameters:
           artifactName: native
           buildExternals: ${{ parameters.buildExternals }}
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           builds:
             - name: ''
             - name: nodeps
@@ -368,6 +369,7 @@ stages:
       - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
         parameters:
           buildExternals: ${{ parameters.buildExternals }}
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           artifactName: native
           emscripten:
             - 2.0.5

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -35,9 +35,9 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: 'Hosted VS2019'
-  VM_IMAGE_MAC: 'Hosted macOS'
-  VM_IMAGE_LINUX: 'Hosted Ubuntu 1804'
+  VM_IMAGE_WINDOWS: 'Azure Pipelines windows-2022'
+  VM_IMAGE_MAC: 'Azure Pipelines macOS-10.15'
+  VM_IMAGE_LINUX: 'Azure Pipelines ubuntu-18.04'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -60,7 +60,7 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          name: $(VM_IMAGE_LINUX)
+          vmImage: $(VM_IMAGE_LINUX)
         steps:
           - checkout: none
           - template: azure-templates-variables.yml

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -35,9 +35,9 @@ variables:
   DOTNET_WORKLOAD_SOURCE: 'https://aka.ms/dotnet/maui/6.0.200/preview.13.json'
   VS_VERSION_PREVIEW: 17/pre
   CONFIGURATION: 'Release'
-  VM_IMAGE_WINDOWS: 'Azure Pipelines windows-2022'
-  VM_IMAGE_MAC: 'Azure Pipelines macOS-10.15'
-  VM_IMAGE_LINUX: 'Azure Pipelines ubuntu-18.04'
+  VM_IMAGE_WINDOWS: 'Hosted VS2019'
+  VM_IMAGE_MAC: 'Hosted macOS'
+  VM_IMAGE_LINUX: 'Hosted Ubuntu 1804'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -60,7 +60,7 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          vmImage: $(VM_IMAGE_LINUX)
+          name: $(VM_IMAGE_LINUX)
         steps:
           - checkout: none
           - template: azure-templates-variables.yml

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -60,7 +60,10 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          vmImage: $(VM_IMAGE_LINUX)
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure Pipelines', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines')) }}:
+            name: ${{ variables.VM_IMAGE_LINUX }}
         steps:
           - checkout: none
           - template: azure-templates-variables.yml

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -38,7 +38,6 @@ variables:
   VM_IMAGE_WINDOWS: 'Azure Pipelines windows-2022'
   VM_IMAGE_MAC: 'Azure Pipelines macOS-10.15'
   VM_IMAGE_LINUX: 'Azure Pipelines ubuntu-18.04'
-  VM_IMAGE_AZURE_PREFIX: 'Azure Pipelines '
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true
   NUGET_DIFF_PRERELEASE: false
@@ -61,9 +60,9 @@ stages:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
         pool:
-          ${{ if startsWith(variables.VM_IMAGE_LINUX, variables.VM_IMAGE_AZURE_PREFIX) }}:
-            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, variables.VM_IMAGE_AZURE_PREFIX, '') }}
-          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, variables.VM_IMAGE_AZURE_PREFIX)) }}:
+          ${{ if startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ') }}:
+            vmImage: ${{ replace(variables.VM_IMAGE_LINUX, 'Azure Pipelines ', '') }}
+          ${{ if not(startsWith(variables.VM_IMAGE_LINUX, 'Azure Pipelines ')) }}:
             name: ${{ variables.VM_IMAGE_LINUX }}
         steps:
           - checkout: none

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,9 +36,9 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX) }}:
-        vmImage: ${{ replace(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX, '') }} SW startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)
+        vmImage: ${{ replace(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX, '') }}
       ${{ if not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)) }}:
-        name: ${{ parameters.vmImage }} NSW not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX))
+        name: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -220,9 +220,13 @@ jobs:
               JavaSdkDirectory: $(JAVA_HOME)
             displayName: Run the bootstrapper for ${{ parameters.target }}
       - ${{ if ne(parameters.docker, '') }}:
-        - bash: docker build --tag skiasharp ${{ parameters.dockerArgs }} .
-          workingDirectory: ${{ parameters.docker }}
+        - task: Docker@2
           displayName: Build the Docker image for ${{ parameters.docker }}
+          inputs:
+            command: build
+            arguments: ${{ parameters.dockerArgs }}
+            tags: skiasharp
+            dockerfile: ${{ parameters.docker }}/Dockerfile
         - bash: |
             echo dotnet tool restore > cmd.sh
             echo dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }} >> cmd.sh

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,9 +36,9 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
+        vmImage: '${{ parameters.vmImage }}'  ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}}  ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
       ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
-        name: ${{ parameters.vmImage }}
+        name: '${{ parameters.vmImage }}' ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,7 +36,7 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, 'Azure-Pipelines-') }}:
-        vmImage: ${{ trim(replace(parameters.vmImage, 'Azure-Pipelines-', '')) }}
+        vmImage: ${{ replace(parameters.vmImage, 'Azure-Pipelines-', '') }}
       ${{ if not(startsWith(parameters.vmImage, 'Azure-Pipelines-')) }}:
         name: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,9 +36,9 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
-        vmImage: '${{ parameters.vmImage }}' ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
+        vmImage: '${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}'
       ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
-        name: '${{ parameters.vmImage }}' ${{ parameters.vmImage }}
+        name: '${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ parameters.vmImage }}'
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,9 +36,9 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
-        vmImage: '${{ parameters.vmImage }}'  ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}}  ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
+        vmImage: '${{ parameters.vmImage }}' ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
       ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
-        name: '${{ parameters.vmImage }}' ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ parameters.vmImage }}
+        name: '${{ parameters.vmImage }}' ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}
@@ -227,6 +227,7 @@ jobs:
             arguments: ${{ parameters.dockerArgs }}
             tags: skiasharp
             dockerfile: ${{ parameters.docker }}/Dockerfile
+            buildContext: ${{ parameters.docker }}
         - bash: |
             echo dotnet tool restore > cmd.sh
             echo dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }} >> cmd.sh

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -34,7 +34,7 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 180
     pool:
-      pool: ${{ parameters.vmImage }}
+      name: ${{ parameters.vmImage }}
       demands: ${{ parameters.demands }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -34,8 +34,11 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 180
     pool:
-      name: ${{ parameters.vmImage }}
       demands: ${{ parameters.demands }}
+      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
+        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }} SW startsWith(parameters.vmImage, 'Azure Pipelines')
+      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
+        name: ${{ parameters.vmImage }} NSW not(startsWith(parameters.vmImage, 'Azure Pipelines'))
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -224,10 +224,9 @@ jobs:
           displayName: Build the Docker image for ${{ parameters.docker }}
           inputs:
             command: build
-            arguments: ${{ parameters.dockerArgs }}
-            tags: skiasharp
-            dockerfile: ${{ parameters.docker }}/Dockerfile
             buildContext: ${{ parameters.docker }}
+            dockerfile: ${{ parameters.docker }}/Dockerfile
+            arguments: --tag skiasharp ${{ parameters.dockerArgs }}
         - bash: |
             echo dotnet tool restore > cmd.sh
             echo dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }} >> cmd.sh

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -34,7 +34,7 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 180
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      pool: ${{ parameters.vmImage }}
       demands: ${{ parameters.demands }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -74,11 +74,11 @@ jobs:
 
       # install extra bits for the native builds
       - ${{ if startsWith(parameters.name, 'native_') }}:
-        # switch to Python 3.x
+        # switch to the correct Python version
         - task: UsePythonVersion@0
-          displayName: Switch to Python to 3.x
+          displayName: Switch to Python to 2.7
           inputs:
-            versionSpec: '3.x'
+            versionSpec: '2.7'
             architecture: 'x64'
         - ${{ if not(contains(parameters.name, '_checks_')) }}:
           # install android ndk

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -34,11 +34,8 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 180
     pool:
+      name: ${{ parameters.vmImage }}
       demands: ${{ parameters.demands }}
-      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }} SW startsWith(parameters.vmImage, 'Azure Pipelines')
-      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
-        name: ${{ parameters.vmImage }} NSW not(startsWith(parameters.vmImage, 'Azure Pipelines'))
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,9 +36,9 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }}
+        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }} SW startsWith(parameters.vmImage, 'Azure Pipelines')
       ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
-        name: ${{ parameters.vmImage }}
+        name: ${{ parameters.vmImage }} NSW not(startsWith(parameters.vmImage, 'Azure Pipelines'))
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -35,10 +35,10 @@ jobs:
     timeoutInMinutes: 180
     pool:
       demands: ${{ parameters.demands }}
-      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
-        vmImage: ${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
-      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
-        name: ${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ parameters.vmImage }}
+      ${{ if startsWith(parameters.vmImage, 'Azure-Pipelines-') }}:
+        vmImage: ${{ trim(replace(parameters.vmImage, 'Azure-Pipelines-', '')) }}
+      ${{ if not(startsWith(parameters.vmImage, 'Azure-Pipelines-')) }}:
+        name: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -71,11 +71,11 @@ jobs:
 
       # install extra bits for the native builds
       - ${{ if startsWith(parameters.name, 'native_') }}:
-        # switch to Python 2.7
+        # switch to Python 3.x
         - task: UsePythonVersion@0
-          displayName: Switch to Python to 2.7
+          displayName: Switch to Python to 3.x
           inputs:
-            versionSpec: '2.7'
+            versionSpec: '3.x'
             architecture: 'x64'
         - ${{ if not(contains(parameters.name, '_checks_')) }}:
           # install android ndk

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -76,9 +76,12 @@ jobs:
       - ${{ if startsWith(parameters.name, 'native_') }}:
         # switch to the correct Python version
         - task: UsePythonVersion@0
-          displayName: Switch to Python to 2.7
+          displayName: Switch to the correct Python version
           inputs:
-            versionSpec: '2.7'
+            ${{ if endsWith(parameters.name, '_windows') }}:
+              versionSpec: '3.x'
+            ${{ if not(endsWith(parameters.name, '_windows')) }}:
+              versionSpec: '2.7'
             architecture: 'x64'
         - ${{ if not(contains(parameters.name, '_checks_')) }}:
           # install android ndk

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -35,10 +35,10 @@ jobs:
     timeoutInMinutes: 180
     pool:
       demands: ${{ parameters.demands }}
-      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }} SW startsWith(parameters.vmImage, 'Azure Pipelines')
-      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
-        name: ${{ parameters.vmImage }} NSW not(startsWith(parameters.vmImage, 'Azure Pipelines'))
+      ${{ if startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX) }}:
+        vmImage: ${{ replace(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX, '') }} SW startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)
+      ${{ if not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)) }}:
+        name: ${{ parameters.vmImage }} NSW not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX))
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -36,9 +36,9 @@ jobs:
     pool:
       demands: ${{ parameters.demands }}
       ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
-        vmImage: '${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}'
+        vmImage: ${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
       ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
-        name: '${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ parameters.vmImage }}'
+        name: ${{ parameters.vmImage }} ${{startsWith(parameters.vmImage, 'Azure Pipelines ')}} ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -34,8 +34,11 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 180
     pool:
-      name: ${{ parameters.vmImage }}
       demands: ${{ parameters.demands }}
+      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
+        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }}
+      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
+        name: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -35,9 +35,9 @@ jobs:
     timeoutInMinutes: 180
     pool:
       demands: ${{ parameters.demands }}
-      ${{ if startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX) }}:
-        vmImage: ${{ replace(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX, '') }}
-      ${{ if not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)) }}:
+      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
+        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
+      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
         name: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -12,7 +12,7 @@ jobs:
     displayName: ${{ parameters.displayName }}
     pool:
       ${{ if startsWith(parameters.vmImage, 'Azure-Pipelines-') }}:
-        vmImage: ${{ trim(replace(parameters.vmImage, 'Azure-Pipelines-', '')) }}
+        vmImage: ${{ replace(parameters.vmImage, 'Azure-Pipelines-', '') }}
       ${{ if not(startsWith(parameters.vmImage, 'Azure-Pipelines-')) }}:
         name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -11,9 +11,9 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     pool:
-      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
-      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
+      ${{ if startsWith(parameters.vmImage, 'Azure-Pipelines-') }}:
+        vmImage: ${{ trim(replace(parameters.vmImage, 'Azure-Pipelines-', '')) }}
+      ${{ if not(startsWith(parameters.vmImage, 'Azure-Pipelines-')) }}:
         name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}
     steps:

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -11,9 +11,9 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     pool:
-      ${{ if startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX) }}:
-        vmImage: ${{ replace(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX, '') }}
-      ${{ if not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)) }}:
+      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines ') }}:
+        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines ', '') }}
+      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines ')) }}:
         name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}
     steps:

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -11,10 +11,7 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     pool:
-      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }}
-      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
-        name: ${{ parameters.vmImage }}
+      name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}
     steps:
       - checkout: none

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -11,7 +11,10 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     pool:
-      name: ${{ parameters.vmImage }}
+      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
+        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }}
+      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
+        name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}
     steps:
       - checkout: none

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -11,9 +11,9 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     pool:
-      ${{ if startsWith(parameters.vmImage, 'Azure Pipelines') }}:
-        vmImage: ${{ replace(parameters.vmImage, 'Azure Pipelines', '') }}
-      ${{ if not(startsWith(parameters.vmImage, 'Azure Pipelines')) }}:
+      ${{ if startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX) }}:
+        vmImage: ${{ replace(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX, '') }}
+      ${{ if not(startsWith(parameters.vmImage, variables.VM_IMAGE_AZURE_PREFIX)) }}:
         name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}
     steps:

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -11,7 +11,7 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      name: ${{ parameters.vmImage }}
     condition: ${{ parameters.condition }}
     steps:
       - checkout: none

--- a/scripts/azure-templates-linux-matrix.yml
+++ b/scripts/azure-templates-linux-matrix.yml
@@ -1,6 +1,7 @@
 parameters:
   artifactName: ''                              # the name of the artifact to merge this run into
   buildExternals: ''                            # the build number to download externals from
+  vmImage: ''                                   # the VM image
   builds:
     - name: ''
       desc: ''
@@ -23,7 +24,7 @@ jobs:
           name: ${{ replace(replace(format('native_linux_{0}_{1}_{2}_{3}_linux', item.arch, item.variant, build.name, item.alt), '__', '_'), '__', '_') }}
           displayName: Linux ${{ replace(replace(replace(replace(replace(format('({0}|{1}|{2}|{3})', item.arch, item.variant, build.name, item.alt), '||', '|'), '||', '|'), '(|', '('), '|)', ')'), '|', ', ') }}
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: ${{ parameters.vmImage }}
           docker: ${{ item.docker }}
           dockerArgs: ${{ item.dockerArgs }}
           target: ${{ coalesce(item.target, 'externals-linux') }}

--- a/scripts/azure-templates-linux-matrix.yml
+++ b/scripts/azure-templates-linux-matrix.yml
@@ -23,7 +23,7 @@ jobs:
           name: ${{ replace(replace(format('native_linux_{0}_{1}_{2}_{3}_linux', item.arch, item.variant, build.name, item.alt), '__', '_'), '__', '_') }}
           displayName: Linux ${{ replace(replace(replace(replace(replace(format('({0}|{1}|{2}|{3})', item.arch, item.variant, build.name, item.alt), '||', '|'), '||', '|'), '(|', '('), '|)', ')'), '|', ', ') }}
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: $(VM_IMAGE_LINUX)
+          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
           docker: ${{ item.docker }}
           dockerArgs: ${{ item.dockerArgs }}
           target: ${{ coalesce(item.target, 'externals-linux') }}

--- a/scripts/azure-templates-linux-matrix.yml
+++ b/scripts/azure-templates-linux-matrix.yml
@@ -23,7 +23,7 @@ jobs:
           name: ${{ replace(replace(format('native_linux_{0}_{1}_{2}_{3}_linux', item.arch, item.variant, build.name, item.alt), '__', '_'), '__', '_') }}
           displayName: Linux ${{ replace(replace(replace(replace(replace(format('({0}|{1}|{2}|{3})', item.arch, item.variant, build.name, item.alt), '||', '|'), '||', '|'), '(|', '('), '|)', ')'), '|', ', ') }}
           buildExternals: ${{ parameters.buildExternals }}
-          vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+          vmImage: $(VM_IMAGE_LINUX)
           docker: ${{ item.docker }}
           dockerArgs: ${{ item.dockerArgs }}
           target: ${{ coalesce(item.target, 'externals-linux') }}

--- a/scripts/azure-templates-wasm-matrix.yml
+++ b/scripts/azure-templates-wasm-matrix.yml
@@ -1,6 +1,7 @@
 parameters:
   artifactName: ''                              # the name of the artifact to merge this run into
   buildExternals: ''                            # the build number to download externals from
+  vmImage: ''                                   # the VM image
   emscripten: [ ]
 
 jobs:
@@ -10,7 +11,7 @@ jobs:
         name: native_wasm_${{ replace(version, '.', '_') }}_linux
         displayName: WASM (${{ version }})
         buildExternals: ${{ parameters.buildExternals }}
-        vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+        vmImage: ${{ parameters.vmImage }}
         docker: scripts/Docker/wasm
         target: externals-wasm
         dockerArgs: --build-arg EMSCRIPTEN_VERSION=${{ version }}

--- a/scripts/azure-templates-wasm-matrix.yml
+++ b/scripts/azure-templates-wasm-matrix.yml
@@ -10,7 +10,7 @@ jobs:
         name: native_wasm_${{ replace(version, '.', '_') }}_linux
         displayName: WASM (${{ version }})
         buildExternals: ${{ parameters.buildExternals }}
-        vmImage: $(VM_IMAGE_LINUX)
+        vmImage: ${{ parameters.VM_IMAGE_LINUX }}
         docker: scripts/Docker/wasm
         target: externals-wasm
         dockerArgs: --build-arg EMSCRIPTEN_VERSION=${{ version }}

--- a/scripts/azure-templates-wasm-matrix.yml
+++ b/scripts/azure-templates-wasm-matrix.yml
@@ -10,7 +10,7 @@ jobs:
         name: native_wasm_${{ replace(version, '.', '_') }}_linux
         displayName: WASM (${{ version }})
         buildExternals: ${{ parameters.buildExternals }}
-        vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+        vmImage: $(VM_IMAGE_LINUX)
         docker: scripts/Docker/wasm
         target: externals-wasm
         dockerArgs: --build-arg EMSCRIPTEN_VERSION=${{ version }}


### PR DESCRIPTION
**Description of Change**

This PR just move the build infrastructure to a different set of agents other than the public, default, hosted Azure VMs.