### PR TITLE
Skip building Tizen on Linux

### DIFF
--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -345,6 +345,7 @@ stages:
             buildAgent: ${{ parameters.buildAgentLinuxNative }}
             packages: $(TIZEN_LINUX_PACKAGES)
             target: externals-tizen
+            condition: false # https://github.com/mono/SkiaSharp/issues/2933
 
   - ${{ if ne(parameters.buildPipelineType, 'tests') }}:
     - stage: native_wasm


### PR DESCRIPTION


**Description of Change**

Skip the Tizen build because it keeps failing on Linux. We are using the Windows build and also have a macOS build.

**Bugs Fixed**

- Fixes https://github.com/mono/SkiaSharp/issues/2933

