### PR TITLE
Use the full library name of libc

### DIFF
--- a/binding/Binding.Shared/PlatformConfiguration.cs
+++ b/binding/Binding.Shared/PlatformConfiguration.cs
@@ -14,6 +14,8 @@ namespace SkiaSharp
 {
 	internal static class PlatformConfiguration
 	{
+		private const string LibCLibrary = "libc";
+
 		public static bool IsUnix { get; }
 
 		public static bool IsWindows { get; }
@@ -91,7 +93,7 @@ namespace SkiaSharp
 			}
 		}
 
-		[DllImport ("c", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+		[DllImport (LibCLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
 		private static extern IntPtr gnu_get_libc_version ();
 #endif
 	}


### PR DESCRIPTION


**Description of Change**

In some situations (or maybe Godot does something) looking for the libc library using the library name without the prefix causes issues.


**Bugs Fixed**

 - Fixes #2200

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [x] Updated documentation
