### PR TITLE
Remove usage of `gsutil`

### DIFF
--- a/native/winui/ANGLE.cake
+++ b/native/winui/ANGLE.cake
@@ -49,17 +49,13 @@ void InitializeAngle(string branch, DirectoryPath ANGLE_PATH, DirectoryPath WINA
         RunPython(ANGLE_PATH, ANGLE_PATH.CombineWithFilePath("build/util/lastchange.py"), $"-o {lastchange}");
     }
 
-    if (!FileExists(ANGLE_PATH.CombineWithFilePath("build/toolchain/win/rc/win/rc.exe"))) {
-        var oldPath = EnvironmentVariable("PATH");
-        try {
-            System.Environment.SetEnvironmentVariable("PATH", DEPOT_PATH.FullPath + System.IO.Path.PathSeparator + oldPath);
-
-            RunPython(ANGLE_PATH,
-                DEPOT_PATH.CombineWithFilePath("download_from_google_storage.py"),
-                $"--no_resume --no_auth --bucket chromium-browser-clang/rc -s build/toolchain/win/rc/win/rc.exe.sha1");
-        } finally {
-            System.Environment.SetEnvironmentVariable("PATH", oldPath);
-        }
+    var rc_exe = "build/toolchain/win/rc/win/rc.exe";
+    var rcPath = ANGLE_PATH.CombineWithFilePath(rc_exe);
+    if (!FileExists(rcPath)) {
+        var shaPath = ANGLE_PATH.CombineWithFilePath($"{rc_exe}.sha1");
+        var sha = System.IO.File.ReadAllText(shaPath.FullPath);
+        var url = $"https://storage.googleapis.com/download/storage/v1/b/chromium-browser-clang/o/rc%2F{sha}?alt=media";
+        DownloadFile(url, rcPath);
     }
 
     if (!FileExists(ANGLE_PATH.CombineWithFilePath("third_party/llvm-build/Release+Asserts/cr_build_revision"))) {

--- a/scripts/cake/shared.cake
+++ b/scripts/cake/shared.cake
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 var TARGET = Argument("t", Argument("target", "Default"));
-var VERBOSITY = Argument("v", Argument("verbosity", Verbosity.Normal));
+var VERBOSITY = Context.Log.Verbosity;
 var CONFIGURATION = Argument("c", Argument("configuration", "Release"));
 
 var VS_INSTALL = Argument("vsinstall", EnvironmentVariable("VS_INSTALL"));
@@ -28,6 +28,7 @@ void RunCake(FilePath cake, string target = null, Dictionary<string, string> arg
     var args = Arguments().ToDictionary(a => a.Key, a => a.Value.LastOrDefault());
 
     args["target"] = target;
+    args["verbosity"] = VERBOSITY.ToString();
 
     if (arguments != null) {
         foreach (var arg in arguments) {


### PR DESCRIPTION
**Description of Change**

The tool brings in dependencies which we don't want, so just use the URI directly to get the file. Specifically https://github.com/GoogleCloudPlatform/gsutil/issues/1478

According to Google, none of the risky dependencies are used and should be dropped, but to satisfy the machines we can just skip the entire process and download the file ourselves.
