### PR TITLE
[Proposal] Add more details to apple touch events

### DIFF
--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
@@ -104,7 +104,18 @@ namespace SkiaSharp.Views.Maui.Platform
 			var cgPoint = touch.LocationInView(View);
 			var point = scalePixels(cgPoint.X, cgPoint.Y);
 
-			var args = new SKTouchEventArgs(id, actionType, point, inContact);
+			SKMouseButton mouse = SKMouseButton.Left;
+			SKTouchDeviceType device = touch.Type switch
+			{
+				UITouchType.IndirectPointer => SKTouchDeviceType.Mouse,
+				UITouchType.Indirect => SKTouchDeviceType.Mouse,
+				UITouchType.Stylus => SKTouchDeviceType.Pen,
+				UITouchType.Direct => SKTouchDeviceType.Touch,
+				_ => SKTouchDeviceType.Touch
+
+			};
+
+			var args = new SKTouchEventArgs(id, actionType, mouse, device, point, inContact, 0);
 			onTouchAction(args);
 			return args.Handled;
 		}


### PR DESCRIPTION
**Description of Change**
Set the `SKTouchDeviceType` more accurately for touch events on Mac or iOS.

This would be very useful to me. Does it seem like a welcome change? I'd like to discuss before working any further.

Building on Mac wasn't working in my fork, so I developed this in another maui hello world project and developed and ran it there.

<!-- Describe your changes here. -->
This diff simply elaborates the device type based on information already in touch event.

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

This will make touch events on iOS and Mac have touch types which are more accurately one of:
```
SKTouchDeviceType.Mouse
SKTouchDeviceType.Pen
SKTouchDeviceType.Touch
```
rather than always `Touch`

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

Same as the above API change.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
