### PR TITLE
[skottie] Handle non-seekable streams

### DIFF
--- a/binding/SkiaSharp.Skottie/Animation.cs
+++ b/binding/SkiaSharp.Skottie/Animation.cs
@@ -43,8 +43,8 @@ namespace SkiaSharp.Skottie
 		{
 			_ = stream ?? throw new ArgumentNullException (nameof (stream));
 
-			using var managed = new SKManagedStream (stream);
-			return TryCreate (managed, out animation);
+			using var data = SKData.Create (stream);
+			return TryCreate (data, out animation);
 		}
 
 		public static Animation? Create (SKStream stream) =>
@@ -57,6 +57,19 @@ namespace SkiaSharp.Skottie
 			_ = stream ?? throw new ArgumentNullException (nameof (stream));
 
 			animation = GetObject (SkottieApi.skottie_animation_make_from_stream (stream.Handle));
+			return animation != null;
+		}
+
+		public static Animation? Create (SKData data) =>
+			TryCreate (data, out var animation)
+				? animation
+				: null;
+
+		public static bool TryCreate (SKData data, [System.Diagnostics.CodeAnalysis.NotNullWhen (true)] out Animation? animation)
+		{
+			_ = data ?? throw new ArgumentNullException (nameof (data));
+
+			animation = GetObject (SkottieApi.skottie_animation_make_from_data ((void*)data.Data, (IntPtr)data.Size));
 			return animation != null;
 		}
 
@@ -92,7 +105,7 @@ namespace SkiaSharp.Skottie
 			=> SeekFrameTime (time.TotalSeconds, ic);
 
 		public TimeSpan Duration
-			=> TimeSpan.FromSeconds(SkottieApi.skottie_animation_get_duration (Handle));
+			=> TimeSpan.FromSeconds (SkottieApi.skottie_animation_get_duration (Handle));
 
 		public double Fps
 			=> SkottieApi.skottie_animation_get_fps (Handle);

--- a/binding/SkiaSharp.Skottie/SkottieApi.generated.cs
+++ b/binding/SkiaSharp.Skottie/SkottieApi.generated.cs
@@ -221,6 +221,20 @@ namespace SkiaSharp
 			(skottie_animation_keepalive_delegate ??= GetSymbol<Delegates.skottie_animation_keepalive> ("skottie_animation_keepalive")).Invoke ();
 		#endif
 
+		// skottie_animation_t* skottie_animation_make_from_data(const char* data, size_t length)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern skottie_animation_t skottie_animation_make_from_data (/* char */ void* data, /* size_t */ IntPtr length);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate skottie_animation_t skottie_animation_make_from_data (/* char */ void* data, /* size_t */ IntPtr length);
+		}
+		private static Delegates.skottie_animation_make_from_data skottie_animation_make_from_data_delegate;
+		internal static skottie_animation_t skottie_animation_make_from_data (/* char */ void* data, /* size_t */ IntPtr length) =>
+			(skottie_animation_make_from_data_delegate ??= GetSymbol<Delegates.skottie_animation_make_from_data> ("skottie_animation_make_from_data")).Invoke (data, length);
+		#endif
+
 		// skottie_animation_t* skottie_animation_make_from_file(const char* path)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]

--- a/tests/Tests/Skottie/AnimationTest.cs
+++ b/tests/Tests/Skottie/AnimationTest.cs
@@ -30,6 +30,29 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void When_Default_TryCreate_From_SKData()
+		{
+			var path = Path.Combine(PathToImages, "LottieLogo1.json");
+			using var data = SKData.Create(path);
+			var result = Animation.TryCreate(data, out var animation);
+
+			Assert.True(result);
+			Assert.NotNull(animation);
+			Assert.NotEqual(IntPtr.Zero, animation.Handle);
+		}
+
+		[SkippableFact]
+		public void When_Default_Create_From_SKData()
+		{
+			var path = Path.Combine(PathToImages, "LottieLogo1.json");
+			using var data = SKData.Create(path);
+			var animation = Animation.Create(data);
+
+			Assert.NotNull(animation);
+			Assert.NotEqual(IntPtr.Zero, animation.Handle);
+		}
+
+		[SkippableFact]
 		public void When_Default_TryCreate_From_SKStream()
 		{
 			var path = Path.Combine(PathToImages, "LottieLogo1.json");
@@ -71,6 +94,30 @@ namespace SkiaSharp.Tests
 			var path = Path.Combine(PathToImages, "LottieLogo1.json");
 			using var fileStream = File.OpenRead(path);
 			var animation = Animation.Create(fileStream);
+
+			Assert.NotNull(animation);
+			Assert.NotEqual(IntPtr.Zero, animation.Handle);
+		}
+
+		[SkippableFact]
+		public void When_Default_TryCreate_From_NonSeekableStream()
+		{
+			var path = Path.Combine(PathToImages, "LottieLogo1.json");
+			using var fileStream = File.OpenRead(path);
+			using var nonseekable = new NonSeekableReadOnlyStream(fileStream);
+			var result = Animation.TryCreate(nonseekable, out var animation);
+
+			Assert.True(result);
+			Assert.NotEqual(IntPtr.Zero, animation?.Handle);
+		}
+
+		[SkippableFact]
+		public void When_Default_Create_From_NonSeekableStream()
+		{
+			var path = Path.Combine(PathToImages, "LottieLogo1.json");
+			using var fileStream = File.OpenRead(path);
+			using var nonseekable = new NonSeekableReadOnlyStream(fileStream);
+			var animation = Animation.Create(nonseekable);
 
 			Assert.NotNull(animation);
 			Assert.NotEqual(IntPtr.Zero, animation.Handle);


### PR DESCRIPTION
**Description of Change**

On Android, the streams for the Assets are not seekable - and the same with streams from the internet. So in order to actually read those, we first need to read the whole thing into a memory buffer.

This is not as expensive as it may sound as this is what happens internally. In C++, the full stream is read into a SKData instance, so pre-doing it in C# is the same thing. In fact, doing it via a data instance in C# opens up the potential to reduce the number of times we hop the interop boundary.

**Bugs Fixed**

None.

**API Changes**

```cs
class Animation {
  public static Animation? Create (SKData data);
  public static bool TryCreate (SKData data, out Animation? animation);
}
```

**Behavioral Changes**
Non-seekable streams can now be used to create animations.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
