### PR TITLE
Update more AI skills

### DIFF
--- a/.github/skills/security-audit/SKILL.md
+++ b/.github/skills/security-audit/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: security-audit
+description: >
+  Audit SkiaSharp's native dependencies for security vulnerabilities and CVEs.
+  Read-only investigation that produces a status report with recommendations.
+
+  Use when user asks to:
+  - Audit security issues or CVEs
+  - Check CVE status across dependencies
+  - Find security-related issues and their PR coverage
+  - Get an overview of open vulnerabilities
+  - See what security work is pending
+
+  Triggers: "security audit", "audit CVEs", "CVE status", "what security issues are open",
+  "check vulnerability status", "security overview", "what CVEs need fixing".
+
+  This skill is READ-ONLY. To actually fix issues, use the `native-dependency-update` skill.
+---
+
+# Security Audit Skill
+
+Investigate security status of SkiaSharp's native dependencies. Produces a report with actionable recommendations.
+
+> ℹ️ This skill is **read-only**. To create PRs and fix issues, use the `native-dependency-update` skill.
+
+## Workflow Overview
+
+```mermaid
+flowchart TD
+    subgraph "1. Gather Data"
+        A[Search SkiaSharp issues<br/>CVE, security, vulnerability] --> B[Search PRs<br/>mono/SkiaSharp + mono/skia]
+        B --> C[Parse DEPS<br/>Get all dependency versions]
+    end
+
+    subgraph "2. Proactive Scan"
+        C --> D[For each dependency:<br/>web search CVEs]
+        D --> E{Current version<br/>affected?}
+        E -->|Yes| F[Note: CVE, severity, min fix version]
+        E -->|No| G[Mark as clean]
+    end
+
+    subgraph "3. Cross-Reference"
+        F --> H[Match: Issues ↔ PRs ↔ CVEs]
+        H --> I{Has issue?}
+        I -->|Yes| J{Has PR?}
+        I -->|No| K[🆕 Undiscovered]
+        J -->|Yes| L{PR sufficient?}
+        J -->|No| M[🔴 Needs attention]
+        L -->|Yes| N[✅ Ready to merge]
+        L -->|No| O[🟡 In progress]
+    end
+
+    subgraph "4. Validate"
+        K & M & N & O --> P{Affects SkiaSharp?}
+        P -->|No| Q[⚪ False positive]
+        P -->|Yes| R[Keep status]
+    end
+
+    subgraph "5. Report"
+        Q & R --> S[Generate report<br/>Priority: User-reported → Severity → Proactive]
+    end
+```
+
+### Priority Order
+
+1. **🔴 User-reported + no PR** → Users are waiting (highest visibility)
+2. **✅ User-reported + PR ready** → Quick wins
+3. **🟡 User-reported + PR needs work** → Unblock these
+4. **🆕 Undiscovered CVEs** → Proactive fixes
+5. **⚪ False positives** → Close with explanation
+
+## Detailed Steps
+
+### Step 1: User-Reported Issues (Highest Priority)
+
+Search mono/SkiaSharp open issues for security-related content:
+- CVE mentions and CVE numbers
+- Keywords: "security", "vulnerability", "advisory"
+- Dependency names: libpng, expat, zlib, webp, harfbuzz, freetype, libjpeg-turbo
+
+For each issue found, extract:
+- Issue number and title
+- CVE number(s) if mentioned
+- Affected dependency
+- Minimum version required to fix (from CVE advisory)
+
+**Why first?** Users are waiting on these. They have the highest visibility and urgency.
+
+### Step 2: PR Coverage
+
+Search for open PRs in both repos that may address security issues:
+
+**mono/SkiaSharp PRs:**
+- Search for dependency names, CVE numbers, "security", "bump", "update"
+
+**mono/skia PRs:**
+- Same search — these contain the actual DEPS changes
+
+Note PRs that:
+- Address reported issues
+- Fix CVEs without a corresponding issue (silent fixes)
+
+### Step 3: Dependency Inventory
+
+Parse `externals/skia/DEPS` to build a complete dependency list with current versions:
+
+```bash
+# Check version for each dependency
+cd externals/skia/third_party/externals/{dep}
+git describe --tags --abbrev=0 2>/dev/null || git log -1 --format='%H (no tag)'
+```
+
+**Security-relevant dependencies:**
+
+| Dependency | DEPS Key | Typical CVE Types |
+|------------|----------|-------------------|
+| libpng | `third_party/externals/libpng` | Buffer overflows, DoS |
+| libexpat | `third_party/externals/expat` | XXE, memory corruption |
+| zlib | `third_party/externals/zlib` | Buffer overflows |
+| libwebp | `third_party/externals/libwebp` | Heap buffer overflow |
+| harfbuzz | `third_party/externals/harfbuzz` | Rare; shaping bugs |
+| freetype | `third_party/externals/freetype` | Font parsing vulnerabilities |
+| libjpeg-turbo | `third_party/externals/libjpeg-turbo` | Decoding vulnerabilities |
+| brotli | `third_party/externals/brotli` | Compression bugs |
+
+### Step 4: Proactive CVE Scan
+
+For **each** dependency (not just those with issues), search for CVEs:
+
+```
+web_search: "{dependency} CVE security vulnerabilities {current year}"
+web_search: "{dependency} {version} CVE"
+```
+
+Check:
+- Is the current version affected?
+- What's the minimum fixed version?
+- What's the severity (CVSS score)?
+- Is it exploited in the wild?
+
+### Step 5: Cross-Reference
+
+Build a matrix matching issues ↔ PRs ↔ CVEs:
+
+| CVE | Issue | PR (SkiaSharp) | PR (skia) | Status |
+|-----|-------|----------------|-----------|--------|
+| CVE-2024-XXXXX | #1234 | #1235 | #99 | ✅ Covered |
+| CVE-2024-YYYYY | #1236 | — | — | 🔴 Needs PR |
+| CVE-2024-ZZZZZ | — | #1240 | #101 | 🟢 Silent fix |
+| CVE-2024-AAAAA | — | — | — | 🆕 Undiscovered |
+
+### Step 6: False Positive Check
+
+For each CVE, verify it actually affects SkiaSharp:
+
+1. Check [references/known-exceptions.md](references/known-exceptions.md)
+2. Verify the affected component is compiled/linked by Skia
+3. Check if SkiaSharp's usage patterns expose the vulnerability
+
+**Quick reference for known false positives:**
+- **MiniZip** (in zlib) — NOT compiled, NOT linked
+- **FreeType's bundled zlib** — Separate from Skia's zlib
+
+## Report Format
+
+### Summary Section
+
+```markdown
+## Security Audit Report
+
+**Date:** {date}
+**Audited:** mono/SkiaSharp native dependencies
+
+### Summary
+
+| Status | Count |
+|--------|-------|
+| ✅ Ready to merge | N |
+| 🟡 In progress | N |
+| 🔴 Needs attention | N |
+| 🆕 Undiscovered | N |
+| ⚪ False positive | N |
+```
+
+### Detailed Findings
+
+Use **separate tables per item** to avoid terminal wrapping issues:
+
+```markdown
+### 1. ✅ libexpat — Ready to merge
+
+| Field | Value |
+|-------|-------|
+| Issues | #3389, #3425 |
+| CVEs | CVE-2025-59375 (HIGH 7.5), CVE-2024-50602 (Medium 5.9) |
+| Current | 2.7.3 |
+| Latest | 2.7.3 |
+| PR | #3458 (CI passing) |
+
+**Action:** Merge when CI passes
+
+---
+
+### 2. 🔴 libpng — Needs attention
+
+| Field | Value |
+|-------|-------|
+| Issues | #1234 |
+| CVEs | CVE-2024-XXXXX (HIGH 8.1) |
+| Current | 1.6.40 |
+| Min fix | 1.6.42 |
+| Latest | 1.6.44 |
+| PR | None |
+
+**Action:** Create PR to update to 1.6.44
+
+---
+
+### 3. 🆕 brotli — Undiscovered CVE
+
+| Field | Value |
+|-------|-------|
+| Issues | None |
+| CVEs | CVE-2024-YYYYY (Medium 5.5) |
+| Current | 1.0.9 |
+| Min fix | 1.1.0 |
+| Latest | 1.1.0 |
+| PR | None |
+
+**Action:** Create issue, then create PR
+
+---
+
+### 4. ⚪ zlib (MiniZip) — False positive
+
+| Field | Value |
+|-------|-------|
+| Issue | #3285 |
+| CVE | CVE-2023-45853 |
+| Status | Not vulnerable |
+
+**Reason:** CVE affects MiniZip only. Skia does not compile or link MiniZip.
+
+**Action:** Close issue with explanation
+```
+
+### Status Legend
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| ✅ Ready to merge | PR exists, fixes CVE, CI passing | Merge |
+| 🟡 In progress | PR exists but needs work (outdated, CI failing) | Update PR |
+| 🔴 Needs attention | User-reported issue, no PR | Create PR |
+| 🆕 Undiscovered | CVE found proactively, no issue/PR | Create issue + PR |
+| ⚪ False positive | CVE doesn't affect SkiaSharp | Close with explanation |
+
+### Priority Order
+
+Report findings in this order:
+
+1. **🔴 User-reported + no PR** → Users are waiting
+2. **✅ User-reported + PR ready** → Quick wins
+3. **🟡 User-reported + PR needs work** → Unblock these
+4. **🆕 Undiscovered CVEs** → Proactive fixes
+5. **⚪ False positives** → Close with explanation
+
+## Recommendations Section
+
+End the report with specific next steps:
+
+```markdown
+### Next Steps
+
+1. **Merge PR #3458** — libexpat update is ready
+2. **Update libwebp PR** — Current targets 1.4.0, latest is 1.6.0
+3. **Create PR for libpng** — Run: `bump libpng to 1.6.44`
+4. **Close #3285** — zlib/MiniZip CVE is false positive
+```
+
+## Known Exceptions
+
+Some components bundled in dependencies are **NOT used** by SkiaSharp. CVEs in these components are false positives.
+
+👉 See [references/known-exceptions.md](references/known-exceptions.md) for the full list with evidence.
+
+**Quick reference:**
+- **MiniZip** (in zlib) — NOT compiled, NOT linked
+- **FreeType's bundled zlib** — Separate from Skia's zlib; check FreeType version independently
+
+## Notes
+
+- **Severity**: Focus on High/Critical CVEs first (CVSS ≥ 7.0)
+- **Exploitability**: Prioritize CVEs exploited in the wild
+- **User visibility**: User-reported issues get priority over proactive finds
+
+## Handoff to Fixes
+
+After completing the audit, the user can:
+
+1. **Merge ready PRs** — Direct action if they have permissions
+2. **Update outdated PRs** — Use `native-dependency-update` skill
+3. **Create missing PRs** — Use `native-dependency-update` skill
+
+Example handoffs:
+- "Merge PR #3458"
+- "Update libwebp to 1.6.0"
+- "Bump libpng to fix CVE-2024-XXXXX"

--- a/.github/skills/security-audit/references/known-exceptions.md
+++ b/.github/skills/security-audit/references/known-exceptions.md
@@ -1,0 +1,88 @@
+# Known Exceptions
+
+CVEs in these components do **NOT** affect SkiaSharp and should be marked as false positives.
+
+## Contents
+
+- [MiniZip (in zlib)](#minizip-in-zlib--not-used)
+- [Actual zlib Usage](#actual-zlib-usage-in-skiasharp)
+
+---
+
+## MiniZip (in zlib) — NOT USED
+
+**Status:** ❌ Not compiled, not linked, not vulnerable
+
+**What is MiniZip?** A zip/unzip library bundled in `zlib/contrib/minizip/`. It provides `unzOpen()`, `zipOpen()`, and related functions for reading/writing ZIP archives.
+
+### Evidence that Skia does NOT use MiniZip
+
+1. **Skia's BUILD.gn excludes MiniZip sources**
+   - File: `externals/skia/third_party/zlib/BUILD.gn`
+   - The `sources` list contains only core zlib files (adler32.c, compress.c, deflate.c, etc.)
+   - No references to `contrib/minizip/` directory
+   - Contrast with Chromium's BUILD.gn at `externals/zlib/BUILD.gn` which DOES include MiniZip — but Skia doesn't use that file
+
+2. **No MiniZip headers included anywhere in Skia**
+   - Searched: `externals/skia/src/` and `externals/skia/include/`
+   - No includes of `unzip.h`, `zip.h`, or `minizip` paths
+   - Command: `grep -r "minizip\|unzip\.h\|zip\.h" src/ include/` returns nothing
+
+3. **No MiniZip function calls in Skia**
+   - Searched for: `unzOpen`, `zipOpen`, `unzClose`, `zipClose`, `unzReadCurrentFile`
+   - Command: `grep -r "unzOpen\|zipOpen" src/ include/` returns nothing
+
+### MiniZip CVE examples that do NOT affect SkiaSharp
+
+- CVE-2023-45853 (if MiniZip-specific — verify the CVE details)
+- Any CVE mentioning `unzip.c`, `zip.c`, `ioapi.c`, or MiniZip functions
+
+### How to verify a zlib CVE
+
+1. Check if the CVE mentions MiniZip, `contrib/minizip`, or zip archive handling
+2. Check if the affected functions are in Skia's BUILD.gn source list
+3. If the CVE is in core zlib (deflate, inflate, adler32, crc32), it DOES affect SkiaSharp
+
+---
+
+## Actual zlib Usage in SkiaSharp
+
+Core zlib (deflate/inflate) **IS** used by SkiaSharp. CVEs affecting these functions DO apply.
+
+| Component | Uses zlib? | Functions Used | Notes |
+|-----------|------------|----------------|-------|
+| **PDF (SkDeflate.cpp)** | ✅ Yes | `deflateInit2`, `deflate`, `deflateEnd` | PDF stream compression |
+| **libpng** | ✅ Yes | Core deflate/inflate | PNG compression (via zlib dependency) |
+| **DNG SDK** (Windows only) | ✅ Yes | `compress2` | RAW image compression |
+| **FreeType** | ⚠️ Bundled | Uses its own copy | Has `src/gzip/` with zlib subset for compressed fonts |
+
+### FreeType bundles its own zlib
+
+- When `skia_use_system_zlib=false` (SkiaSharp's default), FreeType uses `skia_use_freetype_zlib_bundled=true`
+- This means FreeType's zlib copy at `freetype/src/gzip/` is used, NOT Skia's `third_party/zlib`
+- FreeType zlib CVEs should be checked against FreeType's bundled version, not the main zlib checkout
+- Used for: compressed PCF fonts (common with X11 server distributions)
+
+### DNG SDK (Windows only)
+
+- `skia_use_dng_sdk=true` only on Windows builds
+- Uses `compress2()` for RAW/DNG image processing
+- Other platforms do not include DNG SDK
+
+---
+
+## Adding New Exceptions
+
+When you discover a component that is NOT used by SkiaSharp:
+
+1. **Verify thoroughly** with multiple pieces of evidence:
+   - Check BUILD.gn source lists
+   - Search for header includes
+   - Search for function calls
+   - Check build configuration flags
+
+2. **Document the evidence** in this file following the MiniZip example
+
+3. **Include verification commands** so future audits can re-verify
+
+4. **List example CVEs** that would be false positives


### PR DESCRIPTION
This pull request introduces a new security audit skill for SkiaSharp's native dependencies and refines the workflow for updating those dependencies. The main focus is to clearly separate the processes for security auditing (read-only investigation and reporting) and for updating/fixing dependencies. Documentation has been enhanced to guide users on when to use each skill, ensure a more thorough and auditable update process, and prevent common mistakes.

**Security Audit Skill Addition:**

- Introduced a new `security-audit` skill that provides a comprehensive, read-only workflow for auditing SkiaSharp's native dependencies for CVEs and security issues, including detailed reporting, prioritization, and actionable recommendations.
- Added a reference document listing known false positive CVEs (e.g., MiniZip in zlib) that do not affect SkiaSharp, along with evidence and verification steps.

**Native Dependency Update Skill Improvements:**

- Clarified that security audits (CVE checks, PR coverage) should use the new `security-audit` skill, and removed ambiguous triggers from the update skill documentation.
- Expanded the update workflow to require checking for existing PRs before starting work, evaluating their relevance and currency, and reporting findings to the user before proceeding.
- Improved instructions for verifying current and target dependency versions, and for presenting findings to the user, including existing PRs and reasons for updates.
- Simplified and clarified the process for checking CI status and PR merge state, emphasizing the importance of verifying actual PR state rather than just CI status.

**Process and Documentation Clarity:**

- Strengthened language to require following every phase of the update workflow and removed ambiguous language that could be interpreted as permission to skip steps.
- Removed redundant warnings about not pushing directly to main branches, focusing instead on the critical need for PRs and submodule updates. [[1]](diffhunk://#diff-f9c71b6da8951243004ec22339d2de5d5703f868295706fcc613bb26f17365cfL191-L192) [[2]](diffhunk://#diff-f9c71b6da8951243004ec22339d2de5d5703f868295706fcc613bb26f17365cfL203-L204)