### PR TITLE
fix: Add net6.0 ios, android, catalyst, macos, tvos, tizen for Skottie

### DIFF
--- a/binding/SkiaSharp.SceneGraph/SkiaSharp.SceneGraph.csproj
+++ b/binding/SkiaSharp.SceneGraph/SkiaSharp.SceneGraph.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(BasicTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
     <RootNamespace>SkiaSharp.SceneGraph</RootNamespace>
     <AssemblyName>SkiaSharp.SceneGraph</AssemblyName>
     <PackagingGroup>SkiaSharp.Skottie</PackagingGroup>

--- a/binding/SkiaSharp.Skottie/SkiaSharp.Skottie.csproj
+++ b/binding/SkiaSharp.Skottie/SkiaSharp.Skottie.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(BasicTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
     <RootNamespace>SkiaSharp.Skottie</RootNamespace>
     <AssemblyName>SkiaSharp.Skottie</AssemblyName>
     <PackagingGroup>SkiaSharp.Skottie</PackagingGroup>

--- a/nuget/SkiaSharp.Skottie.nuspec
+++ b/nuget/SkiaSharp.Skottie.nuspec
@@ -114,22 +114,16 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.Skottie.dll" target="lib/net6.0-android30.0/SkiaSharp.Skottie.dll" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.Skottie.pdb" target="lib/net6.0-android30.0/SkiaSharp.Skottie.pdb" />
-    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.Skottie.xml" target="lib/net6.0-android30.0/SkiaSharp.Skottie.xml" />
     <file platform="macos" src="lib/net6.0-ios/SkiaSharp.Skottie.dll" target="lib/net6.0-ios13.6/SkiaSharp.Skottie.dll" />
     <file platform="macos" src="lib/net6.0-ios/SkiaSharp.Skottie.pdb" target="lib/net6.0-ios13.6/SkiaSharp.Skottie.pdb" />
-    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.Skottie.xml" target="lib/net6.0-ios13.6/SkiaSharp.Skottie.xml" />
     <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.Skottie.dll" target="lib/net6.0-maccatalyst13.5/SkiaSharp.Skottie.dll" />
     <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.Skottie.pdb" target="lib/net6.0-maccatalyst13.5/SkiaSharp.Skottie.pdb" />
-    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.Skottie.xml" target="lib/net6.0-maccatalyst13.5/SkiaSharp.Skottie.xml" />
     <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.Skottie.dll" target="lib/net6.0-tvos13.4/SkiaSharp.Skottie.dll" />
     <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.Skottie.pdb" target="lib/net6.0-tvos13.4/SkiaSharp.Skottie.pdb" />
-    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.Skottie.xml" target="lib/net6.0-tvos13.4/SkiaSharp.Skottie.xml" />
     <file platform="macos" src="lib/net6.0-macos/SkiaSharp.Skottie.dll" target="lib/net6.0-macos10.15/SkiaSharp.Skottie.dll" />
     <file platform="macos" src="lib/net6.0-macos/SkiaSharp.Skottie.pdb" target="lib/net6.0-macos10.15/SkiaSharp.Skottie.pdb" />
-    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.Skottie.xml" target="lib/net6.0-macos10.15/SkiaSharp.Skottie.xml" />
     <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.Skottie.dll" target="lib/net6.0-tizen7.0/SkiaSharp.Skottie.dll" />
     <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.Skottie.pdb" target="lib/net6.0-tizen7.0/SkiaSharp.Skottie.pdb" />
-    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.Skottie.xml" target="lib/net6.0-tizen7.0/SkiaSharp.Skottie.xml" />
 
     <!-- SkiaSharp.SceneGraph.dll -->
     <file src="lib/net462/SkiaSharp.SceneGraph.dll" />
@@ -159,22 +153,16 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.SceneGraph.dll" target="lib/net6.0-android30.0/SkiaSharp.SceneGraph.dll" />
     <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-android30.0/SkiaSharp.SceneGraph.pdb" />
-    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.SceneGraph.xml" target="lib/net6.0-android30.0/SkiaSharp.SceneGraph.xml" />
     <file platform="macos" src="lib/net6.0-ios/SkiaSharp.SceneGraph.dll" target="lib/net6.0-ios13.6/SkiaSharp.SceneGraph.dll" />
     <file platform="macos" src="lib/net6.0-ios/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-ios13.6/SkiaSharp.SceneGraph.pdb" />
-    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.SceneGraph.xml" target="lib/net6.0-ios13.6/SkiaSharp.SceneGraph.xml" />
     <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.SceneGraph.dll" target="lib/net6.0-maccatalyst13.5/SkiaSharp.SceneGraph.dll" />
     <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-maccatalyst13.5/SkiaSharp.SceneGraph.pdb" />
-    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.SceneGraph.xml" target="lib/net6.0-maccatalyst13.5/SkiaSharp.SceneGraph.xml" />
     <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.SceneGraph.dll" target="lib/net6.0-tvos13.4/SkiaSharp.SceneGraph.dll" />
     <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-tvos13.4/SkiaSharp.SceneGraph.pdb" />
-    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.SceneGraph.xml" target="lib/net6.0-tvos13.4/SkiaSharp.SceneGraph.xml" />
     <file platform="macos" src="lib/net6.0-macos/SkiaSharp.SceneGraph.dll" target="lib/net6.0-macos10.15/SkiaSharp.SceneGraph.dll" />
     <file platform="macos" src="lib/net6.0-macos/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-macos10.15/SkiaSharp.SceneGraph.pdb" />
-    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.SceneGraph.xml" target="lib/net6.0-macos10.15/SkiaSharp.SceneGraph.xml" />
     <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.SceneGraph.dll" target="lib/net6.0-tizen7.0/SkiaSharp.SceneGraph.dll" />
     <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-tizen7.0/SkiaSharp.SceneGraph.pdb" />
-    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.SceneGraph.xml" target="lib/net6.0-tizen7.0/SkiaSharp.SceneGraph.xml" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />

--- a/nuget/SkiaSharp.Skottie.nuspec
+++ b/nuget/SkiaSharp.Skottie.nuspec
@@ -63,6 +63,24 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
       <group targetFramework="net6.0">
         <dependency id="SkiaSharp" version="1.0.0" />
       </group>
+      <group targetFramework="net6.0-ios13.6">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0-maccatalyst13.5">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0-tvos13.4">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0-macos10.15">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0-android30.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
+      <group targetFramework="net6.0-tizen7.0">
+        <dependency id="SkiaSharp" version="1.0.0" />
+      </group>
     </dependencies>
 
   </metadata>
@@ -94,6 +112,25 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/net6.0/SkiaSharp.Skottie.dll" />
     <file src="lib/net6.0/SkiaSharp.Skottie.pdb" />
 
+    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.Skottie.dll" target="lib/net6.0-android30.0/SkiaSharp.Skottie.dll" />
+    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.Skottie.pdb" target="lib/net6.0-android30.0/SkiaSharp.Skottie.pdb" />
+    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.Skottie.xml" target="lib/net6.0-android30.0/SkiaSharp.Skottie.xml" />
+    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.Skottie.dll" target="lib/net6.0-ios13.6/SkiaSharp.Skottie.dll" />
+    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.Skottie.pdb" target="lib/net6.0-ios13.6/SkiaSharp.Skottie.pdb" />
+    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.Skottie.xml" target="lib/net6.0-ios13.6/SkiaSharp.Skottie.xml" />
+    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.Skottie.dll" target="lib/net6.0-maccatalyst13.5/SkiaSharp.Skottie.dll" />
+    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.Skottie.pdb" target="lib/net6.0-maccatalyst13.5/SkiaSharp.Skottie.pdb" />
+    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.Skottie.xml" target="lib/net6.0-maccatalyst13.5/SkiaSharp.Skottie.xml" />
+    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.Skottie.dll" target="lib/net6.0-tvos13.4/SkiaSharp.Skottie.dll" />
+    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.Skottie.pdb" target="lib/net6.0-tvos13.4/SkiaSharp.Skottie.pdb" />
+    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.Skottie.xml" target="lib/net6.0-tvos13.4/SkiaSharp.Skottie.xml" />
+    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.Skottie.dll" target="lib/net6.0-macos10.15/SkiaSharp.Skottie.dll" />
+    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.Skottie.pdb" target="lib/net6.0-macos10.15/SkiaSharp.Skottie.pdb" />
+    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.Skottie.xml" target="lib/net6.0-macos10.15/SkiaSharp.Skottie.xml" />
+    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.Skottie.dll" target="lib/net6.0-tizen7.0/SkiaSharp.Skottie.dll" />
+    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.Skottie.pdb" target="lib/net6.0-tizen7.0/SkiaSharp.Skottie.pdb" />
+    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.Skottie.xml" target="lib/net6.0-tizen7.0/SkiaSharp.Skottie.xml" />
+
     <!-- SkiaSharp.SceneGraph.dll -->
     <file src="lib/net462/SkiaSharp.SceneGraph.dll" />
     <file src="lib/net462/SkiaSharp.SceneGraph.pdb" />
@@ -119,6 +156,25 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
     <file src="lib/net5.0/SkiaSharp.SceneGraph.pdb" />
     <file src="lib/net6.0/SkiaSharp.SceneGraph.dll" />
     <file src="lib/net6.0/SkiaSharp.SceneGraph.pdb" />
+
+    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.SceneGraph.dll" target="lib/net6.0-android30.0/SkiaSharp.SceneGraph.dll" />
+    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-android30.0/SkiaSharp.SceneGraph.pdb" />
+    <file platform="macos,windows" src="lib/net6.0-android/SkiaSharp.SceneGraph.xml" target="lib/net6.0-android30.0/SkiaSharp.SceneGraph.xml" />
+    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.SceneGraph.dll" target="lib/net6.0-ios13.6/SkiaSharp.SceneGraph.dll" />
+    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-ios13.6/SkiaSharp.SceneGraph.pdb" />
+    <file platform="macos" src="lib/net6.0-ios/SkiaSharp.SceneGraph.xml" target="lib/net6.0-ios13.6/SkiaSharp.SceneGraph.xml" />
+    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.SceneGraph.dll" target="lib/net6.0-maccatalyst13.5/SkiaSharp.SceneGraph.dll" />
+    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-maccatalyst13.5/SkiaSharp.SceneGraph.pdb" />
+    <file platform="macos" src="lib/net6.0-maccatalyst/SkiaSharp.SceneGraph.xml" target="lib/net6.0-maccatalyst13.5/SkiaSharp.SceneGraph.xml" />
+    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.SceneGraph.dll" target="lib/net6.0-tvos13.4/SkiaSharp.SceneGraph.dll" />
+    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-tvos13.4/SkiaSharp.SceneGraph.pdb" />
+    <file platform="macos" src="lib/net6.0-tvos/SkiaSharp.SceneGraph.xml" target="lib/net6.0-tvos13.4/SkiaSharp.SceneGraph.xml" />
+    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.SceneGraph.dll" target="lib/net6.0-macos10.15/SkiaSharp.SceneGraph.dll" />
+    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-macos10.15/SkiaSharp.SceneGraph.pdb" />
+    <file platform="macos" src="lib/net6.0-macos/SkiaSharp.SceneGraph.xml" target="lib/net6.0-macos10.15/SkiaSharp.SceneGraph.xml" />
+    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.SceneGraph.dll" target="lib/net6.0-tizen7.0/SkiaSharp.SceneGraph.dll" />
+    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.SceneGraph.pdb" target="lib/net6.0-tizen7.0/SkiaSharp.SceneGraph.pdb" />
+    <file platform="macos" src="lib/net6.0-tizen/SkiaSharp.SceneGraph.xml" target="lib/net6.0-tizen7.0/SkiaSharp.SceneGraph.xml" />
 
     <!-- legal -->
     <file src="LICENSE.txt" />


### PR DESCRIPTION
**Description of Change**

Adds the missing targets for net6.0 ios, android, catalyst, macos, tvos, tizen for Skottie.

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
