### PR TITLE
[CI] Use the APIScan dedicated pool.

### DIFF
--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -916,8 +916,8 @@ stages:
           - package
         complianceEnabled: true
         complianceTimeoutInMinutes: 480
-        windowsPoolName: ${{ parameters.buildAgentHost.pool.name }}
-        windowsImageOverride: ${{ parameters.buildAgentHost.pool.image }}
+        windowsPoolName: 'MAUI-1ESPT'
+        windowsImageOverride: '1ESPT-Windows2022'
         scanArtifacts:
           - nuget
           - nuget_symbols


### PR DESCRIPTION
APIScan calculates the number of CPUs of the vm and throttles accordingly, using a better image results in a huge improvement.

