### PR TITLE
Include the new WASM assets in Blazor for .NET 8

### DIFF
--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.Local.props
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.Local.props
@@ -16,5 +16,8 @@
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))">
     <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.12\st\*.a" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))">
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\st\*.a" />
+  </ItemGroup>
 
 </Project>

--- a/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.props
+++ b/source/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor/nuget/build/net6.0/SkiaSharp.Views.Blazor.props
@@ -17,6 +17,9 @@
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))">
     <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.12\st\*.a" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))">
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\st\*.a" />
+  </ItemGroup>
 
   <ItemGroup>
     <_TempStaticWebAsset Include="$(_SkiaSharpViewsBlazorStaticAssetsRoot)*.js" />


### PR DESCRIPTION
**Description of Change**

Now that we have the new WASM assets, this PR will make sure that installing the SkiaSharp.Views.Blazor package correctly includes the assets for net6-8.