### PR TITLE
Update bitmap SKAlphaType in SKXamlCanvas.Wasm.cs

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SKXamlCanvas.Wasm.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.Wasm/SKXamlCanvas.Wasm.cs
@@ -73,7 +73,7 @@ namespace SkiaSharp.Views.UWP
 		private SKImageInfo CreateBitmap(out SKSizeI unscaledSize, out float dpi)
 		{
 			var size = CreateSize(out unscaledSize, out dpi);
-			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Opaque);
+			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Unpremul);
 
 			if (pixels == null || pixelWidth != info.Width || pixelHeight != info.Height)
 			{


### PR DESCRIPTION
To obtain the expected built bitmap by skia, we need to change the SKAlphaType of the build image. Opaque doesn't give correct results when bluring none opaque colors for example. Premul doesn't work either for a particular reason: In javascript we use the ImageData API.
The ImageData API store the pixels as un-premultiplied. So if we use the premultiplied enum value we end up with wrong pixel colors (same result as Opaque in fact). I tested unpremul value in a project that is using blur, and it gives the correct results.