### PR TITLE
Increase the build number in the new pipeline

### DIFF
--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -8,7 +8,7 @@ variables:
   GIT_URL: $(Build.Repository.Uri)
   FEATURE_NAME: ''
   PREVIEW_LABEL: 'preview.0'
-  BUILD_NUMBER: $[counter(format('_{0}_{1}_{2}__', variables['SKIASHARP_VERSION'], variables['Build.SourceBranch'], variables['PREVIEW_LABEL']), 1)]
+  BUILD_NUMBER: $[counter(format('_{0}_{1}_{2}_', variables['SKIASHARP_VERSION'], variables['Build.SourceBranch'], variables['PREVIEW_LABEL']), 50)]
   BUILD_COUNTER: $[counter('global_counter', 1)]
   TIZEN_LINUX_PACKAGES: libxcb-icccm4 libxcb-render-util0 gettext libxcb-image0 libsdl1.2debian libv4l-0 libxcb-randr0 bridge-utils libxcb-shape0 libpython2.7 openvpn libkf5itemmodels5 libkf5kiowidgets5 libkchart2
   MANAGED_LINUX_PACKAGES: ttf-ancient-fonts ninja-build


### PR DESCRIPTION
**Description of Change**

Increase the build number in the new pipeline. The last build published to the preview feed was 38, but I saw a 41 in the logs. So, let's skip to 50.