### PR TITLE
Enable Windows linker optimizations in Release

### DIFF
--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -41,6 +41,7 @@ Task("libSkiaSharp")
         var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
         var win_vcvars_version = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"win_vcvars_version='{VC_TOOLSET_VERSION}' ";
         var d = CONFIGURATION.ToLower() == "release" ? "" : "d";
+        var linker_opt = CONFIGURATION.ToLower() == "release" ? "" : "NO";
         var spectreLibPath = GetSpectreLibPath(arch);
 
         GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
@@ -63,7 +64,7 @@ Task("libSkiaSharp")
             clang +
             win_vcvars_version +
             $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DSK_ENABLE_LEGACY_SHADERCONTEXT', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +
-            $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP', '/guard:cf', '/LIBPATH:{spectreLibPath}', '/DELAYLOAD:d3d12.dll', '/DELAYLOAD:dxgi.dll', '/DELAYLOAD:D3DCOMPILER_47.dll', '/DEFAULTLIB:delayimp' ] " +
+            $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP', '/guard:cf', '/LIBPATH:{spectreLibPath}', '/DELAYLOAD:d3d12.dll', '/DELAYLOAD:dxgi.dll', '/DELAYLOAD:D3DCOMPILER_47.dll', '/DEFAULTLIB:delayimp', '/OPT:{linker_opt}REF', '/OPT:{linker_opt}ICF' ] " +
             ADDITIONAL_GN_ARGS);
 
         var outDir = OUTPUT_PATH.Combine($"{VARIANT}/{dir}");


### PR DESCRIPTION
**Description of Change**

As per the docs:
```
/DEBUG changes the defaults for the /OPT option from REF to NOREF and from ICF to NOICF, so if you want the original defaults, you must explicitly specify /OPT:REF or /OPT:ICF after the /DEBUG option.
```
Since the scripts enabled DEBUG even in release, those should be reenabled to reduce binary size.

No tests due to being a build configuration only change.

**Bugs Fixed**

- Fixes #3240

**API Changes**

None.

**Behavioral Changes**

Possibly slightly regressed debugging experience of release binaries.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
