### PR TITLE
Avoid async void in SKXamlCanvas.

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Shared/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Shared/SKXamlCanvas.cs
@@ -125,12 +125,12 @@ namespace SkiaSharp.Views.UWP
 			display.DpiChanged -= OnDpiChanged;
 		}
 
-		public new async void Invalidate()
+		public new void Invalidate()
 		{
 			if (Dispatcher.HasThreadAccess)
 				DoInvalidate();
 			else
-				await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, DoInvalidate);
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, DoInvalidate);
 		}
 
 		partial void DoLoaded();


### PR DESCRIPTION
**Description of Change**

The async void will terminate here. And we can ignore the Dispatcher.RunAsync result and we can receive the exception from TaskScheduler.UnobservedTaskException.

See https://github.com/dotnet/runtime/issues/76367

**Bugs Fixed**

- Fixes https://github.com/unoplatform/uno/issues/15123

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

In the original behavior, if the `SKXamlCanvas.Invalidate` method is called in the background thread, it will be scheduled back to the main thread through the `Dispatcher.RunAsync` method. However, if any business code throws an exception in the `PaintSurface` event, it will cause the process to crash.

After the modification, if business code throws an exception in the `PaintSurface` event, the exception will be received in TaskScheduler.UnobservedTaskException, but the process will still be safe. This is very important for client applications as it can greatly enhance stability.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
