### PR TITLE
Add  SKMatrix.MapPoints/MapVectors, SKPath.AddPoly  overloads with Span<SKPoint>

### DIFF
--- a/binding/SkiaSharp/SKMatrix.cs
+++ b/binding/SkiaSharp/SKMatrix.cs
@@ -319,6 +319,18 @@ namespace SkiaSharp
 			return result;
 		}
 
+		public readonly void MapPoints (Span<SKPoint> result, ReadOnlySpan<SKPoint> points)
+		{
+			if (result.Length != points.Length)
+				throw new ArgumentException ("Buffers must be the same size.");
+
+			fixed (SKMatrix* t = &this)
+			fixed (SKPoint* rp = result)
+			fixed (SKPoint* pp = points) {
+				SkiaApi.sk_matrix_map_points (t, rp, pp, result.Length);
+			}
+		}
+
 		public readonly void MapPoints (SKPoint[] result, SKPoint[] points)
 		{
 			if (result == null)
@@ -357,6 +369,18 @@ namespace SkiaSharp
 				SkiaApi.sk_matrix_map_vector (t, x, y, &result);
 			}
 			return result;
+		}
+
+		public readonly void MapVectors (Span<SKPoint> result, ReadOnlySpan<SKPoint> vectors)
+		{
+			if (result.Length != vectors.Length)
+				throw new ArgumentException ("Buffers must be the same size.");
+
+			fixed (SKMatrix* t = &this)
+			fixed (SKPoint* rp = result)
+			fixed (SKPoint* pp = vectors) {
+				SkiaApi.sk_matrix_map_vectors (t, rp, pp, result.Length);
+			}
 		}
 
 		public readonly void MapVectors (SKPoint[] result, SKPoint[] vectors)

--- a/binding/SkiaSharp/SKPath.cs
+++ b/binding/SkiaSharp/SKPath.cs
@@ -390,6 +390,15 @@ namespace SkiaSharp
 		public void AddCircle (float x, float y, float radius, SKPathDirection dir = SKPathDirection.Clockwise) =>
 			SkiaApi.sk_path_add_circle (Handle, x, y, radius, dir);
 
+		public void AddPoly (ReadOnlySpan<SKPoint> points, bool close = true)
+		{
+			if (points == null)
+				throw new ArgumentNullException (nameof (points));
+			fixed (SKPoint* p = points) {
+				SkiaApi.sk_path_add_poly (Handle, p, points.Length, close);
+			}
+		}
+
 		public void AddPoly (SKPoint[] points, bool close = true)
 		{
 			if (points == null)

--- a/tests/Tests/SkiaSharp/SKMatrixTests.cs
+++ b/tests/Tests/SkiaSharp/SKMatrixTests.cs
@@ -82,6 +82,39 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void MatrixMapsSpanPoints()
+		{
+			Span<SKPoint> source = stackalloc[] {
+				new SKPoint(0, 0),
+				new SKPoint(-10, -10),
+				new SKPoint(-10, 10),
+				new SKPoint(10, -10),
+				new SKPoint(10, 10),
+				new SKPoint(-5, -5),
+				new SKPoint(-5, 5),
+				new SKPoint(5, -5),
+				new SKPoint(5, 5),
+			};
+
+			Span<SKPoint> expectedResult = stackalloc[] {
+				new SKPoint(10, 10),
+				new SKPoint(0, 0),
+				new SKPoint(0, 20),
+				new SKPoint(20, 0),
+				new SKPoint(20, 20),
+				new SKPoint(5, 5),
+				new SKPoint(5, 15),
+				new SKPoint(15, 5),
+				new SKPoint(15, 15),
+			};
+
+			var matrix = SKMatrix.CreateTranslation(10, 10);
+			matrix.MapPoints(source, source);
+
+			Assert.True(expectedResult.SequenceEqual(source));
+		}
+
+		[SkippableFact]
 		public void MapRectCreatesModifiedRect()
 		{
 			var rect = SKRect.Create(2, 4, 6, 8);
@@ -132,6 +165,39 @@ namespace SkiaSharp.Tests
 			matrix.MapVectors(source, source);
 
 			Assert.Equal(expectedResult, source);
+		}
+
+		[SkippableFact]
+		public void MatrixMapsSpanVectors()
+		{
+			Span<SKPoint> source = stackalloc[] {
+				new SKPoint(0, 0),
+				new SKPoint(-10, -10),
+				new SKPoint(-10, 10),
+				new SKPoint(10, -10),
+				new SKPoint(10, 10),
+				new SKPoint(-5, -5),
+				new SKPoint(-5, 5),
+				new SKPoint(5, -5),
+				new SKPoint(5, 5),
+			};
+
+			Span<SKPoint> expectedResult = stackalloc[] {
+				new SKPoint(0, 0),
+				new SKPoint(-10, -10),
+				new SKPoint(-10, 10),
+				new SKPoint(10, -10),
+				new SKPoint(10, 10),
+				new SKPoint(-5, -5),
+				new SKPoint(-5, 5),
+				new SKPoint(5, -5),
+				new SKPoint(5, 5),
+			};
+
+			var matrix = SKMatrix.CreateTranslation(10, 10);
+			matrix.MapVectors(source, source);
+
+			Assert.True(expectedResult.SequenceEqual(source));
 		}
 
 		[SkippableFact]


### PR DESCRIPTION
**Description of Change**

When you nead maps several points without heap allocation and with only one pInvoke

cost of pInvoke
```
p1 = matrix.MapPoint(p1);
p2 = matrix.MapPoint(p2);
p3 = matrix.MapPoint(p3);
```
cost of allocation
```
var points = new [] { p1,  p2,  p3 };
matrix.MapPoints(points, points);
```
decision
```
Span<SKPoint> points = stackalloc [] { p1,  p2,  p3 };
matrix.MapPoints(points, points);
```

Miss SKPath.AddPoly tests

**API Changes**

Added: 
 
- `void SKMatrix.MapPoints(Span<SKPoint> result, ReadOnlySpan<SKPoint> points)`
- `void SKMatrix.MapVectors(Span<SKPoint> result, ReadOnlySpan<SKPoint> points)`
- `void SKPath.AddPoly (ReadOnlySpan<SKPoint> points, bool close = true)`

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
