### PR TITLE
Add compatibility overloads for SKFilterQuality

### DIFF
--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -766,11 +766,19 @@ namespace SkiaSharp
 		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling) =>
 			ToShader (tmx, tmy, sampling, null);
 
+		[Obsolete ("Use ToShader(SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling) instead.")]
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKFilterQuality quality) =>
+			ToShader (tmx, tmy, quality.ToSamplingOptions(), null);
+
 		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix) =>
 			ToShader (tmx, tmy, SKSamplingOptions.Default, &localMatrix);
 
 		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling, SKMatrix localMatrix) =>
 			ToShader (tmx, tmy, sampling, &localMatrix);
+
+		[Obsolete ("Use ToShader(SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling, SKMatrix localMatrix) instead.")]
+		public SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKFilterQuality quality, SKMatrix localMatrix) =>
+			ToShader (tmx, tmy, quality.ToSamplingOptions(), &localMatrix);
 
 		private SKShader ToShader (SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling, SKMatrix* localMatrix) =>
 			SKShader.GetObject (SkiaApi.sk_bitmap_make_shader (Handle, tmx, tmy, &sampling, localMatrix));

--- a/binding/SkiaSharp/SKImage.cs
+++ b/binding/SkiaSharp/SKImage.cs
@@ -409,8 +409,16 @@ namespace SkiaSharp
 		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions sampling) =>
 			ToShader (tileX, tileY, sampling, null);
 
+		[Obsolete ("Use ToShader(SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions sampling) instead.")]
+		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKFilterQuality quality) =>
+			ToShader (tileX, tileY, quality.ToSamplingOptions(), null);
+
 		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions sampling, SKMatrix localMatrix) =>
 			ToShader (tileX, tileY, sampling, &localMatrix);
+
+		[Obsolete ("Use ToShader(SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions sampling, SKMatrix localMatrix) instead.")]
+		public SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKFilterQuality quality, SKMatrix localMatrix) =>
+			ToShader (tileX, tileY, quality.ToSamplingOptions(), &localMatrix);
 
 		private SKShader ToShader (SKShaderTileMode tileX, SKShaderTileMode tileY, SKSamplingOptions sampling, SKMatrix* localMatrix) =>
 			SKShader.GetObject (SkiaApi.sk_image_make_shader (Handle, tileX, tileY, &sampling, localMatrix));

--- a/binding/SkiaSharp/SKPaint.cs
+++ b/binding/SkiaSharp/SKPaint.cs
@@ -211,9 +211,7 @@ namespace SkiaSharp
 		[Obsolete ($"Use {nameof (SKSamplingOptions)} instead.")]
 		public SKFilterQuality FilterQuality {
 			get => (SKFilterQuality)SkiaApi.sk_compatpaint_get_filter_quality (Handle);
-			set {
-				SkiaApi.sk_compatpaint_set_filter_quality (Handle, (int)value);
-			}
+			set => SkiaApi.sk_compatpaint_set_filter_quality (Handle, (int)value);
 		}
 
 		[Obsolete ($"Use {nameof (SKFont)}.{nameof (SKFont.Typeface)} instead.")]

--- a/binding/SkiaSharp/SKPaint.cs
+++ b/binding/SkiaSharp/SKPaint.cs
@@ -211,7 +211,9 @@ namespace SkiaSharp
 		[Obsolete ($"Use {nameof (SKSamplingOptions)} instead.")]
 		public SKFilterQuality FilterQuality {
 			get => (SKFilterQuality)SkiaApi.sk_compatpaint_get_filter_quality (Handle);
-			set => SkiaApi.sk_compatpaint_set_filter_quality (Handle, (int)value);
+			set {
+				SkiaApi.sk_compatpaint_set_filter_quality (Handle, (int)value);
+			}
 		}
 
 		[Obsolete ($"Use {nameof (SKFont)}.{nameof (SKFont.Typeface)} instead.")]

--- a/binding/SkiaSharp/SKShader.cs
+++ b/binding/SkiaSharp/SKShader.cs
@@ -80,11 +80,19 @@ namespace SkiaSharp
 		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling) =>
 			src?.ToShader (tmx, tmy, sampling) ?? throw new ArgumentNullException (nameof (src));
 
+		[Obsolete ("Use CreateImage(SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling) instead.")]
+		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKFilterQuality quality) =>
+			src?.ToShader (tmx, tmy, quality.ToSamplingOptions()) ?? throw new ArgumentNullException (nameof (src));
+
 		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKMatrix localMatrix) =>
 			src?.ToShader (tmx, tmy, localMatrix) ?? throw new ArgumentNullException (nameof (src));
 
 		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling, SKMatrix localMatrix) =>
 			src?.ToShader (tmx, tmy, sampling, localMatrix) ?? throw new ArgumentNullException (nameof (src));
+
+		[Obsolete ("Use CreateImage(SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKSamplingOptions sampling, SKMatrix localMatrix) instead.")]
+		public static SKShader CreateImage (SKImage src, SKShaderTileMode tmx, SKShaderTileMode tmy, SKFilterQuality quality, SKMatrix localMatrix) =>
+			src?.ToShader (tmx, tmy, quality.ToSamplingOptions(), localMatrix) ?? throw new ArgumentNullException (nameof (src));
 
 		// CreatePicture
 


### PR DESCRIPTION
Libraries may want to remain supporting both SkiaSharp 2.x and 3.x, as we currently do in Uno Platform.

We achieve this by detecting the assembly version and using UnsafeAccessor when needed for APIs that have changed in SkiaSharp 3.

However, there is one remaining issue for Uno Platform, which is SKFilterQuality. As the overloads now take SKSamplingOptions which is a completely new type in SkiaSharp 3, we can't use UnsafeAccessor to get this to work.

This PR adds new obsolete APIs that accepts SKFilterQuality and forwards it to the SKSamplingOptions overload. For Uno Platform, we will use `paint.FilterQuality` when on 2.x, and use the new shader overloads via UnsafeAccessor when on 3.x

NOTE: This is applicable for any library that needs to remain on 2.x while allowing consumers to upgrade to 3.x.

@mattleibow, if you can review please