### PR TITLE
Fix the use of vcpkg

### DIFF
--- a/native/.gitignore
+++ b/native/.gitignore
@@ -1,2 +1,3 @@
 xcuserdata/
 project.xcworkspace/
+uwp/ANGLE/triplets

--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -122,11 +122,13 @@ Task("ANGLE")
         if (Skip(arch)) return;
 
         var triplet = $"{arch}-uwp{toolset_suffix}";
+        var tripletsRoot = MakeAbsolute ((DirectoryPath)"ANGLE/triplets");
 
         // make the versioned triplets
         if (!string.IsNullOrEmpty(VC_TOOLSET_VERSION)) {
-            var cmake = VCPKG_PATH.CombineWithFilePath ($"triplets/community/{triplet}.cmake");
+            var cmake = tripletsRoot.CombineWithFilePath ($"{triplet}.cmake");
             if (!FileExists (cmake)) {
+                EnsureDirectoryExists (tripletsRoot);
                 var src = VCPKG_PATH.CombineWithFilePath ($"triplets/{arch}-uwp.cmake");
                 if (!FileExists (src))
                     src = VCPKG_PATH.CombineWithFilePath ($"triplets/community/{arch}-uwp.cmake");
@@ -141,7 +143,7 @@ Task("ANGLE")
         var d = CONFIGURATION.ToLower() == "release" ? "" : "debug/";
         var zd = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
-        RunProcess (vcpkg, $"install angle:{triplet}");
+        RunProcess (vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\"");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);

--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -143,12 +143,7 @@ Task("ANGLE")
         var d = CONFIGURATION.ToLower() == "release" ? "" : "debug/";
         var zd = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
-        RunProcess(vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\" --debug");
-
-        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.FullPath.Replace("/", "\\") + "\"");
-        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.CombineWithFilePath($"installed").FullPath.Replace("/", "\\") + "\"");
-        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.CombineWithFilePath($"installed/{triplet}").FullPath.Replace("/", "\\") + "\"");
-        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin").FullPath.Replace("/", "\\") + "\"");
+        RunProcess(vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\"");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);

--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -1,4 +1,4 @@
-bool SKIP_ANGLE = Argument ("skipAngle", false);
+bool SKIP_ANGLE = Argument("skipAngle", false);
 string VC_TOOLSET_VERSION = Argument("vcToolsetVersion", "14.2");
 
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
@@ -102,12 +102,12 @@ Task("ANGLE")
     if (SKIP_ANGLE)
         return;
 
-    if (!DirectoryExists (VCPKG_PATH))
-        RunProcess ("git", $"clone --depth 1 https://github.com/microsoft/vcpkg.git --branch master --single-branch {VCPKG_PATH}");
+    if (!DirectoryExists(VCPKG_PATH))
+        RunProcess("git", $"clone --depth 1 https://github.com/microsoft/vcpkg.git --branch master --single-branch {VCPKG_PATH}");
 
-    var vcpkg = VCPKG_PATH.CombineWithFilePath ("vcpkg.exe");
-    if (!FileExists (vcpkg))
-        RunProcess (VCPKG_PATH.CombineWithFilePath ("bootstrap-vcpkg.bat"));
+    var vcpkg = VCPKG_PATH.CombineWithFilePath("vcpkg.exe");
+    if (!FileExists(vcpkg))
+        RunProcess(VCPKG_PATH.CombineWithFilePath("bootstrap-vcpkg.bat"));
 
     var platform_toolset = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"v{VC_TOOLSET_VERSION.Replace(".", "")}";
     var toolset_suffix = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"-{platform_toolset}";
@@ -122,18 +122,18 @@ Task("ANGLE")
         if (Skip(arch)) return;
 
         var triplet = $"{arch}-uwp{toolset_suffix}";
-        var tripletsRoot = MakeAbsolute ((DirectoryPath)"ANGLE/triplets");
+        var tripletsRoot = MakeAbsolute((DirectoryPath)"ANGLE/triplets");
 
         // make the versioned triplets
         if (!string.IsNullOrEmpty(VC_TOOLSET_VERSION)) {
-            var cmake = tripletsRoot.CombineWithFilePath ($"{triplet}.cmake");
-            if (!FileExists (cmake)) {
-                EnsureDirectoryExists (tripletsRoot);
-                var src = VCPKG_PATH.CombineWithFilePath ($"triplets/{arch}-uwp.cmake");
-                if (!FileExists (src))
-                    src = VCPKG_PATH.CombineWithFilePath ($"triplets/community/{arch}-uwp.cmake");
-                CopyFile (src, cmake);
-                System.IO.File.AppendAllLines (cmake.FullPath, new [] {
+            var cmake = tripletsRoot.CombineWithFilePath($"{triplet}.cmake");
+            if (!FileExists(cmake)) {
+                EnsureDirectoryExists(tripletsRoot);
+                var src = VCPKG_PATH.CombineWithFilePath($"triplets/{arch}-uwp.cmake");
+                if (!FileExists(src))
+                    src = VCPKG_PATH.CombineWithFilePath($"triplets/community/{arch}-uwp.cmake");
+                CopyFile(src, cmake);
+                System.IO.File.AppendAllLines(cmake.FullPath, new [] {
                     $"set(VCPKG_PLATFORM_TOOLSET \"{platform_toolset}\")",
                     $"set(VCPKG_DEP_INFO_OVERRIDE_VARS \"{platform_toolset}\")",
                 });
@@ -143,16 +143,21 @@ Task("ANGLE")
         var d = CONFIGURATION.ToLower() == "release" ? "" : "debug/";
         var zd = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
-        RunProcess (vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\" --debug");
+        RunProcess(vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\" --debug");
+
+        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.FullPath.Replace("/", "\\") + "\"");
+        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.CombineWithFilePath($"installed").FullPath.Replace("/", "\\") + "\"");
+        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.CombineWithFilePath($"installed/{triplet}").FullPath.Replace("/", "\\") + "\"");
+        RunProcess("cmd", "/c \"dir " + VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin").FullPath.Replace("/", "\\") + "\"");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libEGL.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libEGL.pdb"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libGLESv2.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/libGLESv2.pdb"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/zlib{zd}1.dll"), outDir);
-        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath ($"installed/{triplet}/{d}bin/zlib{zd}.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin/libEGL.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin/libEGL.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin/libGLESv2.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin/libGLESv2.pdb"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin/zlib{zd}1.dll"), outDir);
+        CopyFileToDirectory(VCPKG_PATH.CombineWithFilePath($"installed/{triplet}/{d}bin/zlib{zd}.pdb"), outDir);
     }
 });
 

--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -143,7 +143,7 @@ Task("ANGLE")
         var d = CONFIGURATION.ToLower() == "release" ? "" : "debug/";
         var zd = CONFIGURATION.ToLower() == "release" ? "" : "d";
 
-        RunProcess (vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\"");
+        RunProcess (vcpkg, $"install angle:{triplet} --overlay-triplets=\"{tripletsRoot}\" --debug");
 
         var outDir = OUTPUT_PATH.Combine(arch);
         EnsureDirectoryExists(outDir);

--- a/native/uwp/build.cake
+++ b/native/uwp/build.cake
@@ -2,7 +2,7 @@ bool SKIP_ANGLE = Argument("skipAngle", false);
 string VC_TOOLSET_VERSION = Argument("vcToolsetVersion", "14.2");
 
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
-DirectoryPath VCPKG_PATH = MakeAbsolute(ROOT_PATH.Combine("externals/vcpkg"));
+DirectoryPath VCPKG_PATH = EnvironmentVariable("VCPKG_ROOT") ?? MakeAbsolute(ROOT_PATH.Combine("externals/vcpkg"));
 DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native/uwp"));
 
 #load "../../cake/native-shared.cake"

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -18,7 +18,7 @@ parameters:
   configuration: $(CONFIGURATION)               # the build configuration
   buildExternals: ''                            # the build number to download externals from
   buildPipelineType: 'both'                     # the type of build pipeline setup
-  verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
+  verbosity: diagnostic                         # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
   installAndroidNdk: true                       # whether or not to install the Android NDK

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -18,7 +18,7 @@ parameters:
   configuration: $(CONFIGURATION)               # the build configuration
   buildExternals: ''                            # the build number to download externals from
   buildPipelineType: 'both'                     # the type of build pipeline setup
-  verbosity: diagnostic                         # the level of verbosity to use when building
+  verbosity: $(VERBOSITY)                       # the level of verbosity to use when building
   docker: ''                                    # the Docker image to build and use
   dockerArgs: ''                                # any additional arguments to pass to docker build
   installAndroidNdk: true                       # whether or not to install the Android NDK


### PR DESCRIPTION
**Description of Change**

Previously I would download my own vcpkg and use that - then they added it to the image. As of a few weeks ago, there is now a new variable: https://github.com/actions/runner-images/pull/6218

**Bugs Fixed**


 - Fixes https://github.com/microsoft/vcpkg/issues/26818

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
