### PR TITLE
Avoid initializing SKMetalView twice

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -48,7 +48,6 @@ namespace SkiaSharp.Views.tvOS
 		public SKMetalView()
 			: this(CGRect.Empty)
 		{
-			Initialize();
 		}
 
 		// created in code


### PR DESCRIPTION
**Description of Change**

Avoids creating `GRMtlBackendContext` twice (and the duplicate command queue)

**Bugs Fixed**

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
