### PR TITLE
Extract to same folder names

### DIFF
--- a/scripts/azure-pipelines-package.yml
+++ b/scripts/azure-pipelines-package.yml
@@ -141,12 +141,8 @@ extends:
                   $surrogateContents | Set-Content $destFile
                 displayName: Generate the surrogate files
               - pwsh: |
-                  $nupkgs = (Get-ChildItem "$(Build.ArtifactStagingDirectory)\binaries-to-scan\*\*.*nupkg")
-                  foreach ($nupkg in $nupkgs) {
-                    $filename = $nupkg.Name.TrimEnd('.nupkg')
-                    $dest = "$(Build.ArtifactStagingDirectory)\binaries-to-scan\nuget_symbols-extracted\$filename"
-                    Write-Host "Extracting '$nupkg' to '$dest'..."
-                    Expand-Archive $nupkg $dest
-                    Remove-Item $nupkg
-                  }
+                  ./scripts/extract-nupkg-files.ps1 `
+                    -SourcePath "$(Build.ArtifactStagingDirectory)\binaries-to-scan\*\*.*nupkg" `
+                    -DestinationPath "$(Build.ArtifactStagingDirectory)\binaries-to-scan\nuget_symbols-extracted" `
+                    -RemoveOriginal
                 displayName: Extract all the .nupkg files

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -66,13 +66,9 @@ stages:
                 Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
               displayName: Prepare the build artifact for publishing
             - pwsh: |
-                $nupkgs = (Get-ChildItem ".\output\nugets*\*.*nupkg")
-                foreach ($nupkg in $nupkgs) {
-                  $filename = $nupkg.Name.TrimEnd('.nupkg')
-                  $dest = ".\output\extracted_nugets\$filename"
-                  Write-Host "Extracting '$nupkg' to '$dest'..."
-                  Expand-Archive $nupkg $dest
-                }
+                .\scripts\extract-nupkg-files.ps1 `
+                  -SourcePath ".\output\nugets*\*.*nupkg" `
+                  -DestinationPath ".\output\extracted_nugets"
               displayName: Extract all the .nupkg files for scanning
           publishArtifacts:
             - name: package_normal_windows

--- a/scripts/extract-nupkg-files.ps1
+++ b/scripts/extract-nupkg-files.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourcePath,
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationPath,
+    [switch]$RemoveOriginal
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-NuGetPackageInfo {
+    param([string]$ExtractedPath)
+    
+    try {
+        # Get the folder name as fallback (this is the package ID)
+        $packageId = Split-Path $ExtractedPath -Leaf
+    
+        # Try to find the .nuspec file to get the version
+        $nuspecFile = Get-ChildItem -Path $ExtractedPath -Filter "*.nuspec" -Recurse | Select-Object -First 1
+        
+        # Get the package ID and version from the .nuspec
+        [xml]$nuspec = Get-Content $nuspecFile.FullName
+        $packageId = $nuspec.package.metadata.id
+        $version = $nuspec.package.metadata.version
+        
+        # Return folder name based on whether version contains dash
+        if ($version.Contains('-')) {
+            return "$packageId-Preview"
+        } else {
+            return "$packageId-Stable"
+        }
+    }
+    catch {
+        # If parsing fails, fall through
+    }
+    
+    return $null
+}
+
+# Ensure the destination directory exists
+if (-not (Test-Path $DestinationPath)) {
+    New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null
+    Write-Host "Created destination directory: $DestinationPath"
+}
+
+# Find all .nupkg files
+$nupkgs = Get-ChildItem $SourcePath
+if ($nupkgs.Count -eq 0) {
+    Write-Host "No .nupkg files found in: $SourcePath"
+    return
+}
+Write-Host "Found $($nupkgs.Count) .nupkg file(s) to extract"
+
+# Extract each .nupkg file
+foreach ($nupkg in $nupkgs) {
+    $filename = $nupkg.Name.TrimEnd('.nupkg')
+    Write-Host "Extracting '$nupkg' to default location: '$filename'..."
+    
+    # Extract to default location first
+    $defaultDest = Join-Path $DestinationPath $filename
+    Expand-Archive -Path $nupkg.FullName -DestinationPath $defaultDest -Force
+        
+    # Try to get package info from the nuspec to see if we should move
+    $betterFolderName = Get-NuGetPackageInfo -ExtractedPath $defaultDest
+    if ($betterFolderName -and $betterFolderName -ne $filename) {
+        $finalDest = Join-Path $DestinationPath $betterFolderName
+        Move-Item $defaultDest $finalDest
+        Write-Host "Moved '$filename' to '$betterFolderName' based on nuspec info"
+    }
+    
+    if ($RemoveOriginal) {
+        Remove-Item $nupkg.FullName -Force
+        Write-Host "Removed original file: $($nupkg.FullName)"
+    }
+}
+
+Write-Host "Extraction completed successfully"


### PR DESCRIPTION


**Description of Change**

The tools use the full path as a bug ID and this makes everything re-create for every build.