### PR TITLE
fix(wasm): Enable Wasm EH and SIMD in all configurations for net8+

### DIFF
--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -117,7 +117,7 @@ Task("libHarfBuzzSharp")
 {
     bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd") || EMSCRIPTEN_FEATURES.Contains("_simd");;
     bool hasThreadingEnabled = EMSCRIPTEN_FEATURES.Contains("mt");
-    bool hasWasmEH = EMSCRIPTEN_FEATURES.Contains("wasmeh");
+    bool hasWasmEH = EMSCRIPTEN_FEATURES.Contains("_wasmeh");
 
     var emscriptenFeaturesModifiers = 
         EMSCRIPTEN_FEATURES

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -69,6 +69,7 @@ Task("libSkiaSharp")
         $"  '-s', 'WARN_UNALIGNED=1' " + // '-s', 'USE_WEBGL2=1' (experimental)
         $"  { (hasSimdEnabled ? ", '-msimd128'" : "") } " +
         $"  { (hasThreadingEnabled ? ", '-pthread'" : "") } " +
+        $"  { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } " +
         $"] " +
         // SIMD support is based on https://github.com/google/skia/blob/1f193df9b393d50da39570dab77a0bb5d28ec8ef/modules/canvaskit/compile.sh#L57
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
@@ -129,7 +130,7 @@ Task("libHarfBuzzSharp")
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
         $"visibility_hidden=false " +
-        $"extra_cflags=[ { (hasSimdEnabled ? "'-msimd128', " : "") } { (hasThreadingEnabled ? "'-pthread'" : "") } ] " +
+        $"extra_cflags=[ { (hasSimdEnabled ? "'-msimd128', " : "") } { (hasThreadingEnabled ? "'-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -130,7 +130,7 @@ Task("libHarfBuzzSharp")
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
         $"visibility_hidden=false " +
-        $"extra_cflags=[ { (hasSimdEnabled ? "'-msimd128', " : "") } { (hasThreadingEnabled ? "'-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
+        $"extra_cflags=[ '-s', 'WARN_UNALIGNED=1' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         COMPILERS +
         ADDITIONAL_GN_ARGS);

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -405,19 +405,11 @@ stages:
               - 3.1.34:
                 displayName: 3.1.34
                 version: 3.1.34
-                features: st
-              - 3.1.34:
-                displayName: '3.1.34_SIMD'
-                version: 3.1.34
-                features: simd
+                features: _wasmeh,_simd,st
               - 3.1.34:
                 displayName: '3.1.34_Threading'
                 version: 3.1.34
-                features: mt
-              - 3.1.34:
-                displayName: '3.1.34_Threading_SIMD'
-                version: 3.1.34
-                features: mt,simd
+                features: _wasmeh,_simd,mt
 
   - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: managed


### PR DESCRIPTION
**Description of Change**

Enables Wasm EH and SIMD by default for Emscripten 3.1.34 (net8)

**Bugs Fixed**

- Fixes https://github.com/mono/SkiaSharp/issues/2494

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
