### PR TITLE
Use the new CI feed to download the pre-built artifacts

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -92,7 +92,7 @@ if (IsRunningOnWindows ()) {
     throw new Exception ("This script is not running on a known platform.");
 }
 
-var PREVIEW_FEED_URL = Argument ("previewFeed", "https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json");
+var CI_ARTIFACTS_FEED_URL = Argument ("previewFeed", "https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp-CI/nuget/v3/index.json");
 
 var SUPPORTED_NUGETS = new Dictionary<string, Version> {
     // SkiaSharp core

--- a/scripts/cake/UtilsManaged.cake
+++ b/scripts/cake/UtilsManaged.cake
@@ -187,13 +187,13 @@ async Task DownloadPackageAsync(string id, DirectoryPath outputDirectory)
 
     var filter = new NuGetVersions.Filter {
         IncludePrerelease = true,
-        SourceUrl = PREVIEW_FEED_URL,
+        SourceUrl = CI_ARTIFACTS_FEED_URL,
         VersionRange = VersionRange.Parse(version),
     };
 
     var latestVersion = await NuGetVersions.GetLatestAsync(id, filter);
 
-    var comparer = new NuGetDiff(PREVIEW_FEED_URL);
+    var comparer = new NuGetDiff(CI_ARTIFACTS_FEED_URL);
     comparer.PackageCache = PACKAGE_CACHE_PATH.FullPath;
 
     // Track progress dynamically - queue grows as dependencies are discovered


### PR DESCRIPTION
This pull request updates the NuGet package feed URL used for downloading and comparing packages from the preview feed to the CI artifacts feed. The change ensures that the build and utility scripts now reference the CI feed instead of the previous preview feed.

Feed URL update:

* Updated the variable from `PREVIEW_FEED_URL` to `CI_ARTIFACTS_FEED_URL` in `build.cake` and changed its default value to point to the SkiaSharp CI artifacts NuGet feed.
* Updated all references in `scripts/cake/UtilsManaged.cake` to use `CI_ARTIFACTS_FEED_URL` instead of `PREVIEW_FEED_URL` for package source and comparison operations.