### PR TITLE
Make add-comment risk dynamic based on content and confidence

### DIFF
--- a/.github/skills/issue-repro/references/repro-schema.json
+++ b/.github/skills/issue-repro/references/repro-schema.json
@@ -100,7 +100,7 @@
         "medium",
         "high"
       ],
-      "description": "low=reversible/cosmetic. medium=state change. high=irreversible or reputation-sensitive."
+      "description": "low=reversible/cosmetic. medium=state change. high=irreversible or reputation-sensitive. For add-comment, risk is dynamic based on content type and confidence — see schema-cheatsheet.md."
     }
   },
   "properties": {

--- a/.github/skills/issue-repro/references/schema-cheatsheet.md
+++ b/.github/skills/issue-repro/references/schema-cheatsheet.md
@@ -88,6 +88,20 @@ Required: `version`, `source`, `result`
 }
 ```
 
+### `add-comment` Risk Calculation
+
+Risk for `add-comment` actions is computed dynamically from content and confidence:
+
+| Condition | Risk | Rationale |
+|-----------|------|-----------|
+| Factual only (repro findings, version matrix, link references) AND confidence ≥ 0.85 | **low** | Reporting observed facts — minimal reputation exposure |
+| Includes workaround or technical suggestion AND confidence ≥ 0.85 | **medium** | Advice could be wrong, but evidence is strong |
+| Suggests closing, rejects the issue, or states "by-design" (any confidence) | **high** | Telling a reporter their issue isn't valid always needs human review |
+| Any content AND confidence < 0.70 | **high** | Not confident enough to speak for the maintainer |
+| Default / everything else | **medium** | |
+
+Other action type risks remain static: `update-labels`=low, `close-issue`=medium, `link-related`=low, `link-duplicate`=medium, `convert-to-discussion`=high.
+
 ## Common Mistakes
 
 1. **Missing `output` when not-reproduced** — `output` + `versionResults` are required for BOTH `reproduced` AND `not-reproduced`.

--- a/.github/skills/issue-triage/references/schema-cheatsheet.md
+++ b/.github/skills/issue-triage/references/schema-cheatsheet.md
@@ -119,13 +119,25 @@ Read this BEFORE generating JSON. Full schema: `references/triage-schema.json`.
 | Type | Risk | Required Specific Fields |
 |------|------|--------------------------|
 | `update-labels` | low | `labels` (array of strings) |
-| `add-comment` | high | `comment` (markdown string). See `response-guidelines.md`. |
+| `add-comment` | **dynamic** (see below) | `comment` (markdown string). See `response-guidelines.md`. |
 | `close-issue` | medium | — |
 | `link-related` | low | `linkedIssue` (integer) |
 | `link-duplicate` | medium | `linkedIssue` (integer) |
 | `convert-to-discussion` | high | — |
 | `update-project` | low | — |
 | `set-milestone` | low | — |
+
+#### `add-comment` Risk Calculation
+
+Risk for `add-comment` is computed from the comment's content and the action's confidence score:
+
+| Condition | Risk | Rationale |
+|-----------|------|-----------|
+| Factual only (repro findings, version matrix, link references) AND confidence ≥ 0.85 | **low** | Reporting observed facts — minimal reputation exposure |
+| Includes workaround or technical suggestion AND confidence ≥ 0.85 | **medium** | Advice could be wrong, but evidence is strong |
+| Suggests closing, rejects the issue, or states "by-design" (any confidence) | **high** | Telling a reporter their issue isn't valid always needs human review |
+| Any content AND confidence < 0.70 | **high** | Not confident enough to speak for the maintainer |
+| Default / everything else | **medium** | |
 
 ## Common Mistakes
 

--- a/.github/skills/issue-triage/references/triage-schema.json
+++ b/.github/skills/issue-triage/references/triage-schema.json
@@ -135,7 +135,7 @@
         "medium",
         "high"
       ],
-      "description": "low=reversible/cosmetic. medium=state change. high=irreversible or reputation-sensitive."
+      "description": "low=reversible/cosmetic. medium=state change. high=irreversible or reputation-sensitive. For add-comment, risk is dynamic based on content type and confidence — see schema-cheatsheet.md."
     }
   },
   "properties": {


### PR DESCRIPTION
## Summary

Previously, all `add-comment` actions in triage and repro JSON outputs were hardcoded as `high` risk regardless of content. This made the risk field meaningless for comments — every comment required human review equally.

## Changes

Updated the `add-comment` risk from a static mapping to a dynamic calculation based on content type and confidence score:

| Condition | Risk | Rationale |
|-----------|------|-----------|
| Factual only (repro findings, version matrix) AND confidence ≥ 0.85 | **low** | Reporting observed facts — minimal reputation exposure |
| Includes workaround or technical suggestion AND confidence ≥ 0.85 | **medium** | Advice could be wrong, but evidence is strong |
| Suggests closing, rejects the issue, or states "by-design" (any confidence) | **high** | Always needs human review |
| Any content AND confidence < 0.70 | **high** | Not confident enough |
| Default | **medium** | |

### Files changed

- `.github/skills/issue-triage/references/schema-cheatsheet.md` — replaced static table with decision table
- `.github/skills/issue-repro/references/schema-cheatsheet.md` — added decision table
- `.github/skills/issue-triage/references/triage-schema.json` — updated actionRisk description
- `.github/skills/issue-repro/references/repro-schema.json` — updated actionRisk description

### Impact on existing cached JSON

Applying this to all 114 existing cached JSON files:
- **29 actions drop** from high → medium/low (less noise for human review)
- **5 actions elevate** from low/medium → high (close-paired comments that were under-rated)
- **27 unchanged** (already correct)