### PR TITLE
Install missing Tizen packages after image update

### DIFF
--- a/scripts/azure-pipelines-variables.yml
+++ b/scripts/azure-pipelines-variables.yml
@@ -9,7 +9,7 @@ variables:
   PREVIEW_LABEL: 'alpha.1'
   BUILD_NUMBER: $[counter(format('_{0}_{1}_{2}__', variables['SKIASHARP_VERSION'], variables['Build.SourceBranch'], variables['PREVIEW_LABEL']), 1)]
   BUILD_COUNTER: $[counter('global_counter', 1)]
-  TIZEN_LINUX_PACKAGES: libxcb-icccm4 libxcb-render-util0 gettext libxcb-image0 libsdl1.2debian libv4l-0 libxcb-randr0 bridge-utils libxcb-shape0 libpython2.7 openvpn
+  TIZEN_LINUX_PACKAGES: libxcb-icccm4 libxcb-render-util0 gettext libxcb-image0 libsdl1.2debian libv4l-0 libxcb-randr0 bridge-utils libxcb-shape0 libpython2.7 openvpn libkf5itemmodels5 libkf5kiowidgets5 libkchart2
   MANAGED_LINUX_PACKAGES: ttf-ancient-fonts ninja-build
   XCODE_VERSION: '14.3.1'
   XCODE_VERSION_NATIVE: '14.3.1'


### PR DESCRIPTION
**Description of Change**

It appears that after the Azure DevOps image was updated, some packages are no longer on the box. This PR will re-install them for the Tizen installer/SDK.