### PR TITLE
Implement SkCanvas::SaveLayerRec

### DIFF
--- a/binding/SkiaSharp/SKCanvas.cs
+++ b/binding/SkiaSharp/SKCanvas.cs
@@ -68,6 +68,16 @@ namespace SkiaSharp
 			return SkiaApi.sk_canvas_save_layer (Handle, null, paint == null ? IntPtr.Zero : paint.Handle);
 		}
 
+		public int SaveLayer (SKRect bounds, SKPaint paint, SKImageFilter backdrop, SKSaveLayerFlags saveLayerFlags = SKSaveLayerFlags.None)
+		{
+			return SkiaApi.sk_canvas_save_layer_rec (Handle, &bounds, paint == null ? IntPtr.Zero : paint.Handle, backdrop == null ? IntPtr.Zero : backdrop.Handle, (uint)saveLayerFlags);
+		}
+
+		public int SaveLayer (SKRect bounds, SKPaint paint, SKSaveLayerFlags saveLayerFlags)
+		{
+			return SaveLayer (bounds, paint, null, saveLayerFlags);
+		}
+
 		public int SaveLayer () =>
 			SaveLayer (null);
 
@@ -1065,5 +1075,14 @@ namespace SkiaSharp
 				canvas = null;
 			}
 		}
+	}
+
+	[Flags]
+	public enum SKSaveLayerFlags
+	{
+		None = 0,
+		PreserveLCDText = 1 << 1,
+		InitWithPrevious = 1 << 2,
+		UseF16ColorType = 1 << 4,
 	}
 }

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 #region Namespaces
@@ -2299,6 +2299,20 @@ namespace SkiaSharp
 		private static Delegates.sk_canvas_save_layer sk_canvas_save_layer_delegate;
 		internal static Int32 sk_canvas_save_layer (sk_canvas_t ccanvas, SKRect* crect, sk_paint_t cpaint) =>
 			(sk_canvas_save_layer_delegate ??= GetSymbol<Delegates.sk_canvas_save_layer> ("sk_canvas_save_layer")).Invoke (ccanvas, crect, cpaint);
+		#endif
+
+		// int sk_canvas_save_layer_rec(sk_canvas_t* ccanvas, const sk_rect_t* cbounds, const sk_paint_t* cpaint, const sk_imagefilter_t* cfilter, uint32_t flags)
+		#if !USE_DELEGATES
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_canvas_save_layer_rec (sk_canvas_t ccanvas, SKRect* cbounds, sk_paint_t cpaint, sk_imagefilter_t cfilter, uint flags);
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int32 sk_canvas_save_layer_rec (sk_canvas_t ccanvas, SKRect* cbounds, sk_paint_t cpaint, sk_imagefilter_t cfilter, uint flags);
+		}
+		private static Delegates.sk_canvas_save_layer_rec sk_canvas_save_layer_rec_delegate;
+		internal static Int32 sk_canvas_save_layer_rec (sk_canvas_t ccanvas, SKRect* cbounds, sk_paint_t cpaint, sk_imagefilter_t cfilter, uint flags) =>
+			(sk_canvas_save_layer_rec_delegate ??= GetSymbol<Delegates.sk_canvas_save_layer_rec> ("sk_canvas_save_layer_rec")).Invoke (ccanvas, cbounds, cpaint, cfilter, flags);
 		#endif
 
 		// void sk_canvas_scale(sk_canvas_t* ccanvas, float sx, float sy)


### PR DESCRIPTION
**Description of Change**

Implement SkCanvas::SaveLayerRec

**Bugs Fixed**

- Fixes #2773 

**API Changes**

Added: 
 
- `int SKCanvas.SaveLayer(SKRect bounds, SKPaint paint, SKImageFilter backdrop, SKSaveLayerFlags saveLayerFlags = SKSaveLayerFlags.None)`
- `int SKCanvas.SaveLayer(SKRect bounds, SKPaint paint, SKSaveLayerFlags saveLayerFlags)`

**Behavioral Changes**

None.

**Required skia PR**

https://github.com/mono/skia/pull/130

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
