### PR TITLE
fix: Restore nosimd builds for edge enhanced security and safari

### DIFF
--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -114,7 +114,7 @@ Task("libHarfBuzzSharp")
     .WithCriteria(IsRunningOnLinux())
     .Does(() =>
 {
-    bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd") || EMSCRIPTEN_FEATURES.Contains("_simd");;
+    bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd") || EMSCRIPTEN_FEATURES.Contains("_simd");
     bool hasThreadingEnabled = EMSCRIPTEN_FEATURES.Contains("mt");
     bool hasWasmEH = EMSCRIPTEN_FEATURES.Contains("_wasmeh");
 

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -307,15 +307,23 @@ stages:
                 version: 3.1.12
                 features: mt,simd
 
-              # .NET 8 Preview 4
+              # .NET 8
               - 3.1.34:
                 displayName: 3.1.34
                 version: 3.1.34
-                features: _wasmeh,_simd,st
+                features: _wasmeh,st
               - 3.1.34:
                 displayName: '3.1.34_Threading'
                 version: 3.1.34
-                features: _wasmeh,_simd,mt
+                features: _wasmeh,mt
+              - 3.1.34:
+                displayName: '3.1.34_SIMD'
+                version: 3.1.34
+                features: _wasmeh,simd,st
+              - 3.1.34:
+                displayName: '3.1.34_SIMD_Threading'
+                version: 3.1.34
+                features: _wasmeh,simd,mt
 
   - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: managed


### PR DESCRIPTION
**Description of Change**

This change re-introduces no-SIMD WebAssembly native assets, in order for apps be able to work around SIMD not being supported by Microsoft Edge Enhanced Security. 

Related to https://github.com/dotnet/runtime/issues/78872 and https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/774.

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
