### PR TITLE
feat: Generate for Emscripten 3.1.12 and SIMD features

### DIFF
--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -368,9 +368,26 @@ stages:
             vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
             artifactName: native
             emscripten:
-              - 2.0.6
-              - 2.0.23
-              - 3.1.7
+              - 2.0.6:
+                displayName: 2.0.6
+                version: 2.0.6
+                features: none
+              - 2.0.23:
+                displayName: 2.0.23
+                version: 2.0.23
+                features: none
+              - 3.1.7:
+                displayName: 3.1.7
+                version: 3.1.7
+                features: none
+              - 3.1.12:
+                displayName: 3.1.12
+                version: 3.1.12
+                features: none
+              - 3.1.12:
+                displayName: '3.1.12_SIMD'
+                version: 3.1.12
+                features: simd
 
   - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: managed

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -368,11 +368,7 @@ stages:
             vmImage: ${{ parameters.VM_IMAGE_LINUX_NATIVE }}
             artifactName: native
             emscripten:
-              - 2.0.5
               - 2.0.6
-              - 2.0.9
-              - 2.0.11
-              - 2.0.12
               - 2.0.23
               - 3.1.7
 

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -383,7 +383,7 @@ stages:
               - 3.1.12:
                 displayName: 3.1.12
                 version: 3.1.12
-                features: none
+                features: st
               - 3.1.12:
                 displayName: '3.1.12_SIMD'
                 version: 3.1.12

--- a/scripts/azure-templates-wasm-matrix.yml
+++ b/scripts/azure-templates-wasm-matrix.yml
@@ -9,15 +9,15 @@ jobs:
   - ${{ each version in parameters.emscripten }}:
     - template: azure-templates-bootstrapper.yml
       parameters:
-        name: native_wasm_${{ replace(version, '.', '_') }}_linux
-        displayName: WASM (${{ version }})
+        name: native_wasm_${{ replace(version.displayName, '.', '_') }}_linux
+        displayName: WASM (${{ version.displayName }})
         buildExternals: ${{ parameters.buildExternals }}
         buildPipelineType: ${{ parameters.buildPipelineType }}
         vmImage: ${{ parameters.vmImage }}
         docker: scripts/Docker/wasm
         target: externals-wasm
-        dockerArgs: --build-arg EMSCRIPTEN_VERSION=${{ version }}
-        additionalArgs: --emscriptenVersion=${{ version }}
+        dockerArgs: --build-arg EMSCRIPTEN_VERSION=${{ version.version }}
+        additionalArgs: --emscriptenVersion=${{ version.version }} --emscriptenFeatures="${{ version.features }}"
         artifactName: ${{ parameters.artifactName }}
         postBuildSteps:
           - task: PublishBuildArtifacts@1


### PR DESCRIPTION
**Description of Change**

- Adds 3.1.12 Emscripten single-threaded support (Aligned with .NET 7 RC1)
- Adds support for SIMD feature build

**Bugs Fixed**

None.

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
