### PR TITLE
Add function to `SkiaSharp.Harfbuzz` for getting shaped text paths

### DIFF
--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
@@ -44,6 +44,9 @@ namespace SkiaSharp.HarfBuzz
 			if (string.IsNullOrEmpty(text))
 				return new SKPath();
 
+			if (font == null)
+				throw new ArgumentNullException(nameof(font));
+
 			using var shaper = new SKShaper(font.Typeface);
 			return font.GetShapedTextPath(shaper, text, xOffset, yOffset, textAlign);
 		}

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
@@ -26,5 +26,76 @@ namespace SkiaSharp.HarfBuzz
 
 			font.SetScale(scale.Width, scale.Height);
 		}
+
+		public static SKPath GetShapedTextPath(this SKFont font, string text, SKPoint p) =>
+			font.GetShapedTextPath(text, p.X, p.Y);
+
+		public static SKPath GetShapedTextPath(this SKFont font, string text, float x, float y) =>
+			font.GetShapedTextPath(text, x, y, SKTextAlign.Left);
+
+		public static SKPath GetShapedTextPath(this SKFont font, string text, float x, float y, SKTextAlign textAlign)
+		{
+			if (string.IsNullOrEmpty(text))
+				return new SKPath();
+
+			using var shaper = new SKShaper(font.Typeface);
+			return font.GetShapedTextPath(shaper, text, x, y, textAlign);
+		}
+
+		public static SKPath GetShapedTextPath(this SKFont font, SKShaper shaper, string text, float x, float y, SKTextAlign textAlign)
+		{
+			if (string.IsNullOrEmpty(text))
+				return new SKPath();
+
+			if (shaper == null)
+				throw new ArgumentNullException(nameof(shaper));
+			if (font == null)
+				throw new ArgumentNullException(nameof(font));
+
+			font.Typeface = shaper.Typeface;
+
+			// shape the text
+			var result = shaper.Shape(text, x, y, font);
+
+			// adjust alignment
+			var xOffset = 0.0f;
+			if (textAlign != SKTextAlign.Left)
+			{
+				var width = result.Width;
+				if (textAlign == SKTextAlign.Center)
+					width *= 0.5f;
+				xOffset -= width;
+			}
+
+			// get spans for more efficient accessing
+			var glyphSpan = result.Codepoints.AsSpan();
+			var pointSpan = result.Points.AsSpan();
+
+			using var pathBuilder = new SKPathBuilder();
+
+			// generate a path for each glyph
+			for (var i = 0; i < pointSpan.Length; i++)
+			{
+				// get the glyph path
+				using var glyphPath = font.GetGlyphPath((ushort)glyphSpan[i]);
+
+				if (glyphPath is null || glyphPath.IsEmpty)
+					continue;
+
+				// translate the glyph path
+				var point = pointSpan[i];
+				var matrix = new SKMatrix(
+					1, 0, point.X + xOffset,
+					0, 1, point.Y,
+					0, 0, 1
+				);
+				glyphPath.Transform(in matrix);
+
+				// append the glyph path
+				pathBuilder.AddPath(glyphPath);
+			}
+
+			return pathBuilder.Detach();
+		}
 	}
 }

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using HarfBuzzSharp;
 
 namespace SkiaSharp.HarfBuzz
@@ -98,8 +97,6 @@ namespace SkiaSharp.HarfBuzz
 					{
 						glyphPath = font.GetGlyphPath(glyph);
 					}
-
-					Debug.Assert(glyphPath != null);
 #else
 					if (!glyphCache.TryGetValue(glyph, out var glyphPath))
 					{

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
@@ -27,22 +27,28 @@ namespace SkiaSharp.HarfBuzz
 			font.SetScale(scale.Width, scale.Height);
 		}
 
+		public static SKPath GetShapedTextPath(this SKFont font, string text) =>
+			font.GetShapedTextPath(text, 0, 0);
+
 		public static SKPath GetShapedTextPath(this SKFont font, string text, SKPoint p) =>
 			font.GetShapedTextPath(text, p.X, p.Y);
 
-		public static SKPath GetShapedTextPath(this SKFont font, string text, float x, float y) =>
-			font.GetShapedTextPath(text, x, y, SKTextAlign.Left);
+		public static SKPath GetShapedTextPath(this SKFont font, string text, SKPoint p, SKTextAlign textAlign) =>
+			font.GetShapedTextPath(text, p.X, p.Y, textAlign);
 
-		public static SKPath GetShapedTextPath(this SKFont font, string text, float x, float y, SKTextAlign textAlign)
+		public static SKPath GetShapedTextPath(this SKFont font, string text, float xOffset, float yOffset) =>
+			font.GetShapedTextPath(text, xOffset, yOffset, SKTextAlign.Left);
+
+		public static SKPath GetShapedTextPath(this SKFont font, string text, float xOffset, float yOffset, SKTextAlign textAlign)
 		{
 			if (string.IsNullOrEmpty(text))
 				return new SKPath();
 
 			using var shaper = new SKShaper(font.Typeface);
-			return font.GetShapedTextPath(shaper, text, x, y, textAlign);
+			return font.GetShapedTextPath(shaper, text, xOffset, yOffset, textAlign);
 		}
 
-		public static SKPath GetShapedTextPath(this SKFont font, SKShaper shaper, string text, float x, float y, SKTextAlign textAlign)
+		public static SKPath GetShapedTextPath(this SKFont font, SKShaper shaper, string text, float xOffset, float yOffset, SKTextAlign textAlign)
 		{
 			if (string.IsNullOrEmpty(text))
 				return new SKPath();
@@ -55,16 +61,16 @@ namespace SkiaSharp.HarfBuzz
 			font.Typeface = shaper.Typeface;
 
 			// shape the text
-			var result = shaper.Shape(text, x, y, font);
+			var result = shaper.Shape(text, xOffset, yOffset, font);
 
 			// adjust alignment
-			var xOffset = 0.0f;
+			var alignXOffset = 0.0f;
 			if (textAlign != SKTextAlign.Left)
 			{
 				var width = result.Width;
 				if (textAlign == SKTextAlign.Center)
 					width *= 0.5f;
-				xOffset -= width;
+				alignXOffset -= width;
 			}
 
 			// get spans for more efficient accessing
@@ -85,7 +91,7 @@ namespace SkiaSharp.HarfBuzz
 				// translate the glyph path
 				var point = pointSpan[i];
 				var matrix = new SKMatrix(
-					1, 0, point.X + xOffset,
+					1, 0, point.X + alignXOffset,
 					0, 1, point.Y,
 					0, 0, 1
 				);

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/FontExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-
+using System.Collections.Generic;
+using System.Diagnostics;
 using HarfBuzzSharp;
 
 namespace SkiaSharp.HarfBuzz
@@ -82,26 +83,55 @@ namespace SkiaSharp.HarfBuzz
 
 			using var pathBuilder = new SKPathBuilder();
 
-			// generate a path for each glyph
-			for (var i = 0; i < pointSpan.Length; i++)
+			// Many GetGlyphPath calls is faster and allocates less memory than a single GetGlyphPaths call
+			var glyphCache = new Dictionary<ushort, SKPath>();
+			try
 			{
-				// get the glyph path
-				using var glyphPath = font.GetGlyphPath((ushort)glyphSpan[i]);
+				// generate a path for each glyph
+				for (var i = 0; i < pointSpan.Length; i++)
+				{
+					// get the glyph path
+					var glyph = (ushort)glyphSpan[i];
+#if NET6_0_OR_GREATER
+					ref var glyphPath = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(glyphCache, glyph, out var exists);
+					if (!exists)
+					{
+						glyphPath = font.GetGlyphPath(glyph);
+					}
 
-				if (glyphPath is null || glyphPath.IsEmpty)
-					continue;
+					Debug.Assert(glyphPath != null);
+#else
+					if (!glyphCache.TryGetValue(glyph, out var glyphPath))
+					{
+						glyphPath = font.GetGlyphPath(glyph);
+						glyphCache.Add(glyph, glyphPath);
+					}
+#endif
 
-				// translate the glyph path
-				var point = pointSpan[i];
-				var matrix = new SKMatrix(
-					1, 0, point.X + alignXOffset,
-					0, 1, point.Y,
-					0, 0, 1
-				);
-				glyphPath.Transform(in matrix);
+					if (glyphPath is null || glyphPath.IsEmpty)
+						continue;
 
-				// append the glyph path
-				pathBuilder.AddPath(glyphPath);
+					// translate the glyph path
+					var point = pointSpan[i];
+					var matrix = new SKMatrix(
+						1, 0, point.X + alignXOffset,
+						0, 1, point.Y,
+						0, 0, 1
+					);
+					glyphPath.Transform(in matrix);
+
+					// append the glyph path
+					pathBuilder.AddPath(glyphPath);
+				}
+			}
+			finally
+			{
+				foreach (var path in glyphCache.Values)
+				{
+					path.Dispose();
+				}
+
+				glyphCache.Clear();
 			}
 
 			return pathBuilder.Detach();

--- a/tests/Tests/SkiaSharp/SKShaperTest.cs
+++ b/tests/Tests/SkiaSharp/SKShaperTest.cs
@@ -36,6 +36,33 @@ namespace SkiaSharp.HarfBuzz.Tests
 		}
 
 		[SkippableFact]
+		public void GetShapedTextPathExtensionMethodProducesKnownPath()
+		{
+			using (var bitmap = new SKBitmap(new SKImageInfo(512, 512)))
+			using (var canvas = new SKCanvas(bitmap))
+			using (var tf = SKTypeface.FromFile(Path.Combine(PathToFonts, "content-font.ttf")))
+			using (var shaper = new SKShaper(tf))
+			using (var paint = new SKPaint { IsAntialias = true })
+			using (var font = new SKFont { Size = 64, Typeface = tf})
+			{
+				canvas.Clear(SKColors.White);
+
+				using var shapedPath = font.GetShapedTextPath(shaper, "متن", 100, 200, SKTextAlign.Left);
+				canvas.DrawPath(shapedPath, paint);
+
+				canvas.Flush();
+
+				Assert.Equal(SKColors.Black, bitmap.GetPixel(110, 210));
+				Assert.Equal(SKColors.Black, bitmap.GetPixel(127, 196));
+				Assert.Equal(SKColors.Black, bitmap.GetPixel(142, 197));
+				Assert.Equal(SKColors.Black, bitmap.GetPixel(155, 195));
+				Assert.Equal(SKColors.Black, bitmap.GetPixel(131, 181));
+				Assert.Equal(SKColors.White, bitmap.GetPixel(155, 190));
+				Assert.Equal(SKColors.White, bitmap.GetPixel(110, 200));
+			}
+		}
+
+		[SkippableFact]
 		public void CorrectlyShapesArabicScriptAtAnOffset()
 		{
 			var clusters = new uint[] { 4, 2, 0 };
@@ -126,6 +153,34 @@ namespace SkiaSharp.HarfBuzz.Tests
 			font.Size = 64;
 
 			canvas.DrawShapedText("SkiaSharp", 300, 100, align, font, paint);
+
+			AssertTextAlign(bitmap, offset, 0);
+		}
+
+		[SkippableTheory]
+		[InlineData(SKTextAlign.Left, 300)]
+		[InlineData(SKTextAlign.Center, 162)]
+		[InlineData(SKTextAlign.Right, 23)]
+		public void TextAlignMovesTextPathPosition(SKTextAlign align, int offset)
+		{
+			var fontFile = Path.Combine(PathToFonts, "segoeui.ttf");
+			using var tf = SKTypeface.FromFile(fontFile);
+
+			using var bitmap = new SKBitmap(600, 200);
+			using var canvas = new SKCanvas(bitmap);
+
+			canvas.Clear(SKColors.White);
+
+			using var paint = new SKPaint();
+			paint.IsAntialias = true;
+			paint.Color = SKColors.Black;
+
+			using var font = new SKFont();
+			font.Typeface = tf;
+			font.Size = 64;
+
+			using var shapedPath = font.GetShapedTextPath("SkiaSharp", 300, 100, align);
+			canvas.DrawPath(shapedPath, paint);
 
 			AssertTextAlign(bitmap, offset, 0);
 		}


### PR DESCRIPTION
**Description of Change**

<!-- Describe your changes here. -->

Add a class and set of new methods to `SkiaSharp.Harfbuzz` for shaping a text input and returning an `SKPath` of said text input

**Features Resolved**

- Resolves #2512 

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

Added: 
 
- `SKPath GetShapedTextPath(this SKFont font, string text)`
- `SKPath GetShapedTextPath(this SKFont font, string text, SKPoint p)`
- `SKPath GetShapedTextPath(this SKFont font, string text, SKPoint p, SKTextAlign textAlign)`
- `SKPath GetShapedTextPath(this SKFont font, string text, float xOffset, float yOffset)`
- `SKPath GetShapedTextPath(this SKFont font, string text, float xOffset, float yOffset, SKTextAlign textAlign)`
- `SKPath GetShapedTextPath(this SKFont font, SKShaper shaper, string text, float xOffset, float yOffset, SKTextAlign textAlign)`


**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Merged related skia PRs
- [X] Changes adhere to coding standard
- [ ] Updated documentation

**Additional Notes**

If this PR is wanted, I can create a documentation PR as well.