### PR TITLE
triage-issue: schema v2.1 — mandatory codeInvestigation + anti-patterns

### DIFF
--- a/.github/skills/triage-issue/references/triage-examples.md
+++ b/.github/skills/triage-issue/references/triage-examples.md
@@ -2,14 +2,16 @@
 
 Full JSON examples for reference. Read once per session to calibrate output format.
 
+**v2.1 changes:** Every example now includes `analysis.codeInvestigation` — source code signals are mandatory. `schemaVersion` is `"2.1"`.
+
 ## Bug Example
 
-Bug with stack trace, bugSignals required, analysis with fieldRationales and resolution proposals, actions array:
+Bug with stack trace, bugSignals required, analysis with codeInvestigation, fieldRationales and resolution proposals, actions array:
 
 ```json
 {
   "meta": {
-    "schemaVersion": "2.0",
+    "schemaVersion": "2.1",
     "number": 1234,
     "repo": "mono/SkiaSharp",
     "analyzedAt": "2026-02-08T15:00:00Z",
@@ -41,6 +43,10 @@ Bug with stack trace, bugSignals required, analysis with fieldRationales and res
     "keySignals": [
       { "text": "ObjectDisposedException at SKCanvasView.OnDetachedFromWindow", "source": "stack-trace", "interpretation": "Native surface accessed after disposal" },
       { "text": "works on iOS, crashes on Android only", "source": "body", "interpretation": "Platform-specific disposal timing issue" }
+    ],
+    "codeInvestigation": [
+      { "file": "source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Android/SKCanvasView.cs", "lines": "45-78", "relevance": "OnDetachedFromWindow disposes native surface without null-check — use-after-free if called on background thread" },
+      { "file": "source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/iOS/SKCanvasView.cs", "lines": "52-70", "relevance": "iOS equivalent checks IsDisposed before accessing surface — explains why iOS doesn't crash" }
     ],
     "fieldRationales": [
       { "field": "type", "chosen": "type/bug", "expandedReason": "Reporter describes a crash with stack trace during a normal lifecycle event (view detachment). This is clearly broken behavior, not a usage question.", "alternatives": [{ "value": "type/question", "whyRejected": "Not asking how to do something — reporting a crash." }] },
@@ -105,7 +111,7 @@ Question with resolution proposals, bugSignals null, close-with-docs action:
 ```json
 {
   "meta": {
-    "schemaVersion": "2.0",
+    "schemaVersion": "2.1",
     "number": 5678,
     "repo": "mono/SkiaSharp",
     "analyzedAt": "2026-02-08T15:00:00Z",
@@ -131,6 +137,10 @@ Question with resolution proposals, bugSignals null, close-with-docs action:
     "summary": "User asking how to load custom fonts on Linux. Usage question — the API exists and works.",
     "keySignals": [
       { "text": "How do I load a custom .ttf font?", "source": "body", "interpretation": "How-to question about existing API" }
+    ],
+    "codeInvestigation": [
+      { "file": "binding/SkiaSharp/SKTypeface.cs", "lines": "45-62", "relevance": "SKTypeface.FromFile() and FromData() are public, well-documented APIs — confirms this is a usage question, not a missing feature" },
+      { "file": "tests/Tests/SKTypefaceTest.cs", "lines": "28-55", "relevance": "Test coverage for FromFile/FromData confirms these APIs work on Linux (test runs cross-platform)" }
     ],
     "fieldRationales": [
       { "field": "type", "chosen": "type/question", "expandedReason": "Asking how to accomplish a task. No broken behavior described.", "alternatives": [{ "value": "type/documentation", "whyRejected": "Docs exist — user just hasn't found them." }] },
@@ -198,7 +208,7 @@ Same structure as bug, with key differences: `analysis.resolution: null`, `actio
 
 ```json
 {
-  "meta": { "schemaVersion": "2.0", "number": 9999, "repo": "mono/SkiaSharp", "analyzedAt": "2026-02-08T15:00:00Z", "currentLabels": [] },
+  "meta": { "schemaVersion": "2.1", "number": 9999, "repo": "mono/SkiaSharp", "analyzedAt": "2026-02-08T15:00:00Z", "currentLabels": [] },
   "summary": "Duplicate of #1234 — same Android disposal crash",
   "classification": {
     "type": { "value": "type/bug", "confidence": 0.95 },
@@ -221,6 +231,10 @@ Same structure as bug, with key differences: `analysis.resolution: null`, `actio
     "summary": "Identical stack trace and reproduction steps as #1234.",
     "keySignals": [
       { "text": "ObjectDisposedException at SKCanvasView.OnDetachedFromWindow", "source": "stack-trace", "interpretation": "Same crash as #1234" }
+    ],
+    "codeInvestigation": [
+      { "file": "source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Android/SKCanvasView.cs", "lines": "45-78", "relevance": "Same disposal code path as #1234 — confirms duplicate, not a separate issue" },
+      { "file": "source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Android/SKCanvasView.cs", "lines": "12-20", "relevance": "Class declaration and inheritance match #1234's report — same component, same version" }
     ],
     "fieldRationales": [
       { "field": "type", "chosen": "type/bug", "expandedReason": "Same crash as #1234." },

--- a/.github/skills/triage-issue/references/triage-schema.json
+++ b/.github/skills/triage-issue/references/triage-schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mono/SkiaSharp/triage-schema.json",
   "title": "SkiaSharp Issue Triage",
-  "description": "Per-issue AI triage v2.1 with grouped sections: meta, classification, evidence, analysis, output. Classification values ARE full GitHub labels (e.g., 'type/bug', 'os/Linux'). Reasoning lives in analysis.fieldRationales (single source of truth).",
+  "description": "Per-issue AI triage v2.1 with grouped sections: meta, classification, evidence, analysis, output. Classification values ARE full GitHub labels (e.g., 'type/bug', 'os/Linux'). Reasoning lives in analysis.fieldRationales (single source of truth). v2.1 adds mandatory codeInvestigation \u2014 source code signals with file:line citations.",
   "type": "object",
   "required": [
     "meta",
@@ -1246,6 +1246,33 @@
           }
         }
       ]
+    },
+    "sourceSignal": {
+      "type": "object",
+      "description": "A source code signal from investigation. Traces a triage claim to actual code.",
+      "required": [
+        "file",
+        "lines",
+        "relevance"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Relative path from repo root, e.g. 'source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs'."
+        },
+        "lines": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Line range examined, e.g. '54-95' or 'full'."
+        },
+        "relevance": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What this code shows about the issue, e.g. 'Only handles Began/Moved/Ended/Cancelled \u2014 no Entered/Exited'."
+        }
+      }
     }
   },
   "properties": {
@@ -1262,7 +1289,7 @@
       "additionalProperties": false,
       "properties": {
         "schemaVersion": {
-          "const": "2.0"
+          "const": "2.1"
         },
         "number": {
           "type": "integer",
@@ -1432,7 +1459,8 @@
       "required": [
         "summary",
         "keySignals",
-        "fieldRationales"
+        "fieldRationales",
+        "codeInvestigation"
       ],
       "additionalProperties": false,
       "properties": {
@@ -1485,6 +1513,14 @@
               "$ref": "#/$defs/resolutionObject"
             }
           ]
+        },
+        "codeInvestigation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sourceSignal"
+          },
+          "minItems": 1,
+          "description": "Source code signals gathered during mandatory investigation. Like keySignals but from reading actual source files. Every triage must cite at least one source file."
         }
       }
     },
@@ -2155,6 +2191,86 @@
                     "field"
                   ]
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "close-* actions require at least 2 code investigation signals as evidence",
+      "if": {
+        "properties": {
+          "output": {
+            "type": "object",
+            "required": [
+              "actionability"
+            ],
+            "properties": {
+              "actionability": {
+                "type": "object",
+                "properties": {
+                  "suggestedAction": {
+                    "pattern": "^close-"
+                  }
+                },
+                "required": [
+                  "suggestedAction"
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "output"
+        ]
+      },
+      "then": {
+        "properties": {
+          "analysis": {
+            "properties": {
+              "codeInvestigation": {
+                "minItems": 2
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "dismissing relevance (unlikely) requires code investigation evidence",
+      "if": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "required": [
+              "versionAnalysis"
+            ],
+            "properties": {
+              "versionAnalysis": {
+                "type": "object",
+                "properties": {
+                  "currentRelevance": {
+                    "const": "unlikely"
+                  }
+                },
+                "required": [
+                  "currentRelevance"
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "evidence"
+        ]
+      },
+      "then": {
+        "properties": {
+          "analysis": {
+            "properties": {
+              "codeInvestigation": {
+                "minItems": 1
               }
             }
           }


### PR DESCRIPTION
## Summary

Upgrades the triage skill schema from v2.0 to v2.1 with mandatory code investigation requirements.

### Changes

- **Schema v2.1**: Add `codeInvestigation` array to `analysis` (required, min 1 entry)
  - Each entry: `{file, lines, relevance}` — source code signals with file:line citations
  - `close-*` actions require ≥2 code investigation signals
  - Dismissing relevance as `unlikely` requires ≥1 code signal
- **SKILL.md**: Make code investigation mandatory in Phase 2 (before classification)
- **Anti-pattern rules**: No pre-baked delegation, no age-based closure, no assertion without citation, no platform-deprecated=stale assumption
- **Examples**: Updated all 3 triage examples (bug, question, duplicate) with `codeInvestigation` entries
- **Schema version**: Bumped from `2.0` to `2.1`

### Motivation

Code investigation was optional in v2.0, leading to triage outputs that made claims about code behavior without verifying against actual source. This caused incorrect classifications and missed fixes. v2.1 enforces citation-backed analysis.

### Validation

Tested by retriaging the 11 oldest open issues (#209, #243, #310, #315, #425, #528, #533, #552, #576, #607, #911). All 11 triages pass schema v2.1 validation and were cross-checked by Gemini 3 Pro — 11/11 received ✅ across all review dimensions (classification, code investigation, suggested action, resolution, tone).