### PR TITLE
Supports ScaleFactor for GTK 3

### DIFF
--- a/samples/Basic/Gtk3/SkiaSharpSample/MainWindow.cs
+++ b/samples/Basic/Gtk3/SkiaSharpSample/MainWindow.cs
@@ -22,6 +22,7 @@ namespace SkiaSharpSample
 			DeleteEvent += OnWindowDeleteEvent;
 
 			skiaView = new SKDrawingArea();
+			skiaView.IgnorePixelScaling = false;
 			skiaView.PaintSurface += OnPaintSurface;
 			skiaView.Show();
 			Child = skiaView;
@@ -49,7 +50,7 @@ namespace SkiaSharpSample
 			};
 			using var font = new SKFont
 			{
-				Size = 24
+				Size = 24 * ScaleFactor
 			};
 			var coord = new SKPoint(e.Info.Width / 2, (e.Info.Height + font.Size) / 2);
 			canvas.DrawText("SkiaSharp", coord, SKTextAlign.Center, font, paint);

--- a/samples/Basic/Gtk3/SkiaSharpSample/MainWindow.cs
+++ b/samples/Basic/Gtk3/SkiaSharpSample/MainWindow.cs
@@ -22,7 +22,7 @@ namespace SkiaSharpSample
 			DeleteEvent += OnWindowDeleteEvent;
 
 			skiaView = new SKDrawingArea();
-			skiaView.IgnorePixelScaling = false;
+			skiaView.IgnorePixelScaling = true;
 			skiaView.PaintSurface += OnPaintSurface;
 			skiaView.Show();
 			Child = skiaView;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SKDrawingArea.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SKDrawingArea.cs
@@ -11,13 +11,13 @@ namespace SkiaSharp.Views.Gtk
 	{
 		private ImageSurface pix;
 		private SKSurface surface;
-		private bool ignorePixelScaling = true; // Enable by default to keep previous behavior
+		private bool ignorePixelScaling = false;
 
 		public SKDrawingArea()
 		{
 		}
 
-		public SKSize CanvasSize => pix == null ? SKSize.Empty : new SKSize(pix.Width, pix.Height);
+		public SKSize CanvasSize { get; private set; } = SKSize.Empty;
 
 		[Category("Appearance")]
 		public event EventHandler<SKPaintSurfaceEventArgs> PaintSurface;
@@ -60,7 +60,7 @@ namespace SkiaSharp.Views.Gtk
 			}
 
 			// write the pixbuf to the graphics
-			if (!IgnorePixelScaling)
+			if (IgnorePixelScaling)
 			{
 				cr.Scale(1.0f / ScaleFactor, 1.0f / ScaleFactor);
 			}
@@ -90,7 +90,9 @@ namespace SkiaSharp.Views.Gtk
 			var w = alloc.Width;
 			var h = alloc.Height;
 
-			if (!IgnorePixelScaling)
+			CanvasSize = new SKSize(w, h);
+
+			if (IgnorePixelScaling)
 			{
 				w *= ScaleFactor;
 				h *= ScaleFactor;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SKDrawingArea.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Gtk3/SKDrawingArea.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using Cairo;
+using Gtk;
 using SkiaSharp.Views.Desktop;
 
 namespace SkiaSharp.Views.Gtk
@@ -10,6 +11,7 @@ namespace SkiaSharp.Views.Gtk
 	{
 		private ImageSurface pix;
 		private SKSurface surface;
+		private bool ignorePixelScaling = true; // Enable by default to keep previous behavior
 
 		public SKDrawingArea()
 		{
@@ -19,6 +21,16 @@ namespace SkiaSharp.Views.Gtk
 
 		[Category("Appearance")]
 		public event EventHandler<SKPaintSurfaceEventArgs> PaintSurface;
+
+		public bool IgnorePixelScaling
+		{
+			get => ignorePixelScaling;
+			set
+			{
+				ignorePixelScaling = value;
+				QueueDraw();
+			}
+		}
 
 		protected override bool OnDrawn(Context cr)
 		{
@@ -48,6 +60,10 @@ namespace SkiaSharp.Views.Gtk
 			}
 
 			// write the pixbuf to the graphics
+			if (!IgnorePixelScaling)
+			{
+				cr.Scale(1.0f / ScaleFactor, 1.0f / ScaleFactor);
+			}
 			cr.SetSourceSurface(pix, 0, 0);
 			cr.Paint();
 
@@ -73,6 +89,13 @@ namespace SkiaSharp.Views.Gtk
 			var alloc = Allocation;
 			var w = alloc.Width;
 			var h = alloc.Height;
+
+			if (!IgnorePixelScaling)
+			{
+				w *= ScaleFactor;
+				h *= ScaleFactor;
+			}
+
 			var imgInfo = new SKImageInfo(w, h, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
 
 			if (pix == null || pix.Width != imgInfo.Width || pix.Height != imgInfo.Height)


### PR DESCRIPTION
GTK has a simple mechanism to scale the UI on high dpi screens. It's just an `int`. On windows if you set the scaling to 200%, `ScaleFactor` will return 2. At 125%, you still get 1.  (see https://docs.gtk.org/gtk3/method.Widget.get_scale_factor.html)

I modified the code so that we create a bigger surface and then scale down when we render in the Cairo context. I added a `IgnorePixelScaling` to mimic what has be done on other views, I set the default to true so that my changes are completely harmless. You need to opt-in to get the new behavior.

My GTK skills are pretty close to zero, so please look two times at the proposed changes 😅

Tested on Windows only on the GTK sample.

Before (the text is blurry):  
![image](https://github.com/user-attachments/assets/76715b1d-0a69-40f3-95a7-eab7c1fd63f4)

After (the text is sharp):  
![image](https://github.com/user-attachments/assets/ac8ceed4-291a-42c5-9591-7669c5215b19)
