### PR TITLE
Use a snapshot now that 4.0 has been removed

### DIFF
--- a/scripts/install-tizen.ps1
+++ b/scripts/install-tizen.ps1
@@ -4,6 +4,7 @@
 
 Param(
     [string] $Version = "4.1",
+    [string] $Snapshot = "5.6",
     [string] $InstallDestination = $null,
     [boolean] $UpgradeLLVM = $true
 )
@@ -58,9 +59,9 @@ if ($IsMacOS -or $IsLinux) {
 Write-Host "Installing Additional Packages: '$packages'..."
 $packMan = Join-Path (Join-Path "$ts" "package-manager") "package-manager-cli.${ext}"
 if ($IsMacOS -or $IsLinux) {
-    & "bash" "$packMan" install --no-java-check --accept-license "$packages"
+    & "bash" "$packMan" install --no-java-check --accept-license "$packages" -s "Tizen_Studio_$Snapshot"
 } else {
-    & "$packMan" install --no-java-check --accept-license "$packages"
+    & "$packMan" install --no-java-check --accept-license "$packages" -s "Tizen_Studio_$Snapshot"
 }
 
 function Swap-Tool {


### PR DESCRIPTION
**Description of Change**

It appears that most of the older (< 6.0) tools have been removed from the "latest" package manager, so we need to use the snapshots.

See more: https://developer.tizen.org/blog/announcing-tizen-studio-6.0-release

> Added Tizen 9.0 profile and deprecated all Tizen profiles below 6.0.

_I have a feeling this may have been an error since some of the web tools are still there and the wording is "deprecated". But, either way, this will be more consistent for this old branch._