### PR TITLE
Pack using `dotnet pack`

### DIFF
--- a/cake/UtilsManaged.cake
+++ b/cake/UtilsManaged.cake
@@ -1,24 +1,29 @@
 void PackageNuGet(FilePath nuspecPath, DirectoryPath outputPath, bool allowDefaultExcludes = false, string symbolsFormat = null)
 {
     EnsureDirectoryExists(outputPath);
-    var settings = new NuGetPackSettings {
+    var csproj = MakeAbsolute(Directory("./nuget/NuGet.csproj")).FullPath;
+    var restoreSettings = new DotNetRestoreSettings {
+        MSBuildSettings = new DotNetMSBuildSettings {
+            NoLogo = true,
+        },
+        WorkingDirectory = MakeAbsolute(nuspecPath.GetDirectory()),
+    };
+    var settings = new DotNetPackSettings {
+        NoLogo = true,
+        NoBuild = true,
+        Configuration = "Release",
         OutputDirectory = MakeAbsolute(outputPath),
-        BasePath = nuspecPath.GetDirectory(),
-        Properties = new Dictionary<string, string> {
-            // NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead.
-            // NU5105: The package version 'xxx' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients.
-            // NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
-            { "NoWarn", "NU5048,NU5105,NU5125" }
+        WorkingDirectory = MakeAbsolute(nuspecPath.GetDirectory()),
+        IncludeSymbols = !string.IsNullOrEmpty(symbolsFormat),
+        SymbolPackageFormat = symbolsFormat,
+        MSBuildSettings = new DotNetMSBuildSettings {
+            Properties = {
+                { "NuspecFile", new [] { (nuspecPath).FullPath } },
+            },
         },
     };
-    if (allowDefaultExcludes) {
-        settings.ArgumentCustomization = args => args.Append("-NoDefaultExcludes");
-    }
-    if (!string.IsNullOrEmpty(symbolsFormat)) {
-        settings.Symbols = true;
-        settings.SymbolPackageFormat = symbolsFormat;
-    }
-    NuGetPack(nuspecPath, settings);
+    DotNetRestore(csproj, restoreSettings);
+    DotNetPack(csproj, settings);
 }
 
 void RunTests(FilePath testAssembly, bool is32)

--- a/nuget/NuGet.csproj
+++ b/nuget/NuGet.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!-- Prevents default exclusion of NuGet package files and files and folders starting with a dot -->
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+
+    <!-- NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead. -->
+    <!-- NU5105: The package version 'xxx' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. -->
+    <!-- NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. -->
+    <NoWarn>NU5048;NU5105;NU5125</NoWarn>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
**Description of Change**

Packing with `dotnet pack` works much better since it does not require mono on non-Windows platforms. And it is the new way, a pity about that csproj but it is OK...