### PR TITLE
Add semver ordering guidance to release skills

### DIFF
--- a/.github/skills/release-branch/SKILL.md
+++ b/.github/skills/release-branch/SKILL.md
@@ -34,7 +34,8 @@ Create release branches for SkiaSharp versions.
 1. Fetch main and read `SKIASHARP_VERSION` from `scripts/azure-templates-variables.yml`
 2. List existing branches: `git branch -r | grep "release/{version}-preview"`
 3. Next preview = highest + 1 (or 1 if none)
-4. Confirm with user: "Next release will be `X.Y.Z-preview.N`. Proceed?"
+4. **⚠️ Semver check:** Also verify no bare `release/{version}` branch exists — if it does, the stable release is already cut and you should NOT create another preview. Ask the user to confirm.
+5. Confirm with user: "Next release will be `X.Y.Z-preview.N`. Proceed?"
 
 ### User provides version
 
@@ -43,6 +44,10 @@ Use the provided version directly.
 ---
 
 ## Step 2: Determine Release Type
+
+⚠️ **Semver ordering:** A bare version `X.Y.Z` is ALWAYS newer than `X.Y.Z-preview.N`. When listing
+branches to find the latest, remember that `release/3.119.2` > `release/3.119.2-preview.3`.
+Do NOT use alphabetical sorting — it gives wrong results for semver.
 
 | Version Format | Type | Base | PREVIEW_LABEL |
 |----------------|------|------|---------------|

--- a/.github/skills/release-publish/SKILL.md
+++ b/.github/skills/release-publish/SKILL.md
@@ -58,6 +58,13 @@ Publish packages to NuGet.org and finalize releases.
 
 ## Step 1: Confirm Versions
 
+### ⚠️ Semver Version Ordering
+
+When identifying which version to publish, use **semver ordering**, not alphabetical:
+- `3.119.2` (bare) is NEWER than `3.119.2-preview.3` — it's the stable/final release
+- Always verify you are publishing from the correct branch
+- If both `release/3.119.2` and `release/3.119.2-preview.3` exist, the bare version is the latest
+
 **Prerequisite:** release-testing must have passed. Versions should be known from testing.
 
 The user should provide:

--- a/.github/skills/release-testing/SKILL.md
+++ b/.github/skills/release-testing/SKILL.md
@@ -33,6 +33,29 @@ Verify SkiaSharp packages work correctly before publishing.
 
 ---
 
+## ⚠️ CRITICAL: Semver Version Ordering
+
+When identifying which release branch to test, you **MUST** use semver ordering, NOT alphabetical or `sort -V` ordering.
+
+**In semver, a bare version is ALWAYS newer than its prerelease variants:**
+
+```
+3.119.2-preview.1 < 3.119.2-preview.2 < 3.119.2-preview.3 < 3.119.2 (FINAL)
+```
+
+`release/3.119.2` is the **stable release** and is NEWER than `release/3.119.2-preview.3`.
+
+**To find the latest release branch:**
+
+1. List all release branches: `git branch -r | grep "release/"`
+2. Identify the highest base version (e.g., `3.119.2`)
+3. Check if a **bare version branch** exists (e.g., `release/3.119.2`) — if so, that is the latest
+4. If only preview branches exist, the highest preview number is the latest
+
+**⚠️ Getting this wrong means testing the wrong version — wasting the entire process or shipping untested packages.**
+
+---
+
 ## Step 1: Check CI Status
 
 Before testing, verify CI builds have completed. Check commit statuses on the release branch head:


### PR DESCRIPTION
Prevents selecting the wrong release branch when both preview and stable branches exist (e.g., picking `3.119.2-preview.3` instead of `3.119.2`).

In semver, bare versions are always newer than prerelease variants: `3.119.2` > `3.119.2-preview.3`.

### Changes
- **release-testing**: Added critical section before Step 1 with step-by-step process to find the correct branch
- **release-branch**: Added semver check in auto-detect and ordering warning in Step 2
- **release-publish**: Added semver ordering subsection in Step 1