### PR TITLE
Fix Snapshot returning magenta color Apple Metal

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -83,6 +83,7 @@ namespace SkiaSharp.Views.Mac
 			ColorPixelFormat = MTLPixelFormat.BGRA8Unorm;
 			DepthStencilPixelFormat = MTLPixelFormat.Depth32Float_Stencil8;
 			SampleCount = 1;
+			FramebufferOnly = false;
 			Device = device;
 			backendContext = new GRMtlBackendContext
 			{

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -85,7 +85,6 @@ namespace SkiaSharp.Views.Mac
 			SampleCount = 1;
 			FramebufferOnly = false;
 			Device = device;
-			FramebufferOnly=false;
 			backendContext = new GRMtlBackendContext
 			{
 				Device = device,


### PR DESCRIPTION
**Bugs Fixed**

Fixed bug when Flush() -> Snapshot() returns magenta color when using Apple Metal backend. Affects any backdrop logic.

Before / after

![image](https://github.com/mono/SkiaSharp/assets/25801194/5ea796c1-f8be-4a06-a577-e739d787e09e)

Credits to react/google folks: https://groups.google.com/g/skia-discuss/c/FTO0NSR_09Q/m/U0jO5E35AgAJ

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
