### PR TITLE
Clean up SKTextBlobBuilder and SKRunBuffer APIs

### DIFF
--- a/binding/SkiaSharp/SKRunBuffer.cs
+++ b/binding/SkiaSharp/SKRunBuffer.cs
@@ -131,6 +131,8 @@ namespace SkiaSharp
 		public void SetPositions (ReadOnlySpan<SKRotationScaleMatrix> positions) => positions.CopyTo (Positions);
 	}
 
+	// Raw / Struct
+
 	public unsafe readonly struct SKRunBuffer<T>
 	{
 		internal readonly SKRunBufferInternal buffer;

--- a/binding/SkiaSharp/SKRunBuffer.cs
+++ b/binding/SkiaSharp/SKRunBuffer.cs
@@ -21,6 +21,9 @@ namespace SkiaSharp
 		public Span<ushort> Glyphs => new (internalBuffer.glyphs, Size);
 
 		public void SetGlyphs (ReadOnlySpan<ushort> glyphs) => glyphs.CopyTo (Glyphs);
+
+		[Obsolete ("Use Glyphs instead.")]
+		public Span<ushort> GetGlyphSpan () => Glyphs;
 	}
 
 	public sealed unsafe class SKHorizontalRunBuffer : SKRunBuffer
@@ -33,6 +36,9 @@ namespace SkiaSharp
 		public Span<float> Positions => new (internalBuffer.pos, Size);
 
 		public void SetPositions (ReadOnlySpan<float> positions) => positions.CopyTo (Positions);
+
+		[Obsolete ("Use Positions instead.")]
+		public Span<float> GetPositionSpan () => Positions;
 	}
 
 	public sealed unsafe class SKPositionedRunBuffer : SKRunBuffer
@@ -45,6 +51,9 @@ namespace SkiaSharp
 		public Span<SKPoint> Positions => new (internalBuffer.pos, Size);
 
 		public void SetPositions (ReadOnlySpan<SKPoint> positions) => positions.CopyTo (Positions);
+
+		[Obsolete ("Use Positions instead.")]
+		public Span<SKPoint> GetPositionSpan () => Positions;
 	}
 
 	public sealed unsafe class SKRotationScaleRunBuffer : SKRunBuffer
@@ -57,6 +66,12 @@ namespace SkiaSharp
 		public Span<SKRotationScaleMatrix> Positions => new (internalBuffer.pos, Size);
 
 		public void SetPositions (ReadOnlySpan<SKRotationScaleMatrix> positions) => positions.CopyTo (Positions);
+
+		[Obsolete ("Use Positions instead.")]
+		public Span<SKRotationScaleMatrix> GetRotationScaleSpan () => Positions;
+
+		[Obsolete ("Use SetPositions instead.")]
+		public void SetRotationScale (ReadOnlySpan<SKRotationScaleMatrix> positions) => SetPositions (positions);
 	}
 
 	// Text

--- a/binding/SkiaSharp/SKRunBuffer.cs
+++ b/binding/SkiaSharp/SKRunBuffer.cs
@@ -133,14 +133,14 @@ namespace SkiaSharp
 
 	// Raw / Struct
 
-	public unsafe readonly struct SKRunBuffer<T>
+	public unsafe readonly struct SKRawRunBuffer<T>
 	{
 		internal readonly SKRunBufferInternal buffer;
 		private readonly int size;
 		private readonly int posSize;
 		private readonly int textSize;
 
-		internal SKRunBuffer (SKRunBufferInternal buffer, int size, int posSize, int textSize)
+		internal SKRawRunBuffer (SKRunBufferInternal buffer, int size, int posSize, int textSize)
 		{
 			this.buffer = buffer;
 			this.size = size;

--- a/binding/SkiaSharp/SKRunBuffer.cs
+++ b/binding/SkiaSharp/SKRunBuffer.cs
@@ -1,10 +1,11 @@
 ﻿#nullable disable
 
 using System;
-using System.ComponentModel;
 
 namespace SkiaSharp
 {
+	// Base
+
 	public unsafe class SKRunBuffer
 	{
 		internal readonly SKRunBufferInternal internalBuffer;
@@ -17,103 +18,125 @@ namespace SkiaSharp
 
 		public int Size { get; }
 
-		public Span<ushort> GetGlyphSpan () =>
-			new Span<ushort> (internalBuffer.glyphs, internalBuffer.glyphs == null ? 0 : Size);
+		public Span<ushort> Glyphs => new (internalBuffer.glyphs, Size);
 
-		public void SetGlyphs (ReadOnlySpan<ushort> glyphs) =>
-			glyphs.CopyTo (GetGlyphSpan ());
+		public void SetGlyphs (ReadOnlySpan<ushort> glyphs) => glyphs.CopyTo (Glyphs);
 	}
 
 	public sealed unsafe class SKHorizontalRunBuffer : SKRunBuffer
 	{
-		internal SKHorizontalRunBuffer (SKRunBufferInternal buffer, int count)
-			: base (buffer, count)
+		internal SKHorizontalRunBuffer (SKRunBufferInternal buffer, int size)
+			: base (buffer, size)
 		{
 		}
 
-		public Span<float> GetPositionSpan () =>
-			new Span<float> (internalBuffer.pos, internalBuffer.pos == null ? 0 : Size);
+		public Span<float> Positions => new (internalBuffer.pos, Size);
 
-		public void SetPositions (ReadOnlySpan<float> positions) =>
-			positions.CopyTo (GetPositionSpan ());
+		public void SetPositions (ReadOnlySpan<float> positions) => positions.CopyTo (Positions);
 	}
 
 	public sealed unsafe class SKPositionedRunBuffer : SKRunBuffer
 	{
-		internal SKPositionedRunBuffer (SKRunBufferInternal buffer, int count)
-			: base (buffer, count)
+		internal SKPositionedRunBuffer (SKRunBufferInternal buffer, int size)
+			: base (buffer, size)
 		{
 		}
 
-		public Span<SKPoint> GetPositionSpan () =>
-			new Span<SKPoint> (internalBuffer.pos, internalBuffer.pos == null ? 0 : Size);
+		public Span<SKPoint> Positions => new (internalBuffer.pos, Size);
 
-		public void SetPositions (ReadOnlySpan<SKPoint> positions) =>
-			positions.CopyTo (GetPositionSpan ());
+		public void SetPositions (ReadOnlySpan<SKPoint> positions) => positions.CopyTo (Positions);
 	}
 
 	public sealed unsafe class SKRotationScaleRunBuffer : SKRunBuffer
 	{
-		internal SKRotationScaleRunBuffer (SKRunBufferInternal buffer, int count)
-			: base (buffer, count)
+		internal SKRotationScaleRunBuffer (SKRunBufferInternal buffer, int size)
+			: base (buffer, size)
 		{
 		}
 
-		public Span<SKRotationScaleMatrix> GetRotationScaleSpan () =>
-			new Span<SKRotationScaleMatrix> (internalBuffer.pos, Size);
+		public Span<SKRotationScaleMatrix> Positions => new (internalBuffer.pos, Size);
 
-		public void SetRotationScale (ReadOnlySpan<SKRotationScaleMatrix> positions) =>
-			positions.CopyTo (GetRotationScaleSpan ());
+		public void SetPositions (ReadOnlySpan<SKRotationScaleMatrix> positions) => positions.CopyTo (Positions);
 	}
+
+	// Text
 
 	public unsafe class SKTextRunBuffer : SKRunBuffer
 	{
-		internal SKTextRunBuffer (SKRunBufferInternal buffer, int count, int textSize)
-			: base (buffer, count)
+		internal SKTextRunBuffer (SKRunBufferInternal buffer, int size, int textSize)
+			: base (buffer, size)
 		{
 			TextSize = textSize;
 		}
 
 		public int TextSize { get; }
 
-		public Span<byte> GetTextSpan () =>
-			new Span<byte> (internalBuffer.utf8text, internalBuffer.utf8text == null ? 0 : TextSize);
+		public Span<byte> Text => new (internalBuffer.utf8text, TextSize);
 
-		public Span<uint> GetClusterSpan () =>
-			new Span<uint> (internalBuffer.clusters, internalBuffer.clusters == null ? 0 : Size);
+		public Span<uint> Clusters => new (internalBuffer.clusters, Size);
 
-		public void SetText (ReadOnlySpan<byte> text) =>
-			text.CopyTo (GetTextSpan ());
+		public void SetText (ReadOnlySpan<byte> text) => text.CopyTo (Text);
 
-		public void SetClusters (ReadOnlySpan<uint> clusters) =>
-			clusters.CopyTo (GetClusterSpan ());
+		public void SetClusters (ReadOnlySpan<uint> clusters) => clusters.CopyTo (Clusters);
 	}
 
 	public sealed unsafe class SKHorizontalTextRunBuffer : SKTextRunBuffer
 	{
-		internal SKHorizontalTextRunBuffer (SKRunBufferInternal buffer, int count, int textSize)
-			: base (buffer, count, textSize)
+		internal SKHorizontalTextRunBuffer (SKRunBufferInternal buffer, int size, int textSize)
+			: base (buffer, size, textSize)
 		{
 		}
 
-		public Span<float> GetPositionSpan () =>
-			new Span<float> (internalBuffer.pos, internalBuffer.pos == null ? 0 : Size);
+		public Span<float> Positions => new (internalBuffer.pos, Size);
 
-		public void SetPositions (ReadOnlySpan<float> positions) =>
-			positions.CopyTo (GetPositionSpan ());
+		public void SetPositions (ReadOnlySpan<float> positions) => positions.CopyTo (Positions);
 	}
 
 	public sealed unsafe class SKPositionedTextRunBuffer : SKTextRunBuffer
 	{
-		internal SKPositionedTextRunBuffer (SKRunBufferInternal buffer, int count, int textSize)
-			: base (buffer, count, textSize)
+		internal SKPositionedTextRunBuffer (SKRunBufferInternal buffer, int size, int textSize)
+			: base (buffer, size, textSize)
 		{
 		}
 
-		public Span<SKPoint> GetPositionSpan () =>
-			new Span<SKPoint> (internalBuffer.pos, internalBuffer.pos == null ? 0 : Size);
+		public Span<SKPoint> Positions => new (internalBuffer.pos, Size);
 
-		public void SetPositions (ReadOnlySpan<SKPoint> positions) =>
-			positions.CopyTo (GetPositionSpan ());
+		public void SetPositions (ReadOnlySpan<SKPoint> positions) => positions.CopyTo (Positions);
+	}
+
+	public sealed unsafe class SKRotationScaleTextRunBuffer : SKTextRunBuffer
+	{
+		internal SKRotationScaleTextRunBuffer (SKRunBufferInternal buffer, int size, int textSize)
+			: base (buffer, size, textSize)
+		{
+		}
+
+		public Span<SKRotationScaleMatrix> Positions => new (internalBuffer.pos, Size);
+
+		public void SetPositions (ReadOnlySpan<SKRotationScaleMatrix> positions) => positions.CopyTo (Positions);
+	}
+
+	public unsafe readonly struct SKRunBuffer<T>
+	{
+		internal readonly SKRunBufferInternal buffer;
+		private readonly int size;
+		private readonly int posSize;
+		private readonly int textSize;
+
+		internal SKRunBuffer (SKRunBufferInternal buffer, int size, int posSize, int textSize)
+		{
+			this.buffer = buffer;
+			this.size = size;
+			this.posSize = posSize;
+			this.textSize = textSize;
+		}
+
+		public Span<ushort> Glyphs => new (buffer.glyphs, size);
+
+		public Span<T> Positions => new (buffer.pos, posSize);
+
+		public Span<byte> Text => new (buffer.utf8text, textSize);
+
+		public Span<uint> Clusters => new (buffer.clusters, size);
 	}
 }

--- a/binding/SkiaSharp/SKTextBlob.cs
+++ b/binding/SkiaSharp/SKTextBlob.cs
@@ -1,7 +1,4 @@
-﻿#nullable disable
-
-using System;
-using System.ComponentModel;
+﻿using System;
 
 namespace SkiaSharp
 {
@@ -31,27 +28,27 @@ namespace SkiaSharp
 
 		// Create
 
-		public static SKTextBlob Create (string text, SKFont font, SKPoint origin = default) =>
+		public static SKTextBlob? Create (string text, SKFont font, SKPoint origin = default) =>
 			Create (text.AsSpan (), font, origin);
 
-		public static SKTextBlob Create (ReadOnlySpan<char> text, SKFont font, SKPoint origin = default)
+		public static SKTextBlob? Create (ReadOnlySpan<char> text, SKFont font, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return Create (t, text.Length * 2, SKTextEncoding.Utf16, font, origin);
 			}
 		}
 
-		public static SKTextBlob Create (IntPtr text, int length, SKTextEncoding encoding, SKFont font, SKPoint origin = default) =>
+		public static SKTextBlob? Create (IntPtr text, int length, SKTextEncoding encoding, SKFont font, SKPoint origin = default) =>
 			Create (text.AsReadOnlySpan (length), encoding, font, origin);
 
-		public static SKTextBlob Create (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, SKPoint origin = default)
+		public static SKTextBlob? Create (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return Create (t, text.Length, encoding, font, origin);
 			}
 		}
 
-		internal static SKTextBlob Create (void* text, int length, SKTextEncoding encoding, SKFont font, SKPoint origin)
+		internal static SKTextBlob? Create (void* text, int length, SKTextEncoding encoding, SKFont font, SKPoint origin)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -61,35 +58,35 @@ namespace SkiaSharp
 				return null;
 
 			using var builder = new SKTextBlobBuilder ();
-			var buffer = builder.AllocatePositionedRun (font, count);
-			font.GetGlyphs (text, length, encoding, buffer.GetGlyphSpan ());
-			font.GetGlyphPositions (buffer.GetGlyphSpan (), buffer.GetPositionSpan (), origin);
+			builder.AllocatePositionedRun (font, count, null, out var buffer);
+			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
+			font.GetGlyphPositions (buffer.Glyphs, buffer.Positions, origin);
 			return builder.Build ();
 		}
 
 		// CreateHorizontal
 
-		public static SKTextBlob CreateHorizontal (string text, SKFont font, ReadOnlySpan<float> positions, float y) =>
+		public static SKTextBlob? CreateHorizontal (string text, SKFont font, ReadOnlySpan<float> positions, float y) =>
 			CreateHorizontal (text.AsSpan (), font, positions, y);
 
-		public static SKTextBlob CreateHorizontal (ReadOnlySpan<char> text, SKFont font, ReadOnlySpan<float> positions, float y)
+		public static SKTextBlob? CreateHorizontal (ReadOnlySpan<char> text, SKFont font, ReadOnlySpan<float> positions, float y)
 		{
 			fixed (void* t = text) {
 				return CreateHorizontal (t, text.Length * 2, SKTextEncoding.Utf16, font, positions, y);
 			}
 		}
 
-		public static SKTextBlob CreateHorizontal (IntPtr text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<float> positions, float y) =>
+		public static SKTextBlob? CreateHorizontal (IntPtr text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<float> positions, float y) =>
 			CreateHorizontal (text.AsReadOnlySpan (length), encoding, font, positions, y);
 
-		public static SKTextBlob CreateHorizontal (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, ReadOnlySpan<float> positions, float y)
+		public static SKTextBlob? CreateHorizontal (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, ReadOnlySpan<float> positions, float y)
 		{
 			fixed (void* t = text) {
 				return CreateHorizontal (t, text.Length, encoding, font, positions, y);
 			}
 		}
 
-		internal static SKTextBlob CreateHorizontal (void* text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<float> positions, float y)
+		internal static SKTextBlob? CreateHorizontal (void* text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<float> positions, float y)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -99,35 +96,35 @@ namespace SkiaSharp
 				return null;
 
 			using var builder = new SKTextBlobBuilder ();
-			var buffer = builder.AllocateHorizontalRun (font, count, y);
-			font.GetGlyphs (text, length, encoding, buffer.GetGlyphSpan ());
-			positions.CopyTo (buffer.GetPositionSpan ());
+			builder.AllocateHorizontalRun (font, count, y, null, out var buffer);
+			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
+			positions.CopyTo (buffer.Positions);
 			return builder.Build ();
 		}
 
 		// CreatePositioned
 
-		public static SKTextBlob CreatePositioned (string text, SKFont font, ReadOnlySpan<SKPoint> positions) =>
+		public static SKTextBlob? CreatePositioned (string text, SKFont font, ReadOnlySpan<SKPoint> positions) =>
 			CreatePositioned (text.AsSpan (), font, positions);
 
-		public static SKTextBlob CreatePositioned (ReadOnlySpan<char> text, SKFont font, ReadOnlySpan<SKPoint> positions)
+		public static SKTextBlob? CreatePositioned (ReadOnlySpan<char> text, SKFont font, ReadOnlySpan<SKPoint> positions)
 		{
 			fixed (void* t = text) {
 				return CreatePositioned (t, text.Length * 2, SKTextEncoding.Utf16, font, positions);
 			}
 		}
 
-		public static SKTextBlob CreatePositioned (IntPtr text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKPoint> positions) =>
+		public static SKTextBlob? CreatePositioned (IntPtr text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKPoint> positions) =>
 			CreatePositioned (text.AsReadOnlySpan (length), encoding, font, positions);
 
-		public static SKTextBlob CreatePositioned (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKPoint> positions)
+		public static SKTextBlob? CreatePositioned (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKPoint> positions)
 		{
 			fixed (void* t = text) {
 				return CreatePositioned (t, text.Length, encoding, font, positions);
 			}
 		}
 
-		internal static SKTextBlob CreatePositioned (void* text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKPoint> positions)
+		internal static SKTextBlob? CreatePositioned (void* text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKPoint> positions)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -137,35 +134,35 @@ namespace SkiaSharp
 				return null;
 
 			using var builder = new SKTextBlobBuilder ();
-			var buffer = builder.AllocatePositionedRun (font, count);
-			font.GetGlyphs (text, length, encoding, buffer.GetGlyphSpan ());
-			positions.CopyTo (buffer.GetPositionSpan ());
+			builder.AllocatePositionedRun (font, count, null, out var buffer);
+			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
+			positions.CopyTo (buffer.Positions);
 			return builder.Build ();
 		}
 
 		// CreateRotationScale
 
-		public static SKTextBlob CreateRotationScale (string text, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions) =>
+		public static SKTextBlob? CreateRotationScale (string text, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions) =>
 			CreateRotationScale (text.AsSpan (), font, positions);
 
-		public static SKTextBlob CreateRotationScale (ReadOnlySpan<char> text, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
+		public static SKTextBlob? CreateRotationScale (ReadOnlySpan<char> text, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
 		{
 			fixed (void* t = text) {
 				return CreateRotationScale (t, text.Length * 2, SKTextEncoding.Utf16, font, positions);
 			}
 		}
 
-		public static SKTextBlob CreateRotationScale (IntPtr text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions) =>
+		public static SKTextBlob? CreateRotationScale (IntPtr text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions) =>
 			CreateRotationScale (text.AsReadOnlySpan (length), encoding, font, positions);
 
-		public static SKTextBlob CreateRotationScale (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
+		public static SKTextBlob? CreateRotationScale (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
 		{
 			fixed (void* t = text) {
 				return CreateRotationScale (t, text.Length, encoding, font, positions);
 			}
 		}
 
-		internal static SKTextBlob CreateRotationScale (void* text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
+		internal static SKTextBlob? CreateRotationScale (void* text, int length, SKTextEncoding encoding, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -176,34 +173,34 @@ namespace SkiaSharp
 
 			using var builder = new SKTextBlobBuilder ();
 			var buffer = builder.AllocateRotationScaleRun (font, count);
-			font.GetGlyphs (text, length, encoding, buffer.GetGlyphSpan ());
-			positions.CopyTo (buffer.GetRotationScaleSpan ());
+			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
+			positions.CopyTo (buffer.Positions);
 			return builder.Build ();
 		}
 
 		// CreatePathPositioned
 
-		public static SKTextBlob CreatePathPositioned (string text, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
+		public static SKTextBlob? CreatePathPositioned (string text, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
 			CreatePathPositioned (text.AsSpan (), font, path, textAlign, origin);
 
-		public static SKTextBlob CreatePathPositioned (ReadOnlySpan<char> text, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
+		public static SKTextBlob? CreatePathPositioned (ReadOnlySpan<char> text, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return CreatePathPositioned (t, text.Length * 2, SKTextEncoding.Utf16, font, path, textAlign, origin);
 			}
 		}
 
-		public static SKTextBlob CreatePathPositioned (IntPtr text, int length, SKTextEncoding encoding, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
+		public static SKTextBlob? CreatePathPositioned (IntPtr text, int length, SKTextEncoding encoding, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default) =>
 			CreatePathPositioned (text.AsReadOnlySpan (length), encoding, font, path, textAlign, origin);
 
-		public static SKTextBlob CreatePathPositioned (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
+		public static SKTextBlob? CreatePathPositioned (ReadOnlySpan<byte> text, SKTextEncoding encoding, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
 		{
 			fixed (void* t = text) {
 				return CreatePathPositioned (t, text.Length, encoding, font, path, textAlign, origin);
 			}
 		}
 
-		internal static SKTextBlob CreatePathPositioned (void* text, int length, SKTextEncoding encoding, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
+		internal static SKTextBlob? CreatePathPositioned (void* text, int length, SKTextEncoding encoding, SKFont font, SKPath path, SKTextAlign textAlign = SKTextAlign.Left, SKPoint origin = default)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -228,7 +225,7 @@ namespace SkiaSharp
 
 		// GetIntercepts
 
-		public float[] GetIntercepts (float upperBounds, float lowerBounds, SKPaint paint = null)
+		public float[] GetIntercepts (float upperBounds, float lowerBounds, SKPaint? paint = null)
 		{
 			var n = CountIntercepts (upperBounds, lowerBounds, paint);
 			var intervals = new float[n];
@@ -236,7 +233,7 @@ namespace SkiaSharp
 			return intervals;
 		}
 
-		public void GetIntercepts (float upperBounds, float lowerBounds, Span<float> intervals, SKPaint paint = null)
+		public void GetIntercepts (float upperBounds, float lowerBounds, Span<float> intervals, SKPaint? paint = null)
 		{
 			var bounds = stackalloc float[2];
 			bounds[0] = upperBounds;
@@ -248,7 +245,7 @@ namespace SkiaSharp
 
 		// CountIntercepts
 
-		public int CountIntercepts (float upperBounds, float lowerBounds, SKPaint paint = null)
+		public int CountIntercepts (float upperBounds, float lowerBounds, SKPaint? paint = null)
 		{
 			var bounds = stackalloc float[2];
 			bounds[0] = upperBounds;
@@ -258,7 +255,7 @@ namespace SkiaSharp
 
 		//
 
-		internal static SKTextBlob GetObject (IntPtr handle) =>
+		internal static SKTextBlob? GetObject (IntPtr handle) =>
 			handle == IntPtr.Zero ? null : new SKTextBlob (handle, true);
 	}
 
@@ -282,7 +279,7 @@ namespace SkiaSharp
 
 		// Build
 
-		public SKTextBlob Build ()
+		public SKTextBlob? Build ()
 		{
 			var blob = SKTextBlob.GetObject (SkiaApi.sk_textblob_builder_make (Handle));
 			GC.KeepAlive (this);
@@ -293,48 +290,36 @@ namespace SkiaSharp
 
 		public void AddRun (ReadOnlySpan<ushort> glyphs, SKFont font, SKPoint origin = default)
 		{
-			if (font == null)
-				throw new ArgumentNullException (nameof (font));
-
-			var buffer = AllocatePositionedRun (font, glyphs.Length);
-			glyphs.CopyTo (buffer.GetGlyphSpan ());
-			font.GetGlyphPositions (buffer.GetGlyphSpan (), buffer.GetPositionSpan (), origin);
+			AllocatePositionedRun (font, glyphs.Length, null, out var buffer);
+			glyphs.CopyTo (buffer.Glyphs);
+			font.GetGlyphPositions (buffer.Glyphs, buffer.Positions, origin);
 		}
 
 		// AddHorizontalRun
 
 		public void AddHorizontalRun (ReadOnlySpan<ushort> glyphs, SKFont font, ReadOnlySpan<float> positions, float y)
 		{
-			if (font == null)
-				throw new ArgumentNullException (nameof (font));
-
-			var buffer = AllocateHorizontalRun (font, glyphs.Length, y);
-			glyphs.CopyTo (buffer.GetGlyphSpan ());
-			positions.CopyTo (buffer.GetPositionSpan ());
+			AllocateHorizontalRun (font, glyphs.Length, y, null, out var buffer);
+			glyphs.CopyTo (buffer.Glyphs);
+			positions.CopyTo (buffer.Positions);
 		}
 
 		// AddPositionedRun
 
 		public void AddPositionedRun (ReadOnlySpan<ushort> glyphs, SKFont font, ReadOnlySpan<SKPoint> positions)
 		{
-			if (font == null)
-				throw new ArgumentNullException (nameof (font));
-
-			var buffer = AllocatePositionedRun (font, glyphs.Length);
-			glyphs.CopyTo (buffer.GetGlyphSpan ());
-			positions.CopyTo (buffer.GetPositionSpan ());
+			AllocatePositionedRun (font, glyphs.Length, null, out var buffer);
+			glyphs.CopyTo (buffer.Glyphs);
+			positions.CopyTo (buffer.Positions);
 		}
 
 		// AddRotationScaleRun 
 
 		public void AddRotationScaleRun (ReadOnlySpan<ushort> glyphs, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
 		{
-			if (font == null)
-				throw new ArgumentNullException (nameof (font));
-
-			var buffer = AllocateRotationScaleRun (font, glyphs.Length);
-			glyphs.CopyTo (buffer.GetGlyphSpan ());
-			positions.CopyTo (buffer.GetRotationScaleSpan ());
+			AllocateRotationScaleRun (font, glyphs.Length, null, out var buffer);
+			glyphs.CopyTo (buffer.Glyphs);
+			positions.CopyTo (buffer.Positions);
 		}
 
 		// AddPathPositionedRun
@@ -394,6 +379,12 @@ namespace SkiaSharp
 
 		public SKRunBuffer AllocateRun (SKFont font, int count, float x, float y, SKRect? bounds = null)
 		{
+			AllocateRun (font, count, x, y, bounds, out var buffer);
+			return new SKRunBuffer (buffer.buffer, count);
+		}
+
+		public void AllocateRun (SKFont font, int count, float x, float y, SKRect? bounds, out SKRunBuffer<float> buffer)
+		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
 
@@ -403,10 +394,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run (Handle, font.Handle, count, x, y, null, &runbuffer);
 
-			return new SKRunBuffer (runbuffer, count);
+			buffer = new SKRunBuffer<float> (runbuffer, count, 0, 0);
 		}
 
 		public SKTextRunBuffer AllocateTextRun (SKFont font, int count, float x, float y, int textByteCount, SKRect? bounds = null)
+		{
+			AllocateTextRun (font, count, x, y, textByteCount, bounds, out var buffer);
+			return new SKTextRunBuffer (buffer.buffer, count, textByteCount);
+		}
+
+		public void AllocateTextRun (SKFont font, int count, float x, float y, int textByteCount, SKRect? bounds, out SKRunBuffer<float> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -417,12 +414,18 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text (Handle, font.Handle, count, x, y, textByteCount, null, &runbuffer);
 
-			return new SKTextRunBuffer (runbuffer, count, textByteCount);
+			buffer = new SKRunBuffer<float> (runbuffer, count, 0, textByteCount);
 		}
 
 		// AllocateHorizontalRun
 
 		public SKHorizontalRunBuffer AllocateHorizontalRun (SKFont font, int count, float y, SKRect? bounds = null)
+		{
+			AllocateHorizontalRun (font, count, y, bounds, out var buffer);
+			return new SKHorizontalRunBuffer (buffer.buffer, count);
+		}
+
+		public void AllocateHorizontalRun (SKFont font, int count, float y, SKRect? bounds, out SKRunBuffer<float> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -433,10 +436,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_pos_h (Handle, font.Handle, count, y, null, &runbuffer);
 
-			return new SKHorizontalRunBuffer (runbuffer, count);
+			buffer = new SKRunBuffer<float> (runbuffer, count, count, 0);
 		}
 
 		public SKHorizontalTextRunBuffer AllocateHorizontalTextRun (SKFont font, int count, float y, int textByteCount, SKRect? bounds = null)
+		{
+			AllocateHorizontalTextRun (font, count, y, textByteCount, bounds, out var buffer);
+			return new SKHorizontalTextRunBuffer (buffer.buffer, count, textByteCount);
+		}
+
+		public void AllocateHorizontalTextRun (SKFont font, int count, float y, int textByteCount, SKRect? bounds, out SKRunBuffer<float> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -447,12 +456,19 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text_pos_h (Handle, font.Handle, count, y, textByteCount, null, &runbuffer);
 
-			return new SKHorizontalTextRunBuffer (runbuffer, count, textByteCount);
+			buffer = new SKRunBuffer<float> (runbuffer, count, count, textByteCount);
+
 		}
 
 		// AllocatePositionedRun
 
 		public SKPositionedRunBuffer AllocatePositionedRun (SKFont font, int count, SKRect? bounds = null)
+		{
+			AllocatePositionedRun (font, count, bounds, out var buffer);
+			return new SKPositionedRunBuffer (buffer.buffer, count);
+		}
+
+		public void AllocatePositionedRun (SKFont font, int count, SKRect? bounds, out SKRunBuffer<SKPoint> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -463,10 +479,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_pos (Handle, font.Handle, count, null, &runbuffer);
 
-			return new SKPositionedRunBuffer (runbuffer, count);
+			buffer = new SKRunBuffer<SKPoint> (runbuffer, count, count, 0);
 		}
 
 		public SKPositionedTextRunBuffer AllocatePositionedTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
+		{
+			AllocatePositionedTextRun (font, count, textByteCount, bounds, out var buffer);
+			return new SKPositionedTextRunBuffer (buffer.buffer, count, textByteCount);
+		}
+
+		public void AllocatePositionedTextRun (SKFont font, int count, int textByteCount, SKRect? bounds, out SKRunBuffer<SKPoint> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -477,12 +499,18 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text_pos (Handle, font.Handle, count, textByteCount, null, &runbuffer);
 
-			return new SKPositionedTextRunBuffer (runbuffer, count, textByteCount);
+			buffer = new SKRunBuffer<SKPoint> (runbuffer, count, count, textByteCount);
 		}
 
 		// AllocateRotationScaleRun
 
 		public SKRotationScaleRunBuffer AllocateRotationScaleRun (SKFont font, int count, SKRect? bounds = null)
+		{
+			AllocateRotationScaleRun (font, count, bounds, out var buffer);
+			return new SKRotationScaleRunBuffer (buffer.buffer, count);
+		}
+
+		public void AllocateRotationScaleRun (SKFont font, int count, SKRect? bounds, out SKRunBuffer<SKRotationScaleMatrix> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -493,10 +521,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_rsxform (Handle, font.Handle, count, null, &runbuffer);
 
-			return new SKRotationScaleRunBuffer (runbuffer, count);
+			buffer = new SKRunBuffer<SKRotationScaleMatrix> (runbuffer, count, count, 0);
 		}
 
-		public SKRotationScaleRunBuffer AllocateRotationScaleTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
+		public SKRotationScaleTextRunBuffer AllocateRotationScaleTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
+		{
+			AllocateRotationScaleTextRun (font, count, textByteCount, bounds, out var buffer);
+			return new SKRotationScaleTextRunBuffer (buffer.buffer, count, textByteCount);
+		}
+
+		public void AllocateRotationScaleTextRun (SKFont font, int count, int textByteCount, SKRect? bounds, out SKRunBuffer<SKRotationScaleMatrix> buffer)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -507,7 +541,7 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text_rsxform (Handle, font.Handle, count, textByteCount, null, &runbuffer);
 
-			return new SKRotationScaleRunBuffer (runbuffer, count);
+			buffer = new SKRunBuffer<SKRotationScaleMatrix> (runbuffer, count, count, textByteCount);
 		}
 	}
 }

--- a/binding/SkiaSharp/SKTextBlob.cs
+++ b/binding/SkiaSharp/SKTextBlob.cs
@@ -58,7 +58,7 @@ namespace SkiaSharp
 				return null;
 
 			using var builder = new SKTextBlobBuilder ();
-			builder.AllocatePositionedRun (font, count, null, out var buffer);
+			var buffer = builder.AllocateRawPositionedRun (font, count);
 			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
 			font.GetGlyphPositions (buffer.Glyphs, buffer.Positions, origin);
 			return builder.Build ();
@@ -96,7 +96,7 @@ namespace SkiaSharp
 				return null;
 
 			using var builder = new SKTextBlobBuilder ();
-			builder.AllocateHorizontalRun (font, count, y, null, out var buffer);
+			var buffer = builder.AllocateRawHorizontalRun (font, count, y);
 			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
 			positions.CopyTo (buffer.Positions);
 			return builder.Build ();
@@ -134,7 +134,7 @@ namespace SkiaSharp
 				return null;
 
 			using var builder = new SKTextBlobBuilder ();
-			builder.AllocatePositionedRun (font, count, null, out var buffer);
+			var buffer = builder.AllocateRawPositionedRun (font, count);
 			font.GetGlyphs (text, length, encoding, buffer.Glyphs);
 			positions.CopyTo (buffer.Positions);
 			return builder.Build ();
@@ -290,7 +290,7 @@ namespace SkiaSharp
 
 		public void AddRun (ReadOnlySpan<ushort> glyphs, SKFont font, SKPoint origin = default)
 		{
-			AllocatePositionedRun (font, glyphs.Length, null, out var buffer);
+			var buffer = AllocateRawPositionedRun (font, glyphs.Length);
 			glyphs.CopyTo (buffer.Glyphs);
 			font.GetGlyphPositions (buffer.Glyphs, buffer.Positions, origin);
 		}
@@ -299,7 +299,7 @@ namespace SkiaSharp
 
 		public void AddHorizontalRun (ReadOnlySpan<ushort> glyphs, SKFont font, ReadOnlySpan<float> positions, float y)
 		{
-			AllocateHorizontalRun (font, glyphs.Length, y, null, out var buffer);
+			var buffer = AllocateRawHorizontalRun (font, glyphs.Length, y);
 			glyphs.CopyTo (buffer.Glyphs);
 			positions.CopyTo (buffer.Positions);
 		}
@@ -308,7 +308,7 @@ namespace SkiaSharp
 
 		public void AddPositionedRun (ReadOnlySpan<ushort> glyphs, SKFont font, ReadOnlySpan<SKPoint> positions)
 		{
-			AllocatePositionedRun (font, glyphs.Length, null, out var buffer);
+			var buffer = AllocateRawPositionedRun (font, glyphs.Length);
 			glyphs.CopyTo (buffer.Glyphs);
 			positions.CopyTo (buffer.Positions);
 		}
@@ -317,7 +317,7 @@ namespace SkiaSharp
 
 		public void AddRotationScaleRun (ReadOnlySpan<ushort> glyphs, SKFont font, ReadOnlySpan<SKRotationScaleMatrix> positions)
 		{
-			AllocateRotationScaleRun (font, glyphs.Length, null, out var buffer);
+			var buffer = AllocateRawRotationScaleRun (font, glyphs.Length);
 			glyphs.CopyTo (buffer.Glyphs);
 			positions.CopyTo (buffer.Positions);
 		}
@@ -375,15 +375,17 @@ namespace SkiaSharp
 			AddRotationScaleRun (glyphSubset, font, positions);
 		}
 
-		// AllocateRun
+		// Allocate*
+
+		// Allocate*Run
 
 		public SKRunBuffer AllocateRun (SKFont font, int count, float x, float y, SKRect? bounds = null)
 		{
-			AllocateRun (font, count, x, y, bounds, out var buffer);
+			var buffer = AllocateRawRun (font, count, x, y, bounds);
 			return new SKRunBuffer (buffer.buffer, count);
 		}
 
-		public void AllocateRun (SKFont font, int count, float x, float y, SKRect? bounds, out SKRunBuffer<float> buffer)
+		public SKRawRunBuffer<float> AllocateRawRun (SKFont font, int count, float x, float y, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -394,16 +396,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run (Handle, font.Handle, count, x, y, null, &runbuffer);
 
-			buffer = new SKRunBuffer<float> (runbuffer, count, 0, 0);
+			return new SKRawRunBuffer<float> (runbuffer, count, 0, 0);
 		}
 
 		public SKTextRunBuffer AllocateTextRun (SKFont font, int count, float x, float y, int textByteCount, SKRect? bounds = null)
 		{
-			AllocateTextRun (font, count, x, y, textByteCount, bounds, out var buffer);
+			var buffer = AllocateRawTextRun (font, count, x, y, textByteCount, bounds);
 			return new SKTextRunBuffer (buffer.buffer, count, textByteCount);
 		}
 
-		public void AllocateTextRun (SKFont font, int count, float x, float y, int textByteCount, SKRect? bounds, out SKRunBuffer<float> buffer)
+		public SKRawRunBuffer<float> AllocateRawTextRun (SKFont font, int count, float x, float y, int textByteCount, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -414,18 +416,18 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text (Handle, font.Handle, count, x, y, textByteCount, null, &runbuffer);
 
-			buffer = new SKRunBuffer<float> (runbuffer, count, 0, textByteCount);
+			return new SKRawRunBuffer<float> (runbuffer, count, 0, textByteCount);
 		}
 
-		// AllocateHorizontalRun
+		// Allocate*HorizontalRun
 
 		public SKHorizontalRunBuffer AllocateHorizontalRun (SKFont font, int count, float y, SKRect? bounds = null)
 		{
-			AllocateHorizontalRun (font, count, y, bounds, out var buffer);
+			var buffer = AllocateRawHorizontalRun (font, count, y, bounds);
 			return new SKHorizontalRunBuffer (buffer.buffer, count);
 		}
 
-		public void AllocateHorizontalRun (SKFont font, int count, float y, SKRect? bounds, out SKRunBuffer<float> buffer)
+		public SKRawRunBuffer<float> AllocateRawHorizontalRun (SKFont font, int count, float y, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -436,16 +438,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_pos_h (Handle, font.Handle, count, y, null, &runbuffer);
 
-			buffer = new SKRunBuffer<float> (runbuffer, count, count, 0);
+			return new SKRawRunBuffer<float> (runbuffer, count, count, 0);
 		}
 
 		public SKHorizontalTextRunBuffer AllocateHorizontalTextRun (SKFont font, int count, float y, int textByteCount, SKRect? bounds = null)
 		{
-			AllocateHorizontalTextRun (font, count, y, textByteCount, bounds, out var buffer);
+			var buffer = AllocateRawHorizontalTextRun (font, count, y, textByteCount, bounds);
 			return new SKHorizontalTextRunBuffer (buffer.buffer, count, textByteCount);
 		}
 
-		public void AllocateHorizontalTextRun (SKFont font, int count, float y, int textByteCount, SKRect? bounds, out SKRunBuffer<float> buffer)
+		public SKRawRunBuffer<float> AllocateRawHorizontalTextRun (SKFont font, int count, float y, int textByteCount, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -456,7 +458,7 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text_pos_h (Handle, font.Handle, count, y, textByteCount, null, &runbuffer);
 
-			buffer = new SKRunBuffer<float> (runbuffer, count, count, textByteCount);
+			return new SKRawRunBuffer<float> (runbuffer, count, count, textByteCount);
 
 		}
 
@@ -464,11 +466,11 @@ namespace SkiaSharp
 
 		public SKPositionedRunBuffer AllocatePositionedRun (SKFont font, int count, SKRect? bounds = null)
 		{
-			AllocatePositionedRun (font, count, bounds, out var buffer);
+			var buffer = AllocateRawPositionedRun (font, count, bounds);
 			return new SKPositionedRunBuffer (buffer.buffer, count);
 		}
 
-		public void AllocatePositionedRun (SKFont font, int count, SKRect? bounds, out SKRunBuffer<SKPoint> buffer)
+		public SKRawRunBuffer<SKPoint> AllocateRawPositionedRun (SKFont font, int count, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -479,16 +481,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_pos (Handle, font.Handle, count, null, &runbuffer);
 
-			buffer = new SKRunBuffer<SKPoint> (runbuffer, count, count, 0);
+			return new SKRawRunBuffer<SKPoint> (runbuffer, count, count, 0);
 		}
 
 		public SKPositionedTextRunBuffer AllocatePositionedTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
 		{
-			AllocatePositionedTextRun (font, count, textByteCount, bounds, out var buffer);
+			var buffer = AllocateRawPositionedTextRun (font, count, textByteCount, bounds);
 			return new SKPositionedTextRunBuffer (buffer.buffer, count, textByteCount);
 		}
 
-		public void AllocatePositionedTextRun (SKFont font, int count, int textByteCount, SKRect? bounds, out SKRunBuffer<SKPoint> buffer)
+		public SKRawRunBuffer<SKPoint> AllocateRawPositionedTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -499,18 +501,18 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text_pos (Handle, font.Handle, count, textByteCount, null, &runbuffer);
 
-			buffer = new SKRunBuffer<SKPoint> (runbuffer, count, count, textByteCount);
+			return new SKRawRunBuffer<SKPoint> (runbuffer, count, count, textByteCount);
 		}
 
 		// AllocateRotationScaleRun
 
 		public SKRotationScaleRunBuffer AllocateRotationScaleRun (SKFont font, int count, SKRect? bounds = null)
 		{
-			AllocateRotationScaleRun (font, count, bounds, out var buffer);
+			var buffer = AllocateRawRotationScaleRun (font, count, bounds);
 			return new SKRotationScaleRunBuffer (buffer.buffer, count);
 		}
 
-		public void AllocateRotationScaleRun (SKFont font, int count, SKRect? bounds, out SKRunBuffer<SKRotationScaleMatrix> buffer)
+		public SKRawRunBuffer<SKRotationScaleMatrix> AllocateRawRotationScaleRun (SKFont font, int count, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -521,16 +523,16 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_rsxform (Handle, font.Handle, count, null, &runbuffer);
 
-			buffer = new SKRunBuffer<SKRotationScaleMatrix> (runbuffer, count, count, 0);
+			return new SKRawRunBuffer<SKRotationScaleMatrix> (runbuffer, count, count, 0);
 		}
 
 		public SKRotationScaleTextRunBuffer AllocateRotationScaleTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
 		{
-			AllocateRotationScaleTextRun (font, count, textByteCount, bounds, out var buffer);
+			var buffer = AllocateRawRotationScaleTextRun (font, count, textByteCount, bounds);
 			return new SKRotationScaleTextRunBuffer (buffer.buffer, count, textByteCount);
 		}
 
-		public void AllocateRotationScaleTextRun (SKFont font, int count, int textByteCount, SKRect? bounds, out SKRunBuffer<SKRotationScaleMatrix> buffer)
+		public SKRawRunBuffer<SKRotationScaleMatrix> AllocateRawRotationScaleTextRun (SKFont font, int count, int textByteCount, SKRect? bounds = null)
 		{
 			if (font == null)
 				throw new ArgumentNullException (nameof (font));
@@ -541,7 +543,7 @@ namespace SkiaSharp
 			else
 				SkiaApi.sk_textblob_builder_alloc_run_text_rsxform (Handle, font.Handle, count, textByteCount, null, &runbuffer);
 
-			buffer = new SKRunBuffer<SKRotationScaleMatrix> (runbuffer, count, count, textByteCount);
+			return new SKRawRunBuffer<SKRotationScaleMatrix> (runbuffer, count, count, textByteCount);
 		}
 	}
 }

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
@@ -74,7 +74,7 @@ namespace SkiaSharp.HarfBuzz
 
 			// create the text blob
 			using var builder = new SKTextBlobBuilder();
-			builder.AllocatePositionedRun(font, result.Codepoints.Length, null, out var run);
+			var run = builder.AllocateRawPositionedRun(font, result.Codepoints.Length, null);
 
 			// copy the glyphs
 			var g = run.Glyphs;

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
@@ -74,11 +74,11 @@ namespace SkiaSharp.HarfBuzz
 
 			// create the text blob
 			using var builder = new SKTextBlobBuilder();
-			var run = builder.AllocatePositionedRun(font, result.Codepoints.Length);
+			builder.AllocatePositionedRun(font, result.Codepoints.Length, null, out var run);
 
 			// copy the glyphs
-			var g = run.GetGlyphSpan();
-			var p = run.GetPositionSpan();
+			var g = run.Glyphs;
+			var p = run.Positions;
 			for (var i = 0; i < result.Codepoints.Length; i++)
 			{
 				g[i] = (ushort)result.Codepoints[i];

--- a/tests/Tests/SkiaSharp/SKTextBlobTest.cs
+++ b/tests/Tests/SkiaSharp/SKTextBlobTest.cs
@@ -37,7 +37,7 @@ namespace SkiaSharp.Tests
 
 			using var builder = new SKTextBlobBuilder();
 
-			builder.AllocateRun(font, 100, 0, 0, null, out var run);
+			var run = builder.AllocateRawRun(font, 100, 0, 0);
 			Assert.Equal(100, run.Glyphs.Length);
 			Assert.Equal(0, run.Positions.Length);
 			Assert.Equal(0, run.Text.Length);
@@ -68,7 +68,7 @@ namespace SkiaSharp.Tests
 
 			using var builder = new SKTextBlobBuilder();
 
-			builder.AllocateTextRun(font, 100, 0, 0, 50, null, out var run);
+			var run = builder.AllocateRawTextRun(font, 100, 0, 0, 50);
 			Assert.Equal(100, run.Glyphs.Length);
 			Assert.Equal(50, run.Text.Length);
 

--- a/tests/Tests/SkiaSharp/SKTextBlobTest.cs
+++ b/tests/Tests/SkiaSharp/SKTextBlobTest.cs
@@ -17,6 +17,36 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void RunsAllocateNoPositions()
+		{
+			var font = new SKFont();
+
+			using var builder = new SKTextBlobBuilder();
+
+			var run = builder.AllocateRun(font, 100, 0, 0);
+			Assert.Equal(100, run.Glyphs.Length);
+
+			using var blob = builder.Build();
+			Assert.NotNull(blob);
+		}
+
+		[SkippableFact]
+		public void RawRunsAllocateNoPositions()
+		{
+			var font = new SKFont();
+
+			using var builder = new SKTextBlobBuilder();
+
+			builder.AllocateRun(font, 100, 0, 0, null, out var run);
+			Assert.Equal(100, run.Glyphs.Length);
+			Assert.Equal(0, run.Positions.Length);
+			Assert.Equal(0, run.Text.Length);
+
+			using var blob = builder.Build();
+			Assert.NotNull(blob);
+		}
+
+		[SkippableFact]
 		public void TextRunsAllocateTextSpan()
 		{
 			var font = new SKFont();
@@ -24,8 +54,23 @@ namespace SkiaSharp.Tests
 			using var builder = new SKTextBlobBuilder();
 
 			var run = builder.AllocateTextRun(font, 100, 0, 0, 50);
-			Assert.Equal(100, run.GetGlyphSpan().Length);
-			Assert.Equal(50, run.GetTextSpan().Length);
+			Assert.Equal(100, run.Glyphs.Length);
+			Assert.Equal(50, run.Text.Length);
+
+			using var blob = builder.Build();
+			Assert.NotNull(blob);
+		}
+
+		[SkippableFact]
+		public void RawTextRunsAllocateTextSpan()
+		{
+			var font = new SKFont();
+
+			using var builder = new SKTextBlobBuilder();
+
+			builder.AllocateTextRun(font, 100, 0, 0, 50, null, out var run);
+			Assert.Equal(100, run.Glyphs.Length);
+			Assert.Equal(50, run.Text.Length);
 
 			using var blob = builder.Build();
 			Assert.NotNull(blob);
@@ -112,7 +157,7 @@ namespace SkiaSharp.Tests
 
 			run.SetPositions(positions);
 
-			var span = run.GetPositionSpan();
+			var span = run.Positions;
 			Assert.Equal(positions, span.ToArray());
 
 			var floats = new float[6];


### PR DESCRIPTION
**Description of Change**

This is sort of inspired by #2664 but also the `SKRunBuffer` API is a bit weird. In 2.x the skia comments say the text part is not meant to be sued, but it is actually required in some cases.

I had cleaned up the API a bit before, but I see I still needed some work. 

Then #2664 was asking for less allocations, so I am thinking instead of spans, we just return the struct directly (almost) and then it is up to the caller to do the right thing. 

- Fixes https://github.com/mono/SkiaSharp/issues/2776