### PR TITLE
Update Tizen Studio

### DIFF
--- a/scripts/install-tizen.ps1
+++ b/scripts/install-tizen.ps1
@@ -3,7 +3,7 @@
 #  - https://developercommunity.visualstudio.com/content/problem/661596/the-updated-path-doesnt-kick-in.html
 
 Param(
-    [string] $Version = "5.1",
+    [string] $Version = "5.6",
     [string] $InstallDestination = $null,
     [boolean] $UpgradeLLVM = $true
 )


### PR DESCRIPTION
**Description of Change**

Tizen Studio is failing almost all the time on Linux:

```
Install destination is '/home/cloudtest/tizen-studio'...
Downloading SDK to '/home/cloudtest/tizen-temp/tizen-install.bin'...
Validating Java install...
JAVA_HOME is: /usr/lib/jvm/temurin-11-jdk-amd64
PATH contains JAVA_HOME: False
openjdk version "11.0.23" 2024-04-16
OpenJDK Runtime Environment Temurin-11.0.23+9 (build 11.0.23+9)
OpenJDK 64-Bit Server VM Temurin-11.0.23+9 (build 11.0.23+9, mixed mode)
Installing SDK to '/home/cloudtest/tizen-studio'...
setting up jdk at /home/cloudtest/.package-manager/jdk
rm: cannot remove '/home/cloudtest/.package-manager/jdk': No such file or directory
./installer.sh: 4: Syntax error: "(" unexpected
Installing Additional Packages: 'MOBILE-6.0-NativeAppDevelopment'...
/usr/bin/bash: /home/cloudtest/tizen-studio/package-manager/package-manager-cli.bin: No such file or directory
```

Not sure why the install script is invalid:

```
./installer.sh: 4: Syntax error: "(" unexpected
```