### PR TITLE
Make the SKDataStream writeable like SKData

### DIFF
--- a/binding/Binding/SKData.cs
+++ b/binding/Binding/SKData.cs
@@ -1,9 +1,7 @@
-﻿﻿using System;
-using System.Runtime.InteropServices;
+﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
-using System.ComponentModel;
-using System.Buffers;
 
 namespace SkiaSharp
 {
@@ -16,7 +14,7 @@ namespace SkiaSharp
 
 		private static readonly SKData empty;
 
-		static SKData()
+		static SKData ()
 		{
 			empty = new SKDataStatic (SkiaApi.sk_data_new_empty ());
 		}
@@ -53,7 +51,7 @@ namespace SkiaSharp
 		{
 			if (!PlatformConfiguration.Is64Bit && length > UInt32.MaxValue)
 				throw new ArgumentOutOfRangeException (nameof (length), "The length exceeds the size of pointers.");
-			return GetObject (SkiaApi.sk_data_new_with_copy ((void*)bytes, (IntPtr) length));
+			return GetObject (SkiaApi.sk_data_new_with_copy ((void*)bytes, (IntPtr)length));
 		}
 
 		public static SKData CreateCopy (byte[] bytes) =>
@@ -75,10 +73,8 @@ namespace SkiaSharp
 
 		// Create
 
-		public static SKData Create (int size)
-		{
-			return GetObject (SkiaApi.sk_data_new_uninitialized ((IntPtr) size));
-		}
+		public static SKData Create (int size) =>
+			GetObject (SkiaApi.sk_data_new_uninitialized ((IntPtr)size));
 
 		public static SKData Create (long size) =>
 			GetObject (SkiaApi.sk_data_new_uninitialized ((IntPtr)size));
@@ -87,8 +83,8 @@ namespace SkiaSharp
 		{
 			if (!PlatformConfiguration.Is64Bit && size > UInt32.MaxValue)
 				throw new ArgumentOutOfRangeException (nameof (size), "The size exceeds the size of pointers.");
-				
-			return GetObject (SkiaApi.sk_data_new_uninitialized ((IntPtr) size));
+
+			return GetObject (SkiaApi.sk_data_new_uninitialized ((IntPtr)size));
 		}
 
 		public static SKData Create (string filename)
@@ -157,7 +153,7 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 
-			return GetObject (SkiaApi.sk_data_new_from_stream (stream.Handle, (IntPtr) length));
+			return GetObject (SkiaApi.sk_data_new_from_stream (stream.Handle, (IntPtr)length));
 		}
 
 		public static SKData Create (SKStream stream, ulong length)
@@ -165,7 +161,7 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 
-			return GetObject (SkiaApi.sk_data_new_from_stream (stream.Handle, (IntPtr) length));
+			return GetObject (SkiaApi.sk_data_new_from_stream (stream.Handle, (IntPtr)length));
 		}
 
 		public static SKData Create (SKStream stream, long length)
@@ -173,7 +169,7 @@ namespace SkiaSharp
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
 
-			return GetObject (SkiaApi.sk_data_new_from_stream (stream.Handle, (IntPtr) length));
+			return GetObject (SkiaApi.sk_data_new_from_stream (stream.Handle, (IntPtr)length));
 		}
 
 		public static SKData Create (IntPtr address, int length)
@@ -211,7 +207,7 @@ namespace SkiaSharp
 				if (offset > UInt32.MaxValue)
 					throw new ArgumentOutOfRangeException (nameof (offset), "The offset exceeds the size of pointers.");
 			}
-			return GetObject (SkiaApi.sk_data_new_subset (Handle, (IntPtr) offset, (IntPtr) length));
+			return GetObject (SkiaApi.sk_data_new_subset (Handle, (IntPtr)offset, (IntPtr)length));
 		}
 
 		// ToArray
@@ -279,7 +275,7 @@ namespace SkiaSharp
 			private readonly bool disposeHost;
 
 			public unsafe SKDataStream (SKData host, bool disposeHost = false)
-				: base((byte *) host.Data, host.Size)
+				: base ((byte*)host.Data, host.Size, host.Size, FileAccess.ReadWrite)
 			{
 				this.host = host;
 				this.disposeHost = disposeHost;

--- a/tests/Tests/SKDataTest.cs
+++ b/tests/Tests/SKDataTest.cs
@@ -37,6 +37,42 @@ namespace SkiaSharp.Tests
 			Assert.Equal(OddData, data.ToArray());
 		}
 
+		[SkippableFact]
+		public void AsStreamReturnsCorrectStreamData()
+		{
+			var data = SKData.CreateCopy(OddData);
+
+			var stream = data.AsStream();
+
+			var buffer = new byte[5];
+			stream.Read(buffer, 0, 5);
+
+			Assert.Equal(OddData, buffer);
+		}
+
+		[SkippableFact]
+		public void CanWriteToAsStream()
+		{
+			var data = SKData.Create(5);
+
+			var stream = data.AsStream();
+			stream.Write(OddData, 0, 5);
+
+			Assert.Equal(OddData, data.ToArray());
+		}
+
+		[SkippableFact]
+		public void CanCopyToAsStream()
+		{
+			var data = SKData.Create(5);
+
+			var stream = data.AsStream();
+			var ms = new MemoryStream(OddData);
+			ms.CopyTo(stream);
+
+			Assert.Equal(OddData, data.ToArray());
+		}
+
 		[SkippableTheory]
 		[InlineData(null, 0, 0, 0)]
 		[InlineData("", 0, 0, 0)]


### PR DESCRIPTION
**Description of Change**

This PR makes `SKData.AsStream()` a writeable stream so that it can be used to write to the data object.

**Bugs Fixed**
None.

**API Changes**

None.

**Behavioral Changes**

Makes the stream returned by `SKData.AsStream()` writeable.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [x] Updated documentation
