### PR TITLE
Correctly package managed runtime-only files

### DIFF
--- a/binding/NativeAssets.Build.targets
+++ b/binding/NativeAssets.Build.targets
@@ -33,16 +33,20 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindowsNativeAssets)' == 'true'">
-    <None Include="@(NativeWindowsPackageFile)" Link="runtimes\%(RuntimeIdentifier)\native\%(Filename)%(Extension)" />
+    <_NativeWindowsPackageFileToUse Include="@(NativeWindowsPackageFile->HasMetadata('Folder'))" />
+    <_NativeWindowsPackageFileWithNoFolder Include="@(NativeWindowsPackageFile)" />
+    <_NativeWindowsPackageFileWithNoFolder Remove="@(_NativeWindowsPackageFileToUse)" />
+    <_NativeWindowsPackageFileToUse Include="@(_NativeWindowsPackageFileWithNoFolder)" Folder="native" />
+    <None Include="@(_NativeWindowsPackageFileToUse)" Link="runtimes\%(RuntimeIdentifier)\%(Folder)\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <Target Name="_IncludeRuntimesPackageFiles" BeforeTargets="_GetPackageFiles" Condition="'$(IsWindowsNativeAssets)' == 'true'">
     <ItemGroup>
       <_CompletedNativeWindowsPackageFile
-          Include="@(NativeWindowsPackageFile)" 
+          Include="@(_NativeWindowsPackageFileToUse)" 
           TargetFramework="%(RuntimeIdentifier)"
-          TargetPath="native\%(Filename)%(Extension)" 
-          PackagePath="runtimes\%(RuntimeIdentifier)\native\%(Filename)%(Extension)" />
+          TargetPath="%(Folder)\%(Filename)%(Extension)" 
+          PackagePath="runtimes\%(RuntimeIdentifier)\%(Folder)\%(Filename)%(Extension)" />
       <_BuildOutputInPackage Remove="@(_BuildOutputInPackage)" />
       <_BuildOutputInPackage Include="@(_CompletedNativeWindowsPackageFile)" Condition="'%(Extension)' != '.pdb'" />
       <_TargetPathsToSymbols Remove="@(_TargetPathsToSymbols)" />

--- a/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
+++ b/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
@@ -6,11 +6,11 @@
     <IsWindowsNativeAssets>true</IsWindowsNativeAssets>
   </PropertyGroup>
   <ItemGroup>
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" />
+    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
     <NativeWindowsPackageFile Include="..\..\output\native\winui\x64\*" RuntimeIdentifier="win-x64" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" />
+    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
     <NativeWindowsPackageFile Include="..\..\output\native\winui\x86\*" RuntimeIdentifier="win-x86" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" />
+    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
     <NativeWindowsPackageFile Include="..\..\output\native\winui\arm64\*" RuntimeIdentifier="win-arm64" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**Description of Change**

The managed dlls used by references need to be in the lib sub-folder, not native.