### PR TITLE
[ci] Use default feed to install the .NET SDK

### DIFF
--- a/scripts/install-dotnet.ps1
+++ b/scripts/install-dotnet.ps1
@@ -1,7 +1,7 @@
 Param(
   [string] $Version,
   [string] $InstallDir,
-  [string] $FeedUrl = "https://dotnetcli.blob.core.windows.net/public"
+  [string] $FeedUrl = "https://dotnetcli.azureedge.net/dotnet"
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
Attempts to install .NET 6.0.403 have been failing on various jobs:

    Error: Unable to download https://dotnetcli.blob.core.windows.net/public/Sdk/6.0.403/dotnet-dev-win-x64.6.0.403.zip. Returned HTTP status code: 404
    Could not find ".NET Core SDK" with version = 6.0.403

Fix this by preferring the default feed found in the dotnet-install.ps1 script.