### PR TITLE
Add R-Tree overload of beginRecording

### DIFF
--- a/binding/SkiaSharp/SKPictureRecorder.cs
+++ b/binding/SkiaSharp/SKPictureRecorder.cs
@@ -30,6 +30,25 @@ namespace SkiaSharp
 			return OwnedBy (SKCanvas.GetObject (SkiaApi.sk_picture_recorder_begin_recording (Handle, &cullRect), false), this);
 		}
 
+		public SKCanvas BeginRecording (SKRect cullRect, bool useRTree)
+		{
+			// no R-Tree is being used, so use the default path
+			if (!useRTree) {
+				return BeginRecording (cullRect);
+			}
+
+			// an R-Tree was requested, so create the R-Tree BBH factory
+			var rtreeHandle = IntPtr.Zero;
+			try {
+				rtreeHandle = SkiaApi.sk_rtree_factory_new ();
+				return OwnedBy (SKCanvas.GetObject (SkiaApi.sk_picture_recorder_begin_recording_with_bbh_factory (Handle, &cullRect, rtreeHandle), false), this);
+			} finally {
+				if (rtreeHandle != IntPtr.Zero) {
+					SkiaApi.sk_rtree_factory_delete (rtreeHandle);
+				}
+			}
+		}
+
 		public SKPicture EndRecording ()
 		{
 			return SKPicture.GetObject (SkiaApi.sk_picture_recorder_end_recording (Handle));

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -16,6 +16,7 @@ using gr_recording_context_t = System.IntPtr;
 using gr_vk_extensions_t = System.IntPtr;
 using gr_vk_memory_allocator_t = System.IntPtr;
 using gr_vkinterface_t = System.IntPtr;
+using sk_bbh_factory_t = System.IntPtr;
 using sk_bitmap_t = System.IntPtr;
 using sk_blender_t = System.IntPtr;
 using sk_canvas_t = System.IntPtr;
@@ -58,6 +59,7 @@ using sk_region_iterator_t = System.IntPtr;
 using sk_region_spanerator_t = System.IntPtr;
 using sk_region_t = System.IntPtr;
 using sk_rrect_t = System.IntPtr;
+using sk_rtree_factory_t = System.IntPtr;
 using sk_runtimeeffect_t = System.IntPtr;
 using sk_shader_t = System.IntPtr;
 using sk_stream_asset_t = System.IntPtr;
@@ -8119,6 +8121,20 @@ namespace SkiaSharp
 			(sk_picture_recorder_begin_recording_delegate ??= GetSymbol<Delegates.sk_picture_recorder_begin_recording> ("sk_picture_recorder_begin_recording")).Invoke (param0, param1);
 		#endif
 
+		// sk_canvas_t* sk_picture_recorder_begin_recording_with_bbh_factory(sk_picture_recorder_t*, const sk_rect_t*, sk_bbh_factory_t*)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_canvas_t sk_picture_recorder_begin_recording_with_bbh_factory (sk_picture_recorder_t param0, SKRect* param1, sk_bbh_factory_t param2);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_canvas_t sk_picture_recorder_begin_recording_with_bbh_factory (sk_picture_recorder_t param0, SKRect* param1, sk_bbh_factory_t param2);
+		}
+		private static Delegates.sk_picture_recorder_begin_recording_with_bbh_factory sk_picture_recorder_begin_recording_with_bbh_factory_delegate;
+		internal static sk_canvas_t sk_picture_recorder_begin_recording_with_bbh_factory (sk_picture_recorder_t param0, SKRect* param1, sk_bbh_factory_t param2) =>
+			(sk_picture_recorder_begin_recording_with_bbh_factory_delegate ??= GetSymbol<Delegates.sk_picture_recorder_begin_recording_with_bbh_factory> ("sk_picture_recorder_begin_recording_with_bbh_factory")).Invoke (param0, param1, param2);
+		#endif
+
 		// void sk_picture_recorder_delete(sk_picture_recorder_t*)
 		#if !USE_DELEGATES
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
@@ -8229,6 +8245,34 @@ namespace SkiaSharp
 		private static Delegates.sk_picture_unref sk_picture_unref_delegate;
 		internal static void sk_picture_unref (sk_picture_t param0) =>
 			(sk_picture_unref_delegate ??= GetSymbol<Delegates.sk_picture_unref> ("sk_picture_unref")).Invoke (param0);
+		#endif
+
+		// void sk_rtree_factory_delete(sk_rtree_factory_t*)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_rtree_factory_delete (sk_rtree_factory_t param0);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_rtree_factory_delete (sk_rtree_factory_t param0);
+		}
+		private static Delegates.sk_rtree_factory_delete sk_rtree_factory_delete_delegate;
+		internal static void sk_rtree_factory_delete (sk_rtree_factory_t param0) =>
+			(sk_rtree_factory_delete_delegate ??= GetSymbol<Delegates.sk_rtree_factory_delete> ("sk_rtree_factory_delete")).Invoke (param0);
+		#endif
+
+		// sk_rtree_factory_t* sk_rtree_factory_new()
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_rtree_factory_t sk_rtree_factory_new ();
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_rtree_factory_t sk_rtree_factory_new ();
+		}
+		private static Delegates.sk_rtree_factory_new sk_rtree_factory_new_delegate;
+		internal static sk_rtree_factory_t sk_rtree_factory_new () =>
+			(sk_rtree_factory_new_delegate ??= GetSymbol<Delegates.sk_rtree_factory_new> ("sk_rtree_factory_new")).Invoke ();
 		#endif
 
 		#endregion

--- a/tests/Tests/SkiaSharp/SKPictureRecorderTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureRecorderTest.cs
@@ -66,23 +66,20 @@ namespace SkiaSharp.Tests
 			Assert.Equal(cullRect, drawable.Bounds);
 		}
 
-		[InlineData(false, 5)]
-		[InlineData(true, 4)]
+		[InlineData(false, 0, 0, 100, 100)]
+		[InlineData(true, 20, 20, 60, 60)]
 		[SkippableTheory]
-		public void XXX(bool useRTree, int expectedCount)
+		public void UsingRTreeClipsOperations(bool useRTree, int x, int y, int w, int h)
 		{
 			using var recorder = new SKPictureRecorder();
 			var canvas = recorder.BeginRecording(SKRect.Create(100, 100), useRTree);
 
-			canvas.Save();
-			canvas.ClipRect(SKRect.Create(50, 50, 50, 50));
-			canvas.DrawRect(60, 60, 20, 20, new()); // inside clip
-			canvas.DrawRect(20, 20, 20, 20, new()); // outside clip
-			canvas.Restore();
+			canvas.DrawRect(60, 60, 20, 20, new());
+			canvas.DrawRect(20, 20, 20, 20, new());
 			
 			using var picture = recorder.EndRecording();
 
-			Assert.Equal(expectedCount, picture.ApproximateOperationCount);
+			Assert.Equal(SKRect.Create(x, y, w, h), picture.CullRect);
 		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

Add the R-Tree overload of `SKPicture.BeginRecording`. 

The R-Tree factory type (`SkRTreeFactory`) or any other `SkBBHFactory` types are not exposed since it is fairly complicated and not many use cases. It can be added later. For now, we just have a boolean flag indicating whether to use it or not.

**Bugs Fixed**

- Fixes https://github.com/mono/SkiaSharp/issues/2372

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

```cs
class SKPicture {
    public SKCanvas BeginRecording (SKRect cullRect, bool useRTree);
}
```

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

https://github.com/mono/skia/pull/129

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
