### PR TITLE
Return null on invalid resize bounds

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -786,6 +786,9 @@ namespace SkiaSharp
 
 		public SKBitmap Resize (SKImageInfo info, SKFilterQuality quality)
 		{
+			if (info.IsEmpty)
+				return null;
+
 			var dst = new SKBitmap (info);
 			if (ScalePixels (dst, quality)) {
 				return dst;

--- a/tests/Tests/SKBitmapTest.cs
+++ b/tests/Tests/SKBitmapTest.cs
@@ -428,6 +428,26 @@ namespace SkiaSharp.Tests
 			Assert.Equal(SKColors.Blue, dstBmp.GetPixel(75, 75));
 		}
 
+		[SkippableTheory]
+		[InlineData(-1, -1)]
+		[InlineData(0, 0)]
+		[InlineData(-1, 10)]
+		[InlineData(10, -1)]
+		[InlineData(0, 10)]
+		[InlineData(10, 0)]
+		public void BitmapDoesNotCrashOnInvalidResizes(int width, int hight)
+		{
+			using var bitmap = CreateTestBitmap();
+
+			var newInfo = bitmap.Info;
+			newInfo.Width = width;
+			newInfo.Height = hight;
+
+			using var newBitmap = bitmap.Resize(newInfo, SKFilterQuality.High);
+
+			Assert.Null(newBitmap);
+		}
+
 		[SkippableFact]
 		public void CanScalePixels()
 		{


### PR DESCRIPTION
**Description of Change**

It appears the `SKBitmap` constructor can construct a 0x0 bitmap and be fine. However crashes on negative values. Improve the method by just returning null if the bounds are invalid as there is no way it can ever work.

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #2012

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
