### PR TITLE
fix: SKXamlCanvas must not be opaque on MacCatalyst

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI/SKXamlCanvas.AppleiOS.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI/SKXamlCanvas.AppleiOS.cs
@@ -20,7 +20,7 @@ namespace SkiaSharp.Views.UWP
 		public SKXamlCanvas()
 		{
 			Initialize();			
-#if IOS
+#if __IOS__
 			Opaque = false;
 #endif
 		}


### PR DESCRIPTION
**Description of Change**

For `SKXamlCanvas` set `UIView.Opaque` to `false` on Mac-Catalyst too (not just for iOS).

**Bugs Fixed**

- Fixes https://github.com/unoplatform/uno/issues/19675

**API Changes**

None.

**Behavioral Changes**

Mac-Catalyst will now behave like iOS.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
