### PR TITLE
Use the US Gov EO section 4(e)(i) compliant images

### DIFF
--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -18,7 +18,7 @@ parameters:
     default:
       name: AzurePipelines-EO
       demands:
-        - ImageOverride -equals 'AzurePipelinesWindows2022compliant'
+        - ImageOverride -equals AzurePipelinesWindows2022compliant
   - name: VM_IMAGE_MAC
     type: object
     default:

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -28,8 +28,7 @@ parameters:
     type: object
     default:
       name: AzurePipelines-EO
-      demands:
-        - ImageOverride -equals 'AzurePipelinesUbuntu18.04compliant'
+      vmImage: AzurePipelinesUbuntu18.04compliant
 
 variables:
   - template: azure-pipelines-variables.yml

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -12,7 +12,7 @@ parameters:
   - name: buildExternals
     displayName: 'The specific native artifacts to use for this build.'
     type: number
-    default: 0
+    default: 5836456
   - name: VM_IMAGE_WINDOWS
     type: object
     default:

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -16,7 +16,7 @@ parameters:
   - name: VM_IMAGE_WINDOWS
     type: object
     default:
-      name: Azure Pipelines-EO
+      name: AzurePipelines-EO
       demands:
         - ImageOverride -equals 'AzurePipelinesWindows2022compliant'
   - name: VM_IMAGE_MAC
@@ -27,7 +27,7 @@ parameters:
   - name: VM_IMAGE_LINUX
     type: object
     default:
-      name: Azure Pipelines
+      name: AzurePipelines-EO
       demands:
         - ImageOverride -equals 'AzurePipelinesUbuntu18.04compliant'
 

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -16,18 +16,20 @@ parameters:
   - name: VM_IMAGE_WINDOWS
     type: object
     default:
-      name: Azure Pipelines
-      vmImage: windows-2022
+      name: Azure Pipelines-EO
+      demands:
+        - ImageOverride -equals 'AzurePipelinesWindows2022compliant'
   - name: VM_IMAGE_MAC
     type: object
     default:
       name: Azure Pipelines
-      vmImage: macOS-10.15
+      vmImage: internal-macos-11
   - name: VM_IMAGE_LINUX
     type: object
     default:
       name: Azure Pipelines
-      vmImage: ubuntu-18.04
+      demands:
+        - ImageOverride -equals 'AzurePipelinesUbuntu18.04compliant'
 
 variables:
   - template: azure-pipelines-variables.yml

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -409,6 +409,8 @@ stages:
             requiredArtifacts:
               - name: native
             artifactName: managed
+            preBuildSteps:
+              - pwsh: 'dir env:'
             postBuildSteps:
               - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
                 displayName: Delete the native folder


### PR DESCRIPTION
**Description of Change**

This PR makes sure to build any shipping bits on compliant images:
 - Windows: `AzurePipelinesWindows2022compliant`
 - macOS: `internal-macos-11`
 - Linux: `AzurePipelinesUbuntu18.04compliant`

More Info: https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops

