### PR TITLE
Make skill action schemas automation-ready with required data fields

### DIFF
--- a/.github/skills/issue-repro/references/repro-schema.json
+++ b/.github/skills/issue-repro/references/repro-schema.json
@@ -88,7 +88,6 @@
         "convert-to-discussion",
         "link-related",
         "link-duplicate",
-        "update-project",
         "set-milestone"
       ],
       "description": "Type of automatable operation."
@@ -645,6 +644,19 @@
                 "type": "integer",
                 "description": "Issue number to link (for link-related/link-duplicate actions).",
                 "minimum": 1
+              },
+              "stateReason": {
+                "type": "string",
+                "enum": ["completed", "not_planned"],
+                "description": "Required for close-issue. Maps to GitHub API state_reason."
+              },
+              "category": {
+                "type": "string",
+                "description": "Required for convert-to-discussion. GitHub discussion category name."
+              },
+              "milestone": {
+                "type": "string",
+                "description": "Required for set-milestone. Milestone title."
               }
             },
             "description": "A single automatable action."

--- a/.github/skills/issue-repro/references/schema-cheatsheet.md
+++ b/.github/skills/issue-repro/references/schema-cheatsheet.md
@@ -82,7 +82,7 @@ Required: `version`, `source`, `result`
 ```json
 "output": {
   "actionability": { "suggestedAction": "<enum>", "confidence": 0.0-1.0, "reason": "..." },
-  "actions": [{ "type": "<actionType>", "description": "...", "risk": "low|medium|high", "confidence": 0.0-1.0 }],
+  "actions": [{ "type": "<actionType>", "description": "...", "risk": "low|medium|high", "confidence": 0.0-1.0, ...data fields }],
   "proposedResponse": { "body": "GitHub comment markdown", "status": "ready|needs-human-edit|do-not-post" },
   "missingInfo": ["What info is needed from reporter"]
 }
@@ -100,7 +100,33 @@ Risk for `add-comment` actions is computed dynamically from content and confiden
 | Any content AND confidence < 0.70 | **high** | Not confident enough to speak for the maintainer |
 | Default / everything else | **medium** | |
 
-Other action type risks remain static: `update-labels`=low, `close-issue`=medium, `link-related`=low, `link-duplicate`=medium, `convert-to-discussion`=high.
+Other action type risks remain static: `update-labels`=low, `close-issue`=medium, `link-related`=low, `link-duplicate`=medium, `convert-to-discussion`=high, `set-milestone`=low.
+
+### Action Types & Required Fields
+
+| Type | Risk | Required Fields |
+|------|------|-----------------|
+| `update-labels` | low | `labels` (array of label strings to apply) |
+| `add-comment` | **dynamic** (see above) | `comment` (markdown string) |
+| `close-issue` | medium | `stateReason` (`completed` or `not_planned`) |
+| `link-related` | low | `linkedIssue` (integer issue number) |
+| `link-duplicate` | medium | `linkedIssue` (integer issue number) |
+| `convert-to-discussion` | high | `category` (discussion category name) |
+| `set-milestone` | low | `milestone` (milestone title) |
+
+### Action Data Requirements
+
+Every action MUST include its required data fields to be automatable:
+- `update-labels` without `labels` → **invalid**, omit the action
+- `add-comment` without `comment` → **invalid**, omit the action
+- `close-issue` without `stateReason` → **invalid**, omit the action
+- `link-related`/`link-duplicate` without `linkedIssue` → **invalid**, omit the action
+- `convert-to-discussion` without `category` → **invalid**, omit the action
+- `set-milestone` without `milestone` → **invalid**, omit the action
+
+If you cannot determine the required data for an action, do NOT include it. Hollow actions (correct type but missing data) are worse than no action — they pass schema validation but fail at execution time.
+
+If `proposedResponse` contains comment text, also include a matching `add-comment` action with the same text in `comment`.
 
 ## Common Mistakes
 

--- a/.github/skills/issue-triage/references/schema-cheatsheet.md
+++ b/.github/skills/issue-triage/references/schema-cheatsheet.md
@@ -72,7 +72,7 @@ Read this BEFORE generating JSON. Full schema: `references/triage-schema.json`.
 | **category** (proposals) | `workaround`, `fix`, `alternative`, `investigation` |
 | **validated** (proposals) | `untested`, `yes`, `no` |
 | **suggestedReproPlatform** | `linux`, `macos`, `windows` |
-| **actionType** | `update-labels`, `add-comment`, `close-issue`, `convert-to-discussion`, `link-related`, `link-duplicate`, `update-project`, `set-milestone` |
+| **actionType** | `update-labels`, `add-comment`, `close-issue`, `convert-to-discussion`, `link-related`, `link-duplicate`, `set-milestone` |
 
 ### Choosing `suggestedAction` by issue type
 
@@ -114,18 +114,17 @@ Read this BEFORE generating JSON. Full schema: `references/triage-schema.json`.
 
 `missingInfo` is optional — include when reporter needs to provide more details (pair with `request-info` action).
 
-### Action Types & Specific Fields
+### Action Types & Required Fields
 
-| Type | Risk | Required Specific Fields |
-|------|------|--------------------------|
-| `update-labels` | low | `labels` (array of strings) |
+| Type | Risk | Required Fields |
+|------|------|-----------------|
+| `update-labels` | low | `labels` (array of label strings to apply) |
 | `add-comment` | **dynamic** (see below) | `comment` (markdown string). See `response-guidelines.md`. |
-| `close-issue` | medium | — |
-| `link-related` | low | `linkedIssue` (integer) |
-| `link-duplicate` | medium | `linkedIssue` (integer) |
-| `convert-to-discussion` | high | — |
-| `update-project` | low | — |
-| `set-milestone` | low | — |
+| `close-issue` | medium | `stateReason` (`completed` or `not_planned`) |
+| `link-related` | low | `linkedIssue` (integer issue number) |
+| `link-duplicate` | medium | `linkedIssue` (integer issue number) |
+| `convert-to-discussion` | high | `category` (discussion category name) |
+| `set-milestone` | low | `milestone` (milestone title) |
 
 #### `add-comment` Risk Calculation
 

--- a/.github/skills/issue-triage/references/triage-schema.json
+++ b/.github/skills/issue-triage/references/triage-schema.json
@@ -123,7 +123,6 @@
         "convert-to-discussion",
         "link-related",
         "link-duplicate",
-        "update-project",
         "set-milestone"
       ],
       "description": "Type of automatable operation."
@@ -813,6 +812,19 @@
                 "type": "integer",
                 "description": "Issue number to link (for link-related/link-duplicate actions).",
                 "minimum": 1
+              },
+              "stateReason": {
+                "type": "string",
+                "enum": ["completed", "not_planned"],
+                "description": "Required for close-issue. Maps to GitHub API state_reason."
+              },
+              "category": {
+                "type": "string",
+                "description": "Required for convert-to-discussion. GitHub discussion category name."
+              },
+              "milestone": {
+                "type": "string",
+                "description": "Required for set-milestone. Milestone title."
               }
             },
             "description": "A single automatable action."


### PR DESCRIPTION
Follows up on #3547. Makes both triage and repro action schemas fully automatable.

### Problem

The repro skill produces hollow actions — e.g. `update-labels` with no `labels` array, `add-comment` with no `comment` text. An automation runner can't execute these.

Additionally, both schemas were missing fields needed for certain action types (`close-issue` had no `stateReason`, `convert-to-discussion` had no `category`, etc).

### Changes

**Both JSON schemas** (`triage-schema.json` + `repro-schema.json`):
- Added `stateReason` (`completed`|`not_planned`) for `close-issue`
- Added `category` for `convert-to-discussion`
- Added `milestone` for `set-milestone`
- Removed `update-project` (not automatable — requires project board IDs)

**Both cheatsheets**:
- Updated action type table with required fields for every action type
- Repro cheatsheet: added **Action Data Requirements** section preventing hollow actions

### Action field requirements

| Type | Required Fields |
|------|----------------|
| `update-labels` | `labels` (string array) |
| `add-comment` | `comment` (markdown string) |
| `close-issue` | `stateReason` (`completed` or `not_planned`) |
| `link-related` | `linkedIssue` (integer) |
| `link-duplicate` | `linkedIssue` (integer) |
| `convert-to-discussion` | `category` (string) |
| `set-milestone` | `milestone` (string) |