### PR TITLE
Fix release-testing skill package resolution guidance

### DIFF
--- a/.github/skills/release-testing/SKILL.md
+++ b/.github/skills/release-testing/SKILL.md
@@ -83,22 +83,39 @@ Example: `#3.119.2-preview.2.3+3.119.2-preview.2 succeeded`
    - `HarfBuzzSharp ... nuget` line → base version (e.g., `8.3.1.3`)
    - `PREVIEW_LABEL` → label (e.g., `preview.2` or `stable`)
 
-2. Search preview feed:
+2. **Search and filter for the SPECIFIC version:**
+
    ```bash
-   dotnet package search SkiaSharp --source "https://aka.ms/skiasharp-eap/index.json" --exact-match --prerelease --format json
+   # Get ALL versions, then filter to match {base}-{label}.*
+   dotnet package search SkiaSharp \
+     --source "https://aka.ms/skiasharp-eap/index.json" \
+     --exact-match --prerelease --format json \
+     | jq -r '.searchResult[].packages[] | select(.id == "SkiaSharp") | .version' \
+     | grep "^{base}-{label}\."
+   
+   # Example: Find 3.119.2-preview.3.* versions
+   dotnet package search SkiaSharp \
+     --source "https://aka.ms/skiasharp-eap/index.json" \
+     --exact-match --prerelease --format json \
+     | jq -r '.searchResult[].packages[] | select(.id == "SkiaSharp") | .version' \
+     | grep "^3.119.2-preview.3\."
    ```
 
-3. Filter versions matching `{base}-{preview-label}.{build}`, pick latest
+   ⚠️ **CRITICAL:** Use `.version` to get ALL versions, NOT `.latestVersion` which only returns the newest.
+   The feed contains multiple version streams (e.g., 3.119.2 AND 3.119.3), so you MUST filter
+   by the base version and preview label from the release branch.
+
+3. Pick the highest build number from matching versions (e.g., `3.119.2-preview.3.1`)
 
 4. Report to user:
    ```
    Resolved versions:
-     SkiaSharp:     3.119.2-preview.2.3
-     HarfBuzzSharp: 8.3.1.3-preview.2.3
-     Build number:  3
+     SkiaSharp:     3.119.2-preview.3.1
+     HarfBuzzSharp: 8.3.1.3-preview.3.1
+     Build number:  1
    ```
 
-**No packages found?** CI build hasn't completed. Check CI status, wait 2-4 hours.
+**No packages found?** CI build hasn't completed. See [troubleshooting.md](references/troubleshooting.md#package-resolution-errors).
 
 ---
 

--- a/.github/skills/release-testing/references/troubleshooting.md
+++ b/.github/skills/release-testing/references/troubleshooting.md
@@ -2,6 +2,31 @@
 
 Quick reference for common errors and fixes.
 
+## Package Resolution Errors
+
+### Packages appear missing but CI succeeded
+
+**Symptom:** CI shows success, but package search seems to find wrong version or nothing matching your release.
+
+**Cause:** Using `.latestVersion` from the JSON instead of `.version`. The feed contains multiple version streams (e.g., 3.119.2 AND 3.119.3), so `.latestVersion` returns the wrong one.
+
+**Fix:** Use `.version` and filter by base version + label from the release branch:
+
+```bash
+dotnet package search SkiaSharp \
+  --source "https://aka.ms/skiasharp-eap/index.json" \
+  --exact-match --prerelease --format json \
+  | jq -r '.searchResult[].packages[] | select(.id == "SkiaSharp") | .version' \
+  | grep "^3.119.2-preview.3\."
+```
+
+| ❌ Wrong | ✅ Correct |
+|----------|-----------|
+| `.latestVersion` | `.version` |
+| No filtering | Filter by `{base}-{label}.*` |
+
+---
+
 ## Build Errors
 
 | Error | Cause | Fix |


### PR DESCRIPTION
## Summary

Fixes an issue where the release-testing skill could incorrectly report "packages not found" when the EAP feed contains multiple version streams.

## Problem

When monitoring for release packages, the agent was using `.latestVersion` from the JSON response, which only returns the newest version across ALL version streams. When a newer stream exists (e.g., 3.119.3-preview.0), the specific version being released (e.g., 3.119.2-preview.3) would never be found.

## Solution

- Updated Step 2 in SKILL.md to use `.version` with proper filtering by `{base}-{label}.*`
- Added explicit warning about the `.latestVersion` trap
- Added "Package Resolution Errors" section to troubleshooting.md

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | Updated package resolution to use `.version` + filtering |
| `troubleshooting.md` | Added Package Resolution Errors section |

## Testing

Verified the correct command finds packages:
```bash
dotnet package search SkiaSharp \
  --source "https://aka.ms/skiasharp-eap/index.json" \
  --exact-match --prerelease --format json \
  | jq -r '.searchResult[].packages[] | select(.id == "SkiaSharp") | .version' \
  | grep "^3.119.2-preview.3\."
# Output: 3.119.2-preview.3.1
```