### PR TITLE
Don't put metadata in package versions

### DIFF
--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -104,9 +104,9 @@
     <PropertyGroup>
       <Version>$(_VersionNuGetMatch)</Version>
       <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
-      <Version Condition="'$(AssemblyVersionGitBranch)' != '' and !$(AssemblyVersionGitBranch.StartsWith('release/'))">$(Version)+$(AssemblyVersionGitBranch.Replace('/', '-').Replace('\', '-'))</Version>
-      <Version Condition="'$(AssemblyVersionGitSha)' != ''">$(Version).$(AssemblyVersionGitSha)</Version>
       <InformationalVersion>$(Version)</InformationalVersion>
+      <InformationalVersion Condition="'$(AssemblyVersionGitBranch)' != ''">$(InformationalVersion)+$(AssemblyVersionGitBranch.Replace('/', '-').Replace('\', '-'))</InformationalVersion>
+      <InformationalVersion Condition="'$(AssemblyVersionGitSha)' != ''">$(InformationalVersion).$(AssemblyVersionGitSha)</InformationalVersion>
       <AssemblyVersion>$(_VersionAssemblyMatch)</AssemblyVersion>
       <FileVersion>$(_VersionFileMatch)</FileVersion>
     </PropertyGroup>


### PR DESCRIPTION
**Description of Change**

We don't need it as it is in the package metadata and assembly attributes.