### PR TITLE
Log more information about disk space and skip the MSVC builds on public

### DIFF
--- a/native/winui-angle/build.cake
+++ b/native/winui-angle/build.cake
@@ -80,6 +80,9 @@ Task("sync-ANGLE")
         RunPython(ANGLE_PATH, ANGLE_PATH.CombineWithFilePath("tools/clang/scripts/update.py"));
     }
 
+    // long the free space
+    RunProcess("pwsh", ROOT_PATH.CombineWithFilePath("scripts/get-free-space.ps1").FullPath);
+
     // generate Windows App SDK files
     if (!FileExists(WINAPPSDK_PATH.CombineWithFilePath("Microsoft.WindowsAppSDK.nuspec"))) {
         var setup = ANGLE_PATH.CombineWithFilePath("scripts/winappsdk_setup.py");
@@ -87,6 +90,9 @@ Task("sync-ANGLE")
             ROOT_PATH.CombineWithFilePath("scripts/vcvarsall.bat"),
             $"\"{VS_INSTALL}\" \"x64\" \"{PYTHON_EXE}\" \"{setup}\" --output \"{WINAPPSDK_PATH}\"");
     }
+
+    // long the free space
+    RunProcess("pwsh", ROOT_PATH.CombineWithFilePath("scripts/get-free-space.ps1").FullPath);
 });
 
 Task("ANGLE")

--- a/native/winui-angle/build.cake
+++ b/native/winui-angle/build.cake
@@ -80,9 +80,6 @@ Task("sync-ANGLE")
         RunPython(ANGLE_PATH, ANGLE_PATH.CombineWithFilePath("tools/clang/scripts/update.py"));
     }
 
-    // long the free space
-    RunProcess("pwsh", ROOT_PATH.CombineWithFilePath("scripts/get-free-space.ps1").FullPath);
-
     // generate Windows App SDK files
     if (!FileExists(WINAPPSDK_PATH.CombineWithFilePath("Microsoft.WindowsAppSDK.nuspec"))) {
         var setup = ANGLE_PATH.CombineWithFilePath("scripts/winappsdk_setup.py");
@@ -90,9 +87,6 @@ Task("sync-ANGLE")
             ROOT_PATH.CombineWithFilePath("scripts/vcvarsall.bat"),
             $"\"{VS_INSTALL}\" \"x64\" \"{PYTHON_EXE}\" \"{setup}\" --output \"{WINAPPSDK_PATH}\"");
     }
-
-    // long the free space
-    RunProcess("pwsh", ROOT_PATH.CombineWithFilePath("scripts/get-free-space.ps1").FullPath);
 });
 
 Task("ANGLE")

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -82,6 +82,9 @@ jobs:
               targetPath: ${{ additionalArtifact.path }}
 
     steps:
+      - pwsh: .\scripts\get-free-space.ps1
+        displayName: Get the volume information before the run
+
       # prepare
       - checkout: self
         submodules: recursive
@@ -101,7 +104,7 @@ jobs:
       - pwsh: .\scripts\get-build-type.ps1 -ExternalsBuildId '${{ parameters.buildExternals }}'
         displayName: Determine build type
 
-      - pwsh: Get-Volume
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information before the provisioning
 
       # provisioning steps
@@ -276,7 +279,7 @@ jobs:
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
 
-      - pwsh: Get-Volume
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information before downloading artifacts
 
       # download artifacts
@@ -291,7 +294,7 @@ jobs:
           artifacts:
             - name: ${{ parameters.name }}
 
-      - pwsh: Get-Volume
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after downloading artifacts
 
       # pre-build steps
@@ -300,7 +303,7 @@ jobs:
       - ${{ if ne(length(parameters.preBuildSteps), 0) }}:
         - ${{ parameters.preBuildSteps }}
 
-      - pwsh: Get-Volume
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information before the build
 
       # actual build
@@ -371,7 +374,7 @@ jobs:
             retryCountOnTaskFailure: ${{ parameters.retryCount }}
             condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
 
-      - pwsh: Get-Volume
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after the build
 
       # post-build steps
@@ -380,5 +383,5 @@ jobs:
       - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
         - template: /scripts/azure-templates-github-status.yml@self
 
-      - pwsh: Get-Volume
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after the entire run

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -82,13 +82,13 @@ jobs:
               targetPath: ${{ additionalArtifact.path }}
 
     steps:
-      - pwsh: .\scripts\get-free-space.ps1
-        displayName: Get the volume information before the run
-
       # prepare
       - checkout: self
         submodules: recursive
       - template: /scripts/azure-templates-variables.yml@self
+
+      - pwsh: .\scripts\get-free-space.ps1
+        displayName: Get the volume information before the run
 
       # # checkout required skia PR
       # - pwsh: .\scripts\checkout-skia.ps1 -GitHubToken $(GitHub.Token.PublicAccess)

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -82,12 +82,15 @@ jobs:
               targetPath: ${{ additionalArtifact.path }}
 
     steps:
+      - pwsh: if ($IsLinux -or $IsMacOS) { df -h } else { Get-Volume }
+        displayName: Get the volume information before the run
+
       # prepare
       - checkout: self
         submodules: recursive
       - template: /scripts/azure-templates-variables.yml@self
 
-      - pwsh: .\scripts\get-free-space.ps1
+      - pwsh: if ($IsLinux -or $IsMacOS) { df -h } else { Get-Volume }
         displayName: Get the volume information before the run
 
       # # checkout required skia PR

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -91,7 +91,7 @@ jobs:
       - template: /scripts/azure-templates-variables.yml@self
 
       - pwsh: if ($IsLinux -or $IsMacOS) { df -h } else { Get-Volume }
-        displayName: Get the volume information before the run
+        displayName: Get the volume information after the checkout
 
       # # checkout required skia PR
       # - pwsh: .\scripts\checkout-skia.ps1 -GitHubToken $(GitHub.Token.PublicAccess)

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -101,6 +101,9 @@ jobs:
       - pwsh: .\scripts\get-build-type.ps1 -ExternalsBuildId '${{ parameters.buildExternals }}'
         displayName: Determine build type
 
+      - pwsh: Get-Volume
+        displayName: Get the volume information before the provisioning
+
       # provisioning steps
       - ${{ if ne(parameters.buildAgent.provisioningSteps, '') }}:
         - ${{ parameters.buildAgent.provisioningSteps }}
@@ -273,6 +276,9 @@ jobs:
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
 
+      - pwsh: Get-Volume
+        displayName: Get the volume information before downloading artifacts
+
       # download artifacts
       - template: /scripts/azure-templates-download-artifacts.yml@self
         parameters:
@@ -285,11 +291,17 @@ jobs:
           artifacts:
             - name: ${{ parameters.name }}
 
+      - pwsh: Get-Volume
+        displayName: Get the volume information after downloading artifacts
+
       # pre-build steps
       - ${{ if ne(parameters.buildAgent.preBuildSteps, '') }}:
         - ${{ parameters.buildAgent.preBuildSteps }}
       - ${{ if ne(length(parameters.preBuildSteps), 0) }}:
         - ${{ parameters.preBuildSteps }}
+
+      - pwsh: Get-Volume
+        displayName: Get the volume information before the build
 
       # actual build
       - ${{ if ne(parameters.skipSteps, 'true') }}:
@@ -359,8 +371,14 @@ jobs:
             retryCountOnTaskFailure: ${{ parameters.retryCount }}
             condition: and(succeeded(), eq(variables['DOWNLOAD_EXTERNALS'], ''))
 
+      - pwsh: Get-Volume
+        displayName: Get the volume information after the build
+
       # post-build steps
       - ${{ parameters.postBuildSteps }}
 
       - ${{ if eq(parameters.buildPipelineType, 'tests') }}:
         - template: /scripts/azure-templates-github-status.yml@self
+
+      - pwsh: Get-Volume
+        displayName: Get the volume information after the entire run

--- a/scripts/azure-templates-bootstrapper.yml
+++ b/scripts/azure-templates-bootstrapper.yml
@@ -84,14 +84,16 @@ jobs:
     steps:
       - pwsh: if ($IsLinux -or $IsMacOS) { df -h } else { Get-Volume }
         displayName: Get the volume information before the run
+        condition: always()
 
       # prepare
       - checkout: self
         submodules: recursive
       - template: /scripts/azure-templates-variables.yml@self
 
-      - pwsh: if ($IsLinux -or $IsMacOS) { df -h } else { Get-Volume }
+      - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after the checkout
+        condition: always()
 
       # # checkout required skia PR
       # - pwsh: .\scripts\checkout-skia.ps1 -GitHubToken $(GitHub.Token.PublicAccess)
@@ -109,6 +111,7 @@ jobs:
 
       - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information before the provisioning
+        condition: always()
 
       # provisioning steps
       - ${{ if ne(parameters.buildAgent.provisioningSteps, '') }}:
@@ -284,6 +287,7 @@ jobs:
 
       - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information before downloading artifacts
+        condition: always()
 
       # download artifacts
       - template: /scripts/azure-templates-download-artifacts.yml@self
@@ -299,6 +303,7 @@ jobs:
 
       - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after downloading artifacts
+        condition: always()
 
       # pre-build steps
       - ${{ if ne(parameters.buildAgent.preBuildSteps, '') }}:
@@ -308,6 +313,7 @@ jobs:
 
       - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information before the build
+        condition: always()
 
       # actual build
       - ${{ if ne(parameters.skipSteps, 'true') }}:
@@ -379,6 +385,7 @@ jobs:
 
       - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after the build
+        condition: always()
 
       # post-build steps
       - ${{ parameters.postBuildSteps }}
@@ -388,3 +395,4 @@ jobs:
 
       - pwsh: .\scripts\get-free-space.ps1
         displayName: Get the volume information after the entire run
+        condition: always()

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -145,39 +145,40 @@ stages:
             buildAgent: ${{ parameters.buildAgentWindowsNative }}
             target: externals-windows
             additionalArgs: --buildarch=arm64
-        - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native Win32|x86 (Win + MSVC)
-          parameters:
-            name: native_win32_x86_msvc_windows
-            displayName: Win32 x86 [MSVC]
-            sdl: ${{ parameters.sdl }}
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            buildAgent: ${{ parameters.buildAgentWindowsNative }}
-            target: externals-windows
-            additionalArgs: --buildarch=x86 --llvm="msvc"
-            installLlvm: false
-        - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native Win32|x64 (Win + MSVC)
-          parameters:
-            name: native_win32_x64_msvc_windows
-            displayName: Win32 x64 [MSVC]
-            sdl: ${{ parameters.sdl }}
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            buildAgent: ${{ parameters.buildAgentWindowsNative }}
-            target: externals-windows
-            additionalArgs: --buildarch=x64 --llvm="msvc"
-            installLlvm: false
-        - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native Win32|arm64 (Win + MSVC)
-          parameters:
-            name: native_win32_arm64_msvc_windows
-            displayName: Win32 arm64 [MSVC]
-            sdl: ${{ parameters.sdl }}
-            buildExternals: ${{ parameters.buildExternals }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            buildAgent: ${{ parameters.buildAgentWindowsNative }}
-            target: externals-windows
-            additionalArgs: --buildarch=arm64 --llvm="msvc"
-            installLlvm: false
+        - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+          - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native Win32|x86 (Win + MSVC)
+            parameters:
+              name: native_win32_x86_msvc_windows
+              displayName: Win32 x86 [MSVC]
+              sdl: ${{ parameters.sdl }}
+              buildExternals: ${{ parameters.buildExternals }}
+              buildPipelineType: ${{ parameters.buildPipelineType }}
+              buildAgent: ${{ parameters.buildAgentWindowsNative }}
+              target: externals-windows
+              additionalArgs: --buildarch=x86 --llvm="msvc"
+              installLlvm: false
+          - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native Win32|x64 (Win + MSVC)
+            parameters:
+              name: native_win32_x64_msvc_windows
+              displayName: Win32 x64 [MSVC]
+              sdl: ${{ parameters.sdl }}
+              buildExternals: ${{ parameters.buildExternals }}
+              buildPipelineType: ${{ parameters.buildPipelineType }}
+              buildAgent: ${{ parameters.buildAgentWindowsNative }}
+              target: externals-windows
+              additionalArgs: --buildarch=x64 --llvm="msvc"
+              installLlvm: false
+          - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native Win32|arm64 (Win + MSVC)
+            parameters:
+              name: native_win32_arm64_msvc_windows
+              displayName: Win32 arm64 [MSVC]
+              sdl: ${{ parameters.sdl }}
+              buildExternals: ${{ parameters.buildExternals }}
+              buildPipelineType: ${{ parameters.buildPipelineType }}
+              buildAgent: ${{ parameters.buildAgentWindowsNative }}
+              target: externals-windows
+              additionalArgs: --buildarch=arm64 --llvm="msvc"
+              installLlvm: false
         - template: /scripts/azure-templates-bootstrapper.yml@self # Build Native WinUI|x86 (Win)
           parameters:
             name: native_winui_x86_windows
@@ -527,17 +528,18 @@ stages:
             matrixArtifacts:
               - name: native_wasm
                 jobs: $(nativeWasmJobs)
-        - template: /scripts/azure-templates-merger.yml@self # Merge Native MSVC Artifacts
-          parameters:
-            name: native_msvc
-            displayName: Merge Native MSVC Artifacts
-            sdl: ${{ parameters.sdl }}
-            buildPipelineType: ${{ parameters.buildPipelineType }}
-            buildAgent: ${{ parameters.buildAgentHost }}
-            requiredArtifacts:
-              - name: native_win32_x86_msvc_windows
-              - name: native_win32_x64_msvc_windows
-              - name: native_win32_arm64_msvc_windows
+        - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+          - template: /scripts/azure-templates-merger.yml@self # Merge Native MSVC Artifacts
+            parameters:
+              name: native_msvc
+              displayName: Merge Native MSVC Artifacts
+              sdl: ${{ parameters.sdl }}
+              buildPipelineType: ${{ parameters.buildPipelineType }}
+              buildAgent: ${{ parameters.buildAgentHost }}
+              requiredArtifacts:
+                - name: native_win32_x86_msvc_windows
+                - name: native_win32_x64_msvc_windows
+                - name: native_win32_arm64_msvc_windows
 
   - ${{ if ne(parameters.buildPipelineType, 'build') }}:
     - stage: managed

--- a/scripts/get-free-space.ps1
+++ b/scripts/get-free-space.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 if ($IsLinux -or $IsMacOS) {
-    Write-Host "Not supported yet."
+    df -h
 } else {
     Get-Volume
 }


### PR DESCRIPTION
**Description of Change**

The public bots are running out of space.

The MSVC compiler is so heavy that the outputs are over 10.8GB
whereas the LLVM compiler is just under 10.1GB.

The public agent only starts with 12GB and after the checkout we are
left with 10.67GB which is smaller than the 10.8GB required. The LLVM
compiler just manages to pass under the bar with about 600MB spare.

If the SkiaSharp artifacts get any bigger, then we will need custom
machines for the public build.