### PR TITLE
Fix the SKImage.FromPicture implementation

### DIFF
--- a/binding/SkiaSharp/SKImage.cs
+++ b/binding/SkiaSharp/SKImage.cs
@@ -330,16 +330,16 @@ namespace SkiaSharp
 		// create a new image from a picture
 
 		public static SKImage FromPicture (SKPicture picture, SKSizeI dimensions) =>
-			FromPicture (picture, dimensions, null, null, false, null, null);
+			FromPicture (picture, dimensions, null, null, false, SKColorSpace.CreateSrgb (), null);
 
 		public static SKImage FromPicture (SKPicture picture, SKSizeI dimensions, SKMatrix matrix) =>
-			FromPicture (picture, dimensions, &matrix, null, false, null, null);
+			FromPicture (picture, dimensions, &matrix, null, false, SKColorSpace.CreateSrgb (), null);
 
 		public static SKImage FromPicture (SKPicture picture, SKSizeI dimensions, SKPaint paint) =>
-			FromPicture (picture, dimensions, null, paint, false, null, null);
+			FromPicture (picture, dimensions, null, paint, false, SKColorSpace.CreateSrgb (), null);
 
 		public static SKImage FromPicture (SKPicture picture, SKSizeI dimensions, SKMatrix matrix, SKPaint paint) =>
-			FromPicture (picture, dimensions, &matrix, paint, false, null, null);
+			FromPicture (picture, dimensions, &matrix, paint, false, SKColorSpace.CreateSrgb (), null);
 
 		private static SKImage FromPicture (SKPicture picture, SKSizeI dimensions, SKMatrix* matrix, SKPaint paint, bool useFloatingPointBitDepth, SKColorSpace colorspace, SKSurfaceProperties props)
 		{
@@ -347,7 +347,9 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (picture));
 
 			var p = paint?.Handle ?? IntPtr.Zero;
-			return GetObject (SkiaApi.sk_image_new_from_picture (picture.Handle, &dimensions, matrix, p, useFloatingPointBitDepth, colorspace?.Handle ?? IntPtr.Zero, props?.Handle ?? IntPtr.Zero));
+			var cs = colorspace?.Handle ?? IntPtr.Zero;
+			var prps = props?.Handle ?? IntPtr.Zero;
+			return GetObject (SkiaApi.sk_image_new_from_picture (picture.Handle, &dimensions, matrix, p, useFloatingPointBitDepth, cs, prps));
 		}
 
 		public SKData Encode ()

--- a/tests/Tests/SkiaSharp/SKImageTest.cs
+++ b/tests/Tests/SkiaSharp/SKImageTest.cs
@@ -925,5 +925,18 @@ namespace SkiaSharp.Tests
 			using var shader = image.ToRawShader(SKShaderTileMode.Clamp, SKShaderTileMode.Clamp, sampling);
 			Assert.Null(shader);
 		}
+
+		[SkippableFact]
+		public void FromPictureDoesNotCrash()
+		{
+			using var picture = CreateTestPicture();
+
+			using var image = SKImage.FromPicture(picture, new SKSizeI(40, 40));
+
+			using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+			using var bmp = SKBitmap.Decode(data);
+			
+			ValidateTestBitmap(bmp);
+		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKTest.cs
+++ b/tests/Tests/SkiaSharp/SKTest.cs
@@ -139,7 +139,7 @@ namespace SkiaSharp.Tests
 			return recorder.EndRecording();
 		}
 
-		private static void DrawTestBitmap(SKCanvas canvas, int width, int height, byte alpha = 255)
+		protected static void DrawTestBitmap(SKCanvas canvas, int width, int height, byte alpha = 255)
 		{
 			using var paint = new SKPaint();
 


### PR DESCRIPTION

**Description of Change**

This PR bumps the externals/skia as that has a fix for passing null surface props: https://github.com/mono/skia/pull/156

However, it then also fixes the case where creating images from pictures requires a color space. If there is no color space, then null is returned. The docs say null color space is fine, but the code says otherwise. I asked the team to clarify: https://groups.google.com/g/skia-discuss/c/vbFCoMQXF3c

**Bugs Fixed**

- Fixes #3157

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
