### PR TITLE
fix: Remove unused native library block from SkiaSharp.Views.Uno.UI/WinUI

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Reference/nuget/build/netstandard2.0/SkiaSharp.Views.Uno.targets
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Reference/nuget/build/netstandard2.0/SkiaSharp.Views.Uno.targets
@@ -5,8 +5,4 @@
     <UnoRuntimeEnabledPackage Include="SkiaSharp.Views.Uno" PackageBasePath="$(MSBuildThisFileDirectory)..\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="$(SkiaSharpStaticLibraryPath)" Visible="false" />
-  </ItemGroup>
-
 </Project>

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Reference/nuget/build/netstandard2.0/SkiaSharp.Views.Uno.WinUI.targets
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Reference/nuget/build/netstandard2.0/SkiaSharp.Views.Uno.WinUI.targets
@@ -1,12 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 
-    <ItemGroup>
-        <UnoRuntimeEnabledPackage Include="SkiaSharp.Views.Uno.WinUI" PackageBasePath="$(MSBuildThisFileDirectory)..\" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Content Include="$(SkiaSharpStaticLibraryPath)" Visible="false" />
-    </ItemGroup>
+  <ItemGroup>
+    <UnoRuntimeEnabledPackage Include="SkiaSharp.Views.Uno.WinUI" PackageBasePath="$(MSBuildThisFileDirectory)..\" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Description of Change**

Fixes this build issue appearing when using `SkiaSharp.Views.Uno.WinUI` or `SkiaSharp.Views.Uno.UI`:
```
Microsoft.Common.CurrentVersion.targets(5128,5): error MSB3025: 
The source file ".nuget\packages\skiasharp.nativeassets.webassembly\2.88.1\build\netstandard1.0\libSkiaSharp.a" is actually a directory. 
```

where `Content` property is filled regardless of the current target being compiled.

This particular block is properly included here:
https://github.com/mono/SkiaSharp/blob/2ad29861d5a40d3bf78c28ab0a9cb02a8f0fe437/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.targets#L4-L6

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
