### PR TITLE
Add learnings from Copilot memory audit to docs and instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -263,6 +263,8 @@ ThreadLocal<SKPaint> paint = new(() => new SKPaint());
 | Using default parameters in public APIs | ABI breaking |
 | **Skipping failing tests** | **Unacceptable — tests must pass** |
 | **Using `externals-download` after C API changes** | **Causes `EntryPointNotFoundException`** |
+| Passing `fixed` pointers to native objects that outlive the block | GC moves memory → corruption. Use `GCHandle.Alloc(Pinned)` or `Marshal.AllocCoTaskMem` |
+| Testing WASM version changes without cleaning `bin/obj/_framework` | Stale cached native `.wasm` files produce false results |
 
 ---
 

--- a/documentation/adding-libraries.md
+++ b/documentation/adding-libraries.md
@@ -145,7 +145,10 @@ To create a new library:
 1. Create project folder in `source/`
 2. Set required properties: `TargetFrameworks`, `RootNamespace`, `PackagingGroup`
 3. Add version entry to `scripts/VERSIONS.txt`
-4. Build and verify output in `output/` directory
+4. Add entry to `build.cake` `SUPPORTED_NUGETS` dictionary (required for sample packaging)
+5. Build and verify output in `output/` directory
+
+> **⚠️ Dual Registration:** New NuGet package IDs must be registered in **both** `scripts/VERSIONS.txt` (nuget type) AND `build.cake` `SUPPORTED_NUGETS`. Missing either causes the `CreateSamplesDirectory` task to fail when converting `ProjectReference` to `PackageReference` in output samples.
 
 ## Related Documentation
 

--- a/documentation/debugging-methodology.md
+++ b/documentation/debugging-methodology.md
@@ -216,6 +216,10 @@ The actual shared library is in `libfontconfig1` (runtime package).
 
 **Fix:** Download both `-dev` (headers) AND runtime (actual .so) packages in the Dockerfile.
 
+### WASM Stale Artifact Trap
+
+When testing different SkiaSharp NuGet versions on WASM, native `.wasm` binaries are cached in `bin/obj/_framework` and are version-specific (tied to Emscripten version). Changing the NuGet version reference (e.g., via `sed`) without cleaning these directories leaves stale native files, producing false positive/negative results. **Always use fresh project directories per version** or clean `bin/`, `obj/`, and `_framework` before rebuilding.
+
 ---
 
 ## Summary


### PR DESCRIPTION
## Summary

Audited all 159 Copilot memories stored for this repository. Found massive duplication (~57 duplicates) and noise (~100 ephemeral/issue-specific items). Extracted 3 genuinely useful, non-obvious patterns and added them to the appropriate files.

## Changes (4 files, 26 lines added)

### copilot-instructions.md — Anti-Patterns table
- **Pinned pointer lifetime**: `fixed` blocks create temporary pins; native objects that store the pointer outlive the scope → GC corruption
- **WASM stale artifacts**: cached `.wasm` binaries in `bin/obj/_framework` are version-specific; changing NuGet versions without cleaning produces false results

### documentation/memory-management.md — Common Mistake #5
- Full code example showing wrong (`fixed`) vs correct (`GCHandle.Alloc`) patterns for native-retained pointers
- Calls out `HarfBuzzSharp.Blob.FromStream` as a known affected API

### documentation/adding-libraries.md — Summary checklist
- Dual NuGet registration requirement: new packages need entries in **both** `scripts/VERSIONS.txt` and `build.cake` `SUPPORTED_NUGETS`

### documentation/debugging-methodology.md — WASM Stale Artifact Trap
- Explains the version-specific caching behavior and recommends fresh project dirs per version

## What was filtered out

~130 of 159 memories should be deleted from GitHub settings. Key categories of noise:
- 20+ SKSvgCanvas duplicates (13 copies of "SVG closes on Dispose")
- 13 issue-specific findings (#3400, #3435, #3440, etc.)
- 15 dashboard UI implementation details
- 12 schema consistency wishlists (should be GitHub issues)
- 11 Copilot CLI tooling quirks
- 6 data-integrity postmortem notes