### PR TITLE
GRMtlTextureInfo should have readonly getters

### DIFF
--- a/binding/SkiaSharp/GRDefinitions.cs
+++ b/binding/SkiaSharp/GRDefinitions.cs
@@ -84,7 +84,7 @@ namespace SkiaSharp
 		}
 
 		public IntPtr TextureHandle {
-			get => _textureHandle;
+			readonly get => _textureHandle;
 			set {
 				_textureHandle = value;
 #if __IOS__ || __MACOS__
@@ -101,7 +101,7 @@ namespace SkiaSharp
 		}
 
 		public Metal.IMTLTexture Texture {
-			get => _texture;
+			readonly get => _texture;
 			set {
 				_texture = value;
 				_textureHandle = _texture.Handle;


### PR DESCRIPTION
**Description of Change**

Just a few missing `readonly` modifiers of the property getters.