### PR TITLE
Fix stable version handling in release skills

### DIFF
--- a/.github/skills/release-branch/SKILL.md
+++ b/.github/skills/release-branch/SKILL.md
@@ -58,6 +58,10 @@ Do NOT use alphabetical sorting — it gives wrong results for semver.
 
 For stable releases, find latest preview: `git branch -r | grep "release/X.Y.Z-preview" | sort -V | tail -1`
 
+**NuGet version format by release type:**
+- **Preview:** `{base}-{PREVIEW_LABEL}.{build}` (e.g., `3.119.2-preview.2.3`) — build number is part of the prerelease tag
+- **Stable:** `{base}` only (e.g., `3.119.2`) — the build number is NEVER appended to stable versions. On the internal feed, stable builds appear as `{base}-stable.{build}` but the published version is just `{base}`.
+
 ---
 
 ## Step 3: Create Branch and Update PREVIEW_LABEL

--- a/.github/skills/release-publish/SKILL.md
+++ b/.github/skills/release-publish/SKILL.md
@@ -49,6 +49,7 @@ Publish packages to NuGet.org and finalize releases.
 **Preview vs Stable differences:**
 | Step | Preview | Stable |
 |------|---------|--------|
+| 1. NuGet version | `X.Y.Z-preview.N.{build}` | `X.Y.Z` (no build number) |
 | 2. Pipeline checkbox | "Push Preview" | "Push Stable" |
 | 4. Tag format | `vX.Y.Z-preview.N.{build}` | `vX.Y.Z` |
 | 5. GitHub Release | `--prerelease` flag | No flag, attach samples |
@@ -68,14 +69,20 @@ When identifying which version to publish, use **semver ordering**, not alphabet
 **Prerequisite:** release-testing must have passed. Versions should be known from testing.
 
 The user should provide:
-- SkiaSharp version (e.g., `3.119.2-preview.2.3`)
-- HarfBuzzSharp version (e.g., `8.3.1.4-preview.2.3`)
+- **Preview:** SkiaSharp version with build number (e.g., `3.119.2-preview.2.3`)
+- **Stable:** SkiaSharp base version only (e.g., `3.119.2`) — no build number
+
+⚠️ **Stable versions never include a build number.** The build number only appears in the prerelease component (e.g., `3.119.2-preview.2.3`) or in the internal stable tag (e.g., `3.119.2-stable.3`). It is never appended to the base version directly.
 
 If not provided, ask for them using `ask_user`.
 
 **Quick verification** — confirm packages exist on preview feed:
 ```bash
-dotnet package search SkiaSharp --source "https://aka.ms/skiasharp-eap/index.json" --exact-match --prerelease --format json | jq -r '.searchResult[].packages[].version' | grep "{expected-skia-version}"
+# Preview: search for the exact NuGet version
+dotnet package search SkiaSharp --source "https://aka.ms/skiasharp-eap/index.json" --exact-match --prerelease --format json | jq -r '.searchResult[].packages[].version' | grep "{expected-version}"
+
+# Stable: search for internal stable builds (NuGet version is just the base, e.g., 3.119.2)
+dotnet package search SkiaSharp --source "https://aka.ms/skiasharp-eap/index.json" --exact-match --prerelease --format json | jq -r '.searchResult[].packages[].version' | grep "^{base}-stable\."
 ```
 
 If missing, STOP and ask user to verify testing was completed.


### PR DESCRIPTION
Update all 3 release skills to correctly document stable version numbering.

**Problem:** The release skills assumed all NuGet versions include a build number suffix. For stable releases, the NuGet version is just the base (e.g., `3.119.2`) — the build number only appears in the internal feed's prerelease tag (`3.119.2-stable.3`).

**Changes:**
- **release-testing:** Split version resolution (Step 2) into preview vs stable paths; added stable examples for CI version extraction and user reporting
- **release-publish:** Added NuGet version row to Preview vs Stable differences table; split version confirmation into preview vs stable formats with separate verification commands
- **release-branch:** Added NuGet version format note after the release type table