### PR TITLE
Convert SKRect to CGRect correctly

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
@@ -40,7 +40,7 @@ namespace SkiaSharp.Views.Mac
 
 		public static SKRect ToSKRect(this CGRect rect)
 		{
-			return new SKRect((float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
+			return new SKRect((float)rect.Left, (float)rect.Top, (float)rect.Right, (float)rect.Bottom);
 		}
 
 		public static CGRect ToRect(this SKRect rect)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
@@ -40,12 +40,12 @@ namespace SkiaSharp.Views.Mac
 
 		public static SKRect ToSKRect(this CGRect rect)
 		{
-			return new SKRect((float)rect.Left, (float)rect.Top, (float)rect.Right, (float)rect.Bottom);
+			return new SKRect((float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
 		}
 
 		public static CGRect ToRect(this SKRect rect)
 		{
-			return new CGRect(rect.Left, rect.Top, rect.Right, rect.Bottom);
+			return new CGRect(rect.Left, rect.Top, rect.Width, rect.Height);
 		}
 
 		// CGSize

--- a/tests/SkiaSharp.iOS.Tests/iOSExtensionsTests.cs
+++ b/tests/SkiaSharp.iOS.Tests/iOSExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using CoreGraphics;
+using Foundation;
+using Xunit;
 
 namespace SkiaSharp.Views.iOS.Tests
 {
@@ -74,23 +76,6 @@ namespace SkiaSharp.Views.iOS.Tests
 		public void SKRectToCGRect(int x, int y, int w, int h)
 		{
 			var initial = SKRect.Create(x, y, w, h);
-			var expected = new CGRect(x, y, w, h);
-
-			var actual = initial.ToRect();
-
-			Assert.Equal(expected, actual);
-		}
-
-		[SkippableTheory]
-		[InlineData(0, 0, 0, 0)]
-		[InlineData(5, 5, 5, 5)]
-		[InlineData(1, 2, 3, 4)]
-		[InlineData(1, 1, 0, 0)]
-		[InlineData(0, 0, 1, 1)]
-		[InlineData(100, 100, 100, 100)]
-		public void SKRectIToCGRect(int x, int y, int w, int h)
-		{
-			var initial = SKRectI.Create(x, y, w, h);
 			var expected = new CGRect(x, y, w, h);
 
 			var actual = initial.ToRect();

--- a/tests/SkiaSharp.iOS.Tests/iOSExtensionsTests.cs
+++ b/tests/SkiaSharp.iOS.Tests/iOSExtensionsTests.cs
@@ -63,5 +63,39 @@ namespace SkiaSharp.Views.iOS.Tests
 
 			ValidateTestBitmap(uiImage, alpha);
 		}
+
+		[SkippableTheory]
+		[InlineData(0, 0, 0, 0)]
+		[InlineData(5, 5, 5, 5)]
+		[InlineData(1, 2, 3, 4)]
+		[InlineData(1, 1, 0, 0)]
+		[InlineData(0, 0, 1, 1)]
+		[InlineData(100, 100, 100, 100)]
+		public void SKRectToCGRect(int x, int y, int w, int h)
+		{
+			var initial = SKRect.Create(x, y, w, h);
+			var expected = new CGRect(x, y, w, h);
+
+			var actual = initial.ToRect();
+
+			Assert.Equal(expected, actual);
+		}
+
+		[SkippableTheory]
+		[InlineData(0, 0, 0, 0)]
+		[InlineData(5, 5, 5, 5)]
+		[InlineData(1, 2, 3, 4)]
+		[InlineData(1, 1, 0, 0)]
+		[InlineData(0, 0, 1, 1)]
+		[InlineData(100, 100, 100, 100)]
+		public void SKRectIToCGRect(int x, int y, int w, int h)
+		{
+			var initial = SKRectI.Create(x, y, w, h);
+			var expected = new CGRect(x, y, w, h);
+
+			var actual = initial.ToRect();
+
+			Assert.Equal(expected, actual);
+		}
 	}
 }

--- a/tests/SkiaSharp.iOS.Tests/iOSExtensionsTests.cs
+++ b/tests/SkiaSharp.iOS.Tests/iOSExtensionsTests.cs
@@ -82,5 +82,22 @@ namespace SkiaSharp.Views.iOS.Tests
 
 			Assert.Equal(expected, actual);
 		}
+
+		[SkippableTheory]
+		[InlineData(0, 0, 0, 0)]
+		[InlineData(5, 5, 5, 5)]
+		[InlineData(1, 2, 3, 4)]
+		[InlineData(1, 1, 0, 0)]
+		[InlineData(0, 0, 1, 1)]
+		[InlineData(100, 100, 100, 100)]
+		public void CGRectToSKRect(int x, int y, int w, int h)
+		{
+			var initial = new CGRect(x, y, w, h);
+			var expected = SKRect.Create(x, y, w, h);
+
+			var actual = initial.ToSKRect();
+
+			Assert.Equal(expected, actual);
+		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

`SKRect.ToRect()` does not convert to `CGRect` correctly.

**Bugs Fixed**

- Fixes #2242

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
