### PR TITLE
Provide allocate-less overloads of methods in SKTextBlobBuilder

### DIFF
--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
@@ -74,11 +74,9 @@ namespace SkiaSharp.HarfBuzz
 
 			// create the text blob
 			using var builder = new SKTextBlobBuilder();
-			var run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
+			builder.AllocatePositionedRun(font, result.Codepoints.Length, bounds: null, out var p, out var g);
 
 			// copy the glyphs
-			var g = run.GetGlyphSpan();
-			var p = run.GetPositionSpan();
 			for (var i = 0; i < result.Codepoints.Length; i++)
 			{
 				g[i] = (ushort)result.Codepoints[i];


### PR DESCRIPTION
In Uno Platform, we are using `AllocatePositionedRun`, which in some scenarios can be problematic as it's allocating and it's in a hot path. See for example this is a case where this was responsible for 11.3% of all allocations.

![image](https://github.com/mono/SkiaSharp/assets/31348972/b3761455-752d-4d65-9a04-48d78b5cd2b5)

The idea here is to introduce a new API that won't allocate `SKPositionedRunBuffer` and instead give us the `Span`s that we need right away. I have made the same change to APIs other than `AllocatePositionedRun` for parity.

- Fixes https://github.com/mono/SkiaSharp/issues/2776