### PR TITLE
Fix SKPaint.Clone

### DIFF
--- a/binding/SkiaSharp/SKPaint.cs
+++ b/binding/SkiaSharp/SKPaint.cs
@@ -277,7 +277,7 @@ namespace SkiaSharp
 		// Clone
 
 		public SKPaint Clone () =>
-			GetObject (SkiaApi.sk_paint_clone (Handle))!;
+			GetObject (SkiaApi.sk_compatpaint_clone (Handle))!;
 
 		// MeasureText
 

--- a/tests/Tests/SkiaSharp/SKPaintTest.cs
+++ b/tests/Tests/SkiaSharp/SKPaintTest.cs
@@ -720,5 +720,13 @@ namespace SkiaSharp.Tests
 
 			Assert.Same(typeface, paint.Typeface);
 		}
+
+		[SkippableFact]
+		public void Clone()
+		{
+			using var paint = new SKPaint();
+			using var clonedPaint = paint.Clone();
+			using var clonedPaint2 = paint.Clone();
+		}
 	}
 }


### PR DESCRIPTION
Clone should operate on SkCompatPaint

**Description of Change**

Fix crash on dispose of a cloned SKPaint

**Bugs Fixed**

- Fixes #2899

**API Changes**

None.

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
