### PR TITLE
Don't dispose SKStreamAsset in ToHarfBuzzBlob

### DIFF
--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/BlobExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/BlobExtensions.cs
@@ -21,7 +21,7 @@ namespace SkiaSharp.HarfBuzz
 			var memoryBase = asset.GetMemoryBase();
 			if (memoryBase != IntPtr.Zero)
 			{
-				blob = new Blob(memoryBase, size, MemoryMode.ReadOnly, () => asset.Dispose());
+				blob = new Blob(memoryBase, size, MemoryMode.ReadOnly);
 			}
 			else
 			{

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/BlobExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/BlobExtensions.cs
@@ -26,8 +26,16 @@ namespace SkiaSharp.HarfBuzz
 			else
 			{
 				var ptr = Marshal.AllocCoTaskMem(size);
-				asset.Read(ptr, size);
-				blob = new Blob(ptr, size, MemoryMode.ReadOnly, () => Marshal.FreeCoTaskMem(ptr));
+				try
+				{
+					asset.Read(ptr, size);
+					blob = new Blob(ptr, size, MemoryMode.ReadOnly, () => Marshal.FreeCoTaskMem(ptr));
+				}
+				catch
+				{
+					Marshal.FreeCoTaskMem(ptr);
+					throw;
+				}
 			}
 
 			blob.MakeImmutable();

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/SKShaper.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/SKShaper.cs
@@ -17,7 +17,8 @@ namespace SkiaSharp.HarfBuzz
 			Typeface = typeface ?? throw new ArgumentNullException(nameof(typeface));
 
 			int index;
-			using (var blob = Typeface.OpenStream(out index).ToHarfBuzzBlob())
+			using (var stream = Typeface.OpenStream(out index))
+			using (var blob = stream.ToHarfBuzzBlob())
 			using (var face = new Face(blob, index))
 			{
 				face.Index = index;

--- a/tests/Tests/SkiaSharp/BlobExtensionsTest.cs
+++ b/tests/Tests/SkiaSharp/BlobExtensionsTest.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using HarfBuzzSharp;
+using SkiaSharp.Tests;
+using Xunit;
+
+namespace SkiaSharp.HarfBuzz.Tests
+{
+	public class BlobExtensionsTest : SKTest
+	{
+		[SkippableFact]
+		public void ToHarfBuzzBlobDoesNotDisposeStream()
+		{
+			var fontFileName = Path.Combine(PathToFonts, "content-font.ttf");
+			using var tf = SKTypeface.FromFile(fontFileName);
+			using var stream = tf.OpenStream(out var index);
+			using (var blob = stream.ToHarfBuzzBlob())
+			{
+			}
+
+			Assert.False(stream.IsDisposed);
+		}
+
+		[SkippableFact]
+		public void ToHarfBuzzBlobBlobCanBeUsedOutsideStreamLifetime()
+		{
+			static Blob GetBlob(SKTypeface typeface)
+			{
+				using var stream = typeface.OpenStream(out var index);
+				return stream.ToHarfBuzzBlob();
+			}
+
+			var fontFile = Path.Combine(PathToFonts, "content-font.ttf");
+			using var tf = SKTypeface.FromFile(fontFile);
+			using var blob = GetBlob(tf);
+			Assert.Equal(1, blob.FaceCount);
+		}
+	}
+}

--- a/tests/Tests/SkiaSharp/BlobExtensionsTest.cs
+++ b/tests/Tests/SkiaSharp/BlobExtensionsTest.cs
@@ -19,20 +19,5 @@ namespace SkiaSharp.HarfBuzz.Tests
 
 			Assert.False(stream.IsDisposed);
 		}
-
-		[SkippableFact]
-		public void ToHarfBuzzBlobBlobCanBeUsedOutsideStreamLifetime()
-		{
-			static Blob GetBlob(SKTypeface typeface)
-			{
-				using var stream = typeface.OpenStream(out var index);
-				return stream.ToHarfBuzzBlob();
-			}
-
-			var fontFile = Path.Combine(PathToFonts, "content-font.ttf");
-			using var tf = SKTypeface.FromFile(fontFile);
-			using var blob = GetBlob(tf);
-			Assert.Equal(1, blob.FaceCount);
-		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

HarfBuzz Blob should not have dispose ownership of SKStreamAsset as it might still be in use by the caller.

SKShaper should also deterministically dispose the stream.

**Bugs Fixed**

Discussion https://github.com/mono/SkiaSharp/discussions/3373

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

ToHarfBuzzBlob no longer takes dispose ownership of the given SKStreamAsset

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Merged related skia PRs
- [X] Changes adhere to coding standard
- [ ] Updated documentation
