### PR TITLE
Disable serialization assembly generation

### DIFF
--- a/binding/SkiaSharp/SkiaSharp.csproj
+++ b/binding/SkiaSharp/SkiaSharp.csproj
@@ -8,6 +8,7 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <WarningsAsErrors>$(WarningsAsErrors);CA1420;CA1421;</WarningsAsErrors>
     <NoWarn>$(NoWarn);CS8826</NoWarn>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);USE_DELEGATES</DefineConstants>


### PR DESCRIPTION
Prevent Sgen from trying to load reference assemblies when used in projects that use legacy Xml serialization.

**Description of Change**

Added GenerateSerializationAssemblies tag with "off" to the main project

**Bugs Fixed**

A common issue with legacy projects using Xml serialization:
https://github.com/dotnet/msbuild/issues/2707

Sgen generates code so that the runtime no longer needs to use reflection in order to serialize or deserialize xml, speeding up serialization considerably. Adding a reference to SkiaSharp breaks the feature.

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description) 
It has no runtime side effects, just prevents a compiletime error for some projects
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
No related PR found
- [x] Changes adhere to coding standard
- [ ] Updated documentation
Nothing needs to change