### PR TITLE
Start using spans instead of arrays

### DIFF
--- a/binding/SkiaSharp/SKData.cs
+++ b/binding/SkiaSharp/SKData.cs
@@ -57,20 +57,13 @@ namespace SkiaSharp
 			return GetObject (SkiaApi.sk_data_new_with_copy ((void*)bytes, (IntPtr)length));
 		}
 
-		public static SKData CreateCopy (byte[] bytes) =>
+		public static SKData CreateCopy (ReadOnlySpan<byte> bytes) =>
 			CreateCopy (bytes, (ulong)bytes.Length);
 
-		public static SKData CreateCopy (byte[] bytes, ulong length)
+		public static SKData CreateCopy (ReadOnlySpan<byte> bytes, ulong length)
 		{
 			fixed (byte* b = bytes) {
 				return GetObject (SkiaApi.sk_data_new_with_copy (b, (IntPtr)length));
-			}
-		}
-
-		public static SKData CreateCopy (ReadOnlySpan<byte> bytes)
-		{
-			fixed (byte* b = bytes) {
-				return CreateCopy ((IntPtr)b, (ulong)bytes.Length);
 			}
 		}
 

--- a/binding/SkiaSharp/SKImage.cs
+++ b/binding/SkiaSharp/SKImage.cs
@@ -60,18 +60,6 @@ namespace SkiaSharp
 			}
 		}
 
-		public static SKImage FromPixelCopy (SKImageInfo info, byte[] pixels) =>
-			FromPixelCopy (info, pixels, info.RowBytes);
-
-		public static SKImage FromPixelCopy (SKImageInfo info, byte[] pixels, int rowBytes)
-		{
-			if (pixels == null)
-				throw new ArgumentNullException (nameof (pixels));
-			using (var data = SKData.CreateCopy (pixels)) {
-				return FromPixels (info, data, rowBytes);
-			}
-		}
-
 		public static SKImage FromPixelCopy (SKImageInfo info, IntPtr pixels) =>
 			FromPixelCopy (info, pixels, info.RowBytes);
 
@@ -172,18 +160,6 @@ namespace SkiaSharp
 		}
 
 		public static SKImage FromEncodedData (ReadOnlySpan<byte> data)
-		{
-			if (data == null)
-				throw new ArgumentNullException (nameof (data));
-			if (data.Length == 0)
-				throw new ArgumentException ("The data buffer was empty.");
-
-			using (var skdata = SKData.CreateCopy (data)) {
-				return FromEncodedData (skdata);
-			}
-		}
-
-		public static SKImage FromEncodedData (byte[] data)
 		{
 			if (data == null)
 				throw new ArgumentNullException (nameof (data));

--- a/binding/SkiaSharp/SKPathEffect.cs
+++ b/binding/SkiaSharp/SKPathEffect.cs
@@ -61,7 +61,7 @@ namespace SkiaSharp
 			return GetObject(SkiaApi.sk_path_effect_create_2d_path(&matrix, path.Handle));
 		}
 
-		public static SKPathEffect CreateDash(float[] intervals, float phase)
+		public static SKPathEffect CreateDash(ReadOnlySpan<float> intervals, float phase)
 		{
 			if (intervals == null)
 				throw new ArgumentNullException(nameof(intervals));

--- a/binding/SkiaSharp/SKRoundRect.cs
+++ b/binding/SkiaSharp/SKRoundRect.cs
@@ -118,7 +118,7 @@ namespace SkiaSharp
 			SkiaApi.sk_rrect_set_nine_patch (Handle, &rect, leftRadius, topRadius, rightRadius, bottomRadius);
 		}
 
-		public void SetRectRadii (SKRect rect, SKPoint[] radii)
+		public void SetRectRadii (SKRect rect, ReadOnlySpan<SKPoint> radii)
 		{
 			if (radii == null)
 				throw new ArgumentNullException (nameof (radii));


### PR DESCRIPTION
**Description of Change**

This PR is just starting the migration to spans over arrays. Arrays require GC and spans can be arrays. So, a win-win!

**Bugs Fixed**

- Fixes #2613
- Related to #2616

**API Changes**

Removing the explicit array methods and adding spans where there is none.

**Behavioral Changes**

None.


**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [x] Updated documentation
