### PR TITLE
Move the Blazor workaround into WASM

### DIFF
--- a/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
@@ -31,4 +31,22 @@
     <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.56\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>
 
+  <!-- Workaround for https://github.com/dotnet/runtime/issues/109289 -->
+  <Target Name="RuntimeIssue109289_Workaround"
+          AfterTargets="_BrowserWasmWriteRspForLinking">
+    <ItemGroup>
+      <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />
+      <_EmccLinkStepArgs Remove="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
+      <_WasmLinkDependencies Remove="@(_WasmNativeFileForLinking)" />
+
+      <_SkiaSharpToReorder Include="@(_WasmNativeFileForLinking)" Condition="$([System.String]::Copy('%(FullPath)').Contains('libSkiaSharp.a'))" />
+      <_WasmNativeFileForLinking Remove="@(_SkiaSharpToReorder)" />
+      <_WasmNativeFileForLinking Include="@(_SkiaSharpToReorder)" />
+
+      <_EmccLinkStepArgs Include="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
+      <_WasmLinkDependencies Include="@(_WasmNativeFileForLinking)" />
+      <_WasmLinkStepArgs Include="@(_EmccLinkStepArgs)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/binding/IncludeNativeAssets.SkiaSharp.targets
+++ b/binding/IncludeNativeAssets.SkiaSharp.targets
@@ -79,7 +79,24 @@
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\3.1.12\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))" />
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\3.1.34\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\3.1.56\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
-
   </ItemGroup>
+
+  <!-- Workaround for https://github.com/dotnet/runtime/issues/109289 -->
+  <Target Name="RuntimeIssue109289_Workaround"
+          AfterTargets="_BrowserWasmWriteRspForLinking">
+    <ItemGroup>
+      <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />
+      <_EmccLinkStepArgs Remove="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
+      <_WasmLinkDependencies Remove="@(_WasmNativeFileForLinking)" />
+
+      <_SkiaSharpToReorder Include="@(_WasmNativeFileForLinking)" Condition="$([System.String]::Copy('%(FullPath)').Contains('libSkiaSharp.a'))" />
+      <_WasmNativeFileForLinking Remove="@(_SkiaSharpToReorder)" />
+      <_WasmNativeFileForLinking Include="@(_SkiaSharpToReorder)" />
+
+      <_EmccLinkStepArgs Include="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
+      <_WasmLinkDependencies Include="@(_WasmNativeFileForLinking)" />
+      <_WasmLinkStepArgs Include="@(_EmccLinkStepArgs)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/nuget/buildTransitive/SkiaSharp.Views.Blazor.Local.props
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/nuget/buildTransitive/SkiaSharp.Views.Blazor.Local.props
@@ -6,22 +6,4 @@
     <EmccExtraLDFlags>$(EmccExtraLDFlags) --js-library="$(MSBuildThisFileDirectory)SkiaSharpInterop.js"</EmccExtraLDFlags>
   </PropertyGroup>
 
-  <!-- Workaround for https://github.com/dotnet/runtime/issues/109289 -->
-  <Target Name="RuntimeIssue109289_Workaround"
-          AfterTargets="_BrowserWasmWriteRspForLinking">
-    <ItemGroup>
-      <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />
-      <_EmccLinkStepArgs Remove="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
-      <_WasmLinkDependencies Remove="@(_WasmNativeFileForLinking)" />
-
-      <_SkiaSharpToReorder Include="@(_WasmNativeFileForLinking)" Condition="$([System.String]::Copy('%(FullPath)').Contains('libSkiaSharp.a'))" />
-      <_WasmNativeFileForLinking Remove="@(_SkiaSharpToReorder)" />
-      <_WasmNativeFileForLinking Include="@(_SkiaSharpToReorder)" />
-
-      <_EmccLinkStepArgs Include="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
-      <_WasmLinkDependencies Include="@(_WasmNativeFileForLinking)" />
-      <_WasmLinkStepArgs Include="@(_EmccLinkStepArgs)" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/nuget/buildTransitive/SkiaSharp.Views.Blazor.props
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/nuget/buildTransitive/SkiaSharp.Views.Blazor.props
@@ -6,24 +6,6 @@
     <EmccExtraLDFlags>$(EmccExtraLDFlags) --js-library="$(MSBuildThisFileDirectory)SkiaSharpInterop.js"</EmccExtraLDFlags>
   </PropertyGroup>
 
-  <!-- Workaround for https://github.com/dotnet/runtime/issues/109289 -->
-  <Target Name="RuntimeIssue109289_Workaround"
-          AfterTargets="_BrowserWasmWriteRspForLinking">
-    <ItemGroup>
-      <_WasmLinkStepArgs Remove="@(_EmccLinkStepArgs)" />
-      <_EmccLinkStepArgs Remove="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
-      <_WasmLinkDependencies Remove="@(_WasmNativeFileForLinking)" />
-
-      <_SkiaSharpToReorder Include="@(_WasmNativeFileForLinking)" Condition="$([System.String]::Copy('%(FullPath)').Contains('libSkiaSharp.a'))" />
-      <_WasmNativeFileForLinking Remove="@(_SkiaSharpToReorder)" />
-      <_WasmNativeFileForLinking Include="@(_SkiaSharpToReorder)" />
-
-      <_EmccLinkStepArgs Include="&quot;%(_WasmNativeFileForLinking.Identity)&quot;" />
-      <_WasmLinkDependencies Include="@(_WasmNativeFileForLinking)" />
-      <_WasmLinkStepArgs Include="@(_EmccLinkStepArgs)" />
-    </ItemGroup>
-  </Target>
-
   <Import Project="msbuild.build.SkiaSharp.Views.Blazor.props" />
 
 </Project>


### PR DESCRIPTION

**Description of Change**

The workaround needed for WASM is not really Blazor specific and if the project is not using the Blazor views, the fix will not be applied to the build.

The workaround for https://github.com/dotnet/runtime/issues/109289 was added in #3064, however because a project may not be using the SkiaSharp.Views.Blazor package it will still fail.

**Bugs Fixed**

- Fixes #3049
- FIxes https://github.com/mono/SkiaSharp/issues/3074

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
