### PR TITLE
The missing feature in macios is now implemented

### DIFF
--- a/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.targets
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences">
-        <ItemGroup>
-            <_PossibleNativeFramework
-                Include="@(ResolvedFileToPublish)"
-                Condition="
-                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
-                    '%(ResolvedFileToPublish.Filename)' == 'libHarfBuzzSharp' and
-                    '%(ResolvedFileToPublish.Extension)' == '' and
-                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
-                    '%(ResolvedFileToPublish.PathInPackage)' != ''">
-                    <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
-                    <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-            </_PossibleNativeFramework>
-            <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
-                <Kind>Framework</Kind>
-                <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>
-                <NuGetPackageVersion>%(NuGetPackageVersion)</NuGetPackageVersion>
-                <AssetType>%(AssetType)</AssetType>
-                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_PossibleNativeFramework.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
-            </NativeReference>
-            <_PossibleNativeFramework Remove="@(_PossibleNativeFramework)" />
-        </ItemGroup>
-    </Target>
-
 </Project>

--- a/binding/HarfBuzzSharp/nuget/build/macos/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/macos/HarfBuzzSharp.targets
@@ -1,23 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences">
-        <ItemGroup>
-            <_PossibleNativeReference
-                Include="@(ResolvedFileToPublish)"
-                Condition="
-                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
-                    '%(ResolvedFileToPublish.Filename)' == 'libHarfBuzzSharp' and
-                    '%(ResolvedFileToPublish.Extension)' == '.dylib' and
-                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
-                    '%(ResolvedFileToPublish.PathInPackage)' != ''" />
-            <NativeReference Include="@(_PossibleNativeReference)">
-                <Kind>Dynamic</Kind>
-                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_PossibleNativeReference.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
-            </NativeReference>
-            <_PossibleNativeReference Remove="@(_PossibleNativeReference)" />
-        </ItemGroup>
-    </Target>
-
 </Project>

--- a/binding/HarfBuzzSharp/nuget/build/tvos/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/tvos/HarfBuzzSharp.targets
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_HarfBuzzSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences">
-        <ItemGroup>
-            <_PossibleNativeFramework
-                Include="@(ResolvedFileToPublish)"
-                Condition="
-                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
-                    '%(ResolvedFileToPublish.Filename)' == 'libHarfBuzzSharp' and
-                    '%(ResolvedFileToPublish.Extension)' == '' and
-                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
-                    '%(ResolvedFileToPublish.PathInPackage)' != ''">
-                    <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
-                    <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-            </_PossibleNativeFramework>
-            <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
-                <Kind>Framework</Kind>
-                <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>
-                <NuGetPackageVersion>%(NuGetPackageVersion)</NuGetPackageVersion>
-                <AssetType>%(AssetType)</AssetType>
-                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_PossibleNativeFramework.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
-            </NativeReference>
-            <_PossibleNativeFramework Remove="@(_PossibleNativeFramework)" />
-        </ItemGroup>
-    </Target>
-
 </Project>

--- a/binding/SkiaSharp/nuget/build/ios/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/ios/SkiaSharp.targets
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences">
-        <ItemGroup>
-            <_PossibleNativeFramework
-                Include="@(ResolvedFileToPublish)"
-                Condition="
-                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
-                    '%(ResolvedFileToPublish.Filename)' == 'libSkiaSharp' and
-                    '%(ResolvedFileToPublish.Extension)' == '' and
-                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
-                    '%(ResolvedFileToPublish.PathInPackage)' != ''">
-                    <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
-                    <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-            </_PossibleNativeFramework>
-            <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
-                <Kind>Framework</Kind>
-                <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>
-                <NuGetPackageVersion>%(NuGetPackageVersion)</NuGetPackageVersion>
-                <AssetType>%(AssetType)</AssetType>
-                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_PossibleNativeFramework.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
-            </NativeReference>
-            <_PossibleNativeFramework Remove="@(_PossibleNativeFramework)" />
-        </ItemGroup>
-    </Target>
-
 </Project>

--- a/binding/SkiaSharp/nuget/build/macos/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/macos/SkiaSharp.targets
@@ -1,23 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences">
-        <ItemGroup>
-            <_PossibleNativeReference
-                Include="@(ResolvedFileToPublish)"
-                Condition="
-                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
-                    '%(ResolvedFileToPublish.Filename)' == 'libSkiaSharp' and
-                    '%(ResolvedFileToPublish.Extension)' == '.dylib' and
-                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
-                    '%(ResolvedFileToPublish.PathInPackage)' != ''" />
-            <NativeReference Include="@(_PossibleNativeReference)">
-                <Kind>Dynamic</Kind>
-                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_PossibleNativeReference.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
-            </NativeReference>
-            <_PossibleNativeReference Remove="@(_PossibleNativeReference)" />
-        </ItemGroup>
-    </Target>
-
 </Project>

--- a/binding/SkiaSharp/nuget/build/tvos/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/tvos/SkiaSharp.targets
@@ -1,29 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- temporarily work around https://github.com/xamarin/xamarin-macios/issues/11667 -->
-    <Target Name="_SkiaSharpExpandNativeReferencesFixes" BeforeTargets="_ExpandNativeReferences">
-        <ItemGroup>
-            <_PossibleNativeFramework
-                Include="@(ResolvedFileToPublish)"
-                Condition="
-                    '%(ResolvedFileToPublish.AssetType)' == 'native' and
-                    '%(ResolvedFileToPublish.Filename)' == 'libSkiaSharp' and
-                    '%(ResolvedFileToPublish.Extension)' == '' and
-                    '%(ResolvedFileToPublish.NuGetPackageId)' != '' and
-                    '%(ResolvedFileToPublish.PathInPackage)' != ''">
-                    <FrameworkFilename>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.PathInPackage)))))</FrameworkFilename>
-                    <DirectoryName>$([System.IO.Path]::GetDirectoryName(%(ResolvedFileToPublish.FullPath)))</DirectoryName>
-            </_PossibleNativeFramework>
-            <NativeReference Include="%(_PossibleNativeFramework.DirectoryName)" Condition="'%(FrameworkFilename)' == '%(Filename).framework'">
-                <Kind>Framework</Kind>
-                <NuGetPackageId>%(NuGetPackageId)</NuGetPackageId>
-                <NuGetPackageVersion>%(NuGetPackageVersion)</NuGetPackageVersion>
-                <AssetType>%(AssetType)</AssetType>
-                <RuntimeIdentifier>$([System.Text.RegularExpressions.Regex]::Match('%(_PossibleNativeFramework.PathInPackage)', 'runtimes/([^/]+)/native/.*').Groups[1].Value)</RuntimeIdentifier>
-            </NativeReference>
-            <_PossibleNativeFramework Remove="@(_PossibleNativeFramework)" />
-        </ItemGroup>
-    </Target>
-
 </Project>


### PR DESCRIPTION
**Description of Change**

Initially the mac/ios SDKS did not handle the native references in NuGets correctly, but all is good now: https://github.com/xamarin/xamarin-macios/issues/12572

**Bugs Fixed**

- Fixes #1879

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
