### PR TITLE
Optimize the CopyTo method of SKBitmap

### DIFF
--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -188,6 +188,17 @@ namespace SkiaSharp
 			if (colorType == SKColorType.Unknown)
 				return false;
 
+			if (ColorType == destination.ColorType && ColorType == colorType) {
+				if (Width == destination.Width) {
+					var des = destination.GetPixelSpan ();
+					var src = GetPixelSpan ();
+					if(Height<=destination.Height) {
+						return src.TryCopyTo (des);
+					}
+					return src.Slice (0, des.Length).TryCopyTo (des);
+				}
+			}
+
 			using var srcPixmap = PeekPixels ();
 			if (srcPixmap == null)
 				return false;

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -188,40 +188,34 @@ namespace SkiaSharp
 			if (colorType == SKColorType.Unknown)
 				return false;
 
-			if (Width == 0 || Height == 0)
-				return false;
-
-			// To check if we can do a direct copy
-			// If a SKBitmap is created by ExtractSubset, its pixels may not be stored contiguously
-			// In most cases, des and src have the same Size and ColorType
-			int desWidth = destination.Width;
-			int desHeight = destination.Height;
-			if(desWidth==0||desHeight==0)
-				return false;
-			if (ColorType == destination.ColorType && ColorType == colorType) {
-				if (Width * Height * BytesPerPixel == ByteCount &&
-				    desWidth * desHeight * BytesPerPixel == destination.ByteCount) {
-					if (Width == desWidth) {
-						var des = destination.GetPixelSpan ();
-						var src = GetPixelSpan ();
-						if(Height<=desHeight) {
-							return src.TryCopyTo (des);
-						}
-						return src.Slice (0, des.Length).TryCopyTo (des);
+			// Fast path: when no color conversion is required and the destination is
+			// already allocated with the exact same image info as the source, copy the
+			// pixel memory directly instead of going through an SKCanvas. This produces a
+			// byte-identical result to the canvas-based path below, but avoids allocating
+			// a temporary bitmap, shader, paint and canvas.
+			//
+			// The copy is done row by row because the source may have a larger stride than
+			// the destination (for example when it was created via ExtractSubset and its
+			// pixels are not stored contiguously). Any other case (different size, alpha
+			// type, color space or a color type conversion) falls through to the original
+			// path below so the existing semantics are fully preserved.
+			if (colorType == ColorType && !ReferenceEquals (destination, this) && destination.Info == Info) {
+				var srcPixels = (byte*)GetPixels (out _);
+				var dstPixels = (byte*)destination.GetPixels (out _);
+				if (srcPixels != null && dstPixels != null) {
+					var height = Height;
+					var rowBytes = Info.RowBytes;
+					var srcStride = RowBytes;
+					var dstStride = destination.RowBytes;
+					for (var y = 0; y < height; y++) {
+						var src = new Span<byte> (srcPixels + (long)y * srcStride, rowBytes);
+						var dst = new Span<byte> (dstPixels + (long)y * dstStride, rowBytes);
+						src.CopyTo (dst);
 					}
+					GC.KeepAlive (this);
+					GC.KeepAlive (destination);
+					return true;
 				}
-				// Copy row by row
-				var rowBytes = Math.Min (RowBytes, destination.RowBytes);
-				var srcAddress = GetAddress (0, 0);
-				var desAddress = destination.GetAddress (0, 0);
-				var srcOriginalRowBytes = GetAddress (0, 1) - srcAddress;
-				var desOriginalRowBytes = destination.GetAddress (0, 1) - destination.GetAddress (0, 0);
-				for(var row=0;row<Math.Min(Height, desHeight);row++,srcAddress+=srcOriginalRowBytes,desAddress+=desOriginalRowBytes) {
-					var des =new Span<byte> (srcAddress.ToPointer(), rowBytes);
-					var src =new Span<byte> (desAddress.ToPointer(), rowBytes);
-					src.TryCopyTo(des);
-				}
-				return true;
 			}
 
 			using var srcPixmap = PeekPixels ();

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -213,7 +213,11 @@ namespace SkiaSharp
 						src.CopyTo (dst);
 					}
 					GC.KeepAlive (this);
-					GC.KeepAlive (destination);
+					// The pixels were written directly into the destination's existing
+					// pixel buffer, so bump its generation ID to invalidate any Skia caches
+					// (e.g. images or shaders created from the destination). This mirrors the
+					// canvas-based path below, which swaps in a fresh pixel reference.
+					destination.NotifyPixelsChanged ();
 					return true;
 				}
 			}

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -283,6 +283,62 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void CopyToPreallocatedDestinationMatchesCanvasPath()
+		{
+			using var bmp = CreateTestBitmap();
+
+			// Reference: the destination is empty, so CopyTo goes through the original
+			// SKCanvas-based path and allocates the destination itself.
+			using var reference = new SKBitmap();
+			Assert.True(bmp.CopyTo(reference, bmp.ColorType));
+
+			// Optimized: the destination is pre-allocated with the exact same image info,
+			// so CopyTo takes the direct memory-copy fast path.
+			using var fast = new SKBitmap();
+			Assert.True(fast.TryAllocPixels(bmp.Info));
+			Assert.True(bmp.CopyTo(fast, bmp.ColorType));
+
+			// Both paths must produce identical image info and byte-identical pixels,
+			// which must also match the source exactly.
+			Assert.Equal(bmp.Info, reference.Info);
+			Assert.Equal(bmp.Info, fast.Info);
+			Assert.Equal(bmp.GetPixelSpan().ToArray(), fast.GetPixelSpan().ToArray());
+			Assert.Equal(reference.GetPixelSpan().ToArray(), fast.GetPixelSpan().ToArray());
+
+			ValidateTestBitmap(fast);
+		}
+
+		[SkippableFact]
+		public void CopyToPreallocatedDestinationWithSubsetSourceMatchesCanvasPath()
+		{
+			using var full = CreateTestBitmap();
+
+			// A subset shares the pixel buffer of the original, so its row stride
+			// (RowBytes) is larger than the compact Width * BytesPerPixel. This exercises
+			// the row-by-row branch of the fast path with differing source/destination
+			// strides.
+			using var subset = new SKBitmap();
+			Assert.True(full.ExtractSubset(subset, new SKRectI(5, 5, 35, 35)));
+			Assert.True(subset.RowBytes > subset.Info.RowBytes);
+
+			// Reference via the original canvas path (empty destination -> compact copy).
+			using var reference = subset.Copy(subset.ColorType);
+			Assert.NotNull(reference);
+
+			// Optimized fast path into a pre-allocated, compact destination.
+			using var fast = new SKBitmap();
+			Assert.True(fast.TryAllocPixels(subset.Info));
+			Assert.True(subset.CopyTo(fast, subset.ColorType));
+
+			Assert.Equal(subset.Info, fast.Info);
+			Assert.Equal(reference.GetPixelSpan().ToArray(), fast.GetPixelSpan().ToArray());
+
+			for (var y = 0; y < subset.Height; y++)
+				for (var x = 0; x < subset.Width; x++)
+					Assert.Equal(subset.GetPixel(x, y), fast.GetPixel(x, y));
+		}
+
+		[SkippableFact]
 		public void ReleaseBitmapPixelsWasInvoked()
 		{
 			bool released = false;


### PR DESCRIPTION
**Description of Change**

A simple PR

Optimize the CopyTo method of SKBitmap.

Use direct memory copy instead of creating SKCanvas and DrawBitmap when source and destination Bitmap have the same SKColorType and Width.

<!-- Describe your changes here. -->

**Bugs Fixed**

None

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
