### PR TITLE
Fixed SKGLView on Android not being rendered when using a TabBar

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Android/GLTextureView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Android/GLTextureView.cs
@@ -106,7 +106,7 @@ namespace SkiaSharp.Views.Android
 				eglWindowSurfaceFactory = new DefaultWindowSurfaceFactory();
 			}
 			this.renderer = renderer;
-			glThread = new GLThread(thisWeakRef);
+			glThread = new GLThread(thisWeakRef, Width, Height);
 			glThread.Start();
 		}
 
@@ -211,7 +211,7 @@ namespace SkiaSharp.Views.Android
 				{
 					renderMode = glThread.GetRenderMode();
 				}
-				glThread = new GLThread(thisWeakRef);
+				glThread = new GLThread(thisWeakRef, Width, Height);
 				if (renderMode != Rendermode.Continuously)
 				{
 					glThread.SetRenderMode(renderMode);
@@ -713,12 +713,12 @@ namespace SkiaSharp.Views.Android
 			private bool surfaceSizeChanged = true;
 			// End of member variables protected by the sGLThreadManager monitor.
 
-			public GLThread(WeakReference<GLTextureView> glTextureViewWeakRef)
+			public GLThread(WeakReference<GLTextureView> glTextureViewWeakRef, int initialWidth, int initialHeight)
 			{
 				threadManager = new GLThreadManager();
 
-				width = 0;
-				height = 0;
+				width = initialWidth;
+				height = initialHeight;
 				requestRender = true;
 				renderMode = Rendermode.Continuously;
 				textureViewWeakRef = glTextureViewWeakRef;


### PR DESCRIPTION
**Description of Change**

Currently an `SKGLView` on Android will not render when it appears for a second time, such as when the `SKGLView` is placed on a MAUI Tab Page in a TabBar. The first time the Tab with the `SKGLView` is displayed it correctly renders, however when switching to a different Tab and then coming back, the `SKGLView` will not render anymore.

This PR solves this issue by constructing the internal `GLThread` with the current size of the View, instead of relying on Android to call `GLTextureView.OnLayoutChange()`. If the size of the View has not been set yet by Android (which happens when the `SKGLView` is displayed for the first time), the GLTextureView's Width and Height are both 0, just as the default of the GLThread used to be, so it is safe to use these values when constructing the `GLThread`.

**Bugs Fixed**

- Fixes #2550
- Possibly also fixes Mapsui/Mapsui#1896 which has already been mitigated by Mapsui/Mapsui#1934

**API Changes**

No public API changes.

Private API Change:

- `SkiaSharp.Views.Android.GLTextureView.GLThread(WeakReference<GLTextureView> glTextureViewWeakRef)` => `GLThread(WeakReference<GLTextureView> glTextureViewWeakRef, int initialWidth, int initialHeight)`

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
