### PR TITLE
fix: Force use Uno's Roslyn hosted generators instead of Uno.SourceGeneration tasks

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -5,4 +5,12 @@
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0" PrivateAssets="all" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- 
+    Force use Uno's Roslyn hosted generators instead of Uno.SourceGeneration tasks, even when LangVersion below 9.0.
+    The original issue is caused by https://github.com/unoplatform/uno/issues/9297
+    -->
+    <UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
**Description of Change**

Force use Uno's Roslyn hosted generators instead of Uno.SourceGeneration tasks, even when LangVersion below 9.0. The original issue is caused by https://github.com/unoplatform/uno/issues/9297, resulting in :

```
MSBUILD : error : Generation failed: System.MissingMethodException: 
Method not found: 'System.ReadOnlySpan`1<Char> Microsoft.IO.Path.GetFileName(System.ReadOnlySpan`1<Char>)'.
```


**Bugs Fixed**
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
