### PR TITLE
Update libwebp to 1.6.0

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -38,7 +38,7 @@
         "type": "other",
         "other": {
           "name": "libwebp",
-          "version": "1.3.2",
+          "version": "1.6.0",
           "downloadUrl": "https://github.com/webmproject/libwebp"
         }
       }


### PR DESCRIPTION
## Summary
Update libwebp version in cgmanifest.json from 1.3.2 to 1.6.0.

## Companion PR
- mono/skia#166 (contains DEPS and BUILD.gn changes)

## libwebp 1.6.0 Release Notes
- **Security fix**: heap overflow in webpmux (`-get`/`-set`)
- Speed and compression improvements
- Histogram optimizations
- New AVX2 optimizations (optional, auto-enabled when available)
- Various bug fixes

## Testing
- ✅ Local macOS arm64 build succeeded
- ✅ All SkiaSharp tests passed (5340 passed)

## Links
- [libwebp v1.6.0 tag](https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.6.0)