### PR TITLE
Use `<WindowsSdkPackageVersion>` to set the SDK version

### DIFF
--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -247,6 +247,7 @@
   <PropertyGroup>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
+    <WindowsSdkPackageVersion>10.0.19041.27</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <!-- platform version number information -->
@@ -273,7 +274,6 @@
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows10'))">
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.19041.27</WindowsSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.Contains('-tizen'))">
     <SupportedOSPlatformVersion>6.5</SupportedOSPlatformVersion>

--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -273,6 +273,7 @@
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows10'))">
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.19041.27</WindowsSdkPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.Contains('-tizen'))">
     <SupportedOSPlatformVersion>6.5</SupportedOSPlatformVersion>


### PR DESCRIPTION
**Description of Change**

I think the SDK and/or VS updates have brought in some issue, but I think there is another way to do what we want.

We currently have this:

```xml
<FrameworkReference
    Update="Microsoft.Windows.SDK.NET.Ref"
    RuntimeFrameworkVersion="10.0.19041.27"
    TargetingPackVersion="10.0.19041.27" />
```

But that is assuming the framework references are added early and we run late. But, it appears something changed and now the values are either ignored or the items are added in a different place. This results in our adjustments being ignored.

There is another property `<WindowsSdkPackageVersion>` that can be used and feels more official.

I think in net6 something broke with the property so we had to do it via the framework references, but now it appears they fixed it and broke us.