### PR TITLE
Revert SKBitmap.Encode with SKPngEncoderOptions to previous behavior (2.88.8)

### DIFF
--- a/binding/SkiaSharp/SKPixmap.cs
+++ b/binding/SkiaSharp/SKPixmap.cs
@@ -237,7 +237,7 @@ namespace SkiaSharp
 				SKEncodedImageFormat.Jpeg =>
 					Encode (dst, new SKJpegEncoderOptions (quality)),
 				SKEncodedImageFormat.Png =>
-					Encode (dst, new SKPngEncoderOptions ()),
+					Encode (dst, new SKPngEncoderOptions(default, SKPngEncoderOptions.Default.ZLibLevel)),
 				SKEncodedImageFormat.Webp when quality == 100 =>
 					Encode (dst, new SKWebpEncoderOptions (SKWebpEncoderCompression.Lossless, 75)),
 				SKEncodedImageFormat.Webp =>

--- a/binding/SkiaSharp/SKPixmap.cs
+++ b/binding/SkiaSharp/SKPixmap.cs
@@ -237,7 +237,7 @@ namespace SkiaSharp
 				SKEncodedImageFormat.Jpeg =>
 					Encode (dst, new SKJpegEncoderOptions (quality)),
 				SKEncodedImageFormat.Png =>
-					Encode (dst, new SKPngEncoderOptions(default, SKPngEncoderOptions.Default.ZLibLevel)),
+					Encode (dst, SKPngEncoderOptions.Default),
 				SKEncodedImageFormat.Webp when quality == 100 =>
 					Encode (dst, new SKWebpEncoderOptions (SKWebpEncoderCompression.Lossless, 75)),
 				SKEncodedImageFormat.Webp =>


### PR DESCRIPTION
**Description of Change**

Reverts `SKBitmap.Encode` to previous behavior to use default PNG compression.

Until 2.88.8: ZLibLevel 6 is used for PNG compression.
Since 3.0.0:  ZLibLevel 0 is used for PNG compression.

**Bugs Fixed**

- Fixes #3013

**API Changes**

None.

**Behavioral Changes**

Calling `SKBitmap.Encode` or `SKPixmap.Encode (SKWStream, SKEncodedImageFormat, int)` will result in a default PNG compression level (as in 2.88.8). The `SKPngEncoderFilterFlags` are unchanged.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
