### PR TITLE
SKAutoCanvasRestore avoid crash at Dispose when canvas was already disposed

### DIFF
--- a/binding/SkiaSharp/SKCanvas.cs
+++ b/binding/SkiaSharp/SKCanvas.cs
@@ -1065,7 +1065,10 @@ namespace SkiaSharp
 
 		public void Dispose ()
 		{
-			Restore ();
+			//canvas can be GC-ed before us
+			if (canvas != null && canvas.Handle != IntPtr.Zero) {
+				Restore ();
+			}				
 		}
 
 		/// <summary>


### PR DESCRIPTION
**Description of Change**

Have catched this few times myself: might be my bad coding style, but nevertheless `SKAutoCanvasRestore` should not crash app if the canvas inside was already disposed for any reason whatever. So checking to avoid that inside `SKAutoCanvasRestore` `Dispose` method.

**Bugs Fixed**

`SKAutoCanvasRestore` could crash if GC-ed/disposed after the containing canvas native Handler was already released while `canvas` field still not NULL and `Restore()` would be called, then crash app accessing Handle 0.

- Fixes

No known issues identified, still could be related to some unknown random crashes.

No Api changes, a small code change, please see 1 file change below.

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
