### PR TITLE
Fix SKXamlCanvas on Uno Skia to use Bgra8888

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Skia/SKXamlCanvas.Skia.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Skia/SKXamlCanvas.Skia.cs
@@ -81,7 +81,7 @@ namespace SkiaSharp.Views.UWP
 		private SKImageInfo CreateBitmap(out SKSizeI unscaledSize, out float dpi)
 		{
 			var size = CreateSize(out unscaledSize, out dpi);
-			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.Bgra8888, SKAlphaType.Premul);
+			var info = new SKImageInfo(size.Width, size.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
 
 			if (bitmap?.PixelWidth != info.Width || bitmap?.PixelHeight != info.Height)
 				FreeBitmap();

--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Skia/SKXamlCanvas.Skia.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Skia/SKXamlCanvas.Skia.cs
@@ -81,7 +81,7 @@ namespace SkiaSharp.Views.UWP
 		private SKImageInfo CreateBitmap(out SKSizeI unscaledSize, out float dpi)
 		{
 			var size = CreateSize(out unscaledSize, out dpi);
-			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+			var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.Bgra8888, SKAlphaType.Premul);
 
 			if (bitmap?.PixelWidth != info.Width || bitmap?.PixelHeight != info.Height)
 				FreeBitmap();


### PR DESCRIPTION
**Description of Change**

<!-- Describe your changes here. -->
Use Bgra8888 instead of PlatformColorType

**Bugs Fixed**

When not running on Windows where PlatformColorType may not be Bgra8888, rendering will be incorrect. In Uno, both WriteableBitmap and SkiaCompositionSurface deal explicitly with Bgra8888, so the format used in SKXamlCanvas has to match.

https://github.com/unoplatform/uno/blob/1d1f8c9f1f87fbb7e1af9d884049cef06cb46680/src/Uno.UI.Composition/Composition/SkiaCompositionSurface.skia.cs#L64

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
