### PR TITLE
Enable Control Flow Guard for all Windows native DLLs

### DIFF
--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -58,8 +58,8 @@ Task("libSkiaSharp")
             $"skia_use_direct3d={SUPPORT_DIRECT3D} ".ToLower () +
             clang +
             win_vcvars_version +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '-D_HAS_AUTO_PTR_ETC=1' ] " +
-            $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP' ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +
+            $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP', '/guard:cf' ] " +
             ADDITIONAL_GN_ARGS);
 
         var outDir = OUTPUT_PATH.Combine($"{VARIANT}/{dir}");

--- a/native/windows/libHarfBuzzSharp/libHarfBuzzSharp.vcxproj
+++ b/native/windows/libHarfBuzzSharp/libHarfBuzzSharp.vcxproj
@@ -145,10 +145,12 @@
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -161,10 +163,12 @@
       <AdditionalIncludeDirectories>$(HarfBuzzIncludes);$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -177,10 +181,12 @@
       <AdditionalIncludeDirectories>$(HarfBuzzIncludes);$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -195,12 +201,14 @@
       <AdditionalIncludeDirectories>$(HarfBuzzIncludes);$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -215,12 +223,14 @@
       <AdditionalIncludeDirectories>$(HarfBuzzIncludes);$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -235,12 +245,14 @@
       <AdditionalIncludeDirectories>$(HarfBuzzIncludes);$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/native/winui-angle/build.cake
+++ b/native/winui-angle/build.cake
@@ -122,7 +122,9 @@ Task("ANGLE")
                 $"angle_enable_null=false " +
                 $"angle_enable_wgpu=false " +
                 $"angle_enable_gl_desktop_backend=false " +
-                $"angle_enable_vulkan=false");
+                $"angle_enable_vulkan=false " +
+                $"extra_cflags=[ '/guard:cf' ] " +
+                $"extra_ldflags=[ '/guard:cf' ]");
 
             RunNinja(ANGLE_PATH, $"out/winui{suffix}/{arch}", target);
         }

--- a/native/winui/SkiaSharp.Views.WinUI.Native/SkiaSharp.Views.WinUI.Native/SkiaSharp.Views.WinUI.Native.vcxproj
+++ b/native/winui/SkiaSharp.Views.WinUI.Native/SkiaSharp.Views.WinUI.Native/SkiaSharp.Views.WinUI.Native.vcxproj
@@ -112,12 +112,14 @@
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <ModuleDefinitionFile>SkiaSharp_Views_WinUI_Native.def</ModuleDefinitionFile>
       <AdditionalOptions>/DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+      <ControlFlowGuard>true</ControlFlowGuard>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
Enable Control Flow Guard for all Windows native DLLs: libSkiaSharp.dll, libHarfBuzzSharp.dll, SkiaSharp.Views.WinUI.Native.dll, libEGL.dll, and libGLESv2.dll

- Add ControlFlowGuard compiler and linker settings to all configurations
- libSkiaSharp: Add /guard:cf to extra_cflags and extra_ldflags in GN build (applies to all Windows variants including nanoserver)
- libHarfBuzzSharp: Add ControlFlowGuard settings to all Debug/Release builds for Win32, x64, and ARM64 platforms
- SkiaSharp.Views.WinUI.Native: Add ControlFlowGuard settings to all WinUI configurations
- libEGL & libGLESv2: Add /guard:cf to extra_cflags and extra_ldflags in ANGLE GN build for all architectures
- Improves security by preventing ROP/JOP attacks with minimal performance impact



|Library | Purpose | Build System | Architectures | CFG Status |
|-- | -- | -- | -- | --|
|libSkiaSharp.dll | Core 2D Graphics | GN/Ninja (Skia) | Win32, x64, ARM64 | ✅ ENABLED |
|libHarfBuzzSharp.dll | Text Shaping | Visual Studio | Win32, x64, ARM64 | ✅ ENABLED|
|SkiaSharp.Views.WinUI.Native.dll | WinUI Integration | Visual Studio | Win32, x64, ARM64 | ✅ ENABLED|
|libEGL.dll | OpenGL ES Context | GN/Ninja (ANGLE) | x86, x64, arm64 | ✅ ENABLED|
|libGLESv2.dll | OpenGL ES Graphics | GN/Ninja (ANGLE) | x86, x64, arm64 | ✅ ENABLED|


**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
