### PR TITLE
Use a valid "version number" for APIScan

### DIFF
--- a/scripts/extract-nupkg-files.ps1
+++ b/scripts/extract-nupkg-files.ps1
@@ -26,9 +26,9 @@ function Get-NuGetPackageInfo {
         
         # Return folder name based on whether version contains dash
         if ($version.Contains('-')) {
-            return "$packageId-Preview"
+            return "$packageId-0.0.0-preview.0"
         } else {
-            return "$packageId-Stable"
+            return "$packageId-0.0.0"
         }
     }
     catch {


### PR DESCRIPTION
**Description of Change**

We have gone through and processed the exceptions for the verion numbered paths. Would be great not to do it again.