### PR TITLE
Revert "Fix iOS Simulator performance with Metal (#3156)"

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Apple/SKMetalView.cs
@@ -32,15 +32,6 @@ namespace SkiaSharp.Views.tvOS
 
 		private bool designMode;
 
-		private bool DepthStencilModePrivate =>
-		#if __MACCATALYST__
-			false;
-		#elif __MACOS__
-			true;
-		#else
-			ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR;
-		#endif
-
 		private GRMtlBackendContext backendContext;
 		private GRContext context;
 
@@ -92,16 +83,7 @@ namespace SkiaSharp.Views.tvOS
 
 			ColorPixelFormat = MTLPixelFormat.BGRA8Unorm;
 			DepthStencilPixelFormat = MTLPixelFormat.Depth32Float_Stencil8;
-			if (DepthStencilModePrivate)
-			{
-				DepthStencilStorageMode = MTLStorageMode.Private;
-				SampleCount = 4;
-			}
-			else
-			{
-				DepthStencilStorageMode = MTLStorageMode.Shared;
-				SampleCount = 2;
-			}
+			SampleCount = 1;
 			FramebufferOnly = false;
 			Device = device;
 			backendContext = new GRMtlBackendContext


### PR DESCRIPTION
**Description of Change**

This reverts commit c2a1fde1bd3986d907f92445047b8fbc130c122b.

Using MSAA does not appear to improve simulator performance, but breaks SKMetalView for iOS 15 and prior

**Bugs Fixed**

- Fixes #3284

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
