### PR TITLE
Move to macOS 13

### DIFF
--- a/scripts/azure-pipelines-complete-internal.yml
+++ b/scripts/azure-pipelines-complete-internal.yml
@@ -24,7 +24,7 @@ parameters:
     default:
       pool:
         name: Azure Pipelines
-        vmImage: macos-12
+        vmImage: macos-13
   - name: VM_IMAGE_LINUX
     type: object
     default:

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -30,7 +30,7 @@ parameters:
     default:
       pool:
         name: Azure Pipelines
-        vmImage: macos-12
+        vmImage: macos-13
   - name: VM_IMAGE_LINUX
     type: object
     default:

--- a/scripts/azure-pipelines-tests.yml
+++ b/scripts/azure-pipelines-tests.yml
@@ -20,7 +20,7 @@ parameters:
     default:
       pool:
         name: Azure Pipelines
-        vmImage: macos-12
+        vmImage: macos-13
   - name: VM_IMAGE_LINUX
     type: object
     default:

--- a/scripts/azure-pipelines-variables.yml
+++ b/scripts/azure-pipelines-variables.yml
@@ -13,7 +13,7 @@ variables:
   MANAGED_LINUX_PACKAGES: ttf-ancient-fonts ninja-build
   MONO_VERSION_MACOS: '6_12_24'
   MONO_VERSION_LINUX: 'stable-focal/snapshots/6.12.0.182'
-  XCODE_VERSION: 14.2
+  XCODE_VERSION: 14.3.1
   VISUAL_STUDIO_VERSION: ''
   DOTNET_VERSION_PREVIEW: '7.0.302'
   DOTNET_WORKLOAD_SOURCE: 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.86.json'

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -30,7 +30,7 @@ parameters:
     default:
       pool:
         name: Azure Pipelines
-        vmImage: macos-12
+        vmImage: macos-13
   - name: VM_IMAGE_LINUX
     type: object
     default:


### PR DESCRIPTION
**Description of Change**

The new .NET SDK requires Xcode 14.3, which requires macOS 13. 

We obey the SDK.