### PR TITLE
Install .NET 7

### DIFF
--- a/scripts/azure-pipelines-variables.yml
+++ b/scripts/azure-pipelines-variables.yml
@@ -15,8 +15,8 @@ variables:
   MONO_VERSION_LINUX: 'stable-focal/snapshots/6.12.0.182'
   XCODE_VERSION: 13.2.1
   VISUAL_STUDIO_VERSION: ''
-  DOTNET_VERSION_PREVIEW: '6.0.408'
-  DOTNET_WORKLOAD_SOURCE: 'https://maui.blob.core.windows.net/metadata/rollbacks/6.0.553.json'
+  DOTNET_VERSION_PREVIEW: '7.0.302'
+  DOTNET_WORKLOAD_SOURCE: 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.86.json'
   CONFIGURATION: 'Release'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -178,13 +178,6 @@ jobs:
             condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
             inputs:
               packageType: 'sdk'
-              version: 6.0.x
-            retryCountOnTaskFailure: 3
-            displayName: Install .NET Core 6.0.x
-          - task: UseDotNet@2
-            condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
-            inputs:
-              packageType: 'sdk'
               version: 7.0.x
             retryCountOnTaskFailure: 3
             displayName: Install .NET Core 7.0.x

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -181,6 +181,13 @@ jobs:
               version: 6.0.x
             retryCountOnTaskFailure: 3
             displayName: Install .NET Core 6.0.x
+          - task: UseDotNet@2
+            condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
+            inputs:
+              packageType: 'sdk'
+              version: 7.0.x
+            retryCountOnTaskFailure: 3
+            displayName: Install .NET Core 7.0.x
           - pwsh: .\scripts\install-dotnet.ps1 -Version $env:DOTNET_VERSION_PREVIEW -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet"
             displayName: Install the preview version of .NET Core
             retryCountOnTaskFailure: 3

--- a/scripts/install-dotnet-workloads.ps1
+++ b/scripts/install-dotnet-workloads.ps1
@@ -18,7 +18,7 @@ if ($IsPreview) {
 
 Write-Host "Installing .NET workloads..."
 & dotnet workload install `
-  android ios tvos macos maccatalyst wasm-tools maui `
+  android ios tvos macos maccatalyst wasm-tools wasm-tools-net6 maui `
   --from-rollback-file $SourceUrl `
   --source https://api.nuget.org/v3/index.json `
   --source $feed1 `


### PR DESCRIPTION
**Description of Change**

This PR just installs the .NET 7 SDK onto the agents. The libraries are still producing .NET 6 binaries.