### PR TITLE
Add more SKPicture APIs

### DIFF
--- a/binding/SkiaSharp/SKDrawable.cs
+++ b/binding/SkiaSharp/SKDrawable.cs
@@ -65,6 +65,9 @@ namespace SkiaSharp
 			}
 		}
 
+		public int ApproximateBytesUsed =>
+			SkiaApi.sk_drawable_approximate_bytes_used (Handle);
+
 		public void Draw (SKCanvas canvas, in SKMatrix matrix)
 		{
 			fixed (SKMatrix* m = &matrix)

--- a/binding/SkiaSharp/SKDrawable.cs
+++ b/binding/SkiaSharp/SKDrawable.cs
@@ -66,7 +66,7 @@ namespace SkiaSharp
 		}
 
 		public int ApproximateBytesUsed =>
-			SkiaApi.sk_drawable_approximate_bytes_used (Handle);
+			(int)SkiaApi.sk_drawable_approximate_bytes_used (Handle);
 
 		public void Draw (SKCanvas canvas, in SKMatrix matrix)
 		{

--- a/binding/SkiaSharp/SKPicture.cs
+++ b/binding/SkiaSharp/SKPicture.cs
@@ -27,7 +27,7 @@ namespace SkiaSharp
 		}
 
 		public int ApproximateBytesUsed =>
-			SkiaApi.sk_picture_approximate_bytes_used (Handle);
+			(int)SkiaApi.sk_picture_approximate_bytes_used (Handle);
 
 		public int ApproximateOperationCount =>
 			GetApproximateOperationCount (false);

--- a/binding/SkiaSharp/SKPicture.cs
+++ b/binding/SkiaSharp/SKPicture.cs
@@ -26,6 +26,15 @@ namespace SkiaSharp
 			}
 		}
 
+		public int ApproximateBytesUsed =>
+			SkiaApi.sk_picture_approximate_bytes_used (Handle);
+
+		public int ApproximateOperationCount =>
+			GetApproximateOperationCount (false);
+
+		public int GetApproximateOperationCount(bool includeNested) =>
+			SkiaApi.sk_picture_approximate_op_count (Handle, includeNested);
+
 		// Serialize
 
 		public SKData Serialize () =>
@@ -46,6 +55,16 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (stream));
 
 			SkiaApi.sk_picture_serialize_to_stream (Handle, stream.Handle);
+		}
+
+		// Playback
+
+		public void Playback (SKCanvas canvas)
+		{
+			if (canvas is null)
+				throw new ArgumentNullException (nameof (canvas));
+
+			SkiaApi.sk_picture_playback (Handle, canvas.Handle);
 		}
 
 		// ToShader

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -3751,6 +3751,20 @@ namespace SkiaSharp
 
 		#region sk_drawable.h
 
+		// size_t sk_drawable_approximate_bytes_used(const sk_drawable_t* drawable)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_drawable_approximate_bytes_used (sk_drawable_t drawable);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate /* size_t */ IntPtr sk_drawable_approximate_bytes_used (sk_drawable_t drawable);
+		}
+		private static Delegates.sk_drawable_approximate_bytes_used sk_drawable_approximate_bytes_used_delegate;
+		internal static /* size_t */ IntPtr sk_drawable_approximate_bytes_used (sk_drawable_t drawable) =>
+			(sk_drawable_approximate_bytes_used_delegate ??= GetSymbol<Delegates.sk_drawable_approximate_bytes_used> ("sk_drawable_approximate_bytes_used")).Invoke (drawable);
+		#endif
+
 		// void sk_drawable_draw(sk_drawable_t*, sk_canvas_t*, const sk_matrix_t*)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -7937,6 +7951,34 @@ namespace SkiaSharp
 
 		#region sk_picture.h
 
+		// size_t sk_picture_approximate_bytes_used(const sk_picture_t* picture)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_picture_approximate_bytes_used (sk_picture_t picture);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate /* size_t */ IntPtr sk_picture_approximate_bytes_used (sk_picture_t picture);
+		}
+		private static Delegates.sk_picture_approximate_bytes_used sk_picture_approximate_bytes_used_delegate;
+		internal static /* size_t */ IntPtr sk_picture_approximate_bytes_used (sk_picture_t picture) =>
+			(sk_picture_approximate_bytes_used_delegate ??= GetSymbol<Delegates.sk_picture_approximate_bytes_used> ("sk_picture_approximate_bytes_used")).Invoke (picture);
+		#endif
+
+		// int sk_picture_approximate_op_count(const sk_picture_t* picture, bool nested)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_picture_approximate_op_count (sk_picture_t picture, [MarshalAs (UnmanagedType.I1)] bool nested);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int32 sk_picture_approximate_op_count (sk_picture_t picture, [MarshalAs (UnmanagedType.I1)] bool nested);
+		}
+		private static Delegates.sk_picture_approximate_op_count sk_picture_approximate_op_count_delegate;
+		internal static Int32 sk_picture_approximate_op_count (sk_picture_t picture, [MarshalAs (UnmanagedType.I1)] bool nested) =>
+			(sk_picture_approximate_op_count_delegate ??= GetSymbol<Delegates.sk_picture_approximate_op_count> ("sk_picture_approximate_op_count")).Invoke (picture, nested);
+		#endif
+
 		// sk_picture_t* sk_picture_deserialize_from_data(sk_data_t* data)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -8033,6 +8075,20 @@ namespace SkiaSharp
 		private static Delegates.sk_picture_make_shader sk_picture_make_shader_delegate;
 		internal static sk_shader_t sk_picture_make_shader (sk_picture_t src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKFilterMode mode, SKMatrix* localMatrix, SKRect* tile) =>
 			(sk_picture_make_shader_delegate ??= GetSymbol<Delegates.sk_picture_make_shader> ("sk_picture_make_shader")).Invoke (src, tmx, tmy, mode, localMatrix, tile);
+		#endif
+
+		// void sk_picture_playback(const sk_picture_t* picture, sk_canvas_t* canvas)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_picture_playback (sk_picture_t picture, sk_canvas_t canvas);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_picture_playback (sk_picture_t picture, sk_canvas_t canvas);
+		}
+		private static Delegates.sk_picture_playback sk_picture_playback_delegate;
+		internal static void sk_picture_playback (sk_picture_t picture, sk_canvas_t canvas) =>
+			(sk_picture_playback_delegate ??= GetSymbol<Delegates.sk_picture_playback> ("sk_picture_playback")).Invoke (picture, canvas);
 		#endif
 
 		// sk_canvas_t* sk_picture_recorder_begin_recording(sk_picture_recorder_t*, const sk_rect_t*)

--- a/tests/Tests/SkiaSharp/SKDrawableTest.cs
+++ b/tests/Tests/SkiaSharp/SKDrawableTest.cs
@@ -22,6 +22,16 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[SkippableFact]
+		public void CanAccessApproxBytes()
+		{
+			using (var drawable = new TestDrawable())
+			{
+				Assert.Equal(123, drawable.ApproximateBytesUsed);
+				Assert.Equal(1, drawable.ApproxBytesCount);
+			}
+		}
+
 		[Trait(Traits.FailingOn.Key, Traits.FailingOn.Values.macOS)] // Something with sk_sp<SkPicture> SkDrawable::onMakePictureSnapshot() is causing issues
 		[Trait(Traits.FailingOn.Key, Traits.FailingOn.Values.iOS)] // Something with sk_sp<SkPicture> SkDrawable::onMakePictureSnapshot() is causing issues
 		[Trait(Traits.FailingOn.Key, Traits.FailingOn.Values.MacCatalyst)] // Something with sk_sp<SkPicture> SkDrawable::onMakePictureSnapshot() is causing issues
@@ -95,6 +105,7 @@ namespace SkiaSharp.Tests
 		public int DrawFireCount;
 		public int BoundsFireCount;
 		public int SnapshotFireCount;
+		public int ApproxBytesCount;
 
 		protected override void OnDraw(SKCanvas canvas)
 		{
@@ -115,6 +126,13 @@ namespace SkiaSharp.Tests
 			SnapshotFireCount++;
 
 			return base.OnSnapshot();
+		}
+
+		protected override int OnGetApproximateBytesUsed ()
+		{
+			ApproxBytesCount++;
+
+			return 123;
 		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPictureTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureTest.cs
@@ -67,5 +67,47 @@ namespace SkiaSharp.Tests
 
 			ValidateTestBitmap(bmp);
 		}
+
+		[SkippableFact]
+		public void CanPlayback()
+		{
+			using var picture = CreateTestPicture();
+
+			using var bmp = new SKBitmap(40, 40);
+			using var cnv = new SKCanvas(bmp);
+
+			picture.Playback(cnv);
+
+			ValidateTestBitmap(bmp);
+		}
+
+		[SkippableFact]
+		public void CanDrawPicture()
+		{
+			using var picture = CreateTestPicture();
+
+			using var bmp = new SKBitmap(40, 40);
+			using var cnv = new SKCanvas(bmp);
+
+			cnv.DrawPicture(picture);
+
+			ValidateTestBitmap(bmp);
+		}
+
+		[SkippableFact]
+		public void CanGetApproximateOperationCount()
+		{
+			using var picture = CreateTestPicture();
+
+			Assert.Equal(5, picture.ApproximateOperationCount);
+		}
+
+		[SkippableFact]
+		public void CanGetApproximateBytesUsed()
+		{
+			using var picture = CreateTestPicture();
+
+			Assert.Equal(648, picture.ApproximateBytesUsed);
+		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Adding a few new APIs to help with determining picture and drawable "size" as well as adding the `Playback` method to `SKPicture`.

The playback method is different to draw in that draw results in a single "draw the picture" command, but playback effectively replicates what was done to create the picture. There is a small different to the latter in that the picture may optimize/combine commands as well as split commands to best fit into the picture's storage.

**Bugs Fixed**

- Fixes #2881

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

```cs
class SKDrawable {
   public int ApproximateBytesUsed { get; }
}

class SKPicture {
  public int ApproximateBytesUsed { get; }
  public int ApproximateOperationCount { get; }
  public int GetApproximateOperationCount(bool includeNested);
  public void Playback(SKCanvas canvas);
}
```
**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

https://github.com/mono/skia/pull/127

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
