### PR TITLE
Add Tizen x64 and arm64 native build support

### DIFF
--- a/binding/HarfBuzzSharp.NativeAssets.Tizen/HarfBuzzSharp.NativeAssets.Tizen.csproj
+++ b/binding/HarfBuzzSharp.NativeAssets.Tizen/HarfBuzzSharp.NativeAssets.Tizen.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <PackageFile Include="..\..\output\native\tizen\armel\libHarfBuzzSharp.*" PackagePath="runtimes\tizen-armel\native\%(Filename)%(Extension)" />
     <PackageFile Include="..\..\output\native\tizen\i586\libHarfBuzzSharp.*" PackagePath="runtimes\tizen-x86\native\%(Filename)%(Extension)" />
+    <PackageFile Include="..\..\output\native\tizen\x86_64\libHarfBuzzSharp.*" PackagePath="runtimes\tizen-x64\native\%(Filename)%(Extension)" />
+    <PackageFile Include="..\..\output\native\tizen\aarch64\libHarfBuzzSharp.*" PackagePath="runtimes\tizen-arm64\native\%(Filename)%(Extension)" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup>

--- a/binding/IncludeNativeAssets.HarfBuzzSharp.targets
+++ b/binding/IncludeNativeAssets.HarfBuzzSharp.targets
@@ -56,9 +56,19 @@
       <TizenTpkSubDir>bin\runtimes\tizen-armel\native\</TizenTpkSubDir>
       <TizenTpkFileName>libHarfBuzzSharp.so</TizenTpkFileName>
     </TizenTpkFiles>
+    <TizenTpkFiles Include="$(MSBuildThisFileDirectory)..\output\native\tizen\x86_64\libHarfBuzzSharp.so">
+      <Visible>false</Visible>
+      <TizenTpkSubDir>bin\runtimes\tizen-x64\native\</TizenTpkSubDir>
+      <TizenTpkFileName>libHarfBuzzSharp.so</TizenTpkFileName>
+    </TizenTpkFiles>
+    <TizenTpkFiles Include="$(MSBuildThisFileDirectory)..\output\native\tizen\aarch64\libHarfBuzzSharp.so">
+      <Visible>false</Visible>
+      <TizenTpkSubDir>bin\runtimes\tizen-arm64\native\</TizenTpkSubDir>
+      <TizenTpkFileName>libHarfBuzzSharp.so</TizenTpkFileName>
+    </TizenTpkFiles>
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.Contains('-tvos'))and '$(RuntimeIdentifier)' != ''">
+  <ItemGroup Condition="$(TargetFramework.Contains('-tvos')) and '$(RuntimeIdentifier)' != ''">
     <NativeReference Include="$(MSBuildThisFileDirectory)..\output\native\tvossimulator\libHarfBuzzSharp.framework" Kind="Framework" Condition="$(RuntimeIdentifier.StartsWith('tvossimulator'))" />
     <NativeReference Include="$(MSBuildThisFileDirectory)..\output\native\tvos\libHarfBuzzSharp.framework" Kind="Framework" Condition="!$(RuntimeIdentifier.StartsWith('tvossimulator'))" />
   </ItemGroup>

--- a/binding/IncludeNativeAssets.SkiaSharp.targets
+++ b/binding/IncludeNativeAssets.SkiaSharp.targets
@@ -56,6 +56,16 @@
       <TizenTpkSubDir>bin\runtimes\tizen-armel\native\</TizenTpkSubDir>
       <TizenTpkFileName>libSkiaSharp.so</TizenTpkFileName>
     </TizenTpkFiles>
+    <TizenTpkFiles Include="$(MSBuildThisFileDirectory)..\output\native\tizen\x86_64\libSkiaSharp.so">
+      <Visible>false</Visible>
+      <TizenTpkSubDir>bin\runtimes\tizen-x64\native\</TizenTpkSubDir>
+      <TizenTpkFileName>libSkiaSharp.so</TizenTpkFileName>
+    </TizenTpkFiles>
+    <TizenTpkFiles Include="$(MSBuildThisFileDirectory)..\output\native\tizen\aarch64\libSkiaSharp.so">
+      <Visible>false</Visible>
+      <TizenTpkSubDir>bin\runtimes\tizen-arm64\native\</TizenTpkSubDir>
+      <TizenTpkFileName>libSkiaSharp.so</TizenTpkFileName>
+    </TizenTpkFiles>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-tvos')) and '$(RuntimeIdentifier)' != ''">

--- a/binding/SkiaSharp.NativeAssets.Tizen/SkiaSharp.NativeAssets.Tizen.csproj
+++ b/binding/SkiaSharp.NativeAssets.Tizen/SkiaSharp.NativeAssets.Tizen.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <PackageFile Include="..\..\output\native\tizen\armel\libSkiaSharp.*" PackagePath="runtimes\tizen-armel\native\%(Filename)%(Extension)" />
     <PackageFile Include="..\..\output\native\tizen\i586\libSkiaSharp.*" PackagePath="runtimes\tizen-x86\native\%(Filename)%(Extension)" />
+    <PackageFile Include="..\..\output\native\tizen\x86_64\libSkiaSharp.*" PackagePath="runtimes\tizen-x64\native\%(Filename)%(Extension)" />
+    <PackageFile Include="..\..\output\native\tizen\aarch64\libSkiaSharp.*" PackagePath="runtimes\tizen-arm64\native\%(Filename)%(Extension)" />
   </ItemGroup>
   <Target Name="IncludeAdditionalTfmSpecificPackageFiles">
     <ItemGroup>

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -9,20 +9,33 @@ DirectoryPath TIZEN_STUDIO_HOME = EnvironmentVariable("TIZEN_STUDIO_HOME") ?? PR
 
 var bat = IsRunningOnWindows() ? ".bat" : "";
 var tizen = TIZEN_STUDIO_HOME.CombineWithFilePath($"tools/ide/bin/tizen{bat}").FullPath;
-var tizenVersion = "6.0";
+
+void SetProjectProfile(string projectDir, string profile)
+{
+    var propFile = MakeAbsolute((FilePath)$"{projectDir}/project_def.prop").FullPath;
+    var propContent = System.IO.File.ReadAllText(propFile);
+    var newContent = System.Text.RegularExpressions.Regex.Replace(
+        propContent, @"^profile = .+$", $"profile = {profile}",
+        System.Text.RegularExpressions.RegexOptions.Multiline);
+    if (newContent == propContent)
+        throw new Exception($"Failed to set profile in '{propFile}': no 'profile = ...' line found.");
+    System.IO.File.WriteAllText(propFile, newContent);
+}
 
 Task("libSkiaSharp")
     .IsDependentOn("git-sync-deps")
     .Does(() =>
 {
-    Build("armel", "arm", $"mobile-{tizenVersion}-device.core");
-    Build("i586", "x86", $"mobile-{tizenVersion}-emulator.core");
+    Build("armel", "arm",   "arm",     "mobile-6.0-device.core",       "mobile-6.0", "6.0");
+    Build("i586",  "x86",   "x86",     "mobile-6.0-emulator.core",     "mobile-6.0", "6.0");
+    Build("x86_64","x64",   "x86_64",  "tizen-8.0-emulator64.core",    "tizen-8.0",  "8.0");
+    Build("aarch64","arm64","aarch64",  "tizen-8.0-device64.core",      "tizen-8.0",  "8.0");
 
-    void Build(string arch, string skiaArch, string rootstrap)
+    void Build(string outputDir, string skiaArch, string tizenArch, string rootstrap, string profile, string ncliVersion)
     {
-        if (Skip(arch)) return;
+        if (Skip(outputDir)) return;
 
-        GnNinja($"tizen/{arch}", "skia modules/skottie",
+        GnNinja($"tizen/{outputDir}", "skia modules/skottie",
            $"target_os='tizen' " +
            $"target_cpu='{skiaArch}' " +
            $"skia_enable_ganesh=true " +
@@ -38,14 +51,20 @@ Task("libSkiaSharp")
            $"skia_enable_skottie=true " +
            $"extra_cflags=[ '-DSKIA_C_DLL', '-DXML_DEV_URANDOM' ] " +
            $"ncli='{TIZEN_STUDIO_HOME}' " +
-           $"ncli_version='{tizenVersion}'");
+           $"ncli_version='{ncliVersion}'");
+
+        SetProjectProfile("libSkiaSharp", profile);
+
+        var buildDir = MakeAbsolute((DirectoryPath)$"libSkiaSharp/{CONFIGURATION}");
+        if (DirectoryExists(buildDir))
+            DeleteDirectory(buildDir, new DeleteDirectorySettings { Recursive = true, Force = true });
 
         RunProcess(tizen, new ProcessSettings {
-           Arguments = $"build-native -a {skiaArch} -c llvm -C {CONFIGURATION} -r {rootstrap}" ,
+           Arguments = $"build-native -a {tizenArch} -c llvm -C {CONFIGURATION} -r {rootstrap}",
            WorkingDirectory = MakeAbsolute((DirectoryPath)"libSkiaSharp").FullPath,
         });
 
-        var outDir = OUTPUT_PATH.Combine(arch);
+        var outDir = OUTPUT_PATH.Combine(outputDir);
         EnsureDirectoryExists(outDir);
         CopyFile($"libSkiaSharp/{CONFIGURATION}/libskiasharp.so", outDir.CombineWithFilePath("libSkiaSharp.so"));
     }
@@ -54,19 +73,27 @@ Task("libSkiaSharp")
 Task("libHarfBuzzSharp")
     .Does(() =>
 {
-    Build("armel", "arm", $"mobile-{tizenVersion}-device.core");
-    Build("i586", "x86", $"mobile-{tizenVersion}-emulator.core");
+    Build("armel", "arm",     "mobile-6.0-device.core",     "mobile-6.0");
+    Build("i586",  "x86",     "mobile-6.0-emulator.core",   "mobile-6.0");
+    Build("x86_64","x86_64",  "tizen-8.0-emulator64.core",  "tizen-8.0");
+    Build("aarch64","aarch64","tizen-8.0-device64.core",     "tizen-8.0");
 
-    void Build(string arch, string cliArch, string rootstrap)
+    void Build(string outputDir, string tizenArch, string rootstrap, string profile)
     {
-        if (Skip(arch)) return;
+        if (Skip(outputDir)) return;
+
+        SetProjectProfile("libHarfBuzzSharp", profile);
+
+        var buildDir = MakeAbsolute((DirectoryPath)$"libHarfBuzzSharp/{CONFIGURATION}");
+        if (DirectoryExists(buildDir))
+            DeleteDirectory(buildDir, new DeleteDirectorySettings { Recursive = true, Force = true });
 
         RunProcess(tizen, new ProcessSettings {
-            Arguments = $"build-native -a {cliArch} -c llvm -C {CONFIGURATION} -r {rootstrap}" ,
+            Arguments = $"build-native -a {tizenArch} -c llvm -C {CONFIGURATION} -r {rootstrap}",
             WorkingDirectory = MakeAbsolute((DirectoryPath)"libHarfBuzzSharp").FullPath,
         });
 
-        var outDir = OUTPUT_PATH.Combine(arch);
+        var outDir = OUTPUT_PATH.Combine(outputDir);
         EnsureDirectoryExists(outDir);
         CopyFile($"libHarfBuzzSharp/{CONFIGURATION}/libharfbuzzsharp.so", outDir.CombineWithFilePath("libHarfBuzzSharp.so"));
     }

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -14,11 +14,11 @@ void SetProjectProfile(string projectDir, string profile)
 {
     var propFile = MakeAbsolute((FilePath)$"{projectDir}/project_def.prop").FullPath;
     var propContent = System.IO.File.ReadAllText(propFile);
-    var newContent = System.Text.RegularExpressions.Regex.Replace(
-        propContent, @"^profile = .+$", $"profile = {profile}",
-        System.Text.RegularExpressions.RegexOptions.Multiline);
-    if (newContent == propContent)
+    var regex = new System.Text.RegularExpressions.Regex(
+        @"^profile = .+$", System.Text.RegularExpressions.RegexOptions.Multiline);
+    if (!regex.IsMatch(propContent))
         throw new Exception($"Failed to set profile in '{propFile}': no 'profile = ...' line found.");
+    var newContent = regex.Replace(propContent, $"profile = {profile}");
     System.IO.File.WriteAllText(propFile, newContent);
 }
 

--- a/native/tizen/libHarfBuzzSharp/project_def.prop
+++ b/native/tizen/libHarfBuzzSharp/project_def.prop
@@ -1,5 +1,5 @@
 type = sharedLib
-profile = mobile-4.0
+profile = tizen-8.0
 
 src_root = $(abspath ../../../externals/skia/third_party/externals/harfbuzz/src)
 ext_root = $(abspath ../../../externals/skia/third_party/harfbuzz)

--- a/native/tizen/libSkiaSharp/project_def.prop
+++ b/native/tizen/libSkiaSharp/project_def.prop
@@ -1,5 +1,5 @@
 type = sharedLib
-profile = mobile-6.0
+profile = tizen-8.0
 
 skia_root = $(abspath ../../../externals/skia)
 


### PR DESCRIPTION
## Summary

Add 64-bit (x86_64, aarch64) native library builds for Tizen alongside existing 32-bit (arm, x86) builds.

### Architecture matrix

| Arch | Output Dir | RID | Rootstrap | Profile |
|------|-----------|-----|-----------|---------|
| ARM 32 | armel | tizen-armel | mobile-6.0-device.core | mobile-6.0 |
| x86 32 | i586 | tizen-x86 | mobile-6.0-emulator.core | mobile-6.0 |
| **x64** | **x86_64** | **tizen-x64** | **tizen-8.0-emulator64.core** | **tizen-8.0** |
| **ARM64** | **aarch64** | **tizen-arm64** | **tizen-8.0-device64.core** | **tizen-8.0** |

### Changes

| File | Change |
|------|--------|
| `externals/skia` | Submodule update → mono/skia#175 (GN config for x64/arm64 target_cpu) |
| `native/tizen/build.cake` | Refactored with `SetProjectProfile()` helper; builds all 4 architectures; cleans stale build dirs between arch switches |
| `binding/IncludeNativeAssets.SkiaSharp.targets` | Add tizen-x64 and tizen-arm64 TizenTpkFiles entries |
| `binding/IncludeNativeAssets.HarfBuzzSharp.targets` | Same + fix missing space in tvOS condition |
| `binding/SkiaSharp.NativeAssets.Tizen/*.csproj` | Add x86_64 and aarch64 PackageFile entries |
| `binding/HarfBuzzSharp.NativeAssets.Tizen/*.csproj` | Same |

RIDs match Samsung's official `RuntimeIdentifierGraph.json`.

### Depends on

- mono/skia#175 — GN build config for Tizen x64/arm64 target_cpu