### PR TITLE
Bring Metal APIs to a common .NET TFM

### DIFF
--- a/binding/SkiaSharp/GRBackendTexture.cs
+++ b/binding/SkiaSharp/GRBackendTexture.cs
@@ -25,8 +25,6 @@ namespace SkiaSharp
 			CreateVulkan (width, height, vkInfo);
 		}
 
-#if __IOS__ || __MACOS__
-
 		public GRBackendTexture (int width, int height, bool mipmapped, GRMtlTextureInfo mtlInfo)
 			: this (IntPtr.Zero, true)
 		{
@@ -37,8 +35,6 @@ namespace SkiaSharp
 				throw new InvalidOperationException ("Unable to create a new GRBackendTexture instance.");
 			}
 		}
-
-#endif
 
 		private void CreateGl (int width, int height, bool mipmapped, GRGlTextureInfo glInfo)
 		{

--- a/binding/SkiaSharp/GRContext.cs
+++ b/binding/SkiaSharp/GRContext.cs
@@ -63,8 +63,6 @@ namespace SkiaSharp
 			}
 		}
 
-#if __IOS__ || __MACOS__
-
 		// CreateMetal
 
 		public static GRContext CreateMetal (GRMtlBackendContext backendContext) =>
@@ -75,18 +73,16 @@ namespace SkiaSharp
 			if (backendContext == null)
 				throw new ArgumentNullException (nameof (backendContext));
 
-			var device = backendContext.Device;
-			var queue = backendContext.Queue;
+			var device = backendContext.DeviceHandle;
+			var queue = backendContext.QueueHandle;
 
 			if (options == null) {
-				return GetObject (SkiaApi.gr_direct_context_make_metal ((void*)(IntPtr)device.Handle, (void*)(IntPtr)queue.Handle));
+				return GetObject (SkiaApi.gr_direct_context_make_metal ((void*)device, (void*)queue));
 			} else {
 				var opts = options.ToNative ();
-				return GetObject (SkiaApi.gr_direct_context_make_metal_with_options ((void*)(IntPtr)device.Handle, (void*)(IntPtr)queue.Handle, &opts));
+				return GetObject (SkiaApi.gr_direct_context_make_metal_with_options ((void*)device, (void*)queue, &opts));
 			}
 		}
-
-#endif
 
 		//
 

--- a/binding/SkiaSharp/GRDefinitions.cs
+++ b/binding/SkiaSharp/GRDefinitions.cs
@@ -74,24 +74,48 @@ namespace SkiaSharp
 		}
 	}
 
-#if __IOS__ || __MACOS__
-
 	public unsafe partial struct GRMtlTextureInfo
 	{
+		private IntPtr _textureHandle;
+
+		public GRMtlTextureInfo (IntPtr textureHandle)
+		{
+			TextureHandle = textureHandle;
+		}
+
+		public IntPtr TextureHandle {
+			get => _textureHandle;
+			set {
+				_textureHandle = value;
+#if __IOS__ || __MACOS__
+				_texture = null;
+#endif
+			}
+		}
+
+#if __IOS__ || __MACOS__
+		private Metal.IMTLTexture _texture;
 		public GRMtlTextureInfo (Metal.IMTLTexture texture)
 		{
 			Texture = texture;
 		}
 
-		public Metal.IMTLTexture Texture { get; set; }
+		public Metal.IMTLTexture Texture {
+			get => _texture;
+			set {
+				_texture = value;
+				_textureHandle = _texture.Handle;
+			}
+		}
+#endif
 
 		internal GRMtlTextureInfoNative ToNative () =>
 			new GRMtlTextureInfoNative {
-				fTexture = (void*)(IntPtr)Texture.Handle
+				fTexture = (void*)TextureHandle
 			};
 
 		public readonly bool Equals (GRMtlTextureInfo obj) =>
-			Texture == obj.Texture;
+			TextureHandle == obj.TextureHandle;
 
 		public readonly override bool Equals (object obj) =>
 			obj is GRMtlTextureInfo f && Equals (f);
@@ -105,12 +129,10 @@ namespace SkiaSharp
 		public readonly override int GetHashCode ()
 		{
 			var hash = new HashCode ();
-			hash.Add (Texture);
+			hash.Add (TextureHandle);
 			return hash.ToHashCode ();
 		}
 	}
-
-#endif
 
 	public static partial class SkiaExtensions
 	{

--- a/binding/SkiaSharp/GRMtlBackendContext.cs
+++ b/binding/SkiaSharp/GRMtlBackendContext.cs
@@ -1,16 +1,56 @@
 ﻿#nullable disable
 
-#if __IOS__ || __MACOS__
 using System;
+#if __IOS__ || __MACOS__
 using Metal;
+#endif
 
 namespace SkiaSharp
 {
 	public class GRMtlBackendContext : IDisposable
 	{
-		public IMTLDevice Device { get; set; }
+		private IntPtr _deviceHandle, _queueHandle;
 
-		public IMTLCommandQueue Queue { get; set; }
+		public IntPtr DeviceHandle {
+			get => _deviceHandle;
+			set {
+				_deviceHandle = value;
+#if __IOS__ || __MACOS__
+				_device = null;
+#endif
+			}
+		}
+
+		public IntPtr QueueHandle {
+			get => _queueHandle;
+			set {
+				_queueHandle = value;
+#if __IOS__ || __MACOS__
+				_queue = null;
+#endif
+			}
+		}
+
+#if __IOS__ || __MACOS__
+		private IMTLDevice _device;
+		private IMTLCommandQueue _queue;
+
+		public IMTLDevice Device {
+			get => _device;
+			set {
+				_device = value;
+				_deviceHandle = _device.Handle;
+			}
+		}
+
+		public IMTLCommandQueue Queue {
+			get => _queue;
+			set {
+				_queue = value;
+				_queueHandle = _queue.Handle;
+			}
+		}
+#endif
 
 		protected virtual void Dispose (bool disposing)
 		{
@@ -23,4 +63,3 @@ namespace SkiaSharp
 		}
 	}
 }
-#endif


### PR DESCRIPTION
**Description of Change**

Currently all Metal related APIs are hardcoded to .NET iOS and .NET macOS TFM. 
It makes it a bit more difficult to use these APIs, when consuming library either doesn't use these targets or just wants to abstract these calls without an extra TFM.

In Avalonia, for macOS specifically, we don't use "net8.0-macos" target, as all necessary AppKit API we call from our native library. Thus, we don't have typical .NET IMtlDevice and friends, instead we only have pointers. 

This caused a problem on our side, but there is no problem that can't be solved with some reflection:https://github.com/AvaloniaUI/Avalonia/blob/master/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalApi.cs 

From the API perspective, I think changes in this PR do make sense:
1. Bringing all metal APIs like CreateContext to common SkiaSharp TFM, but only exposing pointers.
2. Keep old API for backward compatibility.
3. Integrate old typed members with new IntPtr members, reducing chance of making a mistake (though, it's relatively low).

**API Changes**

Metal APIs backported to common TFM, but with IntPtr members.
Note: SkiaSharp.Views package API wasn't changed, as it would be way more involving.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation

Can be considered a backport candidate, but understandably 2.88 might have API freeze at this point.