### PR TITLE
Use the version of gn that works on old Apline

### DIFF
--- a/scripts/Docker/alpine/amd64/Dockerfile
+++ b/scripts/Docker/alpine/amd64/Dockerfile
@@ -6,8 +6,10 @@ FROM amd64/alpine:3.9
 RUN apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys --allow-untrusted
 RUN apk add --no-cache bash curl wget python python3 git build-base ninja fontconfig-dev libintl clang
 
+# use the specific commit before the tool switched to C++20 which is too new for this old alpine
 RUN git clone https://gn.googlesource.com/gn /usr/share/gn \
     && cd /usr/share/gn \
+    && git checkout d4be45bb28fbfc16a41a1e02c86137df6815f2dd \
     && python build/gen.py --allow-warning \
     && ninja -C out \
     && /usr/share/gn/out/gn --version


### PR DESCRIPTION


**Description of Change**

The new versions of gn require C++20 which is not easily available on the very old Alpine.

**Bugs Fixed**

- CI stopped working

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
