### PR TITLE
[Uno] Default Opaque to false for SKXamlCanvas on MacOS and iOS

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Mac/SKXamlCanvas.macOS.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Mac/SKXamlCanvas.macOS.cs
@@ -20,6 +20,9 @@ namespace SkiaSharp.Views.UWP
 		public SKXamlCanvas()
 		{
 			Initialize();
+#if MACOS
+			Opaque = false;
+#endif
 		}
 
 		partial void DoLoaded() =>

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.iOS/SKXamlCanvas.iOS.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.iOS/SKXamlCanvas.iOS.cs
@@ -19,7 +19,10 @@ namespace SkiaSharp.Views.UWP
 
 		public SKXamlCanvas()
 		{
-			Initialize();
+			Initialize();			
+#if IOS
+			Opaque = false;
+#endif
 		}
 
 		partial void DoLoaded() =>


### PR DESCRIPTION
**Description of Change**

See canvas default opacity to none on mac and iOS to align on other platforms.

**Bugs Fixed**

**API Changes**

None.

**Behavioral Changes**

By default, canvas will be transparent instead of black.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
