### PR TITLE
Install a specific Tizen version

### DIFF
--- a/scripts/azure-pipelines-variables.yml
+++ b/scripts/azure-pipelines-variables.yml
@@ -17,6 +17,7 @@ variables:
   VISUAL_STUDIO_VERSION: ''
   DOTNET_VERSION_PREVIEW: '6.0.408'
   DOTNET_WORKLOAD_SOURCE: 'https://maui.blob.core.windows.net/metadata/rollbacks/6.0.553.json'
+  DOTNET_WORKLOAD_TIZEN: '7.0.400'
   CONFIGURATION: 'Release'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   THROW_ON_TEST_FAILURE: true

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -202,11 +202,11 @@ jobs:
                 condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''), ne(variables.VISUAL_STUDIO_VERSION, ''))
           # install workloads
           - ${{ if not(endsWith(parameters.name, '_linux')) }}:
-            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE" -IsPreview $true
+            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE" -Tizen "$env:DOTNET_WORKLOAD_TIZEN" -IsPreview $true
               condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''), ne(variables.DOTNET_VERSION_PREVIEW, ''))
               retryCountOnTaskFailure: 3
               displayName: Install the preview .NET Core workloads
-            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE" -IsPreview $false
+            - pwsh: .\scripts\install-dotnet-workloads.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet" -SourceUrl "$env:DOTNET_WORKLOAD_SOURCE" -Tizen "$env:DOTNET_WORKLOAD_TIZEN" -IsPreview $false
               condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''), eq(variables.DOTNET_VERSION_PREVIEW, ''))
               retryCountOnTaskFailure: 3
               displayName: Install the .NET Core workloads

--- a/scripts/install-dotnet-workloads.ps1
+++ b/scripts/install-dotnet-workloads.ps1
@@ -1,6 +1,7 @@
 Param(
   [string] $SourceUrl,
   [string] $InstallDir,
+  [string] $Tizen = '<latest>',
   [boolean] $IsPreview = $true
 )
 
@@ -27,6 +28,6 @@ Write-Host "Installing .NET workloads..."
 
 Write-Host "Installing Tizen workloads..."
 Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
-./workload-install.ps1
+./workload-install.ps1 -Version "$Tizen"
 
 exit $LASTEXITCODE


### PR DESCRIPTION
**Description of Change**

The Tizen workload seems to have a bug where all the default os versions are bumped to 8 so that net6.0-tizen is now implicitly net6.0-tizen8. 0

There are some workarounds, such as using an explicit version or updating the manifest, but I am just going to use the older version of the package for now. 