### PR TITLE
Added SKCanvas.DrawPoints with a count override to allow for partial …

### DIFF
--- a/binding/SkiaSharp/SKCanvas.cs
+++ b/binding/SkiaSharp/SKCanvas.cs
@@ -420,6 +420,17 @@ namespace SkiaSharp
 			}
 		}
 
+		public void DrawPoints (SKPointMode mode, SKPoint[] points, int count, SKPaint paint)
+		{
+			if (paint == null)
+				throw new ArgumentNullException (nameof (paint));
+			if (points == null)
+				throw new ArgumentNullException (nameof (points));
+			fixed (SKPoint* p = points) {
+				SkiaApi.sk_canvas_draw_points (Handle, mode, (IntPtr)count, p, paint.Handle);
+			}
+		}
+
 		// DrawPoint
 
 		public void DrawPoint (SKPoint p, SKPaint paint)


### PR DESCRIPTION
…point array drawing.

**Description of Change**

Sometimes it's useful to pass an array of points to `SKCanvas.DrawPoints` but not to draw all of them.  The API currently doesn't accept Spans<T> at this point, so it is a stop-gap until that decision has been made.

No tests added currently as there is not currently a test in the `tests/Tests/SkiaSharp/SKCanvasTest.cs` file for drawing points.

**Bugs Fixed**

- Fixes #2986

**API Changes**

Add `public void SKCanvasDrawPoints (SKPointMode mode, SKPoint[] points, int count, SKPaint paint)` overload.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
