### PR TITLE
Don't try to enter/exit a critical section that has been deleted

### DIFF
--- a/binding/Binding/PlatformLock.cs
+++ b/binding/Binding/PlatformLock.cs
@@ -114,12 +114,16 @@ namespace SkiaSharp.Internals
 
 			void Enter ()
 			{
-				EnterCriticalSection (_cs);
+				if (_cs != IntPtr.Zero) {
+					EnterCriticalSection(_cs);
+				}
 			}
 
 			void Leave ()
 			{
-				LeaveCriticalSection (_cs);
+				if (_cs != IntPtr.Zero) {
+					LeaveCriticalSection(_cs);
+				}
 			}
 
 			public void EnterReadLock () { Enter (); }


### PR DESCRIPTION
**Description of Change**

Fix for the `AccessViolationException` thrown from the finalizer thread when trying to deregister a handle after the `NonAlertableWin32Lock` has already been finalized.

**Bugs Fixed**

- Fixes #2194 

**API Changes**

None.

**Behavioral Changes**

No longer throws an uncatchable `AccessViolationException` from the finalizer thread.

**Required skia PR**

None.