### PR TITLE
Enable blank issues in issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Questions and/or Discussions
     url: https://github.com/mono/SkiaSharp/discussions


### PR DESCRIPTION
This pull request makes a minor configuration change to the issue templates by enabling blank issues on GitHub. This allows users to open issues without using a predefined template.

- Enabled blank issues by setting `blank_issues_enabled` to `true` in `.github/ISSUE_TEMPLATE/config.yml`