### PR TITLE
Update skia to m116

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ However, these are easy to install as they are found on the various websites. If
 
 Here are some links to show the differences in our code as compared to Google's code.
 
-What version are we on? [**m115**](https://github.com/google/skia/tree/chrome/m115)  
-Are we up-to-date with Google? [Compare](https://github.com/mono/skia/compare/skiasharp...google:chrome/m115)  
-What have we added? [Compare](https://github.com/google/skia/compare/chrome/m115...mono:skiasharp)  
+What version are we on? [**m116**](https://github.com/google/skia/tree/chrome/m116)  
+Are we up-to-date with Google? [Compare](https://github.com/mono/skia/compare/skiasharp...google:chrome/m116)  
+What have we added? [Compare](https://github.com/google/skia/compare/chrome/m116...mono:skiasharp)  

--- a/binding/SkiaSharp/SKImageFilter.cs
+++ b/binding/SkiaSharp/SKImageFilter.cs
@@ -34,26 +34,6 @@ namespace SkiaSharp
 				return GetObject (SkiaApi.sk_imagefilter_new_matrix_transform (m, &sampling, input?.Handle ?? IntPtr.Zero));
 		}
 
-
-		// CreateAlphaThreshold
-
-		[Obsolete("Use CreateAlphaThreshold(SKRegion, float, float, SKImageFilter) instead.", true)]
-		public static SKImageFilter CreateAlphaThreshold(SKRectI region, float innerThreshold, float outerThreshold, SKImageFilter? input)
-		{
-			var reg = new SKRegion ();
-			reg.SetRect (region);
-			return CreateAlphaThreshold (reg, innerThreshold, outerThreshold, input);
-		}
-
-		public static SKImageFilter CreateAlphaThreshold (SKRegion region, float innerThreshold, float outerThreshold) =>
-			CreateAlphaThreshold (region, innerThreshold, outerThreshold, null);
-
-		public static SKImageFilter CreateAlphaThreshold (SKRegion region, float innerThreshold, float outerThreshold, SKImageFilter? input)
-		{
-			_ = region ?? throw new ArgumentNullException (nameof (region));
-			return GetObject (SkiaApi.sk_imagefilter_new_alpha_threshold (region.Handle, innerThreshold, outerThreshold, input?.Handle ?? IntPtr.Zero));
-		}
-
 		// CreateBlur
 
 		public static SKImageFilter CreateBlur (float sigmaX, float sigmaY) =>

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,7 +1,7 @@
 # dependencies
 mdoc                                            release     5.8.9
 harfbuzz                                        release     8.3.0
-skia                                            release     m115
+skia                                            release     m116
 xunit                                           release     2.4.2
 xunit.runner.console                            release     2.4.2
 OpenTK                                          release     3.1.0
@@ -23,12 +23,12 @@ ANGLE                                           release     chromium/6275
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   115
+libSkiaSharp            milestone   116
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      115.0.0
+libSkiaSharp            soname      116.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.60830.0
 


### PR DESCRIPTION
**Description of Change**

The numbers are so close and the API is almost identical. I do see a missing API so we might as well lose it for now since we are breaking and we then have to break less in the next version.

**API Changes**

Removed: 
 - `SKImageFilter.CreateAlphaThreshold`  
   The image filter `SKImageFilter.CreateAlphaThreshold` is no longer implemented in native skia and has been removed.  
   According to Google:
   > `SkImageFilters::AlphaThreshold` has been removed. Its only use was in ChromeOS and that usage has been replaced with a `Blend(kSrcIn, input, Picture(region))` filter graph to achieve the same effect.  

   There does not seem to be an equivalent replacement, but also I have not seen any usages of it.

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

https://github.com/mono/skia/pull/122

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
