### PR TITLE
Add pen as device type and pressure for iOS touch events

### DIFF
--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
@@ -104,9 +104,23 @@ namespace SkiaSharp.Views.Maui.Platform
 			var cgPoint = touch.LocationInView(View);
 			var point = scalePixels(cgPoint.X, cgPoint.Y);
 
-			var args = new SKTouchEventArgs(id, actionType, point, inContact);
+			var deviceType = GetDeviceType(touch);
+
+			var pressure = (float)touch.Force;
+
+			var args = new SKTouchEventArgs(id, actionType, SKMouseButton.Left, deviceType, point, inContact, 0, pressure);
 			onTouchAction(args);
 			return args.Handled;
 		}
+
+		private static SKTouchDeviceType GetDeviceType(UITouch touch) =>
+			touch.Type switch
+			{
+				UITouchType.Direct => SKTouchDeviceType.Touch,
+				UITouchType.Indirect => SKTouchDeviceType.Touch,
+				UITouchType.Stylus => SKTouchDeviceType.Pen,
+				UITouchType.IndirectPointer => SKTouchDeviceType.Touch,
+				_ => SKTouchDeviceType.Touch,
+			};
 	}
 }


### PR DESCRIPTION
**Description of Change**

As mentioned in https://github.com/mono/SkiaSharp/pull/1191#issuecomment-608457631, add device type support for pen touch events on iOS. Android and UWP are already implemented appropriately.

**Bugs Fixed**

- Related to issue #1186

**API Changes**

None

**Behavioral Changes**

The Apple Pencil will now be correctly recognized as pen device type. In addition, the pressure value will also be propagated to the touch event.

Although there is no change in terms of method signatures, I want to point out that the default iOS implementation for pressure reports a value of 0 when the current touch has no pressure information. Before the change it was a fixed value of 1. In my opinion, this also goes along with the Android definition that reads that the value for pressure ranges from 0 (no pressure at all) to 1 (normal pressure). iOS also defines "normal pressure" as 1, but may also very well go beyond for stronger pressure.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
