### PR TITLE
Fix iOS Simulator performance with Metal

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -36,7 +36,7 @@ namespace SkiaSharp.Views.Mac
 		#elif __MACOS__
 			true;
 		#else
-			ObjCRuntime.Runtime.Arch == Arch.SIMULATOR;
+			ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR;
 		#endif
 
 		private GRMtlBackendContext backendContext;

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -7,7 +7,7 @@ using Foundation;
 using Metal;
 using MetalKit;
 
-bool DepthStencilModePrivate =>
+readonly bool DepthStencilModePrivate =>
 #if __MACCATALYST__
     false;
 #elif __MACOS__

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -7,15 +7,6 @@ using Foundation;
 using Metal;
 using MetalKit;
 
-readonly bool DepthStencilModePrivate =>
-#if __MACCATALYST__
-    false;
-#elif __MACOS__
-	true;
-#else
-    ObjCRuntime.Runtime.Arch == Arch.SIMULATOR;
-#endif
-
 #if __IOS__
 namespace SkiaSharp.Views.iOS
 #elif __MACOS__
@@ -39,6 +30,14 @@ namespace SkiaSharp.Views.Mac
 
 		private bool designMode;
 
+readonly bool DepthStencilModePrivate =>
+#if __MACCATALYST__
+    false;
+#elif __MACOS__
+	true;
+#else
+    ObjCRuntime.Runtime.Arch == Arch.SIMULATOR;
+#endif
 		private GRMtlBackendContext backendContext;
 		private GRContext context;
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -82,7 +82,16 @@ namespace SkiaSharp.Views.Mac
 
 			ColorPixelFormat = MTLPixelFormat.BGRA8Unorm;
 			DepthStencilPixelFormat = MTLPixelFormat.Depth32Float_Stencil8;
-			SampleCount = 1;
+			if (DeviceInfo.Current.DeviceType == DeviceType.Virtual)
+			{
+				DepthStencilStorageMode = MTLStorageMode.Private;
+				SampleCount = 4;
+			}
+			else
+			{
+				DepthStencilStorageMode = MTLStorageMode.Shared;
+				SampleCount = 2;
+			}
 			FramebufferOnly = false;
 			Device = device;
 			backendContext = new GRMtlBackendContext

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -7,6 +7,15 @@ using Foundation;
 using Metal;
 using MetalKit;
 
+bool DepthStencilModePrivate =>
+#if __MACCATALYST__
+    false;
+#elif __MACOS__
+	true;
+#else
+    ObjCRuntime.Runtime.Arch == Arch.SIMULATOR;
+#endif
+
 #if __IOS__
 namespace SkiaSharp.Views.iOS
 #elif __MACOS__
@@ -82,7 +91,7 @@ namespace SkiaSharp.Views.Mac
 
 			ColorPixelFormat = MTLPixelFormat.BGRA8Unorm;
 			DepthStencilPixelFormat = MTLPixelFormat.Depth32Float_Stencil8;
-			if (DeviceInfo.Current.DeviceType == DeviceType.Virtual)
+			if (DepthStencilModePrivate)
 			{
 				DepthStencilStorageMode = MTLStorageMode.Private;
 				SampleCount = 4;

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -1,4 +1,4 @@
-﻿#if __IOS__ || __MACOS__
+#if __IOS__ || __MACOS__
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -30,14 +30,15 @@ namespace SkiaSharp.Views.Mac
 
 		private bool designMode;
 
-readonly bool DepthStencilModePrivate =>
-#if __MACCATALYST__
-    false;
-#elif __MACOS__
-	true;
-#else
-    ObjCRuntime.Runtime.Arch == Arch.SIMULATOR;
-#endif
+		private bool DepthStencilModePrivate =>
+		#if __MACCATALYST__
+			false;
+		#elif __MACOS__
+			true;
+		#else
+			ObjCRuntime.Runtime.Arch == Arch.SIMULATOR;
+		#endif
+
 		private GRMtlBackendContext backendContext;
 		private GRContext context;
 


### PR DESCRIPTION
This comes from a new synced branch.

Had iOS simulator lagging on M1 at 9 fps with SKGLView, so had to adjust its platform-related code for iOS to unlock 60 fps.
Just followed Apple guidelines for simulator:   https://developer.apple.com/documentation/metal/developing-metal-apps-that-run-in-simulator?language=objc

replacing `SampleCount = 1;` (no MSAA) inside `SKMetalView` with:

```csharp
			if (DeviceInfo.Current.DeviceType == DeviceType.Virtual)
			{
				DepthStencilStorageMode = MTLStorageMode.Private;
				SampleCount = 4;
			}
			else
			{
				DepthStencilStorageMode = MTLStorageMode.Shared;
				SampleCount = 2;
			}
```
 
Works fine in DrawnUi now, wanted to share.
