### PR TITLE
Added PostScriptName property to SkTypeface

### DIFF
--- a/binding/SkiaSharp/SKTypeface.cs
+++ b/binding/SkiaSharp/SKTypeface.cs
@@ -142,6 +142,8 @@ namespace SkiaSharp
 
 		public int GlyphCount => SkiaApi.sk_typeface_count_glyphs (Handle);
 
+		public string PostScriptName => (string)SKString.GetObject (SkiaApi.sk_typeface_get_post_script_name (Handle));
+
 		// GetTableTags
 
 		public int TableCount => SkiaApi.sk_typeface_count_tables (Handle);

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -16471,6 +16471,25 @@ namespace SkiaSharp
 			(sk_typeface_get_family_name_delegate ??= GetSymbol<Delegates.sk_typeface_get_family_name> ("sk_typeface_get_family_name")).Invoke (typeface);
 		#endif
 
+		// sk_string_t* sk_typeface_get_post_script_name(const sk_typeface_t* typeface)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_string_t sk_typeface_get_post_script_name (sk_typeface_t typeface);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_string_t sk_typeface_get_post_script_name (sk_typeface_t typeface);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_string_t sk_typeface_get_post_script_name (sk_typeface_t typeface);
+		}
+		private static Delegates.sk_typeface_get_post_script_name sk_typeface_get_post_script_name_delegate;
+		internal static sk_string_t sk_typeface_get_post_script_name (sk_typeface_t typeface) =>
+			(sk_typeface_get_post_script_name_delegate ??= GetSymbol<Delegates.sk_typeface_get_post_script_name> ("sk_typeface_get_post_script_name")).Invoke (typeface);
+		#endif
+
 		// sk_font_style_slant_t sk_typeface_get_font_slant(const sk_typeface_t* typeface)
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT

--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -48,7 +48,6 @@ namespace SkiaSharp.Views.tvOS
 		public SKMetalView()
 			: this(CGRect.Empty)
 		{
-			Initialize();
 		}
 
 		// created in code

--- a/tests/Tests/SkiaSharp/SKTypefaceTest.cs
+++ b/tests/Tests/SkiaSharp/SKTypefaceTest.cs
@@ -56,6 +56,15 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void TestPostScriptName()
+		{
+			using (var typeface = SKTypeface.FromFile(Path.Combine(PathToFonts, "CourierNew.ttf")))
+			{
+				Assert.Equal("CourierNewPSMT", typeface.PostScriptName);
+			}
+		}
+
+		[SkippableFact]
 		public void CanReadNonASCIIFile()
 		{
 			using (var typeface = SKTypeface.FromFile(Path.Combine(PathToFonts, "上田雅美.ttf")))


### PR DESCRIPTION
**Description of Change**

Added PostScriptName property to SkTypeface

**Bugs Fixed**

None.  Added a missing binding.

**API Changes**

None.

List all API changes here (or just put None), example:

Added: 
 
- `string SkTypeface.PostScriptName { get; set; }`

**Behavioral Changes**

None.

**Required skia PR**

None.

https://github.com/mono/skia/pull/158

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation