### PR TITLE
Dispose temporary vertices in SKCanvas.DrawVertices

### DIFF
--- a/binding/SkiaSharp/SKCanvas.cs
+++ b/binding/SkiaSharp/SKCanvas.cs
@@ -911,25 +911,25 @@ namespace SkiaSharp
 
 		public void DrawVertices (SKVertexMode vmode, SKPoint[] vertices, SKColor[] colors, SKPaint paint)
 		{
-			var vert = SKVertices.CreateCopy (vmode, vertices, colors);
+			using var vert = SKVertices.CreateCopy (vmode, vertices, colors);
 			DrawVertices (vert, SKBlendMode.Modulate, paint);
 		}
 
 		public void DrawVertices (SKVertexMode vmode, SKPoint[] vertices, SKPoint[] texs, SKColor[] colors, SKPaint paint)
 		{
-			var vert = SKVertices.CreateCopy (vmode, vertices, texs, colors);
+			using var vert = SKVertices.CreateCopy (vmode, vertices, texs, colors);
 			DrawVertices (vert, SKBlendMode.Modulate, paint);
 		}
 
 		public void DrawVertices (SKVertexMode vmode, SKPoint[] vertices, SKPoint[] texs, SKColor[] colors, UInt16[] indices, SKPaint paint)
 		{
-			var vert = SKVertices.CreateCopy (vmode, vertices, texs, colors, indices);
+			using var vert = SKVertices.CreateCopy (vmode, vertices, texs, colors, indices);
 			DrawVertices (vert, SKBlendMode.Modulate, paint);
 		}
 
 		public void DrawVertices (SKVertexMode vmode, SKPoint[] vertices, SKPoint[] texs, SKColor[] colors, SKBlendMode mode, UInt16[] indices, SKPaint paint)
 		{
-			var vert = SKVertices.CreateCopy (vmode, vertices, texs, colors, indices);
+			using var vert = SKVertices.CreateCopy (vmode, vertices, texs, colors, indices);
 			DrawVertices (vert, mode, paint);
 		}
 


### PR DESCRIPTION
**Description of Change**

Deterministically dispose temporary SKVertices in DrawVertices overloads

**Bugs Fixed**



**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Merged related skia PRs
- [X] Changes adhere to coding standard
- [ ] Updated documentation
