### PR TITLE
libjpeg is not used

### DIFF
--- a/scripts/guardian/cve-triage.json
+++ b/scripts/guardian/cve-triage.json
@@ -4,6 +4,44 @@
   "version": 1,
   "vulnerabilities": [
     {
+      "id": "CVE-2020-14152",
+      "source": {
+        "name": "NVD",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-14152"
+      },
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2020-14152&vector=AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:H&version=3.1"
+          },
+          "score": 7.1,
+          "severity": "high",
+          "method": "CVSSv31",
+          "vector": "AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:H"
+        }
+      ],
+      "description": "In IJG JPEG (aka libjpeg) before 9d, jpeg_mem_available() in jmemnobs.c in djpeg does not honor the max_memory_to_use setting, possibly causing excessive memory consumption.",
+      "recommendation": "",
+      "advisories": [],
+      "created": "NOT_KNOWN",
+      "published": "NOT_KNOWN",
+      "updated": "",
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_present",
+        "response": [
+          "will_not_fix"
+        ],
+        "detail": "libjpeg is not used and the real dependency is libjpeg-turbo which never had this issue: https://github.com/libjpeg-turbo/libjpeg-turbo/issues/500#issuecomment-772625597."
+      },
+      "affects": [
+        {
+          "ref": "urn:cbt:1/icu-project#international_components_for_unicode-1.8.1"
+        }
+      ]
+    },
+    {
       "id": "CVE-2007-4770",
       "source": {
         "name": "NVD",


### PR DESCRIPTION
**Description of Change**

There is a CVE report `CVE-2023-25193` of libjpeg being used, however, it is not and the libjpeg-turbo is used instead. In addition, the libjpeg-turb codebase is from the time the issue was fixed - and it was not a security issue.


See more: https://github.com/libjpeg-turbo/libjpeg-turbo/issues/500#issuecomment-772625597