### PR TITLE
Fix CI after VS updates

### DIFF
--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -1,4 +1,5 @@
-var SKIP_ANGLE = Argument ("skipAngle", false);
+bool SKIP_ANGLE = Argument ("skipAngle", false);
+string VC_TOOLSET_VERSION = Argument("vcToolsetVersion", "14.2");
 
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
 DirectoryPath VCPKG_PATH = MakeAbsolute(ROOT_PATH.Combine("externals/vcpkg"));
@@ -21,6 +22,7 @@ Task("libSkiaSharp")
     {
         if (Skip(arch)) return;
 
+        var win_vcvars_version = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"win_vcvars_version='{VC_TOOLSET_VERSION}' ";
         var d = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
         GnNinja($"uwp/{arch}", "SkiaSharp",
@@ -35,6 +37,7 @@ Task("libSkiaSharp")
             $"skia_use_system_libpng=false " +
             $"skia_use_system_libwebp=false " +
             $"skia_use_system_zlib=false " +
+            win_vcvars_version +
             $"extra_cflags=[  " +
             $"  '-DSKIA_C_DLL', '/MD{d}', '/EHsc', '/Z7', " +
             $"  '-DSK_HAS_DWRITE_1_H', '-DSK_HAS_DWRITE_2_H', '-DNO_GETENV', '-D_HAS_AUTO_PTR_ETC=1' ] " +
@@ -105,6 +108,9 @@ Task("ANGLE")
     if (!FileExists (vcpkg))
         RunProcess (VCPKG_PATH.CombineWithFilePath ("bootstrap-vcpkg.bat"));
 
+    var platform_toolset = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"v{VC_TOOLSET_VERSION.Replace(".", "")}";
+    var toolset_suffix = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"-{platform_toolset}";
+
     Build("x86");
     Build("x64");
     Build("arm");
@@ -114,19 +120,36 @@ Task("ANGLE")
     {
         if (Skip(arch)) return;
 
+        var triplet = $"{arch}-uwp{toolset_suffix}";
+
+        // make the versioned triplets
+        if (!string.IsNullOrEmpty(VC_TOOLSET_VERSION)) {
+            var cmake = VCPKG_PATH.CombineWithFilePath ($"triplets/community/{triplet}.cmake");
+            if (!FileExists (cmake)) {
+                var src = VCPKG_PATH.CombineWithFilePath ($"triplets/{arch}-uwp.cmake");
+                if (!FileExists (src))
+                    src = VCPKG_PATH.CombineWithFilePath ($"triplets/community/{arch}-uwp.cmake");
+                CopyFile (src, cmake);
+                System.IO.File.AppendAllLines (cmake.FullPath, new [] {
+                    $"set(VCPKG_PLATFORM_TOOLSET \"{platform_toolset}\")",
+                    $"set(VCPKG_DEP_INFO_OVERRIDE_VARS \"{platform_toolset}\")",
+                });
+            }
+        }
+
         var d = CONFIGURATION.ToLower() == "release" ? "" : "debug/";
         var zd = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
-        RunProcess (vcpkg, $"install angle:{arch}-uwp");
+        RunProcess (vcpkg, $"install angle:{triplet}");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libEGL.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libEGL.pdb"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libGLESv2.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/libGLESv2.pdb"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/zlib{zd}1.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{arch}-uwp/{d}bin/zlib{zd}.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libEGL.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libEGL.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libGLESv2.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libGLESv2.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/zlib{zd}1.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/zlib{zd}.pdb"), outDir);
     }
 });
 

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -2,6 +2,7 @@ DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
 DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native"));
 
 DirectoryPath LLVM_HOME = Argument("llvm", EnvironmentVariable("LLVM_HOME") ?? "C:/Program Files/LLVM");
+string VC_TOOLSET_VERSION = Argument("vcToolsetVersion", "14.2");
 
 string SUPPORT_VULKAN_VAR = Argument ("supportVulkan", EnvironmentVariable ("SUPPORT_VULKAN") ?? "true");
 bool SUPPORT_VULKAN = SUPPORT_VULKAN_VAR == "1" || SUPPORT_VULKAN_VAR.ToLower () == "true";
@@ -31,6 +32,7 @@ Task("libSkiaSharp")
         if (Skip(arch)) return;
 
         var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
+        var win_vcvars_version = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"win_vcvars_version='{VC_TOOLSET_VERSION}' ";
         var d = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
         GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
@@ -48,6 +50,7 @@ Task("libSkiaSharp")
             $"skia_use_system_zlib=false " +
             $"skia_use_vulkan={SUPPORT_VULKAN} ".ToLower () +
             clang +
+            win_vcvars_version +
             $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '-D_HAS_AUTO_PTR_ETC=1' ] " +
             $"extra_ldflags=[ '/DEBUG:FULL' ] " +
             ADDITIONAL_GN_ARGS);

--- a/scripts/install-llvm.ps1
+++ b/scripts/install-llvm.ps1
@@ -27,4 +27,8 @@ Write-Host "Installing LLVM..."
 # make sure that LLVM is in LLVM_HOME
 Write-Host "##vso[task.setvariable variable=LLVM_HOME;]$InstallDestination";
 
+# TODO: update the version of `win_vcvars_version` in
+#       - native\windows\build.cake
+#       - native\uwp\build.cake
+
 exit $LASTEXITCODE


### PR DESCRIPTION
**Description of Change**

Some tools updated and we are not ready for it. The VC toolset 14.3 requires LLVM 13, so we need to go back down.

Requires: https://github.com/mono/skia/pull/86