### PR TITLE
Make the GetPixels() method in WindowsExtensions public

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/UWPExtensions.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/UWPExtensions.cs
@@ -173,7 +173,7 @@ namespace SkiaSharp.Views.UWP
 			}
 		}
 
-		internal static IntPtr GetPixels(this WriteableBitmap bitmap) =>
+		public static IntPtr GetPixels(this WriteableBitmap bitmap) =>
 			bitmap.PixelBuffer.GetByteBuffer();
 
 		internal static IntPtr GetByteBuffer(this IBuffer buffer) =>


### PR DESCRIPTION
**Description of Change**

We would like to use the GetPixels() method in our custom SKXamlCanvas.

**Bugs Fixed**

None.

**API Changes**

The access modifier of the GetPixels method is changed from internal to public.

Changed:

 - `internal static IntPtr GetPixels(this WriteableBitmap bitmap) => public static IntPtr GetPixels(this WriteableBitmap bitmap)`

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
