### PR TITLE
Add Linux Docker integration tests for release testing

### DIFF
--- a/.github/skills/release-testing/SKILL.md
+++ b/.github/skills/release-testing/SKILL.md
@@ -199,6 +199,7 @@ Planned test matrix:
   - Mac Catalyst:  Current macOS
   - Blazor:        Chromium
   - Console:       .NET runtime
+  - Linux (Docker): Docker container (mcr.microsoft.com/dotnet/sdk:8.0)
 
 Proceed with this matrix?
 ```
@@ -240,6 +241,7 @@ dotnet test -p:SkiaSharpVersion={version} -p:HarfBuzzSharpVersion={hb-version}
 # Run by category
 dotnet test --filter "FullyQualifiedName~SmokeTests" ...
 dotnet test --filter "FullyQualifiedName~ConsoleTests" ...
+dotnet test --filter "FullyQualifiedName~LinuxConsoleTests" ...
 dotnet test --filter "FullyQualifiedName~BlazorTests" ...
 dotnet test --filter "FullyQualifiedName~MauiiOSTests" ... -p:iOSDevice="iPhone 14 Pro" -p:iOSVersion="16.2"
 dotnet test --filter "FullyQualifiedName~MauiMacCatalystTests" ...
@@ -303,6 +305,7 @@ dotnet test --filter "FullyQualifiedName~MauiAndroidTests" ... \
 |------|------------|------------|------|
 | SmokeTests | Once | - | ~2s |
 | ConsoleTests | Once | - | ~20s |
+| LinuxConsoleTests | Once (Docker) | - | ~2min |
 | BlazorTests | Once | - | ~2min |
 | MauiMacCatalystTests | Once | - | ~2min |
 | MauiiOSTests | ✅ Yes | ✅ Yes | ~2min each |
@@ -360,6 +363,7 @@ Proceed to **release-publish** ONLY when:
 |------|----------|---------|--------|
 | SmokeTests | .NET | - | ✅ Passed |
 | ConsoleTests | .NET | - | ✅ Passed |
+| LinuxConsoleTests | Docker Linux | - | ✅ Passed |
 | BlazorTests | Chromium | - | ✅ Passed |
 | MauiMacCatalystTests | macOS | - | ✅ Passed |
 | MauiiOSTests | iOS 16.2 (oldest) | iPhone 14 Pro | ✅ Passed |

--- a/.github/skills/release-testing/references/monitoring.md
+++ b/.github/skills/release-testing/references/monitoring.md
@@ -32,6 +32,18 @@ Update the TODO checklist at each phase. When using `read_bash` during long oper
 
 **Feedback:** These are fast enough that a single TODO update per test is sufficient.
 
+### LinuxConsoleTests (Docker)
+
+| Phase | Duration | Output Indicator |
+|-------|----------|------------------|
+| Build test project | 5-10s | "Determining projects to restore..." |
+| Docker image build | 30-90s | "Building Docker image..." |
+| Run in container | 5-10s | "Running in Docker container..." |
+| Complete | - | "Passed! - Failed: 0, Passed: 2" |
+
+**First run is slower** (~90s) due to Docker image layer caching. Subsequent runs use cached layers (~10s).
+Docker tests require `SkiaSharp.NativeAssets.Linux.NoDependencies` which bundles all native deps statically.
+
 ### MAUI Platform Tests (iOS, Android, MacCatalyst)
 
 | Phase | Duration | Output Indicator |

--- a/.github/skills/release-testing/references/setup.md
+++ b/.github/skills/release-testing/references/setup.md
@@ -12,6 +12,17 @@ npm install -g appium
 appium driver install mac2 uiautomator2 xcuitest
 ```
 
+### Docker (Linux tests)
+
+Docker Desktop must be installed and running. Verify with:
+
+```bash
+docker --version
+docker info --format '{{.OSType}}'  # Should output "linux"
+```
+
+The `LinuxConsoleTests` use `SkiaSharp.NativeAssets.Linux.NoDependencies` (statically linked) to avoid system dependency issues in minimal containers.
+
 ### Playwright (Blazor tests)
 
 ```bash
@@ -110,6 +121,7 @@ Before running release tests, verify:
 4. **iOS runtimes available** — at least 2 different versions
 5. **Appium installed** — `which appium` returns path
 6. **Appium drivers installed** — `appium driver list --installed` shows uiautomator2, xcuitest
+7. **Docker available** — `docker info` succeeds (for Linux console tests)
 
 **If any check fails:** Fix before proceeding. Do not skip tests.
 

--- a/.github/skills/release-testing/references/troubleshooting.md
+++ b/.github/skills/release-testing/references/troubleshooting.md
@@ -121,6 +121,16 @@ Or use Console.app → select simulator device.
 | `Timeout waiting for selector` | App didn't render | Check Blazor app console for errors |
 | `Blazor server failed to start` | Env vars from parent | Fixed in test code (ClearDotNetEnvironmentVariables) |
 
+## Docker Errors (Linux Console Tests)
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Docker is not available` | Docker not installed/running | Install Docker Desktop, start it |
+| `undefined symbol: uuid_generate_random` | Using `NativeAssets.Linux` instead of `NoDependencies` | Use `SkiaSharp.NativeAssets.Linux.NoDependencies` |
+| `Fontconfig error: Cannot load default config file` | No fontconfig in container | Expected with `NoDependencies` — not an error |
+| `Cannot connect to the Docker daemon` | Docker Desktop not running | Start Docker Desktop |
+| Docker image build slow | No layer cache | Normal on first run (~90s), cached after |
+
 ## Platform-Specific Notes
 
 ### macOS /var symlink issue

--- a/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
@@ -1,0 +1,189 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SkiaSharp.Tests.Integration;
+
+/// <summary>
+/// Tests that verify SkiaSharp and HarfBuzzSharp packages work in Linux containers via Docker.
+/// </summary>
+[Trait("Category", "Platform")]
+public class LinuxConsoleTests(ITestOutputHelper output) : PlatformTestBase(output)
+{
+    private static bool IsDockerAvailable()
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("docker", "info")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            using var process = System.Diagnostics.Process.Start(psi)!;
+            process.WaitForExit(10000);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SkippableFact]
+    public async Task SkiaSharpRunsOnLinux()
+    {
+        Skip.IfNot(IsDockerAvailable(), "Docker is not available");
+
+        Output.WriteLine($"Testing SkiaSharp {SkiaVersion} in Linux Docker container");
+
+        var drawCode = TestImage.GetDrawCode();
+        var programCs = $$"""
+            using SkiaSharp;
+            
+            using var bitmap = new SKBitmap({{TestImage.Width}}, {{TestImage.Height}});
+            using var canvas = new SKCanvas(bitmap);
+            
+            {{drawCode}}
+            
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var stream = File.OpenWrite("/app/output.png");
+            data.SaveTo(stream);
+            Console.WriteLine("SUCCESS");
+            """;
+
+        var outputPath = Path.Combine(TestDir, "output.png");
+        await RunInDocker("skiasharp-linux-test", programCs, outputPath,
+            ("SkiaSharp", SkiaVersion),
+            ("SkiaSharp.NativeAssets.Linux.NoDependencies", SkiaVersion));
+
+        Assert.True(File.Exists(outputPath), "Output PNG should exist");
+        var actualImage = await File.ReadAllBytesAsync(outputPath);
+        await VerifyScreenshot(actualImage, "linux-console-skiasharp");
+    }
+
+    [SkippableFact]
+    public async Task HarfBuzzSharpRunsOnLinux()
+    {
+        Skip.IfNot(IsDockerAvailable(), "Docker is not available");
+
+        Output.WriteLine($"Testing HarfBuzzSharp {HarfBuzzVersion} in Linux Docker container");
+
+        var programCs = $$"""
+            using SkiaSharp;
+            using HarfBuzzSharp;
+            
+            // Shape text with HarfBuzz
+            {{TestText.GetShapeCode()}}
+            {{TestText.GetOutputCode()}}
+            
+            // Render to image
+            using var bitmap = new SKBitmap(400, 100);
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(SKColors.White);
+            
+            using var paint = new SKPaint { Color = SKColors.Black, IsAntialias = true };
+            using var font = new SKFont(SKTypeface.Default, 32);
+            canvas.DrawText("{{TestText.SampleText}}", 20, 60, SKTextAlign.Left, font, paint);
+            
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var stream = File.OpenWrite("/app/output.png");
+            data.SaveTo(stream);
+            Console.WriteLine("SUCCESS");
+            """;
+
+        var outputPath = Path.Combine(TestDir, "output.png");
+        var result = await RunInDocker("harfbuzz-linux-test", programCs, outputPath,
+            ("SkiaSharp", SkiaVersion),
+            ("SkiaSharp.NativeAssets.Linux.NoDependencies", SkiaVersion),
+            ("HarfBuzzSharp", HarfBuzzVersion),
+            ("HarfBuzzSharp.NativeAssets.Linux", HarfBuzzVersion));
+
+        Assert.True(TestText.ValidateOutput(result), "HarfBuzz output validation failed");
+        Assert.True(File.Exists(outputPath), "Output PNG should exist");
+
+        var actualImage = await File.ReadAllBytesAsync(outputPath);
+        await SaveScreenshot(actualImage, "linux-console-harfbuzzsharp");
+        Assert.True(actualImage.Length > 200, "Screenshot should have content");
+    }
+
+    private async Task<string> RunInDocker(string projectName, string programCs, string outputPath,
+        params (string Name, string Version)[] packages)
+    {
+        // Create project files in TestDir
+        var projectDir = Path.Combine(TestDir, projectName);
+        Directory.CreateDirectory(projectDir);
+
+        File.WriteAllText(Path.Combine(projectDir, "Program.cs"), programCs);
+
+        // Build csproj with package references
+        var packageRefs = string.Join("\n    ",
+            packages.Select(p => $"<PackageReference Include=\"{p.Name}\" Version=\"{p.Version}\" />"));
+
+        File.WriteAllText(Path.Combine(projectDir, $"{projectName}.csproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net8.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+              </PropertyGroup>
+              <ItemGroup>
+                {packageRefs}
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Combine(projectDir, "nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="SkiaSharp Preview" value="https://aka.ms/skiasharp-eap/index.json" />
+                <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+            </configuration>
+            """);
+
+        // Build and run in Docker using dotnet publish (resolves RID-specific native assets)
+        var dockerfile = Path.Combine(projectDir, "Dockerfile");
+        File.WriteAllText(dockerfile, $"""
+            FROM mcr.microsoft.com/dotnet/sdk:8.0
+            WORKDIR /src
+            COPY {projectName}.csproj nuget.config ./
+            RUN dotnet restore
+            COPY Program.cs ./
+            RUN dotnet publish -c Release --no-restore -o /app
+            WORKDIR /app
+            ENTRYPOINT ["dotnet", "{projectName}.dll"]
+            """);
+
+        var tag = $"skiasharp-test-{projectName}".ToLowerInvariant();
+
+        // Build Docker image
+        Output.WriteLine("Building Docker image...");
+        await Run("docker", $"build -t {tag} {projectDir}", timeoutSeconds: 180);
+
+        // Run container with a dedicated output directory mounted
+        Output.WriteLine("Running in Docker container...");
+        var mountDir = Path.Combine(TestDir, $"{projectName}-out");
+        Directory.CreateDirectory(mountDir);
+        var result = await Run("docker",
+            $"run --rm --entrypoint sh -v {mountDir}:/out {tag} -c \"dotnet {projectName}.dll && cp /app/output.png /out/output.png\"",
+            timeoutSeconds: 60);
+
+        Output.WriteLine(result);
+
+        // Copy output from mount dir to expected path
+        var mountedOutput = Path.Combine(mountDir, "output.png");
+        if (File.Exists(mountedOutput))
+            File.Copy(mountedOutput, outputPath, overwrite: true);
+
+        Output.WriteLine(result);
+
+        // Clean up image
+        try { await Run("docker", $"rmi {tag}", timeoutSeconds: 30); } catch { }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

Adds Linux Docker integration tests to the release testing workflow, ensuring SkiaSharp and HarfBuzzSharp packages work correctly in Linux containers.

## Changes

### New test: `LinuxConsoleTests.cs`
- **`SkiaSharpRunsOnLinux`** — Creates a console app in a Docker Linux container (`mcr.microsoft.com/dotnet/sdk:8.0`), draws a test image with SkiaSharp, and verifies the output PNG via screenshot comparison
- **`HarfBuzzSharpRunsOnLinux`** — Shapes text with HarfBuzz, renders with SkiaSharp, validates glyph output and screenshot
- Uses `SkiaSharp.NativeAssets.Linux.NoDependencies` (statically linked) to avoid system dependency issues in minimal containers
- Tests are automatically skipped when Docker is not available

### Updated release-testing skill docs
- **SKILL.md** — Added `LinuxConsoleTests` to test execution order, test commands, confirm matrix, and final report format
- **setup.md** — Added Docker prerequisites and pre-flight check
- **monitoring.md** — Added Docker test phase timing and feedback guidance
- **troubleshooting.md** — Added Docker-specific error table

## Testing

All tests passed against `3.119.2-stable.2`:

| Test | Status |
|------|--------|
| LinuxConsoleTests.SkiaSharpRunsOnLinux | ✅ Passed |
| LinuxConsoleTests.HarfBuzzSharpRunsOnLinux | ✅ Passed |