### PR TITLE
Add a cron job to make sure all is well

### DIFF
--- a/scripts/azure-pipelines-native.yml
+++ b/scripts/azure-pipelines-native.yml
@@ -5,6 +5,14 @@ trigger:
 
 pr: none
 
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily midnight build for main
+    branches:
+      include:
+        - main
+    always: true
+
 parameters:
   - name: buildExternals
     displayName: 'The Build ID containing the specific native artifacts to use:'

--- a/scripts/azure-pipelines-package.yml
+++ b/scripts/azure-pipelines-package.yml
@@ -2,6 +2,14 @@ trigger: none
 
 pr: none
 
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily midnight build for main
+    branches:
+      include:
+        - main
+    always: true
+
 parameters:
   - name: buildAgentHost
     displayName: 'The generic host build agent configuration:'


### PR DESCRIPTION
**Description of Change**

Build everything every midnight. This will not only give us nightly builds, but also make sure CI is still working.

We also use this to generate all the compliance and security things. They take too long to run as part of the normal CI, so we run them at night.