### PR TITLE
Removing nesting levels through block-scoped `using` statement

### DIFF
--- a/binding/Binding/SKDocument.cs
+++ b/binding/Binding/SKDocument.cs
@@ -145,37 +145,37 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (stream));
 			}
 
-			using (var title = SKString.Create (metadata.Title))
-			using (var author = SKString.Create (metadata.Author))
-			using (var subject = SKString.Create (metadata.Subject))
-			using (var keywords = SKString.Create (metadata.Keywords))
-			using (var creator = SKString.Create (metadata.Creator))
-			using (var producer = SKString.Create (metadata.Producer)) {
-				var cmetadata = new SKDocumentPdfMetadataInternal {
-					fTitle = title?.Handle ?? IntPtr.Zero,
-					fAuthor = author?.Handle ?? IntPtr.Zero,
-					fSubject = subject?.Handle ?? IntPtr.Zero,
-					fKeywords = keywords?.Handle ?? IntPtr.Zero,
-					fCreator = creator?.Handle ?? IntPtr.Zero,
-					fProducer = producer?.Handle ?? IntPtr.Zero,
-					fRasterDPI = metadata.RasterDpi,
-					fPDFA = metadata.PdfA ? (byte)1 : (byte)0,
-					fEncodingQuality = metadata.EncodingQuality,
-				};
+			using var title = SKString.Create (metadata.Title);
+			using var author = SKString.Create (metadata.Author);
+			using var subject = SKString.Create (metadata.Subject);
+			using var keywords = SKString.Create (metadata.Keywords);
+			using var creator = SKString.Create (metadata.Creator);
+			using var producer = SKString.Create (metadata.Producer);
 
-				SKTimeDateTimeInternal creation;
-				if (metadata.Creation != null) {
-					creation = SKTimeDateTimeInternal.Create (metadata.Creation.Value);
-					cmetadata.fCreation = &creation;
-				}
-				SKTimeDateTimeInternal modified;
-				if (metadata.Modified != null) {
-					modified = SKTimeDateTimeInternal.Create (metadata.Modified.Value);
-					cmetadata.fModified = &modified;
-				}
+			var cmetadata = new SKDocumentPdfMetadataInternal {
+				fTitle = title?.Handle ?? IntPtr.Zero,
+				fAuthor = author?.Handle ?? IntPtr.Zero,
+				fSubject = subject?.Handle ?? IntPtr.Zero,
+				fKeywords = keywords?.Handle ?? IntPtr.Zero,
+				fCreator = creator?.Handle ?? IntPtr.Zero,
+				fProducer = producer?.Handle ?? IntPtr.Zero,
+				fRasterDPI = metadata.RasterDpi,
+				fPDFA = metadata.PdfA ? (byte)1 : (byte)0,
+				fEncodingQuality = metadata.EncodingQuality,
+			};
 
-				return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream_with_metadata (stream.Handle, &cmetadata)), stream);
+			SKTimeDateTimeInternal creation;
+			if (metadata.Creation != null) {
+				creation = SKTimeDateTimeInternal.Create (metadata.Creation.Value);
+				cmetadata.fCreation = &creation;
 			}
+			SKTimeDateTimeInternal modified;
+			if (metadata.Modified != null) {
+				modified = SKTimeDateTimeInternal.Create (metadata.Modified.Value);
+				cmetadata.fModified = &modified;
+			}
+
+			return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream_with_metadata (stream.Handle, &cmetadata)), stream);
 		}
 
 		internal static SKDocument GetObject (IntPtr handle) =>

--- a/binding/Binding/SKDrawable.cs
+++ b/binding/Binding/SKDrawable.cs
@@ -90,12 +90,11 @@ namespace SkiaSharp
 
 		protected virtual SKPicture OnSnapshot ()
 		{
-			using (var recorder = new SKPictureRecorder ()) {
-				var canvas = recorder.BeginRecording (Bounds);
-				Draw (canvas, 0, 0);
-				return recorder.EndRecording ();
-			}
-		}
+			using var recorder = new SKPictureRecorder();
+			var canvas = recorder.BeginRecording(Bounds);
+			Draw(canvas, 0, 0);
+			return recorder.EndRecording();
+        }
 
 		[MonoPInvokeCallback (typeof (SKManagedDrawableDrawProxyDelegate))]
 		private static void DrawInternal (IntPtr d, void* context, IntPtr canvas)

--- a/binding/Binding/SKFontManager.cs
+++ b/binding/Binding/SKFontManager.cs
@@ -44,10 +44,9 @@ namespace SkiaSharp
 
 		public string GetFamilyName (int index)
 		{
-			using (var str = new SKString ()) {
-				SkiaApi.sk_fontmgr_get_family_name (Handle, index, str.Handle);
-				return (string)str;
-			}
+			using var str = new SKString();
+			SkiaApi.sk_fontmgr_get_family_name(Handle, index, str.Handle);
+			return (string)str;
 		}
 
 		public string[] GetFontFamilies () => FontFamilies.ToArray ();

--- a/binding/Binding/SKFontStyleSet.cs
+++ b/binding/Binding/SKFontStyleSet.cs
@@ -25,12 +25,11 @@ namespace SkiaSharp
 
 		public string GetStyleName (int index)
 		{
-			using (var str = new SKString ()) {
-				SkiaApi.sk_fontstyleset_get_style (Handle, index, IntPtr.Zero, str.Handle);
-				GC.KeepAlive(this);
-				return (string)str;
-			}
-		}
+			using var str = new SKString();
+			SkiaApi.sk_fontstyleset_get_style(Handle, index, IntPtr.Zero, str.Handle);
+			GC.KeepAlive(this);
+			return (string)str;
+        }
 
 		public SKTypeface CreateTypeface (int index)
 		{

--- a/binding/Binding/SKImage.cs
+++ b/binding/Binding/SKImage.cs
@@ -484,13 +484,13 @@ namespace SkiaSharp
 			// this involves a copy from gpu to cpu first
 			if (IsTextureBacked) {
 				var info = new SKImageInfo (Width, Height, ColorType, AlphaType, ColorSpace);
-				using (var temp = new SKBitmap (info))
-				using (var pixmap = temp.PeekPixels ()) {
-					if (pixmap != null && ReadPixels (pixmap, 0, 0)) {
-						return serializer.Encode (pixmap);
-					}
+				using var temp = new SKBitmap (info);
+				using var pixmap = temp.PeekPixels();
+				if (pixmap != null && ReadPixels(pixmap, 0, 0))
+				{
+					return serializer.Encode(pixmap);
 				}
-			}
+            }
 
 			// some error
 			return null;

--- a/binding/Binding/SKManagedStream.cs
+++ b/binding/Binding/SKManagedStream.cs
@@ -44,10 +44,9 @@ namespace SkiaSharp
 
 		public SKStreamAsset ToMemoryStream ()
 		{
-			using (var native = new SKDynamicMemoryWStream ()) {
-				CopyTo (native);
-				return native.DetachAsStream ();
-			}
+			using var native = new SKDynamicMemoryWStream();
+			CopyTo(native);
+			return native.DetachAsStream();
 		}
 
 		protected override void Dispose (bool disposing) =>

--- a/binding/Binding/SKPath.cs
+++ b/binding/Binding/SKPath.cs
@@ -466,10 +466,9 @@ namespace SkiaSharp
 
 		public string ToSvgPathData ()
 		{
-			using (var str = new SKString ()) {
-				SkiaApi.sk_path_to_svg_string (Handle, str.Handle);
-				return (string)str;
-			}
+			using var str = new SKString();
+			SkiaApi.sk_path_to_svg_string(Handle, str.Handle);
+			return (string)str;
 		}
 
 		public static SKPath ParseSvgPathData (string svgPath)

--- a/binding/HarfBuzzSharp.Shared/Blob.cs
+++ b/binding/HarfBuzzSharp.Shared/Blob.cs
@@ -78,13 +78,13 @@ namespace HarfBuzzSharp
 		{
 			// TODO: check to see if we can avoid the second copy (the ToArray)
 
-			using (var ms = new MemoryStream ()) {
-				stream.CopyTo (ms);
-				var data = ms.ToArray ();
+			using var ms = new MemoryStream();
+			stream.CopyTo(ms);
+			var data = ms.ToArray();
 
-				fixed (byte* dataPtr = data) {
-					return new Blob ((IntPtr)dataPtr, data.Length, MemoryMode.ReadOnly, () => ms.Dispose ());
-				}
+			fixed (byte* dataPtr = data)
+			{
+				return new Blob((IntPtr)dataPtr, data.Length, MemoryMode.ReadOnly, () => ms.Dispose());
 			}
 		}
 

--- a/binding/HarfBuzzSharp.Shared/Buffer.cs
+++ b/binding/HarfBuzzSharp.Shared/Buffer.cs
@@ -315,30 +315,31 @@ namespace HarfBuzzSharp
 			if (end == -1)
 				end = Length;
 
-			using (var buffer = MemoryPool<byte>.Shared.Rent ())
-			using (var pinned = buffer.Memory.Pin ()) {
-				var bufferSize = buffer.Memory.Length;
-				var currentPosition = (uint)start;
-				var builder = new StringBuilder (bufferSize);
+			using var buffer = MemoryPool<byte>.Shared.Rent ();
+			using var pinned = buffer.Memory.Pin();
 
-				while (currentPosition < end) {
-					uint consumed;
-					currentPosition += HarfBuzzApi.hb_buffer_serialize_glyphs (
-						Handle,
-						(uint)currentPosition,
-						(uint)end,
-						pinned.Pointer,
-						(uint)bufferSize,
-						&consumed,
-						font?.Handle ?? IntPtr.Zero,
-						format,
-						flags);
+			var bufferSize = buffer.Memory.Length;
+			var currentPosition = (uint)start;
+			var builder = new StringBuilder(bufferSize);
 
-					builder.Append (Marshal.PtrToStringAnsi ((IntPtr)pinned.Pointer, (int)consumed));
-				}
+			while (currentPosition < end)
+			{
+				uint consumed;
+				currentPosition += HarfBuzzApi.hb_buffer_serialize_glyphs(
+					Handle,
+					(uint)currentPosition,
+					(uint)end,
+					pinned.Pointer,
+					(uint)bufferSize,
+					&consumed,
+					font?.Handle ?? IntPtr.Zero,
+					format,
+					flags);
 
-				return builder.ToString ();
+				builder.Append(Marshal.PtrToStringAnsi((IntPtr)pinned.Pointer, (int)consumed));
 			}
+
+			return builder.ToString();
 		}
 
 		public void DeserializeGlyphs (string data) =>

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/SKShaper.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/SKShaper.cs
@@ -102,27 +102,26 @@ namespace SkiaSharp.HarfBuzz
 				return new Result();
 			}
 
-			using (var buffer = new Buffer())
+			using var buffer = new Buffer();
+
+			switch (paint.TextEncoding)
 			{
-				switch (paint.TextEncoding)
-				{
-					case SKTextEncoding.Utf8:
-						buffer.AddUtf8(text);
-						break;
-					case SKTextEncoding.Utf16:
-						buffer.AddUtf16(text);
-						break;
-					case SKTextEncoding.Utf32:
-						buffer.AddUtf32(text);
-						break;
-					default:
-						throw new NotSupportedException("TextEncoding of type GlyphId is not supported.");
-				}
-
-				buffer.GuessSegmentProperties();
-
-				return Shape(buffer, xOffset, yOffset, paint);
+				case SKTextEncoding.Utf8:
+					buffer.AddUtf8(text);
+					break;
+				case SKTextEncoding.Utf16:
+					buffer.AddUtf16(text);
+					break;
+				case SKTextEncoding.Utf32:
+					buffer.AddUtf32(text);
+					break;
+				default:
+					throw new NotSupportedException("TextEncoding of type GlyphId is not supported.");
 			}
+
+			buffer.GuessSegmentProperties();
+
+			return Shape(buffer, xOffset, yOffset, paint);
 		}
 
 		public class Result

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/AndroidExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/AndroidExtensions.cs
@@ -131,12 +131,10 @@ namespace SkiaSharp.Views.Android
 
 		public static Bitmap ToBitmap(this SKBitmap skiaBitmap)
 		{
-			using (var pixmap = skiaBitmap.PeekPixels())
-			{
-				var bmp = pixmap.ToBitmap();
-				GC.KeepAlive(skiaBitmap);
-				return bmp;
-			}
+			using var pixmap = skiaBitmap.PeekPixels();
+			var bmp = pixmap.ToBitmap();
+			GC.KeepAlive(skiaBitmap);
+			return bmp;
 		}
 
 		public static Bitmap ToBitmap(this SKImage skiaImage)
@@ -189,11 +187,9 @@ namespace SkiaSharp.Views.Android
 
 		public static Bitmap ToBitmap(this SKPixmap skiaPixmap)
 		{
-			using (var image = SKImage.FromPixels(skiaPixmap))
-			{
-				var bmp = image.ToBitmap();
-				return bmp;
-			}
+			using var image = SKImage.FromPixels(skiaPixmap);
+			var bmp = image.ToBitmap();
+			return bmp;
 		}
 
 		public static Bitmap ToBitmap(this SKPicture skiaPicture, SKSizeI dimensions)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/AppleExtensions.cs
@@ -110,13 +110,11 @@ namespace SkiaSharp.Views.Mac
 
 		public static void ToSKPixmap(this CGImage cgImage, SKPixmap pixmap)
 		{
-			using (var colorSpace = CGColorSpace.CreateDeviceRGB())
-			using (var context = new CGBitmapContext(pixmap.GetPixels(), pixmap.Width, pixmap.Height, 8, pixmap.RowBytes, colorSpace, CGBitmapFlags.PremultipliedLast | CGBitmapFlags.ByteOrder32Big))
-			{
-				CGRect rect = new CGRect(0, 0, cgImage.Width, cgImage.Height);
-				context.ClearRect(rect);
-				context.DrawImage(rect, cgImage);
-			}
+			using var colorSpace = CGColorSpace.CreateDeviceRGB();
+			using var context = new CGBitmapContext(pixmap.GetPixels(), pixmap.Width, pixmap.Height, 8, pixmap.RowBytes, colorSpace, CGBitmapFlags.PremultipliedLast | CGBitmapFlags.ByteOrder32Big);
+			CGRect rect = new CGRect(0, 0, cgImage.Width, cgImage.Height);
+			context.ClearRect(rect);
+			context.DrawImage(rect, cgImage);
 		}
 
 		public static SKImage ToSKImage(this CGImage cgImage)
@@ -199,11 +197,9 @@ namespace SkiaSharp.Views.Mac
 
 		public static void ToSKPixmap(this CIImage ciImage, SKPixmap pixmap)
 		{
-			using (var colorSpace = CGColorSpace.CreateDeviceRGB())
-			using (var context = new CIContext(null))
-			{
-				context.RenderToBitmap(ciImage, pixmap.GetPixels(), pixmap.RowBytes, ciImage.Extent, (int)CIFormat.kRGBA8, colorSpace);
-			}
+			using var colorSpace = CGColorSpace.CreateDeviceRGB();
+			using var context = new CIContext(null);
+			context.RenderToBitmap(ciImage, pixmap.GetPixels(), pixmap.RowBytes, ciImage.Extent, (int)CIFormat.kRGBA8, colorSpace);
 		}
 
 		public static SKImage ToSKImage(this CIImage ciImage)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCanvasLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Apple/SKCanvasLayer.cs
@@ -47,37 +47,36 @@ namespace SkiaSharp.Views.Mac
 			base.DrawInContext(ctx);
 
 			// create the skia context
-			using (var surface = drawable.CreateSurface(Bounds, ContentsScale, out var info))
+			using var surface = drawable.CreateSurface(Bounds, ContentsScale, out var info);
+
+			if (info.Width == 0 || info.Height == 0)
 			{
-				if (info.Width == 0 || info.Height == 0)
-				{
-					CanvasSize = SKSize.Empty;
-					return;
-				}
+				CanvasSize = SKSize.Empty;
+				return;
+			}
 
-				var userVisibleSize = IgnorePixelScaling
-					? new SKSizeI((int)Bounds.Width, (int)Bounds.Height)
-					: info.Size;
+			var userVisibleSize = IgnorePixelScaling
+				? new SKSizeI((int)Bounds.Width, (int)Bounds.Height)
+				: info.Size;
 
-				CanvasSize = userVisibleSize;
+			CanvasSize = userVisibleSize;
 
-				if (IgnorePixelScaling)
-				{
-					var skiaCanvas = surface.Canvas;
-					skiaCanvas.Scale((float)ContentsScale);
-					skiaCanvas.Save();
-				}
+			if (IgnorePixelScaling)
+			{
+				var skiaCanvas = surface.Canvas;
+				skiaCanvas.Scale((float)ContentsScale);
+				skiaCanvas.Save();
+			}
 
-				// draw on the image using SKiaSharp
-				OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info.WithSize(userVisibleSize), info));
+			// draw on the image using SKiaSharp
+			OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info.WithSize(userVisibleSize), info));
 #pragma warning disable CS0618 // Type or member is obsolete
-				DrawInSurface(surface, info);
-				SKDelegate?.DrawInSurface(surface, info);
+			DrawInSurface(surface, info);
+			SKDelegate?.DrawInSurface(surface, info);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-				// draw the surface to the context
-				drawable.DrawSurface(ctx, Bounds, info, surface);
-			}
+			// draw the surface to the context
+			drawable.DrawSurface(ctx, Bounds, info, surface);
 		}
 
 		public event EventHandler<SKPaintSurfaceEventArgs> PaintSurface;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKCanvasView.cs
@@ -86,39 +86,37 @@ namespace SkiaSharp.Views.iOS
 				return;
 
 			// create the skia context
-			using (var surface = drawable.CreateSurface(Bounds, ContentScaleFactor, out var info))
+			using var surface = drawable.CreateSurface(Bounds, ContentScaleFactor, out var info);
+
+			if (info.Width == 0 || info.Height == 0)
 			{
-				if (info.Width == 0 || info.Height == 0)
-				{
-					CanvasSize = SKSize.Empty;
-					return;
-				}
+				CanvasSize = SKSize.Empty;
+				return;
+			}
 
-				var userVisibleSize = IgnorePixelScaling
-					? new SKSizeI((int)Bounds.Width, (int)Bounds.Height)
-					: info.Size;
+			var userVisibleSize = IgnorePixelScaling
+				? new SKSizeI((int)Bounds.Width, (int)Bounds.Height)
+				: info.Size;
 
-				CanvasSize = userVisibleSize;
+			CanvasSize = userVisibleSize;
 
-				if (IgnorePixelScaling)
-				{
-					var skiaCanvas = surface.Canvas;
-					skiaCanvas.Scale((float)ContentScaleFactor);
-					skiaCanvas.Save();
-				}
+			if (IgnorePixelScaling)
+			{
+				var skiaCanvas = surface.Canvas;
+				skiaCanvas.Scale((float)ContentScaleFactor);
+				skiaCanvas.Save();
+			}
 
-				using (var ctx = UIGraphics.GetCurrentContext())
-				{
-					// draw on the image using SKiaSharp
-					OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info.WithSize(userVisibleSize), info));
+			using var ctx = UIGraphics.GetCurrentContext();
+
+			// draw on the image using SKiaSharp
+			OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info.WithSize(userVisibleSize), info));
 #pragma warning disable CS0618 // Type or member is obsolete
-					DrawInSurface(surface, info);
+			DrawInSurface(surface, info);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-					// draw the surface to the context
-					drawable.DrawSurface(ctx, Bounds, info, surface);
-				}
-			}
+			// draw the surface to the context
+			drawable.DrawSurface(ctx, Bounds, info, surface);
 		}
 
 		public override void WillMoveToWindow(UIWindow window)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/SKCanvasView.cs
@@ -47,19 +47,18 @@ namespace SkiaSharp.Views.Tizen
 				return;
 
 			// draw directly into the EFL image data
-			using (var surface = SKSurface.Create(info, Evas.evas_object_image_data_get(evasImage, true), info.RowBytes))
-			{
-				if (IgnorePixelScaling)
-				{
-					var skiaCanvas = surface.Canvas;
-					skiaCanvas.Scale((float)ScalingInfo.ScalingFactor);
-					skiaCanvas.Save();
-				}
+			using var surface = SKSurface.Create(info, Evas.evas_object_image_data_get(evasImage, true), info.RowBytes);
 
-				// draw using SkiaSharp
-				OnDrawFrame(new SKPaintSurfaceEventArgs(surface, info.WithSize(canvasSize), info));
-				surface.Canvas.Flush();
+			if (IgnorePixelScaling)
+			{
+				var skiaCanvas = surface.Canvas;
+				skiaCanvas.Scale((float)ScalingInfo.ScalingFactor);
+				skiaCanvas.Save();
 			}
+
+			// draw using SkiaSharp
+			OnDrawFrame(new SKPaintSurfaceEventArgs(surface, info.WithSize(canvasSize), info));
+			surface.Canvas.Flush();
 		}
 
 		protected sealed override bool UpdateSurfaceSize(Rect geometry)

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/UWPExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/UWPExtensions.cs
@@ -107,13 +107,11 @@ namespace SkiaSharp.Views.UWP
 
 		public static WriteableBitmap ToWriteableBitmap(this SKBitmap skiaBitmap)
 		{
-			using (var pixmap = skiaBitmap.PeekPixels())
-			using (var image = SKImage.FromPixels(pixmap))
-			{
-				var wb = image.ToWriteableBitmap();
-				GC.KeepAlive(skiaBitmap);
-				return wb;
-			}
+			using var pixmap = skiaBitmap.PeekPixels();
+			using var image = SKImage.FromPixels(pixmap);
+			var wb = image.ToWriteableBitmap();
+			GC.KeepAlive(skiaBitmap);
+			return wb;
 		}
 
 		public static WriteableBitmap ToWriteableBitmap(this SKPixmap pixmap)
@@ -156,10 +154,8 @@ namespace SkiaSharp.Views.UWP
 
 			if (pixmap.ColorType == SKImageInfo.PlatformColorType)
 			{
-				using (var image = SKImage.FromPixels(pixmap.Info, bitmap.GetPixels()))
-				{
-					return image.ReadPixels(pixmap, 0, 0);
-				}
+				using var image = SKImage.FromPixels(pixmap.Info, bitmap.GetPixels());
+				return image.ReadPixels(pixmap, 0, 0);
 			}
 			else
 			{

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WPFExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/WPFExtensions.cs
@@ -59,10 +59,8 @@ namespace SkiaSharp.Views.WPF
 
 		public static WriteableBitmap ToWriteableBitmap(this SKPicture picture, SKSizeI dimensions)
 		{
-			using (var image = SKImage.FromPicture(picture, dimensions))
-			{
-				return image.ToWriteableBitmap();
-			}
+			using var image = SKImage.FromPicture(picture, dimensions);
+			return image.ToWriteableBitmap();
 		}
 
 		public static WriteableBitmap ToWriteableBitmap(this SKImage skiaImage)
@@ -86,21 +84,17 @@ namespace SkiaSharp.Views.WPF
 
 		public static WriteableBitmap ToWriteableBitmap(this SKBitmap skiaBitmap)
 		{
-			using (var pixmap = skiaBitmap.PeekPixels())
-			using (var image = SKImage.FromPixels(pixmap))
-			{
-				var wb = image.ToWriteableBitmap();
-				GC.KeepAlive(skiaBitmap);
-				return wb;
-			}
+			using var pixmap = skiaBitmap.PeekPixels();
+			using var image = SKImage.FromPixels(pixmap);
+			var wb = image.ToWriteableBitmap();
+			GC.KeepAlive(skiaBitmap);
+			return wb;
 		}
 
 		public static WriteableBitmap ToWriteableBitmap(this SKPixmap pixmap)
 		{
-			using (var image = SKImage.FromPixels(pixmap))
-			{
-				return image.ToWriteableBitmap();
-			}
+			using var image = SKImage.FromPixels(pixmap);
+			return image.ToWriteableBitmap();
 		}
 
 		public static SKBitmap ToSKBitmap(this BitmapSource bitmap)
@@ -144,10 +138,8 @@ namespace SkiaSharp.Views.WPF
 				// we have to copy the pixels into a format that we understand
 				// and then into a desired format
 				// TODO: we can still do a bit more for other cases where the color types are the same
-				using (var tempImage = bitmap.ToSKImage())
-				{
-					tempImage.ReadPixels(pixmap, 0, 0);
-				}
+				using var tempImage = bitmap.ToSKImage();
+				tempImage.ReadPixels(pixmap, 0, 0);
 			}
 		}
 	}


### PR DESCRIPTION
**Description of Change**

Purely syntactic changed for improved readability

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
