### PR TITLE
Fix load the font which the name contains unicode text

### DIFF
--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -59,7 +59,7 @@ namespace SkiaSharp
 
 		public SKFontStyleSet GetFontStyles (string familyName)
 		{
-			var familyNameUtf8ByteList = Encoding.UTF8.GetBytes(familyName);
+			var familyNameUtf8ByteList = StringUtilities.GetEncodedText(familyName,SKTextEncoding.Utf8, addNull: true);
 			fixed (byte* familyNamePointer = familyNameUtf8ByteList)
 			{
 				return SKFontStyleSet.GetObject (SkiaApi.sk_fontmgr_match_family (Handle, new IntPtr(familyNamePointer)));
@@ -73,7 +73,7 @@ namespace SkiaSharp
 		{
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
-			var familyNameUtf8ByteList = Encoding.UTF8.GetBytes(familyName);
+			var familyNameUtf8ByteList = StringUtilities.GetEncodedText (familyName, SKTextEncoding.Utf8, addNull: true);
 			fixed (byte* familyNamePointer = familyNameUtf8ByteList)
 			{
 				var tf = SKTypeface.GetObject(SkiaApi.sk_fontmgr_match_family_style(Handle, new IntPtr(familyNamePointer), style.Handle));
@@ -190,9 +190,13 @@ namespace SkiaSharp
 			if (familyName == null)
 				familyName = string.Empty;
 
-			var tf = SKTypeface.GetObject (SkiaApi.sk_fontmgr_match_family_style_character (Handle, familyName, style.Handle, bcp47, bcp47?.Length ?? 0, character));
-			tf?.PreventPublicDisposal ();
-			return tf;
+			var familyNameUtf8ByteList = StringUtilities.GetEncodedText (familyName, SKTextEncoding.Utf8, addNull: true);
+			fixed (byte* familyNamePointer = familyNameUtf8ByteList)
+			{
+				var tf = SKTypeface.GetObject (SkiaApi.sk_fontmgr_match_family_style_character (Handle, new IntPtr (familyNamePointer), style.Handle, bcp47, bcp47?.Length ?? 0, character));
+				tf?.PreventPublicDisposal ();
+				return tf;
+			}
 		}
 
 		public static SKFontManager CreateDefault ()

--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace SkiaSharp
 {
@@ -58,7 +59,11 @@ namespace SkiaSharp
 
 		public SKFontStyleSet GetFontStyles (string familyName)
 		{
-			return SKFontStyleSet.GetObject (SkiaApi.sk_fontmgr_match_family (Handle, familyName));
+			var familyNameUtf8ByteList = Encoding.UTF8.GetBytes(familyName);
+			fixed (byte* familyNamePointer = familyNameUtf8ByteList)
+			{
+				return SKFontStyleSet.GetObject (SkiaApi.sk_fontmgr_match_family (Handle, new IntPtr(familyNamePointer)));
+			}
 		}
 
 		public SKTypeface MatchFamily (string familyName) =>
@@ -68,10 +73,13 @@ namespace SkiaSharp
 		{
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
-
-			var tf = SKTypeface.GetObject (SkiaApi.sk_fontmgr_match_family_style (Handle, familyName, style.Handle));
-			tf?.PreventPublicDisposal ();
-			return tf;
+			var familyNameUtf8ByteList = Encoding.UTF8.GetBytes(familyName);
+			fixed (byte* familyNamePointer = familyNameUtf8ByteList)
+			{
+				var tf = SKTypeface.GetObject(SkiaApi.sk_fontmgr_match_family_style(Handle, new IntPtr(familyNamePointer), style.Handle));
+				tf?.PreventPublicDisposal();
+				return tf;
+			}
 		}
 
 		public SKTypeface MatchTypeface (SKTypeface face, SKFontStyle style)

--- a/binding/Binding/SKTypeface.cs
+++ b/binding/Binding/SKTypeface.cs
@@ -76,9 +76,13 @@ namespace SkiaSharp
 			if (style == null)
 				throw new ArgumentNullException (nameof (style));
 
-			var tf = GetObject (SkiaApi.sk_typeface_create_from_name (familyName, style.Handle));
-			tf?.PreventPublicDisposal ();
-			return tf;
+			var familyNameUtf8ByteList = StringUtilities.GetEncodedText (familyName, SKTextEncoding.Utf8, addNull:true);
+			fixed (byte* familyNamePointer = familyNameUtf8ByteList)
+			{
+				var tf = GetObject (SkiaApi.sk_typeface_create_from_name (new IntPtr (familyNamePointer), style.Handle));
+				tf?.PreventPublicDisposal ();
+				return tf;
+			}
 		}
 
 		public static SKTypeface FromFamilyName (string familyName, SKFontStyleWeight weight, SKFontStyleWidth width, SKFontStyleSlant slant)

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -12397,14 +12397,14 @@ namespace SkiaSharp
 		// sk_typeface_t* sk_fontmgr_match_family_style_character(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style, const char** bcp47, int bcp47Count, int32_t character)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
+		internal static extern sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
+			internal delegate sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
 		}
 		private static Delegates.sk_fontmgr_match_family_style_character sk_fontmgr_match_family_style_character_delegate;
-		internal static sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character) =>
+		internal static sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character) =>
 			(sk_fontmgr_match_family_style_character_delegate ??= GetSymbol<Delegates.sk_fontmgr_match_family_style_character> ("sk_fontmgr_match_family_style_character")).Invoke (param0, familyName, style, bcp47, bcp47Count, character);
 		#endif
 
@@ -12677,14 +12677,14 @@ namespace SkiaSharp
 		// sk_typeface_t* sk_typeface_create_from_name(const char* familyName, const sk_fontstyle_t* style)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_typeface_create_from_name ([MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
+		internal static extern sk_typeface_t sk_typeface_create_from_name (IntPtr familyName, sk_fontstyle_t style);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_typeface_t sk_typeface_create_from_name ([MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
+			internal delegate sk_typeface_t sk_typeface_create_from_name (IntPtr familyName, sk_fontstyle_t style);
 		}
 		private static Delegates.sk_typeface_create_from_name sk_typeface_create_from_name_delegate;
-		internal static sk_typeface_t sk_typeface_create_from_name ([MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style) =>
+		internal static sk_typeface_t sk_typeface_create_from_name (IntPtr familyName, sk_fontstyle_t style) =>
 			(sk_typeface_create_from_name_delegate ??= GetSymbol<Delegates.sk_typeface_create_from_name> ("sk_typeface_create_from_name")).Invoke (familyName, style);
 		#endif
 

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -12370,7 +12370,7 @@ namespace SkiaSharp
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, IntPtr familyName);
-#else
+		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 			internal delegate sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, IntPtr familyName);
@@ -12378,13 +12378,13 @@ namespace SkiaSharp
 		private static Delegates.sk_fontmgr_match_family sk_fontmgr_match_family_delegate;
 		internal static sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, IntPtr familyName) =>
 			(sk_fontmgr_match_family_delegate ??= GetSymbol<Delegates.sk_fontmgr_match_family> ("sk_fontmgr_match_family")).Invoke (param0, familyName);
-#endif
+		#endif
 
 		// sk_typeface_t* sk_fontmgr_match_family_style(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style)
-#if !USE_DELEGATES
+		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style);
-#else
+		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 			internal delegate sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style);
@@ -12392,10 +12392,10 @@ namespace SkiaSharp
 		private static Delegates.sk_fontmgr_match_family_style sk_fontmgr_match_family_style_delegate;
 		internal static sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style) =>
 			(sk_fontmgr_match_family_style_delegate ??= GetSymbol<Delegates.sk_fontmgr_match_family_style> ("sk_fontmgr_match_family_style")).Invoke (param0, familyName, style);
-#endif
+		#endif
 
 		// sk_typeface_t* sk_fontmgr_match_family_style_character(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style, const char** bcp47, int bcp47Count, int32_t character)
-#if !USE_DELEGATES
+		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
 		#else

--- a/binding/Binding/SkiaApi.generated.cs
+++ b/binding/Binding/SkiaApi.generated.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 #region Namespaces
@@ -12369,33 +12369,33 @@ namespace SkiaSharp
 		// sk_fontstyleset_t* sk_fontmgr_match_family(sk_fontmgr_t*, const char* familyName)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName);
-		#else
+		internal static extern sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, IntPtr familyName);
+#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName);
+			internal delegate sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, IntPtr familyName);
 		}
 		private static Delegates.sk_fontmgr_match_family sk_fontmgr_match_family_delegate;
-		internal static sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName) =>
+		internal static sk_fontstyleset_t sk_fontmgr_match_family (sk_fontmgr_t param0, IntPtr familyName) =>
 			(sk_fontmgr_match_family_delegate ??= GetSymbol<Delegates.sk_fontmgr_match_family> ("sk_fontmgr_match_family")).Invoke (param0, familyName);
-		#endif
+#endif
 
 		// sk_typeface_t* sk_fontmgr_match_family_style(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style)
-		#if !USE_DELEGATES
+#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
-		#else
+		internal static extern sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style);
+#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style);
+			internal delegate sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style);
 		}
 		private static Delegates.sk_fontmgr_match_family_style sk_fontmgr_match_family_style_delegate;
-		internal static sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style) =>
+		internal static sk_typeface_t sk_fontmgr_match_family_style (sk_fontmgr_t param0, IntPtr familyName, sk_fontstyle_t style) =>
 			(sk_fontmgr_match_family_style_delegate ??= GetSymbol<Delegates.sk_fontmgr_match_family_style> ("sk_fontmgr_match_family_style")).Invoke (param0, familyName, style);
-		#endif
+#endif
 
 		// sk_typeface_t* sk_fontmgr_match_family_style_character(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style, const char** bcp47, int bcp47Count, int32_t character)
-		#if !USE_DELEGATES
+#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern sk_typeface_t sk_fontmgr_match_family_style_character (sk_fontmgr_t param0, [MarshalAs (UnmanagedType.LPStr)] String familyName, sk_fontstyle_t style, [MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[] bcp47, Int32 bcp47Count, Int32 character);
 		#else

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -422,23 +422,23 @@
       },
       "sk_fontmgr_match_family": {
         "parameters": {
-          "1": "[MarshalAs (UnmanagedType.LPStr)] String"
+          "1": "IntPtr"
         }
       },
       "sk_fontmgr_match_family_style": {
         "parameters": {
-          "1": "[MarshalAs (UnmanagedType.LPStr)] String"
+          "1": "IntPtr"
         }
       },
       "sk_fontmgr_match_family_style_character": {
         "parameters": {
-          "1": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "1": "IntPtr",
           "3": "[MarshalAs (UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] String[]"
         }
       },
       "sk_typeface_create_from_name": {
         "parameters": {
-          "0": "[MarshalAs (UnmanagedType.LPStr)] String"
+          "0": "IntPtr"
         }
       },
       "sk_path_parse_svg_string": {


### PR DESCRIPTION
**Description of Change**

I change the string input argument from `string` to IntPtr. The `sk_fontmgr_match_family_style` should input the `utf8` encoding string, but we will input the Unicode16 string to it. That is why we can not load the font which the font name contains the unicode text, such as the Chinese font.

**Bugs Fixed**

- Fixes #1914

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

Now, we can load the font which the font name contains unicode text, such as the Chinese font.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
