### PR TITLE
Make two DrawText methods obsolete because of #3122

### DIFF
--- a/binding/SkiaSharp/SKCanvas.cs
+++ b/binding/SkiaSharp/SKCanvas.cs
@@ -619,6 +619,7 @@ namespace SkiaSharp
 		public void DrawText (string text, float x, float y, SKPaint paint) =>
 			DrawText (text, x, y, paint.TextAlign, paint.GetFont (), paint);
 
+		[Obsolete ("Use DrawText(string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.")]
 		public void DrawText (string text, SKPoint p, SKFont font, SKPaint paint) =>
 #pragma warning disable CS0618 // Type or member is obsolete (TODO: replace paint.TextAlign with SKTextAlign.Left)
 			DrawText (text, p, paint.TextAlign, font, paint);
@@ -627,6 +628,7 @@ namespace SkiaSharp
 		public void DrawText (string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) =>
 			DrawText (text, p.X, p.Y, textAlign, font, paint);
 
+		[Obsolete ("Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.")]
 		public void DrawText (string text, float x, float y, SKFont font, SKPaint paint) =>
 #pragma warning disable CS0618 // Type or member is obsolete (TODO: replace paint.TextAlign with SKTextAlign.Left)
 			DrawText (text, x, y, paint.TextAlign, font, paint);


### PR DESCRIPTION
**Description of Change**

Made two DrawText methods obsolete that use the obsolete SKPaint.TextAlign, which caused a text to disappeared after drawing the same text multiple times. Two other DrawText methods were already obsolete, seemingly also because of the obsolete SKPaint.TextAlign.

**Bugs Fixed**

- Fixes https://github.com/mono/SkiaSharp/issues/3122

**API Changes**

Users will get a warning (or error if WarningAsError is true) when calling these methods.

Made obsolete:

- `public void DrawText (string text, SKPoint p, SKFont font, SKPaint paint)`
- `public void DrawText (string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint)`

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**
- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation

Perhaps documentation needs to be updated, not sure what or how.