### PR TITLE
fix(wasm): Adjust for invalid globbing for 3.1.12 archive lookup

### DIFF
--- a/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.props
+++ b/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.props
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <SkiaSharpStaticLibrary Include="$(SkiaSharpStaticLibraryPath)\*\*.a" />
+        <SkiaSharpStaticLibrary Include="$(SkiaSharpStaticLibraryPath)\**\*.a" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Description of Change**

Fixes the globbing pattern used for 3.1.12 lookups, as now there are subfolders to discriminate builds based on runtime features.

**Bugs Fixed**

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
