### PR TITLE
fix: Disambiguate SKGLView for uno and maui targets

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
@@ -18,14 +18,15 @@ namespace SkiaSharp.Views.tvOS
 namespace SkiaSharp.Views.iOS
 #endif
 {
-	[Register(nameof(SKGLView))]
 	[DesignTimeVisible(true)]
 #if HAS_UNO
-	internal
+	[Register("Uno_" + nameof(SKGLView))]
+	internal class SKGLView
 #else
-	public
+	[Register(nameof(SKGLView))]
+	public class SKGLView 
 #endif
-	class SKGLView : GLKView, IGLKViewDelegate, IComponent
+	: GLKView, IGLKViewDelegate, IComponent
 	{
 		private const SKColorType colorType = SKColorType.Rgba8888;
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
@@ -20,7 +20,6 @@ namespace SkiaSharp.Views.iOS
 {
 	[DesignTimeVisible(true)]
 #if HAS_UNO
-	[Register("Uno_" + nameof(SKGLView))]
 	internal class SKGLView
 #else
 	[Register(nameof(SKGLView))]


### PR DESCRIPTION
**Description of Change**

Disambiguates `SKGLView` native type when using Uno and MAUI concurrently.

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
