### PR TITLE
Added `readonly` modifiers to most fields that aren't modified after their creation

### DIFF
--- a/binding/Binding/SKAbstractManagedStream.cs
+++ b/binding/Binding/SKAbstractManagedStream.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-namespace SkiaSharp
+﻿namespace SkiaSharp
 {
-	public unsafe abstract class SKAbstractManagedStream : SKStreamAsset
+    public unsafe abstract class SKAbstractManagedStream : SKStreamAsset
 	{
 		private static readonly SKManagedStreamDelegates delegates;
 
-		private int fromNative;
+		private readonly int fromNative;
 
 		static SKAbstractManagedStream ()
 		{

--- a/binding/Binding/SKAbstractManagedWStream.cs
+++ b/binding/Binding/SKAbstractManagedWStream.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-namespace SkiaSharp
+﻿namespace SkiaSharp
 {
-	public unsafe abstract class SKAbstractManagedWStream : SKWStream
+    public unsafe abstract class SKAbstractManagedWStream : SKWStream
 	{
 		private static readonly SKManagedWStreamDelegates delegates;
 
-		private int fromNative;
+		private readonly int fromNative;
 
 		static SKAbstractManagedWStream ()
 		{

--- a/binding/Binding/SKDrawable.cs
+++ b/binding/Binding/SKDrawable.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-namespace SkiaSharp
+﻿namespace SkiaSharp
 {
-	public unsafe class SKDrawable : SKObject, ISKReferenceCounted
+    public unsafe class SKDrawable : SKObject, ISKReferenceCounted
 	{
 		private static readonly SKManagedDrawableDelegates delegates;
 
-		private int fromNative;
+		private readonly int fromNative;
 
 		static SKDrawable ()
 		{

--- a/binding/Binding/SKFrontBufferedManagedStream.cs
+++ b/binding/Binding/SKFrontBufferedManagedStream.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.IO;
-
-namespace SkiaSharp
+﻿namespace SkiaSharp
 {
-	public class SKFrontBufferedManagedStream : SKAbstractManagedStream
+    public class SKFrontBufferedManagedStream : SKAbstractManagedStream
 	{
 		private SKStream stream;
-		private bool disposeStream;
+		private readonly bool disposeStream;
 
 		private readonly bool hasLength;
 		private readonly int streamLength;

--- a/binding/Binding/SKObject.cs
+++ b/binding/Binding/SKObject.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-namespace SkiaSharp
+﻿namespace SkiaSharp
 {
-	public abstract class SKObject : SKNativeObject
+    public abstract class SKObject : SKNativeObject
 	{
 		private readonly object locker = new object ();
 
@@ -227,7 +222,7 @@ namespace SkiaSharp
 	{
 		internal bool fromFinalizer = false;
 
-		private int isDisposed = 0;
+		private readonly int isDisposed = 0;
 
 		internal SKNativeObject (IntPtr handle)
 			: this (handle, true)

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/CanvasExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz.Shared/CanvasExtensions.cs
@@ -24,11 +24,11 @@ namespace SkiaSharp.HarfBuzz
 			if (string.IsNullOrEmpty(text))
 				return;
 
-			if (canvas == null)
+			if (canvas is null)
 				throw new ArgumentNullException(nameof(canvas));
-			if (shaper == null)
+			if (shaper is null)
 				throw new ArgumentNullException(nameof(shaper));
-			if (paint == null)
+			if (paint is null)
 				throw new ArgumentNullException(nameof(paint));
 
 			using var font = paint.ToFont();

--- a/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SKImageSourceHandler.cs
+++ b/source/SkiaSharp.Views.Forms/SkiaSharp.Views.Forms.Tizen/SKImageSourceHandler.cs
@@ -25,7 +25,7 @@ namespace SkiaSharp.Views.Forms
 {
 	public sealed class SKImageSourceHandler : IImageSourceHandler
 	{
-		private StreamImageSourceHandler handler = new StreamImageSourceHandler();
+		private readonly StreamImageSourceHandler handler = new StreamImageSourceHandler();
 
 		public Task<bool> LoadImageAsync(ElmImage image, ImageSource imageSource, CancellationToken cancelationToken = default(CancellationToken))
 		{

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno/SKSwapChainPanel.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno/SKSwapChainPanel.cs
@@ -28,7 +28,7 @@ namespace SkiaSharp.Views.UWP
 				typeof(SKSwapChainPanel),
 				new PropertyMetadata(Visibility.Visible, OnVisibilityChanged));
 
-		private static bool designMode = DesignMode.DesignModeEnabled;
+		private static readonly bool designMode = DesignMode.DesignModeEnabled;
 
 		private bool isVisible = true;
 		private bool enableRenderLoop = false;

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno/SKXamlCanvas.cs
@@ -30,7 +30,7 @@ namespace SkiaSharp.Views.UWP
 				typeof(SKXamlCanvas),
 				new PropertyMetadata(Visibility.Visible, OnVisibilityChanged));
 
-		private static bool designMode = DesignMode.DesignModeEnabled;
+		private static readonly bool designMode = DesignMode.DesignModeEnabled;
 
 		private bool ignorePixelScaling;
 		private bool isVisible = true;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
@@ -35,7 +35,7 @@ namespace SkiaSharp.Views.UWP
 				typeof(SKXamlCanvas),
 				new PropertyMetadata(Visibility.Visible, OnVisibilityChanged));
 
-		private static bool designMode = DesignMode.DesignModeEnabled;
+		private static readonly bool designMode = DesignMode.DesignModeEnabled;
 
 		private IntPtr pixels;
 		private WriteableBitmap bitmap;


### PR DESCRIPTION
...The only exception being a field in `GLTextureView.cs`, since the change would conflict with a previous pull request.
As an extra, I removed unused namespace references in the files that were changed that didn't contain conditional compilation directives.
The behavior should be identical, so the tests shoulnd't be changed.

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs (not applicable)
- [x] Changes adhere to coding standard
- [ ] Updated documentation (not applicable)
