### PR TITLE
Add support for nullable and add newer TFMs

### DIFF
--- a/binding/Directory.Build.targets
+++ b/binding/Directory.Build.targets
@@ -1,5 +1,19 @@
 <Project>
 
+  <!-- annd some compatibility packages for the really old platforms -->
+  <ItemGroup Condition="
+      '$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="
+      $(TargetFramework.StartsWith('net4')) or
+      $(TargetFramework.StartsWith('netstandard1')) or
+      $(TargetFramework.StartsWith('uap10')) or
+      '$(TargetFramework)' == 'netstandard2.0' or
+      '$(TargetFramework)' == 'tizen40'">
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)..\source\SkiaSharp.Build.targets" />
 
 </Project>

--- a/binding/HarfBuzzSharp.Classic/HarfBuzzSharp.Classic.csproj
+++ b/binding/HarfBuzzSharp.Classic/HarfBuzzSharp.Classic.csproj
@@ -41,14 +41,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'tizen40'">
     <!-- Tizen -->
-    <PackageReference Include="System.Memory" Version="4.5.3" />
     <None Include="..\..\output\native\tizen\armel\libHarfBuzzSharp.*" Link="nuget\build\$(TargetFramework)\arm\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\tizen\i386\libHarfBuzzSharp.*" Link="nuget\build\$(TargetFramework)\x86\%(Filename)%(Extension)" />
     <None Include="..\HarfBuzzSharp\nuget\build\tizen40\HarfBuzzSharp.targets" Link="nuget\build\$(TargetFramework)\HarfBuzzSharp.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap10'))">
     <!-- UWP -->
-    <PackageReference Include="System.Memory" Version="4.5.3" />
     <None Include="..\..\output\native\uwp\x64\libHarfBuzzSharp*" Link="nuget\runtimes\win10-x64\nativeassets\uap10.0\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\uwp\x86\libHarfBuzzSharp*" Link="nuget\runtimes\win10-x86\nativeassets\uap10.0\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\uwp\arm\libHarfBuzzSharp*" Link="nuget\runtimes\win10-arm\nativeassets\uap10.0\%(Filename)%(Extension)" />

--- a/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
+++ b/binding/HarfBuzzSharp/HarfBuzzSharp.csproj
@@ -9,12 +9,6 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);USE_DELEGATES</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.3" />
-  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
     <!-- macOS -->
     <None Include="..\..\output\native\osx\libHarfBuzzSharp*" Link="nuget\runtimes\osx\native\%(Filename)%(Extension)" />

--- a/binding/SkiaSharp.Classic/SkiaSharp.Classic.csproj
+++ b/binding/SkiaSharp.Classic/SkiaSharp.Classic.csproj
@@ -40,14 +40,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'tizen40'">
     <!-- Tizen -->
-    <PackageReference Include="System.Memory" Version="4.5.3" />
     <None Include="..\..\output\native\tizen\armel\libSkiaSharp.*" Link="nuget\build\$(TargetFramework)\arm\libSkiaSharp.so" />
     <None Include="..\..\output\native\tizen\i386\libSkiaSharp.*" Link="nuget\build\$(TargetFramework)\x86\libSkiaSharp.so" />
     <None Include="..\SkiaSharp\nuget\build\tizen40\SkiaSharp.targets" Link="nuget\build\$(TargetFramework)\SkiaSharp.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap10'))">
     <!-- UWP -->
-    <PackageReference Include="System.Memory" Version="4.5.3" />
     <None Include="..\..\output\native\uwp\x64\libSkiaSharp*" Link="nuget\runtimes\win10-x64\nativeassets\uap10.0\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\uwp\x86\libSkiaSharp*" Link="nuget\runtimes\win10-x86\nativeassets\uap10.0\%(Filename)%(Extension)" />
     <None Include="..\..\output\native\uwp\arm\libSkiaSharp*" Link="nuget\runtimes\win10-arm\nativeassets\uap10.0\%(Filename)%(Extension)" />

--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -8,12 +8,6 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);USE_DELEGATES</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.3" />
-  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
     <!-- macOS -->
     <None Include="..\..\output\native\osx\libSkiaSharp*" Link="nuget\runtimes\osx\native\%(Filename)%(Extension)" />

--- a/nuget/HarfBuzzSharp.NativeAssets.Win32.nuspec
+++ b/nuget/HarfBuzzSharp.NativeAssets.Win32.nuspec
@@ -31,6 +31,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       </group>
       <group targetFramework="netstandard1.3">
       </group>
+      <group targetFramework="netcoreapp3.1">
+      </group>
+      <group targetFramework="net5.0">
+      </group>
     </dependencies>
 
   </metadata>
@@ -51,6 +55,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- placeholders -->
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/HarfBuzzSharp.NativeAssets.macOS.nuspec
+++ b/nuget/HarfBuzzSharp.NativeAssets.macOS.nuspec
@@ -35,6 +35,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       </group>
       <group targetFramework="netstandard1.3">
       </group>
+      <group targetFramework="netcoreapp3.1">
+      </group>
+      <group targetFramework="net5.0">
+      </group>
     </dependencies>
 
   </metadata>
@@ -56,6 +60,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="_._" target="lib/net6.0-macos10.15/_._" />
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
+++ b/nuget/HarfbuzzSharp.NativeAssets.Linux.nuspec
@@ -33,6 +33,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="netstandard1.3">
         <dependency id="HarfBuzzSharp" version="1.0.0" />
       </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="HarfBuzzSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="HarfBuzzSharp" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -51,6 +57,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- placeholders -->
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/HarfbuzzSharp.nuspec
+++ b/nuget/HarfbuzzSharp.nuspec
@@ -43,6 +43,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
         <dependency id="HarfBuzzSharp.NativeAssets.macOS" version="1.0.0" />
         <dependency id="System.Memory" version="1.0.0" />
       </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="HarfBuzzSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="HarfBuzzSharp.NativeAssets.macOS" version="1.0.0" />
+      </group>
       <group targetFramework="monoandroid1.0">
         <dependency id="HarfBuzzSharp.NativeAssets.Android" version="1.0.0" />
       </group>
@@ -69,6 +73,18 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="tizen40">
         <dependency id="HarfBuzzSharp.NativeAssets.Tizen" version="1.0.0" />
         <dependency id="System.Memory" version="1.0.0" />
+      </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="HarfBuzzSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="HarfBuzzSharp.NativeAssets.macOS" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="HarfBuzzSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="HarfBuzzSharp.NativeAssets.macOS" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="HarfBuzzSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="HarfBuzzSharp.NativeAssets.macOS" version="1.0.0" />
       </group>
       <group targetFramework="net6.0-ios13.6">
         <dependency id="HarfBuzzSharp.NativeAssets.iOS" version="1.0.0" />
@@ -100,6 +116,9 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/netstandard2.0/HarfBuzzSharp.dll" />
     <file src="lib/netstandard2.0/HarfBuzzSharp.pdb" />
     <file src="lib/netstandard2.0/HarfBuzzSharp.xml" />
+    <file src="lib/netstandard2.1/HarfBuzzSharp.dll" />
+    <file src="lib/netstandard2.1/HarfBuzzSharp.pdb" />
+    <file src="lib/netstandard2.1/HarfBuzzSharp.xml" />
     <file platform="macos,windows" src="lib/monoandroid1.0/HarfBuzzSharp.dll" />
     <file platform="macos,windows" src="lib/monoandroid1.0/HarfBuzzSharp.pdb" />
     <file platform="macos,windows" src="lib/monoandroid1.0/HarfBuzzSharp.xml" />
@@ -124,6 +143,15 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/tizen40/HarfBuzzSharp.dll" />
     <file src="lib/tizen40/HarfBuzzSharp.pdb" />
     <file src="lib/tizen40/HarfBuzzSharp.xml" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.dll" target="lib/netcoreapp3.1/HarfBuzzSharp.dll" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.pdb" target="lib/netcoreapp3.1/HarfBuzzSharp.pdb" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.xml" target="lib/netcoreapp3.1/HarfBuzzSharp.xml" />
+    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.dll" target="lib/net5.0/HarfBuzzSharp.dll" />
+    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.pdb" target="lib/net5.0/HarfBuzzSharp.pdb" />
+    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.xml" target="lib/net5.0/HarfBuzzSharp.xml" />
+    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.dll" target="lib/net6.0/HarfBuzzSharp.dll" />
+    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.pdb" target="lib/net6.0/HarfBuzzSharp.pdb" />
+    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.xml" target="lib/net6.0/HarfBuzzSharp.xml" />
     <file platform="macos,windows" src="lib/net6.0-android/HarfBuzzSharp.dll" target="lib/net6.0-android30.0/HarfBuzzSharp.dll" />
     <file platform="macos,windows" src="lib/net6.0-android/HarfBuzzSharp.pdb" target="lib/net6.0-android30.0/HarfBuzzSharp.pdb" />
     <file platform="macos,windows" src="lib/net6.0-android/HarfBuzzSharp.xml" target="lib/net6.0-android30.0/HarfBuzzSharp.xml" />

--- a/nuget/HarfbuzzSharp.nuspec
+++ b/nuget/HarfbuzzSharp.nuspec
@@ -143,15 +143,15 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/tizen40/HarfBuzzSharp.dll" />
     <file src="lib/tizen40/HarfBuzzSharp.pdb" />
     <file src="lib/tizen40/HarfBuzzSharp.xml" />
-    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.dll" target="lib/netcoreapp3.1/HarfBuzzSharp.dll" />
-    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.pdb" target="lib/netcoreapp3.1/HarfBuzzSharp.pdb" />
-    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.xml" target="lib/netcoreapp3.1/HarfBuzzSharp.xml" />
-    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.dll" target="lib/net5.0/HarfBuzzSharp.dll" />
-    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.pdb" target="lib/net5.0/HarfBuzzSharp.pdb" />
-    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.xml" target="lib/net5.0/HarfBuzzSharp.xml" />
-    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.dll" target="lib/net6.0/HarfBuzzSharp.dll" />
-    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.pdb" target="lib/net6.0/HarfBuzzSharp.pdb" />
-    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.xml" target="lib/net6.0/HarfBuzzSharp.xml" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.dll" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.pdb" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/HarfBuzzSharp.xml" />
+    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.dll" />
+    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.pdb" />
+    <file platform="macos,windows" src="lib/net5.0/HarfBuzzSharp.xml" />
+    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.dll" />
+    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.pdb" />
+    <file platform="macos,windows" src="lib/net6.0/HarfBuzzSharp.xml" />
     <file platform="macos,windows" src="lib/net6.0-android/HarfBuzzSharp.dll" target="lib/net6.0-android30.0/HarfBuzzSharp.dll" />
     <file platform="macos,windows" src="lib/net6.0-android/HarfBuzzSharp.pdb" target="lib/net6.0-android30.0/HarfBuzzSharp.pdb" />
     <file platform="macos,windows" src="lib/net6.0-android/HarfBuzzSharp.xml" target="lib/net6.0-android30.0/HarfBuzzSharp.xml" />

--- a/nuget/SkiaSharp.HarfBuzz.nuspec
+++ b/nuget/SkiaSharp.HarfBuzz.nuspec
@@ -76,12 +76,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/netcoreapp3.1/SkiaSharp.HarfBuzz.dll" />
     <file src="lib/netcoreapp3.1/SkiaSharp.HarfBuzz.pdb" />
     <file src="lib/netcoreapp3.1/SkiaSharp.HarfBuzz.xml" />
-    <file src="lib/netstandard5.0/SkiaSharp.HarfBuzz.dll" />
-    <file src="lib/netstandard5.0/SkiaSharp.HarfBuzz.pdb" />
-    <file src="lib/netstandard5.0/SkiaSharp.HarfBuzz.xml" />
-    <file src="lib/netstandard6.0/SkiaSharp.HarfBuzz.dll" />
-    <file src="lib/netstandard6.0/SkiaSharp.HarfBuzz.pdb" />
-    <file src="lib/netstandard6.0/SkiaSharp.HarfBuzz.xml" />
+    <file src="lib/net5.0/SkiaSharp.HarfBuzz.dll" />
+    <file src="lib/net5.0/SkiaSharp.HarfBuzz.pdb" />
+    <file src="lib/net5.0/SkiaSharp.HarfBuzz.xml" />
+    <file src="lib/net6.0/SkiaSharp.HarfBuzz.dll" />
+    <file src="lib/net6.0/SkiaSharp.HarfBuzz.pdb" />
+    <file src="lib/net6.0/SkiaSharp.HarfBuzz.xml" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.HarfBuzz.nuspec
+++ b/nuget/SkiaSharp.HarfBuzz.nuspec
@@ -39,6 +39,22 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="HarfBuzzSharp" version="1.0.0" />
       </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="HarfBuzzSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="HarfBuzzSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="HarfBuzzSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="HarfBuzzSharp" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -51,9 +67,21 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/netstandard2.0/SkiaSharp.HarfBuzz.dll" />
     <file src="lib/netstandard2.0/SkiaSharp.HarfBuzz.pdb" />
     <file src="lib/netstandard2.0/SkiaSharp.HarfBuzz.xml" />
+    <file src="lib/netstandard2.1/SkiaSharp.HarfBuzz.dll" />
+    <file src="lib/netstandard2.1/SkiaSharp.HarfBuzz.pdb" />
+    <file src="lib/netstandard2.1/SkiaSharp.HarfBuzz.xml" />
     <file src="lib/net462/SkiaSharp.HarfBuzz.dll" />
     <file src="lib/net462/SkiaSharp.HarfBuzz.pdb" />
     <file src="lib/net462/SkiaSharp.HarfBuzz.xml" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.HarfBuzz.dll" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.HarfBuzz.pdb" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.HarfBuzz.xml" />
+    <file src="lib/netstandard5.0/SkiaSharp.HarfBuzz.dll" />
+    <file src="lib/netstandard5.0/SkiaSharp.HarfBuzz.pdb" />
+    <file src="lib/netstandard5.0/SkiaSharp.HarfBuzz.xml" />
+    <file src="lib/netstandard6.0/SkiaSharp.HarfBuzz.dll" />
+    <file src="lib/netstandard6.0/SkiaSharp.HarfBuzz.pdb" />
+    <file src="lib/netstandard6.0/SkiaSharp.HarfBuzz.xml" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.NativeAssets.Linux.NoDependencies.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.NoDependencies.nuspec
@@ -46,6 +46,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="netstandard1.3">
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -64,6 +70,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- placeholders -->
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.NativeAssets.Linux.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Linux.nuspec
@@ -34,6 +34,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="netstandard1.3">
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -52,6 +58,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- placeholders -->
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.NativeAssets.Win32.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.Win32.nuspec
@@ -32,6 +32,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       </group>
       <group targetFramework="netstandard1.3">
       </group>
+      <group targetFramework="netcoreapp3.1">
+      </group>
+      <group targetFramework="net5.0">
+      </group>
     </dependencies>
 
   </metadata>
@@ -52,6 +56,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- placeholders -->
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.NativeAssets.macOS.nuspec
+++ b/nuget/SkiaSharp.NativeAssets.macOS.nuspec
@@ -36,6 +36,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       </group>
       <group targetFramework="netstandard1.3">
       </group>
+      <group targetFramework="netcoreapp3.1">
+      </group>
+      <group targetFramework="net5.0">
+      </group>
     </dependencies>
 
   </metadata>
@@ -57,6 +61,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="_._" target="lib/net6.0-macos10.15/_._" />
     <file src="_._" target="lib/net462/_._" />
     <file src="_._" target="lib/netstandard1.3/_._" />
+    <file src="_._" target="lib/netcoreapp3.1/_._" />
+    <file src="_._" target="lib/net5.0/_._" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.Skottie.nuspec
+++ b/nuget/SkiaSharp.Skottie.nuspec
@@ -36,6 +36,9 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="netstandard2.0">
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
       <group targetFramework="monoandroid1.0">
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
@@ -51,6 +54,15 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="xamarinmac2.0">
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -63,6 +75,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/netstandard1.3/SkiaSharp.Skottie.pdb" />
     <file src="lib/netstandard2.0/SkiaSharp.Skottie.dll" />
     <file src="lib/netstandard2.0/SkiaSharp.Skottie.pdb" />
+    <file src="lib/netstandard2.1/SkiaSharp.Skottie.dll" />
+    <file src="lib/netstandard2.1/SkiaSharp.Skottie.pdb" />
     <file src="lib/monoandroid10.0/SkiaSharp.Skottie.dll" />
     <file src="lib/monoandroid10.0/SkiaSharp.Skottie.pdb" />
     <file src="lib/xamarinios1.0/SkiaSharp.Skottie.dll" />
@@ -73,6 +87,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/xamarinwatchos1.0/SkiaSharp.Skottie.pdb" />
     <file src="lib/xamarinmac2.0/SkiaSharp.Skottie.dll" />
     <file src="lib/xamarinmac2.0/SkiaSharp.Skottie.pdb" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.Skottie.dll" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.Skottie.pdb" />
+    <file src="lib/net5.0/SkiaSharp.Skottie.dll" />
+    <file src="lib/net5.0/SkiaSharp.Skottie.pdb" />
+    <file src="lib/net6.0/SkiaSharp.Skottie.dll" />
+    <file src="lib/net6.0/SkiaSharp.Skottie.pdb" />
 
     <!-- SkiaSharp.SceneGraph.dll -->
     <file src="lib/net462/SkiaSharp.SceneGraph.dll" />
@@ -81,6 +101,8 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/netstandard1.3/SkiaSharp.SceneGraph.pdb" />
     <file src="lib/netstandard2.0/SkiaSharp.SceneGraph.dll" />
     <file src="lib/netstandard2.0/SkiaSharp.SceneGraph.pdb" />
+    <file src="lib/netstandard2.1/SkiaSharp.SceneGraph.dll" />
+    <file src="lib/netstandard2.1/SkiaSharp.SceneGraph.pdb" />
     <file src="lib/monoandroid10.0/SkiaSharp.SceneGraph.dll" />
     <file src="lib/monoandroid10.0/SkiaSharp.SceneGraph.pdb" />
     <file src="lib/xamarinios1.0/SkiaSharp.SceneGraph.dll" />
@@ -91,6 +113,12 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/xamarinwatchos1.0/SkiaSharp.SceneGraph.pdb" />
     <file src="lib/xamarinmac2.0/SkiaSharp.SceneGraph.dll" />
     <file src="lib/xamarinmac2.0/SkiaSharp.SceneGraph.pdb" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.SceneGraph.dll" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.SceneGraph.pdb" />
+    <file src="lib/net5.0/SkiaSharp.SceneGraph.dll" />
+    <file src="lib/net5.0/SkiaSharp.SceneGraph.pdb" />
+    <file src="lib/net6.0/SkiaSharp.SceneGraph.dll" />
+    <file src="lib/net6.0/SkiaSharp.SceneGraph.pdb" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.Vulkan.SharpVk.nuspec
+++ b/nuget/SkiaSharp.Vulkan.SharpVk.nuspec
@@ -31,6 +31,22 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
         <dependency id="SkiaSharp" version="1.0.0" />
         <dependency id="SharpVk" version="1.0.0" />
       </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="SharpVk" version="1.0.0" />
+      </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="SharpVk" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="SharpVk" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+        <dependency id="SharpVk" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -39,7 +55,19 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <!-- SkiaSharp.Vulkan.SharpVk.dll -->
     <file src="lib/netstandard2.0/SkiaSharp.Vulkan.SharpVk.dll" />
     <file src="lib/netstandard2.0/SkiaSharp.Vulkan.SharpVk.pdb" />
-    <!-- <file src="lib/netstandard2.0/SkiaSharp.Vulkan.SharpVk.xml" /> -->
+    <file src="lib/netstandard2.0/SkiaSharp.Vulkan.SharpVk.xml" />
+    <file src="lib/netstandard2.1/SkiaSharp.Vulkan.SharpVk.dll" />
+    <file src="lib/netstandard2.1/SkiaSharp.Vulkan.SharpVk.pdb" />
+    <file src="lib/netstandard2.1/SkiaSharp.Vulkan.SharpVk.xml" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.Vulkan.SharpVk.dll" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.Vulkan.SharpVk.pdb" />
+    <file src="lib/netcoreapp3.1/SkiaSharp.Vulkan.SharpVk.xml" />
+    <file src="lib/net5.0/SkiaSharp.Vulkan.SharpVk.dll" />
+    <file src="lib/net5.0/SkiaSharp.Vulkan.SharpVk.pdb" />
+    <file src="lib/net5.0/SkiaSharp.Vulkan.SharpVk.xml" />
+    <file src="lib/net6.0/SkiaSharp.Vulkan.SharpVk.dll" />
+    <file src="lib/net6.0/SkiaSharp.Vulkan.SharpVk.pdb" />
+    <file src="lib/net6.0/SkiaSharp.Vulkan.SharpVk.xml" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.nuspec
+++ b/nuget/SkiaSharp.nuspec
@@ -44,6 +44,10 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
         <dependency id="SkiaSharp.NativeAssets.macOS" version="1.0.0" />
         <dependency id="System.Memory" version="1.0.0" />
       </group>
+      <group targetFramework="netstandard2.1">
+        <dependency id="SkiaSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="SkiaSharp.NativeAssets.macOS" version="1.0.0" />
+      </group>
       <group targetFramework="monoandroid1.0">
         <dependency id="SkiaSharp.NativeAssets.Android" version="1.0.0" />
       </group>
@@ -70,6 +74,18 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="tizen40">
         <dependency id="SkiaSharp.NativeAssets.Tizen" version="1.0.0" />
         <dependency id="System.Memory" version="1.0.0" />
+      </group>
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="SkiaSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="SkiaSharp.NativeAssets.macOS" version="1.0.0" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="SkiaSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="SkiaSharp.NativeAssets.macOS" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="SkiaSharp.NativeAssets.Win32" version="1.0.0" />
+        <dependency id="SkiaSharp.NativeAssets.macOS" version="1.0.0" />
       </group>
       <group targetFramework="net6.0-ios13.6">
         <dependency id="SkiaSharp.NativeAssets.iOS" version="1.0.0" />
@@ -104,6 +120,9 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/netstandard2.0/SkiaSharp.dll" />
     <file src="lib/netstandard2.0/SkiaSharp.pdb" />
     <file src="lib/netstandard2.0/SkiaSharp.xml" />
+    <file src="lib/netstandard2.1/SkiaSharp.dll" />
+    <file src="lib/netstandard2.1/SkiaSharp.pdb" />
+    <file src="lib/netstandard2.1/SkiaSharp.xml" />
     <file platform="macos,windows" src="lib/monoandroid1.0/SkiaSharp.dll" />
     <file platform="macos,windows" src="lib/monoandroid1.0/SkiaSharp.pdb" />
     <file platform="macos,windows" src="lib/monoandroid1.0/SkiaSharp.xml" />
@@ -128,6 +147,15 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/tizen40/SkiaSharp.dll" />
     <file src="lib/tizen40/SkiaSharp.pdb" />
     <file src="lib/tizen40/SkiaSharp.xml" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.dll" target="lib/netcoreapp3.1/SkiaSharp.dll" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.pdb" target="lib/netcoreapp3.1/SkiaSharp.pdb" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.xml" target="lib/netcoreapp3.1/SkiaSharp.xml" />
+    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.dll" target="lib/net5.0/SkiaSharp.dll" />
+    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.pdb" target="lib/net5.0/SkiaSharp.pdb" />
+    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.xml" target="lib/net5.0/SkiaSharp.xml" />
+    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.dll" target="lib/net6.0/SkiaSharp.dll" />
+    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.pdb" target="lib/net6.0/SkiaSharp.pdb" />
+    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.xml" target="lib/net6.0/SkiaSharp.xml" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.dll" target="lib/net6.0-android30.0/SkiaSharp.dll" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.pdb" target="lib/net6.0-android30.0/SkiaSharp.pdb" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.xml" target="lib/net6.0-android30.0/SkiaSharp.xml" />

--- a/nuget/SkiaSharp.nuspec
+++ b/nuget/SkiaSharp.nuspec
@@ -147,15 +147,15 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/tizen40/SkiaSharp.dll" />
     <file src="lib/tizen40/SkiaSharp.pdb" />
     <file src="lib/tizen40/SkiaSharp.xml" />
-    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.dll" target="lib/netcoreapp3.1/SkiaSharp.dll" />
-    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.pdb" target="lib/netcoreapp3.1/SkiaSharp.pdb" />
-    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.xml" target="lib/netcoreapp3.1/SkiaSharp.xml" />
-    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.dll" target="lib/net5.0/SkiaSharp.dll" />
-    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.pdb" target="lib/net5.0/SkiaSharp.pdb" />
-    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.xml" target="lib/net5.0/SkiaSharp.xml" />
-    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.dll" target="lib/net6.0/SkiaSharp.dll" />
-    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.pdb" target="lib/net6.0/SkiaSharp.pdb" />
-    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.xml" target="lib/net6.0/SkiaSharp.xml" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.dll" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.pdb" />
+    <file platform="macos,windows" src="lib/netcoreapp3.1/SkiaSharp.xml" />
+    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.dll" />
+    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.pdb" />
+    <file platform="macos,windows" src="lib/net5.0/SkiaSharp.xml" />
+    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.dll" />
+    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.pdb" />
+    <file platform="macos,windows" src="lib/net6.0/SkiaSharp.xml" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.dll" target="lib/net6.0-android30.0/SkiaSharp.dll" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.pdb" target="lib/net6.0-android30.0/SkiaSharp.pdb" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.xml" target="lib/net6.0-android30.0/SkiaSharp.xml" />

--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -47,8 +47,10 @@
 
   <!-- .NET Standard, .NET FX and .NET 6 -->
   <PropertyGroup>
-    <BasicTargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net462;netcoreapp3.1;net5.0</BasicTargetFrameworks>
-    <BasicTargetFrameworks Condition="$(BuildingForNet6)">$(BasicTargetFrameworks);net6.0</BasicTargetFrameworks>
+    <AncientTargetFrameworks>netstandard1.3</AncientTargetFrameworks>
+    <BasicTargetFrameworksWithoutAncient>netstandard2.0;netstandard2.1;net462;netcoreapp3.1;net5.0</BasicTargetFrameworksWithoutAncient>
+    <BasicTargetFrameworksWithoutAncient Condition="$(BuildingForNet6)">$(BasicTargetFrameworksWithoutAncient);net6.0</BasicTargetFrameworksWithoutAncient>
+    <BasicTargetFrameworks>$(AncientTargetFrameworks);$(BasicTargetFrameworksWithoutAncient)</BasicTargetFrameworks>
     <Net6PlatformTargetFrameworks>net6.0-ios;net6.0-maccatalyst;net6.0-tvos;net6.0-macos;net6.0-android</Net6PlatformTargetFrameworks>
     <Net6PlatformTargetFrameworks Condition="$(IsNet6TizenSupported)">$(Net6PlatformTargetFrameworks);net6.0-tizen</Net6PlatformTargetFrameworks>
   </PropertyGroup>

--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -47,16 +47,16 @@
 
   <!-- .NET Standard, .NET FX and .NET 6 -->
   <PropertyGroup>
-    <BasicTargetFrameworks>netstandard1.3;netstandard2.0;net462</BasicTargetFrameworks>
+    <BasicTargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net462;netcoreapp3.1;net5.0</BasicTargetFrameworks>
+    <BasicTargetFrameworks Condition="$(BuildingForNet6)">$(BasicTargetFrameworks);net6.0</BasicTargetFrameworks>
     <Net6PlatformTargetFrameworks>net6.0-ios;net6.0-maccatalyst;net6.0-tvos;net6.0-macos;net6.0-android</Net6PlatformTargetFrameworks>
     <Net6PlatformTargetFrameworks Condition="$(IsNet6TizenSupported)">$(Net6PlatformTargetFrameworks);net6.0-tizen</Net6PlatformTargetFrameworks>
-    <Net6TargetFrameworks>net6.0;$(Net6PlatformTargetFrameworks)</Net6TargetFrameworks>
   </PropertyGroup>
 
   <!-- Base TFMs for the core parts -->
   <PropertyGroup>
     <AllTargetFrameworks>$(BasicTargetFrameworks)</AllTargetFrameworks>
-    <AllTargetFrameworks Condition="$(BuildingForNet6)">$(AllTargetFrameworks);$(Net6TargetFrameworks)</AllTargetFrameworks>
+    <AllTargetFrameworks Condition="$(BuildingForNet6)">$(AllTargetFrameworks);$(Net6PlatformTargetFrameworks)</AllTargetFrameworks>
   </PropertyGroup>
 
   <!-- .NET MAUI -->

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -54,6 +54,10 @@
     <PackageReference Include="mdoc" Version="5.8.9" PrivateAssets="All" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- HACK: Do not copy the native bootstrap files -->
   <Target Name="_RemoveWasdkBootstrapDll" BeforeTargets="ResolveReferences">
     <ItemGroup>

--- a/source/SkiaSharp.Vulkan/SkiaSharp.Vulkan.SharpVk/SkiaSharp.Vulkan.SharpVk.csproj
+++ b/source/SkiaSharp.Vulkan/SkiaSharp.Vulkan.SharpVk/SkiaSharp.Vulkan.SharpVk.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(BasicTargetFrameworksWithoutAncient)</TargetFrameworks>
     <RootNamespace>SkiaSharp</RootNamespace>
     <AssemblyName>SkiaSharp.Vulkan.SharpVk</AssemblyName>
     <SignAssembly>false</SignAssembly>

--- a/source/SkiaSharpSource.Windows-net6.slnf
+++ b/source/SkiaSharpSource.Windows-net6.slnf
@@ -6,6 +6,7 @@
       "..\\binding\\SkiaSharp.SceneGraph\\SkiaSharp.SceneGraph.csproj",
       "..\\binding\\SkiaSharp.Skottie\\SkiaSharp.Skottie.csproj",
       "..\\binding\\SkiaSharp\\SkiaSharp.csproj",
+      "SkiaSharp.HarfBuzz\\SkiaSharp.HarfBuzz\\SkiaSharp.HarfBuzz.csproj",
       "SkiaSharp.Views.Blazor\\SkiaSharp.Views.Blazor\\SkiaSharp.Views.Blazor.csproj",
       "SkiaSharp.Views.Maui\\SkiaSharp.Views.Maui.Controls.Compatibility\\SkiaSharp.Views.Maui.Controls.Compatibility.csproj",
       "SkiaSharp.Views.Maui\\SkiaSharp.Views.Maui.Controls\\SkiaSharp.Views.Maui.Controls.csproj",

--- a/source/SkiaSharpSource.Windows-net6.slnf
+++ b/source/SkiaSharpSource.Windows-net6.slnf
@@ -14,6 +14,7 @@
       "SkiaSharp.Views.Uno\\SkiaSharp.Views.Uno.WinUI.Mobile\\SkiaSharp.Views.Uno.WinUI.Mobile.csproj",
       "SkiaSharp.Views.WinUI\\SkiaSharp.Views.WinUI\\SkiaSharp.Views.WinUI.csproj",
       "SkiaSharp.Views\\SkiaSharp.Views\\SkiaSharp.Views.csproj",
+      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.SharpVk\\SkiaSharp.Vulkan.SharpVk.csproj",
     ]
   }
 }


### PR DESCRIPTION
**Description of Change**

Adds the base support for nullable reference types.

This also adds the "newer" TFMs to the list so that we can start to migrate to that and eventually drop the older ones.

New TFMs:
 - netstandard2.1 (for all the netstandard people to get new nullable things)
 - netcoreapp3.1 (the baseline for new .net)
 - net5.0 (mainly for winui apps as they tend to be net5 from templates
 - net6.0 (the future)
