### PR TITLE
[Tizen] Fixes Canvas Size calculation

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.cs
@@ -72,8 +72,8 @@ namespace SkiaSharp.Views.Tizen
 
 			if (IgnorePixelScaling)
 			{
-				canvasSize.Width = (int)ScalingInfo.FromPixel(geometry.Width);
-				canvasSize.Height = (int)ScalingInfo.FromPixel(geometry.Height);
+				canvasSize.Width = (int)Math.Round(ScalingInfo.FromPixel(geometry.Width));
+				canvasSize.Height = (int)Math.Round(ScalingInfo.FromPixel(geometry.Height));
 			}
 			else
 			{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.nui.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.nui.cs
@@ -1,4 +1,5 @@
-﻿using Tizen.NUI;
+﻿using System;
+using Tizen.NUI;
 
 namespace SkiaSharp.Views.Tizen.NUI
 {
@@ -53,8 +54,8 @@ namespace SkiaSharp.Views.Tizen.NUI
 					skiaCanvas.Scale((float)ScalingInfo.ScalingFactor);
 					skiaCanvas.Save();
 
-					canvasSize.Width = (int)ScalingInfo.FromPixel(width);
-					canvasSize.Height = (int)ScalingInfo.FromPixel(height);
+					canvasSize.Width = (int)Math.Round(ScalingInfo.FromPixel(width));
+					canvasSize.Height = (int)Math.Round(ScalingInfo.FromPixel(height));
 				}
 				else
 				{


### PR DESCRIPTION
**Description of Change**
<!-- Describe your changes here. -->
 - Fixes Canvas size calculation
    - When use IgnorePixelScaling, a pixel based canvas size was convert to scaled pixel
    - but, decimal part was cut by casting int, it cause error of size


**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
