### PR TITLE
Do not stretch the background

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/SKXamlCanvas.cs
@@ -233,7 +233,7 @@ namespace SkiaSharp.Views.UWP
 					ImageSource = bitmap,
 					AlignmentX = AlignmentX.Left,
 					AlignmentY = AlignmentY.Top,
-					Stretch = Stretch.None
+					Stretch = Stretch.Fill
 				};
 				Background = brush;
 			}

--- a/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/SKXamlCanvas.cs
@@ -233,7 +233,7 @@ namespace SkiaSharp.Views.UWP
 					ImageSource = bitmap,
 					AlignmentX = AlignmentX.Left,
 					AlignmentY = AlignmentY.Top,
-					Stretch = Stretch.Fill
+					Stretch = Stretch.None
 				};
 				Background = brush;
 			}


### PR DESCRIPTION
**Description of Change**

When a view is resized, the canvas is not yet resized and updated to match. Before this PR, the canvas would be stretched to fill the view. This PR make sure to not stretch the canvas but instead keep it fixed.

The reason for the scaling in the first place is that `WriteableBitmap` does not have a DPI parameter. As a result, we have to create a larger bitmap than the view such that when it is scaled down to match the view size, the resolution matches that of the rest of the app. Previously, the larger canvas was just squashed to fit, but this was non-uniform. This PR always scales the canvas to the correct size preserving the aspect ratio.

**Bugs Fixed**

- None.

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
