### PR TITLE
Fix shader disposal in SKBitmap.CopyTo

### DIFF
--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -200,8 +200,10 @@ namespace SkiaSharp
 
 			using var canvas = new SKCanvas (temp);
 
+			using var shader = ToShader ();
+
 			using var paint = new SKPaint {
-				Shader = ToShader (),
+				Shader = shader,
 				BlendMode = SKBlendMode.Src
 			};
 


### PR DESCRIPTION
**Description of Change**

Make shader disposal deterministic in SKBitmap.CopyTo

**Bugs Fixed**

Fixes: #2915

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [X] Changes adhere to coding standard
- [ ] Updated documentation
