### PR TITLE
Update skia to Milestone 118

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ However, these are easy to install as they are found on the various websites. If
 
 Here are some links to show the differences in our code as compared to Google's code.
 
-What version are we on? [**m116**](https://github.com/google/skia/tree/chrome/m117)  
-Are we up-to-date with Google? [Compare](https://github.com/mono/skia/compare/skiasharp...google:chrome/m117)  
-What have we added? [Compare](https://github.com/google/skia/compare/chrome/m117...mono:skiasharp)  
+What version are we on? [**m118**](https://github.com/google/skia/tree/chrome/m118)  
+Are we up-to-date with Google? [Compare](https://github.com/mono/skia/compare/skiasharp...google:chrome/m118)  
+What have we added? [Compare](https://github.com/google/skia/compare/chrome/m118...mono:skiasharp)  

--- a/binding/SkiaSharp/EnumMappings.cs
+++ b/binding/SkiaSharp/EnumMappings.cs
@@ -23,6 +23,7 @@ namespace SkiaSharp
 				GRBackend.Metal => GRBackendNative.Metal,
 				GRBackend.OpenGL => GRBackendNative.OpenGL,
 				GRBackend.Vulkan => GRBackendNative.Vulkan,
+				GRBackend.Dawn => GRBackendNative.Unsupported,
 				GRBackend.Direct3D => GRBackendNative.Direct3D,
 				GRBackend.Unsupported => GRBackendNative.Unsupported,
 				_ => throw new ArgumentOutOfRangeException (nameof (backend), $"Unknown backend: '{backend}'"),

--- a/binding/SkiaSharp/EnumMappings.cs
+++ b/binding/SkiaSharp/EnumMappings.cs
@@ -12,6 +12,7 @@ namespace SkiaSharp
 		Vulkan = 2,
 		Dawn = 3,
 		Direct3D = 4,
+		Unsupported = 5,
 	}
 
 	public static partial class SkiaExtensions
@@ -22,8 +23,8 @@ namespace SkiaSharp
 				GRBackend.Metal => GRBackendNative.Metal,
 				GRBackend.OpenGL => GRBackendNative.OpenGL,
 				GRBackend.Vulkan => GRBackendNative.Vulkan,
-				GRBackend.Dawn => GRBackendNative.Dawn,
 				GRBackend.Direct3D => GRBackendNative.Direct3D,
+				GRBackend.Unsupported => GRBackendNative.Unsupported,
 				_ => throw new ArgumentOutOfRangeException (nameof (backend), $"Unknown backend: '{backend}'"),
 			};
 
@@ -33,8 +34,8 @@ namespace SkiaSharp
 				GRBackendNative.Metal => GRBackend.Metal,
 				GRBackendNative.OpenGL => GRBackend.OpenGL,
 				GRBackendNative.Vulkan => GRBackend.Vulkan,
-				GRBackendNative.Dawn => GRBackend.Dawn,
 				GRBackendNative.Direct3D => GRBackend.Direct3D,
+				GRBackendNative.Unsupported => GRBackend.Unsupported,
 				_ => throw new ArgumentOutOfRangeException (nameof (backend), $"Unknown backend: '{backend}'"),
 			};
 

--- a/binding/SkiaSharp/GRBackendRenderTarget.cs
+++ b/binding/SkiaSharp/GRBackendRenderTarget.cs
@@ -18,19 +18,31 @@ namespace SkiaSharp
 			CreateGl (width, height, sampleCount, stencilBits, glInfo);
 		}
 
+		[Obsolete ("Use GRBackendRenderTarget(int width, int height, GRVkImageInfo vkImageInfo) instead.")]
 		public GRBackendRenderTarget (int width, int height, int sampleCount, GRVkImageInfo vkImageInfo)
+			: this (width, height, vkImageInfo)
+		{
+		}
+
+		public GRBackendRenderTarget (int width, int height, GRVkImageInfo vkImageInfo)
 			: this (IntPtr.Zero, true)
 		{
-			CreateVulkan (width, height, sampleCount, vkImageInfo);
+			CreateVulkan (width, height, vkImageInfo);
 		}
 
 #if __IOS__ || __MACOS__
 
+		[Obsolete ("Use GRBackendRenderTarget(int width, int height, GRMtlTextureInfo mtlInfo) instead.")]
 		public GRBackendRenderTarget (int width, int height, int sampleCount, GRMtlTextureInfo mtlInfo)
+			: this (width, height, mtlInfo)
+		{
+		}
+
+		public GRBackendRenderTarget (int width, int height, GRMtlTextureInfo mtlInfo)
 			: this (IntPtr.Zero, true)
 		{
 			var info = mtlInfo.ToNative ();
-			Handle = SkiaApi.gr_backendrendertarget_new_metal (width, height, sampleCount, &info);
+			Handle = SkiaApi.gr_backendrendertarget_new_metal (width, height, &info);
 
 			if (Handle == IntPtr.Zero) {
 				throw new InvalidOperationException ("Unable to create a new GRBackendRenderTarget instance.");
@@ -48,9 +60,9 @@ namespace SkiaSharp
 			}
 		}
 
-		private void CreateVulkan (int width, int height, int sampleCount, GRVkImageInfo vkImageInfo)
+		private void CreateVulkan (int width, int height, GRVkImageInfo vkImageInfo)
 		{
-			Handle = SkiaApi.gr_backendrendertarget_new_vulkan (width, height, sampleCount, &vkImageInfo);
+			Handle = SkiaApi.gr_backendrendertarget_new_vulkan (width, height, &vkImageInfo);
 
 			if (Handle == IntPtr.Zero) {
 				throw new InvalidOperationException ("Unable to create a new GRBackendRenderTarget instance.");

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -287,42 +287,42 @@ namespace SkiaSharp
 			(gr_backendrendertarget_new_gl_delegate ??= GetSymbol<Delegates.gr_backendrendertarget_new_gl> ("gr_backendrendertarget_new_gl")).Invoke (width, height, samples, stencils, glInfo);
 		#endif
 
-		// gr_backendrendertarget_t* gr_backendrendertarget_new_metal(int width, int height, int samples, const gr_mtl_textureinfo_t* mtlInfo)
+		// gr_backendrendertarget_t* gr_backendrendertarget_new_metal(int width, int height, const gr_mtl_textureinfo_t* mtlInfo)
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (SKIA)]
-		internal static partial gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, Int32 samples, GRMtlTextureInfoNative* mtlInfo);
+		internal static partial gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, GRMtlTextureInfoNative* mtlInfo);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, Int32 samples, GRMtlTextureInfoNative* mtlInfo);
+		internal static extern gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, GRMtlTextureInfoNative* mtlInfo);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, Int32 samples, GRMtlTextureInfoNative* mtlInfo);
+			internal delegate gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, GRMtlTextureInfoNative* mtlInfo);
 		}
 		private static Delegates.gr_backendrendertarget_new_metal gr_backendrendertarget_new_metal_delegate;
-		internal static gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, Int32 samples, GRMtlTextureInfoNative* mtlInfo) =>
-			(gr_backendrendertarget_new_metal_delegate ??= GetSymbol<Delegates.gr_backendrendertarget_new_metal> ("gr_backendrendertarget_new_metal")).Invoke (width, height, samples, mtlInfo);
+		internal static gr_backendrendertarget_t gr_backendrendertarget_new_metal (Int32 width, Int32 height, GRMtlTextureInfoNative* mtlInfo) =>
+			(gr_backendrendertarget_new_metal_delegate ??= GetSymbol<Delegates.gr_backendrendertarget_new_metal> ("gr_backendrendertarget_new_metal")).Invoke (width, height, mtlInfo);
 		#endif
 
-		// gr_backendrendertarget_t* gr_backendrendertarget_new_vulkan(int width, int height, int samples, const gr_vk_imageinfo_t* vkImageInfo)
+		// gr_backendrendertarget_t* gr_backendrendertarget_new_vulkan(int width, int height, const gr_vk_imageinfo_t* vkImageInfo)
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (SKIA)]
-		internal static partial gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, Int32 samples, GRVkImageInfo* vkImageInfo);
+		internal static partial gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, GRVkImageInfo* vkImageInfo);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, Int32 samples, GRVkImageInfo* vkImageInfo);
+		internal static extern gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, GRVkImageInfo* vkImageInfo);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, Int32 samples, GRVkImageInfo* vkImageInfo);
+			internal delegate gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, GRVkImageInfo* vkImageInfo);
 		}
 		private static Delegates.gr_backendrendertarget_new_vulkan gr_backendrendertarget_new_vulkan_delegate;
-		internal static gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, Int32 samples, GRVkImageInfo* vkImageInfo) =>
-			(gr_backendrendertarget_new_vulkan_delegate ??= GetSymbol<Delegates.gr_backendrendertarget_new_vulkan> ("gr_backendrendertarget_new_vulkan")).Invoke (width, height, samples, vkImageInfo);
+		internal static gr_backendrendertarget_t gr_backendrendertarget_new_vulkan (Int32 width, Int32 height, GRVkImageInfo* vkImageInfo) =>
+			(gr_backendrendertarget_new_vulkan_delegate ??= GetSymbol<Delegates.gr_backendrendertarget_new_vulkan> ("gr_backendrendertarget_new_vulkan")).Invoke (width, height, vkImageInfo);
 		#endif
 
 		// void gr_backendtexture_delete(gr_backendtexture_t* texture)
@@ -19994,8 +19994,8 @@ namespace SkiaSharp {
 		Metal = 2,
 		// DIRECT3D_GR_BACKEND = 3
 		Direct3D = 3,
-		// DAWN_GR_BACKEND = 4
-		Dawn = 4,
+		// UNSUPPORTED_GR_BACKEND = 5
+		Unsupported = 5,
 	}
 
 	// gr_surfaceorigin_t

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,7 +1,7 @@
 # dependencies
 mdoc                                            release     5.8.9
 harfbuzz                                        release     8.3.0
-skia                                            release     m117
+skia                                            release     m118
 xunit                                           release     2.4.2
 xunit.runner.console                            release     2.4.2
 OpenTK                                          release     3.1.0
@@ -23,12 +23,12 @@ ANGLE                                           release     chromium/6275
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   117
+libSkiaSharp            milestone   118
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      117.0.0
+libSkiaSharp            soname      118.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.60830.0
 

--- a/tests/Tests/SkiaSharp/EnumMappingsTest.cs
+++ b/tests/Tests/SkiaSharp/EnumMappingsTest.cs
@@ -11,7 +11,10 @@ namespace SkiaSharp.Tests
 		{
 			foreach (GRBackend value in Enum.GetValues(typeof(GRBackend)))
 			{
-				Assert.Equal(value.ToString(), value.ToNative().ToString());
+				if (value == GRBackend.Dawn)
+					Assert.Equal("Unsupported", value.ToNative().ToString());
+				else
+					Assert.Equal(value.ToString(), value.ToNative().ToString());
 			}
 
 			foreach (GRBackendNative value in Enum.GetValues(typeof(GRBackendNative)))


### PR DESCRIPTION
**Description of Change**

Updating the version to the next one.

**API Changes**

* Enum value `GRBackend.Dawn` is no longer used
* Enum value `GRBackend.Unsupported` is added
* The samples parameter when creating a `GRBackendRenderTarget` for Vulkan and Metal were never used, so that overload is now obsolete and there is a new overload that does not have that parameter.

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

https://github.com/mono/skia/pull/139

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
