### PR TITLE
fix: Force roslyn generation for xamarin targets

### DIFF
--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -30,6 +30,9 @@
   <PropertyGroup>
     <!-- Disable csc shared compilation to reduce memory usage on CI -->
     <UseSharedCompilation>False</UseSharedCompilation>
+
+    <!-- Force the use of Uno Roslyn generators to reduce memory usage on CI -->
+    <UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
   </PropertyGroup>
 
   <!-- Classic Tizen, Xamarin and UWP -->

--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -27,6 +27,11 @@
     <LangVersion Condition="$(IsWindows)">10.0</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Disable csc shared compilation to reduce memory usage on CI -->
+    <UseSharedCompilation>False</UseSharedCompilation>
+  </PropertyGroup>
+
   <!-- Classic Tizen, Xamarin and UWP -->
   <PropertyGroup>
     <ClassicTargetFrameworks>tizen40</ClassicTargetFrameworks>


### PR DESCRIPTION
**Description of Change**

This will improve memory consumption on CI, as there will not be an Uno.SourceGenerationTasks process running in the background,

**Bugs Fixed**

None.

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
