### PR TITLE
Update SkiaSharp package source URL in nuget.config

### DIFF
--- a/tests/SkiaSharp.Tests.Integration/nuget.config
+++ b/tests/SkiaSharp.Tests.Integration/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="SkiaSharp Preview" value="https://aka.ms/skiasharp-eap/index.json" />
+    <add key="skiasharp-preview" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This pull request updates the NuGet package source for SkiaSharp previews in the test project configuration. The new source points to the official Azure DevOps feed instead of the previous preview endpoint. This ensures that package resolution uses the most current and supported location.