### PR TITLE
Make PlatformConfiguration properties trimmable (fixes tvOS compilation)

### DIFF
--- a/binding/Binding.Shared/PlatformConfiguration.cs
+++ b/binding/Binding.Shared/PlatformConfiguration.cs
@@ -18,41 +18,51 @@ namespace SkiaSharp.Internals
 	{
 		private const string LibCLibrary = "libc";
 
-		public static bool IsUnix { get; }
+		public static bool IsUnix => IsMac || IsLinux;
 
-		public static bool IsWindows { get; }
-
-		public static bool IsMac { get; }
-
-		public static bool IsLinux { get; }
-
-		public static bool IsArm { get; }
-
-		public static bool Is64Bit { get; }
-
-		static PlatformConfiguration ()
-		{
+		public static bool IsWindows {
 #if WINDOWS_UWP
-			IsMac = false;
-			IsLinux = false;
-			IsUnix = false;
-			IsWindows = true;
-
-			var arch = Package.Current.Id.Architecture;
-			const ProcessorArchitecture arm64 = (ProcessorArchitecture)12;
-			IsArm = arch == ProcessorArchitecture.Arm || arch == arm64;
+			get => true;
+#elif NET6_0_OR_GREATER
+			get => OperatingSystem.IsWindows ();
 #else
-			IsMac = RuntimeInformation.IsOSPlatform (OSPlatform.OSX);
-			IsLinux = RuntimeInformation.IsOSPlatform (OSPlatform.Linux);
-			IsUnix = IsMac || IsLinux;
-			IsWindows = RuntimeInformation.IsOSPlatform (OSPlatform.Windows);
-
-			var arch = RuntimeInformation.ProcessArchitecture;
-			IsArm = arch == Architecture.Arm || arch == Architecture.Arm64;
+			get => RuntimeInformation.IsOSPlatform (OSPlatform.Windows);
 #endif
-
-			Is64Bit = IntPtr.Size == 8;
 		}
+
+		public static bool IsMac {
+#if WINDOWS_UWP
+			get => false;
+#elif NET6_0_OR_GREATER
+			get => OperatingSystem.IsMacOS ();
+#else
+			get => RuntimeInformation.IsOSPlatform (OSPlatform.OSX);
+#endif
+		}
+
+		public static bool IsLinux {
+#if WINDOWS_UWP
+			get => false;
+#elif NET6_0_OR_GREATER
+			get => OperatingSystem.IsLinux ();
+#else
+			get => RuntimeInformation.IsOSPlatform (OSPlatform.Linux);
+#endif
+		}
+
+		public static bool IsArm {
+#if WINDOWS_UWP
+			get {
+				var arch = Package.Current.Id.Architecture;
+				const ProcessorArchitecture arm64 = (ProcessorArchitecture)12;
+				return arch == ProcessorArchitecture.Arm || arch == arm64;
+			}
+#else
+			get => RuntimeInformation.ProcessArchitecture is Architecture.Arm or Architecture.Arm64;
+#endif
+		}
+
+		public static bool Is64Bit => IntPtr.Size == 8;
 
 		private static string linuxFlavor;
 


### PR DESCRIPTION
**Description of Change**

Previously SkiaSharp used old APIs to conditionally execute platform specific APIs. Specifically, RuntimeInformation.IsOSPlatform is known to be non-trimmable.

It caused some Windows PInvokes to be included in the non-windows binaries. For most platform it didn't really cause any problems, but apparently tvOS linker is more sensitive (see #2715)

This PR changes PlatformConfiguration class:
1.  Use newer trimmer friendly `OperatingSystem.IsWindows()` method instead of non-trimmable `RuntimeInformation.IsOSPlatform (OSPlatform.Windows)`.
2. Remove static ctor, and instead move these checks to the property getters. 

On .NET6+ targets with trimmer enabled these calls will be eliminated and values will be inlined.

Non trimmed SkiaSharp:
<img width="458" alt="Screenshot 2024-01-14 at 10 25 25 PM" src="https://github.com/mono/SkiaSharp/assets/3163374/afac94b9-68f4-4fc8-af04-761180e7b458">

Trimmed SkiaSharp with "-r tvos-arm64" (hint for the compiler to replace OperatingSystem.IsWindows with "false").
As we can see, windows specific class is completely removed as unused.
<img width="458" alt="Screenshot 2024-01-14 at 10 25 35 PM" src="https://github.com/mono/SkiaSharp/assets/3163374/473d76dc-1455-437a-a01b-98752404797c">


**Bugs Fixed**

- Fixes #2715

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation

This PR should also be backportable with no conflicts.