### PR TITLE
feat(wasm): Add mt and mt+simd, fix harfbuzz for emsdk 3.1.12

### DIFF
--- a/binding/HarfBuzzSharp/nuget/build/wasm/HarfBuzzSharp.props
+++ b/binding/HarfBuzzSharp/nuget/build/wasm/HarfBuzzSharp.props
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <HarfBuzzSharpStaticLibrary Include="$(HarfBuzzSharpStaticLibraryPath)\*\*.a" />
+        <HarfBuzzSharpStaticLibrary Include="$(HarfBuzzSharpStaticLibraryPath)\**\*.a" />
     </ItemGroup>
 
 </Project>

--- a/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/wasm/SkiaSharp.targets
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
+  <Choose>
+    <When Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
+
+      <ItemGroup>
         <Content Include="@(SkiaSharpStaticLibrary)" Visible="false" />
-    </ItemGroup>
+      </ItemGroup>
+
+      <ItemGroup>
+        <!-- Include the GL symbol when running under net7 (https://github.com/dotnet/runtime/issues/76077) -->
+        <WasmShellEmccExportedRuntimeMethod Include="GL" />
+
+        <!-- Enable GLCtx when threading is available -->
+        <WasmShellExtraEmccFlags Condition="'$(WasmShellEnableThreads)'=='True'" Include="-s OFFSCREEN_FRAMEBUFFER=1" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
 </Project>

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -61,6 +61,8 @@ Task("libSkiaSharp")
         $"  '-DSKIA_C_DLL', '-DXML_POOR_ENTROPY', " + 
         $" {(!hasSimdEnabled ? "'-DSKNX_NO_SIMD', " : "")} '-DSK_DISABLE_AAA', '-DGR_GL_CHECK_ALLOC_WITH_GET_ERROR=0', " +
         $"  '-s', 'WARN_UNALIGNED=1' " + // '-s', 'USE_WEBGL2=1' (experimental)
+        $"  { (hasSimdEnabled ? ", '-msimd128'" : "") } " +
+        $"  { (hasThreadingEnabled ? ", '-pthread'" : "") } " +
         $"] " +
         // SIMD support is based on https://github.com/google/skia/blob/1f193df9b393d50da39570dab77a0bb5d28ec8ef/modules/canvaskit/compile.sh#L57
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } ] " +
@@ -115,6 +117,7 @@ Task("libHarfBuzzSharp")
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
         $"visibility_hidden=false " +
+        $"extra_cflags=[ { (hasSimdEnabled ? "'-msimd128', " : "") } { (hasThreadingEnabled ? "'-pthread'" : "") } ] " +
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -24,6 +24,7 @@ Task("libSkiaSharp")
     .Does(() =>
 {
     bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd");
+    bool hasThreadingEnabled = EMSCRIPTEN_FEATURES.Contains("mt");
 
     GnNinja($"wasm", "SkiaSharp",
         $"target_os='linux' " +
@@ -62,7 +63,7 @@ Task("libSkiaSharp")
         $"  '-s', 'WARN_UNALIGNED=1' " + // '-s', 'USE_WEBGL2=1' (experimental)
         $"] " +
         // SIMD support is based on https://github.com/google/skia/blob/1f193df9b393d50da39570dab77a0bb5d28ec8ef/modules/canvaskit/compile.sh#L57
-        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } ] " +
+        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") { (hasThreadingEnabled ? ", '-pthread'" : "") } } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);
 
@@ -111,12 +112,15 @@ Task("libHarfBuzzSharp")
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
         $"visibility_hidden=false " +
+        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") { (hasThreadingEnabled ? ", '-pthread'" : "") } } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);
 
     var outDir = OUTPUT_PATH.Combine($"wasm");
     if (!string.IsNullOrEmpty(EMSCRIPTEN_VERSION))
         outDir = outDir.Combine("libHarfBuzzSharp.a").Combine(EMSCRIPTEN_VERSION);
+    if (EMSCRIPTEN_FEATURES.Length != 0)
+        outDir = outDir.Combine(string.Join(",", EMSCRIPTEN_FEATURES));
     EnsureDirectoryExists(outDir);
     var so = SKIA_PATH.CombineWithFilePath($"out/wasm/libHarfBuzzSharp.a");
     CopyFileToDirectory(so, outDir);

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -63,7 +63,7 @@ Task("libSkiaSharp")
         $"  '-s', 'WARN_UNALIGNED=1' " + // '-s', 'USE_WEBGL2=1' (experimental)
         $"] " +
         // SIMD support is based on https://github.com/google/skia/blob/1f193df9b393d50da39570dab77a0bb5d28ec8ef/modules/canvaskit/compile.sh#L57
-        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") { (hasThreadingEnabled ? ", '-pthread'" : "") } } ] " +
+        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);
 
@@ -107,12 +107,15 @@ Task("libHarfBuzzSharp")
     .WithCriteria(IsRunningOnLinux())
     .Does(() =>
 {
+    bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd");
+    bool hasThreadingEnabled = EMSCRIPTEN_FEATURES.Contains("mt");
+
     GnNinja($"wasm", "HarfBuzzSharp",
         $"target_os='linux' " +
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
         $"visibility_hidden=false " +
-        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") { (hasThreadingEnabled ? ", '-pthread'" : "") } } ] " +
+        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);
 

--- a/scripts/azure-pipelines-variables.yml
+++ b/scripts/azure-pipelines-variables.yml
@@ -15,7 +15,7 @@ variables:
   MONO_VERSION_LINUX: 'stable-focal/snapshots/6.12.0.182'
   XCODE_VERSION: 13.2.1
   VISUAL_STUDIO_VERSION: '17/pre'
-  DOTNET_VERSION_PREVIEW: '6.0.401'
+  DOTNET_VERSION_PREVIEW: '6.0.402'
   DOTNET_WORKLOAD_SOURCE: 'https://maui.blob.core.windows.net/metadata/rollbacks/6.0.540.json'
   CONFIGURATION: 'Release'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -388,6 +388,14 @@ stages:
                 displayName: '3.1.12_SIMD'
                 version: 3.1.12
                 features: simd
+              - 3.1.12:
+                displayName: '3.1.12_Threading'
+                version: 3.1.12
+                features: mt
+              - 3.1.12:
+                displayName: '3.1.12_Threading_SIMD'
+                version: 3.1.12
+                features: mt,simd
 
   - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: managed

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SKSwapChainPanel.Wasm.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SKSwapChainPanel.Wasm.cs
@@ -21,7 +21,7 @@ namespace SkiaSharp.Views.UWP
 #if HAS_UNO_WINUI
 		const string SKSwapChainPanelTypeFullName = "SkiaSharp.Views.Windows." + nameof(SKSwapChainPanel);
 #else
-		const string SKSwapChainPanelTypeFullName = "SkiaSharp.Views.UWP" + nameof(SKSwapChainPanel);
+		const string SKSwapChainPanelTypeFullName = "SkiaSharp.Views.UWP." + nameof(SKSwapChainPanel);
 #endif
 
 		private const int ResourceCacheBytes = 256 * 1024 * 1024; // 256 MB

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SKXamlCanvas.Wasm.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SKXamlCanvas.Wasm.cs
@@ -90,6 +90,8 @@ namespace SkiaSharp.Views.UWP
 
 		private void FreeBitmap()
 		{
+			WebAssemblyRuntime.InvokeJS(SKXamlCanvasFullTypeName + $".clearCanvas(\"{this.GetHtmlId()}\");");
+
 			if (pixels != null)
 			{
 				pixelsHandle.Free();

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/WasmScripts/SkiaSharp.Views.Uno.Wasm.js
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/WasmScripts/SkiaSharp.Views.Uno.Wasm.js
@@ -140,14 +140,22 @@
                     // make current
                     GL.makeContextCurrent(ctx);
 
+                    // Starting from .NET 7 the GLctx is defined in an inaccessible scope
+                    // when the current GL context changes. We need to pick it up from the
+                    // GL.currentContext instead.
+                    let currentGLctx = GL.currentContext && GL.currentContext.GLctx;
+
+                    if (!currentGLctx)
+                        throw `Failed to get current WebGL context`;
+
                     // read values
                     this.canvas = canvas;
                     var info = {
                         ctx: ctx,
-                        fbo: GLctx.getParameter(GLctx.FRAMEBUFFER_BINDING),
-                        stencil: GLctx.getParameter(GLctx.STENCIL_BITS),
-                        sample: 0, // TODO: GLctx.getParameter(GLctx.SAMPLES)
-                        depth: GLctx.getParameter(GLctx.DEPTH_BITS),
+                        fbo: currentGLctx.getParameter(currentGLctx.FRAMEBUFFER_BINDING),
+                        stencil: currentGLctx.getParameter(currentGLctx.STENCIL_BITS),
+                        sample: 0, // TODO: currentGLctx.getParameter(GLctx.SAMPLES)
+                        depth: currentGLctx.getParameter(currentGLctx.DEPTH_BITS),
                     };
 
                     // format as array for nicer parsing


### PR DESCRIPTION
**Description of Change**

Adds explicit support for multi-threaded and SIMD combinations.

**Bugs Fixed**

- Parts #2285, still requires .NET SDK-specific adjustments.
- Fixes incorrect UWP type name for Uno Wasm
- Adds support for software rendering in Browser secure context (Used with threads)
- GL, GLctx and threading fixes (related to https://github.com/dotnet/runtime/issues/76077)

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
