### PR TITLE
fix(uno): Ensure that the canvas' context is active when rendering

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Wasm/WasmScripts/SkiaSharp.Views.Uno.Wasm.js
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Wasm/WasmScripts/SkiaSharp.Views.Uno.Wasm.js
@@ -106,6 +106,9 @@
                     this.currentRequest = window.requestAnimationFrame(() => {
 
                         if (this.requestRender) {
+                            // make current for this canvas instance
+                            GL.makeContextCurrent(this.glCtx);
+
                             this.requestRender();
                         }
 
@@ -178,12 +181,12 @@
                             throw `No <canvas> with id ${canvasOrCanvasId} was found`;
                     }
 
-                    var ctx = SKSwapChainPanel.createWebGLContext(canvas);
-                    if (!ctx || ctx < 0)
+                    this.glCtx = SKSwapChainPanel.createWebGLContext(canvas);
+                    if (!this.glCtx || this.glCtx < 0)
                         throw `Failed to create WebGL context: err ${ctx}`;
 
                     // make current
-                    GL.makeContextCurrent(ctx);
+                    GL.makeContextCurrent(this.glCtx);
 
                     // Starting from .NET 7 the GLctx is defined in an inaccessible scope
                     // when the current GL context changes. We need to pick it up from the
@@ -196,7 +199,7 @@
                     // read values
                     this.canvas = canvas;
                     return {
-                        ctx: ctx,
+                        ctx: this.glCtx,
                         fbo: currentGLctx.getParameter(currentGLctx.FRAMEBUFFER_BINDING),
                         stencil: currentGLctx.getParameter(currentGLctx.STENCIL_BITS),
                         sample: 0, // TODO: currentGLctx.getParameter(GLctx.SAMPLES)


### PR DESCRIPTION
**Description of Change**

Ensures the that the GL context is current when rendering for a given SKSwapChainPanel, allowing for multiple instances to be rendered correctly in an app.

**Bugs Fixed**

- Fixes https://github.com/mono/SkiaSharp/issues/2551

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
