### PR TITLE
[Android] Additional check to avoid ObjectDisposedException

### DIFF
--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Android/SKTouchHandler.cs
@@ -22,7 +22,7 @@ namespace SkiaSharp.Views.Forms
 
 		public void SetEnabled(View view, bool enableTouchEvents)
 		{
-			if (view != null)
+			if (view != null && view.Handle != IntPtr.Zero)
 			{
 				view.Touch -= OnTouch;
 				if (enableTouchEvents)


### PR DESCRIPTION
**Description of Change**

Add an additional check to prevent exception. See related topics:

[[Bug] ImgeButtonRenderer used with Effect is disposed before calling OnDetach which may cause exception #13889](https://github.com/xamarin/Xamarin.Forms/issues/13889)
[Fix ObjectDisposedException issues for renderers OnElementPropertyChanged #9764](https://github.com/xamarin/Xamarin.Forms/pull/9764)

Since it's used in single place I think it's not worth creating/copying all these extensions from XF source.

Tests aren't provided cause it's not easy to replicate the exception.

**Bugs Fixed**

- Fixes #1614 

**API Changes**
None.

**Behavioral Changes**
None.

**Required skia PR**
None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
