### PR TITLE
Skip updating GitHub status when no token is available

### DIFF
--- a/scripts/azure-templates-github-status.yml
+++ b/scripts/azure-templates-github-status.yml
@@ -6,6 +6,10 @@ parameters:
 
 steps:
   - pwsh: |
+      if ('$(Github.Token.Status)' -eq '') {
+        Write-Host "GitHub status token was empty. Skipping status updates."
+        return
+      }
       $state = 'pending'
       if ('${{ parameters.state }}') {
         $state = '${{ parameters.state }}'


### PR DESCRIPTION
**Description of Change**

This PR just allows the status updates to be skipped if we don't have a token.