### PR TITLE
Fix the version processing

### DIFF
--- a/scripts/set-build-variables.ps1
+++ b/scripts/set-build-variables.ps1
@@ -63,7 +63,7 @@ Write-Host "`n# Checking for secondary build information..."
 if ($env:BUILD_REASON -eq "ResourceTrigger" -or $env:BUILD_REASON -eq "Manual") {
     Write-Host "Working with $env:RESOURCES_PIPELINE_SKIASHARP_RUNNAME"
     if ($env:RESOURCES_PIPELINE_SKIASHARP_RUNNAME) {
-        $match = [regex]::Match("$env:RESOURCES_PIPELINE_SKIASHARP_RUNNAME", '.*\-(.+)\.(\d+)')
+        $match = [regex]::Match("$env:RESOURCES_PIPELINE_SKIASHARP_RUNNAME", '^[^+]*-([^+]+)\.(\d+)(?:\+|$)')
         $label = $match.Groups[1].Value
         Write-Host "Preview label: $label"
         $env:PREVIEW_LABEL = $label


### PR DESCRIPTION
This pull request updates the regular expression used to extract the preview label from the `RESOURCES_PIPELINE_SKIASHARP_RUNNAME` environment variable in the `scripts/set-build-variables.ps1` script. The new regex is more precise and robust, ensuring correct parsing of the label even when additional metadata is present.

Build variable extraction improvement:

* Updated the regex pattern in `scripts/set-build-variables.ps1` to handle build run names with or without additional metadata after a plus sign (`+`), improving the accuracy of the preview label extraction.