### PR TITLE
Modernized getter and setter syntax in a few places

### DIFF
--- a/binding/Binding/SKBitmap.cs
+++ b/binding/Binding/SKBitmap.cs
@@ -329,41 +329,25 @@ namespace SkiaSharp
 			}
 		}
 
-		public int Width {
-			get { return Info.Width; }
-		}
+        public int Width => Info.Width;
 
-		public int Height {
-			get { return Info.Height; }
-		}
+        public int Height => Info.Height;
 
-		public SKColorType ColorType {
-			get { return Info.ColorType; }
-		}
+        public SKColorType ColorType => Info.ColorType;
 
-		public SKAlphaType AlphaType {
-			get { return Info.AlphaType; }
-		}
+        public SKAlphaType AlphaType => Info.AlphaType;
 
-		public SKColorSpace ColorSpace {
-			get { return Info.ColorSpace; }
-		}
+        public SKColorSpace ColorSpace => Info.ColorSpace;
 
-		public int BytesPerPixel {
-			get { return Info.BytesPerPixel; }
-		}
+        public int BytesPerPixel => Info.BytesPerPixel;
 
-		public int RowBytes {
-			get { return (int)SkiaApi.sk_bitmap_get_row_bytes (Handle); }
-		}
+        public int RowBytes => (int)SkiaApi.sk_bitmap_get_row_bytes(Handle);
 
-		public int ByteCount {
-			get { return (int)SkiaApi.sk_bitmap_get_byte_count (Handle); }
-		}
+        public int ByteCount => (int)SkiaApi.sk_bitmap_get_byte_count(Handle);
 
-		// *Pixels*
+        // *Pixels*
 
-		public IntPtr GetPixels () =>
+        public IntPtr GetPixels () =>
 			GetPixels (out _);
 
 		public ReadOnlySpan<byte> GetPixelSpan ()
@@ -443,23 +427,15 @@ namespace SkiaSharp
 			}
 		}
 
-		public bool IsEmpty {
-			get { return Info.IsEmpty; }
-		}
+        public bool IsEmpty => Info.IsEmpty;
 
-		public bool IsNull {
-			get { return SkiaApi.sk_bitmap_is_null (Handle); }
-		}
+        public bool IsNull => SkiaApi.sk_bitmap_is_null(Handle);
 
-		public bool DrawsNothing {
-			get { return IsEmpty || IsNull; }
-		}
+        public bool DrawsNothing => IsEmpty || IsNull;
 
-		public bool IsImmutable {
-			get { return SkiaApi.sk_bitmap_is_immutable (Handle); }
-		}
+        public bool IsImmutable => SkiaApi.sk_bitmap_is_immutable(Handle);
 
-		[Obsolete]
+        [Obsolete]
 		public bool IsVolatile {
 			get => false;
 			set { }

--- a/binding/Binding/SKFrontBufferedStream.cs
+++ b/binding/Binding/SKFrontBufferedStream.cs
@@ -49,8 +49,8 @@ namespace SkiaSharp
 
 		public override long Position
 		{
-			get { return currentOffset; }
-			set { Seek(value, SeekOrigin.Begin); }
+			readonly get => currentOffset;
+			set => Seek(value, SeekOrigin.Begin);
 		}
 
 		public override void Flush()

--- a/binding/Binding/SKPathMeasure.cs
+++ b/binding/Binding/SKPathMeasure.cs
@@ -36,23 +36,15 @@ namespace SkiaSharp
 		protected override void DisposeNative () =>
 			SkiaApi.sk_pathmeasure_destroy (Handle);
 
-		// properties
+        // properties
 
-		public float Length {
-			get {
-				return SkiaApi.sk_pathmeasure_get_length (Handle);
-			}
-		}
+        public float Length => SkiaApi.sk_pathmeasure_get_length(Handle);
 
-		public bool IsClosed {
-			get {
-				return SkiaApi.sk_pathmeasure_is_closed (Handle);
-			}
-		}
+        public bool IsClosed => SkiaApi.sk_pathmeasure_is_closed(Handle);
 
-		// SetPath
+        // SetPath
 
-		public void SetPath (SKPath path) =>
+        public void SetPath (SKPath path) =>
 			SetPath (path, false);
 
 		public void SetPath (SKPath path, bool forceClosed)

--- a/binding/Binding/SKStream.cs
+++ b/binding/Binding/SKStream.cs
@@ -9,14 +9,10 @@ namespace SkiaSharp
 			: base (handle, owns)
 		{
 		}
-		
-		public bool IsAtEnd {
-			get {
-				return SkiaApi.sk_stream_is_at_end (Handle);
-			}
-		}
 
-		public SByte ReadSByte ()
+        public bool IsAtEnd => SkiaApi.sk_stream_is_at_end(Handle);
+
+        public SByte ReadSByte ()
 		{
 			if (ReadSByte (out var buffer))
 				return buffer;
@@ -163,34 +159,18 @@ namespace SkiaSharp
 
 		internal SKStream Duplicate () => GetObject (SkiaApi.sk_stream_duplicate (Handle));
 
-		public bool HasPosition {
-			get {
-				return SkiaApi.sk_stream_has_position (Handle);
-			}
+        public bool HasPosition => SkiaApi.sk_stream_has_position(Handle);
+
+        public int Position {
+			get => (int)SkiaApi.sk_stream_get_position (Handle);
+			set => Seek (value);
 		}
 
-		public int Position {
-			get {
-				return (int)SkiaApi.sk_stream_get_position (Handle);
-			}
-			set { 
-				Seek (value);
-			}
-		}
+        public bool HasLength => SkiaApi.sk_stream_has_length(Handle);
 
-		public bool HasLength {
-			get {
-				return SkiaApi.sk_stream_has_length (Handle);
-			}
-		}
+        public int Length => (int)SkiaApi.sk_stream_get_length(Handle);
 
-		public int Length {
-			get {
-				return (int)SkiaApi.sk_stream_get_length (Handle);
-			}
-		}
-
-		internal static SKStream GetObject (IntPtr handle) =>
+        internal static SKStream GetObject (IntPtr handle) =>
 			GetOrAddObject<SKStream> (handle, (h, o) => new SKStreamImplementation (h, o));
 	}
 
@@ -376,14 +356,10 @@ namespace SkiaSharp
 			: base (handle, owns)
 		{
 		}
-		
-		public virtual int BytesWritten {
-			get {
-				return (int)SkiaApi.sk_wstream_bytes_written (Handle);
-			}
-		}
 
-		public virtual bool Write (byte[] buffer, int size)
+        public virtual int BytesWritten => (int)SkiaApi.sk_wstream_bytes_written(Handle);
+
+        public virtual bool Write (byte[] buffer, int size)
 		{
 			fixed (byte* b = buffer) {
 				return SkiaApi.sk_wstream_write (Handle, (void*)b, (IntPtr)size);

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKCanvasView.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKCanvasView.cs
@@ -51,14 +51,14 @@ namespace SkiaSharp.Views.Forms
 
 		public bool IgnorePixelScaling
 		{
-			get { return (bool)GetValue(IgnorePixelScalingProperty); }
-			set { SetValue(IgnorePixelScalingProperty, value); }
+			get => (bool)GetValue(IgnorePixelScalingProperty);
+			set => SetValue(IgnorePixelScalingProperty, value);
 		}
 
 		public bool EnableTouchEvents
 		{
-			get { return (bool)GetValue(EnableTouchEventsProperty); }
-			set { SetValue(EnableTouchEventsProperty, value); }
+			get => (bool)GetValue(EnableTouchEventsProperty);
+			set => SetValue(EnableTouchEventsProperty, value);
 		}
 
 		// the user asks to repaint

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKGLView.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKGLView.cs
@@ -29,14 +29,14 @@ namespace SkiaSharp.Views.Forms
 
 		public bool HasRenderLoop
 		{
-			get { return (bool)GetValue(HasRenderLoopProperty); }
-			set { SetValue(HasRenderLoopProperty, value); }
+			get => (bool)GetValue(HasRenderLoopProperty);
+			set => SetValue(HasRenderLoopProperty, value);
 		}
 
 		public bool EnableTouchEvents
 		{
-			get { return (bool)GetValue(EnableTouchEventsProperty); }
-			set { SetValue(EnableTouchEventsProperty, value); }
+			get => (bool)GetValue(EnableTouchEventsProperty);
+			set => SetValue(EnableTouchEventsProperty, value);
 		}
 
 		// the user can subscribe to repaint

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKImageSource.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Shared/SKImageSource.cs
@@ -19,8 +19,8 @@ namespace SkiaSharp.Views.Forms
 
 		public SKImage Image
 		{
-			get { return (SKImage)GetValue(ImageProperty); }
-			set { SetValue(ImageProperty, value); }
+			get => (SKImage)GetValue(ImageProperty);
+			set => SetValue(ImageProperty, value);
 		}
 
 		public override Task<bool> Cancel()
@@ -55,8 +55,8 @@ namespace SkiaSharp.Views.Forms
 
 		public SKBitmap Bitmap
 		{
-			get { return (SKBitmap)GetValue(BitmapProperty); }
-			set { SetValue(BitmapProperty, value); }
+			get => (SKBitmap)GetValue(BitmapProperty);
+			set => SetValue(BitmapProperty, value);
 		}
 
 		public override Task<bool> Cancel()
@@ -91,8 +91,8 @@ namespace SkiaSharp.Views.Forms
 
 		public SKPixmap Pixmap
 		{
-			get { return (SKPixmap)GetValue(PixmapProperty); }
-			set { SetValue(PixmapProperty, value); }
+			get => (SKPixmap)GetValue(PixmapProperty);
+			set => SetValue(PixmapProperty, value);
 		}
 
 		public override Task<bool> Cancel()
@@ -129,14 +129,14 @@ namespace SkiaSharp.Views.Forms
 
 		public SKPicture Picture
 		{
-			get { return (SKPicture)GetValue(PictureProperty); }
-			set { SetValue(PictureProperty, value); }
+			get => (SKPicture)GetValue(PictureProperty);
+			set => SetValue(PictureProperty, value);
 		}
 
 		public SKSizeI Dimensions
 		{
-			get { return (SKSizeI)GetValue(DimensionsProperty); }
-			set { SetValue(DimensionsProperty, value); }
+			get => (SKSizeI)GetValue(DimensionsProperty);
+			set => SetValue(DimensionsProperty, value);
 		}
 
 		public override Task<bool> Cancel()

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Android/GLTextureView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Android/GLTextureView.cs
@@ -146,8 +146,8 @@ namespace SkiaSharp.Views.Android
 
 		public Rendermode RenderMode
 		{
-			get { return glThread.GetRenderMode(); }
-			set { glThread.SetRenderMode(value); }
+			get => glThread.GetRenderMode();
+			set => glThread.SetRenderMode(value);
 		}
 
 		public void RequestRender()

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLLayer.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLLayer.cs
@@ -116,7 +116,7 @@ namespace SkiaSharp.Views.iOS
 
 		public override CGRect Frame
 		{
-			get { return base.Frame; }
+			get => base.Frame;
 			set
 			{
 				base.Frame = value;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.AppleiOS/SKGLView.cs
@@ -175,7 +175,7 @@ namespace SkiaSharp.Views.iOS
 
 		public override CGRect Frame
 		{
-			get { return base.Frame; }
+			get => base.Frame;
 			set
 			{
 				base.Frame = value;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/CustomRenderingView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Tizen/CustomRenderingView.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using ElmSharp;
-using SkiaSharp.Views.Tizen.Interop;
+﻿using SkiaSharp.Views.Tizen.Interop;
 
 namespace SkiaSharp.Views.Tizen
 {
-	public abstract class CustomRenderingView : Widget
+    public abstract class CustomRenderingView : Widget
 	{
 		private readonly Evas.ImagePixelsSetCallback redrawCallback;
 
@@ -24,7 +22,7 @@ namespace SkiaSharp.Views.Tizen
 
 		public RenderingMode RenderingMode
 		{
-			get { return renderingMode; }
+			get => renderingMode;
 			set
 			{
 				if (renderingMode != value)


### PR DESCRIPTION
**API Changes**

None.

**Behavioral Changes**

None. Just turned the getter of a property in `SKFrontBufferedStream.cs` from a `get` to a `readonly get`, since it's just reading from a field. This doesn't require any changes in the tests

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs (not applicable)
- [x] Changes adhere to coding standard
- [ ] Updated documentation (not necessary)
