### PR TITLE
Include the NativeReference for Hot Restart

### DIFF
--- a/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp/nuget/build/ios/HarfBuzzSharp.targets
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <ItemGroup Condition="'$(IsHotRestartBuild)' == 'true' and '$(RuntimeIdentifier)' != ''">
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\iossimulator\native\libHarfBuzzSharp.framework" Kind="Framework" Condition="$(RuntimeIdentifier.StartsWith('iossimulator'))" />
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libHarfBuzzSharp.framework" Kind="Framework" Condition="!$(RuntimeIdentifier.StartsWith('iossimulator'))" />
+    </ItemGroup>
+
 </Project>

--- a/binding/SkiaSharp/nuget/build/ios/SkiaSharp.targets
+++ b/binding/SkiaSharp/nuget/build/ios/SkiaSharp.targets
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <ItemGroup Condition="'$(IsHotRestartBuild)' == 'true' and '$(RuntimeIdentifier)' != ''">
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\iossimulator\native\libSkiaSharp.framework" Kind="Framework" Condition="$(RuntimeIdentifier.StartsWith('iossimulator'))" />
+        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libSkiaSharp.framework" Kind="Framework" Condition="!$(RuntimeIdentifier.StartsWith('iossimulator'))" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Description of Change**

Some versions of .NET do not automatically copy NativeReferences from the runtimes/ios/native folder in Hot Restart scenarios. This PR makes sure to always include it.

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
