### PR TITLE
The C API is incremented

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -37,7 +37,7 @@ Xamarin.Forms                                   reference   4.4.0.991757
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs
 libSkiaSharp            milestone   88
-libSkiaSharp            increment   0
+libSkiaSharp            increment   1
 
 # native sonames
 libSkiaSharp            soname      88.0.0


### PR DESCRIPTION
**Description of Change**

Every time the C API changes, we need to bump the C API increment. The last change (skottie) changed it.

**Bugs Fixed**

None.

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

https://github.com/mono/skia/pull/94

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
