### PR TITLE
`SKVertices`: `CreateCopy` is missing overload to pass vertices' and indexes' offset + count

### DIFF
--- a/binding/Binding/SKVertices.cs
+++ b/binding/Binding/SKVertices.cs
@@ -32,6 +32,19 @@ namespace SkiaSharp
 
 		public static SKVertices CreateCopy (SKVertexMode vmode, SKPoint[] positions, SKPoint[] texs, SKColor[] colors, UInt16[] indices)
 		{
+			var vertexCount = positions.Length;
+			var indexCount = indices?.Length ?? 0;
+
+			return CreateCopy (vmode, vertexCount, positions, texs, colors, indexCount, indices);
+		}
+
+		public static SKVertices CreateCopy (SKVertexMode vmode, int vertexCount, SKPoint[] positions, SKPoint[] texs, SKColor[] colors, int indexCount, UInt16[] indices)
+		{
+			return CreateCopy (vmode, 0, vertexCount, positions, texs, colors, 0, indexCount, indices);
+		}
+
+		public static SKVertices CreateCopy (SKVertexMode vmode, int vertexOffset, int vertexCount, SKPoint[] positions, SKPoint[] texs, SKColor[] colors, int indexOffset, int indexCount, UInt16[] indices)
+		{
 			if (positions == null)
 				throw new ArgumentNullException (nameof (positions));
 
@@ -40,14 +53,23 @@ namespace SkiaSharp
 			if (colors != null && positions.Length != colors.Length)
 				throw new ArgumentException ("The number of colors must match the number of vertices.", nameof (colors));
 
-			var vertexCount = positions.Length;
-			var indexCount = indices?.Length ?? 0;
+			if (vertexOffset >= positions.Length)
+				throw new ArgumentException ("The vertex offset should be in bounds of vertex array.", nameof (vertexOffset));
+
+			if (vertexOffset + vertexCount >= positions.Length)
+				throw new ArgumentException ("The vertex count should be in bounds of vertex array.", nameof (vertexOffset));
+
+			if (indexOffset >= indices.Length)
+				throw new ArgumentException ("The index offset should be in bounds of index array.", nameof (vertexOffset));
+
+			if (indexOffset + indexCount >= indices.Length)
+				throw new ArgumentException ("The vertex count should be in bounds of vertex array.", nameof (vertexOffset));
 
 			fixed (SKPoint* p = positions)
 			fixed (SKPoint* t = texs)
 			fixed (SKColor* c = colors)
 			fixed (UInt16* i = indices) {
-				return GetObject (SkiaApi.sk_vertices_make_copy (vmode, vertexCount, p, t, (uint*)c, indexCount, i));
+				return GetObject (SkiaApi.sk_vertices_make_copy (vmode, vertexCount, p + vertexOffset, t + vertexOffset, (uint*)c + vertexOffset, indexCount, i + indexOffset));
 			}
 		}
 

--- a/binding/Binding/SKVertices.cs
+++ b/binding/Binding/SKVertices.cs
@@ -56,20 +56,20 @@ namespace SkiaSharp
 			if (vertexOffset >= positions.Length)
 				throw new ArgumentException ("The vertex offset should be in bounds of vertex array.", nameof (vertexOffset));
 
-			if (vertexOffset + vertexCount >= positions.Length)
+			if (vertexOffset + vertexCount > positions.Length)
 				throw new ArgumentException ("The vertex count should be in bounds of vertex array.", nameof (vertexOffset));
 
 			if (indexOffset >= indices.Length)
 				throw new ArgumentException ("The index offset should be in bounds of index array.", nameof (vertexOffset));
 
-			if (indexOffset + indexCount >= indices.Length)
+			if (indexOffset + indexCount > indices.Length)
 				throw new ArgumentException ("The vertex count should be in bounds of vertex array.", nameof (vertexOffset));
 
 			fixed (SKPoint* p = positions)
 			fixed (SKPoint* t = texs)
 			fixed (SKColor* c = colors)
 			fixed (UInt16* i = indices) {
-				return GetObject (SkiaApi.sk_vertices_make_copy (vmode, vertexCount, p + vertexOffset, t + vertexOffset, (uint*)c + vertexOffset, indexCount, i + indexOffset));
+				return GetObject (SkiaApi.sk_vertices_make_copy (vmode, vertexCount, p + vertexOffset * sizeof(SKPoint), t + vertexOffset * sizeof(SKPoint), (uint*)c + vertexOffset * sizeof(uint), indexCount, i + indexOffset * sizeof(ushort)));
 			}
 		}
 


### PR DESCRIPTION
**Description of Change**

Add the ability to pass offsets and counts to the `SKVertices` struct for passing them to the DrawVertices call.

**Features Resolved**

- Resolves #2431

**API Changes**

Added: 
 
- `SKVertices SKVertices.CreateCopy(SKVertexMode vmode, int vertexCount, SKPoint[] positions, SKPoint[] texs, SKColor[] colors, int indexCount, UInt16[] indices);`
- `SKVertices SKVertices.CreateCopy (SKVertexMode vmode, int vertexOffset, int vertexCount, SKPoint[] positions, SKPoint[] texs, SKColor[] colors, int indexOffset, int indexCount, UInt16[] indices)`

**Behavioral Changes**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation

---

Regarding tests - I can't find any tests related to `SKVertices` class usage at all.

The documentation PR is in progress.