### PR TITLE
[azure-pipelines-native] Add CI triggers for primary branches

### DIFF
--- a/scripts/azure-pipelines-native.yml
+++ b/scripts/azure-pipelines-native.yml
@@ -1,4 +1,7 @@
-trigger: none
+trigger:
+- main
+- dev*
+- release*
 
 pr: none
 

--- a/scripts/azure-pipelines-native.yml
+++ b/scripts/azure-pipelines-native.yml
@@ -1,6 +1,5 @@
 trigger:
 - main
-- dev*
 - release*
 
 pr: none

--- a/scripts/azure-pipelines-native.yml
+++ b/scripts/azure-pipelines-native.yml
@@ -1,6 +1,7 @@
 trigger:
-- main
-- release*
+  - main
+  - develop
+  - release/*
 
 pr: none
 


### PR DESCRIPTION
Restores the CI triggers to allow SkiaSharp-Native to run against main
and release branches.