### PR TITLE
Add support for more advanced PDF metadata

### DIFF
--- a/binding/SkiaSharp/SKDocument.cs
+++ b/binding/SkiaSharp/SKDocument.cs
@@ -220,7 +220,7 @@ public unsafe class SKDocument : SKObject, ISKReferenceCounted, ISKSkipObjectReg
 		return (metadataHandle, structureHandle);
 	}
 
-	private static IntPtr ToNative (SKPdfStructureElement? structure)
+	private static IntPtr ToNative (SKPdfStructureElementNode? structure)
 	{
 		if (structure is null)
 			return IntPtr.Zero;
@@ -293,5 +293,16 @@ public unsafe class SKDocument : SKObject, ISKReferenceCounted, ISKSkipObjectReg
 		}
 
 		return handle;
+	}
+}
+
+public static class SkPdfDocumentExtensions
+{
+	public static void DrawPdfNodeAnnotation (this SKCanvas canvas, int nodeId)
+	{
+		if (canvas is null)
+			throw new ArgumentNullException (nameof (canvas));
+
+		SkiaApi.sk_canvas_draw_pdf_node_id_annotation (canvas.Handle, nodeId);
 	}
 }

--- a/binding/SkiaSharp/SKDocument.cs
+++ b/binding/SkiaSharp/SKDocument.cs
@@ -1,269 +1,297 @@
 ﻿using System;
-using System.ComponentModel;
-using System.IO;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using System.IO;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
 
-namespace SkiaSharp
+namespace SkiaSharp;
+
+public unsafe class SKDocument : SKObject, ISKReferenceCounted, ISKSkipObjectRegistration
 {
-    public unsafe class SKDocument : SKObject, ISKReferenceCounted, ISKSkipObjectRegistration
+	public const float DefaultRasterDpi = 72.0f;
+
+	internal SKDocument (IntPtr handle, bool owns)
+		: base (handle, owns)
 	{
-		public const float DefaultRasterDpi = 72.0f;
+	}
 
-		internal SKDocument (IntPtr handle, bool owns)
-			: base (handle, owns)
-		{
+	protected override void Dispose (bool disposing) =>
+		base.Dispose (disposing);
+
+	public void Abort () =>
+		SkiaApi.sk_document_abort (Handle);
+
+	public SKCanvas BeginPage (float width, float height) =>
+		OwnedBy (SKCanvas.GetObject (SkiaApi.sk_document_begin_page (Handle, width, height, null), false), this);
+
+	public SKCanvas BeginPage (float width, float height, SKRect content) =>
+		OwnedBy (SKCanvas.GetObject (SkiaApi.sk_document_begin_page (Handle, width, height, &content), false), this);
+
+	public void EndPage () =>
+		SkiaApi.sk_document_end_page (Handle);
+
+	public void Close () =>
+		SkiaApi.sk_document_close (Handle);
+
+	// CreateXps
+
+	public static SKDocument? CreateXps (string path) =>
+		CreateXps (path, DefaultRasterDpi);
+
+	public static SKDocument? CreateXps (Stream stream) =>
+		CreateXps (stream, DefaultRasterDpi);
+
+	public static SKDocument? CreateXps (SKWStream stream) =>
+		CreateXps (stream, DefaultRasterDpi);
+
+	public static SKDocument? CreateXps (string path, float dpi)
+	{
+		if (path == null) {
+			throw new ArgumentNullException (nameof (path));
 		}
 
-		protected override void Dispose (bool disposing) =>
-			base.Dispose (disposing);
+		var stream = SKFileWStream.OpenStream (path);
+		return Owned (CreateXps (stream, dpi), stream);
+	}
 
-		public void Abort () =>
-			SkiaApi.sk_document_abort (Handle);
-
-		public SKCanvas BeginPage (float width, float height) =>
-			OwnedBy (SKCanvas.GetObject (SkiaApi.sk_document_begin_page (Handle, width, height, null), false), this);
-
-		public SKCanvas BeginPage (float width, float height, SKRect content) =>
-			OwnedBy (SKCanvas.GetObject (SkiaApi.sk_document_begin_page (Handle, width, height, &content), false), this);
-
-		public void EndPage () =>
-			SkiaApi.sk_document_end_page (Handle);
-
-		public void Close () =>
-			SkiaApi.sk_document_close (Handle);
-
-		// CreateXps
-
-		public static SKDocument? CreateXps (string path) =>
-			CreateXps (path, DefaultRasterDpi);
-
-		public static SKDocument? CreateXps (Stream stream) =>
-			CreateXps (stream, DefaultRasterDpi);
-
-		public static SKDocument? CreateXps (SKWStream stream) =>
-			CreateXps (stream, DefaultRasterDpi);
-
-		public static SKDocument? CreateXps (string path, float dpi)
-		{
-			if (path == null) {
-				throw new ArgumentNullException (nameof (path));
-			}
-
-			var stream = SKFileWStream.OpenStream (path);
-			return Owned (CreateXps (stream, dpi), stream);
+	public static SKDocument? CreateXps (Stream stream, float dpi)
+	{
+		if (stream == null) {
+			throw new ArgumentNullException (nameof (stream));
 		}
 
-		public static SKDocument? CreateXps (Stream stream, float dpi)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
+		var managed = new SKManagedWStream (stream);
+		return Owned (CreateXps (managed, dpi), managed);
+	}
 
-			var managed = new SKManagedWStream (stream);
-			return Owned (CreateXps (managed, dpi), managed);
+	public static SKDocument? CreateXps (SKWStream stream, float dpi)
+	{
+		if (stream == null) {
+			throw new ArgumentNullException (nameof (stream));
 		}
 
-		public static SKDocument? CreateXps (SKWStream stream, float dpi)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
+		return Referenced (GetObject (SkiaApi.sk_document_create_xps_from_stream (stream.Handle, dpi)), stream);
+	}
 
-			return Referenced (GetObject (SkiaApi.sk_document_create_xps_from_stream (stream.Handle, dpi)), stream);
+	// CreatePdf
+
+	public static SKDocument CreatePdf (string path)
+	{
+		if (path == null) {
+			throw new ArgumentNullException (nameof (path));
 		}
 
-		// CreatePdf
+		var stream = SKFileWStream.OpenStream (path);
+		return Owned (CreatePdf (stream), stream);
+	}
 
-		public static SKDocument CreatePdf (string path)
-		{
-			if (path == null) {
-				throw new ArgumentNullException (nameof (path));
-			}
-
-			var stream = SKFileWStream.OpenStream (path);
-			return Owned (CreatePdf (stream), stream);
+	public static SKDocument CreatePdf (Stream stream)
+	{
+		if (stream == null) {
+			throw new ArgumentNullException (nameof (stream));
 		}
 
-		public static SKDocument CreatePdf (Stream stream)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
+		var managed = new SKManagedWStream (stream);
+		return Owned (CreatePdf (managed), managed);
+	}
 
-			var managed = new SKManagedWStream (stream);
-			return Owned (CreatePdf (managed), managed);
+	public static SKDocument CreatePdf (SKWStream stream)
+	{
+		if (stream == null) {
+			throw new ArgumentNullException (nameof (stream));
 		}
 
-		public static SKDocument CreatePdf (SKWStream stream)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
+		return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream (stream.Handle)), stream);
+	}
 
-			return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream (stream.Handle)), stream);
+	public static SKDocument CreatePdf (string path, float dpi) =>
+		CreatePdf (path, new SKPdfMetadata { RasterDpi = dpi });
+
+	public static SKDocument CreatePdf (Stream stream, float dpi) =>
+		CreatePdf (stream, new SKPdfMetadata { RasterDpi = dpi });
+
+	public static SKDocument CreatePdf (SKWStream stream, float dpi) =>
+		CreatePdf (stream, new SKPdfMetadata { RasterDpi = dpi });
+
+	[Obsolete ("Use CreatePdf(string, SKPdfMetadata) instead.")]
+	public static SKDocument CreatePdf (string path, SKDocumentPdfMetadata metadata) =>
+		CreatePdf (path, new SKPdfMetadata (metadata));
+
+	[Obsolete ("Use CreatePdf(Stream, SKPdfMetadata) instead.")]
+	public static SKDocument CreatePdf (Stream stream, SKDocumentPdfMetadata metadata) =>
+		CreatePdf (stream, new SKPdfMetadata (metadata));
+
+	[Obsolete ("Use CreatePdf(SKWStream, SKPdfMetadata) instead.")]
+	public static SKDocument CreatePdf (SKWStream stream, SKDocumentPdfMetadata metadata) =>
+		CreatePdf (stream, new SKPdfMetadata (metadata));
+
+	public static SKDocument CreatePdf (string path, SKPdfMetadata metadata)
+	{
+		if (path is null) {
+			throw new ArgumentNullException (nameof (path));
 		}
 
-		public static SKDocument CreatePdf (string path, float dpi) =>
-			CreatePdf (path, new SKDocumentPdfMetadata (dpi));
+		var stream = SKFileWStream.OpenStream (path);
+		return Owned (CreatePdf (stream, metadata), stream);
+	}
 
-		public static SKDocument CreatePdf (Stream stream, float dpi) =>
-			CreatePdf (stream, new SKDocumentPdfMetadata (dpi));
-
-		public static SKDocument CreatePdf (SKWStream stream, float dpi) =>
-			CreatePdf (stream, new SKDocumentPdfMetadata (dpi));
-
-		public static SKDocument CreatePdf (string path, SKDocumentPdfMetadata metadata) =>
-			CreatePdf (path, new SKPdfMetadata (metadata));
-
-		public static SKDocument CreatePdf (Stream stream, SKDocumentPdfMetadata metadata) =>
-			CreatePdf (stream, new SKPdfMetadata (metadata));
-
-		public static SKDocument CreatePdf (SKWStream stream, SKDocumentPdfMetadata metadata) =>
-			CreatePdf (stream, new SKPdfMetadata (metadata));
-
-		public static SKDocument CreatePdf (string path, SKPdfMetadata metadata)
-		{
-			if (path == null) {
-				throw new ArgumentNullException (nameof (path));
-			}
-
-			var stream = SKFileWStream.OpenStream (path);
-			return Owned (CreatePdf (stream, metadata), stream);
+	public static SKDocument CreatePdf (Stream stream, SKPdfMetadata metadata)
+	{
+		if (stream == null) {
+			throw new ArgumentNullException (nameof (stream));
 		}
 
-		public static SKDocument CreatePdf (Stream stream, SKPdfMetadata metadata)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
+		var managed = new SKManagedWStream (stream);
+		return Owned (CreatePdf (managed, metadata), managed);
+	}
 
-			var managed = new SKManagedWStream (stream);
-			return Owned (CreatePdf (managed, metadata), managed);
+	public static SKDocument CreatePdf (SKWStream stream, SKPdfMetadata metadata)
+	{
+		if (stream is null) {
+			throw new ArgumentNullException (nameof (stream));
 		}
 
-		public static SKDocument CreatePdf (SKWStream stream, SKPdfMetadata metadata)
-		{
-			if (stream == null) {
-				throw new ArgumentNullException (nameof (stream));
-			}
+		var (metadataHandle, structureHandle) = ToNative (metadata);
 
-			var structureHandle = ToNative (metadata.Structure);
+		try {
+			return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream_with_metadata (stream.Handle, metadataHandle)), stream);
+		} finally {
+			if (metadataHandle != IntPtr.Zero)
+				SkiaApi.sk_pdf_metadata_delete (metadataHandle);
 
-			var metadataHandle = SkiaApi.sk_pdf_metadata_new ();
+			// dispose because the root node is not owned
+			if (structureHandle != IntPtr.Zero)
+				SkiaApi.sk_pdf_structure_element_delete (structureHandle);
+		}
+	}
 
-			try {
-				if (metadata.Title is not null) {
-					using var title = SKString.CreateRaw (metadata.Title);
-					SkiaApi.sk_pdf_metadata_set_title (metadataHandle, title.Handle);
-				}
-				using var author = SKString.CreateRaw (metadata.Author);
-				SkiaApi.sk_pdf_metadata_set_author (metadataHandle, author.Handle);
-				using var subject = SKString.CreateRaw (metadata.Subject);
-				SkiaApi.sk_pdf_metadata_set_subject (metadataHandle, subject.Handle);
-				using var keywords = SKString.CreateRaw (metadata.Keywords);
-				SkiaApi.sk_pdf_metadata_set_keywords (metadataHandle, keywords.Handle);
-				using var creator = SKString.CreateRaw (metadata.Creator);
-				SkiaApi.sk_pdf_metadata_set_creator (metadataHandle, creator.Handle);
-				using var producer = SKString.CreateRaw (metadata.Producer);
-				SkiaApi.sk_pdf_metadata_set_producer (metadataHandle, producer.Handle);
+	internal static SKDocument? GetObject (IntPtr handle) =>
+		handle == IntPtr.Zero ? null : new SKDocument (handle, true);
 
-				if (metadata.Creation is not null) {
-					var creation = SKTimeDateTimeInternal.Create (metadata.Creation.Value);
-					SkiaApi.sk_pdf_metadata_set_creation (metadataHandle, &creation);
-				}
+	private static (IntPtr Metadata, IntPtr Structure) ToNative (SKPdfMetadata metadata)
+	{
+		var metadataHandle = SkiaApi.sk_pdf_metadata_new ();
 
-				if (metadata.Modified is not null) {
-					var modified = SKTimeDateTimeInternal.Create (metadata.Modified.Value);
-					SkiaApi.sk_pdf_metadata_set_modified (metadataHandle, &modified);
-				}
-
-				SkiaApi.sk_pdf_metadata_set_raster_dpi (metadataHandle, metadata.RasterDpi);
-				SkiaApi.sk_pdf_metadata_set_pdfa (metadataHandle, metadata.PdfA);
-				SkiaApi.sk_pdf_metadata_set_encoding_quality (metadataHandle, metadata.EncodingQuality);
-				SkiaApi.sk_pdf_metadata_set_compression_level (metadataHandle, metadata.Compression);
-
-				SkiaApi.sk_pdf_metadata_set_structure_element_tree_root (metadataHandle, structureHandle);
-
-				return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream_with_metadata (stream.Handle, &cmetadata)), stream);
-			} finally {
-				if (metadataHandle != IntPtr.Zero)
-					SkiaApi.sk_pdf_metadata_delete (metadataHandle);
-
-				// dispose because the root node is not owned
-				if (structureHandle != IntPtr.Zero)
-					SkiaApi.sk_pdf_structure_element_delete (structureHandle);
-			}
+		if (metadata.Title is not null) {
+			using var title = SKString.CreateRaw (metadata.Title);
+			SkiaApi.sk_pdf_metadata_set_title (metadataHandle, title.Handle);
+		}
+		if (metadata.Author is not null) {
+			using var author = SKString.CreateRaw (metadata.Author);
+			SkiaApi.sk_pdf_metadata_set_author (metadataHandle, author.Handle);
+		}
+		if (metadata.Subject is not null) {
+			using var subject = SKString.CreateRaw (metadata.Subject);
+			SkiaApi.sk_pdf_metadata_set_subject (metadataHandle, subject.Handle);
+		}
+		if (metadata.Keywords is not null) {
+			using var keywords = SKString.CreateRaw (metadata.Keywords);
+			SkiaApi.sk_pdf_metadata_set_keywords (metadataHandle, keywords.Handle);
+		}
+		if (metadata.Creator is not null) {
+			using var creator = SKString.CreateRaw (metadata.Creator);
+			SkiaApi.sk_pdf_metadata_set_creator (metadataHandle, creator.Handle);
+		}
+		if (metadata.Producer is not null) {
+			using var producer = SKString.CreateRaw (metadata.Producer);
+			SkiaApi.sk_pdf_metadata_set_producer (metadataHandle, producer.Handle);
+		}
+		if (metadata.Creation is not null) {
+			var creation = SKTimeDateTimeInternal.Create (metadata.Creation.Value);
+			SkiaApi.sk_pdf_metadata_set_creation (metadataHandle, &creation);
+		}
+		if (metadata.Modified is not null) {
+			var modified = SKTimeDateTimeInternal.Create (metadata.Modified.Value);
+			SkiaApi.sk_pdf_metadata_set_modified (metadataHandle, &modified);
 		}
 
-		internal static SKDocument GetObject (IntPtr handle) =>
-			handle == IntPtr.Zero ? null : new SKDocument (handle, true);
+		SkiaApi.sk_pdf_metadata_set_raster_dpi (metadataHandle, metadata.RasterDpi);
+		SkiaApi.sk_pdf_metadata_set_pdfa (metadataHandle, metadata.PdfA);
+		SkiaApi.sk_pdf_metadata_set_encoding_quality (metadataHandle, metadata.EncodingQuality);
+		SkiaApi.sk_pdf_metadata_set_compression_level (metadataHandle, metadata.Compression);
 
-		static IntPtr ToNative(SKPdfStructureElement? structure)
-		{
-			if (structure is null)
-				return IntPtr.Zero;
+		IntPtr structureHandle;
+		if (metadata.Structure is not null) {
+			structureHandle = ToNative (metadata.Structure);
+			SkiaApi.sk_pdf_metadata_set_structure_element_tree_root (metadataHandle, structureHandle);
+		} else {
+			structureHandle = IntPtr.Zero;
+		}
 
-			var handle = SkiaApi.sk_pdf_structure_element_new ();
+		return (metadataHandle, structureHandle);
+	}
 
-			SkiaApi.sk_pdf_structure_element_set_node_id (handle, structure.Id);
-			
+	private static IntPtr ToNative (SKPdfStructureElement? structure)
+	{
+		if (structure is null)
+			return IntPtr.Zero;
+
+		var handle = SkiaApi.sk_pdf_structure_element_new ();
+
+		SkiaApi.sk_pdf_structure_element_set_node_id (handle, structure.Id);
+
 #if NET5_0_OR_GREATER
-			if (structure.AdditionalNodeIds is List<int> nodes) {
-				var span = CollectionsMarshal.AsSpan (nodes);
-				SkiaApi.sk_pdf_structure_element_add_additional_node_ids (handle, &span, span.Length);
-			} else
+		if (structure.AdditionalNodeIds is List<int> nodes) {
+			var span = CollectionsMarshal.AsSpan (nodes);
+			fixed (int* ptr = span) {
+				SkiaApi.sk_pdf_structure_element_add_additional_node_ids (handle, ptr, span.Length);
+			}
+		} else
 #endif
-			{
-				using var nodes = Utils.ToRentedArray (structure.AdditionalNodeIds);
-				SkiaApi.sk_pdf_structure_element_add_additional_node_ids (handle, &nodes, nodes.Length);
+		{
+			using var nodesArray = Utils.ToRentedArray (structure.AdditionalNodeIds);
+			fixed (int* ptr = nodesArray) {
+				SkiaApi.sk_pdf_structure_element_add_additional_node_ids (handle, ptr, (IntPtr)nodesArray.Length);
 			}
+		}
 
-			using var type = SKString.CreateRaw (structure.Type);
-			SkiaApi.sk_pdf_structure_element_set_type_string (handle, type.Handle);
+		using var type = SKString.CreateRaw (structure.Type);
+		SkiaApi.sk_pdf_structure_element_set_type_string (handle, type.Handle);
 
-			using var alt = SKString.CreateRaw (structure.Alt);
-			SkiaApi.sk_pdf_structure_element_set_alt (handle, alt.Handle);
+		using var alt = SKString.CreateRaw (structure.Alt);
+		SkiaApi.sk_pdf_structure_element_set_alt (handle, alt.Handle);
 
-			using var lang = SKString.CreateRaw (structure.Language);
-			SkiaApi.sk_pdf_structure_element_set_lang (handle, lang.Handle);
+		using var lang = SKString.CreateRaw (structure.Language);
+		SkiaApi.sk_pdf_structure_element_set_lang (handle, lang.Handle);
 
-			if (structure.Attributes.Inner.Count > 0) {
-				foreach (var attr in structure.Attributes.Inner) {
-					switch (attr.Value) {
-						case int intValue:
-							SkiaApi.sk_pdf_structure_element_add_int_attribute (handle, attr.Owner, attr.Name, intValue);
-							break;
-						case float floatValue:
-							SkiaApi.sk_pdf_structure_element_add_float_attribute (handle, attr.Owner, attr.Name, floatValue);
-							break;
-						case string stringValue:
-							SkiaApi.sk_pdf_structure_element_add_int_attribute (handle, attr.Owner, attr.Name, stringValue);
-							break;
-						case int[] intArray:
-							SkiaApi.sk_pdf_structure_element_add_node_id_array_attribute (handle, attr.Owner, attr.Name, &intArray, intArray.Length);
-							break;
-						case float[] floatArray:
-							SkiaApi.sk_pdf_structure_element_add_float_array_attribute (handle, attr.Owner, attr.Name, &floatArray, floatArray.Length);
-							break;
-						default:
-							// TODO
-							break;
-					}
-				}
-			}
-
-			if (structure.Children.Count > 0) {
-				foreach (var child in structure.Children) {
-					// do not dispose as the parent takes ownership
-					var childHandle = ToNative (child);
-					if (childHandle == IntPtr.Zero)
-						continue;
-					SkiaApi.sk_pdf_structure_element_add_child (handle, childHandle);
+		if (structure.Attributes.Inner.Count > 0) {
+			foreach (var (owner, name, val) in structure.Attributes.Inner) {
+				switch (val) {
+					case int intValue:
+						SkiaApi.sk_pdf_structure_element_add_int_attribute (handle, owner, name, intValue);
+						break;
+					case float floatValue:
+						SkiaApi.sk_pdf_structure_element_add_float_attribute (handle, owner, name, floatValue);
+						break;
+					case string stringValue:
+						SkiaApi.sk_pdf_structure_element_add_name_attribute (handle, owner, name, stringValue);
+						break;
+					case int[] intArray:
+						fixed (int* ptr = intArray) {
+							SkiaApi.sk_pdf_structure_element_add_node_id_array_attribute (handle, owner, name, ptr, (IntPtr)intArray.Length);
+						}
+						break;
+					case float[] floatArray:
+						fixed (float* ptr = floatArray) {
+							SkiaApi.sk_pdf_structure_element_add_float_array_attribute (handle, owner, name, ptr, (IntPtr)floatArray.Length);
+						}
+						break;
+					default:
+						// TODO
+						break;
 				}
 			}
 		}
+
+		if (structure.Children.Count > 0) {
+			foreach (var child in structure.Children) {
+				// do not dispose as the parent takes ownership
+				var childHandle = ToNative (child);
+				if (childHandle == IntPtr.Zero)
+					continue;
+				SkiaApi.sk_pdf_structure_element_add_child (handle, childHandle);
+			}
+		}
+
+		return handle;
 	}
 }

--- a/binding/SkiaSharp/SKDocument.cs
+++ b/binding/SkiaSharp/SKDocument.cs
@@ -1,12 +1,10 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.IO;
 
 namespace SkiaSharp
 {
-	public unsafe class SKDocument : SKObject, ISKReferenceCounted, ISKSkipObjectRegistration
+    public unsafe class SKDocument : SKObject, ISKReferenceCounted, ISKSkipObjectRegistration
 	{
 		public const float DefaultRasterDpi = 72.0f;
 
@@ -35,16 +33,16 @@ namespace SkiaSharp
 
 		// CreateXps
 
-		public static SKDocument CreateXps (string path) =>
+		public static SKDocument? CreateXps (string path) =>
 			CreateXps (path, DefaultRasterDpi);
 
-		public static SKDocument CreateXps (Stream stream) =>
+		public static SKDocument? CreateXps (Stream stream) =>
 			CreateXps (stream, DefaultRasterDpi);
 
-		public static SKDocument CreateXps (SKWStream stream) =>
+		public static SKDocument? CreateXps (SKWStream stream) =>
 			CreateXps (stream, DefaultRasterDpi);
 
-		public static SKDocument CreateXps (string path, float dpi)
+		public static SKDocument? CreateXps (string path, float dpi)
 		{
 			if (path == null) {
 				throw new ArgumentNullException (nameof (path));
@@ -54,7 +52,7 @@ namespace SkiaSharp
 			return Owned (CreateXps (stream, dpi), stream);
 		}
 
-		public static SKDocument CreateXps (Stream stream, float dpi)
+		public static SKDocument? CreateXps (Stream stream, float dpi)
 		{
 			if (stream == null) {
 				throw new ArgumentNullException (nameof (stream));
@@ -64,7 +62,7 @@ namespace SkiaSharp
 			return Owned (CreateXps (managed, dpi), managed);
 		}
 
-		public static SKDocument CreateXps (SKWStream stream, float dpi)
+		public static SKDocument? CreateXps (SKWStream stream, float dpi)
 		{
 			if (stream == null) {
 				throw new ArgumentNullException (nameof (stream));

--- a/binding/SkiaSharp/SKDocument.cs
+++ b/binding/SkiaSharp/SKDocument.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.IO;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
@@ -149,59 +150,120 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (stream));
 			}
 
-			using var title = SKString.Create (metadata.Title);
-			using var author = SKString.Create (metadata.Author);
-			using var subject = SKString.Create (metadata.Subject);
-			using var keywords = SKString.Create (metadata.Keywords);
-			using var creator = SKString.Create (metadata.Creator);
-			using var producer = SKString.Create (metadata.Producer);
-
-			SKTimeDateTimeInternal creation;
-			if (metadata.Creation is not null)
-				creation = SKTimeDateTimeInternal.Create (metadata.Creation.Value);
-
-			SKTimeDateTimeInternal modified;
-			if (metadata.Modified is not null)
-				modified = SKTimeDateTimeInternal.Create (metadata.Modified.Value);
+			var structureHandle = ToNative (metadata.Structure);
 
 			var metadataHandle = SkiaApi.sk_pdf_metadata_new ();
 
 			try {
-				SkiaApi.sk_pdf_metadata_set_title(metadataHandle, title?.Handle ?? IntPtr.Zero);
-				SkiaApi.sk_pdf_metadata_set_author(metadataHandle, author?.Handle ?? IntPtr.Zero);
-				SkiaApi.sk_pdf_metadata_set_subject(metadataHandle, subject?.Handle ?? IntPtr.Zero);
-				SkiaApi.sk_pdf_metadata_set_keywords(metadataHandle, keywords?.Handle ?? IntPtr.Zero);
-				SkiaApi.sk_pdf_metadata_set_creator(metadataHandle, creator?.Handle ?? IntPtr.Zero);
-				SkiaApi.sk_pdf_metadata_set_producer(metadataHandle, producer?.Handle ?? IntPtr.Zero);
-				
-				SkiaApi.sk_pdf_metadata_set_creation(metadataHandle, &creation);
-				SkiaApi.sk_pdf_metadata_set_modified(metadataHandle, &modified);
+				if (metadata.Title is not null) {
+					using var title = SKString.CreateRaw (metadata.Title);
+					SkiaApi.sk_pdf_metadata_set_title (metadataHandle, title.Handle);
+				}
+				using var author = SKString.CreateRaw (metadata.Author);
+				SkiaApi.sk_pdf_metadata_set_author (metadataHandle, author.Handle);
+				using var subject = SKString.CreateRaw (metadata.Subject);
+				SkiaApi.sk_pdf_metadata_set_subject (metadataHandle, subject.Handle);
+				using var keywords = SKString.CreateRaw (metadata.Keywords);
+				SkiaApi.sk_pdf_metadata_set_keywords (metadataHandle, keywords.Handle);
+				using var creator = SKString.CreateRaw (metadata.Creator);
+				SkiaApi.sk_pdf_metadata_set_creator (metadataHandle, creator.Handle);
+				using var producer = SKString.CreateRaw (metadata.Producer);
+				SkiaApi.sk_pdf_metadata_set_producer (metadataHandle, producer.Handle);
 
-				SkiaApi.sk_pdf_metadata_set_raster_dpi(metadataHandle, metadata.RasterDpi);
-				SkiaApi.sk_pdf_metadata_set_pdfa(metadataHandle, metadata.PdfA);
-				SkiaApi.sk_pdf_metadata_set_encoding_quality(metadataHandle, metadata.EncodingQuality);
-				SkiaApi.sk_pdf_metadata_set_compression_level(metadataHandle, metadata.Compression);
+				if (metadata.Creation is not null) {
+					var creation = SKTimeDateTimeInternal.Create (metadata.Creation.Value);
+					SkiaApi.sk_pdf_metadata_set_creation (metadataHandle, &creation);
+				}
+
+				if (metadata.Modified is not null) {
+					var modified = SKTimeDateTimeInternal.Create (metadata.Modified.Value);
+					SkiaApi.sk_pdf_metadata_set_modified (metadataHandle, &modified);
+				}
+
+				SkiaApi.sk_pdf_metadata_set_raster_dpi (metadataHandle, metadata.RasterDpi);
+				SkiaApi.sk_pdf_metadata_set_pdfa (metadataHandle, metadata.PdfA);
+				SkiaApi.sk_pdf_metadata_set_encoding_quality (metadataHandle, metadata.EncodingQuality);
+				SkiaApi.sk_pdf_metadata_set_compression_level (metadataHandle, metadata.Compression);
+
+				SkiaApi.sk_pdf_metadata_set_structure_element_tree_root (metadataHandle, structureHandle);
 
 				return Referenced (GetObject (SkiaApi.sk_document_create_pdf_from_stream_with_metadata (stream.Handle, &cmetadata)), stream);
 			} finally {
 				if (metadataHandle != IntPtr.Zero)
-					SkiaApi.sk_pdf_metadata_delete(metadataHandle);
+					SkiaApi.sk_pdf_metadata_delete (metadataHandle);
+
+				// dispose because the root node is not owned
+				if (structureHandle != IntPtr.Zero)
+					SkiaApi.sk_pdf_structure_element_delete (structureHandle);
 			}
 		}
 
 		internal static SKDocument GetObject (IntPtr handle) =>
 			handle == IntPtr.Zero ? null : new SKDocument (handle, true);
 
-		static SKPdfStructureElementNative ToNative(SKPdfStructureElement structure)
+		static IntPtr ToNative(SKPdfStructureElement? structure)
 		{
-			var t = new Memory<int> ();
-			var x = t.Pin ();
-			int* tt = (int*)x.Pointer;
+			if (structure is null)
+				return IntPtr.Zero;
 
-			new SKPdfStructureElementInternal {
-				fAdditionalNodeIds = tt,
-				fAdditionalNodeIdsSize = structure.AdditionalNodeIds.Count,
-			};
+			var handle = SkiaApi.sk_pdf_structure_element_new ();
+
+			SkiaApi.sk_pdf_structure_element_set_node_id (handle, structure.Id);
+			
+#if NET5_0_OR_GREATER
+			if (structure.AdditionalNodeIds is List<int> nodes) {
+				var span = CollectionsMarshal.AsSpan (nodes);
+				SkiaApi.sk_pdf_structure_element_add_additional_node_ids (handle, &span, span.Length);
+			} else
+#endif
+			{
+				using var nodes = Utils.ToRentedArray (structure.AdditionalNodeIds);
+				SkiaApi.sk_pdf_structure_element_add_additional_node_ids (handle, &nodes, nodes.Length);
+			}
+
+			using var type = SKString.CreateRaw (structure.Type);
+			SkiaApi.sk_pdf_structure_element_set_type_string (handle, type.Handle);
+
+			using var alt = SKString.CreateRaw (structure.Alt);
+			SkiaApi.sk_pdf_structure_element_set_alt (handle, alt.Handle);
+
+			using var lang = SKString.CreateRaw (structure.Language);
+			SkiaApi.sk_pdf_structure_element_set_lang (handle, lang.Handle);
+
+			if (structure.Attributes.Inner.Count > 0) {
+				foreach (var attr in structure.Attributes.Inner) {
+					switch (attr.Value) {
+						case int intValue:
+							SkiaApi.sk_pdf_structure_element_add_int_attribute (handle, attr.Owner, attr.Name, intValue);
+							break;
+						case float floatValue:
+							SkiaApi.sk_pdf_structure_element_add_float_attribute (handle, attr.Owner, attr.Name, floatValue);
+							break;
+						case string stringValue:
+							SkiaApi.sk_pdf_structure_element_add_int_attribute (handle, attr.Owner, attr.Name, stringValue);
+							break;
+						case int[] intArray:
+							SkiaApi.sk_pdf_structure_element_add_node_id_array_attribute (handle, attr.Owner, attr.Name, &intArray, intArray.Length);
+							break;
+						case float[] floatArray:
+							SkiaApi.sk_pdf_structure_element_add_float_array_attribute (handle, attr.Owner, attr.Name, &floatArray, floatArray.Length);
+							break;
+						default:
+							// TODO
+							break;
+					}
+				}
+			}
+
+			if (structure.Children.Count > 0) {
+				foreach (var child in structure.Children) {
+					// do not dispose as the parent takes ownership
+					var childHandle = ToNative (child);
+					if (childHandle == IntPtr.Zero)
+						continue;
+					SkiaApi.sk_pdf_structure_element_add_child (handle, childHandle);
+				}
+			}
 		}
 	}
 }

--- a/binding/SkiaSharp/SKPdfMetadata.cs
+++ b/binding/SkiaSharp/SKPdfMetadata.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SkiaSharp;
 
@@ -13,52 +14,93 @@ public class SKPdfMetadata
 	{
 	}
 
+	internal SKPdfMetadata (SKDocumentPdfMetadata metadata)
+	{
+		Title = metadata.Title;
+		Author = metadata.Author;
+		Subject = metadata.Subject;
+		Keywords = metadata.Keywords;
+		Creator = metadata.Creator;
+		Producer = metadata.Producer;
+		Creation = metadata.Creation;
+		Modified = metadata.Modified;
+		RasterDpi = metadata.RasterDpi;
+		PdfA = metadata.PdfA;
+		EncodingQuality = metadata.EncodingQuality;
+	}
+
 	public string? Title { get; set; }
 
 	public string? Author { get; set; }
-	
+
 	public string? Subject { get; set; }
-	
+
 	public string? Keywords { get; set; }
-	
+
 	public string? Creator { get; set; }
-	
+
 	public string? Producer { get; set; }
-	
+
 	public DateTime? Creation { get; set; }
-	
+
 	public DateTime? Modified { get; set; }
-	
+
 	public float RasterDpi { get; set; } = DefaultRasterDpi;
-	
+
 	public bool PdfA { get; set; }
-	
+
 	public int EncodingQuality { get; set; } = DefaultEncodingQuality;
-	
+
 	public SKPdfCompression Compression { get; set; } = SKPdfCompression.Default;
 
-	public SKPdfStructure? Structure { get; set; }
+	public SKPdfStructureElement? Structure { get; set; }
 }
 
-public class SKPdfStructure
+public class SKPdfStructureElement
 {
-	public SKPdfStructure(int id, string type)
+	private List<SKPdfStructureElement>? children;
+	private List<int>? additionalNodeIds;
+	private SKPdfAttributeList? attributes;
+
+	public SKPdfStructureElement (int id, string type)
 	{
 		Id = id;
 		Type = type;
 	}
-		
+
 	public int Id { get; }
 
 	public string Type { get; }
-	
-	public string? Alt { get; }
 
-	public string? Language { get; }
+	public string? Alt { get; set; }
 
-	public IList<SKPdfStructure> Children { get; set; }
+	public string? Language { get; set; }
 
-	public IList<int> AdditionalNodeIds { get; set; }
+	public IList<SKPdfStructureElement> Children => children ??= new ();
 
-	public IList<SKPdfAttribute> Attributes { get; set; }
+	public IList<int> AdditionalNodeIds => additionalNodeIds ??= new ();
+
+	public SKPdfAttributeList Attributes => attributes ??= new ();
+}
+
+public class SKPdfAttributeList
+{
+	private List<(string Owner, string Name, object Value)> attributes = new ();
+
+	internal IReadOnlyList<(string Owner, string Name, object Value)> Inner => attributes;
+
+	public void Add (string owner, string name, int value) =>
+		attributes.Add ((owner, name, value));
+
+	public void Add (string owner, string name, float value) =>
+		attributes.Add ((owner, name, value));
+
+	public void Add (string owner, string name, string value) =>
+		attributes.Add ((owner, name, value));
+
+	public void Add (string owner, string name, IEnumerable<int> value) =>
+		attributes.Add ((owner, name, value));
+
+	public void Add (string owner, string name, IEnumerable<float> value) =>
+		attributes.Add ((owner, name, value));
 }

--- a/binding/SkiaSharp/SKPdfMetadata.cs
+++ b/binding/SkiaSharp/SKPdfMetadata.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace SkiaSharp;
+
+public class SKPdfMetadata
+{
+	public const float DefaultRasterDpi = SKDocument.DefaultRasterDpi;
+
+	public const int DefaultEncodingQuality = 101;
+
+	public SKPdfMetadata ()
+	{
+	}
+
+	public string? Title { get; set; }
+
+	public string? Author { get; set; }
+	
+	public string? Subject { get; set; }
+	
+	public string? Keywords { get; set; }
+	
+	public string? Creator { get; set; }
+	
+	public string? Producer { get; set; }
+	
+	public DateTime? Creation { get; set; }
+	
+	public DateTime? Modified { get; set; }
+	
+	public float RasterDpi { get; set; } = DefaultRasterDpi;
+	
+	public bool PdfA { get; set; }
+	
+	public int EncodingQuality { get; set; } = DefaultEncodingQuality;
+	
+	public SKPdfCompression Compression { get; set; } = SKPdfCompression.Default;
+
+	public SKPdfStructure? Structure { get; set; }
+}
+
+public class SKPdfStructure
+{
+	public SKPdfStructure(int id, string type)
+	{
+		Id = id;
+		Type = type;
+	}
+		
+	public int Id { get; }
+
+	public string Type { get; }
+	
+	public string? Alt { get; }
+
+	public string? Language { get; }
+
+	public IList<SKPdfStructure> Children { get; set; }
+
+	public IList<int> AdditionalNodeIds { get; set; }
+
+	public IList<SKPdfAttribute> Attributes { get; set; }
+}

--- a/binding/SkiaSharp/SKPdfMetadata.cs
+++ b/binding/SkiaSharp/SKPdfMetadata.cs
@@ -53,16 +53,16 @@ public class SKPdfMetadata
 
 	public SKPdfCompression Compression { get; set; } = SKPdfCompression.Default;
 
-	public SKPdfStructureElement? Structure { get; set; }
+	public SKPdfStructureElementNode? Structure { get; set; }
 }
 
-public class SKPdfStructureElement
+public class SKPdfStructureElementNode
 {
-	private List<SKPdfStructureElement>? children;
+	private List<SKPdfStructureElementNode>? children;
 	private List<int>? additionalNodeIds;
 	private SKPdfAttributeList? attributes;
 
-	public SKPdfStructureElement (int id, string type)
+	public SKPdfStructureElementNode (int id, string type)
 	{
 		Id = id;
 		Type = type;
@@ -76,7 +76,7 @@ public class SKPdfStructureElement
 
 	public string? Language { get; set; }
 
-	public IList<SKPdfStructureElement> Children => children ??= new ();
+	public IList<SKPdfStructureElementNode> Children => children ??= new ();
 
 	public IList<int> AdditionalNodeIds => additionalNodeIds ??= new ();
 

--- a/binding/SkiaSharp/SKPdfMetadata.cs
+++ b/binding/SkiaSharp/SKPdfMetadata.cs
@@ -99,8 +99,8 @@ public class SKPdfAttributeList
 		attributes.Add ((owner, name, value));
 
 	public void Add (string owner, string name, IEnumerable<int> value) =>
-		attributes.Add ((owner, name, value));
+		attributes.Add ((owner, name, value.ToArray ()));
 
 	public void Add (string owner, string name, IEnumerable<float> value) =>
-		attributes.Add ((owner, name, value));
+		attributes.Add ((owner, name, value.ToArray ()));
 }

--- a/binding/SkiaSharp/SKString.cs
+++ b/binding/SkiaSharp/SKString.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace SkiaSharp
@@ -20,7 +18,7 @@ namespace SkiaSharp
 			}
 		}
 		
-		public SKString (byte [] src, long length)
+		public SKString (ReadOnlySpan<byte> src, long length)
 			: base (CreateCopy (src, length), true)
 		{
 			if (Handle == IntPtr.Zero) {
@@ -28,14 +26,19 @@ namespace SkiaSharp
 			}
 		}
 		
-		private static IntPtr CreateCopy (byte [] src, long length)
+		private static IntPtr CreateCopy (ReadOnlySpan<byte> src, long length)
 		{
+			if (src is null)
+				throw new ArgumentNullException (nameof (src));
+			if (length > src.Length)
+				throw new ArgumentOutOfRangeException (nameof (length));
+
 			fixed (byte* s = src) {
 				return SkiaApi.sk_string_new_with_copy (s, (IntPtr)length);
 			}
 		}
 
-		public SKString (byte [] src)
+		public SKString (ReadOnlySpan<byte> src)
 			: this (src, src.Length)
 		{
 		}
@@ -57,7 +60,8 @@ namespace SkiaSharp
 			return skString.ToString ();
 		}
 		
-		internal static SKString Create (string str)
+		[return: NotNullIfNotNull(nameof(str))]
+		internal static SKString? Create (string? str)
 		{
 			if (str == null) {
 				return null;

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -48,6 +48,8 @@ using sk_path_iterator_t = System.IntPtr;
 using sk_path_rawiterator_t = System.IntPtr;
 using sk_path_t = System.IntPtr;
 using sk_pathmeasure_t = System.IntPtr;
+using sk_pdf_metadata_t = System.IntPtr;
+using sk_pdf_structure_element_t = System.IntPtr;
 using sk_picture_recorder_t = System.IntPtr;
 using sk_picture_t = System.IntPtr;
 using sk_pixelref_factory_t = System.IntPtr;
@@ -3722,14 +3724,14 @@ namespace SkiaSharp
 		// sk_document_t* sk_document_create_pdf_from_stream_with_metadata(sk_wstream_t* stream, const sk_pdf_metadata_t* metadata)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKPdfMetadataInternal* metadata);
+		internal static extern sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, sk_pdf_metadata_t metadata);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKPdfMetadataInternal* metadata);
+			internal delegate sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, sk_pdf_metadata_t metadata);
 		}
 		private static Delegates.sk_document_create_pdf_from_stream_with_metadata sk_document_create_pdf_from_stream_with_metadata_delegate;
-		internal static sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKPdfMetadataInternal* metadata) =>
+		internal static sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, sk_pdf_metadata_t metadata) =>
 			(sk_document_create_pdf_from_stream_with_metadata_delegate ??= GetSymbol<Delegates.sk_document_create_pdf_from_stream_with_metadata> ("sk_document_create_pdf_from_stream_with_metadata")).Invoke (stream, metadata);
 		#endif
 
@@ -3773,6 +3775,412 @@ namespace SkiaSharp
 		private static Delegates.sk_document_unref sk_document_unref_delegate;
 		internal static void sk_document_unref (sk_document_t document) =>
 			(sk_document_unref_delegate ??= GetSymbol<Delegates.sk_document_unref> ("sk_document_unref")).Invoke (document);
+		#endif
+
+		// void sk_pdf_metadata_delete(sk_pdf_metadata_t* metadata)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_delete (sk_pdf_metadata_t metadata);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_delete (sk_pdf_metadata_t metadata);
+		}
+		private static Delegates.sk_pdf_metadata_delete sk_pdf_metadata_delete_delegate;
+		internal static void sk_pdf_metadata_delete (sk_pdf_metadata_t metadata) =>
+			(sk_pdf_metadata_delete_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_delete> ("sk_pdf_metadata_delete")).Invoke (metadata);
+		#endif
+
+		// sk_pdf_metadata_t* sk_pdf_metadata_new()
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_pdf_metadata_t sk_pdf_metadata_new ();
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_pdf_metadata_t sk_pdf_metadata_new ();
+		}
+		private static Delegates.sk_pdf_metadata_new sk_pdf_metadata_new_delegate;
+		internal static sk_pdf_metadata_t sk_pdf_metadata_new () =>
+			(sk_pdf_metadata_new_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_new> ("sk_pdf_metadata_new")).Invoke ();
+		#endif
+
+		// void sk_pdf_metadata_set_author(sk_pdf_metadata_t* metadata, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_author (sk_pdf_metadata_t metadata, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_author (sk_pdf_metadata_t metadata, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_author sk_pdf_metadata_set_author_delegate;
+		internal static void sk_pdf_metadata_set_author (sk_pdf_metadata_t metadata, sk_string_t value) =>
+			(sk_pdf_metadata_set_author_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_author> ("sk_pdf_metadata_set_author")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_compression_level(sk_pdf_metadata_t* metadata, sk_pdf_compression_t value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_compression_level (sk_pdf_metadata_t metadata, SKPdfCompression value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_compression_level (sk_pdf_metadata_t metadata, SKPdfCompression value);
+		}
+		private static Delegates.sk_pdf_metadata_set_compression_level sk_pdf_metadata_set_compression_level_delegate;
+		internal static void sk_pdf_metadata_set_compression_level (sk_pdf_metadata_t metadata, SKPdfCompression value) =>
+			(sk_pdf_metadata_set_compression_level_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_compression_level> ("sk_pdf_metadata_set_compression_level")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_creation(sk_pdf_metadata_t* metadata, sk_time_datetime_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_creation (sk_pdf_metadata_t metadata, SKTimeDateTimeInternal* value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_creation (sk_pdf_metadata_t metadata, SKTimeDateTimeInternal* value);
+		}
+		private static Delegates.sk_pdf_metadata_set_creation sk_pdf_metadata_set_creation_delegate;
+		internal static void sk_pdf_metadata_set_creation (sk_pdf_metadata_t metadata, SKTimeDateTimeInternal* value) =>
+			(sk_pdf_metadata_set_creation_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_creation> ("sk_pdf_metadata_set_creation")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_creator(sk_pdf_metadata_t* metadata, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_creator (sk_pdf_metadata_t metadata, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_creator (sk_pdf_metadata_t metadata, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_creator sk_pdf_metadata_set_creator_delegate;
+		internal static void sk_pdf_metadata_set_creator (sk_pdf_metadata_t metadata, sk_string_t value) =>
+			(sk_pdf_metadata_set_creator_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_creator> ("sk_pdf_metadata_set_creator")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_encoding_quality(sk_pdf_metadata_t* metadata, int value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_encoding_quality (sk_pdf_metadata_t metadata, Int32 value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_encoding_quality (sk_pdf_metadata_t metadata, Int32 value);
+		}
+		private static Delegates.sk_pdf_metadata_set_encoding_quality sk_pdf_metadata_set_encoding_quality_delegate;
+		internal static void sk_pdf_metadata_set_encoding_quality (sk_pdf_metadata_t metadata, Int32 value) =>
+			(sk_pdf_metadata_set_encoding_quality_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_encoding_quality> ("sk_pdf_metadata_set_encoding_quality")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_keywords(sk_pdf_metadata_t* metadata, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_keywords (sk_pdf_metadata_t metadata, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_keywords (sk_pdf_metadata_t metadata, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_keywords sk_pdf_metadata_set_keywords_delegate;
+		internal static void sk_pdf_metadata_set_keywords (sk_pdf_metadata_t metadata, sk_string_t value) =>
+			(sk_pdf_metadata_set_keywords_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_keywords> ("sk_pdf_metadata_set_keywords")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_modified(sk_pdf_metadata_t* metadata, sk_time_datetime_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_modified (sk_pdf_metadata_t metadata, SKTimeDateTimeInternal* value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_modified (sk_pdf_metadata_t metadata, SKTimeDateTimeInternal* value);
+		}
+		private static Delegates.sk_pdf_metadata_set_modified sk_pdf_metadata_set_modified_delegate;
+		internal static void sk_pdf_metadata_set_modified (sk_pdf_metadata_t metadata, SKTimeDateTimeInternal* value) =>
+			(sk_pdf_metadata_set_modified_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_modified> ("sk_pdf_metadata_set_modified")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_pdfa(sk_pdf_metadata_t* metadata, bool value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_pdfa (sk_pdf_metadata_t metadata, [MarshalAs (UnmanagedType.I1)] bool value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_pdfa (sk_pdf_metadata_t metadata, [MarshalAs (UnmanagedType.I1)] bool value);
+		}
+		private static Delegates.sk_pdf_metadata_set_pdfa sk_pdf_metadata_set_pdfa_delegate;
+		internal static void sk_pdf_metadata_set_pdfa (sk_pdf_metadata_t metadata, [MarshalAs (UnmanagedType.I1)] bool value) =>
+			(sk_pdf_metadata_set_pdfa_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_pdfa> ("sk_pdf_metadata_set_pdfa")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_producer(sk_pdf_metadata_t* metadata, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_producer (sk_pdf_metadata_t metadata, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_producer (sk_pdf_metadata_t metadata, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_producer sk_pdf_metadata_set_producer_delegate;
+		internal static void sk_pdf_metadata_set_producer (sk_pdf_metadata_t metadata, sk_string_t value) =>
+			(sk_pdf_metadata_set_producer_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_producer> ("sk_pdf_metadata_set_producer")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_raster_dpi(sk_pdf_metadata_t* metadata, float value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_raster_dpi (sk_pdf_metadata_t metadata, Single value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_raster_dpi (sk_pdf_metadata_t metadata, Single value);
+		}
+		private static Delegates.sk_pdf_metadata_set_raster_dpi sk_pdf_metadata_set_raster_dpi_delegate;
+		internal static void sk_pdf_metadata_set_raster_dpi (sk_pdf_metadata_t metadata, Single value) =>
+			(sk_pdf_metadata_set_raster_dpi_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_raster_dpi> ("sk_pdf_metadata_set_raster_dpi")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_structure_element_tree_root(sk_pdf_metadata_t* metadata, sk_pdf_structure_element_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_structure_element_tree_root (sk_pdf_metadata_t metadata, sk_pdf_structure_element_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_structure_element_tree_root (sk_pdf_metadata_t metadata, sk_pdf_structure_element_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_structure_element_tree_root sk_pdf_metadata_set_structure_element_tree_root_delegate;
+		internal static void sk_pdf_metadata_set_structure_element_tree_root (sk_pdf_metadata_t metadata, sk_pdf_structure_element_t value) =>
+			(sk_pdf_metadata_set_structure_element_tree_root_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_structure_element_tree_root> ("sk_pdf_metadata_set_structure_element_tree_root")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_subject(sk_pdf_metadata_t* metadata, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_subject (sk_pdf_metadata_t metadata, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_subject (sk_pdf_metadata_t metadata, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_subject sk_pdf_metadata_set_subject_delegate;
+		internal static void sk_pdf_metadata_set_subject (sk_pdf_metadata_t metadata, sk_string_t value) =>
+			(sk_pdf_metadata_set_subject_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_subject> ("sk_pdf_metadata_set_subject")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_metadata_set_title(sk_pdf_metadata_t* metadata, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_metadata_set_title (sk_pdf_metadata_t metadata, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_metadata_set_title (sk_pdf_metadata_t metadata, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_metadata_set_title sk_pdf_metadata_set_title_delegate;
+		internal static void sk_pdf_metadata_set_title (sk_pdf_metadata_t metadata, sk_string_t value) =>
+			(sk_pdf_metadata_set_title_delegate ??= GetSymbol<Delegates.sk_pdf_metadata_set_title> ("sk_pdf_metadata_set_title")).Invoke (metadata, value);
+		#endif
+
+		// void sk_pdf_structure_element_add_additional_node_id(sk_pdf_structure_element_t* element, int value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_additional_node_id (sk_pdf_structure_element_t element, Int32 value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_additional_node_id (sk_pdf_structure_element_t element, Int32 value);
+		}
+		private static Delegates.sk_pdf_structure_element_add_additional_node_id sk_pdf_structure_element_add_additional_node_id_delegate;
+		internal static void sk_pdf_structure_element_add_additional_node_id (sk_pdf_structure_element_t element, Int32 value) =>
+			(sk_pdf_structure_element_add_additional_node_id_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_additional_node_id> ("sk_pdf_structure_element_add_additional_node_id")).Invoke (element, value);
+		#endif
+
+		// void sk_pdf_structure_element_add_additional_node_ids(sk_pdf_structure_element_t* element, int* value, size_t count)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_additional_node_ids (sk_pdf_structure_element_t element, Int32* value, /* size_t */ IntPtr count);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_additional_node_ids (sk_pdf_structure_element_t element, Int32* value, /* size_t */ IntPtr count);
+		}
+		private static Delegates.sk_pdf_structure_element_add_additional_node_ids sk_pdf_structure_element_add_additional_node_ids_delegate;
+		internal static void sk_pdf_structure_element_add_additional_node_ids (sk_pdf_structure_element_t element, Int32* value, /* size_t */ IntPtr count) =>
+			(sk_pdf_structure_element_add_additional_node_ids_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_additional_node_ids> ("sk_pdf_structure_element_add_additional_node_ids")).Invoke (element, value, count);
+		#endif
+
+		// void sk_pdf_structure_element_add_child(sk_pdf_structure_element_t* element, sk_pdf_structure_element_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_child (sk_pdf_structure_element_t element, sk_pdf_structure_element_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_child (sk_pdf_structure_element_t element, sk_pdf_structure_element_t value);
+		}
+		private static Delegates.sk_pdf_structure_element_add_child sk_pdf_structure_element_add_child_delegate;
+		internal static void sk_pdf_structure_element_add_child (sk_pdf_structure_element_t element, sk_pdf_structure_element_t value) =>
+			(sk_pdf_structure_element_add_child_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_child> ("sk_pdf_structure_element_add_child")).Invoke (element, value);
+		#endif
+
+		// void sk_pdf_structure_element_add_float_array_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, float* values, size_t count)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single* values, /* size_t */ IntPtr count);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single* values, /* size_t */ IntPtr count);
+		}
+		private static Delegates.sk_pdf_structure_element_add_float_array_attribute sk_pdf_structure_element_add_float_array_attribute_delegate;
+		internal static void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single* values, /* size_t */ IntPtr count) =>
+			(sk_pdf_structure_element_add_float_array_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_float_array_attribute> ("sk_pdf_structure_element_add_float_array_attribute")).Invoke (element, owner, name, values, count);
+		#endif
+
+		// void sk_pdf_structure_element_add_float_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, float value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single value);
+		}
+		private static Delegates.sk_pdf_structure_element_add_float_attribute sk_pdf_structure_element_add_float_attribute_delegate;
+		internal static void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single value) =>
+			(sk_pdf_structure_element_add_float_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_float_attribute> ("sk_pdf_structure_element_add_float_attribute")).Invoke (element, owner, name, value);
+		#endif
+
+		// void sk_pdf_structure_element_add_int_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, int value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32 value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32 value);
+		}
+		private static Delegates.sk_pdf_structure_element_add_int_attribute sk_pdf_structure_element_add_int_attribute_delegate;
+		internal static void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32 value) =>
+			(sk_pdf_structure_element_add_int_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_int_attribute> ("sk_pdf_structure_element_add_int_attribute")).Invoke (element, owner, name, value);
+		#endif
+
+		// void sk_pdf_structure_element_add_name_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, const char* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, /* char */ void* value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, /* char */ void* value);
+		}
+		private static Delegates.sk_pdf_structure_element_add_name_attribute sk_pdf_structure_element_add_name_attribute_delegate;
+		internal static void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, /* char */ void* value) =>
+			(sk_pdf_structure_element_add_name_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_name_attribute> ("sk_pdf_structure_element_add_name_attribute")).Invoke (element, owner, name, value);
+		#endif
+
+		// void sk_pdf_structure_element_add_node_id_array_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, int* values, size_t count)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32* values, /* size_t */ IntPtr count);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32* values, /* size_t */ IntPtr count);
+		}
+		private static Delegates.sk_pdf_structure_element_add_node_id_array_attribute sk_pdf_structure_element_add_node_id_array_attribute_delegate;
+		internal static void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32* values, /* size_t */ IntPtr count) =>
+			(sk_pdf_structure_element_add_node_id_array_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_node_id_array_attribute> ("sk_pdf_structure_element_add_node_id_array_attribute")).Invoke (element, owner, name, values, count);
+		#endif
+
+		// void sk_pdf_structure_element_delete(sk_pdf_structure_element_t* element)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_delete (sk_pdf_structure_element_t element);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_delete (sk_pdf_structure_element_t element);
+		}
+		private static Delegates.sk_pdf_structure_element_delete sk_pdf_structure_element_delete_delegate;
+		internal static void sk_pdf_structure_element_delete (sk_pdf_structure_element_t element) =>
+			(sk_pdf_structure_element_delete_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_delete> ("sk_pdf_structure_element_delete")).Invoke (element);
+		#endif
+
+		// sk_pdf_structure_element_t* sk_pdf_structure_element_new()
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_pdf_structure_element_t sk_pdf_structure_element_new ();
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_pdf_structure_element_t sk_pdf_structure_element_new ();
+		}
+		private static Delegates.sk_pdf_structure_element_new sk_pdf_structure_element_new_delegate;
+		internal static sk_pdf_structure_element_t sk_pdf_structure_element_new () =>
+			(sk_pdf_structure_element_new_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_new> ("sk_pdf_structure_element_new")).Invoke ();
+		#endif
+
+		// void sk_pdf_structure_element_set_alt(sk_pdf_structure_element_t* element, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_set_alt (sk_pdf_structure_element_t element, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_set_alt (sk_pdf_structure_element_t element, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_structure_element_set_alt sk_pdf_structure_element_set_alt_delegate;
+		internal static void sk_pdf_structure_element_set_alt (sk_pdf_structure_element_t element, sk_string_t value) =>
+			(sk_pdf_structure_element_set_alt_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_set_alt> ("sk_pdf_structure_element_set_alt")).Invoke (element, value);
+		#endif
+
+		// void sk_pdf_structure_element_set_lang(sk_pdf_structure_element_t* element, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_set_lang (sk_pdf_structure_element_t element, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_set_lang (sk_pdf_structure_element_t element, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_structure_element_set_lang sk_pdf_structure_element_set_lang_delegate;
+		internal static void sk_pdf_structure_element_set_lang (sk_pdf_structure_element_t element, sk_string_t value) =>
+			(sk_pdf_structure_element_set_lang_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_set_lang> ("sk_pdf_structure_element_set_lang")).Invoke (element, value);
+		#endif
+
+		// void sk_pdf_structure_element_set_node_id(sk_pdf_structure_element_t* element, int value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_set_node_id (sk_pdf_structure_element_t element, Int32 value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_set_node_id (sk_pdf_structure_element_t element, Int32 value);
+		}
+		private static Delegates.sk_pdf_structure_element_set_node_id sk_pdf_structure_element_set_node_id_delegate;
+		internal static void sk_pdf_structure_element_set_node_id (sk_pdf_structure_element_t element, Int32 value) =>
+			(sk_pdf_structure_element_set_node_id_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_set_node_id> ("sk_pdf_structure_element_set_node_id")).Invoke (element, value);
+		#endif
+
+		// void sk_pdf_structure_element_set_type_string(sk_pdf_structure_element_t* element, sk_string_t* value)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_pdf_structure_element_set_type_string (sk_pdf_structure_element_t element, sk_string_t value);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_pdf_structure_element_set_type_string (sk_pdf_structure_element_t element, sk_string_t value);
+		}
+		private static Delegates.sk_pdf_structure_element_set_type_string sk_pdf_structure_element_set_type_string_delegate;
+		internal static void sk_pdf_structure_element_set_type_string (sk_pdf_structure_element_t element, sk_string_t value) =>
+			(sk_pdf_structure_element_set_type_string_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_set_type_string> ("sk_pdf_structure_element_set_type_string")).Invoke (element, value);
 		#endif
 
 		#endregion
@@ -14589,187 +14997,6 @@ namespace SkiaSharp {
 
 	}
 
-	// sk_pdf_attribute_item_t
-	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKPdfAttributeItemInternal : IEquatable<SKPdfAttributeItemInternal> {
-		// public sk_string_t* fOwner
-		public sk_string_t fOwner;
-
-		// public sk_string_t* fName
-		public sk_string_t fName;
-
-		// public void* fValue
-		public void* fValue;
-
-		// public int fValueSize
-		public Int32 fValueSize;
-
-		// public int fValueType
-		public Int32 fValueType;
-
-		public readonly bool Equals (SKPdfAttributeItemInternal obj) =>
-			fOwner == obj.fOwner && fName == obj.fName && fValue == obj.fValue && fValueSize == obj.fValueSize && fValueType == obj.fValueType;
-
-		public readonly override bool Equals (object obj) =>
-			obj is SKPdfAttributeItemInternal f && Equals (f);
-
-		public static bool operator == (SKPdfAttributeItemInternal left, SKPdfAttributeItemInternal right) =>
-			left.Equals (right);
-
-		public static bool operator != (SKPdfAttributeItemInternal left, SKPdfAttributeItemInternal right) =>
-			!left.Equals (right);
-
-		public readonly override int GetHashCode ()
-		{
-			var hash = new HashCode ();
-			hash.Add (fOwner);
-			hash.Add (fName);
-			hash.Add (fValue);
-			hash.Add (fValueSize);
-			hash.Add (fValueType);
-			return hash.ToHashCode ();
-		}
-
-	}
-
-	// sk_pdf_metadata_t
-	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKPdfMetadataInternal : IEquatable<SKPdfMetadataInternal> {
-		// public sk_string_t* fTitle
-		public sk_string_t fTitle;
-
-		// public sk_string_t* fAuthor
-		public sk_string_t fAuthor;
-
-		// public sk_string_t* fSubject
-		public sk_string_t fSubject;
-
-		// public sk_string_t* fKeywords
-		public sk_string_t fKeywords;
-
-		// public sk_string_t* fCreator
-		public sk_string_t fCreator;
-
-		// public sk_string_t* fProducer
-		public sk_string_t fProducer;
-
-		// public sk_time_datetime_t* fCreation
-		public SKTimeDateTimeInternal* fCreation;
-
-		// public sk_time_datetime_t* fModified
-		public SKTimeDateTimeInternal* fModified;
-
-		// public float fRasterDPI
-		public Single fRasterDPI;
-
-		// public bool fPDFA
-		public Byte fPDFA;
-
-		// public int fEncodingQuality
-		public Int32 fEncodingQuality;
-
-		// public sk_pdf_compression_t fCompression
-		public SKPdfCompression fCompression;
-
-		// public sk_pdf_structure_element_t* fStructureElementTreeRoot
-		public SKPdfStructureElementInternal* fStructureElementTreeRoot;
-
-		public readonly bool Equals (SKPdfMetadataInternal obj) =>
-			fTitle == obj.fTitle && fAuthor == obj.fAuthor && fSubject == obj.fSubject && fKeywords == obj.fKeywords && fCreator == obj.fCreator && fProducer == obj.fProducer && fCreation == obj.fCreation && fModified == obj.fModified && fRasterDPI == obj.fRasterDPI && fPDFA == obj.fPDFA && fEncodingQuality == obj.fEncodingQuality && fCompression == obj.fCompression && fStructureElementTreeRoot == obj.fStructureElementTreeRoot;
-
-		public readonly override bool Equals (object obj) =>
-			obj is SKPdfMetadataInternal f && Equals (f);
-
-		public static bool operator == (SKPdfMetadataInternal left, SKPdfMetadataInternal right) =>
-			left.Equals (right);
-
-		public static bool operator != (SKPdfMetadataInternal left, SKPdfMetadataInternal right) =>
-			!left.Equals (right);
-
-		public readonly override int GetHashCode ()
-		{
-			var hash = new HashCode ();
-			hash.Add (fTitle);
-			hash.Add (fAuthor);
-			hash.Add (fSubject);
-			hash.Add (fKeywords);
-			hash.Add (fCreator);
-			hash.Add (fProducer);
-			hash.Add (fCreation);
-			hash.Add (fModified);
-			hash.Add (fRasterDPI);
-			hash.Add (fPDFA);
-			hash.Add (fEncodingQuality);
-			hash.Add (fCompression);
-			hash.Add (fStructureElementTreeRoot);
-			return hash.ToHashCode ();
-		}
-
-	}
-
-	// sk_pdf_structure_element_t
-	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKPdfStructureElementInternal : IEquatable<SKPdfStructureElementInternal> {
-		// public sk_string_t* fTypeString
-		public sk_string_t fTypeString;
-
-		// public sk_pdf_structure_element_t* fChildren
-		public SKPdfStructureElementInternal* fChildren;
-
-		// public int fChildrenSize
-		public Int32 fChildrenSize;
-
-		// public int fNodeId
-		public Int32 fNodeId;
-
-		// public int* fAdditionalNodeIds
-		public Int32* fAdditionalNodeIds;
-
-		// public int fAdditionalNodeIdsSize
-		public Int32 fAdditionalNodeIdsSize;
-
-		// public sk_pdf_attribute_item_t* fAttributes
-		public SKPdfAttributeItemInternal* fAttributes;
-
-		// public int fAttributesSize
-		public Int32 fAttributesSize;
-
-		// public sk_string_t* fAlt
-		public sk_string_t fAlt;
-
-		// public sk_string_t* fLang
-		public sk_string_t fLang;
-
-		public readonly bool Equals (SKPdfStructureElementInternal obj) =>
-			fTypeString == obj.fTypeString && fChildren == obj.fChildren && fChildrenSize == obj.fChildrenSize && fNodeId == obj.fNodeId && fAdditionalNodeIds == obj.fAdditionalNodeIds && fAdditionalNodeIdsSize == obj.fAdditionalNodeIdsSize && fAttributes == obj.fAttributes && fAttributesSize == obj.fAttributesSize && fAlt == obj.fAlt && fLang == obj.fLang;
-
-		public readonly override bool Equals (object obj) =>
-			obj is SKPdfStructureElementInternal f && Equals (f);
-
-		public static bool operator == (SKPdfStructureElementInternal left, SKPdfStructureElementInternal right) =>
-			left.Equals (right);
-
-		public static bool operator != (SKPdfStructureElementInternal left, SKPdfStructureElementInternal right) =>
-			!left.Equals (right);
-
-		public readonly override int GetHashCode ()
-		{
-			var hash = new HashCode ();
-			hash.Add (fTypeString);
-			hash.Add (fChildren);
-			hash.Add (fChildrenSize);
-			hash.Add (fNodeId);
-			hash.Add (fAdditionalNodeIds);
-			hash.Add (fAdditionalNodeIdsSize);
-			hash.Add (fAttributes);
-			hash.Add (fAttributesSize);
-			hash.Add (fAlt);
-			hash.Add (fLang);
-			return hash.ToHashCode ();
-		}
-
-	}
-
 	// sk_pngencoder_options_t
 	[StructLayout (LayoutKind.Sequential)]
 	public readonly unsafe partial struct SKPngEncoderOptions : IEquatable<SKPngEncoderOptions> {
@@ -15837,20 +16064,6 @@ namespace SkiaSharp {
 		Xor = 3,
 		// REVERSE_DIFFERENCE_SK_PATHOP = 4
 		ReverseDifference = 4,
-	}
-
-	// sk_pdf_attribute_item_type_t
-	internal enum SKPdfAttributeItemTypeInternal {
-		// INT_SK_PDF_ATTRIBUTE_ITEM_TYPE = 0
-		Int = 0,
-		// FLOAT_SK_PDF_ATTRIBUTE_ITEM_TYPE = 1
-		Float = 1,
-		// NAME_SK_PDF_ATTRIBUTE_ITEM_TYPE = 2
-		Name = 2,
-		// FLOAT_ARRAY_SK_PDF_ATTRIBUTE_ITEM_TYPE = 3
-		FloatArray = 3,
-		// NODE_ID_ARRAY_SK_PDF_ATTRIBUTE_ITEM_TYPE = 4
-		NodeIdArray = 4,
 	}
 
 	// sk_pdf_compression_t

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -4032,70 +4032,70 @@ namespace SkiaSharp
 		// void sk_pdf_structure_element_add_float_array_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, float* values, size_t count)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single* values, /* size_t */ IntPtr count);
+		internal static extern void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Single* values, /* size_t */ IntPtr count);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single* values, /* size_t */ IntPtr count);
+			internal delegate void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Single* values, /* size_t */ IntPtr count);
 		}
 		private static Delegates.sk_pdf_structure_element_add_float_array_attribute sk_pdf_structure_element_add_float_array_attribute_delegate;
-		internal static void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single* values, /* size_t */ IntPtr count) =>
+		internal static void sk_pdf_structure_element_add_float_array_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Single* values, /* size_t */ IntPtr count) =>
 			(sk_pdf_structure_element_add_float_array_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_float_array_attribute> ("sk_pdf_structure_element_add_float_array_attribute")).Invoke (element, owner, name, values, count);
 		#endif
 
 		// void sk_pdf_structure_element_add_float_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, float value)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single value);
+		internal static extern void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Single value);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single value);
+			internal delegate void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Single value);
 		}
 		private static Delegates.sk_pdf_structure_element_add_float_attribute sk_pdf_structure_element_add_float_attribute_delegate;
-		internal static void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Single value) =>
+		internal static void sk_pdf_structure_element_add_float_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Single value) =>
 			(sk_pdf_structure_element_add_float_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_float_attribute> ("sk_pdf_structure_element_add_float_attribute")).Invoke (element, owner, name, value);
 		#endif
 
 		// void sk_pdf_structure_element_add_int_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, int value)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32 value);
+		internal static extern void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Int32 value);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32 value);
+			internal delegate void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Int32 value);
 		}
 		private static Delegates.sk_pdf_structure_element_add_int_attribute sk_pdf_structure_element_add_int_attribute_delegate;
-		internal static void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32 value) =>
+		internal static void sk_pdf_structure_element_add_int_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Int32 value) =>
 			(sk_pdf_structure_element_add_int_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_int_attribute> ("sk_pdf_structure_element_add_int_attribute")).Invoke (element, owner, name, value);
 		#endif
 
 		// void sk_pdf_structure_element_add_name_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, const char* value)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, /* char */ void* value);
+		internal static extern void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, [MarshalAs (UnmanagedType.LPStr)] String value);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, /* char */ void* value);
+			internal delegate void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, [MarshalAs (UnmanagedType.LPStr)] String value);
 		}
 		private static Delegates.sk_pdf_structure_element_add_name_attribute sk_pdf_structure_element_add_name_attribute_delegate;
-		internal static void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, /* char */ void* value) =>
+		internal static void sk_pdf_structure_element_add_name_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, [MarshalAs (UnmanagedType.LPStr)] String value) =>
 			(sk_pdf_structure_element_add_name_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_name_attribute> ("sk_pdf_structure_element_add_name_attribute")).Invoke (element, owner, name, value);
 		#endif
 
 		// void sk_pdf_structure_element_add_node_id_array_attribute(sk_pdf_structure_element_t* element, const char* owner, const char* name, int* values, size_t count)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32* values, /* size_t */ IntPtr count);
+		internal static extern void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Int32* values, /* size_t */ IntPtr count);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32* values, /* size_t */ IntPtr count);
+			internal delegate void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Int32* values, /* size_t */ IntPtr count);
 		}
 		private static Delegates.sk_pdf_structure_element_add_node_id_array_attribute sk_pdf_structure_element_add_node_id_array_attribute_delegate;
-		internal static void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, /* char */ void* owner, /* char */ void* name, Int32* values, /* size_t */ IntPtr count) =>
+		internal static void sk_pdf_structure_element_add_node_id_array_attribute (sk_pdf_structure_element_t element, [MarshalAs (UnmanagedType.LPStr)] String owner, [MarshalAs (UnmanagedType.LPStr)] String name, Int32* values, /* size_t */ IntPtr count) =>
 			(sk_pdf_structure_element_add_node_id_array_attribute_delegate ??= GetSymbol<Delegates.sk_pdf_structure_element_add_node_id_array_attribute> ("sk_pdf_structure_element_add_node_id_array_attribute")).Invoke (element, owner, name, values, count);
 		#endif
 

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -467,6 +467,34 @@ namespace SkiaSharp
 			(gr_direct_context_flush_and_submit_delegate ??= GetSymbol<Delegates.gr_direct_context_flush_and_submit> ("gr_direct_context_flush_and_submit")).Invoke (context, syncCpu);
 		#endif
 
+		// void gr_direct_context_flush_image(gr_direct_context_t* context, const sk_image_t* image)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void gr_direct_context_flush_image (gr_direct_context_t context, sk_image_t image);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void gr_direct_context_flush_image (gr_direct_context_t context, sk_image_t image);
+		}
+		private static Delegates.gr_direct_context_flush_image gr_direct_context_flush_image_delegate;
+		internal static void gr_direct_context_flush_image (gr_direct_context_t context, sk_image_t image) =>
+			(gr_direct_context_flush_image_delegate ??= GetSymbol<Delegates.gr_direct_context_flush_image> ("gr_direct_context_flush_image")).Invoke (context, image);
+		#endif
+
+		// void gr_direct_context_flush_surface(gr_direct_context_t* context, sk_surface_t* surface)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void gr_direct_context_flush_surface (gr_direct_context_t context, sk_surface_t surface);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void gr_direct_context_flush_surface (gr_direct_context_t context, sk_surface_t surface);
+		}
+		private static Delegates.gr_direct_context_flush_surface gr_direct_context_flush_surface_delegate;
+		internal static void gr_direct_context_flush_surface (gr_direct_context_t context, sk_surface_t surface) =>
+			(gr_direct_context_flush_surface_delegate ??= GetSymbol<Delegates.gr_direct_context_flush_surface> ("gr_direct_context_flush_surface")).Invoke (context, surface);
+		#endif
+
 		// void gr_direct_context_free_gpu_resources(gr_direct_context_t* context)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -3691,17 +3719,17 @@ namespace SkiaSharp
 			(sk_document_create_pdf_from_stream_delegate ??= GetSymbol<Delegates.sk_document_create_pdf_from_stream> ("sk_document_create_pdf_from_stream")).Invoke (stream);
 		#endif
 
-		// sk_document_t* sk_document_create_pdf_from_stream_with_metadata(sk_wstream_t* stream, const sk_document_pdf_metadata_t* metadata)
+		// sk_document_t* sk_document_create_pdf_from_stream_with_metadata(sk_wstream_t* stream, const sk_pdf_metadata_t* metadata)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKDocumentPdfMetadataInternal* metadata);
+		internal static extern sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKPdfMetadataInternal* metadata);
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKDocumentPdfMetadataInternal* metadata);
+			internal delegate sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKPdfMetadataInternal* metadata);
 		}
 		private static Delegates.sk_document_create_pdf_from_stream_with_metadata sk_document_create_pdf_from_stream_with_metadata_delegate;
-		internal static sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKDocumentPdfMetadataInternal* metadata) =>
+		internal static sk_document_t sk_document_create_pdf_from_stream_with_metadata (sk_wstream_t stream, SKPdfMetadataInternal* metadata) =>
 			(sk_document_create_pdf_from_stream_with_metadata_delegate ??= GetSymbol<Delegates.sk_document_create_pdf_from_stream_with_metadata> ("sk_document_create_pdf_from_stream_with_metadata")).Invoke (stream, metadata);
 		#endif
 
@@ -5011,20 +5039,6 @@ namespace SkiaSharp
 			(sk_image_make_raster_image_delegate ??= GetSymbol<Delegates.sk_image_make_raster_image> ("sk_image_make_raster_image")).Invoke (cimage);
 		#endif
 
-		// sk_shader_t* sk_image_make_shader(const sk_image_t* image, sk_shader_tilemode_t tileX, sk_shader_tilemode_t tileY, const sk_sampling_options_t* sampling, const sk_matrix_t* cmatrix)
-		#if !USE_DELEGATES
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_shader_t sk_image_make_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix);
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_shader_t sk_image_make_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix);
-		}
-		private static Delegates.sk_image_make_shader sk_image_make_shader_delegate;
-		internal static sk_shader_t sk_image_make_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix) =>
-			(sk_image_make_shader_delegate ??= GetSymbol<Delegates.sk_image_make_shader> ("sk_image_make_shader")).Invoke (image, tileX, tileY, sampling, cmatrix);
-		#endif
-
 		// sk_shader_t* sk_image_make_raw_shader(const sk_image_t* image, sk_shader_tilemode_t tileX, sk_shader_tilemode_t tileY, const sk_sampling_options_t* sampling, const sk_matrix_t* cmatrix)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -5037,6 +5051,20 @@ namespace SkiaSharp
 		private static Delegates.sk_image_make_raw_shader sk_image_make_raw_shader_delegate;
 		internal static sk_shader_t sk_image_make_raw_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix) =>
 			(sk_image_make_raw_shader_delegate ??= GetSymbol<Delegates.sk_image_make_raw_shader> ("sk_image_make_raw_shader")).Invoke (image, tileX, tileY, sampling, cmatrix);
+		#endif
+
+		// sk_shader_t* sk_image_make_shader(const sk_image_t* image, sk_shader_tilemode_t tileX, sk_shader_tilemode_t tileY, const sk_sampling_options_t* sampling, const sk_matrix_t* cmatrix)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_shader_t sk_image_make_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_shader_t sk_image_make_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix);
+		}
+		private static Delegates.sk_image_make_shader sk_image_make_shader_delegate;
+		internal static sk_shader_t sk_image_make_shader (sk_image_t image, SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions* sampling, SKMatrix* cmatrix) =>
+			(sk_image_make_shader_delegate ??= GetSymbol<Delegates.sk_image_make_shader> ("sk_image_make_shader")).Invoke (image, tileX, tileY, sampling, cmatrix);
 		#endif
 
 		// sk_image_t* sk_image_make_subset(const sk_image_t* cimage, gr_direct_context_t* context, const sk_irect_t* subset)
@@ -5344,20 +5372,6 @@ namespace SkiaSharp
 		#endregion
 
 		#region sk_imagefilter.h
-
-		// sk_imagefilter_t* sk_imagefilter_new_alpha_threshold(const sk_region_t* region, float innerThreshold, float outerThreshold, const sk_imagefilter_t* input)
-		#if !USE_DELEGATES
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_imagefilter_t sk_imagefilter_new_alpha_threshold (sk_region_t region, Single innerThreshold, Single outerThreshold, sk_imagefilter_t input);
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_imagefilter_t sk_imagefilter_new_alpha_threshold (sk_region_t region, Single innerThreshold, Single outerThreshold, sk_imagefilter_t input);
-		}
-		private static Delegates.sk_imagefilter_new_alpha_threshold sk_imagefilter_new_alpha_threshold_delegate;
-		internal static sk_imagefilter_t sk_imagefilter_new_alpha_threshold (sk_region_t region, Single innerThreshold, Single outerThreshold, sk_imagefilter_t input) =>
-			(sk_imagefilter_new_alpha_threshold_delegate ??= GetSymbol<Delegates.sk_imagefilter_new_alpha_threshold> ("sk_imagefilter_new_alpha_threshold")).Invoke (region, innerThreshold, outerThreshold, input);
-		#endif
 
 		// sk_imagefilter_t* sk_imagefilter_new_arithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor, const sk_imagefilter_t* background, const sk_imagefilter_t* foreground, const sk_rect_t* cropRect)
 		#if !USE_DELEGATES
@@ -13733,73 +13747,6 @@ namespace SkiaSharp {
 
 	}
 
-	// sk_document_pdf_metadata_t
-	[StructLayout (LayoutKind.Sequential)]
-	internal unsafe partial struct SKDocumentPdfMetadataInternal : IEquatable<SKDocumentPdfMetadataInternal> {
-		// public sk_string_t* fTitle
-		public sk_string_t fTitle;
-
-		// public sk_string_t* fAuthor
-		public sk_string_t fAuthor;
-
-		// public sk_string_t* fSubject
-		public sk_string_t fSubject;
-
-		// public sk_string_t* fKeywords
-		public sk_string_t fKeywords;
-
-		// public sk_string_t* fCreator
-		public sk_string_t fCreator;
-
-		// public sk_string_t* fProducer
-		public sk_string_t fProducer;
-
-		// public sk_time_datetime_t* fCreation
-		public SKTimeDateTimeInternal* fCreation;
-
-		// public sk_time_datetime_t* fModified
-		public SKTimeDateTimeInternal* fModified;
-
-		// public float fRasterDPI
-		public Single fRasterDPI;
-
-		// public bool fPDFA
-		public Byte fPDFA;
-
-		// public int fEncodingQuality
-		public Int32 fEncodingQuality;
-
-		public readonly bool Equals (SKDocumentPdfMetadataInternal obj) =>
-			fTitle == obj.fTitle && fAuthor == obj.fAuthor && fSubject == obj.fSubject && fKeywords == obj.fKeywords && fCreator == obj.fCreator && fProducer == obj.fProducer && fCreation == obj.fCreation && fModified == obj.fModified && fRasterDPI == obj.fRasterDPI && fPDFA == obj.fPDFA && fEncodingQuality == obj.fEncodingQuality;
-
-		public readonly override bool Equals (object obj) =>
-			obj is SKDocumentPdfMetadataInternal f && Equals (f);
-
-		public static bool operator == (SKDocumentPdfMetadataInternal left, SKDocumentPdfMetadataInternal right) =>
-			left.Equals (right);
-
-		public static bool operator != (SKDocumentPdfMetadataInternal left, SKDocumentPdfMetadataInternal right) =>
-			!left.Equals (right);
-
-		public readonly override int GetHashCode ()
-		{
-			var hash = new HashCode ();
-			hash.Add (fTitle);
-			hash.Add (fAuthor);
-			hash.Add (fSubject);
-			hash.Add (fKeywords);
-			hash.Add (fCreator);
-			hash.Add (fProducer);
-			hash.Add (fCreation);
-			hash.Add (fModified);
-			hash.Add (fRasterDPI);
-			hash.Add (fPDFA);
-			hash.Add (fEncodingQuality);
-			return hash.ToHashCode ();
-		}
-
-	}
-
 	// sk_fontmetrics_t
 	[StructLayout (LayoutKind.Sequential)]
 	public unsafe partial struct SKFontMetrics : IEquatable<SKFontMetrics> {
@@ -14637,6 +14584,187 @@ namespace SkiaSharp {
 			hash.Add (m31);
 			hash.Add (m32);
 			hash.Add (m33);
+			return hash.ToHashCode ();
+		}
+
+	}
+
+	// sk_pdf_attribute_item_t
+	[StructLayout (LayoutKind.Sequential)]
+	internal unsafe partial struct SKPdfAttributeItemInternal : IEquatable<SKPdfAttributeItemInternal> {
+		// public sk_string_t* fOwner
+		public sk_string_t fOwner;
+
+		// public sk_string_t* fName
+		public sk_string_t fName;
+
+		// public void* fValue
+		public void* fValue;
+
+		// public int fValueSize
+		public Int32 fValueSize;
+
+		// public int fValueType
+		public Int32 fValueType;
+
+		public readonly bool Equals (SKPdfAttributeItemInternal obj) =>
+			fOwner == obj.fOwner && fName == obj.fName && fValue == obj.fValue && fValueSize == obj.fValueSize && fValueType == obj.fValueType;
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKPdfAttributeItemInternal f && Equals (f);
+
+		public static bool operator == (SKPdfAttributeItemInternal left, SKPdfAttributeItemInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPdfAttributeItemInternal left, SKPdfAttributeItemInternal right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fOwner);
+			hash.Add (fName);
+			hash.Add (fValue);
+			hash.Add (fValueSize);
+			hash.Add (fValueType);
+			return hash.ToHashCode ();
+		}
+
+	}
+
+	// sk_pdf_metadata_t
+	[StructLayout (LayoutKind.Sequential)]
+	internal unsafe partial struct SKPdfMetadataInternal : IEquatable<SKPdfMetadataInternal> {
+		// public sk_string_t* fTitle
+		public sk_string_t fTitle;
+
+		// public sk_string_t* fAuthor
+		public sk_string_t fAuthor;
+
+		// public sk_string_t* fSubject
+		public sk_string_t fSubject;
+
+		// public sk_string_t* fKeywords
+		public sk_string_t fKeywords;
+
+		// public sk_string_t* fCreator
+		public sk_string_t fCreator;
+
+		// public sk_string_t* fProducer
+		public sk_string_t fProducer;
+
+		// public sk_time_datetime_t* fCreation
+		public SKTimeDateTimeInternal* fCreation;
+
+		// public sk_time_datetime_t* fModified
+		public SKTimeDateTimeInternal* fModified;
+
+		// public float fRasterDPI
+		public Single fRasterDPI;
+
+		// public bool fPDFA
+		public Byte fPDFA;
+
+		// public int fEncodingQuality
+		public Int32 fEncodingQuality;
+
+		// public sk_pdf_compression_t fCompression
+		public SKPdfCompression fCompression;
+
+		// public sk_pdf_structure_element_t* fStructureElementTreeRoot
+		public SKPdfStructureElementInternal* fStructureElementTreeRoot;
+
+		public readonly bool Equals (SKPdfMetadataInternal obj) =>
+			fTitle == obj.fTitle && fAuthor == obj.fAuthor && fSubject == obj.fSubject && fKeywords == obj.fKeywords && fCreator == obj.fCreator && fProducer == obj.fProducer && fCreation == obj.fCreation && fModified == obj.fModified && fRasterDPI == obj.fRasterDPI && fPDFA == obj.fPDFA && fEncodingQuality == obj.fEncodingQuality && fCompression == obj.fCompression && fStructureElementTreeRoot == obj.fStructureElementTreeRoot;
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKPdfMetadataInternal f && Equals (f);
+
+		public static bool operator == (SKPdfMetadataInternal left, SKPdfMetadataInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPdfMetadataInternal left, SKPdfMetadataInternal right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fTitle);
+			hash.Add (fAuthor);
+			hash.Add (fSubject);
+			hash.Add (fKeywords);
+			hash.Add (fCreator);
+			hash.Add (fProducer);
+			hash.Add (fCreation);
+			hash.Add (fModified);
+			hash.Add (fRasterDPI);
+			hash.Add (fPDFA);
+			hash.Add (fEncodingQuality);
+			hash.Add (fCompression);
+			hash.Add (fStructureElementTreeRoot);
+			return hash.ToHashCode ();
+		}
+
+	}
+
+	// sk_pdf_structure_element_t
+	[StructLayout (LayoutKind.Sequential)]
+	internal unsafe partial struct SKPdfStructureElementInternal : IEquatable<SKPdfStructureElementInternal> {
+		// public sk_string_t* fTypeString
+		public sk_string_t fTypeString;
+
+		// public sk_pdf_structure_element_t* fChildren
+		public SKPdfStructureElementInternal* fChildren;
+
+		// public int fChildrenSize
+		public Int32 fChildrenSize;
+
+		// public int fNodeId
+		public Int32 fNodeId;
+
+		// public int* fAdditionalNodeIds
+		public Int32* fAdditionalNodeIds;
+
+		// public int fAdditionalNodeIdsSize
+		public Int32 fAdditionalNodeIdsSize;
+
+		// public sk_pdf_attribute_item_t* fAttributes
+		public SKPdfAttributeItemInternal* fAttributes;
+
+		// public int fAttributesSize
+		public Int32 fAttributesSize;
+
+		// public sk_string_t* fAlt
+		public sk_string_t fAlt;
+
+		// public sk_string_t* fLang
+		public sk_string_t fLang;
+
+		public readonly bool Equals (SKPdfStructureElementInternal obj) =>
+			fTypeString == obj.fTypeString && fChildren == obj.fChildren && fChildrenSize == obj.fChildrenSize && fNodeId == obj.fNodeId && fAdditionalNodeIds == obj.fAdditionalNodeIds && fAdditionalNodeIdsSize == obj.fAdditionalNodeIdsSize && fAttributes == obj.fAttributes && fAttributesSize == obj.fAttributesSize && fAlt == obj.fAlt && fLang == obj.fLang;
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKPdfStructureElementInternal f && Equals (f);
+
+		public static bool operator == (SKPdfStructureElementInternal left, SKPdfStructureElementInternal right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPdfStructureElementInternal left, SKPdfStructureElementInternal right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (fTypeString);
+			hash.Add (fChildren);
+			hash.Add (fChildrenSize);
+			hash.Add (fNodeId);
+			hash.Add (fAdditionalNodeIds);
+			hash.Add (fAdditionalNodeIdsSize);
+			hash.Add (fAttributes);
+			hash.Add (fAttributesSize);
+			hash.Add (fAlt);
+			hash.Add (fLang);
 			return hash.ToHashCode ();
 		}
 
@@ -15709,6 +15837,34 @@ namespace SkiaSharp {
 		Xor = 3,
 		// REVERSE_DIFFERENCE_SK_PATHOP = 4
 		ReverseDifference = 4,
+	}
+
+	// sk_pdf_attribute_item_type_t
+	internal enum SKPdfAttributeItemTypeInternal {
+		// INT_SK_PDF_ATTRIBUTE_ITEM_TYPE = 0
+		Int = 0,
+		// FLOAT_SK_PDF_ATTRIBUTE_ITEM_TYPE = 1
+		Float = 1,
+		// NAME_SK_PDF_ATTRIBUTE_ITEM_TYPE = 2
+		Name = 2,
+		// FLOAT_ARRAY_SK_PDF_ATTRIBUTE_ITEM_TYPE = 3
+		FloatArray = 3,
+		// NODE_ID_ARRAY_SK_PDF_ATTRIBUTE_ITEM_TYPE = 4
+		NodeIdArray = 4,
+	}
+
+	// sk_pdf_compression_t
+	public enum SKPdfCompression {
+		// DEFAULT_SK_PDF_COMPRESSION = -1
+		Default = -1,
+		// NONE_SK_PDF_COMPRESSION = 0
+		None = 0,
+		// LOW_SK_PDF_COMPRESSION = 1
+		Low = 1,
+		// AVERAGE_SK_PDF_COMPRESSION = 6
+		Average = 6,
+		// HIGH_SK_PDF_COMPRESSION = 9
+		High = 9,
 	}
 
 	// sk_pixelgeometry_t

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -3665,6 +3665,20 @@ namespace SkiaSharp
 
 		#region sk_document.h
 
+		// void sk_canvas_draw_pdf_node_id_annotation(sk_canvas_t* t, int nodeId)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_canvas_draw_pdf_node_id_annotation (sk_canvas_t t, Int32 nodeId);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_canvas_draw_pdf_node_id_annotation (sk_canvas_t t, Int32 nodeId);
+		}
+		private static Delegates.sk_canvas_draw_pdf_node_id_annotation sk_canvas_draw_pdf_node_id_annotation_delegate;
+		internal static void sk_canvas_draw_pdf_node_id_annotation (sk_canvas_t t, Int32 nodeId) =>
+			(sk_canvas_draw_pdf_node_id_annotation_delegate ??= GetSymbol<Delegates.sk_canvas_draw_pdf_node_id_annotation> ("sk_canvas_draw_pdf_node_id_annotation")).Invoke (t, nodeId);
+		#endif
+
 		// void sk_document_abort(sk_document_t* document)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]

--- a/binding/SkiaSharp/Util.cs
+++ b/binding/SkiaSharp/Util.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 #if NETSTANDARD1_3 || WINDOWS_UWP
@@ -60,6 +61,16 @@ namespace SkiaSharp
 			}
 		}
 
+#if NET45_OR_GREATER || NETSTANDARD2_0
+		public static int GetBytes (this Encoding encoding, ReadOnlySpan<char> text, Span<byte> bytes)
+		{
+			fixed (char* t = text)
+			fixed (byte* b = bytes) {
+				return encoding.GetBytes (t, text.Length, b, bytes.Length);
+			}
+		}
+#endif
+
 		public static RentedArray<T> RentArray<T> (int length, bool nullIfEmpty = false) =>
 			nullIfEmpty && length <= 0
 				? default
@@ -77,8 +88,8 @@ namespace SkiaSharp
 		public static RentedArray<T> ToRentedArray<T> (IList<T> list)
 		{
 			var rented = new RentedArray<T> (list.Count);
-			for	(var idx = 0; idx < list.Count; idx++) {
-				rented [idx] = list [idx];
+			for (var idx = 0; idx < list.Count; idx++) {
+				rented[idx] = list[idx];
 			}
 			return rented;
 		}

--- a/binding/SkiaSharp/Util.cs
+++ b/binding/SkiaSharp/Util.cs
@@ -74,6 +74,15 @@ namespace SkiaSharp
 			return handles;
 		}
 
+		public static RentedArray<T> ToRentedArray<T> (IList<T> list)
+		{
+			var rented = new RentedArray<T> (list.Count);
+			for	(var idx = 0; idx < list.Count; idx++) {
+				rented [idx] = list [idx];
+			}
+			return rented;
+		}
+
 		internal readonly ref struct RentedArray<T>
 		{
 			internal RentedArray (int length)
@@ -174,6 +183,24 @@ namespace SkiaSharp
 				SKTextEncoding.Utf8 => Encoding.UTF8.GetBytes (text),
 				SKTextEncoding.Utf16 => Encoding.Unicode.GetBytes (text),
 				SKTextEncoding.Utf32 => Encoding.UTF32.GetBytes (text),
+				_ => throw new ArgumentOutOfRangeException (nameof (encoding), $"Encoding {encoding} is not supported."),
+			};
+
+		public static int GetEncodedText (ReadOnlySpan<char> text, Span<byte> bytes, SKTextEncoding encoding) =>
+			encoding switch {
+				SKTextEncoding.Utf8 => Encoding.UTF8.GetBytes (text, bytes),
+				SKTextEncoding.Utf16 => Encoding.Unicode.GetBytes (text, bytes),
+				SKTextEncoding.Utf32 => Encoding.UTF32.GetBytes (text, bytes),
+				_ => throw new ArgumentOutOfRangeException (nameof (encoding), $"Encoding {encoding} is not supported."),
+			};
+
+		// GetMaxByteCount
+
+		public static int GetMaxByteCount (ReadOnlySpan<char> text, SKTextEncoding encoding) =>
+			encoding switch {
+				SKTextEncoding.Utf8 => Encoding.UTF8.GetMaxByteCount (text.Length),
+				SKTextEncoding.Utf16 => Encoding.Unicode.GetMaxByteCount (text.Length),
+				SKTextEncoding.Utf32 => Encoding.UTF32.GetMaxByteCount (text.Length),
 				_ => throw new ArgumentOutOfRangeException (nameof (encoding), $"Encoding {encoding} is not supported."),
 			};
 

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -373,8 +373,20 @@
         "cs": "SKCodecOptionsInternal",
         "internal": true
       },
-      "sk_document_pdf_metadata_t": {
-        "cs": "SKDocumentPdfMetadataInternal",
+      "sk_pdf_metadata_t": {
+        "cs": "SKPdfMetadataInternal",
+        "internal": true
+      },
+      "sk_pdf_attribute_item_type_t": {
+        "cs": "SKPdfAttributeItemTypeInternal",
+        "internal": true
+      },
+      "sk_pdf_attribute_item_t": {
+        "cs": "SKPdfAttributeItemInternal",
+        "internal": true
+      },
+      "sk_pdf_structure_element_t": {
+        "cs": "SKPdfStructureElementInternal",
         "internal": true
       },
       "sk_lattice_t": {

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -491,6 +491,37 @@
         "parameters": {
           "1": "[MarshalAs (UnmanagedType.LPStr)] String"
         }
+      },
+      "sk_pdf_structure_element_add_int_attribute": {
+        "parameters": {
+          "1": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "2": "[MarshalAs (UnmanagedType.LPStr)] String"
+        }
+      },
+      "sk_pdf_structure_element_add_float_attribute": {
+        "parameters": {
+          "1": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "2": "[MarshalAs (UnmanagedType.LPStr)] String"
+        }
+      },
+      "sk_pdf_structure_element_add_name_attribute": {
+        "parameters": {
+          "1": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "2": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "3": "[MarshalAs (UnmanagedType.LPStr)] String"
+        }
+      },
+      "sk_pdf_structure_element_add_node_id_array_attribute": {
+        "parameters": {
+          "1": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "2": "[MarshalAs (UnmanagedType.LPStr)] String"
+        }
+      },
+      "sk_pdf_structure_element_add_float_array_attribute": {
+        "parameters": {
+          "1": "[MarshalAs (UnmanagedType.LPStr)] String",
+          "2": "[MarshalAs (UnmanagedType.LPStr)] String"
+        }
       }
     }
   }

--- a/tests/Tests/SkiaSharp/SKDocumentTest.cs
+++ b/tests/Tests/SkiaSharp/SKDocumentTest.cs
@@ -242,21 +242,62 @@ namespace SkiaSharp.Tests
 				font.Size = 20;
 
 				// The node ID should cover both the text and the annotation.
-				SkPDF::SetNodeId(canvas, 2);
-				canvas->drawString("Click to visit Google.com", 72, 72, font, paint);
-				SkRect linkRect = SkRect::MakeXYWH(
-					SkIntToScalar(72), SkIntToScalar(54),
-					SkIntToScalar(218), SkIntToScalar(24));
-				sk_sp<SkData> url(SkData::MakeWithCString("http://www.google.com"));
-				SkAnnotateRectWithURL(canvas, linkRect, url.get());
+				canvas.SetPdfNodeId(2);
+				canvasDrawText("Click to visit Google.com", 72, 72, font, paint);
+				var linkRect = SKRect.Create(72, 54, 218, 24);
+				canvas.DrawUrlAnnotation(linkRect, "http://www.google.com");
 
-				document->endPage();
-				document->close();
-				outputStream.flush();
+				document.EndPage();
+				document.Close();
+            }
 
+            Assert.True(stream.Length > 0);
+            Assert.True(stream.Position > 0);
+        }
 
-                doc.EndPage();
-                doc.Close();
+		[SkippableFact]
+		public void CanCreateTaggedPdfWithConstructorStructures()
+		{
+            var metadata = new SKPdfMetadata
+            {
+                Title = "Example Tagged PDF With Links",
+                Creator = "Skia",
+                Creation = DateTime.Now,
+                Modified = DateTime.Now,
+            	// The document tag.
+				Structure = new SKPdfStructureElement(1, "Document")
+				{
+					Language = "en-US",
+					Children =
+					{
+						// A link.
+						new SKPdfStructureElement(2, "Link")
+					}
+				}
+            };
+
+            using var stream = new MemoryStream();
+            using (var doc = SKDocument.CreatePdf(stream, metadata))
+            {
+                Assert.NotNull(doc);
+
+				var canvas = doc.BeginPage(612, 792);  // U.S. Letter
+                Assert.NotNull(canvas);
+
+				var paint = new SKPaint();
+				paint.Color = SKColors.Blue;
+
+				var font = new SKFont();
+				font.Size = 20;
+
+				// The node ID should cover both the text and the annotation.
+				canvas.SetPdfNodeId(2);
+				canvasDrawText("Click to visit Google.com", 72, 72, font, paint);
+				var linkRect = SKRect.Create(72, 54, 218, 24);
+				canvas.DrawUrlAnnotation(linkRect, "http://www.google.com");
+
+				document.EndPage();
+				document.Close();
             }
 
             Assert.True(stream.Length > 0);

--- a/tests/Tests/SkiaSharp/SKDocumentTest.cs
+++ b/tests/Tests/SkiaSharp/SKDocumentTest.cs
@@ -215,13 +215,13 @@ namespace SkiaSharp.Tests
 
 			// The document tag.
 			var root = new SKPdfStructureElement();
-			root.NodeId = 1;
+			root.Id = 1;
 			root.Type = "Document";
 			root.Language = "en-US";
 
 			// A link.
 			var l1 = new SKPdfStructureElement();
-			l1.NodeId = 2;
+			l1.Id = 2;
 			l1.Type = "Link";
 			root.Children.Add(l1);
 

--- a/tests/Tests/SkiaSharp/SKDocumentTest.cs
+++ b/tests/Tests/SkiaSharp/SKDocumentTest.cs
@@ -237,6 +237,48 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void MetadataIsAddedToFile()
+		{
+			var now = DateTime.Now;
+			var metadata = new SKPdfMetadata
+			{
+				Title = "A1",
+				Author = "A2",
+				Subject = "A3",
+				Keywords = "A4",
+				Creator = "A5",
+				Creation = now,
+				Modified = now,
+			};
+
+			using var pdf = new MemoryStream();
+			using (var doc = SKDocument.CreatePdf(pdf, metadata))
+			{
+				doc.BeginPage(612.0f, 792.0f);
+				doc.Close();
+			}
+
+			pdf.Position = 0;
+			using var reader = new StreamReader(pdf);
+			var data = reader.ReadToEnd();
+
+			var expectations = new string[] {
+				"/Title (A1)",
+				"/Author (A2)",
+				"/Subject (A3)",
+				"/Keywords (A4)",
+				"/Creator (A5)",
+				"/Producer (Skia/PDF ",
+				"/CreationDate (D:",
+				"/ModDate (D:"
+			};
+			foreach (var expectation in expectations)
+			{
+				Assert.Contains(expectation, data);
+			}
+		}
+
+		[SkippableFact]
 		public void CanCreateTaggedLinkPdf()
 		{
 			var metadata = new SKPdfMetadata();
@@ -281,9 +323,6 @@ namespace SkiaSharp.Tests
 
 			Assert.True(stream.Length > 0);
 			Assert.True(stream.Position > 0);
-
-			stream.Position = 0;
-			SaveStream(stream, "test.pdf");
 		}
 
 		[SkippableFact]

--- a/tests/Tests/SkiaSharp/SKTest.cs
+++ b/tests/Tests/SkiaSharp/SKTest.cs
@@ -55,6 +55,8 @@ namespace SkiaSharp.Tests
 
 		protected static void SaveStream(Stream stream, string filename)
 		{
+			stream.Position = 0;
+
 			using var file = File.Create(Path.Combine(PathToImages, filename));
 			stream.CopyTo(file);
 		}

--- a/tests/Tests/SkiaSharp/SKTest.cs
+++ b/tests/Tests/SkiaSharp/SKTest.cs
@@ -53,6 +53,12 @@ namespace SkiaSharp.Tests
 			return new SKMemoryStream(bytes);
 		}
 
+		protected static void SaveStream(Stream stream, string filename)
+		{
+			using var file = File.Create(Path.Combine(PathToImages, filename));
+			stream.CopyTo(file);
+		}
+
 		protected static void SaveSurface(SKSurface surface, string filename = "output.png")
 		{
 			using var image = surface.Snapshot();


### PR DESCRIPTION
**Description of Change**

This PR is a WIP for adding better support for the PDF metadata. The new features are structure elements and other tags.

**Bugs Fixed**

- Fixes #2046

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
