### PR TITLE
Set Uno iOS SKSwapChainPanel to non-opaque for consistency

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.iOS/SKSwapChainPanel.iOS.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.iOS/SKSwapChainPanel.iOS.cs
@@ -34,6 +34,8 @@ namespace SkiaSharp.Views.UWP
 		partial void DoLoaded()
 		{
 			glView = new SKGLView(Bounds);
+			// Force the opacity to false for consistency with the other platforms
+			glView.Opaque = false;
 			glView.PaintSurface += OnPaintSurface;
 			AddSubview(glView);
 		}


### PR DESCRIPTION
set to non opaque for consistency

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
