### PR TITLE
Exclude code that will never run on Apple

### DIFF
--- a/binding/Binding.Shared/PlatformConfiguration.cs
+++ b/binding/Binding.Shared/PlatformConfiguration.cs
@@ -85,7 +85,7 @@ namespace SkiaSharp.Internals
 			set => linuxFlavor = value;
 		}
 
-#if WINDOWS_UWP
+#if WINDOWS_UWP || __IOS__ || __TVOS__ || __MACOS__ || __MACCATALYST__ || __ANDROID__
 		public static bool IsGlibc { get; }
 #else
 		private static readonly Lazy<bool> isGlibcLazy = new Lazy<bool> (IsGlibcImplementation);

--- a/binding/SkiaSharp/PlatformLock.cs
+++ b/binding/SkiaSharp/PlatformLock.cs
@@ -68,9 +68,11 @@ namespace SkiaSharp.Internals
 		/// <returns>A reference to a new platform lock implementation</returns>
 		public static IPlatformLock DefaultFactory ()
 		{
+#if !(__IOS__ || __TVOS__ || __MACOS__ || __MACCATALYST__ || __ANDROID__)
 			if (PlatformConfiguration.IsWindows)
 				return new NonAlertableWin32Lock ();
 			else
+#endif
 				return new ReadWriteLock ();
 		}
 
@@ -90,6 +92,7 @@ namespace SkiaSharp.Internals
 			ReaderWriterLockSlim _lock = new ReaderWriterLockSlim ();
 		}
 
+#if !(__IOS__ || __TVOS__ || __MACOS__ || __MACCATALYST__ || __ANDROID__)
 		/// <summary>
 		/// Windows platform lock uses Win32 CRITICAL_SECTION
 		/// </summary>
@@ -169,6 +172,6 @@ namespace SkiaSharp.Internals
 			static extern void LeaveCriticalSection (IntPtr lpCriticalSection);
 #endif
 		}
+#endif
 	}
-
 }

--- a/binding/SkiaSharp/SKAutoCoInitialize.cs
+++ b/binding/SkiaSharp/SKAutoCoInitialize.cs
@@ -12,9 +12,11 @@ namespace SkiaSharp
 
 		public SKAutoCoInitialize()
 		{
+#if !(__IOS__ || __TVOS__ || __MACOS__ || __MACCATALYST__ || __ANDROID__)
 			if (PlatformConfiguration.IsWindows)
 				hResult = CoInitializeEx(IntPtr.Zero, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
 			else
+#endif
 				hResult = S_OK;
 		}
 
@@ -24,8 +26,10 @@ namespace SkiaSharp
 		{
 			if (hResult >= 0)
 			{
+#if !(__IOS__ || __TVOS__ || __MACOS__ || __MACCATALYST__ || __ANDROID__)
 				if (PlatformConfiguration.IsWindows)
 					CoUninitialize();
+#endif
 
 				hResult = -1;
 			}
@@ -41,6 +45,7 @@ namespace SkiaSharp
 		private const uint COINIT_DISABLE_OLE1DDE = 0x4;
 		private const uint COINIT_SPEED_OVER_MEMORY = 0x8;
 
+#if !(__IOS__ || __TVOS__ || __MACOS__ || __MACCATALYST__ || __ANDROID__)
 #if USE_LIBRARY_IMPORT
 		[LibraryImport("ole32.dll", SetLastError = true)]
 		private static partial long CoInitializeEx(IntPtr pvReserved, uint dwCoInit);
@@ -51,6 +56,7 @@ namespace SkiaSharp
 		private static extern long CoInitializeEx([In, Optional] IntPtr pvReserved, [In] uint dwCoInit);
 		[DllImport("ole32.dll", CharSet = CharSet.Ansi, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
 		private static extern void CoUninitialize();
+#endif
 #endif
 	}
 }


### PR DESCRIPTION
**Description of Change**

These APIs are fine to leave in for most cases, but I see tvOS fails AOT because it can't find the imports to Win32 things.

This PR just removes them entirely from Apple and Android builds as they will never exist. We have to leave it for the others because a net8.0 dll could run on macOS or Windows with GTK things,