### PR TITLE
[release/2.x] Do not stretch the background

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.UWP/SKXamlCanvas.cs
@@ -233,7 +233,7 @@ namespace SkiaSharp.Views.UWP
 					ImageSource = bitmap,
 					AlignmentX = AlignmentX.Left,
 					AlignmentY = AlignmentY.Top,
-					Stretch = Stretch.Fill
+					Stretch = Stretch.None
 				};
 				Background = brush;
 			}


### PR DESCRIPTION


**Description of Change**

When resizing a view, the background will be stretched making the image distorted and not a great experience.

This PR make sure to never scale the background brush and rather keep it top-left aligned.

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
