### PR TITLE
Fix the incorrect call in SafeRef.

### DIFF
--- a/binding/SkiaSharp/SKObject.cs
+++ b/binding/SkiaSharp/SKObject.cs
@@ -313,7 +313,7 @@ namespace SkiaSharp
 			if (obj is ISKNonVirtualReferenceCounted nvrefcnt)
 				nvrefcnt.ReferenceNative ();
 			else
-				SkiaApi.sk_refcnt_safe_unref (obj.Handle);
+				SkiaApi.sk_refcnt_safe_ref (obj.Handle);
 		}
 
 		public static void SafeUnRef (this ISKReferenceCounted obj)


### PR DESCRIPTION
**Description of Change**

`SafeRef` should call  `sk_refcnt_safe_ref` instead `sk_refcnt_safe_unref`.

**Bugs Fixed**

Fix the incorrect behavior of `SafeRef`.

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
