### PR TITLE
Correctly free resources in Uno Platform's SKXamlCanvas

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Skia/SKXamlCanvas.Skia.cs
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Skia/SKXamlCanvas.Skia.cs
@@ -129,6 +129,6 @@ namespace SkiaSharp.Views.UWP
 			}
 		}
 
-		private void FreeBitmap() => _bitmap = null;
+		private void FreeBitmap() => bitmap = null;
 	}
 }


### PR DESCRIPTION
**Description of Change**

Freeing `pixels` field in Uno Platform's `SKXamlCanvas` should not free `bitmap` and vice versa.

**Bugs Fixed**

- Fixes https://github.com/mono/SkiaSharp/issues/3430

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

Code no longer throws in case the canvas size changes.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
