### PR TITLE
[release/2.x] Add some new overloads for better compat

### DIFF
--- a/binding/Binding/SKImageFilter.cs
+++ b/binding/Binding/SKImageFilter.cs
@@ -74,6 +74,9 @@ namespace SkiaSharp
 
 		// CreateMatrix
 
+		public static SKImageFilter CreateMatrix(SKMatrix matrix) =>
+  			CreateMatrix(matrix, SKFilterQuality.Medium, null);
+
 		public static SKImageFilter CreateMatrix(SKMatrix matrix, SKFilterQuality quality, SKImageFilter input = null)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_matrix(&matrix, quality, input == null ? IntPtr.Zero : input.Handle));

--- a/binding/Binding/SKImageFilter.cs
+++ b/binding/Binding/SKImageFilter.cs
@@ -89,7 +89,10 @@ namespace SkiaSharp
 
 		}
 
-		public static SKImageFilter CreateAlphaThreshold(SKRegion region, float innerThreshold, float outerThreshold, SKImageFilter input = null)
+		public static SKImageFilter CreateAlphaThreshold(SKRegion region, float innerThreshold, float outerThreshold) =>
+			CreateAlphaThreshold(region, innerThreshold, outerThreshold, null);
+
+		public static SKImageFilter CreateAlphaThreshold(SKRegion region, float innerThreshold, float outerThreshold, SKImageFilter input)
 		{
 			if (region == null)
 				throw new ArgumentNullException (nameof (region));
@@ -98,15 +101,42 @@ namespace SkiaSharp
 
 		// CreateBlur
 
-		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY) =>
+			CreateBlur (sigmaX, sigmaY, SKShaderTileMode.Decal, null, null);
+
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKImageFilter input) =>
+			CreateBlur (sigmaX, sigmaY, SKShaderTileMode.Decal, input, null);
+
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKImageFilter input, SKRect cropRect) =>
+			CreateBlur (sigmaX, sigmaY, SKShaderTileMode.Decal, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
 			CreateBlur (sigmaX, sigmaY, SKShaderTileMode.Decal, input, cropRect);
 
-		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKShaderTileMode tileMode, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKShaderTileMode tileMode) =>
+			CreateBlur (sigmaX, sigmaY, tileMode, null, null);
+
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKShaderTileMode tileMode, SKImageFilter input) =>
+			CreateBlur (sigmaX, sigmaY, tileMode, input, null);
+
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKShaderTileMode tileMode, SKImageFilter input, SKRect cropRect) =>
+			CreateBlur (sigmaX, sigmaY, tileMode, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY, SKShaderTileMode tileMode, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
 			GetObject (SkiaApi.sk_imagefilter_new_blur (sigmaX, sigmaY, tileMode, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 
 		// CreateColorFilter
 
-		public static SKImageFilter CreateColorFilter(SKColorFilter cf, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateColorFilter(SKColorFilter cf) =>
+			CreateColorFilter(cf, null, null);
+
+		public static SKImageFilter CreateColorFilter(SKColorFilter cf, SKImageFilter input) =>
+			CreateColorFilter(cf, input, null);
+
+		public static SKImageFilter CreateColorFilter(SKColorFilter cf, SKImageFilter input, SKRect cropRect) =>
+			CreateColorFilter(cf, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateColorFilter(SKColorFilter cf, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			if (cf == null)
 				throw new ArgumentNullException(nameof(cf));
@@ -131,7 +161,16 @@ namespace SkiaSharp
 		public static SKImageFilter CreateDisplacementMapEffect (SKDisplacementMapEffectChannelSelectorType xChannelSelector, SKDisplacementMapEffectChannelSelectorType yChannelSelector, float scale, SKImageFilter displacement, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
 			CreateDisplacementMapEffect (xChannelSelector.ToColorChannel (), yChannelSelector.ToColorChannel (), scale, displacement, input, cropRect);
 
-		public static SKImageFilter CreateDisplacementMapEffect (SKColorChannel xChannelSelector, SKColorChannel yChannelSelector, float scale, SKImageFilter displacement, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateDisplacementMapEffect (SKColorChannel xChannelSelector, SKColorChannel yChannelSelector, float scale, SKImageFilter displacement) =>
+			CreateDisplacementMapEffect (xChannelSelector, yChannelSelector, scale, displacement, null, null);
+
+		public static SKImageFilter CreateDisplacementMapEffect (SKColorChannel xChannelSelector, SKColorChannel yChannelSelector, float scale, SKImageFilter displacement, SKImageFilter input) =>
+			CreateDisplacementMapEffect (xChannelSelector, yChannelSelector, scale, displacement, input, null);
+
+		public static SKImageFilter CreateDisplacementMapEffect (SKColorChannel xChannelSelector, SKColorChannel yChannelSelector, float scale, SKImageFilter displacement, SKImageFilter input, SKRect cropRect) =>
+			CreateDisplacementMapEffect (xChannelSelector, yChannelSelector, scale, displacement, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateDisplacementMapEffect (SKColorChannel xChannelSelector, SKColorChannel yChannelSelector, float scale, SKImageFilter displacement, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			if (displacement == null)
 				throw new ArgumentNullException (nameof (displacement));
@@ -147,49 +186,140 @@ namespace SkiaSharp
 				? CreateDropShadowOnly (dx, dy, sigmaX, sigmaY, color, input, cropRect)
 				: CreateDropShadow (dx, dy, sigmaX, sigmaY, color, input, cropRect);
 
-		public static SKImageFilter CreateDropShadow (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
+		public static SKImageFilter CreateDropShadow (float dx, float dy, float sigmaX, float sigmaY, SKColor color) =>
+			CreateDropShadow (dx, dy, sigmaX, sigmaY, color, null, null);
+
+		public static SKImageFilter CreateDropShadow (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input) =>
+			CreateDropShadow (dx, dy, sigmaX, sigmaY, color, input, null);
+
+		public static SKImageFilter CreateDropShadow (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input, SKRect cropRect) =>
+			CreateDropShadow (dx, dy, sigmaX, sigmaY, color, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateDropShadow (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
 			GetObject (SkiaApi.sk_imagefilter_new_drop_shadow (dx, dy, sigmaX, sigmaY, (uint)color, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 
-		public static SKImageFilter CreateDropShadowOnly (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
+		// CreateDropShadowOnly
+
+		public static SKImageFilter CreateDropShadowOnly (float dx, float dy, float sigmaX, float sigmaY, SKColor color) =>
+			CreateDropShadowOnly (dx, dy, sigmaX, sigmaY, color, null, null);
+
+		public static SKImageFilter CreateDropShadowOnly (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input) =>
+			CreateDropShadowOnly (dx, dy, sigmaX, sigmaY, color, input, null);
+
+		public static SKImageFilter CreateDropShadowOnly (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input, SKRect cropRect) =>
+			CreateDropShadowOnly (dx, dy, sigmaX, sigmaY, color, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateDropShadowOnly (float dx, float dy, float sigmaX, float sigmaY, SKColor color, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
 			GetObject (SkiaApi.sk_imagefilter_new_drop_shadow_only (dx, dy, sigmaX, sigmaY, (uint)color, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 
-		// Create*LitDiffuse
+		// CreateDistantLitDiffuse
 
-		public static SKImageFilter CreateDistantLitDiffuse(SKPoint3 direction, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateDistantLitDiffuse (SKPoint3 direction, SKColor lightColor, float surfaceScale, float kd) =>
+			CreateDistantLitDiffuse (direction, lightColor, surfaceScale, kd, null, null);
+
+		public static SKImageFilter CreateDistantLitDiffuse (SKPoint3 direction, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input) =>
+			CreateDistantLitDiffuse (direction, lightColor, surfaceScale, kd, input, null);
+
+		public static SKImageFilter CreateDistantLitDiffuse (SKPoint3 direction, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input, SKRect cropRect) =>
+			CreateDistantLitDiffuse (direction, lightColor, surfaceScale, kd, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateDistantLitDiffuse(SKPoint3 direction, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_distant_lit_diffuse(&direction, (uint)lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
-		public static SKImageFilter CreatePointLitDiffuse(SKPoint3 location, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		// CreatePointLitDiffuse
+
+		public static SKImageFilter CreatePointLitDiffuse (SKPoint3 location, SKColor lightColor, float surfaceScale, float kd) =>
+			CreatePointLitDiffuse (location, lightColor, surfaceScale, kd, null, null);
+
+		public static SKImageFilter CreatePointLitDiffuse (SKPoint3 location, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input) =>
+			CreatePointLitDiffuse (location, lightColor, surfaceScale, kd, input, null);
+
+		public static SKImageFilter CreatePointLitDiffuse (SKPoint3 location, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input, SKRect cropRect) =>
+			CreatePointLitDiffuse (location, lightColor, surfaceScale, kd, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreatePointLitDiffuse(SKPoint3 location, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_point_lit_diffuse(&location, (uint)lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
-		public static SKImageFilter CreateSpotLitDiffuse(SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		// CreateSpotLitDiffuse
+
+		public static SKImageFilter CreateSpotLitDiffuse (SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float kd) =>
+			CreateSpotLitDiffuse (location, target, specularExponent, cutoffAngle, lightColor, surfaceScale, kd, null, null);
+
+		public static SKImageFilter CreateSpotLitDiffuse (SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input) =>
+			CreateSpotLitDiffuse (location, target, specularExponent, cutoffAngle, lightColor, surfaceScale, kd, input, null);
+
+		public static SKImageFilter CreateSpotLitDiffuse (SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input, SKRect cropRect) =>
+			CreateSpotLitDiffuse (location, target, specularExponent, cutoffAngle, lightColor, surfaceScale, kd, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateSpotLitDiffuse(SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float kd, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_spot_lit_diffuse(&location, &target, specularExponent, cutoffAngle, (uint)lightColor, surfaceScale, kd, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
-		// Create*LitSpecular
+		// CreateDistantLitSpecular
 
-		public static SKImageFilter CreateDistantLitSpecular(SKPoint3 direction, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateDistantLitSpecular (SKPoint3 direction, SKColor lightColor, float surfaceScale, float ks, float shininess) =>
+			CreateDistantLitSpecular (direction, lightColor, surfaceScale, ks, shininess, null, null);
+
+		public static SKImageFilter CreateDistantLitSpecular (SKPoint3 direction, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input) =>
+			CreateDistantLitSpecular (direction, lightColor, surfaceScale, ks, shininess, input, null);
+
+		public static SKImageFilter CreateDistantLitSpecular (SKPoint3 direction, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input, SKRect cropRect) =>
+			CreateDistantLitSpecular (direction, lightColor, surfaceScale, ks, shininess, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateDistantLitSpecular(SKPoint3 direction, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_distant_lit_specular(&direction, (uint)lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
-		public static SKImageFilter CreatePointLitSpecular(SKPoint3 location, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		// CreatePointLitSpecular
+
+		public static SKImageFilter CreatePointLitSpecular (SKPoint3 location, SKColor lightColor, float surfaceScale, float ks, float shininess) =>
+			CreatePointLitSpecular (location, lightColor, surfaceScale, ks, shininess, null, null);
+
+		public static SKImageFilter CreatePointLitSpecular (SKPoint3 location, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input) =>
+			CreatePointLitSpecular (location, lightColor, surfaceScale, ks, shininess, input, null);
+
+		public static SKImageFilter CreatePointLitSpecular (SKPoint3 location, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input, SKRect cropRect) =>
+			CreatePointLitSpecular (location, lightColor, surfaceScale, ks, shininess, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreatePointLitSpecular(SKPoint3 location, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_point_lit_specular(&location, (uint)lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
-		public static SKImageFilter CreateSpotLitSpecular(SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		// CreateSpotLitSpecular
+
+		public static SKImageFilter CreateSpotLitSpecular (SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float ks, float shininess) =>
+			CreateSpotLitSpecular (location, target, specularExponent, cutoffAngle, lightColor, surfaceScale, ks, shininess, null, null);
+
+		public static SKImageFilter CreateSpotLitSpecular (SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input) =>
+			CreateSpotLitSpecular (location, target, specularExponent, cutoffAngle, lightColor, surfaceScale, ks, shininess, input, null);
+
+		public static SKImageFilter CreateSpotLitSpecular (SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input, SKRect cropRect) =>
+			CreateSpotLitSpecular (location, target, specularExponent, cutoffAngle, lightColor, surfaceScale, ks, shininess, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateSpotLitSpecular(SKPoint3 location, SKPoint3 target, float specularExponent, float cutoffAngle, SKColor lightColor, float surfaceScale, float ks, float shininess, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_spot_lit_specular(&location, &target, specularExponent, cutoffAngle, (uint)lightColor, surfaceScale, ks, shininess, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		// CreateMagnifier
 
-		public static SKImageFilter CreateMagnifier(SKRect src, float inset, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateMagnifier (SKRect src, float inset) =>
+			CreateMagnifier (src, inset, null, null);
+
+		public static SKImageFilter CreateMagnifier (SKRect src, float inset, SKImageFilter input) =>
+			CreateMagnifier (src, inset, input, null);
+
+		public static SKImageFilter CreateMagnifier (SKRect src, float inset, SKImageFilter input, SKRect cropRect) =>
+			CreateMagnifier (src, inset, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateMagnifier(SKRect src, float inset, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_magnifier(&src, inset, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
@@ -197,11 +327,23 @@ namespace SkiaSharp
 		// CreateMatrixConvolution
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use CreateMatrixConvolution(SKSizeI, float[], float, float, SKPointI, SKShaderTileMode, bool, SKImageFilter, SKImageFilter.CropRect) instead.")]
+		[Obsolete ("Use CreateMatrixConvolution(SKSizeI, ReadOnlySpan<float>, float, float, SKPointI, SKShaderTileMode, bool, SKImageFilter, SKImageFilter.CropRect) instead.")]
 		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, float[] kernel, float gain, float bias, SKPointI kernelOffset, SKMatrixConvolutionTileMode tileMode, bool convolveAlpha, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
 			CreateMatrixConvolution (kernelSize, kernel, gain, bias, kernelOffset, tileMode.ToShaderTileMode (), convolveAlpha, input, cropRect);
 
-		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, float[] kernel, float gain, float bias, SKPointI kernelOffset, SKShaderTileMode tileMode, bool convolveAlpha, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, ReadOnlySpan<float> kernel, float gain, float bias, SKPointI kernelOffset, SKShaderTileMode tileMode, bool convolveAlpha) =>
+			CreateMatrixConvolution (kernelSize, kernel, gain, bias, kernelOffset, tileMode, convolveAlpha, null, null);
+
+		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, ReadOnlySpan<float> kernel, float gain, float bias, SKPointI kernelOffset, SKShaderTileMode tileMode, bool convolveAlpha, SKImageFilter input) =>
+			CreateMatrixConvolution (kernelSize, kernel, gain, bias, kernelOffset, tileMode, convolveAlpha, input, null);
+
+		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, ReadOnlySpan<float> kernel, float gain, float bias, SKPointI kernelOffset, SKShaderTileMode tileMode, bool convolveAlpha, SKImageFilter input, SKRect cropRect) =>
+			CreateMatrixConvolution (kernelSize, kernel, gain, bias, kernelOffset, tileMode, convolveAlpha, input, new CropRect (cropRect));
+
+		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, float[] kernel, float gain, float bias, SKPointI kernelOffset, SKShaderTileMode tileMode, bool convolveAlpha, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
+			CreateMatrixConvolution (kernelSize, new ReadOnlySpan<float>(kernel), gain, bias, kernelOffset, tileMode, convolveAlpha, input, cropRect);
+
+		public static SKImageFilter CreateMatrixConvolution (SKSizeI kernelSize, ReadOnlySpan<float> kernel, float gain, float bias, SKPointI kernelOffset, SKShaderTileMode tileMode, bool convolveAlpha, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			if (kernel == null)
 				throw new ArgumentNullException (nameof (kernel));
@@ -221,19 +363,37 @@ namespace SkiaSharp
 			return CreateMerge(new [] { first, second }, cropRect);
 		}
 
-		public static SKImageFilter CreateMerge(SKImageFilter first, SKImageFilter second, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateMerge (SKImageFilter first, SKImageFilter second) =>
+			CreateMerge (first, second, null);
+
+		public static SKImageFilter CreateMerge (SKImageFilter first, SKImageFilter second, SKRect cropRect) =>
+			CreateMerge (first, second, new CropRect(cropRect));
+
+		public static SKImageFilter CreateMerge(SKImageFilter first, SKImageFilter second, SKImageFilter.CropRect cropRect)
 		{
-			return CreateMerge(new [] { first, second }, cropRect);
+			using var array = Utils.RentArray<SKImageFilter> (2);
+			array[0] = first;
+			array[1] = second;
+			return CreateMerge(array, cropRect);
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete("Use CreateMerge(SKImageFilter[], SKImageFilter.CropRect) instead.")]
+		[Obsolete("Use CreateMerge(ReadOnlySpan<SKImageFilter>, SKImageFilter.CropRect) instead.")]
 		public static SKImageFilter CreateMerge(SKImageFilter[] filters, SKBlendMode[] modes, SKImageFilter.CropRect cropRect = null)
 		{
 			return CreateMerge (filters, cropRect);
 		}
 
-		public static SKImageFilter CreateMerge(SKImageFilter[] filters, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateMerge (ReadOnlySpan<SKImageFilter> filters) =>
+			CreateMerge (filters, null);
+
+		public static SKImageFilter CreateMerge (ReadOnlySpan<SKImageFilter> filters, SKRect cropRect) =>
+			CreateMerge (filters, new CropRect(cropRect));
+
+		public static SKImageFilter CreateMerge(SKImageFilter[] filters, SKImageFilter.CropRect cropRect) =>
+			CreateMerge (new ReadOnlySpan<SKImageFilter>(filters), cropRect);
+
+		public static SKImageFilter CreateMerge(ReadOnlySpan<SKImageFilter> filters, SKImageFilter.CropRect cropRect)
 		{
 			if (filters == null)
 				throw new ArgumentNullException(nameof(filters));
@@ -249,27 +409,54 @@ namespace SkiaSharp
 
 		// CreateDilate
 
-		public static SKImageFilter CreateDilate(int radiusX, int radiusY, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
+		public static SKImageFilter CreateDilate(int radiusX, int radiusY, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
 			CreateDilate ((float)radiusX, (float)radiusY, input, cropRect);
 
-		public static SKImageFilter CreateDilate(float radiusX, float radiusY, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateDilate (float radiusX, float radiusY) =>
+			CreateDilate (radiusX, radiusY, null, null);
+
+		public static SKImageFilter CreateDilate (float radiusX, float radiusY, SKImageFilter input) =>
+			CreateDilate (radiusX, radiusY, input, null);
+
+		public static SKImageFilter CreateDilate (float radiusX, float radiusY, SKImageFilter input, SKRect cropRect) =>
+			CreateDilate (radiusX, radiusY, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateDilate(float radiusX, float radiusY, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_dilate(radiusX, radiusY, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		// CreateErode
 
-		public static SKImageFilter CreateErode(int radiusX, int radiusY, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null) =>
+		public static SKImageFilter CreateErode(int radiusX, int radiusY, SKImageFilter input, SKImageFilter.CropRect cropRect) =>
 			CreateErode ((float)radiusX, (float)radiusY, input, cropRect);
 
-		public static SKImageFilter CreateErode(float radiusX, float radiusY, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateErode (float radiusX, float radiusY) =>
+			CreateErode (radiusX, radiusY, null, null);
+
+		public static SKImageFilter CreateErode (float radiusX, float radiusY, SKImageFilter input) =>
+			CreateErode (radiusX, radiusY, input, null);
+
+		public static SKImageFilter CreateErode (float radiusX, float radiusY, SKImageFilter input, SKRect cropRect) =>
+			CreateErode (radiusX, radiusY, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateErode(float radiusX, float radiusY, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_erode(radiusX, radiusY, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		// CreateOffset
 
-		public static SKImageFilter CreateOffset(float dx, float dy, SKImageFilter input = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateOffset (float radiusX, float radiusY) =>
+			CreateOffset (radiusX, radiusY, null, null);
+
+		public static SKImageFilter CreateOffset (float radiusX, float radiusY, SKImageFilter input) =>
+			CreateOffset (radiusX, radiusY, input, null);
+
+		public static SKImageFilter CreateOffset (float radiusX, float radiusY, SKImageFilter input, SKRect cropRect) =>
+			CreateOffset (radiusX, radiusY, input, new CropRect(cropRect));
+
+		public static SKImageFilter CreateOffset(float dx, float dy, SKImageFilter input, SKImageFilter.CropRect cropRect)
 		{
 			return GetObject(SkiaApi.sk_imagefilter_new_offset(dx, dy, input == null ? IntPtr.Zero : input.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
@@ -292,29 +479,41 @@ namespace SkiaSharp
 
 		// CreateTile
 
+		public static SKImageFilter CreateTile (SKRect src, SKRect dst) =>
+			CreateTile (src, dst, null);
+
 		public static SKImageFilter CreateTile(SKRect src, SKRect dst, SKImageFilter input)
 		{
-			if (input == null)
-				throw new ArgumentNullException(nameof(input));
-			return GetObject(SkiaApi.sk_imagefilter_new_tile(&src, &dst, input.Handle));
+			return GetObject(SkiaApi.sk_imagefilter_new_tile(&src, &dst, input?.Handle ?? IntPtr.Zero));
 		}
 
 		// CreateBlendMode
 
-		public static SKImageFilter CreateBlendMode(SKBlendMode mode, SKImageFilter background, SKImageFilter foreground = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateBlendMode (SKBlendMode mode, SKImageFilter background) =>
+			CreateBlendMode (mode, background, null, null);
+
+		public static SKImageFilter CreateBlendMode (SKBlendMode mode, SKImageFilter background, SKImageFilter foreground) =>
+			CreateBlendMode (mode, background, foreground, null);
+
+		public static SKImageFilter CreateBlendMode (SKBlendMode mode, SKImageFilter background, SKImageFilter foreground, SKRect cropRect) =>
+			CreateBlendMode (mode, background, foreground, new CropRect(cropRect));
+
+		public static SKImageFilter CreateBlendMode(SKBlendMode mode, SKImageFilter background, SKImageFilter foreground, SKImageFilter.CropRect cropRect)
 		{
-			if (background == null)
-				throw new ArgumentNullException(nameof(background));
-			return GetObject(SkiaApi.sk_imagefilter_new_xfermode(mode, background.Handle, foreground == null ? IntPtr.Zero : foreground.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject(SkiaApi.sk_imagefilter_new_xfermode(mode, background?.Handle ?? IntPtr.Zero, foreground?.Handle ?? IntPtr.Zero, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		// CreateArithmetic
 
-		public static SKImageFilter CreateArithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor, SKImageFilter background, SKImageFilter foreground = null, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreateArithmetic (float k1, float k2, float k3, float k4, bool enforcePMColor, SKImageFilter background, SKImageFilter foreground) =>
+			CreateArithmetic (k1, k2, k3, k4, enforcePMColor, background, foreground, null);
+
+		public static SKImageFilter CreateArithmetic (float k1, float k2, float k3, float k4, bool enforcePMColor, SKImageFilter background, SKImageFilter foreground, SKRect cropRect) =>
+			CreateArithmetic (k1, k2, k3, k4, enforcePMColor, background, foreground, new CropRect(cropRect));
+
+		public static SKImageFilter CreateArithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor, SKImageFilter background, SKImageFilter foreground, SKImageFilter.CropRect cropRect)
 		{
-			if (background == null)
-				throw new ArgumentNullException(nameof(background));
-			return GetObject(SkiaApi.sk_imagefilter_new_arithmetic(k1, k2, k3, k4, enforcePMColor, background.Handle, foreground == null ? IntPtr.Zero : foreground.Handle, cropRect == null ? IntPtr.Zero : cropRect.Handle));
+			return GetObject(SkiaApi.sk_imagefilter_new_arithmetic(k1, k2, k3, k4, enforcePMColor, background?.Handle ?? IntPtr.Zero, foreground?.Handle ?? IntPtr.Zero, cropRect == null ? IntPtr.Zero : cropRect.Handle));
 		}
 
 		// CreateImage
@@ -335,7 +534,13 @@ namespace SkiaSharp
 
 		// CreatePaint
 
-		public static SKImageFilter CreatePaint(SKPaint paint, SKImageFilter.CropRect cropRect = null)
+		public static SKImageFilter CreatePaint (SKPaint paint) =>
+			CreatePaint (paint, null);
+
+		public static SKImageFilter CreatePaint (SKPaint paint, SKRect cropRect) =>
+			CreatePaint (paint, new CropRect (cropRect));
+
+		public static SKImageFilter CreatePaint (SKPaint paint, SKImageFilter.CropRect cropRect)
 		{
 			if (paint == null)
 				throw new ArgumentNullException(nameof(paint));
@@ -345,9 +550,28 @@ namespace SkiaSharp
 		internal static SKImageFilter GetObject (IntPtr handle) =>
 			GetOrAddObject (handle, (h, o) => new SKImageFilter (h, o));
 
+		// CreateShader
+
+		public static SKImageFilter CreateShader (SKShader shader) =>
+			CreateShader (shader, false, null);
+
+		public static SKImageFilter CreateShader (SKShader shader, bool dither) =>
+			CreateShader (shader, dither, null);
+
+		public static SKImageFilter CreateShader (SKShader shader, bool dither, SKRect cropRect) =>
+			CreateShader (shader, dither, new CropRect (cropRect));
+
+		public static SKImageFilter CreateShader (SKShader shader, bool dither, SKImageFilter.CropRect cropRect)
+		{
+			var paint = new SKPaint ();
+			paint.Shader = shader;
+			paint.IsDither = dither;
+			return CreatePaint (paint, cropRect);
+		}
+
 		//
 
-		public class CropRect : SKObject
+		public class CropRect : SKObject, ISKSkipObjectRegistration
 		{
 			internal CropRect(IntPtr handle, bool owns)
 				: base(handle, owns)


### PR DESCRIPTION
**Description of Change**

In SkiaSharp 3.x, the overloads no longer take the `SKImageFilter.CropRect` and instead use a plain `SKRect`.

This PR adds a bunch of overloads into the 2.x series that are present in 3.x - notably the `SKImageFilter.CropRect` to `SKRect` as well as some others. `CreateShader` is also new and really `CreatePaint` is a `CreateShader` under the hood in C++.

For the variations of `CreateMatrix` with the different `in` overloads, I will add this back into 3.x using the mechanism in https://github.com/mono/SkiaSharp/pull/2789

Instead of a single overload with all the default parameters, the new overloads avoid defaults so we can not require nullable structs as well as not use the `CropRect` class if the crop rect is not in use.

After this PR lands, libraries that want to be compatible with 3.x will need to:

 - Switch to the `SKRect` overloads
 - Switch to `CreateShader`
 - Switch to `ReadOnlySpan` overloads
 - Recompile to get C# to pick the correct overloads if default parameters are used

**Bugs Fixed**

- Related to https://github.com/mono/SkiaSharp/pull/2756
- Related to #2790 

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
