### PR TITLE
Intercept and capture GL for .NET

### DIFF
--- a/nuget/SkiaSharp.Views.Blazor.nuspec
+++ b/nuget/SkiaSharp.Views.Blazor.nuspec
@@ -44,7 +44,9 @@ Please visit https://go.microsoft.com/fwlink/?linkid=868517 to view the release 
 
     <!-- the build bits -->
     <file src="build/net6.0/SkiaSharp.Views.Blazor.props" />
+    <file src="build/net6.0/SkiaSharpGLInterop.js" />
     <file src="build/net6.0/SkiaSharp.Views.Blazor.props" target="buildTransitive/net6.0/SkiaSharp.Views.Blazor.props" />
+    <file src="build/net6.0/SkiaSharpGLInterop.js" target="buildTransitive/net6.0/SkiaSharpGLInterop.js" />
 
     <!-- the js/css files -->
     <file src="staticwebassets\*" target="staticwebassets\" />

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/Internal/SKHtmlCanvasInterop.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/Internal/SKHtmlCanvasInterop.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -44,6 +46,15 @@ namespace SkiaSharp.Views.Blazor.Internal
 			if (callbackReference != null)
 				throw new InvalidOperationException("Unable to initialize the same canvas more than once.");
 
+			try
+			{
+				InterceptGLObject();
+			}
+			catch
+			{
+				// no-op
+			}
+
 			callbackReference = DotNetObjectReference.Create(callbackHelper);
 
 			return Invoke<GLInfo>(InitGLSymbol, htmlCanvas, htmlElementId, callbackReference);
@@ -76,5 +87,9 @@ namespace SkiaSharp.Views.Blazor.Internal
 			Invoke(PutImageDataSymbol, htmlCanvas, intPtr.ToInt64(), rawSize.Width, rawSize.Height);
 
 		public record GLInfo(int ContextId, uint FboId, int Stencils, int Samples, int Depth);
+
+		// Workaround for https://github.com/dotnet/runtime/issues/76077
+		[DllImport("libSkiaSharp", CallingConvention = CallingConvention.Cdecl)]
+		static extern JSObject InterceptGLObject();
 	}
 }

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/Internal/SKHtmlCanvasInterop.cs
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/Internal/SKHtmlCanvasInterop.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -90,6 +89,6 @@ namespace SkiaSharp.Views.Blazor.Internal
 
 		// Workaround for https://github.com/dotnet/runtime/issues/76077
 		[DllImport("libSkiaSharp", CallingConvention = CallingConvention.Cdecl)]
-		static extern JSObject InterceptGLObject();
+		static extern void InterceptGLObject();
 	}
 }

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.Local.props
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.Local.props
@@ -5,6 +5,11 @@
     <WasmBuildNative Condition="'$(WasmBuildNative)' == ''">true</WasmBuildNative>
   </PropertyGroup>
 
+  <!-- Workaround for https://github.com/dotnet/runtime/issues/76077 -->
+  <PropertyGroup>
+    <EmccExtraLDFlags>$(EmccExtraLDFlags) --js-library="$(MSBuildThisFileDirectory)\SkiaSharpGLInterop.js"</EmccExtraLDFlags>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))">
     <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\2.0.23\*.a" />
   </ItemGroup>

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.props
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.props
@@ -6,6 +6,11 @@
     <_SkiaSharpViewsBlazorStaticAssetsRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\staticwebassets'))\</_SkiaSharpViewsBlazorStaticAssetsRoot>
   </PropertyGroup>
 
+  <!-- Workaround for https://github.com/dotnet/runtime/issues/76077 -->
+  <PropertyGroup>
+    <EmccExtraLDFlags>$(EmccExtraLDFlags) --js-library="$(MSBuildThisFileDirectory)\SkiaSharpGLInterop.js"</EmccExtraLDFlags>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))">
     <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\2.0.23\*.a" />
   </ItemGroup>

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharpGLInterop.js
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharpGLInterop.js
@@ -1,0 +1,15 @@
+﻿// Workaround for https://github.com/dotnet/runtime/issues/76077
+// Special thanks to the Avalonia UI team
+
+var SkiaSharpGLInterop = {
+	$SkiaSharpLibrary: {
+		internal_func: function () {
+		}
+	},
+	InterceptGLObject: function () {
+		globalThis.SkiaSharpGL = GL
+	}
+}
+
+autoAddDeps(SkiaSharpGLInterop, '$SkiaSharpLibrary')
+mergeInto(LibraryManager.library, SkiaSharpGLInterop)

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/wwwroot/SKHtmlCanvas.ts
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/wwwroot/SKHtmlCanvas.ts
@@ -111,9 +111,11 @@ export class SKHtmlCanvas {
 			}
 
 			// make current
+			const GL = SKHtmlCanvas.getGL();
 			GL.makeContextCurrent(ctx);
 
 			// read values
+			const GLctx = SKHtmlCanvas.getGLctx();
 			const fbo = GLctx.getParameter(GLctx.FRAMEBUFFER_BINDING);
 			this.glInfo = {
 				context: ctx,
@@ -148,6 +150,7 @@ export class SKHtmlCanvas {
 		this.renderLoopRequest = window.requestAnimationFrame(() => {
 			if (this.glInfo) {
 				// make current
+				const GL = SKHtmlCanvas.getGL();
 				GL.makeContextCurrent(this.glInfo.context);
 			}
 
@@ -212,6 +215,7 @@ export class SKHtmlCanvas {
 			renderViaOffscreenBackBuffer: 0,
 		};
 
+		const GL = SKHtmlCanvas.getGL();
 		let ctx: WebGLRenderingContext = GL.createContext(htmlCanvas, contextAttributes);
 		if (!ctx && contextAttributes.majorVersion > 1) {
 			console.warn('Falling back to WebGL 1.0');
@@ -221,5 +225,14 @@ export class SKHtmlCanvas {
 		}
 
 		return ctx;
+	}
+
+	static getGL(): any {
+		return (globalThis as any).SkiaSharpGL || (Module as any).GL || GL;
+	}
+
+	static getGLctx(): WebGLRenderingContext {
+		const GL = SKHtmlCanvas.getGL();
+		return GL.currentContext && GL.currentContext.GLctx || GLctx;
 	}
 }


### PR DESCRIPTION
**Description of Change**

As a result of the GL and GLctx instance not being exposed by default in .NET 7 (https://github.com/dotnet/runtime/issues/76077), we can hook into the setup of dotnet.js and then use that captured instance.

**Bugs Fixed**

- Fixes #2267

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
