### PR TITLE
Skip the preview feed if not on a preview .NET

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -12,7 +12,7 @@ parameters:
   - name: buildExternals
     displayName: 'The specific native artifacts to use for this build.'
     type: number
-    default: 5764837
+    default: 0
   - name: VM_IMAGE_WINDOWS
     type: string
     default: 'Azure-Pipelines-windows-2022'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -12,7 +12,7 @@ parameters:
   - name: buildExternals
     displayName: 'The specific native artifacts to use for this build.'
     type: number
-    default: 0
+    default: 5764837
   - name: VM_IMAGE_WINDOWS
     type: string
     default: 'Azure-Pipelines-windows-2022'

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -123,7 +123,11 @@ jobs:
             - pwsh: .\scripts\select-vs.ps1
               displayName: Select Visual Studio
           - ${{ if not(endsWith(parameters.name, '_linux')) }}:
-            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE"
+            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE" -IsPreview $true
+              condition: ne(variables.DOTNET_VERSION_PREVIEW, '')
+              displayName: Install the preview .NET Core workloads
+            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE" -IsPreview $false
+              condition: eq(variables.DOTNET_VERSION_PREVIEW, '')
               displayName: Install the .NET Core workloads
           # display dotnet info
           - pwsh: dotnet --info

--- a/scripts/install-dotnet-workloads.ps1
+++ b/scripts/install-dotnet-workloads.ps1
@@ -1,17 +1,23 @@
 Param(
     [string] $InstallDir,
-    [string] $SourceUrl
+    [string] $SourceUrl,
+    [boolean] $IsPreview = $true
 )
 
 $ErrorActionPreference = 'Stop'
 
 $env:DOTNET_ROOT="$InstallDir"
 
+$previewFeed = 'https://api.nuget.org/v3/index.json'
+if ($IsPreview) {
+  $previewFeed = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json'
+}
+
 Write-Host "Installing workloads..."
 & dotnet workload install `
   android ios tvos macos maccatalyst wasm-tools maui `
   --from-rollback-file $SourceUrl `
   --source https://api.nuget.org/v3/index.json `
-  --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
+  --source $previewFeed
 
 exit $LASTEXITCODE


### PR DESCRIPTION
**Description of Change**

It appears that the workload installer randomly selects a feed to use to download packages.

I think I got a case where a version existed on both feeds - but as part of a separate build - one of which was signed and the other not.

This PR makes sure that if it is not a preview version of .NET, then it does not use the preview version of the workloads.