### PR TITLE
Remove the unused arm64e architecture

### DIFF
--- a/native/ios/build.cake
+++ b/native/ios/build.cake
@@ -23,7 +23,7 @@ Task("libSkiaSharp")
         Build("iphonesimulator", "x86_64", "x64");
         Build("iphonesimulator", "arm64", "arm64");
         Build("iphoneos", "arm64", "arm64");
-        Build("iphoneos", "arm64", "arm64", "arm64e");
+        // Build("iphoneos", "arm64", "arm64", "arm64e");
 
         SafeCopy(
             $"libSkiaSharp/bin/{CONFIGURATION}/iphonesimulator/x86_64.xcarchive",
@@ -86,7 +86,7 @@ Task("libHarfBuzzSharp")
         Build("iphonesimulator", "x86_64");
         Build("iphonesimulator", "arm64");
         Build("iphoneos", "arm64");
-        Build("iphoneos", "arm64e");
+        // Build("iphoneos", "arm64e");
 
         SafeCopy(
             $"libHarfBuzzSharp/bin/{CONFIGURATION}/iphonesimulator/x86_64.xcarchive",


### PR DESCRIPTION
**Description of Change**

Apple doesn't allow submissions with that architecture. In this PR I will just comment it out and when it is ready for use I will add it back.

**Bugs Fixed**

- Fixes #2584

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [x] Updated documentation
