### PR TITLE
[build] Address CVE-2024-30105

### DIFF
--- a/source/SkiaSharp.DotNet.Interactive/SkiaSharp.DotNet.Interactive.csproj
+++ b/source/SkiaSharp.DotNet.Interactive/SkiaSharp.DotNet.Interactive.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.23313.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.25110.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/advisories/GHSA-hh2w-p6rv-4g7w

Bumps Microsoft.DotNet.Interactive to v1.0.0-beta.25110.2 to bring in
an updated version of System.Text.Json.