### PR TITLE
Add AI skill for native dependency updates

### DIFF
--- a/.github/skills/native-dependency-update/SKILL.md
+++ b/.github/skills/native-dependency-update/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: native-dependency-update
+description: >
+  Update native dependencies (libpng, libexpat, zlib, libwebp, harfbuzz, freetype, libjpeg-turbo, etc.)
+  in SkiaSharp's Skia fork. Handles security CVE fixes, bug fixes, and version bumps.
+  
+  Use when user asks to:
+  - Bump/update a native dependency (libpng, zlib, expat, webp, etc.)
+  - Fix a CVE or security vulnerability in a native library
+  - Update Skia's DEPS file
+  - Check what version of a dependency is currently used
+  - Analyze breaking changes between dependency versions
+  
+  Triggers: "bump libpng", "update zlib", "fix CVE in expat", "update native deps",
+  "what version of libpng", "check for breaking changes", "update DEPS".
+---
+
+# Native Dependency Update Skill
+
+Update native dependencies in SkiaSharp's Skia fork (mono/skia).
+
+## Architecture
+
+```
+SkiaSharp repo
+└── externals/skia (mono/skia fork, submodule)
+    ├── DEPS (pins dependencies to commit hashes)
+    └── third_party/
+        ├── {dep}/BUILD.gn (build config)
+        └── externals/{dep}/ (source checkout)
+```
+
+**Key insight:** Changes go to mono/skia first, then SkiaSharp updates its submodule.
+
+## Workflow
+
+### 1. Find Current Version
+
+Check `externals/skia/DEPS` for the dependency. Format:
+```
+"third_party/externals/{name}": "{mirror_url}@{commit_hash}",
+```
+
+Navigate to `externals/skia/third_party/externals/{name}` and inspect the commit to determine the current version. Each project has different tagging conventions—explore before assuming.
+
+### 2. Find Target Version
+
+- **For CVE fixes:** Check the advisory for the fixed version
+- **For bug fixes:** Check upstream changelog/releases
+- **For general updates:** Check what upstream Google Skia uses, or use latest stable
+
+**Getting the commit hash:** Use `git rev-parse {tag}^{commit}` (not just `git rev-parse {tag}`) to handle annotated tags correctly. The DEPS file requires full 40-character commit hashes.
+
+### 3. Analyze Breaking Changes
+
+Compare current and target versions for:
+- **Changelog entries** mentioning breaking changes or API changes
+- **New source files** that may need adding to BUILD.gn
+- **Deleted source files** that would break the build
+- **API changes** in headers (added/removed/changed functions)
+
+Risk assessment:
+- Security-only releases → usually safe, no breaking changes
+- Patch versions (1.2.3 → 1.2.4) → typically safe
+- Minor versions (1.2 → 1.3) → read changelog carefully
+- Major versions (1.x → 2.x) → expect breaking changes
+
+👉 **See [references/breaking-changes.md](references/breaking-changes.md)** for detailed analysis guidance.
+
+### 4. Update and Build
+
+1. Edit `externals/skia/DEPS` with the new commit hash
+
+2. If needed, update `externals/skia/third_party/{dep}/BUILD.gn` (rare—only when new source files are added to the library)
+
+3. Build one platform/arch to verify (from repo root):
+   ```bash
+   dotnet cake --target=externals-macos --arch=arm64   # or x64
+   dotnet cake --target=externals-windows --arch=x64  
+   dotnet cake --target=externals-linux --arch=x64
+   ```
+
+4. Run tests via Cake (handles platform-specific skip traits correctly):
+   ```bash
+   dotnet cake --target=tests-netcore --skipExternals=all
+   ```
+
+**Tip:** Use `--arch` to build only one architecture (arm64, x64, arm, x86). Always use `dotnet cake --target=tests-netcore` for testing—it properly filters tests that should be skipped on each platform. Running `dotnet test` directly will cause crashes from tests that throw exceptions expecting to be skipped.
+
+**If build fails:** Check compiler errors for missing symbols or files. Usually means BUILD.gn needs updating (new source files) or an API changed. See [references/breaking-changes.md](references/breaking-changes.md) for guidance.
+
+### 5. Create PRs
+
+**Both PRs must be created together** - CI requires both to exist for validation. All three (issue + both PRs) should be cross-linked.
+
+#### Step 1: Find related issues
+
+Search for existing issues in SkiaSharp related to the dependency update:
+```bash
+gh search issues --repo mono/SkiaSharp "{dependency name}"
+```
+
+#### Step 2: Create mono/skia PR
+
+Create branch and PR in `externals/skia`:
+```bash
+cd externals/skia
+git checkout -b dev/update-{dep}
+git add DEPS
+git commit -m "Update {dep} to {version}"
+git push origin dev/update-{dep}
+gh pr create --repo mono/skia --base skiasharp --head dev/update-{dep} \
+  --title "Update {dep} to {version}"
+```
+
+Fill out the PR template:
+- **SkiaSharp Issue:** Link to the issue (e.g., `Related to https://github.com/mono/SkiaSharp/issues/NNNN`)
+- **Required SkiaSharp PR:** Leave as placeholder initially, update after creating SkiaSharp PR
+
+#### Step 3: Create SkiaSharp PR
+
+Create branch and PR in main repo:
+```bash
+cd ../..  # back to SkiaSharp root
+git checkout -b dev/update-{dep}
+git add cgmanifest.json
+git commit -m "Update {dep} to {version}"
+git push origin dev/update-{dep}
+gh pr create --repo mono/SkiaSharp --base main --head dev/update-{dep} \
+  --title "Update {dep} to {version}"
+```
+
+Fill out the PR template:
+- **Bugs Fixed:** Link with "Fixes" to auto-close (e.g., `- Fixes https://github.com/mono/SkiaSharp/issues/NNNN`)
+- **Required skia PR:** Link to mono/skia PR (e.g., `https://github.com/mono/skia/pull/NNN`)
+
+#### Step 4: Update mono/skia PR
+
+Go back and edit the mono/skia PR to add the SkiaSharp PR link:
+```bash
+gh pr edit {skia-pr-number} --repo mono/skia --body "..."
+```
+
+Update **Required SkiaSharp PR** to link to the SkiaSharp PR.
+
+#### Result
+
+All three are now cross-linked:
+- Issue → closed by SkiaSharp PR on merge
+- mono/skia PR → links to issue and SkiaSharp PR
+- SkiaSharp PR → links to issue and mono/skia PR
+
+**Merge order:** Merge mono/skia PR first, then the SkiaSharp PR.
+
+## Common Dependencies
+
+| Dependency | DEPS Key | Notes |
+|------------|----------|-------|
+| libpng | `third_party/externals/libpng` | PNG images |
+| libexpat | `third_party/externals/expat` | XML/SVG parsing |
+| zlib | `third_party/externals/zlib` | Compression |
+| libwebp | `third_party/externals/libwebp` | WebP images |
+| harfbuzz | `third_party/externals/harfbuzz` | Text shaping |
+| freetype | `third_party/externals/freetype` | Font rendering |
+| libjpeg-turbo | `third_party/externals/libjpeg-turbo` | JPEG images |
+
+Dependencies use Google-hosted mirrors (URLs visible in DEPS file).
+
+## Security Update Checklist
+
+- [ ] Identify CVE numbers and affected dependency
+- [ ] Find fixed version from advisory
+- [ ] Verify fix is in target commit
+- [ ] Check for additional CVEs fixed in newer versions
+- [ ] Analyze for breaking changes (usually none)
+- [ ] Update DEPS, build, test
+- [ ] Document CVEs in PR description
+- [ ] Update `cgmanifest.json` for compliance scanning
+
+## References
+
+- [references/breaking-changes.md](references/breaking-changes.md) - Detailed breaking change analysis guidance
+- [documentation/building.md](../../../documentation/building.md) - Full build prerequisites and setup
+- [documentation/maintaining.md](../../../documentation/maintaining.md) - Maintainer processes and update cadence
+- [CONTRIBUTING.md](../../../CONTRIBUTING.md) - PR guidelines and code standards

--- a/.github/skills/native-dependency-update/references/breaking-changes.md
+++ b/.github/skills/native-dependency-update/references/breaking-changes.md
@@ -1,0 +1,145 @@
+# Breaking Change Analysis
+
+Guidance for analyzing breaking changes when updating native dependencies.
+
+## Contents
+
+- [Risk Levels](#risk-levels)
+- [What to Analyze](#what-to-analyze)
+- [Risk by Version Type](#risk-by-version-type)
+- [Library-Specific Notes](#library-specific-notes)
+- [BUILD.gn Updates](#buildgn-updates)
+- [Analysis Summary Template](#analysis-summary-template)
+
+## Risk Levels
+
+| Level | Description | Action |
+|-------|-------------|--------|
+| ✅ Safe | No breaking changes | Direct update |
+| ⚠️ Minor | New optional features | May need BUILD.gn update |
+| 🔴 Breaking | API/ABI changes | Requires code changes |
+
+## What to Analyze
+
+### 1. Changelog/Release Notes
+
+Most projects document changes in files like CHANGES, CHANGELOG, NEWS, HISTORY, or RELEASE_NOTES. Read through the versions between current and target to understand what changed.
+
+Look for:
+- "Breaking change" or "API change" mentions
+- Deprecated features being removed
+- Function renames or signature changes
+- New required dependencies
+
+### 2. Source File Changes
+
+Compare the current and target versions to identify file-level changes:
+
+**New source files** - May need to be added to BUILD.gn, especially if they're:
+- Core library files (not tests/examples)
+- Platform-specific optimizations (ARM NEON, Intel SSE, RISC-V RVV)
+
+**Deleted source files** - Will break the build if BUILD.gn still references them.
+
+**Modified source files** - Usually fine, but worth noting the scope of changes.
+
+### 3. Header/API Changes
+
+Examine changes to public header files to understand API evolution:
+
+**Added exports** - New functionality, backwards compatible (safe)
+
+**Removed exports** - Breaking change! Code using these will fail to compile/link.
+
+**Changed signatures** - Breaking change! Callers need to be updated.
+
+Many libraries have a symbols export file (symbols.def, exports.def, etc.) that clearly shows what's added or removed.
+
+### 4. Build System Changes
+
+Check if the library's own build configuration changed in ways that affect Skia's BUILD.gn:
+- New required compiler defines
+- New source file organization
+- Changed include paths
+- New or removed dependencies
+
+## Risk by Version Type
+
+**Security-only releases** - Usually patch the minimum code necessary. Very low risk.
+
+**Patch versions (1.2.3 → 1.2.4)** - Bug fixes, typically backwards compatible. Low risk.
+
+**Minor versions (1.2.x → 1.3.x)** - New features, deprecations may be introduced. Medium risk.
+
+**Major versions (1.x → 2.x)** - Expect breaking changes. High risk, detailed analysis required.
+
+## Library-Specific Notes
+
+### libpng
+- Very stable API, rarely breaks
+- New platform optimizations added over time (ARM, SSE, RISC-V)
+- Check `scripts/symbols.def` for export changes
+- Security fixes are typically drop-in replacements
+
+### libexpat
+- Stable parser API
+- Check for new required initialization or cleanup functions
+- Memory allocation behavior may change
+
+### zlib
+- Extremely stable, core API unchanged for decades
+- MiniZip is a separate optional component—check if Skia uses it before worrying about MiniZip CVEs
+
+### libwebp
+- Encoder/decoder APIs are stable
+- New image format features may be added
+
+### harfbuzz
+- Shaping API is stable
+- Font function callbacks may evolve
+- Check for deprecated functions being removed
+
+### libjpeg-turbo
+- Very stable API
+- Platform-specific SIMD optimizations may be added
+
+### freetype
+- Rendering API is stable
+- Font loading functions occasionally evolve
+
+## BUILD.gn Updates
+
+BUILD.gn changes are typically needed when:
+1. **New source files** are added to the core library
+2. **Platform-specific code** is added (new CPU architecture support)
+3. **New compile defines** are required
+4. **Dependencies change** (new deps added or removed)
+
+BUILD.gn changes are usually NOT needed for:
+- Bug fixes in existing files
+- Security patches
+- Documentation updates
+- Test/example changes
+- New platform support SkiaSharp doesn't use (RISC-V, LoongArch, MIPS)
+
+The BUILD.gn lives at `externals/skia/third_party/{dep}/BUILD.gn`. Look at existing patterns—sources are listed explicitly, platform-specific code uses `if (current_cpu == "...")` conditionals.
+
+## Analysis Summary Template
+
+When reporting analysis results:
+
+```
+## {dep} {old_version} → {new_version}
+
+**Risk:** ✅ Safe / ⚠️ Minor / 🔴 Breaking
+
+**Changes:**
+- New APIs: {description or "None"}
+- Removed APIs: {description or "None"}
+- New source files: {list or "None"}
+- Deleted source files: {list or "None"}
+
+**BUILD.gn Impact:** {description or "No changes needed"}
+
+**Recommendation:** {Safe to upgrade / Needs BUILD.gn update / Needs code changes}
+```


### PR DESCRIPTION
**Description of Change**

Adds a new AI skill to guide updating native dependencies (libpng, zlib, harfbuzz, freetype, etc.) in SkiaSharp's Skia fork.

The skill provides:
- **Workflow documentation** - Step-by-step process for version bumps and security fixes
- **Breaking change analysis** - Guidance for evaluating API changes, new source files, and compatibility
- **PR creation process** - Proper cross-linking between issues and PRs in both mono/skia and SkiaSharp repos
- **Testing instructions** - Using Cake targets with proper skip trait handling
- **Common dependency reference** - Quick lookup table for DEPS keys

This skill was developed while updating libpng (see #3452) and captures the learned process for future updates.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description) - Documentation only
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation