### PR TITLE
Provide Span overload for SetRectRadii

### DIFF
--- a/binding/SkiaSharp/SKRoundRect.cs
+++ b/binding/SkiaSharp/SKRoundRect.cs
@@ -122,12 +122,8 @@ namespace SkiaSharp
 		{
 			if (radii == null)
 				throw new ArgumentNullException (nameof (radii));
-			if (radii.Length != 4)
-				throw new ArgumentException ("Radii must have a length of 4.", nameof (radii));
 
-			fixed (SKPoint* r = radii) {
-				SkiaApi.sk_rrect_set_rect_radii (Handle, &rect, r);
-			}
+			SetRectRadii(rect, radii.AsSpan());
 		}
 
 		public void SetRectRadii (SKRect rect, Span<SKPoint> radii)

--- a/binding/SkiaSharp/SKRoundRect.cs
+++ b/binding/SkiaSharp/SKRoundRect.cs
@@ -130,6 +130,16 @@ namespace SkiaSharp
 			}
 		}
 
+		public void SetRectRadii (SKRect rect, Span<SKPoint> radii)
+		{
+			if (radii.Length != 4)
+				throw new ArgumentException ("Radii must have a length of 4.", nameof (radii));
+
+			fixed (SKPoint* r = radii) {
+				SkiaApi.sk_rrect_set_rect_radii (Handle, &rect, r);
+			}
+		}
+
 		public bool Contains (SKRect rect)
 		{
 			return SkiaApi.sk_rrect_contains (Handle, &rect);

--- a/binding/SkiaSharp/SKRoundRect.cs
+++ b/binding/SkiaSharp/SKRoundRect.cs
@@ -126,7 +126,7 @@ namespace SkiaSharp
 			SetRectRadii(rect, radii.AsSpan());
 		}
 
-		public void SetRectRadii (SKRect rect, Span<SKPoint> radii)
+		public void SetRectRadii (SKRect rect, ReadOnlySpan<SKPoint> radii)
 		{
 			if (radii.Length != 4)
 				throw new ArgumentException ("Radii must have a length of 4.", nameof (radii));


### PR DESCRIPTION
**Description of Change**

This allows stackalloc-ed arrays to be passed.

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
