### PR TITLE
Fix CI again

### DIFF
--- a/scripts/azure-pipelines-variables.yml
+++ b/scripts/azure-pipelines-variables.yml
@@ -17,7 +17,7 @@ variables:
   XCODE_VERSION: 14.2
   VISUAL_STUDIO_VERSION: ''
   DOTNET_VERSION_PREVIEW: '7.0.302'
-  DOTNET_WORKLOAD_SOURCE: 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.81.json'
+  DOTNET_WORKLOAD_SOURCE: 'https://github.com/dotnet/maui/releases/download/7.0.81/7.0.81.json'
   DOTNET_WORKLOAD_TIZEN: '7.0.111'
   CONFIGURATION: 'Release'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/scripts/install-dotnet-workloads.ps1
+++ b/scripts/install-dotnet-workloads.ps1
@@ -24,6 +24,7 @@ Write-Host "Installing .NET workloads..."
   --source $feed1 `
   --source $feed2 `
   --source $feed3 `
+  --verbosity diagnostic `
   --skip-sign-check
 
 Write-Host "Installing Tizen workloads..."


### PR DESCRIPTION
**Description of Change**

~I fell asleep and CI broke.~

The maui rollback files are now hosted in the maui repository instead of the blob storage.