### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,259 +1,258 @@
 {
-    "registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/mono/skia.git",
-                    "commitHash": "acad4805dfadf801d6ea62a93652c70a3fbbe10e"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/skia",
-                    "commitHash": "74907ac6a2bbc293ded973abc09ab6a20e1ee450"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-                    "commitHash": "44134341fa8b46e83bad3bef48a8bc6badaa3083"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/harfbuzz/harfbuzz.git",
-                    "commitHash": "be97e9d678017d4ec66625fa2b17ef3485552cad"
-                }
-            }
-        },
-
-
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/chromium/buildtools.git",
-                    "commitHash": "505de88083136eefd056e5ee4ca0f01fe9b33de8"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/common.git",
-                    "commitHash": "9737551d7a52c3db3262db5856e6bcd62c462b92"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/angle/angle.git",
-                    "commitHash": "b001528ffa00e7c15a5002124f707570e59a5697"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://android.googlesource.com/platform/external/dng_sdk.git",
-                    "commitHash": "96443b262250c390b0caefbf3eed8463ba35ecae"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://android.googlesource.com/platform/external/expat.git",
-                    "commitHash": "e5aa0a2cb0a5f759ef31c0819dc67d9b14246a4a"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/third_party/freetype2.git",
-                    "commitHash": "8cf046c38d4c6ada76ba070562beff0d5041f795"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://android.googlesource.com/platform/external/googletest",
-                    "commitHash": "dd43b9998e9a44a579a7aba6c1309407d1a5ed95"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/third_party/harfbuzz.git",
-                    "commitHash": "6af6c1114a3495584ac4197c62592741c407b5a2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/chromium/deps/icu.git",
-                    "commitHash": "ec9c1133693148470ffe2e5e53576998e3650c1d"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/external/github.com/ocornut/imgui.git",
-                    "commitHash": "6384eee34f08cb7eab8d835043e1738e4adcdf75"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
-                    "commitHash": "7165f6ac4c482e68475c9e1dac086f9e12fff0d0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/external/github.com/libjpeg-turbo/libjpeg-turbo.git",
-                    "commitHash": "f935068432d8f0a9af77a9d713c3887950eb134b"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/third_party/libpng.git",
-                    "commitHash": "2ee8cb0559bf826d9bc5c0b0f3c9015f51190814"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/webm/libwebp.git",
-                    "commitHash": "6b7a95fd8385baa6d18c96d5c0f2bea5632faf55"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/external/github.com/lua/lua.git",
-                    "commitHash": "e354c6355e7f48e087678ec49e340ca0696725b1"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://android.googlesource.com/platform/external/libmicrohttpd",
-                    "commitHash": "748945ec6f1c67b7efc934ab0808e1d32f2fb98d"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://android.googlesource.com/platform/external/piex.git",
-                    "commitHash": "bb217acdca1cc0c16b704669dd6f91a1b509c406"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/external/github.com/Tencent/rapidjson.git",
-                    "commitHash": "af223d44f4e8d3772cb1ac0ce8bc2a132b51717f"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/third_party/sdl",
-                    "commitHash": "5d7cfcca344034aff9327f77fc181ae3754e7a90"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git",
-                    "commitHash": "b18b09b6114b9b7fe6fc2f96d8b15e8a72f66916"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git",
-                    "commitHash": "661ad91124e6af2272afd00f804d8aa276e17107"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git",
-                    "commitHash": "e9e4393b1c5aad7553c05782acefbe32b42644bd"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://swiftshader.googlesource.com/SwiftShader",
-                    "commitHash": "cbb80f5f0078a9941f3ec43e83e52c3d15a43bea"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://chromium.googlesource.com/chromium/src/third_party/zlib",
-                    "commitHash": "e7afdfe128e01ca480a28f757b571957befdd962"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Version": 1,
+  "registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/mono/skia.git",
+          "commitHash": "acad4805dfadf801d6ea62a93652c70a3fbbe10e"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/skia",
+          "commitHash": "74907ac6a2bbc293ded973abc09ab6a20e1ee450"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
+          "commitHash": "44134341fa8b46e83bad3bef48a8bc6badaa3083"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/harfbuzz/harfbuzz.git",
+          "commitHash": "be97e9d678017d4ec66625fa2b17ef3485552cad"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/chromium/buildtools.git",
+          "commitHash": "505de88083136eefd056e5ee4ca0f01fe9b33de8"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/common.git",
+          "commitHash": "9737551d7a52c3db3262db5856e6bcd62c462b92"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/angle/angle.git",
+          "commitHash": "b001528ffa00e7c15a5002124f707570e59a5697"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://android.googlesource.com/platform/external/dng_sdk.git",
+          "commitHash": "96443b262250c390b0caefbf3eed8463ba35ecae"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://android.googlesource.com/platform/external/expat.git",
+          "commitHash": "e5aa0a2cb0a5f759ef31c0819dc67d9b14246a4a"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/third_party/freetype2.git",
+          "commitHash": "8cf046c38d4c6ada76ba070562beff0d5041f795"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://android.googlesource.com/platform/external/googletest",
+          "commitHash": "dd43b9998e9a44a579a7aba6c1309407d1a5ed95"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/third_party/harfbuzz.git",
+          "commitHash": "6af6c1114a3495584ac4197c62592741c407b5a2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/chromium/deps/icu.git",
+          "commitHash": "ec9c1133693148470ffe2e5e53576998e3650c1d"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/external/github.com/ocornut/imgui.git",
+          "commitHash": "6384eee34f08cb7eab8d835043e1738e4adcdf75"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
+          "commitHash": "7165f6ac4c482e68475c9e1dac086f9e12fff0d0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/external/github.com/libjpeg-turbo/libjpeg-turbo.git",
+          "commitHash": "f935068432d8f0a9af77a9d713c3887950eb134b"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/third_party/libpng.git",
+          "commitHash": "2ee8cb0559bf826d9bc5c0b0f3c9015f51190814"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/webm/libwebp.git",
+          "commitHash": "6b7a95fd8385baa6d18c96d5c0f2bea5632faf55"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/external/github.com/lua/lua.git",
+          "commitHash": "e354c6355e7f48e087678ec49e340ca0696725b1"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://android.googlesource.com/platform/external/libmicrohttpd",
+          "commitHash": "748945ec6f1c67b7efc934ab0808e1d32f2fb98d"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://android.googlesource.com/platform/external/piex.git",
+          "commitHash": "bb217acdca1cc0c16b704669dd6f91a1b509c406"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/external/github.com/Tencent/rapidjson.git",
+          "commitHash": "af223d44f4e8d3772cb1ac0ce8bc2a132b51717f"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/third_party/sdl",
+          "commitHash": "5d7cfcca344034aff9327f77fc181ae3754e7a90"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git",
+          "commitHash": "b18b09b6114b9b7fe6fc2f96d8b15e8a72f66916"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git",
+          "commitHash": "661ad91124e6af2272afd00f804d8aa276e17107"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git",
+          "commitHash": "e9e4393b1c5aad7553c05782acefbe32b42644bd"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://swiftshader.googlesource.com/SwiftShader",
+          "commitHash": "cbb80f5f0078a9941f3ec43e83e52c3d15a43bea"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://chromium.googlesource.com/chromium/src/third_party/zlib",
+          "commitHash": "e7afdfe128e01ca480a28f757b571957befdd962"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.