### PR TITLE
Preserve and pack the Android symbols

### DIFF
--- a/binding/HarfBuzzSharp.NativeAssets.Android/HarfBuzzSharp.NativeAssets.Android.csproj
+++ b/binding/HarfBuzzSharp.NativeAssets.Android/HarfBuzzSharp.NativeAssets.Android.csproj
@@ -4,12 +4,13 @@
     <TargetFrameworks Condition="'$(TFMNext)' != ''">$(TargetFrameworks);$(TFMNext)-android$(TPVAndroidNext)</TargetFrameworks>
     <PackagingGroup>HarfBuzzSharp</PackagingGroup>
     <Title>$(PackagingGroup) - Native Assets for Android</Title>
+    <IsNativeAssetsProject>true</IsNativeAssetsProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageFile Include="..\..\output\native\android\x86\libHarfBuzzSharp*" PackagePath="runtimes\android-x86\native\%(Filename)%(Extension)" />
-    <PackageFile Include="..\..\output\native\android\x86_64\libHarfBuzzSharp*" PackagePath="runtimes\android-x64\native\%(Filename)%(Extension)" />
-    <PackageFile Include="..\..\output\native\android\armeabi-v7a\libHarfBuzzSharp*" PackagePath="runtimes\android-arm\native\%(Filename)%(Extension)" />
-    <PackageFile Include="..\..\output\native\android\arm64-v8a\libHarfBuzzSharp*" PackagePath="runtimes\android-arm64\native\%(Filename)%(Extension)" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\x86\libHarfBuzzSharp*" RuntimeIdentifier="android-x86" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\x86_64\libHarfBuzzSharp*" RuntimeIdentifier="android-x64" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\armeabi-v7a\libHarfBuzzSharp*" RuntimeIdentifier="android-arm" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\arm64-v8a\libHarfBuzzSharp*" RuntimeIdentifier="android-arm64" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup>

--- a/binding/HarfBuzzSharp.NativeAssets.Win32/HarfBuzzSharp.NativeAssets.Win32.csproj
+++ b/binding/HarfBuzzSharp.NativeAssets.Win32/HarfBuzzSharp.NativeAssets.Win32.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>$(BasicTargetFrameworks);$(WindowsTargetFrameworks)</TargetFrameworks>
     <PackagingGroup>HarfBuzzSharp</PackagingGroup>
     <Title>$(PackagingGroup) - Native Assets for Win32</Title>
-    <IsWindowsNativeAssets>true</IsWindowsNativeAssets>
+    <IsNativeAssetsProject>true</IsNativeAssetsProject>
   </PropertyGroup>
   <ItemGroup>
-    <NativeWindowsPackageFile Include="..\..\output\native\windows\x64\libHarfBuzzSharp*" RuntimeIdentifier="win-x64" />
-    <NativeWindowsPackageFile Include="..\..\output\native\windows\x86\libHarfBuzzSharp*" RuntimeIdentifier="win-x86" />
-    <NativeWindowsPackageFile Include="..\..\output\native\windows\arm64\libHarfBuzzSharp*" RuntimeIdentifier="win-arm64" />
+    <NativeAssetPackageFile Include="..\..\output\native\windows\x64\libHarfBuzzSharp*" RuntimeIdentifier="win-x64" />
+    <NativeAssetPackageFile Include="..\..\output\native\windows\x86\libHarfBuzzSharp*" RuntimeIdentifier="win-x86" />
+    <NativeAssetPackageFile Include="..\..\output\native\windows\arm64\libHarfBuzzSharp*" RuntimeIdentifier="win-arm64" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/binding/NativeAssets.Build.targets
+++ b/binding/NativeAssets.Build.targets
@@ -25,32 +25,31 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup Condition="'$(IsWindowsNativeAssets)' == 'true'">
+  <PropertyGroup Condition="'$(IsNativeAssetsProject)' == 'true'">
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <IncludeSymbols>true</IncludeSymbols>
     <BuildOutputTargetFolder>runtimes</BuildOutputTargetFolder>
-    <ExcludeSymbolsFromPackage>false</ExcludeSymbolsFromPackage>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsWindowsNativeAssets)' == 'true'">
-    <_NativeWindowsPackageFileToUse Include="@(NativeWindowsPackageFile->HasMetadata('Folder'))" />
-    <_NativeWindowsPackageFileWithNoFolder Include="@(NativeWindowsPackageFile)" />
-    <_NativeWindowsPackageFileWithNoFolder Remove="@(_NativeWindowsPackageFileToUse)" />
-    <_NativeWindowsPackageFileToUse Include="@(_NativeWindowsPackageFileWithNoFolder)" Folder="native" />
-    <None Include="@(_NativeWindowsPackageFileToUse)" Link="runtimes\%(RuntimeIdentifier)\%(Folder)\%(Filename)%(Extension)" />
+  <ItemGroup Condition="'$(IsNativeAssetsProject)' == 'true'">
+    <_NativeAssetPackageFileToUse Include="@(NativeAssetPackageFile->HasMetadata('Folder'))" />
+    <_NativeAssetPackageFileWithNoFolder Include="@(NativeAssetPackageFile)" />
+    <_NativeAssetPackageFileWithNoFolder Remove="@(_NativeAssetPackageFileToUse)" />
+    <_NativeAssetPackageFileToUse Include="@(_NativeAssetPackageFileWithNoFolder)" Folder="native" />
+    <None Include="@(_NativeAssetPackageFileToUse)" Link="runtimes\%(RuntimeIdentifier)\%(Folder)\%(Filename)%(Extension)" />
   </ItemGroup>
 
-  <Target Name="_IncludeRuntimesPackageFiles" BeforeTargets="_GetPackageFiles" Condition="'$(IsWindowsNativeAssets)' == 'true'">
+  <Target Name="_IncludeRuntimesPackageFiles" BeforeTargets="_GetPackageFiles" Condition="'$(IsNativeAssetsProject)' == 'true'">
     <ItemGroup>
-      <_CompletedNativeWindowsPackageFile
-          Include="@(_NativeWindowsPackageFileToUse)" 
-          TargetFramework="%(RuntimeIdentifier)"
-          TargetPath="%(Folder)\%(Filename)%(Extension)" 
+      <_CompletedNativeAssetPackageFile
+          Include="@(_NativeAssetPackageFileToUse)" 
+          TargetFramework="$(TFMCurrent)"
+          TargetPath="..\%(RuntimeIdentifier)\%(Folder)\%(Filename)%(Extension)" 
           PackagePath="runtimes\%(RuntimeIdentifier)\%(Folder)\%(Filename)%(Extension)" />
       <_BuildOutputInPackage Remove="@(_BuildOutputInPackage)" />
-      <_BuildOutputInPackage Include="@(_CompletedNativeWindowsPackageFile)" Condition="'%(Extension)' != '.pdb'" />
+      <_BuildOutputInPackage Include="@(_CompletedNativeAssetPackageFile)" Condition="'%(Extension)' != '.pdb' and '%(Extension)' != '.dbg'" />
       <_TargetPathsToSymbols Remove="@(_TargetPathsToSymbols)" />
-      <_TargetPathsToSymbols Include="@(_CompletedNativeWindowsPackageFile)" Condition="'%(Extension)' == '.pdb'" />
+      <_TargetPathsToSymbols Include="@(_CompletedNativeAssetPackageFile)" Condition="'%(Extension)' == '.pdb' or '%(Extension)' == '.dbg'" />
     </ItemGroup>
   </Target>
 

--- a/binding/SkiaSharp.NativeAssets.Android/SkiaSharp.NativeAssets.Android.csproj
+++ b/binding/SkiaSharp.NativeAssets.Android/SkiaSharp.NativeAssets.Android.csproj
@@ -4,12 +4,13 @@
     <TargetFrameworks Condition="'$(TFMNext)' != ''">$(TargetFrameworks);$(TFMNext)-android$(TPVAndroidNext)</TargetFrameworks>
     <PackagingGroup>SkiaSharp</PackagingGroup>
     <Title>$(PackagingGroup) - Native Assets for Android</Title>
+    <IsNativeAssetsProject>true</IsNativeAssetsProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageFile Include="..\..\output\native\android\x86\libSkiaSharp*" PackagePath="runtimes\android-x86\native\%(Filename)%(Extension)" />
-    <PackageFile Include="..\..\output\native\android\x86_64\libSkiaSharp*" PackagePath="runtimes\android-x64\native\%(Filename)%(Extension)" />
-    <PackageFile Include="..\..\output\native\android\armeabi-v7a\libSkiaSharp*" PackagePath="runtimes\android-arm\native\%(Filename)%(Extension)" />
-    <PackageFile Include="..\..\output\native\android\arm64-v8a\libSkiaSharp*" PackagePath="runtimes\android-arm64\native\%(Filename)%(Extension)" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\x86\libSkiaSharp*" RuntimeIdentifier="android-x86" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\x86_64\libSkiaSharp*" RuntimeIdentifier="android-x64" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\armeabi-v7a\libSkiaSharp*" RuntimeIdentifier="android-arm" />
+    <NativeAssetPackageFile Include="..\..\output\native\android\arm64-v8a\libSkiaSharp*" RuntimeIdentifier="android-arm64" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup>

--- a/binding/SkiaSharp.NativeAssets.NanoServer/SkiaSharp.NativeAssets.NanoServer.csproj
+++ b/binding/SkiaSharp.NativeAssets.NanoServer/SkiaSharp.NativeAssets.NanoServer.csproj
@@ -4,10 +4,10 @@
     <PackagingGroup>SkiaSharp</PackagingGroup>
     <Title>$(PackagingGroup) - Native Assets for Windows Nano Server</Title>
     <PackageNotes>This variation of the Windows native assets includes the build of libSkiaSharp.dll that does not make use of the typeface subsetting when creating XPS documents (CreateFontPackage from FONTSUB.dll).</PackageNotes>
-    <IsWindowsNativeAssets>true</IsWindowsNativeAssets>
+    <IsNativeAssetsProject>true</IsNativeAssetsProject>
   </PropertyGroup>
   <ItemGroup>
-    <NativeWindowsPackageFile Include="..\..\output\native\nanoserver\x64\libSkiaSharp*" RuntimeIdentifier="win-x64" />
+    <NativeAssetPackageFile Include="..\..\output\native\nanoserver\x64\libSkiaSharp*" RuntimeIdentifier="win-x64" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/binding/SkiaSharp.NativeAssets.Win32/SkiaSharp.NativeAssets.Win32.csproj
+++ b/binding/SkiaSharp.NativeAssets.Win32/SkiaSharp.NativeAssets.Win32.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>$(BasicTargetFrameworks);$(WindowsTargetFrameworks)</TargetFrameworks>
     <PackagingGroup>SkiaSharp</PackagingGroup>
     <Title>$(PackagingGroup) - Native Assets for Win32</Title>
-    <IsWindowsNativeAssets>true</IsWindowsNativeAssets>
+    <IsNativeAssetsProject>true</IsNativeAssetsProject>
   </PropertyGroup>
   <ItemGroup>
-    <NativeWindowsPackageFile Include="..\..\output\native\windows\x64\libSkiaSharp*" RuntimeIdentifier="win-x64" />
-    <NativeWindowsPackageFile Include="..\..\output\native\windows\x86\libSkiaSharp*" RuntimeIdentifier="win-x86" />
-    <NativeWindowsPackageFile Include="..\..\output\native\windows\arm64\libSkiaSharp*" RuntimeIdentifier="win-arm64" />
+    <NativeAssetPackageFile Include="..\..\output\native\windows\x64\libSkiaSharp*" RuntimeIdentifier="win-x64" />
+    <NativeAssetPackageFile Include="..\..\output\native\windows\x86\libSkiaSharp*" RuntimeIdentifier="win-x86" />
+    <NativeAssetPackageFile Include="..\..\output\native\windows\arm64\libSkiaSharp*" RuntimeIdentifier="win-arm64" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
+++ b/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
@@ -3,14 +3,14 @@
     <TargetFrameworks>$(WindowsTargetFrameworks)</TargetFrameworks>
     <PackagingGroup>SkiaSharp</PackagingGroup>
     <Title>$(PackagingGroup) - Native Assets for Windows UI (WinUI 3)</Title>
-    <IsWindowsNativeAssets>true</IsWindowsNativeAssets>
+    <IsNativeAssetsProject>true</IsNativeAssetsProject>
   </PropertyGroup>
   <ItemGroup>
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\x64\*" RuntimeIdentifier="win-x64" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\x86\*" RuntimeIdentifier="win-x86" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
-    <NativeWindowsPackageFile Include="..\..\output\native\winui\arm64\*" RuntimeIdentifier="win-arm64" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\x64\*" RuntimeIdentifier="win-x64" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\x86\*" RuntimeIdentifier="win-x86" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\arm64\*" RuntimeIdentifier="win-arm64" />
   </ItemGroup>
 </Project>

--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -2,35 +2,13 @@ DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
 DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native/android"));
 
 #load "../../scripts/cake/native-shared.cake"
-
-DirectoryPath ANDROID_NDK_HOME = Argument("ndk", EnvironmentVariable("ANDROID_NDK_HOME") ?? EnvironmentVariable("ANDROID_NDK_ROOT") ?? PROFILE_PATH.Combine("android-ndk").FullPath);
+#load "../../scripts/cake/ndk.cake"
 
 string SUPPORT_VULKAN_VAR = Argument ("supportVulkan", EnvironmentVariable ("SUPPORT_VULKAN") ?? "true");
 bool SUPPORT_VULKAN = SUPPORT_VULKAN_VAR == "1" || SUPPORT_VULKAN_VAR.ToLower () == "true";
 
 Information("Android NDK Path: {0}", ANDROID_NDK_HOME);
 Information("Building Vulkan: {0}", SUPPORT_VULKAN);
-
-void CheckAlignment(FilePath so)
-{
-    Information($"Making sure that everything is 16 KB aligned...");
-
-    var prebuilt = ANDROID_NDK_HOME.CombineWithFilePath("toolchains/llvm/prebuilt").FullPath;
-    var objdump = GetFiles($"{prebuilt}/*/bin/llvm-objdump*").FirstOrDefault() ?? throw new Exception("Could not find llvm-objdump");
-    RunProcess(objdump.FullPath, $"-p {so}", out var stdout);
-
-    var loads = stdout
-        .Where(l => l.Trim().StartsWith("LOAD"))
-        .ToList();
-
-    if (loads.Any(l => !l.Trim().EndsWith("align 2**14"))) {
-        Information(String.Join(Environment.NewLine + "    ", stdout));
-        throw new Exception($"{so} contained a LOAD that was not 16 KB aligned.");
-    } else {
-        Information("Everything is 16 KB aligned:");
-        Information(String.Join(Environment.NewLine, loads));
-    }
-}
 
 Task("libSkiaSharp")
     .IsDependentOn("git-sync-deps")
@@ -61,16 +39,14 @@ Task("libSkiaSharp")
             $"skia_use_system_zlib=false " +
             $"skia_use_vulkan={SUPPORT_VULKAN} ".ToLower () +
             $"skia_enable_skottie=true " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM' ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM', '-g', '-ggdb3' ] " +
             $"extra_ldflags=[ '-Wl,-z,max-page-size=16384' ] " +
             $"ndk='{ANDROID_NDK_HOME}' " +
             $"ndk_api=21");
 
-        var so = SKIA_PATH.CombineWithFilePath($"out/android/{arch}/libSkiaSharp.so");
-        var outDir = OUTPUT_PATH.Combine(arch);
-        EnsureDirectoryExists(outDir);
-        CopyFileToDirectory(so, outDir);
-        CheckAlignment(so);
+        StripCopy(
+            SKIA_PATH.CombineWithFilePath($"out/android/{arch}/libSkiaSharp.so"),
+            OUTPUT_PATH.Combine(arch));
     }
 });
 
@@ -78,9 +54,6 @@ Task("libHarfBuzzSharp")
     .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows())
     .Does(() =>
 {
-    var cmd = IsRunningOnWindows() ? ".cmd" : "";
-    var ndkbuild = ANDROID_NDK_HOME.CombineWithFilePath($"ndk-build{cmd}").FullPath;
-
     Build("x86");
     Build("x86_64");
     Build("armeabi-v7a");
@@ -90,16 +63,11 @@ Task("libHarfBuzzSharp")
     {
         if (Skip(arch)) return;
 
-        RunProcess(ndkbuild, new ProcessSettings {
-            Arguments = $"APP_ABI={arch}",
-            WorkingDirectory = "libHarfBuzzSharp",
-        });
+        RunNdkBuild(arch, "libHarfBuzzSharp");
 
-        var so = $"libHarfBuzzSharp/libs/{arch}/libHarfBuzzSharp.so";
-        var outDir = OUTPUT_PATH.Combine(arch);
-        EnsureDirectoryExists(outDir);
-        CopyFileToDirectory(so, outDir);
-        CheckAlignment(so);
+        StripCopy(
+            $"libHarfBuzzSharp/libs/{arch}/libHarfBuzzSharp.so",
+            OUTPUT_PATH.Combine(arch));
     }
 });
 

--- a/native/android/libHarfBuzzSharp/jni/Application.mk
+++ b/native/android/libHarfBuzzSharp/jni/Application.mk
@@ -3,4 +3,5 @@ APP_PLATFORM := android-21
 NDK_TOOLCHAIN_VERSION := clang
 APP_STL := c++_static
 APP_OPTIM := release
+APP_STRIP_MODE := none
 APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/native/android/libHarfBuzzSharp/jni/HarfBuzzSharp.mk
+++ b/native/android/libHarfBuzzSharp/jni/HarfBuzzSharp.mk
@@ -1,8 +1,6 @@
 
 include $(CLEAR_VARS)
 
-cmd-strip = $(PRIVATE_STRIP) --strip-all $(call host-path,$1)
-
 src_root = $(abspath ../../../externals/skia/third_party/externals/harfbuzz/src)
 ext_root = $(abspath ../../../externals/skia/third_party/harfbuzz)
 
@@ -10,12 +8,12 @@ LOCAL_MODULE           := HarfBuzzSharp
 
 LOCAL_C_INCLUDES       := . $(src_root) $(ext_root)
 
-LOCAL_LDFLAGS          := -s -Wl,--gc-sections -Wl,-z,max-page-size=16384
+LOCAL_LDFLAGS          := -Wl,--gc-sections -Wl,-z,max-page-size=16384
 
 LOCAL_CFLAGS           := -DNDEBUG                                                                  \
                           -DHAVE_CONFIG_OVERRIDE_H -DHAVE_OT -DHB_NO_FALLBACK_SHAPE                 \
                           -fno-rtti -fno-exceptions -fno-threadsafe-statics -fPIC                   \
-                          -g -Os -ffunction-sections -fdata-sections
+                          -Os -ffunction-sections -fdata-sections -g -ggdb3
 
 LOCAL_CPPFLAGS         := -std=c++11
 

--- a/scripts/cake/ndk.cake
+++ b/scripts/cake/ndk.cake
@@ -1,0 +1,86 @@
+DirectoryPath ANDROID_NDK_HOME = Argument("ndk", EnvironmentVariable("ANDROID_NDK_HOME") ?? EnvironmentVariable("ANDROID_NDK_ROOT") ?? PROFILE_PATH.Combine("android-ndk").FullPath);
+
+
+void CheckAlignment(FilePath so)
+{
+    Information($"Making sure that everything is 16 KB aligned...");
+
+    var prebuilt = ANDROID_NDK_HOME.CombineWithFilePath("toolchains/llvm/prebuilt").FullPath;
+    var objdump = GetFiles($"{prebuilt}/*/bin/llvm-objdump*").FirstOrDefault() ?? throw new Exception("Could not find llvm-objdump");
+    RunProcess(objdump.FullPath, $"-p {so}", out var stdout);
+
+    var loads = stdout
+        .Where(l => l.Trim().StartsWith("LOAD"))
+        .ToList();
+
+    if (loads.Any(l => !l.Trim().EndsWith("align 2**14"))) {
+        Information(String.Join(Environment.NewLine + "    ", stdout));
+        throw new Exception($"{so} contained a LOAD that was not 16 KB aligned.");
+    } else {
+        Information("Everything is 16 KB aligned:");
+        Information(String.Join(Environment.NewLine, loads));
+    }
+}
+
+void StripCopy(FilePath so, DirectoryPath outDir)
+{
+    Information($"Stripping and copying {so} to {outDir}...");
+
+    EnsureDirectoryExists(outDir);
+
+    CopyFileToDirectory(so, outDir);
+    so = outDir.CombineWithFilePath(so.GetFilename());
+    CheckAlignment(so);
+
+    ExtractAndStripSymbols(so);
+}
+
+FilePath ExtractAndStripSymbols(FilePath so)
+{
+    Information($"Extracting debug symbols from {so}...");
+
+    var prebuilt = ANDROID_NDK_HOME.Combine("toolchains/llvm/prebuilt");
+    var objcopy = GetFiles($"{prebuilt}/*/bin/llvm-objcopy*").FirstOrDefault() ?? throw new Exception("Could not find llvm-objcopy");
+
+    var symbolsFile = so.ChangeExtension(".so.dbg");
+
+    // Record original size before stripping
+    var originalSize = new System.IO.FileInfo(so.FullPath).Length;
+
+    // Step 1: Extract debug symbols to separate file
+    Information($"Creating symbols file: {symbolsFile}");
+    RunProcess(objcopy, $"--only-keep-debug \"{so}\" \"{symbolsFile}\"");
+
+    // Step 2: Strip debug symbols from main binary (keep essential symbols)
+    Information($"Stripping debug symbols from main binary: {so}");
+    RunProcess(objcopy, $"--strip-debug --strip-unneeded \"{so}\"");
+
+    // Step 3: Add debug link to connect stripped binary with symbols file
+    Information($"Linking stripped binary to symbols file...");
+    RunProcess(objcopy.FullPath, $"--add-gnu-debuglink=\"{symbolsFile}\" \"{so}\"");
+
+    // Report final sizes
+    var strippedSize = new System.IO.FileInfo(so.FullPath).Length;
+    var symbolsSize = new System.IO.FileInfo(symbolsFile.FullPath).Length;
+    var savedBytes = originalSize - strippedSize;
+    var savedPercent = savedBytes / (double)originalSize * 100.0;
+
+    Information($"Symbol extraction complete:");
+    Information($"  Original size:   {originalSize / 1024.0 / 1024.0:F1} MB ({originalSize:N0} bytes)");
+    Information($"  Stripped binary: {strippedSize / 1024.0 / 1024.0:F1} MB ({strippedSize:N0} bytes)");
+    Information($"  Symbols file:    {symbolsSize / 1024.0 / 1024.0:F1} MB ({symbolsSize:N0} bytes)");
+    Information($"  Space saved:     {savedBytes / 1024.0 / 1024.0:F1} MB ({savedBytes:N0} bytes, {savedPercent:F1}%)");
+
+    return symbolsFile;
+}
+
+void RunNdkBuild(string arch, DirectoryPath working)
+{
+    var cmd = IsRunningOnWindows() ? ".cmd" : "";
+    var ndkbuild = ANDROID_NDK_HOME.CombineWithFilePath($"ndk-build{cmd}").FullPath;
+
+    RunProcess(ndkbuild, new ProcessSettings {
+        Arguments = $"APP_ABI={arch}",
+        WorkingDirectory = working.FullPath,
+    });
+}

--- a/source/SkiaSharp.NuGet.targets
+++ b/source/SkiaSharp.NuGet.targets
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_IncludeAdditionalTfmSpecificPackageFiles</TargetsForTfmSpecificContentInPackage>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder Condition="'$(ExcludeSymbolsFromPackage)' != 'false'">$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.so</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder);.dbg</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This pull request refactors the native asset packaging logic for SkiaSharp and HarfBuzzSharp to unify and modernize how native binaries and debug symbols are handled across platforms, especially for Android and Windows. The changes introduce a new, consistent property and item group for native asset projects, update build scripts to extract and package debug symbols, and streamline symbol handling in NuGet packaging.

**Native asset packaging unification:**

* Replaced platform-specific project property `IsWindowsNativeAssets` with a unified `IsNativeAssetsProject` property in all relevant `.csproj` files, and standardized the item group from `NativeWindowsPackageFile`/`PackageFile` to `NativeAssetPackageFile` for both Android and Windows projects. (`binding/SkiaSharp.NativeAssets.Win32/SkiaSharp.NativeAssets.Win32.csproj`, `binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj`, `binding/SkiaSharp.NativeAssets.NanoServer/SkiaSharp.NativeAssets.NanoServer.csproj`, `binding/HarfBuzzSharp.NativeAssets.Win32/HarfBuzzSharp.NativeAssets.Win32.csproj`, `binding/HarfBuzzSharp.NativeAssets.Android/HarfBuzzSharp.NativeAssets.Android.csproj`, `binding/SkiaSharp.NativeAssets.Android/SkiaSharp.NativeAssets.Android.csproj`) [[1]](diffhunk://#diff-d955338449e43951b418b7c7c90de61af14107d672ed7cbb831c210c642cc85eL6-R11) [[2]](diffhunk://#diff-b5714154803a2e77f57398cd2efa2f3d3f7f12be92abc0d0baa89f90d0979f7cL6-R14) [[3]](diffhunk://#diff-16fa36b38e988694aa88ec6031104d034a345d04201dd9dfa6a6af66b6a34241L7-R10) [[4]](diffhunk://#diff-43db30200e046f72748674141b845a93d6964b4fbe6269b7153f597dedeec0edR7-R13) [[5]](diffhunk://#diff-dd6569b5fae8f93900a3a611fc2321ece5a6fd3ec6f80030817800aee8ccb3c2R7-R13) [[6]](diffhunk://#diff-a6d73f2b3d575e70ed303e33427d709bcb7cf156dfdd64a25402980286f0e2f4L6-R11)

* Updated `NativeAssets.Build.targets` to use the new property and item group, ensuring all platforms use the same logic for including native binaries and symbols in NuGet packages. This includes improved symbol file handling for both `.pdb` and `.dbg` files. (`binding/NativeAssets.Build.targets`)

**Android build and symbol extraction improvements:**

* Refactored the Android build script to use a shared `ndk.cake` module, which now provides functions for alignment checking, symbol extraction, and stripping. The build process now extracts debug symbols into `.dbg` files and links them to the stripped binaries, improving debugging support. (`native/android/build.cake`, `scripts/cake/ndk.cake`) [[1]](diffhunk://#diff-4b2d4d6e454c8a73a9705904c2475addfb60c3be7555ccaf05033281e59b3235L5-L34) [[2]](diffhunk://#diff-4b2d4d6e454c8a73a9705904c2475addfb60c3be7555ccaf05033281e59b3235L64-L83) [[3]](diffhunk://#diff-4b2d4d6e454c8a73a9705904c2475addfb60c3be7555ccaf05033281e59b3235L93-R70) [[4]](diffhunk://#diff-45d844f2378066bca87e208ba8a1ac764689f556306980d2e21570daa13eac62R1-R86)

* Updated Android native build flags to disable automatic stripping, and added debug info flags (`-g -ggdb3`) to both SkiaSharp and HarfBuzzSharp builds, ensuring debug symbols are available for extraction. (`native/android/libHarfBuzzSharp/jni/Application.mk`, `native/android/libHarfBuzzSharp/jni/HarfBuzzSharp.mk`) [[1]](diffhunk://#diff-70485081f253dbdb14f0929da89a2c238b68c0f37367167160380741991278ddR6) [[2]](diffhunk://#diff-4920896f8be133b1ae5dbde7d88287540db3b9e527aa1acf53af75ff000aa379L4-R16)

**NuGet packaging and symbol file support:**

* Modified `SkiaSharp.NuGet.targets` to always allow `.pdb` and `.so` files in the package output, and to include `.dbg` files in the symbols package, ensuring that debug symbols extracted during the build are properly packaged. (`source/SkiaSharp.NuGet.targets`)

**Dependency update:**

* Updated the Skia submodule to a newer commit, likely pulling in upstream changes or fixes. (`externals/skia`)

These changes collectively improve the maintainability and debugging experience for native assets across platforms, and provide a more consistent packaging workflow.