### PR TITLE
Only process assemblies that exist

### DIFF
--- a/source/SkiaSharp.Build.targets
+++ b/source/SkiaSharp.Build.targets
@@ -151,7 +151,7 @@ internal partial class VersionConstants {
 	<Target Name="_RemoveObsoleteItemsFromReferenceAssembly"
           AfterTargets="CoreCompile"
           Condition="'$(ProduceReferenceAssembly)' == 'true'">
-		<RemoveObsoleteSymbols Assembly="@(IntermediateRefAssembly)" />
+		<RemoveObsoleteSymbols Assembly="@(IntermediateRefAssembly)" Condition="Exists('@(IntermediateRefAssembly)')" />
 	</Target>
 
   <!--


### PR DESCRIPTION
**Description of Change**

The assembly needs to exist in order to be processed. Some design time builds trigger things before the build has run.