### PR TITLE
Force an older version of the Windows SDK

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -25,7 +25,7 @@ Uno.UI                                          release     4.0.8
 Uno.WinUI                                       release     4.0.13
 Microsoft.WindowsAppSDK                         release     1.0.3
 Microsoft.Maui.Graphics                         release     6.0.300-rc.2.1310
-Microsoft.Windows.SDK.NET.Ref                   release     10.0.18362.22
+Microsoft.Windows.SDK.NET.Ref                   release     10.0.19041.24
 Microsoft.AspNetCore.Components.Web             release     6.0.0
 
 # additional references used by the tooling

--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -261,4 +261,9 @@ internal partial class VersionConstants {
 
   <Import Project="SkiaSharp.Build.WinUI.NetCore.targets" Condition=" '$(EnablePriGenTooling)' != 'true' and '$(TargetPlatformIdentifier)' == 'windows' and '$(EnablePreviewMsixTooling)' == 'true' and '$(UseMaui)' != 'true' and '$(UseMauiCore)' != 'true' " />
 
+  <!-- Make sure we always build with a lower version of WinRT.Runtime.dll -->
+  <ItemGroup>
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.24" TargetingPackVersion="10.0.19041.24" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Description of Change**

Seems the newer .NET 6 SDK brings in newer dependencies and .NET 7 does not like that.

**Bugs Fixed**

- Fixes #2271
- Fixes #2272

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
