### PR TITLE
Make pipelines better

### DIFF
--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -42,7 +42,7 @@ variables:
 stages:
   - template: azure-templates-stages.yml
     parameters:
-      isBuildPipeline: 'both'
+      buildPipelineType: 'both'
       buildExternals: ${{ parameters.buildExternals }}
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -13,6 +13,12 @@ parameters:
     displayName: 'The specific native artifacts to use for this build.'
     type: number
     default: 0
+  - name: VM_IMAGE_HOST
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: ubuntu-18.04
   - name: VM_IMAGE_WINDOWS
     type: object
     default:
@@ -32,9 +38,7 @@ parameters:
         name: Azure Pipelines
         vmImage: ubuntu-18.04
 
-pool:
-  name: Azure Pipelines
-  vmImage: ubuntu-18.04
+pool: ${{ parameters.VM_IMAGE_HOST.pool }}
 
 variables:
   - template: azure-pipelines-variables.yml
@@ -44,6 +48,7 @@ stages:
     parameters:
       buildPipelineType: 'both'
       buildExternals: ${{ parameters.buildExternals }}
+      VM_IMAGE_HOST: ${{ parameters.VM_IMAGE_HOST }}
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -8,51 +8,45 @@ pr:
   - develop
   - patch/*
 
+parameters:
+  - name: buildExternals
+    displayName: 'The specific native artifacts to use for this build.'
+    type: number
+    default: 0
+  - name: VM_IMAGE_WINDOWS
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: windows-2022
+  - name: VM_IMAGE_MAC
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: macos-12
+  - name: VM_IMAGE_LINUX
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: ubuntu-18.04
+
 pool:
   name: Azure Pipelines
   vmImage: ubuntu-18.04
 
-jobs:
-  - job: testing
-    steps:
-      - checkout: none
-      - pwsh: echo hello
+variables:
+  - template: azure-pipelines-variables.yml
 
-# parameters:
-#   - name: buildExternals
-#     displayName: 'The specific native artifacts to use for this build.'
-#     type: number
-#     default: 0
-#   - name: VM_IMAGE_WINDOWS
-#     type: object
-#     default:
-#       pool:
-#         name: Azure Pipelines
-#         vmImage: windows-2022
-#   - name: VM_IMAGE_MAC
-#     type: object
-#     default:
-#       pool:
-#         name: Azure Pipelines
-#         vmImage: macos-12
-#   - name: VM_IMAGE_LINUX
-#     type: object
-#     default:
-#       pool:
-#         name: Azure Pipelines
-#         vmImage: ubuntu-18.04
-
-# variables:
-#   - template: azure-pipelines-variables.yml
-
-# stages:
-#   - template: azure-templates-stages.yml
-#     parameters:
-#       isBuildPipeline: 'both'
-#       buildExternals: ${{ parameters.buildExternals }}
-#       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
-#       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
-#       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
-#       VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC }}
-#       VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
-#       VM_IMAGE_LINUX_NATIVE: ${{ parameters.VM_IMAGE_LINUX }}
+stages:
+  - template: azure-templates-stages.yml
+    parameters:
+      isBuildPipeline: 'both'
+      buildExternals: ${{ parameters.buildExternals }}
+      VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
+      VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
+      VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
+      VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC }}
+      VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
+      VM_IMAGE_LINUX_NATIVE: ${{ parameters.VM_IMAGE_LINUX }}

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -25,6 +25,12 @@ parameters:
       pool:
         name: Azure Pipelines
         vmImage: windows-2022
+  - name: VM_IMAGE_MAC_NATIVE
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: macos-11
   - name: VM_IMAGE_MAC
     type: object
     default:
@@ -54,6 +60,6 @@ stages:
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
-      VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC }}
+      VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
       VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
       VM_IMAGE_LINUX_NATIVE: ${{ parameters.VM_IMAGE_LINUX }}

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -12,41 +12,47 @@ pool:
   name: Azure Pipelines
   vmImage: ubuntu-18.04
 
-parameters:
-  - name: buildExternals
-    displayName: 'The specific native artifacts to use for this build.'
-    type: number
-    default: 0
-  - name: VM_IMAGE_WINDOWS
-    type: object
-    default:
-      pool:
-        name: Azure Pipelines
-        vmImage: windows-2022
-  - name: VM_IMAGE_MAC
-    type: object
-    default:
-      pool:
-        name: Azure Pipelines
-        vmImage: macos-12
-  - name: VM_IMAGE_LINUX
-    type: object
-    default:
-      pool:
-        name: Azure Pipelines
-        vmImage: ubuntu-18.04
+jobs:
+  - job: testing
+    steps:
+      - checkout: none
+      - pwsh: echo hello
 
-variables:
-  - template: azure-pipelines-variables.yml
+# parameters:
+#   - name: buildExternals
+#     displayName: 'The specific native artifacts to use for this build.'
+#     type: number
+#     default: 0
+#   - name: VM_IMAGE_WINDOWS
+#     type: object
+#     default:
+#       pool:
+#         name: Azure Pipelines
+#         vmImage: windows-2022
+#   - name: VM_IMAGE_MAC
+#     type: object
+#     default:
+#       pool:
+#         name: Azure Pipelines
+#         vmImage: macos-12
+#   - name: VM_IMAGE_LINUX
+#     type: object
+#     default:
+#       pool:
+#         name: Azure Pipelines
+#         vmImage: ubuntu-18.04
 
-stages:
-  - template: azure-templates-stages.yml
-    parameters:
-      isBuildPipeline: 'both'
-      buildExternals: ${{ parameters.buildExternals }}
-      VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
-      VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
-      VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
-      VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC }}
-      VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
-      VM_IMAGE_LINUX_NATIVE: ${{ parameters.VM_IMAGE_LINUX }}
+# variables:
+#   - template: azure-pipelines-variables.yml
+
+# stages:
+#   - template: azure-templates-stages.yml
+#     parameters:
+#       isBuildPipeline: 'both'
+#       buildExternals: ${{ parameters.buildExternals }}
+#       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
+#       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
+#       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
+#       VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC }}
+#       VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
+#       VM_IMAGE_LINUX_NATIVE: ${{ parameters.VM_IMAGE_LINUX }}

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -35,14 +35,6 @@ parameters:
 variables:
   - template: azure-pipelines-variables.yml
 
-resources:
-  repositories:
-    - repository: xamarin-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
-      ref: refs/heads/main
-
 stages:
   - template: azure-templates-stages.yml
     parameters:

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -19,33 +19,12 @@ parameters:
       pool:
         name: Azure Pipelines
         vmImage: windows-2022
-  - name: VM_IMAGE_MAC_NATIVE
-    type: object
-    default:
-      pool:
-        name: Azure Pipelines
-        vmImage: macos-11
   - name: VM_IMAGE_MAC
     type: object
     default:
       pool:
-        name: VSEng-VSMac-Xamarin-Shared
-        vmImage: VSEng-VSMac-Xamarin-Shared
-        demands:
-          - macOS.Name -equals Monterey
-          - macOS.Architecture -equals x64
-          - Agent.HasDevices -equals False
-          - Agent.IsPaired -equals False
-      variables:
-        XCODE_VERSION: 13.3.0
-      provisioningSteps:
-        - task: xamops.azdevex.provisionator-task.provisionator@1
-          displayName: 'Provision Xamarin'
-          inputs:
-            provisioning_script: ./scripts/provisionator.csx
-            provisioning_extra_args: --force
-          env:
-            AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
+        name: Azure Pipelines
+        vmImage: macos-12
   - name: VM_IMAGE_LINUX
     type: object
     default:
@@ -67,11 +46,11 @@ resources:
 stages:
   - template: azure-templates-stages.yml
     parameters:
-      buildPipelineType: 'build'
+      isBuildPipeline: 'both'
       buildExternals: ${{ parameters.buildExternals }}
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}
-      VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+      VM_IMAGE_MAC_NATIVE: ${{ parameters.VM_IMAGE_MAC }}
       VM_IMAGE_LINUX: ${{ parameters.VM_IMAGE_LINUX }}
       VM_IMAGE_LINUX_NATIVE: ${{ parameters.VM_IMAGE_LINUX }}

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -8,6 +8,10 @@ pr:
   - develop
   - patch/*
 
+pool:
+  name: Azure Pipelines
+  vmImage: ubuntu-18.04
+
 parameters:
   - name: buildExternals
     displayName: 'The specific native artifacts to use for this build.'

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -38,7 +38,9 @@ parameters:
         name: Azure Pipelines
         vmImage: ubuntu-18.04
 
-pool: ${{ parameters.VM_IMAGE_HOST.pool }}
+pool:
+  name: Azure Pipelines
+  vmImage: ubuntu-18.04
 
 variables:
   - template: azure-pipelines-variables.yml

--- a/scripts/azure-pipelines-tests.yml
+++ b/scripts/azure-pipelines-tests.yml
@@ -40,8 +40,6 @@ resources:
       source: SkiaSharp
       trigger: true
 
-pool: ${{ parameters.VM_IMAGE_HOST.pool }}
-
 variables:
   - template: azure-pipelines-variables.yml
 

--- a/scripts/azure-pipelines-tests.yml
+++ b/scripts/azure-pipelines-tests.yml
@@ -3,6 +3,12 @@ trigger: none
 pr: none
 
 parameters:
+  - name: VM_IMAGE_HOST
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: ubuntu-18.04
   - name: VM_IMAGE_WINDOWS
     type: object
     default:
@@ -22,9 +28,6 @@ parameters:
         name: Azure Pipelines
         vmImage: ubuntu-18.04
 
-variables:
-  - template: azure-pipelines-variables.yml
-
 resources:
   repositories:
     - repository: xamarin-templates
@@ -37,10 +40,16 @@ resources:
       source: SkiaSharp
       trigger: true
 
+pool: ${{ parameters.VM_IMAGE_HOST.pool }}
+
+variables:
+  - template: azure-pipelines-variables.yml
+
 stages:
   - template: azure-templates-stages.yml
     parameters:
       buildPipelineType: 'tests'
+      VM_IMAGE_HOST: ${{ parameters.VM_IMAGE_HOST }}
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}

--- a/scripts/azure-pipelines-tests.yml
+++ b/scripts/azure-pipelines-tests.yml
@@ -28,6 +28,9 @@ parameters:
         name: Azure Pipelines
         vmImage: ubuntu-18.04
 
+variables:
+  - template: azure-pipelines-variables.yml
+
 resources:
   repositories:
     - repository: xamarin-templates
@@ -39,9 +42,6 @@ resources:
     - pipeline: SkiaSharp
       source: SkiaSharp
       trigger: true
-
-variables:
-  - template: azure-pipelines-variables.yml
 
 stages:
   - template: azure-templates-stages.yml

--- a/scripts/azure-pipelines-tests.yml
+++ b/scripts/azure-pipelines-tests.yml
@@ -40,7 +40,7 @@ resources:
 stages:
   - template: azure-templates-stages.yml
     parameters:
-      isBuildPipeline: false
+      buildPipelineType: 'tests'
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -67,8 +67,6 @@ resources:
       endpoint: xamarin
       ref: refs/heads/main
 
-pool: ${{ parameters.VM_IMAGE_HOST.pool }}
-
 variables:
   - template: azure-pipelines-variables.yml
 

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -13,6 +13,12 @@ parameters:
     displayName: 'The specific native artifacts to use for this build.'
     type: number
     default: 0
+  - name: VM_IMAGE_HOST
+    type: object
+    default:
+      pool:
+        name: Azure Pipelines
+        vmImage: ubuntu-18.04
   - name: VM_IMAGE_WINDOWS
     type: object
     default:
@@ -53,9 +59,6 @@ parameters:
         name: Azure Pipelines
         vmImage: ubuntu-18.04
 
-variables:
-  - template: azure-pipelines-variables.yml
-
 resources:
   repositories:
     - repository: xamarin-templates
@@ -64,11 +67,17 @@ resources:
       endpoint: xamarin
       ref: refs/heads/main
 
+pool: ${{ parameters.VM_IMAGE_HOST.pool }}
+
+variables:
+  - template: azure-pipelines-variables.yml
+
 stages:
   - template: azure-templates-stages.yml
     parameters:
       buildPipelineType: 'build'
       buildExternals: ${{ parameters.buildExternals }}
+      VM_IMAGE_HOST: ${{ parameters.VM_IMAGE_HOST }}
       VM_IMAGE_WINDOWS: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_WINDOWS_NATIVE: ${{ parameters.VM_IMAGE_WINDOWS }}
       VM_IMAGE_MAC: ${{ parameters.VM_IMAGE_MAC }}

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -59,6 +59,9 @@ parameters:
         name: Azure Pipelines
         vmImage: ubuntu-18.04
 
+variables:
+  - template: azure-pipelines-variables.yml
+
 resources:
   repositories:
     - repository: xamarin-templates
@@ -66,9 +69,6 @@ resources:
       name: xamarin/yaml-templates
       endpoint: xamarin
       ref: refs/heads/main
-
-variables:
-  - template: azure-pipelines-variables.yml
 
 stages:
   - template: azure-templates-stages.yml

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -38,7 +38,7 @@ jobs:
       parameters:
         name: ${{ parameters.name }}
         displayName: ${{ parameters.displayName }}
-        vmImage: ${{ parameters.vmImage.pool }}
+        pool: ${{ parameters.vmImage.pool }}
         packages: ${{ parameters.packages }}
         target: ${{ parameters.target }}
         dependsOn: ${{ parameters.dependsOn }}
@@ -85,7 +85,7 @@ jobs:
       parameters:
         name: ${{ parameters.name }}
         displayName: ${{ parameters.displayName }}
-        vmImage: ${{ parameters.vmImage.pool }}
+        pool: ${{ parameters.vmImage.pool }}
         packages: ${{ parameters.packages }}
         target: ${{ parameters.target }}
         dependsOn: ${{ parameters.dependsOn }}

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -17,7 +17,7 @@ parameters:
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
   buildExternals: ''                            # the build number to download externals from
-  isBuildPipeline: true
+  buildPipelineType: 'both'                     # the type of build pipeline setup
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -112,7 +112,7 @@ jobs:
         condition: ${{ parameters.condition }}
         shouldPublish: ${{ parameters.shouldPublish }}
         configuration: ${{ parameters.configuration }}
-        isBuildPipeline: ${{ parameters.isBuildPipeline }}
+        buildPipelineType: ${{ parameters.buildPipelineType }}
         verbosity: ${{ parameters.verbosity }}
         docker: ${{ parameters.docker }}
         dockerArgs: ${{ parameters.dockerArgs }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -1,7 +1,7 @@
 parameters:
   name: ''                                      # in the form type_platform_host
   displayName: ''                               # the human name
-  vmImage: ''                                   # the VM image
+  pool: ''                                      # the agent pool
   packages: ''                                  # any additional packages
   target: ''                                    # the bootstrapper target
   dependsOn: []                                 # the dependiencies
@@ -34,7 +34,7 @@ jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 180
-    pool: ${{ parameters.vmImage }}
+    pool: ${{ parameters.pool }}
     dependsOn: ${{ parameters.dependsOn }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}

--- a/scripts/azure-templates-build.yml
+++ b/scripts/azure-templates-build.yml
@@ -16,7 +16,7 @@ parameters:
   condition: succeeded()                        # whether or not to run this template
   shouldPublish: true                           # whether or not to publish the artifacts
   configuration: $(CONFIGURATION)               # the build configuration
-  isBuildPipeline: true
+  buildPipelineType: 'both'                     # the type of build pipeline setup
   verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
@@ -44,7 +44,7 @@ jobs:
         submodules: recursive
       - template: azure-templates-variables.yml
 
-      - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+      - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
         - template: azure-templates-github-status.yml
           parameters:
             state: 'pending'
@@ -271,5 +271,5 @@ jobs:
             verbosity: 'Verbose'
             alertWarningLevel: 'High'
 
-      - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+      - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
         - template: azure-templates-github-status.yml

--- a/scripts/azure-templates-download.yml
+++ b/scripts/azure-templates-download.yml
@@ -1,7 +1,7 @@
 parameters:
   name: ''                                      # in the form type_platform_host
   displayName: ''                               # the human name
-  vmImage: ''                                   # the VM image
+  pool: ''                                      # the agent pool
   condition: succeeded()                        # whether or not to run this template
   buildExternals: ''                            # the build number to download externals from
   postBuildSteps: []                            # any additional steps to run after the build
@@ -10,7 +10,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     displayName: ${{ parameters.displayName }}
-    pool: ${{ parameters.vmImage }}
+    pool: ${{ parameters.pool }}
     condition: ${{ parameters.condition }}
     variables: ${{ parameters.variables }}
     steps:

--- a/scripts/azure-templates-linux-matrix.yml
+++ b/scripts/azure-templates-linux-matrix.yml
@@ -1,7 +1,7 @@
 parameters:
   artifactName: ''                              # the name of the artifact to merge this run into
   buildExternals: ''                            # the build number to download externals from
-  isBuildPipeline: true
+  buildPipelineType: 'both'                     # the type of build pipeline setup
   vmImage: ''                                   # the VM image
   builds:
     - name: ''
@@ -25,7 +25,7 @@ jobs:
           name: ${{ replace(replace(format('native_linux_{0}_{1}_{2}_{3}_linux', item.arch, item.variant, build.name, item.alt), '__', '_'), '__', '_') }}
           displayName: Linux ${{ replace(replace(replace(replace(replace(format('({0}|{1}|{2}|{3})', item.arch, item.variant, build.name, item.alt), '||', '|'), '||', '|'), '(|', '('), '|)', ')'), '|', ', ') }}
           buildExternals: ${{ parameters.buildExternals }}
-          isBuildPipeline: ${{ parameters.isBuildPipeline }}
+          buildPipelineType: ${{ parameters.buildPipelineType }}
           vmImage: ${{ parameters.vmImage }}
           docker: ${{ item.docker }}
           dockerArgs: ${{ item.dockerArgs }}

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -20,915 +20,916 @@ stages:
           - template: azure-templates-variables.yml
             parameters:
               updateBuild: true
-          - template: azure-templates-github-status.yml
-            parameters:
-              context: 'SkiaSharp-Tests'
-              state: 'pending'
-              displayName: Queue up the status for the tests pipeline
-          - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-            - template: azure-templates-github-status.yml
-
-  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-    - stage: native_windows
-      displayName: Native Windows
-      dependsOn: prepare
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (Win)
-          parameters:
-            name: native_android_x86_windows
-            displayName: Android x86
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=x86
-            installWindowsSdk: false
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (Win)
-          parameters:
-            name: native_android_x64_windows
-            displayName: Android x64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=x64
-            installWindowsSdk: false
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Android|arm (Win)
-          parameters:
-            name: native_android_arm_windows
-            displayName: Android arm
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=arm
-            installWindowsSdk: false
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (Win)
-          parameters:
-            name: native_android_arm64_windows
-            displayName: Android arm64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=arm64
-            installWindowsSdk: false
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Tizen (Win)
-          parameters:
-            name: native_tizen_windows
-            displayName: Tizen
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-tizen
-            installWindowsSdk: false
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x86 (Win)
-          parameters:
-            name: native_uwp_angle_x86_windows
-            displayName: ANGLE x86
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: ANGLE
-            additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x64 (Win)
-          parameters:
-            name: native_uwp_angle_x64_windows
-            displayName: ANGLE x64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: ANGLE
-            additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm (Win)
-          parameters:
-            name: native_uwp_angle_arm_windows
-            displayName: ANGLE arm
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: ANGLE
-            additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm64 (Win)
-          parameters:
-            name: native_uwp_angle_arm64_windows
-            displayName: ANGLE arm64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: ANGLE
-            additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native UWP|x86 (Win)
-          parameters:
-            name: native_uwp_x86_windows
-            displayName: UWP x86
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-uwp
-            additionalArgs: --buildarch=x86 --skipAngle=true
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native UWP|x64 (Win)
-          parameters:
-            name: native_uwp_x64_windows
-            displayName: UWP x64
-            buildExternals: ${{ parameters.buildExternals }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-uwp
-            additionalArgs: --buildarch=x64 --skipAngle=true
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native UWP|arm (Win)
-          parameters:
-            name: native_uwp_arm_windows
-            displayName: UWP arm
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-uwp
-            additionalArgs: --buildarch=arm --skipAngle=true
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native UWP|arm64 (Win)
-          parameters:
-            name: native_uwp_arm64_windows
-            displayName: UWP arm64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-uwp
-            additionalArgs: --buildarch=arm64 --skipAngle=true
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Win32|x86 (Win)
-          parameters:
-            name: native_win32_x86_windows
-            displayName: Win32 x86
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-windows
-            additionalArgs: --buildarch=x86
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Win32|x64 (Win)
-          parameters:
-            name: native_win32_x64_windows
-            displayName: Win32 x64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-windows
-            additionalArgs: --buildarch=x64
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Win32|arm64 (Win)
-          parameters:
-            name: native_win32_arm64_windows
-            displayName: Win32 arm64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-windows
-            additionalArgs: --buildarch=arm64
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native NanoServer|x64 (Win)
-          parameters:
-            name: native_win32_x64_nanoserver_windows
-            displayName: Nano Server x64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-            target: externals-nanoserver
-            additionalArgs: --buildarch=x64
-            artifactName: native
-
-  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-    - stage: native_macos
-      displayName: Native macOS
-      dependsOn: prepare
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (macOS)
-          parameters:
-            name: native_android_x86_macos
-            displayName: Android x86
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=x86
-        - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
-          parameters:
-            name: native_android_x64_macos
-            displayName: Android x64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=x64
-        - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
-          parameters:
-            name: native_android_arm_macos
-            displayName: Android arm
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=arm
-        - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
-          parameters:
-            name: native_android_arm64_macos
-            displayName: Android arm64
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-android
-            additionalArgs: --buildarch=arm64
-        - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
-          parameters:
-            name: native_ios_macos
-            displayName: iOS
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-ios
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
-          parameters:
-            name: native_maccatalyst_macos
-            displayName: Mac Catalyst
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-maccatalyst
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
-          parameters:
-            name: native_macos_macos
-            displayName: macOS
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-macos
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
-          parameters:
-            name: native_tvos_macos
-            displayName: tvOS
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-tvos
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
-          parameters:
-            name: native_watchos_macos
-            displayName: watchOS
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-watchos
-            artifactName: native
-        - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
-          parameters:
-            name: native_tizen_macos
-            displayName: Tizen
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-            target: externals-tizen
-            condition: false # TODO: TIZEN INSTALL BUGS
-
-  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-    - stage: native_linux
-      displayName: Native Linux
-      dependsOn: prepare
-      jobs:
-        - template: azure-templates-linux-matrix.yml # Build Native Linux (Linux)
-          parameters:
-            artifactName: native
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
-            builds:
-              - name: ''
-              - name: nodeps
-                desc: 'No Deps'
-                additionalArgs: --verifyExcluded=fontconfig
-                gnArgs: skia_use_fontconfig=false
-            matrix:
-              - arch: x64
-                docker: scripts/Docker/debian9/amd64
-              - arch: x64
-                variant: alpine
-                docker: scripts/Docker/alpine/amd64
-              - arch: arm
-                docker: scripts/Docker/debian9/clang-cross
-                target: externals-linux-clang-cross
-              - arch: arm64
-                docker: scripts/Docker/debian9/clang-cross
-                dockerArgs: --build-arg TOOLCHAIN_ARCH=aarch64-linux-gnu --build-arg TOOLCHAIN_ARCH_SHORT=arm64
-                target: externals-linux-clang-cross
-        - template: azure-templates-bootstrapper.yml # Build Native Tizen (Linux)
-          parameters:
-            name: native_tizen_linux
-            displayName: Tizen
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
-            packages: $(TIZEN_LINUX_PACKAGES)
-            target: externals-tizen
-
-  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-    - stage: native_wasm
-      displayName: Native WASM
-      dependsOn: prepare
-      jobs:
-        - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
-          parameters:
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
-            artifactName: native
-            emscripten:
-              - 2.0.5
-              - 2.0.6
-              - 2.0.9
-              - 2.0.11
-              - 2.0.12
-              - 2.0.23
-
-  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-    - stage: managed
-      displayName: Build Managed
-      dependsOn:
-        - native_windows
-        - native_macos
-        - native_linux
-        - native_wasm
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Build Managed (Windows)
-          parameters:
-            name: managed_windows
-            displayName: Managed (Windows)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: libs
-            additionalArgs: --skipExternals="all"
-            installPreviewVs: true
-            requiredArtifacts:
-              - name: native
-            artifactName: managed
-            postBuildSteps:
-              - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
-                displayName: Delete the native folder
-        - template: azure-templates-bootstrapper.yml # Build Managed (macOS)
-          parameters:
-            name: managed_macos
-            displayName: Managed (macOS)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC }}
-            target: libs
-            additionalArgs: --skipExternals="all"
-            requiredArtifacts:
-              - name: native
-            artifactName: managed
-            postBuildSteps:
-              - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
-                displayName: Delete the native folder
-        - template: azure-templates-bootstrapper.yml # Build Managed (Linux)
-          parameters:
-            name: managed_linux
-            displayName: Managed (Linux)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-            packages: $(MANAGED_LINUX_PACKAGES)
-            target: libs
-            additionalArgs: --skipExternals="all"
-            requiredArtifacts:
-              - name: native
-            artifactName: managed
-            postBuildSteps:
-              - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
-                displayName: Delete the native folder
-
-  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-    - stage: package
-      displayName: Package NuGets
-      dependsOn: managed
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Package NuGets
-          parameters:
-            name: package_windows
-            displayName: Package NuGets
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: nuget
-            additionalArgs: --packall=true --skipbuild=true
-            installWindowsSdk: false
-            installAndroidSdk: false
-            installDotNet: false
-            requiredArtifacts:
-              - name: managed
-              - name: native
-            postBuildSteps:
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the nuget artifacts
-                inputs:
-                  artifactName: nuget
-                  pathToPublish: 'output/nugets'
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the special nuget artifacts
-                inputs:
-                  artifactName: nuget_special
-                  pathToPublish: 'output/nugets-special'
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the special nuget artifacts
-                inputs:
-                  artifactName: nuget_symbols
-                  pathToPublish: 'output/nugets-symbols'
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the SignList.xml into nuget artifacts
-                inputs:
-                  artifactName: nuget
-                  pathToPublish: 'SignList.xml'
-              - pwsh: |
-                  Remove-Item ./output/native/ -Recurse -Force
-                  Remove-Item ./output/nugets/ -Recurse -Force
-                  Remove-Item ./output/nugets-special/ -Recurse -Force
-                  Remove-Item ./output/nugets-symbols/ -Recurse -Force
-                displayName: Delete the pre-published folders
-
-  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
-    - stage: api_diff
-      displayName: API Diff
-      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-        dependsOn: prepare
-      ${{ if eq(parameters.buildPipelineType, 'both') }}:
-        dependsOn: package
-      jobs:
-        - template: azure-templates-bootstrapper.yml # API Diff
-          parameters:
-            name: api_diff_windows
-            displayName: API Diff
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: docs-api-diff
-            additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: package_windows
-              - name: nuget
-                dir: nugets
-            preBuildSteps:
-              - pwsh: .\scripts\install-gtk.ps1
-                displayName: Install GTK# 2.12
-            postBuildSteps:
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the API diffs
-                condition: always()
-                inputs:
-                  artifactName: api-diff
-                  pathToPublish: '$(Build.SourcesDirectory)\output\api-diff'
-
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
-    - stage: signing
-      displayName: Sign NuGets
-      dependsOn: package
-      jobs:
-        - template: sign-artifacts/jobs/v2.yml@xamarin-templates
-          parameters:
-            ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/')) }}:
-              signType: 'Real'
-            ${{ if not(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))) }}:
-              signType: 'Test'
-
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
-    - stage: sbom
-      displayName: 'Software Bill of Materials'
-      dependsOn: signing
-      jobs:
-      - template: compliance/sbom/job.v1.yml@xamarin-templates        # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
-        parameters:
-          artifactNames: ['nuget']
-          packageName: 'SkiaSharp'
-          packageFilter: '*.nupkg'
-
-  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
-    - stage: tests
-      displayName: Tests
-      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-        dependsOn: prepare
-      ${{ if eq(parameters.buildPipelineType, 'both') }}:
-        dependsOn:
-          - native_windows
-          - native_macos
-          - native_linux
-          - native_wasm
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Tests|netfx (Windows)
-          parameters:
-            name: tests_netfx_windows
-            displayName: Windows (.NET Framework)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: tests-netfx
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            installPreviewVs: true
-            installWindowsSdk: false
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_win32_x86_windows
-              - name: native_win32_x64_windows
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the .NET Framework test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
-                  testRunTitle: 'Windows .NET Framework Tests'
-        - template: azure-templates-bootstrapper.yml # Tests|netcore (Windows)
-          parameters:
-            name: tests_netcore_windows
-            displayName: Windows (.NET Core)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: tests-netcore
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            installWindowsSdk: false
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_win32_x86_windows
-              - name: native_win32_x64_windows
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the .NET Core test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
-                  testRunTitle: 'Windows .NET Core Tests'
-              - task: PublishBuildArtifacts@1
-                displayName: 'Publish the code coverage results'
-                inputs:
-                  artifactName: coverage_netcore_windows
-                  pathToPublish: 'output/coverage'
-        - template: azure-templates-bootstrapper.yml # Tests|netfx (macOS)
-          parameters:
-            name: tests_netfx_macos
-            displayName: macOS (.NET Framework)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC }}
-            target: tests-netfx
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_macos_macos
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the Mono test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
-                  testRunTitle: 'macOS Mono Tests'
-        - template: azure-templates-bootstrapper.yml # Tests|netcore (macOS)
-          parameters:
-            name: tests_netcore_macos
-            displayName: macOS (.NET Core)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC }}
-            target: tests-netcore
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_macos_macos
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the .NET Core test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
-                  testRunTitle: 'macOS .NET Core Tests'
-              - task: PublishBuildArtifacts@1
-                displayName: 'Publish the code coverage results'
-                inputs:
-                  artifactName: coverage_netcore_macos
-                  pathToPublish: 'output/coverage'
-        - template: azure-templates-bootstrapper.yml # Tests|android (macOS)
-          parameters:
-            name: tests_android_macos
-            displayName: Android (macOS)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC }}
-            target: tests-android
-            additionalArgs: --device=android-emulator-64_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_android_x86_macos
-              - name: native_android_x64_macos
-              - name: native_android_arm_macos
-              - name: native_android_arm64_macos
-            preBuildSteps:
-              - pwsh: .\scripts\install-android-package.ps1 -Package "emulator"
-                displayName: Install the Android emulator
-              - pwsh: .\scripts\install-android-package.ps1 -Package "system-images;android-30;google_apis_playstore;x86_64"
-                displayName: Install the Android API 30 emulator image
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the Android test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'output/logs/testlogs/SkiaSharp.Android.Tests/**/TestResults.xml'
-                  testRunTitle: 'Android Tests'
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the test logs
-                condition: always()
-                inputs:
-                  artifactName: testlogs_android
-                  pathToPublish: 'output/logs/testlogs'
-        - template: azure-templates-bootstrapper.yml # Tests|ios (macOS)
-          parameters:
-            name: tests_ios_macos
-            displayName: iOS (macOS)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC }}
-            target: tests-ios
-            additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_ios_macos
-            preBuildSteps:
-              - template: azure-templates-provisioning-profiles.yml
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the iOS test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'output/logs/testlogs/SkiaSharp.iOS.Tests/**/TestResults.xml'
-                  testRunTitle: 'iOS Tests'
-              - task: PublishBuildArtifacts@1
-                displayName: Publish the test logs
-                condition: always()
-                inputs:
-                  artifactName: testlogs_ios
-                  pathToPublish: 'output/logs/testlogs'
-        - template: azure-templates-bootstrapper.yml # Tests|netfx (Linux)
-          parameters:
-            name: tests_netfx_linux
-            displayName: Linux (.NET Framework)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-            packages: $(MANAGED_LINUX_PACKAGES)
-            target: tests-netfx
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_linux_x64_linux
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the Mono test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
-                  testRunTitle: 'Linux Mono Tests'
-        - template: azure-templates-bootstrapper.yml # Tests|netcore (Linux)
-          parameters:
-            name: tests_netcore_linux
-            displayName: Linux (.NET Core)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-            packages: $(MANAGED_LINUX_PACKAGES)
-            target: tests-netcore
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_linux_x64_linux
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the .NET Core test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
-                  testRunTitle: 'Linux .NET Core Tests'
-              - task: PublishBuildArtifacts@1
-                displayName: 'Publish the code coverage results'
-                inputs:
-                  artifactName: coverage_netcore_linux
-                  pathToPublish: 'output/coverage'
-        - template: azure-templates-bootstrapper.yml # Tests [WASM] (Linux)
-          parameters:
-            name: tests_wasm_linux
-            displayName: WASM (Linux)
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-            packages: $(MANAGED_LINUX_PACKAGES) ninja-build
-            target: tests-wasm
-            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
-            shouldPublish: false
-            requiredArtifacts:
-              - name: native_wasm_linux
-            installEmsdk: true
-            initScript: source ~/emsdk/emsdk_env.sh
-            postBuildSteps:
-              - task: PublishTestResults@2
-                displayName: Publish the WASM test results
-                condition: always()
-                inputs:
-                  testResultsFormat: xUnit
-                  testResultsFiles: 'tests/SkiaSharp*.Wasm.Tests/**/TestResults.xml'
-                  testRunTitle: 'Linux WASM Tests'
-        # TODO: add tests for linux alpine
-        # TODO: add tests for linux no dependencies
-        # TODO: add tests for windows nano server
-        - job: coverage_reports                      # Coverage Reports
-          displayName: Coverage Reports
-          pool: ${{ parameters.VM_IMAGE_LINUX }}
-          dependsOn:
-            - tests_netcore_windows
-            - tests_netcore_macos
-            - tests_netcore_linux
-          steps:
-            - checkout: self
-            - template: azure-templates-variables.yml
-            - template: azure-templates-github-status.yml
-              parameters:
-                state: 'pending'
-            - task: DownloadBuildArtifacts@0
-              displayName: Download the coverage_netcore_windows artifact
-              inputs:
-                artifactName: coverage_netcore_windows
-                downloadPath: output
-            - task: DownloadBuildArtifacts@0
-              displayName: Download the coverage_netcore_macos artifact
-              inputs:
-                artifactName: coverage_netcore_macos
-                downloadPath: output
-            - task: DownloadBuildArtifacts@0
-              displayName: Download the coverage_netcore_linux artifact
-              inputs:
-                artifactName: coverage_netcore_linux
-                downloadPath: output
-            - task: PublishCodeCoverageResults@1
-              displayName: 'Publish the code coverage results'
-              inputs:
-                codeCoverageTool: Cobertura
-                summaryFileLocation: 'output/**/Cobertura.xml'
-            - template: azure-templates-github-status.yml
-
-  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
-    - stage: samples
-      displayName: Samples
-      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-        dependsOn: prepare
-      ${{ if eq(parameters.buildPipelineType, 'both') }}:
-        dependsOn: package
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Build Samples (Windows)
-          parameters:
-            name: samples_windows
-            displayName: Windows
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: samples
-            installPreviewVs: true
-            requiredArtifacts:
-              - name: nuget
-                dir: nugets
-            postBuildSteps:
-              - pwsh: Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
-                displayName: Delete the nugets folder
-        - template: azure-templates-bootstrapper.yml # Build Samples (macOS)
-          parameters:
-            name: samples_macos
-            displayName: macOS
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_MAC }}
-            target: samples
-            shouldPublish: false
-            requiredArtifacts:
-              - name: nuget
-                dir: nugets
-            preBuildSteps:
-              - template: azure-templates-provisioning-profiles.yml
-        - template: azure-templates-bootstrapper.yml # Build Samples (Linux)
-          parameters:
-            name: samples_linux
-            displayName: Linux
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-            packages: $(MANAGED_LINUX_PACKAGES)
-            target: samples
-            shouldPublish: false
-            requiredArtifacts:
-              - name: nuget
-                dir: nugets
-            installEmsdk: true
-            initScript: source ~/emsdk/emsdk_env.sh
-
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests')) }}:
-    - stage: checks
-      displayName: Run Code Checks
-      dependsOn: prepare
-      jobs:
-        - template: azure-templates-bootstrapper.yml # Run Code Checks
-          parameters:
-            name: native_checks_windows
-            displayName: Run Code Checks
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
-            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-            target: git-sync-deps
-            installWindowsSdk: false
-            installAndroidSdk: false
-            installDotNet: false
-            shouldPublish: false
-            postBuildSteps:
-              - task: CredScan@2
-                displayName: Analyze source for credentials
-                condition: always()
-                inputs:
-                  toolMajorVersion: 'V2'
-              - task: PoliCheck@1
-                displayName: Run PoliCheck
-                condition: always()
-                inputs:
-                  inputType: 'Basic'
-                  targetType: 'F'
-              - task: SdtReport@1
-                displayName: Create security analysis report
-                condition: always()
-                inputs:
-                  AllTools: false
-                  APIScan: false
-                  BinSkim: false
-                  CodesignValidation: false
-                  CredScan: true
-                  FortifySCA: false
-                  FxCop: false
-                  ModernCop: false
-                  MSRD: false
-                  PoliCheck: true
-                  RoslynAnalyzers: false
-                  SDLNativeRules: false
-                  Semmle: false
-                  TSLint: false
-                  ToolLogsNotFoundAction: 'Standard'
-              - task: PublishSecurityAnalysisLogs@3
-                displayName: Publish security analysis logs
-                condition: always()
-              - task: TSAUpload@1
-                displayName: Publish TSA logs
-                condition: always()
-                continueOnError: true
-                inputs:
-                  tsaVersion: 'TsaV2'
-                  codebase: 'NewOrUpdate'
-                  tsaEnvironment: 'PROD'
-                  codeBaseName: 'SkiaSharp_main'
-                  notificationAlias: 'xamacomd@microsoft.com'
-                  notifyAlwaysV2: false
-                  instanceUrlForTsaV2: 'DEVDIV'
-                  projectNameDEVDIV: 'DevDiv'
-                  areaPath: 'DevDiv\VS Client - Runtime SDKs\SkiaSharp'
-                  iterationPath: 'DevDiv\OneVS'
-                  uploadAPIScan: false
-                  uploadBinSkim: false
-                  uploadCredScan: true
-                  uploadFortifySCA: false
-                  uploadFxCop: false
-                  uploadModernCop: false
-                  uploadPoliCheck: true
-                  uploadPREfast: false
-                  uploadRoslyn: false
-                  uploadTSLint: false
-                  uploadAsync: true
-
-  - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-    - stage: finalize
-      displayName: Finalize Build
-      dependsOn:
-        - api_diff
-        - samples
-        - tests
-      jobs:
-        - job: finalize                              # Finalize Build
-          displayName: Finalize Build
-          pool: ${{ parameters.VM_IMAGE_LINUX }}
-          steps:
-            - checkout: none
-            - template: azure-templates-variables.yml
+          - ${{ if eq(parameters.buildPipelineType, 'build') }}:
             - template: azure-templates-github-status.yml
               parameters:
                 context: 'SkiaSharp-Tests'
-                displayName: Update the final status for the tests pipeline
+                state: 'pending'
+                displayName: Queue up the status for the tests pipeline
+          - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+            - template: azure-templates-github-status.yml
+
+  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: native_windows
+  #     displayName: Native Windows
+  #     dependsOn: prepare
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (Win)
+  #         parameters:
+  #           name: native_android_x86_windows
+  #           displayName: Android x86
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=x86
+  #           installWindowsSdk: false
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (Win)
+  #         parameters:
+  #           name: native_android_x64_windows
+  #           displayName: Android x64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=x64
+  #           installWindowsSdk: false
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (Win)
+  #         parameters:
+  #           name: native_android_arm_windows
+  #           displayName: Android arm
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=arm
+  #           installWindowsSdk: false
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (Win)
+  #         parameters:
+  #           name: native_android_arm64_windows
+  #           displayName: Android arm64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=arm64
+  #           installWindowsSdk: false
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Win)
+  #         parameters:
+  #           name: native_tizen_windows
+  #           displayName: Tizen
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-tizen
+  #           installWindowsSdk: false
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x86 (Win)
+  #         parameters:
+  #           name: native_uwp_angle_x86_windows
+  #           displayName: ANGLE x86
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: ANGLE
+  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x64 (Win)
+  #         parameters:
+  #           name: native_uwp_angle_x64_windows
+  #           displayName: ANGLE x64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: ANGLE
+  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm (Win)
+  #         parameters:
+  #           name: native_uwp_angle_arm_windows
+  #           displayName: ANGLE arm
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: ANGLE
+  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm64 (Win)
+  #         parameters:
+  #           name: native_uwp_angle_arm64_windows
+  #           displayName: ANGLE arm64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: ANGLE
+  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|x86 (Win)
+  #         parameters:
+  #           name: native_uwp_x86_windows
+  #           displayName: UWP x86
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-uwp
+  #           additionalArgs: --buildarch=x86 --skipAngle=true
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|x64 (Win)
+  #         parameters:
+  #           name: native_uwp_x64_windows
+  #           displayName: UWP x64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-uwp
+  #           additionalArgs: --buildarch=x64 --skipAngle=true
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm (Win)
+  #         parameters:
+  #           name: native_uwp_arm_windows
+  #           displayName: UWP arm
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-uwp
+  #           additionalArgs: --buildarch=arm --skipAngle=true
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm64 (Win)
+  #         parameters:
+  #           name: native_uwp_arm64_windows
+  #           displayName: UWP arm64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-uwp
+  #           additionalArgs: --buildarch=arm64 --skipAngle=true
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Win32|x86 (Win)
+  #         parameters:
+  #           name: native_win32_x86_windows
+  #           displayName: Win32 x86
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-windows
+  #           additionalArgs: --buildarch=x86
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Win32|x64 (Win)
+  #         parameters:
+  #           name: native_win32_x64_windows
+  #           displayName: Win32 x64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-windows
+  #           additionalArgs: --buildarch=x64
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Win32|arm64 (Win)
+  #         parameters:
+  #           name: native_win32_arm64_windows
+  #           displayName: Win32 arm64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-windows
+  #           additionalArgs: --buildarch=arm64
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native NanoServer|x64 (Win)
+  #         parameters:
+  #           name: native_win32_x64_nanoserver_windows
+  #           displayName: Nano Server x64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+  #           target: externals-nanoserver
+  #           additionalArgs: --buildarch=x64
+  #           artifactName: native
+
+  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: native_macos
+  #     displayName: Native macOS
+  #     dependsOn: prepare
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (macOS)
+  #         parameters:
+  #           name: native_android_x86_macos
+  #           displayName: Android x86
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=x86
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
+  #         parameters:
+  #           name: native_android_x64_macos
+  #           displayName: Android x64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=x64
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
+  #         parameters:
+  #           name: native_android_arm_macos
+  #           displayName: Android arm
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=arm
+  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
+  #         parameters:
+  #           name: native_android_arm64_macos
+  #           displayName: Android arm64
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-android
+  #           additionalArgs: --buildarch=arm64
+  #       - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
+  #         parameters:
+  #           name: native_ios_macos
+  #           displayName: iOS
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-ios
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
+  #         parameters:
+  #           name: native_maccatalyst_macos
+  #           displayName: Mac Catalyst
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-maccatalyst
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
+  #         parameters:
+  #           name: native_macos_macos
+  #           displayName: macOS
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-macos
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
+  #         parameters:
+  #           name: native_tvos_macos
+  #           displayName: tvOS
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-tvos
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
+  #         parameters:
+  #           name: native_watchos_macos
+  #           displayName: watchOS
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-watchos
+  #           artifactName: native
+  #       - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
+  #         parameters:
+  #           name: native_tizen_macos
+  #           displayName: Tizen
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+  #           target: externals-tizen
+  #           condition: false # TODO: TIZEN INSTALL BUGS
+
+  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: native_linux
+  #     displayName: Native Linux
+  #     dependsOn: prepare
+  #     jobs:
+  #       - template: azure-templates-linux-matrix.yml # Build Native Linux (Linux)
+  #         parameters:
+  #           artifactName: native
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
+  #           builds:
+  #             - name: ''
+  #             - name: nodeps
+  #               desc: 'No Deps'
+  #               additionalArgs: --verifyExcluded=fontconfig
+  #               gnArgs: skia_use_fontconfig=false
+  #           matrix:
+  #             - arch: x64
+  #               docker: scripts/Docker/debian9/amd64
+  #             - arch: x64
+  #               variant: alpine
+  #               docker: scripts/Docker/alpine/amd64
+  #             - arch: arm
+  #               docker: scripts/Docker/debian9/clang-cross
+  #               target: externals-linux-clang-cross
+  #             - arch: arm64
+  #               docker: scripts/Docker/debian9/clang-cross
+  #               dockerArgs: --build-arg TOOLCHAIN_ARCH=aarch64-linux-gnu --build-arg TOOLCHAIN_ARCH_SHORT=arm64
+  #               target: externals-linux-clang-cross
+  #       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Linux)
+  #         parameters:
+  #           name: native_tizen_linux
+  #           displayName: Tizen
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
+  #           packages: $(TIZEN_LINUX_PACKAGES)
+  #           target: externals-tizen
+
+  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: native_wasm
+  #     displayName: Native WASM
+  #     dependsOn: prepare
+  #     jobs:
+  #       - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
+  #         parameters:
+  #           buildExternals: ${{ parameters.buildExternals }}
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
+  #           artifactName: native
+  #           emscripten:
+  #             - 2.0.5
+  #             - 2.0.6
+  #             - 2.0.9
+  #             - 2.0.11
+  #             - 2.0.12
+  #             - 2.0.23
+
+  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: managed
+  #     displayName: Build Managed
+  #     dependsOn:
+  #       - native_windows
+  #       - native_macos
+  #       - native_linux
+  #       - native_wasm
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Build Managed (Windows)
+  #         parameters:
+  #           name: managed_windows
+  #           displayName: Managed (Windows)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: libs
+  #           additionalArgs: --skipExternals="all"
+  #           installPreviewVs: true
+  #           requiredArtifacts:
+  #             - name: native
+  #           artifactName: managed
+  #           postBuildSteps:
+  #             - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
+  #               displayName: Delete the native folder
+  #       - template: azure-templates-bootstrapper.yml # Build Managed (macOS)
+  #         parameters:
+  #           name: managed_macos
+  #           displayName: Managed (macOS)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
+  #           target: libs
+  #           additionalArgs: --skipExternals="all"
+  #           requiredArtifacts:
+  #             - name: native
+  #           artifactName: managed
+  #           postBuildSteps:
+  #             - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
+  #               displayName: Delete the native folder
+  #       - template: azure-templates-bootstrapper.yml # Build Managed (Linux)
+  #         parameters:
+  #           name: managed_linux
+  #           displayName: Managed (Linux)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+  #           packages: $(MANAGED_LINUX_PACKAGES)
+  #           target: libs
+  #           additionalArgs: --skipExternals="all"
+  #           requiredArtifacts:
+  #             - name: native
+  #           artifactName: managed
+  #           postBuildSteps:
+  #             - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
+  #               displayName: Delete the native folder
+
+  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: package
+  #     displayName: Package NuGets
+  #     dependsOn: managed
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Package NuGets
+  #         parameters:
+  #           name: package_windows
+  #           displayName: Package NuGets
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: nuget
+  #           additionalArgs: --packall=true --skipbuild=true
+  #           installWindowsSdk: false
+  #           installAndroidSdk: false
+  #           installDotNet: false
+  #           requiredArtifacts:
+  #             - name: managed
+  #             - name: native
+  #           postBuildSteps:
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the nuget artifacts
+  #               inputs:
+  #                 artifactName: nuget
+  #                 pathToPublish: 'output/nugets'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the special nuget artifacts
+  #               inputs:
+  #                 artifactName: nuget_special
+  #                 pathToPublish: 'output/nugets-special'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the special nuget artifacts
+  #               inputs:
+  #                 artifactName: nuget_symbols
+  #                 pathToPublish: 'output/nugets-symbols'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the SignList.xml into nuget artifacts
+  #               inputs:
+  #                 artifactName: nuget
+  #                 pathToPublish: 'SignList.xml'
+  #             - pwsh: |
+  #                 Remove-Item ./output/native/ -Recurse -Force
+  #                 Remove-Item ./output/nugets/ -Recurse -Force
+  #                 Remove-Item ./output/nugets-special/ -Recurse -Force
+  #                 Remove-Item ./output/nugets-symbols/ -Recurse -Force
+  #               displayName: Delete the pre-published folders
+
+  # - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+  #   - stage: api_diff
+  #     displayName: API Diff
+  #     ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+  #       dependsOn: prepare
+  #     ${{ if eq(parameters.buildPipelineType, 'both') }}:
+  #       dependsOn: package
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # API Diff
+  #         parameters:
+  #           name: api_diff_windows
+  #           displayName: API Diff
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: docs-api-diff
+  #           additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: package_windows
+  #             - name: nuget
+  #               dir: nugets
+  #           preBuildSteps:
+  #             - pwsh: .\scripts\install-gtk.ps1
+  #               displayName: Install GTK# 2.12
+  #           postBuildSteps:
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the API diffs
+  #               condition: always()
+  #               inputs:
+  #                 artifactName: api-diff
+  #                 pathToPublish: '$(Build.SourcesDirectory)\output\api-diff'
+
+  # - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
+  #   - stage: signing
+  #     displayName: Sign NuGets
+  #     dependsOn: package
+  #     jobs:
+  #       - template: sign-artifacts/jobs/v2.yml@xamarin-templates
+  #         parameters:
+  #           ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/')) }}:
+  #             signType: 'Real'
+  #           ${{ if not(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))) }}:
+  #             signType: 'Test'
+
+  # - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
+  #   - stage: sbom
+  #     displayName: 'Software Bill of Materials'
+  #     dependsOn: signing
+  #     jobs:
+  #     - template: compliance/sbom/job.v1.yml@xamarin-templates        # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
+  #       parameters:
+  #         artifactNames: ['nuget']
+  #         packageName: 'SkiaSharp'
+  #         packageFilter: '*.nupkg'
+
+  # - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+  #   - stage: tests
+  #     displayName: Tests
+  #     ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+  #       dependsOn: prepare
+  #     ${{ if eq(parameters.buildPipelineType, 'both') }}:
+  #       dependsOn:
+  #         - native_windows
+  #         - native_macos
+  #         - native_linux
+  #         - native_wasm
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Tests|netfx (Windows)
+  #         parameters:
+  #           name: tests_netfx_windows
+  #           displayName: Windows (.NET Framework)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: tests-netfx
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           installPreviewVs: true
+  #           installWindowsSdk: false
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_win32_x86_windows
+  #             - name: native_win32_x64_windows
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the .NET Framework test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'Windows .NET Framework Tests'
+  #       - template: azure-templates-bootstrapper.yml # Tests|netcore (Windows)
+  #         parameters:
+  #           name: tests_netcore_windows
+  #           displayName: Windows (.NET Core)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: tests-netcore
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           installWindowsSdk: false
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_win32_x86_windows
+  #             - name: native_win32_x64_windows
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the .NET Core test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'Windows .NET Core Tests'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: 'Publish the code coverage results'
+  #               inputs:
+  #                 artifactName: coverage_netcore_windows
+  #                 pathToPublish: 'output/coverage'
+  #       - template: azure-templates-bootstrapper.yml # Tests|netfx (macOS)
+  #         parameters:
+  #           name: tests_netfx_macos
+  #           displayName: macOS (.NET Framework)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
+  #           target: tests-netfx
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_macos_macos
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the Mono test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'macOS Mono Tests'
+  #       - template: azure-templates-bootstrapper.yml # Tests|netcore (macOS)
+  #         parameters:
+  #           name: tests_netcore_macos
+  #           displayName: macOS (.NET Core)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
+  #           target: tests-netcore
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_macos_macos
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the .NET Core test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'macOS .NET Core Tests'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: 'Publish the code coverage results'
+  #               inputs:
+  #                 artifactName: coverage_netcore_macos
+  #                 pathToPublish: 'output/coverage'
+  #       - template: azure-templates-bootstrapper.yml # Tests|android (macOS)
+  #         parameters:
+  #           name: tests_android_macos
+  #           displayName: Android (macOS)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
+  #           target: tests-android
+  #           additionalArgs: --device=android-emulator-64_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_android_x86_macos
+  #             - name: native_android_x64_macos
+  #             - name: native_android_arm_macos
+  #             - name: native_android_arm64_macos
+  #           preBuildSteps:
+  #             - pwsh: .\scripts\install-android-package.ps1 -Package "emulator"
+  #               displayName: Install the Android emulator
+  #             - pwsh: .\scripts\install-android-package.ps1 -Package "system-images;android-30;google_apis_playstore;x86_64"
+  #               displayName: Install the Android API 30 emulator image
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the Android test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'output/logs/testlogs/SkiaSharp.Android.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'Android Tests'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the test logs
+  #               condition: always()
+  #               inputs:
+  #                 artifactName: testlogs_android
+  #                 pathToPublish: 'output/logs/testlogs'
+  #       - template: azure-templates-bootstrapper.yml # Tests|ios (macOS)
+  #         parameters:
+  #           name: tests_ios_macos
+  #           displayName: iOS (macOS)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
+  #           target: tests-ios
+  #           additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_ios_macos
+  #           preBuildSteps:
+  #             - template: azure-templates-provisioning-profiles.yml
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the iOS test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'output/logs/testlogs/SkiaSharp.iOS.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'iOS Tests'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: Publish the test logs
+  #               condition: always()
+  #               inputs:
+  #                 artifactName: testlogs_ios
+  #                 pathToPublish: 'output/logs/testlogs'
+  #       - template: azure-templates-bootstrapper.yml # Tests|netfx (Linux)
+  #         parameters:
+  #           name: tests_netfx_linux
+  #           displayName: Linux (.NET Framework)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+  #           packages: $(MANAGED_LINUX_PACKAGES)
+  #           target: tests-netfx
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_linux_x64_linux
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the Mono test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'Linux Mono Tests'
+  #       - template: azure-templates-bootstrapper.yml # Tests|netcore (Linux)
+  #         parameters:
+  #           name: tests_netcore_linux
+  #           displayName: Linux (.NET Core)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+  #           packages: $(MANAGED_LINUX_PACKAGES)
+  #           target: tests-netcore
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_linux_x64_linux
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the .NET Core test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'Linux .NET Core Tests'
+  #             - task: PublishBuildArtifacts@1
+  #               displayName: 'Publish the code coverage results'
+  #               inputs:
+  #                 artifactName: coverage_netcore_linux
+  #                 pathToPublish: 'output/coverage'
+  #       - template: azure-templates-bootstrapper.yml # Tests [WASM] (Linux)
+  #         parameters:
+  #           name: tests_wasm_linux
+  #           displayName: WASM (Linux)
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+  #           packages: $(MANAGED_LINUX_PACKAGES) ninja-build
+  #           target: tests-wasm
+  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: native_wasm_linux
+  #           installEmsdk: true
+  #           initScript: source ~/emsdk/emsdk_env.sh
+  #           postBuildSteps:
+  #             - task: PublishTestResults@2
+  #               displayName: Publish the WASM test results
+  #               condition: always()
+  #               inputs:
+  #                 testResultsFormat: xUnit
+  #                 testResultsFiles: 'tests/SkiaSharp*.Wasm.Tests/**/TestResults.xml'
+  #                 testRunTitle: 'Linux WASM Tests'
+  #       # TODO: add tests for linux alpine
+  #       # TODO: add tests for linux no dependencies
+  #       # TODO: add tests for windows nano server
+  #       - job: coverage_reports                      # Coverage Reports
+  #         displayName: Coverage Reports
+  #         pool: ${{ parameters.VM_IMAGE_LINUX }}
+  #         dependsOn:
+  #           - tests_netcore_windows
+  #           - tests_netcore_macos
+  #           - tests_netcore_linux
+  #         steps:
+  #           - checkout: self
+  #           - template: azure-templates-variables.yml
+  #           - template: azure-templates-github-status.yml
+  #             parameters:
+  #               state: 'pending'
+  #           - task: DownloadBuildArtifacts@0
+  #             displayName: Download the coverage_netcore_windows artifact
+  #             inputs:
+  #               artifactName: coverage_netcore_windows
+  #               downloadPath: output
+  #           - task: DownloadBuildArtifacts@0
+  #             displayName: Download the coverage_netcore_macos artifact
+  #             inputs:
+  #               artifactName: coverage_netcore_macos
+  #               downloadPath: output
+  #           - task: DownloadBuildArtifacts@0
+  #             displayName: Download the coverage_netcore_linux artifact
+  #             inputs:
+  #               artifactName: coverage_netcore_linux
+  #               downloadPath: output
+  #           - task: PublishCodeCoverageResults@1
+  #             displayName: 'Publish the code coverage results'
+  #             inputs:
+  #               codeCoverageTool: Cobertura
+  #               summaryFileLocation: 'output/**/Cobertura.xml'
+  #           - template: azure-templates-github-status.yml
+
+  # - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+  #   - stage: samples
+  #     displayName: Samples
+  #     ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+  #       dependsOn: prepare
+  #     ${{ if eq(parameters.buildPipelineType, 'both') }}:
+  #       dependsOn: package
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Build Samples (Windows)
+  #         parameters:
+  #           name: samples_windows
+  #           displayName: Windows
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: samples
+  #           installPreviewVs: true
+  #           requiredArtifacts:
+  #             - name: nuget
+  #               dir: nugets
+  #           postBuildSteps:
+  #             - pwsh: Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
+  #               displayName: Delete the nugets folder
+  #       - template: azure-templates-bootstrapper.yml # Build Samples (macOS)
+  #         parameters:
+  #           name: samples_macos
+  #           displayName: macOS
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
+  #           target: samples
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: nuget
+  #               dir: nugets
+  #           preBuildSteps:
+  #             - template: azure-templates-provisioning-profiles.yml
+  #       - template: azure-templates-bootstrapper.yml # Build Samples (Linux)
+  #         parameters:
+  #           name: samples_linux
+  #           displayName: Linux
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+  #           packages: $(MANAGED_LINUX_PACKAGES)
+  #           target: samples
+  #           shouldPublish: false
+  #           requiredArtifacts:
+  #             - name: nuget
+  #               dir: nugets
+  #           installEmsdk: true
+  #           initScript: source ~/emsdk/emsdk_env.sh
+
+  # - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests')) }}:
+  #   - stage: checks
+  #     displayName: Run Code Checks
+  #     dependsOn: prepare
+  #     jobs:
+  #       - template: azure-templates-bootstrapper.yml # Run Code Checks
+  #         parameters:
+  #           name: native_checks_windows
+  #           displayName: Run Code Checks
+  #           buildPipelineType: ${{ parameters.buildPipelineType }}
+  #           condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
+  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+  #           target: git-sync-deps
+  #           installWindowsSdk: false
+  #           installAndroidSdk: false
+  #           installDotNet: false
+  #           shouldPublish: false
+  #           postBuildSteps:
+  #             - task: CredScan@2
+  #               displayName: Analyze source for credentials
+  #               condition: always()
+  #               inputs:
+  #                 toolMajorVersion: 'V2'
+  #             - task: PoliCheck@1
+  #               displayName: Run PoliCheck
+  #               condition: always()
+  #               inputs:
+  #                 inputType: 'Basic'
+  #                 targetType: 'F'
+  #             - task: SdtReport@1
+  #               displayName: Create security analysis report
+  #               condition: always()
+  #               inputs:
+  #                 AllTools: false
+  #                 APIScan: false
+  #                 BinSkim: false
+  #                 CodesignValidation: false
+  #                 CredScan: true
+  #                 FortifySCA: false
+  #                 FxCop: false
+  #                 ModernCop: false
+  #                 MSRD: false
+  #                 PoliCheck: true
+  #                 RoslynAnalyzers: false
+  #                 SDLNativeRules: false
+  #                 Semmle: false
+  #                 TSLint: false
+  #                 ToolLogsNotFoundAction: 'Standard'
+  #             - task: PublishSecurityAnalysisLogs@3
+  #               displayName: Publish security analysis logs
+  #               condition: always()
+  #             - task: TSAUpload@1
+  #               displayName: Publish TSA logs
+  #               condition: always()
+  #               continueOnError: true
+  #               inputs:
+  #                 tsaVersion: 'TsaV2'
+  #                 codebase: 'NewOrUpdate'
+  #                 tsaEnvironment: 'PROD'
+  #                 codeBaseName: 'SkiaSharp_main'
+  #                 notificationAlias: 'xamacomd@microsoft.com'
+  #                 notifyAlwaysV2: false
+  #                 instanceUrlForTsaV2: 'DEVDIV'
+  #                 projectNameDEVDIV: 'DevDiv'
+  #                 areaPath: 'DevDiv\VS Client - Runtime SDKs\SkiaSharp'
+  #                 iterationPath: 'DevDiv\OneVS'
+  #                 uploadAPIScan: false
+  #                 uploadBinSkim: false
+  #                 uploadCredScan: true
+  #                 uploadFortifySCA: false
+  #                 uploadFxCop: false
+  #                 uploadModernCop: false
+  #                 uploadPoliCheck: true
+  #                 uploadPREfast: false
+  #                 uploadRoslyn: false
+  #                 uploadTSLint: false
+  #                 uploadAsync: true
+
+  # - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+  #   - stage: finalize
+  #     displayName: Finalize Build
+  #     dependsOn:
+  #       - api_diff
+  #       - samples
+  #       - tests
+  #     jobs:
+  #       - job: finalize                              # Finalize Build
+  #         displayName: Finalize Build
+  #         pool: ${{ parameters.VM_IMAGE_LINUX }}
+  #         steps:
+  #           - checkout: none
+  #           - template: azure-templates-variables.yml
+  #           - template: azure-templates-github-status.yml
+  #             parameters:
+  #               context: 'SkiaSharp-Tests'
+  #               displayName: Update the final status for the tests pipeline

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -14,7 +14,9 @@ stages:
     jobs:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
-        pool: ${{ parameters.VM_IMAGE_LINUX }}
+        pool:
+          name: Azure Pipelines
+          vmImage: ubuntu-18.04
         steps:
           - checkout: none
           - template: azure-templates-variables.yml

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -1,5 +1,5 @@
 parameters:
-  isBuildPipeline: true
+  buildPipelineType: 'both'
   buildExternals: 0
   VM_IMAGE_WINDOWS: ''
   VM_IMAGE_WINDOWS_NATIVE: ''
@@ -25,10 +25,10 @@ stages:
               context: 'SkiaSharp-Tests'
               state: 'pending'
               displayName: Queue up the status for the tests pipeline
-          - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+          - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
             - template: azure-templates-github-status.yml
 
-  - ${{ if eq(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: native_windows
       displayName: Native Windows
       dependsOn: prepare
@@ -38,7 +38,7 @@ stages:
             name: native_android_x86_windows
             displayName: Android x86
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=x86
@@ -49,7 +49,7 @@ stages:
             name: native_android_x64_windows
             displayName: Android x64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=x64
@@ -60,7 +60,7 @@ stages:
             name: native_android_arm_windows
             displayName: Android arm
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=arm
@@ -71,7 +71,7 @@ stages:
             name: native_android_arm64_windows
             displayName: Android arm64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=arm64
@@ -82,7 +82,7 @@ stages:
             name: native_tizen_windows
             displayName: Tizen
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-tizen
             installWindowsSdk: false
@@ -92,7 +92,7 @@ stages:
             name: native_uwp_angle_x86_windows
             displayName: ANGLE x86
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: ANGLE
             additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
@@ -102,7 +102,7 @@ stages:
             name: native_uwp_angle_x64_windows
             displayName: ANGLE x64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: ANGLE
             additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
@@ -112,7 +112,7 @@ stages:
             name: native_uwp_angle_arm_windows
             displayName: ANGLE arm
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: ANGLE
             additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
@@ -122,7 +122,7 @@ stages:
             name: native_uwp_angle_arm64_windows
             displayName: ANGLE arm64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: ANGLE
             additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
@@ -132,7 +132,7 @@ stages:
             name: native_uwp_x86_windows
             displayName: UWP x86
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-uwp
             additionalArgs: --buildarch=x86 --skipAngle=true
@@ -151,7 +151,7 @@ stages:
             name: native_uwp_arm_windows
             displayName: UWP arm
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-uwp
             additionalArgs: --buildarch=arm --skipAngle=true
@@ -161,7 +161,7 @@ stages:
             name: native_uwp_arm64_windows
             displayName: UWP arm64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-uwp
             additionalArgs: --buildarch=arm64 --skipAngle=true
@@ -171,7 +171,7 @@ stages:
             name: native_win32_x86_windows
             displayName: Win32 x86
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-windows
             additionalArgs: --buildarch=x86
@@ -181,7 +181,7 @@ stages:
             name: native_win32_x64_windows
             displayName: Win32 x64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-windows
             additionalArgs: --buildarch=x64
@@ -191,7 +191,7 @@ stages:
             name: native_win32_arm64_windows
             displayName: Win32 arm64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-windows
             additionalArgs: --buildarch=arm64
@@ -201,13 +201,13 @@ stages:
             name: native_win32_x64_nanoserver_windows
             displayName: Nano Server x64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
             target: externals-nanoserver
             additionalArgs: --buildarch=x64
             artifactName: native
 
-  - ${{ if eq(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: native_macos
       displayName: Native macOS
       dependsOn: prepare
@@ -217,7 +217,7 @@ stages:
             name: native_android_x86_macos
             displayName: Android x86
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=x86
@@ -226,7 +226,7 @@ stages:
             name: native_android_x64_macos
             displayName: Android x64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=x64
@@ -235,7 +235,7 @@ stages:
             name: native_android_arm_macos
             displayName: Android arm
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=arm
@@ -244,7 +244,7 @@ stages:
             name: native_android_arm64_macos
             displayName: Android arm64
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-android
             additionalArgs: --buildarch=arm64
@@ -253,7 +253,7 @@ stages:
             name: native_ios_macos
             displayName: iOS
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-ios
             artifactName: native
@@ -262,7 +262,7 @@ stages:
             name: native_maccatalyst_macos
             displayName: Mac Catalyst
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-maccatalyst
             artifactName: native
@@ -271,7 +271,7 @@ stages:
             name: native_macos_macos
             displayName: macOS
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-macos
             artifactName: native
@@ -280,7 +280,7 @@ stages:
             name: native_tvos_macos
             displayName: tvOS
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-tvos
             artifactName: native
@@ -289,7 +289,7 @@ stages:
             name: native_watchos_macos
             displayName: watchOS
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-watchos
             artifactName: native
@@ -298,12 +298,12 @@ stages:
             name: native_tizen_macos
             displayName: Tizen
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
             target: externals-tizen
             condition: false # TODO: TIZEN INSTALL BUGS
 
-  - ${{ if eq(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: native_linux
       displayName: Native Linux
       dependsOn: prepare
@@ -312,7 +312,7 @@ stages:
           parameters:
             artifactName: native
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
             builds:
               - name: ''
@@ -338,12 +338,12 @@ stages:
             name: native_tizen_linux
             displayName: Tizen
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
             packages: $(TIZEN_LINUX_PACKAGES)
             target: externals-tizen
 
-  - ${{ if eq(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: native_wasm
       displayName: Native WASM
       dependsOn: prepare
@@ -351,7 +351,7 @@ stages:
         - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
           parameters:
             buildExternals: ${{ parameters.buildExternals }}
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
             artifactName: native
             emscripten:
@@ -362,7 +362,7 @@ stages:
               - 2.0.12
               - 2.0.23
 
-  - ${{ if eq(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: managed
       displayName: Build Managed
       dependsOn:
@@ -375,7 +375,7 @@ stages:
           parameters:
             name: managed_windows
             displayName: Managed (Windows)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: libs
             additionalArgs: --skipExternals="all"
@@ -390,7 +390,7 @@ stages:
           parameters:
             name: managed_macos
             displayName: Managed (macOS)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC }}
             target: libs
             additionalArgs: --skipExternals="all"
@@ -404,7 +404,7 @@ stages:
           parameters:
             name: managed_linux
             displayName: Managed (Linux)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX }}
             packages: $(MANAGED_LINUX_PACKAGES)
             target: libs
@@ -416,7 +416,7 @@ stages:
               - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
                 displayName: Delete the native folder
 
-  - ${{ if eq(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: package
       displayName: Package NuGets
       dependsOn: managed
@@ -425,7 +425,7 @@ stages:
           parameters:
             name: package_windows
             displayName: Package NuGets
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: nuget
             additionalArgs: --packall=true --skipbuild=true
@@ -463,7 +463,7 @@ stages:
                   Remove-Item ./output/nugets-symbols/ -Recurse -Force
                 displayName: Delete the pre-published folders
 
-  - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: api_diff
       displayName: API Diff
       dependsOn: prepare
@@ -472,7 +472,7 @@ stages:
           parameters:
             name: api_diff_windows
             displayName: API Diff
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: docs-api-diff
             additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
@@ -492,7 +492,7 @@ stages:
                   artifactName: api-diff
                   pathToPublish: '$(Build.SourcesDirectory)\output\api-diff'
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), eq(parameters.isBuildPipeline, 'true'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
     - stage: signing
       displayName: Sign NuGets
       dependsOn: package
@@ -504,7 +504,7 @@ stages:
             ${{ if not(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))) }}:
               signType: 'Test'
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), eq(parameters.isBuildPipeline, 'true'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
     - stage: sbom
       displayName: 'Software Bill of Materials'
       dependsOn: signing
@@ -515,7 +515,7 @@ stages:
           packageName: 'SkiaSharp'
           packageFilter: '*.nupkg'
 
-  - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: tests
       displayName: Tests
       dependsOn: prepare
@@ -524,7 +524,7 @@ stages:
           parameters:
             name: tests_netfx_windows
             displayName: Windows (.NET Framework)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: tests-netfx
             additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -546,7 +546,7 @@ stages:
           parameters:
             name: tests_netcore_windows
             displayName: Windows (.NET Core)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: tests-netcore
             additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -572,7 +572,7 @@ stages:
           parameters:
             name: tests_netfx_macos
             displayName: macOS (.NET Framework)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC }}
             target: tests-netfx
             additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -591,7 +591,7 @@ stages:
           parameters:
             name: tests_netcore_macos
             displayName: macOS (.NET Core)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC }}
             target: tests-netcore
             additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -615,7 +615,7 @@ stages:
           parameters:
             name: tests_android_macos
             displayName: Android (macOS)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC }}
             target: tests-android
             additionalArgs: --device=android-emulator-64_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -648,7 +648,7 @@ stages:
           parameters:
             name: tests_ios_macos
             displayName: iOS (macOS)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC }}
             target: tests-ios
             additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
@@ -675,7 +675,7 @@ stages:
           parameters:
             name: tests_netfx_linux
             displayName: Linux (.NET Framework)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX }}
             packages: $(MANAGED_LINUX_PACKAGES)
             target: tests-netfx
@@ -695,7 +695,7 @@ stages:
           parameters:
             name: tests_netcore_linux
             displayName: Linux (.NET Core)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX }}
             packages: $(MANAGED_LINUX_PACKAGES)
             target: tests-netcore
@@ -720,7 +720,7 @@ stages:
           parameters:
             name: tests_wasm_linux
             displayName: WASM (Linux)
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX }}
             packages: $(MANAGED_LINUX_PACKAGES) ninja-build
             target: tests-wasm
@@ -776,7 +776,7 @@ stages:
                 summaryFileLocation: 'output/**/Cobertura.xml'
             - template: azure-templates-github-status.yml
 
-  - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: samples
       displayName: Samples
       dependsOn: prepare
@@ -785,7 +785,7 @@ stages:
           parameters:
             name: samples_windows
             displayName: Windows
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: samples
             installPreviewVs: true
@@ -799,7 +799,7 @@ stages:
           parameters:
             name: samples_macos
             displayName: macOS
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_MAC }}
             target: samples
             shouldPublish: false
@@ -812,7 +812,7 @@ stages:
           parameters:
             name: samples_linux
             displayName: Linux
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             vmImage: ${{ parameters.VM_IMAGE_LINUX }}
             packages: $(MANAGED_LINUX_PACKAGES)
             target: samples
@@ -823,7 +823,7 @@ stages:
             installEmsdk: true
             initScript: source ~/emsdk/emsdk_env.sh
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), eq(parameters.isBuildPipeline, 'true')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests')) }}:
     - stage: checks
       displayName: Run Code Checks
       dependsOn: prepare
@@ -832,7 +832,7 @@ stages:
           parameters:
             name: native_checks_windows
             displayName: Run Code Checks
-            isBuildPipeline: ${{ parameters.isBuildPipeline }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
             condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
             vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
             target: git-sync-deps
@@ -901,7 +901,7 @@ stages:
                   uploadTSLint: false
                   uploadAsync: true
 
-  - ${{ if ne(parameters.isBuildPipeline, 'true') }}:
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: finalize
       displayName: Finalize Build
       dependsOn:

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -5,6 +5,8 @@ parameters:
   - name: buildExternals
     type: number
     default: 0
+  - name: VM_IMAGE_HOST
+    type: object
   - name: VM_IMAGE_WINDOWS
     type: object
   - name: VM_IMAGE_WINDOWS_NATIVE
@@ -24,7 +26,7 @@ stages:
     jobs:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
-        pool: ${{ parameters.VM_IMAGE_LINUX }}
+        pool: ${{ parameters.VM_IMAGE_HOST.pool }}
         steps:
           - checkout: none
           - template: azure-templates-variables.yml
@@ -764,7 +766,7 @@ stages:
         # TODO: add tests for windows nano server
         - job: coverage_reports                      # Coverage Reports
           displayName: Coverage Reports
-          pool: ${{ parameters.VM_IMAGE_LINUX }}
+          pool: ${{ parameters.VM_IMAGE_HOST.pool }}
           dependsOn:
             - tests_netcore_windows
             - tests_netcore_macos
@@ -935,7 +937,7 @@ stages:
       jobs:
         - job: finalize                              # Finalize Build
           displayName: Finalize Build
-          pool: ${{ parameters.VM_IMAGE_LINUX }}
+          pool: ${{ parameters.VM_IMAGE_HOST.pool }}
           steps:
             - checkout: none
             - template: azure-templates-variables.yml

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -39,907 +39,907 @@ stages:
           - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
             - template: azure-templates-github-status.yml
 
-  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: native_windows
-  #     displayName: Native Windows
-  #     dependsOn: prepare
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (Win)
-  #         parameters:
-  #           name: native_android_x86_windows
-  #           displayName: Android x86
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=x86
-  #           installWindowsSdk: false
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (Win)
-  #         parameters:
-  #           name: native_android_x64_windows
-  #           displayName: Android x64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=x64
-  #           installWindowsSdk: false
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (Win)
-  #         parameters:
-  #           name: native_android_arm_windows
-  #           displayName: Android arm
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=arm
-  #           installWindowsSdk: false
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (Win)
-  #         parameters:
-  #           name: native_android_arm64_windows
-  #           displayName: Android arm64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=arm64
-  #           installWindowsSdk: false
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Win)
-  #         parameters:
-  #           name: native_tizen_windows
-  #           displayName: Tizen
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-tizen
-  #           installWindowsSdk: false
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x86 (Win)
-  #         parameters:
-  #           name: native_uwp_angle_x86_windows
-  #           displayName: ANGLE x86
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: ANGLE
-  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x64 (Win)
-  #         parameters:
-  #           name: native_uwp_angle_x64_windows
-  #           displayName: ANGLE x64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: ANGLE
-  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm (Win)
-  #         parameters:
-  #           name: native_uwp_angle_arm_windows
-  #           displayName: ANGLE arm
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: ANGLE
-  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm64 (Win)
-  #         parameters:
-  #           name: native_uwp_angle_arm64_windows
-  #           displayName: ANGLE arm64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: ANGLE
-  #           additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|x86 (Win)
-  #         parameters:
-  #           name: native_uwp_x86_windows
-  #           displayName: UWP x86
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-uwp
-  #           additionalArgs: --buildarch=x86 --skipAngle=true
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|x64 (Win)
-  #         parameters:
-  #           name: native_uwp_x64_windows
-  #           displayName: UWP x64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-uwp
-  #           additionalArgs: --buildarch=x64 --skipAngle=true
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm (Win)
-  #         parameters:
-  #           name: native_uwp_arm_windows
-  #           displayName: UWP arm
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-uwp
-  #           additionalArgs: --buildarch=arm --skipAngle=true
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native UWP|arm64 (Win)
-  #         parameters:
-  #           name: native_uwp_arm64_windows
-  #           displayName: UWP arm64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-uwp
-  #           additionalArgs: --buildarch=arm64 --skipAngle=true
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Win32|x86 (Win)
-  #         parameters:
-  #           name: native_win32_x86_windows
-  #           displayName: Win32 x86
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-windows
-  #           additionalArgs: --buildarch=x86
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Win32|x64 (Win)
-  #         parameters:
-  #           name: native_win32_x64_windows
-  #           displayName: Win32 x64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-windows
-  #           additionalArgs: --buildarch=x64
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Win32|arm64 (Win)
-  #         parameters:
-  #           name: native_win32_arm64_windows
-  #           displayName: Win32 arm64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-windows
-  #           additionalArgs: --buildarch=arm64
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native NanoServer|x64 (Win)
-  #         parameters:
-  #           name: native_win32_x64_nanoserver_windows
-  #           displayName: Nano Server x64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
-  #           target: externals-nanoserver
-  #           additionalArgs: --buildarch=x64
-  #           artifactName: native
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+    - stage: native_windows
+      displayName: Native Windows
+      dependsOn: prepare
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (Win)
+          parameters:
+            name: native_android_x86_windows
+            displayName: Android x86
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=x86
+            installWindowsSdk: false
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (Win)
+          parameters:
+            name: native_android_x64_windows
+            displayName: Android x64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=x64
+            installWindowsSdk: false
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Android|arm (Win)
+          parameters:
+            name: native_android_arm_windows
+            displayName: Android arm
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=arm
+            installWindowsSdk: false
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (Win)
+          parameters:
+            name: native_android_arm64_windows
+            displayName: Android arm64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=arm64
+            installWindowsSdk: false
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Tizen (Win)
+          parameters:
+            name: native_tizen_windows
+            displayName: Tizen
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-tizen
+            installWindowsSdk: false
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x86 (Win)
+          parameters:
+            name: native_uwp_angle_x86_windows
+            displayName: ANGLE x86
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: ANGLE
+            additionalArgs: -Script .\native\uwp\build.cake --buildarch=x86
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|x64 (Win)
+          parameters:
+            name: native_uwp_angle_x64_windows
+            displayName: ANGLE x64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: ANGLE
+            additionalArgs: -Script .\native\uwp\build.cake --buildarch=x64
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm (Win)
+          parameters:
+            name: native_uwp_angle_arm_windows
+            displayName: ANGLE arm
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: ANGLE
+            additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build ANGLE UWP|arm64 (Win)
+          parameters:
+            name: native_uwp_angle_arm64_windows
+            displayName: ANGLE arm64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: ANGLE
+            additionalArgs: -Script .\native\uwp\build.cake --buildarch=arm64
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native UWP|x86 (Win)
+          parameters:
+            name: native_uwp_x86_windows
+            displayName: UWP x86
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-uwp
+            additionalArgs: --buildarch=x86 --skipAngle=true
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native UWP|x64 (Win)
+          parameters:
+            name: native_uwp_x64_windows
+            displayName: UWP x64
+            buildExternals: ${{ parameters.buildExternals }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-uwp
+            additionalArgs: --buildarch=x64 --skipAngle=true
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native UWP|arm (Win)
+          parameters:
+            name: native_uwp_arm_windows
+            displayName: UWP arm
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-uwp
+            additionalArgs: --buildarch=arm --skipAngle=true
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native UWP|arm64 (Win)
+          parameters:
+            name: native_uwp_arm64_windows
+            displayName: UWP arm64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-uwp
+            additionalArgs: --buildarch=arm64 --skipAngle=true
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Win32|x86 (Win)
+          parameters:
+            name: native_win32_x86_windows
+            displayName: Win32 x86
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-windows
+            additionalArgs: --buildarch=x86
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Win32|x64 (Win)
+          parameters:
+            name: native_win32_x64_windows
+            displayName: Win32 x64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-windows
+            additionalArgs: --buildarch=x64
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Win32|arm64 (Win)
+          parameters:
+            name: native_win32_arm64_windows
+            displayName: Win32 arm64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-windows
+            additionalArgs: --buildarch=arm64
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native NanoServer|x64 (Win)
+          parameters:
+            name: native_win32_x64_nanoserver_windows
+            displayName: Nano Server x64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS_NATIVE }}
+            target: externals-nanoserver
+            additionalArgs: --buildarch=x64
+            artifactName: native
 
-  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: native_macos
-  #     displayName: Native macOS
-  #     dependsOn: prepare
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (macOS)
-  #         parameters:
-  #           name: native_android_x86_macos
-  #           displayName: Android x86
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=x86
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
-  #         parameters:
-  #           name: native_android_x64_macos
-  #           displayName: Android x64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=x64
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
-  #         parameters:
-  #           name: native_android_arm_macos
-  #           displayName: Android arm
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=arm
-  #       - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
-  #         parameters:
-  #           name: native_android_arm64_macos
-  #           displayName: Android arm64
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-android
-  #           additionalArgs: --buildarch=arm64
-  #       - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
-  #         parameters:
-  #           name: native_ios_macos
-  #           displayName: iOS
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-ios
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
-  #         parameters:
-  #           name: native_maccatalyst_macos
-  #           displayName: Mac Catalyst
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-maccatalyst
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
-  #         parameters:
-  #           name: native_macos_macos
-  #           displayName: macOS
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-macos
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
-  #         parameters:
-  #           name: native_tvos_macos
-  #           displayName: tvOS
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-tvos
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
-  #         parameters:
-  #           name: native_watchos_macos
-  #           displayName: watchOS
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-watchos
-  #           artifactName: native
-  #       - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
-  #         parameters:
-  #           name: native_tizen_macos
-  #           displayName: Tizen
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
-  #           target: externals-tizen
-  #           condition: false # TODO: TIZEN INSTALL BUGS
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+    - stage: native_macos
+      displayName: Native macOS
+      dependsOn: prepare
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Build Native Android|x86 (macOS)
+          parameters:
+            name: native_android_x86_macos
+            displayName: Android x86
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=x86
+        - template: azure-templates-bootstrapper.yml # Build Native Android|x64 (macOS)
+          parameters:
+            name: native_android_x64_macos
+            displayName: Android x64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=x64
+        - template: azure-templates-bootstrapper.yml # Build Native Android|arm (macOS)
+          parameters:
+            name: native_android_arm_macos
+            displayName: Android arm
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=arm
+        - template: azure-templates-bootstrapper.yml # Build Native Android|arm64 (macOS)
+          parameters:
+            name: native_android_arm64_macos
+            displayName: Android arm64
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-android
+            additionalArgs: --buildarch=arm64
+        - template: azure-templates-bootstrapper.yml # Build Native iOS (macOS)
+          parameters:
+            name: native_ios_macos
+            displayName: iOS
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-ios
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Mac Catalyst (macOS)
+          parameters:
+            name: native_maccatalyst_macos
+            displayName: Mac Catalyst
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-maccatalyst
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native macOS (macOS)
+          parameters:
+            name: native_macos_macos
+            displayName: macOS
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-macos
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native tvOS (macOS)
+          parameters:
+            name: native_tvos_macos
+            displayName: tvOS
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-tvos
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native watchOS (macOS)
+          parameters:
+            name: native_watchos_macos
+            displayName: watchOS
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-watchos
+            artifactName: native
+        - template: azure-templates-bootstrapper.yml # Build Native Tizen (macOS)
+          parameters:
+            name: native_tizen_macos
+            displayName: Tizen
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC_NATIVE }}
+            target: externals-tizen
+            condition: false # TODO: TIZEN INSTALL BUGS
 
-  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: native_linux
-  #     displayName: Native Linux
-  #     dependsOn: prepare
-  #     jobs:
-  #       - template: azure-templates-linux-matrix.yml # Build Native Linux (Linux)
-  #         parameters:
-  #           artifactName: native
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
-  #           builds:
-  #             - name: ''
-  #             - name: nodeps
-  #               desc: 'No Deps'
-  #               additionalArgs: --verifyExcluded=fontconfig
-  #               gnArgs: skia_use_fontconfig=false
-  #           matrix:
-  #             - arch: x64
-  #               docker: scripts/Docker/debian9/amd64
-  #             - arch: x64
-  #               variant: alpine
-  #               docker: scripts/Docker/alpine/amd64
-  #             - arch: arm
-  #               docker: scripts/Docker/debian9/clang-cross
-  #               target: externals-linux-clang-cross
-  #             - arch: arm64
-  #               docker: scripts/Docker/debian9/clang-cross
-  #               dockerArgs: --build-arg TOOLCHAIN_ARCH=aarch64-linux-gnu --build-arg TOOLCHAIN_ARCH_SHORT=arm64
-  #               target: externals-linux-clang-cross
-  #       - template: azure-templates-bootstrapper.yml # Build Native Tizen (Linux)
-  #         parameters:
-  #           name: native_tizen_linux
-  #           displayName: Tizen
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
-  #           packages: $(TIZEN_LINUX_PACKAGES)
-  #           target: externals-tizen
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+    - stage: native_linux
+      displayName: Native Linux
+      dependsOn: prepare
+      jobs:
+        - template: azure-templates-linux-matrix.yml # Build Native Linux (Linux)
+          parameters:
+            artifactName: native
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
+            builds:
+              - name: ''
+              - name: nodeps
+                desc: 'No Deps'
+                additionalArgs: --verifyExcluded=fontconfig
+                gnArgs: skia_use_fontconfig=false
+            matrix:
+              - arch: x64
+                docker: scripts/Docker/debian9/amd64
+              - arch: x64
+                variant: alpine
+                docker: scripts/Docker/alpine/amd64
+              - arch: arm
+                docker: scripts/Docker/debian9/clang-cross
+                target: externals-linux-clang-cross
+              - arch: arm64
+                docker: scripts/Docker/debian9/clang-cross
+                dockerArgs: --build-arg TOOLCHAIN_ARCH=aarch64-linux-gnu --build-arg TOOLCHAIN_ARCH_SHORT=arm64
+                target: externals-linux-clang-cross
+        - template: azure-templates-bootstrapper.yml # Build Native Tizen (Linux)
+          parameters:
+            name: native_tizen_linux
+            displayName: Tizen
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
+            packages: $(TIZEN_LINUX_PACKAGES)
+            target: externals-tizen
 
-  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: native_wasm
-  #     displayName: Native WASM
-  #     dependsOn: prepare
-  #     jobs:
-  #       - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
-  #         parameters:
-  #           buildExternals: ${{ parameters.buildExternals }}
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
-  #           artifactName: native
-  #           emscripten:
-  #             - 2.0.5
-  #             - 2.0.6
-  #             - 2.0.9
-  #             - 2.0.11
-  #             - 2.0.12
-  #             - 2.0.23
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+    - stage: native_wasm
+      displayName: Native WASM
+      dependsOn: prepare
+      jobs:
+        - template: azure-templates-wasm-matrix.yml # Build Native WASM (Linux)
+          parameters:
+            buildExternals: ${{ parameters.buildExternals }}
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
+            artifactName: native
+            emscripten:
+              - 2.0.5
+              - 2.0.6
+              - 2.0.9
+              - 2.0.11
+              - 2.0.12
+              - 2.0.23
 
-  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: managed
-  #     displayName: Build Managed
-  #     dependsOn:
-  #       - native_windows
-  #       - native_macos
-  #       - native_linux
-  #       - native_wasm
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Build Managed (Windows)
-  #         parameters:
-  #           name: managed_windows
-  #           displayName: Managed (Windows)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: libs
-  #           additionalArgs: --skipExternals="all"
-  #           installPreviewVs: true
-  #           requiredArtifacts:
-  #             - name: native
-  #           artifactName: managed
-  #           postBuildSteps:
-  #             - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
-  #               displayName: Delete the native folder
-  #       - template: azure-templates-bootstrapper.yml # Build Managed (macOS)
-  #         parameters:
-  #           name: managed_macos
-  #           displayName: Managed (macOS)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
-  #           target: libs
-  #           additionalArgs: --skipExternals="all"
-  #           requiredArtifacts:
-  #             - name: native
-  #           artifactName: managed
-  #           postBuildSteps:
-  #             - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
-  #               displayName: Delete the native folder
-  #       - template: azure-templates-bootstrapper.yml # Build Managed (Linux)
-  #         parameters:
-  #           name: managed_linux
-  #           displayName: Managed (Linux)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-  #           packages: $(MANAGED_LINUX_PACKAGES)
-  #           target: libs
-  #           additionalArgs: --skipExternals="all"
-  #           requiredArtifacts:
-  #             - name: native
-  #           artifactName: managed
-  #           postBuildSteps:
-  #             - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
-  #               displayName: Delete the native folder
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+    - stage: managed
+      displayName: Build Managed
+      dependsOn:
+        - native_windows
+        - native_macos
+        - native_linux
+        - native_wasm
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Build Managed (Windows)
+          parameters:
+            name: managed_windows
+            displayName: Managed (Windows)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: libs
+            additionalArgs: --skipExternals="all"
+            installPreviewVs: true
+            requiredArtifacts:
+              - name: native
+            artifactName: managed
+            postBuildSteps:
+              - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
+                displayName: Delete the native folder
+        - template: azure-templates-bootstrapper.yml # Build Managed (macOS)
+          parameters:
+            name: managed_macos
+            displayName: Managed (macOS)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC }}
+            target: libs
+            additionalArgs: --skipExternals="all"
+            requiredArtifacts:
+              - name: native
+            artifactName: managed
+            postBuildSteps:
+              - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
+                displayName: Delete the native folder
+        - template: azure-templates-bootstrapper.yml # Build Managed (Linux)
+          parameters:
+            name: managed_linux
+            displayName: Managed (Linux)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+            packages: $(MANAGED_LINUX_PACKAGES)
+            target: libs
+            additionalArgs: --skipExternals="all"
+            requiredArtifacts:
+              - name: native
+            artifactName: managed
+            postBuildSteps:
+              - pwsh: Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
+                displayName: Delete the native folder
 
-  # - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: package
-  #     displayName: Package NuGets
-  #     dependsOn: managed
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Package NuGets
-  #         parameters:
-  #           name: package_windows
-  #           displayName: Package NuGets
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: nuget
-  #           additionalArgs: --packall=true --skipbuild=true
-  #           installWindowsSdk: false
-  #           installAndroidSdk: false
-  #           installDotNet: false
-  #           requiredArtifacts:
-  #             - name: managed
-  #             - name: native
-  #           postBuildSteps:
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the nuget artifacts
-  #               inputs:
-  #                 artifactName: nuget
-  #                 pathToPublish: 'output/nugets'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the special nuget artifacts
-  #               inputs:
-  #                 artifactName: nuget_special
-  #                 pathToPublish: 'output/nugets-special'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the special nuget artifacts
-  #               inputs:
-  #                 artifactName: nuget_symbols
-  #                 pathToPublish: 'output/nugets-symbols'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the SignList.xml into nuget artifacts
-  #               inputs:
-  #                 artifactName: nuget
-  #                 pathToPublish: 'SignList.xml'
-  #             - pwsh: |
-  #                 Remove-Item ./output/native/ -Recurse -Force
-  #                 Remove-Item ./output/nugets/ -Recurse -Force
-  #                 Remove-Item ./output/nugets-special/ -Recurse -Force
-  #                 Remove-Item ./output/nugets-symbols/ -Recurse -Force
-  #               displayName: Delete the pre-published folders
+  - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
+    - stage: package
+      displayName: Package NuGets
+      dependsOn: managed
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Package NuGets
+          parameters:
+            name: package_windows
+            displayName: Package NuGets
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: nuget
+            additionalArgs: --packall=true --skipbuild=true
+            installWindowsSdk: false
+            installAndroidSdk: false
+            installDotNet: false
+            requiredArtifacts:
+              - name: managed
+              - name: native
+            postBuildSteps:
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the nuget artifacts
+                inputs:
+                  artifactName: nuget
+                  pathToPublish: 'output/nugets'
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the special nuget artifacts
+                inputs:
+                  artifactName: nuget_special
+                  pathToPublish: 'output/nugets-special'
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the special nuget artifacts
+                inputs:
+                  artifactName: nuget_symbols
+                  pathToPublish: 'output/nugets-symbols'
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the SignList.xml into nuget artifacts
+                inputs:
+                  artifactName: nuget
+                  pathToPublish: 'SignList.xml'
+              - pwsh: |
+                  Remove-Item ./output/native/ -Recurse -Force
+                  Remove-Item ./output/nugets/ -Recurse -Force
+                  Remove-Item ./output/nugets-special/ -Recurse -Force
+                  Remove-Item ./output/nugets-symbols/ -Recurse -Force
+                displayName: Delete the pre-published folders
 
-  # - ${{ if ne(parameters.buildPipelineType, 'build') }}:
-  #   - stage: api_diff
-  #     displayName: API Diff
-  #     ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-  #       dependsOn: prepare
-  #     ${{ if eq(parameters.buildPipelineType, 'both') }}:
-  #       dependsOn: package
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # API Diff
-  #         parameters:
-  #           name: api_diff_windows
-  #           displayName: API Diff
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: docs-api-diff
-  #           additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: package_windows
-  #             - name: nuget
-  #               dir: nugets
-  #           preBuildSteps:
-  #             - pwsh: .\scripts\install-gtk.ps1
-  #               displayName: Install GTK# 2.12
-  #           postBuildSteps:
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the API diffs
-  #               condition: always()
-  #               inputs:
-  #                 artifactName: api-diff
-  #                 pathToPublish: '$(Build.SourcesDirectory)\output\api-diff'
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+    - stage: api_diff
+      displayName: API Diff
+      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+        dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'both') }}:
+        dependsOn: package
+      jobs:
+        - template: azure-templates-bootstrapper.yml # API Diff
+          parameters:
+            name: api_diff_windows
+            displayName: API Diff
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: docs-api-diff
+            additionalArgs: --nugetDiffPrerelease=$(NUGET_DIFF_PRERELEASE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: package_windows
+              - name: nuget
+                dir: nugets
+            preBuildSteps:
+              - pwsh: .\scripts\install-gtk.ps1
+                displayName: Install GTK# 2.12
+            postBuildSteps:
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the API diffs
+                condition: always()
+                inputs:
+                  artifactName: api-diff
+                  pathToPublish: '$(Build.SourcesDirectory)\output\api-diff'
 
-  # - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
-  #   - stage: signing
-  #     displayName: Sign NuGets
-  #     dependsOn: package
-  #     jobs:
-  #       - template: sign-artifacts/jobs/v2.yml@xamarin-templates
-  #         parameters:
-  #           ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/')) }}:
-  #             signType: 'Real'
-  #           ${{ if not(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))) }}:
-  #             signType: 'Test'
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
+    - stage: signing
+      displayName: Sign NuGets
+      dependsOn: package
+      jobs:
+        - template: sign-artifacts/jobs/v2.yml@xamarin-templates
+          parameters:
+            ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/')) }}:
+              signType: 'Real'
+            ${{ if not(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))) }}:
+              signType: 'Test'
 
-  # - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
-  #   - stage: sbom
-  #     displayName: 'Software Bill of Materials'
-  #     dependsOn: signing
-  #     jobs:
-  #     - template: compliance/sbom/job.v1.yml@xamarin-templates        # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
-  #       parameters:
-  #         artifactNames: ['nuget']
-  #         packageName: 'SkiaSharp'
-  #         packageFilter: '*.nupkg'
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests'), ne(variables['System.PullRequest.IsFork'], 'true')) }}:
+    - stage: sbom
+      displayName: 'Software Bill of Materials'
+      dependsOn: signing
+      jobs:
+      - template: compliance/sbom/job.v1.yml@xamarin-templates        # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
+        parameters:
+          artifactNames: ['nuget']
+          packageName: 'SkiaSharp'
+          packageFilter: '*.nupkg'
 
-  # - ${{ if ne(parameters.buildPipelineType, 'build') }}:
-  #   - stage: tests
-  #     displayName: Tests
-  #     ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-  #       dependsOn: prepare
-  #     ${{ if eq(parameters.buildPipelineType, 'both') }}:
-  #       dependsOn:
-  #         - native_windows
-  #         - native_macos
-  #         - native_linux
-  #         - native_wasm
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Tests|netfx (Windows)
-  #         parameters:
-  #           name: tests_netfx_windows
-  #           displayName: Windows (.NET Framework)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: tests-netfx
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           installPreviewVs: true
-  #           installWindowsSdk: false
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_win32_x86_windows
-  #             - name: native_win32_x64_windows
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the .NET Framework test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'Windows .NET Framework Tests'
-  #       - template: azure-templates-bootstrapper.yml # Tests|netcore (Windows)
-  #         parameters:
-  #           name: tests_netcore_windows
-  #           displayName: Windows (.NET Core)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: tests-netcore
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           installWindowsSdk: false
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_win32_x86_windows
-  #             - name: native_win32_x64_windows
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the .NET Core test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'Windows .NET Core Tests'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: 'Publish the code coverage results'
-  #               inputs:
-  #                 artifactName: coverage_netcore_windows
-  #                 pathToPublish: 'output/coverage'
-  #       - template: azure-templates-bootstrapper.yml # Tests|netfx (macOS)
-  #         parameters:
-  #           name: tests_netfx_macos
-  #           displayName: macOS (.NET Framework)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
-  #           target: tests-netfx
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_macos_macos
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the Mono test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'macOS Mono Tests'
-  #       - template: azure-templates-bootstrapper.yml # Tests|netcore (macOS)
-  #         parameters:
-  #           name: tests_netcore_macos
-  #           displayName: macOS (.NET Core)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
-  #           target: tests-netcore
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_macos_macos
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the .NET Core test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'macOS .NET Core Tests'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: 'Publish the code coverage results'
-  #               inputs:
-  #                 artifactName: coverage_netcore_macos
-  #                 pathToPublish: 'output/coverage'
-  #       - template: azure-templates-bootstrapper.yml # Tests|android (macOS)
-  #         parameters:
-  #           name: tests_android_macos
-  #           displayName: Android (macOS)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
-  #           target: tests-android
-  #           additionalArgs: --device=android-emulator-64_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_android_x86_macos
-  #             - name: native_android_x64_macos
-  #             - name: native_android_arm_macos
-  #             - name: native_android_arm64_macos
-  #           preBuildSteps:
-  #             - pwsh: .\scripts\install-android-package.ps1 -Package "emulator"
-  #               displayName: Install the Android emulator
-  #             - pwsh: .\scripts\install-android-package.ps1 -Package "system-images;android-30;google_apis_playstore;x86_64"
-  #               displayName: Install the Android API 30 emulator image
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the Android test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'output/logs/testlogs/SkiaSharp.Android.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'Android Tests'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the test logs
-  #               condition: always()
-  #               inputs:
-  #                 artifactName: testlogs_android
-  #                 pathToPublish: 'output/logs/testlogs'
-  #       - template: azure-templates-bootstrapper.yml # Tests|ios (macOS)
-  #         parameters:
-  #           name: tests_ios_macos
-  #           displayName: iOS (macOS)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
-  #           target: tests-ios
-  #           additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_ios_macos
-  #           preBuildSteps:
-  #             - template: azure-templates-provisioning-profiles.yml
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the iOS test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'output/logs/testlogs/SkiaSharp.iOS.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'iOS Tests'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: Publish the test logs
-  #               condition: always()
-  #               inputs:
-  #                 artifactName: testlogs_ios
-  #                 pathToPublish: 'output/logs/testlogs'
-  #       - template: azure-templates-bootstrapper.yml # Tests|netfx (Linux)
-  #         parameters:
-  #           name: tests_netfx_linux
-  #           displayName: Linux (.NET Framework)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-  #           packages: $(MANAGED_LINUX_PACKAGES)
-  #           target: tests-netfx
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_linux_x64_linux
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the Mono test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'Linux Mono Tests'
-  #       - template: azure-templates-bootstrapper.yml # Tests|netcore (Linux)
-  #         parameters:
-  #           name: tests_netcore_linux
-  #           displayName: Linux (.NET Core)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-  #           packages: $(MANAGED_LINUX_PACKAGES)
-  #           target: tests-netcore
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_linux_x64_linux
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the .NET Core test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'Linux .NET Core Tests'
-  #             - task: PublishBuildArtifacts@1
-  #               displayName: 'Publish the code coverage results'
-  #               inputs:
-  #                 artifactName: coverage_netcore_linux
-  #                 pathToPublish: 'output/coverage'
-  #       - template: azure-templates-bootstrapper.yml # Tests [WASM] (Linux)
-  #         parameters:
-  #           name: tests_wasm_linux
-  #           displayName: WASM (Linux)
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-  #           packages: $(MANAGED_LINUX_PACKAGES) ninja-build
-  #           target: tests-wasm
-  #           additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: native_wasm_linux
-  #           installEmsdk: true
-  #           initScript: source ~/emsdk/emsdk_env.sh
-  #           postBuildSteps:
-  #             - task: PublishTestResults@2
-  #               displayName: Publish the WASM test results
-  #               condition: always()
-  #               inputs:
-  #                 testResultsFormat: xUnit
-  #                 testResultsFiles: 'tests/SkiaSharp*.Wasm.Tests/**/TestResults.xml'
-  #                 testRunTitle: 'Linux WASM Tests'
-  #       # TODO: add tests for linux alpine
-  #       # TODO: add tests for linux no dependencies
-  #       # TODO: add tests for windows nano server
-  #       - job: coverage_reports                      # Coverage Reports
-  #         displayName: Coverage Reports
-  #         pool: ${{ parameters.VM_IMAGE_LINUX }}
-  #         dependsOn:
-  #           - tests_netcore_windows
-  #           - tests_netcore_macos
-  #           - tests_netcore_linux
-  #         steps:
-  #           - checkout: self
-  #           - template: azure-templates-variables.yml
-  #           - template: azure-templates-github-status.yml
-  #             parameters:
-  #               state: 'pending'
-  #           - task: DownloadBuildArtifacts@0
-  #             displayName: Download the coverage_netcore_windows artifact
-  #             inputs:
-  #               artifactName: coverage_netcore_windows
-  #               downloadPath: output
-  #           - task: DownloadBuildArtifacts@0
-  #             displayName: Download the coverage_netcore_macos artifact
-  #             inputs:
-  #               artifactName: coverage_netcore_macos
-  #               downloadPath: output
-  #           - task: DownloadBuildArtifacts@0
-  #             displayName: Download the coverage_netcore_linux artifact
-  #             inputs:
-  #               artifactName: coverage_netcore_linux
-  #               downloadPath: output
-  #           - task: PublishCodeCoverageResults@1
-  #             displayName: 'Publish the code coverage results'
-  #             inputs:
-  #               codeCoverageTool: Cobertura
-  #               summaryFileLocation: 'output/**/Cobertura.xml'
-  #           - template: azure-templates-github-status.yml
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+    - stage: tests
+      displayName: Tests
+      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+        dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'both') }}:
+        dependsOn:
+          - native_windows
+          - native_macos
+          - native_linux
+          - native_wasm
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Tests|netfx (Windows)
+          parameters:
+            name: tests_netfx_windows
+            displayName: Windows (.NET Framework)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: tests-netfx
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            installPreviewVs: true
+            installWindowsSdk: false
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_win32_x86_windows
+              - name: native_win32_x64_windows
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the .NET Framework test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
+                  testRunTitle: 'Windows .NET Framework Tests'
+        - template: azure-templates-bootstrapper.yml # Tests|netcore (Windows)
+          parameters:
+            name: tests_netcore_windows
+            displayName: Windows (.NET Core)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: tests-netcore
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            installWindowsSdk: false
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_win32_x86_windows
+              - name: native_win32_x64_windows
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the .NET Core test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
+                  testRunTitle: 'Windows .NET Core Tests'
+              - task: PublishBuildArtifacts@1
+                displayName: 'Publish the code coverage results'
+                inputs:
+                  artifactName: coverage_netcore_windows
+                  pathToPublish: 'output/coverage'
+        - template: azure-templates-bootstrapper.yml # Tests|netfx (macOS)
+          parameters:
+            name: tests_netfx_macos
+            displayName: macOS (.NET Framework)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC }}
+            target: tests-netfx
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_macos_macos
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the Mono test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
+                  testRunTitle: 'macOS Mono Tests'
+        - template: azure-templates-bootstrapper.yml # Tests|netcore (macOS)
+          parameters:
+            name: tests_netcore_macos
+            displayName: macOS (.NET Core)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC }}
+            target: tests-netcore
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_macos_macos
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the .NET Core test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
+                  testRunTitle: 'macOS .NET Core Tests'
+              - task: PublishBuildArtifacts@1
+                displayName: 'Publish the code coverage results'
+                inputs:
+                  artifactName: coverage_netcore_macos
+                  pathToPublish: 'output/coverage'
+        - template: azure-templates-bootstrapper.yml # Tests|android (macOS)
+          parameters:
+            name: tests_android_macos
+            displayName: Android (macOS)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC }}
+            target: tests-android
+            additionalArgs: --device=android-emulator-64_30 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_android_x86_macos
+              - name: native_android_x64_macos
+              - name: native_android_arm_macos
+              - name: native_android_arm64_macos
+            preBuildSteps:
+              - pwsh: .\scripts\install-android-package.ps1 -Package "emulator"
+                displayName: Install the Android emulator
+              - pwsh: .\scripts\install-android-package.ps1 -Package "system-images;android-30;google_apis_playstore;x86_64"
+                displayName: Install the Android API 30 emulator image
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the Android test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'output/logs/testlogs/SkiaSharp.Android.Tests/**/TestResults.xml'
+                  testRunTitle: 'Android Tests'
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the test logs
+                condition: always()
+                inputs:
+                  artifactName: testlogs_android
+                  pathToPublish: 'output/logs/testlogs'
+        - template: azure-templates-bootstrapper.yml # Tests|ios (macOS)
+          parameters:
+            name: tests_ios_macos
+            displayName: iOS (macOS)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC }}
+            target: tests-ios
+            additionalArgs: --device=ios-simulator-64 --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_ios_macos
+            preBuildSteps:
+              - template: azure-templates-provisioning-profiles.yml
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the iOS test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'output/logs/testlogs/SkiaSharp.iOS.Tests/**/TestResults.xml'
+                  testRunTitle: 'iOS Tests'
+              - task: PublishBuildArtifacts@1
+                displayName: Publish the test logs
+                condition: always()
+                inputs:
+                  artifactName: testlogs_ios
+                  pathToPublish: 'output/logs/testlogs'
+        - template: azure-templates-bootstrapper.yml # Tests|netfx (Linux)
+          parameters:
+            name: tests_netfx_linux
+            displayName: Linux (.NET Framework)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+            packages: $(MANAGED_LINUX_PACKAGES)
+            target: tests-netfx
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_linux_x64_linux
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the Mono test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.Desktop.Tests/**/TestResults.xml'
+                  testRunTitle: 'Linux Mono Tests'
+        - template: azure-templates-bootstrapper.yml # Tests|netcore (Linux)
+          parameters:
+            name: tests_netcore_linux
+            displayName: Linux (.NET Core)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+            packages: $(MANAGED_LINUX_PACKAGES)
+            target: tests-netcore
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=$(ENABLE_CODE_COVERAGE)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_linux_x64_linux
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the .NET Core test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.NetCore.Tests/**/TestResults.xml'
+                  testRunTitle: 'Linux .NET Core Tests'
+              - task: PublishBuildArtifacts@1
+                displayName: 'Publish the code coverage results'
+                inputs:
+                  artifactName: coverage_netcore_linux
+                  pathToPublish: 'output/coverage'
+        - template: azure-templates-bootstrapper.yml # Tests [WASM] (Linux)
+          parameters:
+            name: tests_wasm_linux
+            displayName: WASM (Linux)
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+            packages: $(MANAGED_LINUX_PACKAGES) ninja-build
+            target: tests-wasm
+            additionalArgs: --skipExternals="all" --throwOnTestFailure=$(THROW_ON_TEST_FAILURE) --coverage=false --chromedriver=$(CHROMEWEBDRIVER)
+            shouldPublish: false
+            requiredArtifacts:
+              - name: native_wasm_linux
+            installEmsdk: true
+            initScript: source ~/emsdk/emsdk_env.sh
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the WASM test results
+                condition: always()
+                inputs:
+                  testResultsFormat: xUnit
+                  testResultsFiles: 'tests/SkiaSharp*.Wasm.Tests/**/TestResults.xml'
+                  testRunTitle: 'Linux WASM Tests'
+        # TODO: add tests for linux alpine
+        # TODO: add tests for linux no dependencies
+        # TODO: add tests for windows nano server
+        - job: coverage_reports                      # Coverage Reports
+          displayName: Coverage Reports
+          pool: ${{ parameters.VM_IMAGE_LINUX }}
+          dependsOn:
+            - tests_netcore_windows
+            - tests_netcore_macos
+            - tests_netcore_linux
+          steps:
+            - checkout: self
+            - template: azure-templates-variables.yml
+            - template: azure-templates-github-status.yml
+              parameters:
+                state: 'pending'
+            - task: DownloadBuildArtifacts@0
+              displayName: Download the coverage_netcore_windows artifact
+              inputs:
+                artifactName: coverage_netcore_windows
+                downloadPath: output
+            - task: DownloadBuildArtifacts@0
+              displayName: Download the coverage_netcore_macos artifact
+              inputs:
+                artifactName: coverage_netcore_macos
+                downloadPath: output
+            - task: DownloadBuildArtifacts@0
+              displayName: Download the coverage_netcore_linux artifact
+              inputs:
+                artifactName: coverage_netcore_linux
+                downloadPath: output
+            - task: PublishCodeCoverageResults@1
+              displayName: 'Publish the code coverage results'
+              inputs:
+                codeCoverageTool: Cobertura
+                summaryFileLocation: 'output/**/Cobertura.xml'
+            - template: azure-templates-github-status.yml
 
-  # - ${{ if ne(parameters.buildPipelineType, 'build') }}:
-  #   - stage: samples
-  #     displayName: Samples
-  #     ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-  #       dependsOn: prepare
-  #     ${{ if eq(parameters.buildPipelineType, 'both') }}:
-  #       dependsOn: package
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Build Samples (Windows)
-  #         parameters:
-  #           name: samples_windows
-  #           displayName: Windows
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: samples
-  #           installPreviewVs: true
-  #           requiredArtifacts:
-  #             - name: nuget
-  #               dir: nugets
-  #           postBuildSteps:
-  #             - pwsh: Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
-  #               displayName: Delete the nugets folder
-  #       - template: azure-templates-bootstrapper.yml # Build Samples (macOS)
-  #         parameters:
-  #           name: samples_macos
-  #           displayName: macOS
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_MAC }}
-  #           target: samples
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: nuget
-  #               dir: nugets
-  #           preBuildSteps:
-  #             - template: azure-templates-provisioning-profiles.yml
-  #       - template: azure-templates-bootstrapper.yml # Build Samples (Linux)
-  #         parameters:
-  #           name: samples_linux
-  #           displayName: Linux
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           vmImage: ${{ parameters.VM_IMAGE_LINUX }}
-  #           packages: $(MANAGED_LINUX_PACKAGES)
-  #           target: samples
-  #           shouldPublish: false
-  #           requiredArtifacts:
-  #             - name: nuget
-  #               dir: nugets
-  #           installEmsdk: true
-  #           initScript: source ~/emsdk/emsdk_env.sh
+  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+    - stage: samples
+      displayName: Samples
+      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+        dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'both') }}:
+        dependsOn: package
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Build Samples (Windows)
+          parameters:
+            name: samples_windows
+            displayName: Windows
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: samples
+            installPreviewVs: true
+            requiredArtifacts:
+              - name: nuget
+                dir: nugets
+            postBuildSteps:
+              - pwsh: Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
+                displayName: Delete the nugets folder
+        - template: azure-templates-bootstrapper.yml # Build Samples (macOS)
+          parameters:
+            name: samples_macos
+            displayName: macOS
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_MAC }}
+            target: samples
+            shouldPublish: false
+            requiredArtifacts:
+              - name: nuget
+                dir: nugets
+            preBuildSteps:
+              - template: azure-templates-provisioning-profiles.yml
+        - template: azure-templates-bootstrapper.yml # Build Samples (Linux)
+          parameters:
+            name: samples_linux
+            displayName: Linux
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            vmImage: ${{ parameters.VM_IMAGE_LINUX }}
+            packages: $(MANAGED_LINUX_PACKAGES)
+            target: samples
+            shouldPublish: false
+            requiredArtifacts:
+              - name: nuget
+                dir: nugets
+            installEmsdk: true
+            initScript: source ~/emsdk/emsdk_env.sh
 
-  # - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests')) }}:
-  #   - stage: checks
-  #     displayName: Run Code Checks
-  #     dependsOn: prepare
-  #     jobs:
-  #       - template: azure-templates-bootstrapper.yml # Run Code Checks
-  #         parameters:
-  #           name: native_checks_windows
-  #           displayName: Run Code Checks
-  #           buildPipelineType: ${{ parameters.buildPipelineType }}
-  #           condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
-  #           vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
-  #           target: git-sync-deps
-  #           installWindowsSdk: false
-  #           installAndroidSdk: false
-  #           installDotNet: false
-  #           shouldPublish: false
-  #           postBuildSteps:
-  #             - task: CredScan@2
-  #               displayName: Analyze source for credentials
-  #               condition: always()
-  #               inputs:
-  #                 toolMajorVersion: 'V2'
-  #             - task: PoliCheck@1
-  #               displayName: Run PoliCheck
-  #               condition: always()
-  #               inputs:
-  #                 inputType: 'Basic'
-  #                 targetType: 'F'
-  #             - task: SdtReport@1
-  #               displayName: Create security analysis report
-  #               condition: always()
-  #               inputs:
-  #                 AllTools: false
-  #                 APIScan: false
-  #                 BinSkim: false
-  #                 CodesignValidation: false
-  #                 CredScan: true
-  #                 FortifySCA: false
-  #                 FxCop: false
-  #                 ModernCop: false
-  #                 MSRD: false
-  #                 PoliCheck: true
-  #                 RoslynAnalyzers: false
-  #                 SDLNativeRules: false
-  #                 Semmle: false
-  #                 TSLint: false
-  #                 ToolLogsNotFoundAction: 'Standard'
-  #             - task: PublishSecurityAnalysisLogs@3
-  #               displayName: Publish security analysis logs
-  #               condition: always()
-  #             - task: TSAUpload@1
-  #               displayName: Publish TSA logs
-  #               condition: always()
-  #               continueOnError: true
-  #               inputs:
-  #                 tsaVersion: 'TsaV2'
-  #                 codebase: 'NewOrUpdate'
-  #                 tsaEnvironment: 'PROD'
-  #                 codeBaseName: 'SkiaSharp_main'
-  #                 notificationAlias: 'xamacomd@microsoft.com'
-  #                 notifyAlwaysV2: false
-  #                 instanceUrlForTsaV2: 'DEVDIV'
-  #                 projectNameDEVDIV: 'DevDiv'
-  #                 areaPath: 'DevDiv\VS Client - Runtime SDKs\SkiaSharp'
-  #                 iterationPath: 'DevDiv\OneVS'
-  #                 uploadAPIScan: false
-  #                 uploadBinSkim: false
-  #                 uploadCredScan: true
-  #                 uploadFortifySCA: false
-  #                 uploadFxCop: false
-  #                 uploadModernCop: false
-  #                 uploadPoliCheck: true
-  #                 uploadPREfast: false
-  #                 uploadRoslyn: false
-  #                 uploadTSLint: false
-  #                 uploadAsync: true
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), ne(parameters.buildPipelineType, 'tests')) }}:
+    - stage: checks
+      displayName: Run Code Checks
+      dependsOn: prepare
+      jobs:
+        - template: azure-templates-bootstrapper.yml # Run Code Checks
+          parameters:
+            name: native_checks_windows
+            displayName: Run Code Checks
+            buildPipelineType: ${{ parameters.buildPipelineType }}
+            condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/patch/'))
+            vmImage: ${{ parameters.VM_IMAGE_WINDOWS}}
+            target: git-sync-deps
+            installWindowsSdk: false
+            installAndroidSdk: false
+            installDotNet: false
+            shouldPublish: false
+            postBuildSteps:
+              - task: CredScan@2
+                displayName: Analyze source for credentials
+                condition: always()
+                inputs:
+                  toolMajorVersion: 'V2'
+              - task: PoliCheck@1
+                displayName: Run PoliCheck
+                condition: always()
+                inputs:
+                  inputType: 'Basic'
+                  targetType: 'F'
+              - task: SdtReport@1
+                displayName: Create security analysis report
+                condition: always()
+                inputs:
+                  AllTools: false
+                  APIScan: false
+                  BinSkim: false
+                  CodesignValidation: false
+                  CredScan: true
+                  FortifySCA: false
+                  FxCop: false
+                  ModernCop: false
+                  MSRD: false
+                  PoliCheck: true
+                  RoslynAnalyzers: false
+                  SDLNativeRules: false
+                  Semmle: false
+                  TSLint: false
+                  ToolLogsNotFoundAction: 'Standard'
+              - task: PublishSecurityAnalysisLogs@3
+                displayName: Publish security analysis logs
+                condition: always()
+              - task: TSAUpload@1
+                displayName: Publish TSA logs
+                condition: always()
+                continueOnError: true
+                inputs:
+                  tsaVersion: 'TsaV2'
+                  codebase: 'NewOrUpdate'
+                  tsaEnvironment: 'PROD'
+                  codeBaseName: 'SkiaSharp_main'
+                  notificationAlias: 'xamacomd@microsoft.com'
+                  notifyAlwaysV2: false
+                  instanceUrlForTsaV2: 'DEVDIV'
+                  projectNameDEVDIV: 'DevDiv'
+                  areaPath: 'DevDiv\VS Client - Runtime SDKs\SkiaSharp'
+                  iterationPath: 'DevDiv\OneVS'
+                  uploadAPIScan: false
+                  uploadBinSkim: false
+                  uploadCredScan: true
+                  uploadFortifySCA: false
+                  uploadFxCop: false
+                  uploadModernCop: false
+                  uploadPoliCheck: true
+                  uploadPREfast: false
+                  uploadRoslyn: false
+                  uploadTSLint: false
+                  uploadAsync: true
 
-  # - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
-  #   - stage: finalize
-  #     displayName: Finalize Build
-  #     dependsOn:
-  #       - api_diff
-  #       - samples
-  #       - tests
-  #     jobs:
-  #       - job: finalize                              # Finalize Build
-  #         displayName: Finalize Build
-  #         pool: ${{ parameters.VM_IMAGE_LINUX }}
-  #         steps:
-  #           - checkout: none
-  #           - template: azure-templates-variables.yml
-  #           - template: azure-templates-github-status.yml
-  #             parameters:
-  #               context: 'SkiaSharp-Tests'
-  #               displayName: Update the final status for the tests pipeline
+  - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+    - stage: finalize
+      displayName: Finalize Build
+      dependsOn:
+        - api_diff
+        - samples
+        - tests
+      jobs:
+        - job: finalize                              # Finalize Build
+          displayName: Finalize Build
+          pool: ${{ parameters.VM_IMAGE_LINUX }}
+          steps:
+            - checkout: none
+            - template: azure-templates-variables.yml
+            - template: azure-templates-github-status.yml
+              parameters:
+                context: 'SkiaSharp-Tests'
+                displayName: Update the final status for the tests pipeline

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -1,12 +1,22 @@
 parameters:
-  buildPipelineType: 'both'
-  buildExternals: 0
-  VM_IMAGE_WINDOWS: ''
-  VM_IMAGE_WINDOWS_NATIVE: ''
-  VM_IMAGE_MAC: ''
-  VM_IMAGE_MAC_NATIVE: ''
-  VM_IMAGE_LINUX: ''
-  VM_IMAGE_LINUX_NATIVE: ''
+  - name: buildPipelineType
+    type: string
+    default: 'both'
+  - name: buildExternals
+    type: number
+    default: 0
+  - name: VM_IMAGE_WINDOWS
+    type: object
+  - name: VM_IMAGE_WINDOWS_NATIVE
+    type: object
+  - name: VM_IMAGE_MAC
+    type: object
+  - name: VM_IMAGE_MAC_NATIVE
+    type: object
+  - name: VM_IMAGE_LINUX
+    type: object
+  - name: VM_IMAGE_LINUX_NATIVE
+    type: object
 
 stages:
   - stage: prepare
@@ -14,9 +24,7 @@ stages:
     jobs:
       - job: prepare                               # Prepare Build
         displayName: Prepare Build
-        pool:
-          name: Azure Pipelines
-          vmImage: ubuntu-18.04
+        pool: ${{ parameters.VM_IMAGE_LINUX }}
         steps:
           - checkout: none
           - template: azure-templates-variables.yml

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -466,7 +466,10 @@ stages:
   - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: api_diff
       displayName: API Diff
-      dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+        dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'both') }}:
+        dependsOn: package
       jobs:
         - template: azure-templates-bootstrapper.yml # API Diff
           parameters:
@@ -518,7 +521,14 @@ stages:
   - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: tests
       displayName: Tests
-      dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+        dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'both') }}:
+        dependsOn:
+          - native_windows
+          - native_macos
+          - native_linux
+          - native_wasm
       jobs:
         - template: azure-templates-bootstrapper.yml # Tests|netfx (Windows)
           parameters:
@@ -779,7 +789,10 @@ stages:
   - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: samples
       displayName: Samples
-      dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'tests') }}:
+        dependsOn: prepare
+      ${{ if eq(parameters.buildPipelineType, 'both') }}:
+        dependsOn: package
       jobs:
         - template: azure-templates-bootstrapper.yml # Build Samples (Windows)
           parameters:
@@ -901,7 +914,7 @@ stages:
                   uploadTSLint: false
                   uploadAsync: true
 
-  - ${{ if ne(parameters.buildPipelineType, 'build') }}:
+  - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
     - stage: finalize
       displayName: Finalize Build
       dependsOn:

--- a/scripts/azure-templates-wasm-matrix.yml
+++ b/scripts/azure-templates-wasm-matrix.yml
@@ -1,7 +1,7 @@
 parameters:
   artifactName: ''                              # the name of the artifact to merge this run into
   buildExternals: ''                            # the build number to download externals from
-  isBuildPipeline: false
+  buildPipelineType: false
   vmImage: ''                                   # the VM image
   emscripten: [ ]
 
@@ -12,7 +12,7 @@ jobs:
         name: native_wasm_${{ replace(version, '.', '_') }}_linux
         displayName: WASM (${{ version }})
         buildExternals: ${{ parameters.buildExternals }}
-        isBuildPipeline: ${{ parameters.isBuildPipeline }}
+        buildPipelineType: ${{ parameters.buildPipelineType }}
         vmImage: ${{ parameters.vmImage }}
         docker: scripts/Docker/wasm
         target: externals-wasm


### PR DESCRIPTION
**Description of Change**

This PR tries to make builds easier for external contributors.

There are now 3 pipelines:
 1. **azure-pipelines-complete.yml**  
    For any contributor to use when setting up a custom pipeline to build SkiaSharp - and is also what we will use when we set up a public CI build.
 3. **azure-pipelines.yml**  
    For the first step in the split pipeline that _just_ builds binaries and creates [signed] NuGet packages.
 4. **azure-pipelines-tests.yml**  
    For the second step in the split pipeline that _just_ runs tests and compiles samples using the packages from the first step.