### PR TITLE
Fix loongarch64 Linux builds on main

### DIFF
--- a/native/linux/build.cake
+++ b/native/linux/build.cake
@@ -21,6 +21,14 @@ string CC = Argument("cc", EnvironmentVariable("CC"));
 string CXX = Argument("cxx", EnvironmentVariable("CXX"));
 string AR = Argument("ar", EnvironmentVariable("AR"));
 
+string GetSkiaArch(string arch) =>
+    arch switch {
+        // Skia's GN files use "loong64", while the rest of our build and packaging
+        // pipeline uses the more explicit "loongarch64".
+        "loongarch64" => "loong64",
+        _ => arch,
+    };
+
 string VARIANT = string.IsNullOrEmpty(BUILD_VARIANT) ? "linux" : BUILD_VARIANT?.Trim();
 
 if (BUILD_ARCH.Length == 0)
@@ -62,6 +70,8 @@ Task("libSkiaSharp")
     foreach (var arch in BUILD_ARCH) {
         if (Skip(arch)) return;
 
+        var skiaArch = GetSkiaArch(arch);
+
         var soname = GetVersion("libSkiaSharp", "soname");
         var map = MakeAbsolute((FilePath)"libSkiaSharp/libSkiaSharp.map");
 
@@ -82,7 +92,7 @@ Task("libSkiaSharp")
 
         GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
             $"target_os='linux' " +
-            $"target_cpu='{arch}' " +
+            $"target_cpu='{skiaArch}' " +
             $"skia_enable_ganesh={(SUPPORT_GPU ? "true" : "false")} " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
@@ -121,12 +131,14 @@ Task("libHarfBuzzSharp")
     foreach (var arch in BUILD_ARCH) {
         if (Skip(arch)) return;
 
+        var skiaArch = GetSkiaArch(arch);
+
         var soname = GetVersion("HarfBuzz", "soname");
         var map = MakeAbsolute((FilePath)"libHarfBuzzSharp/libHarfBuzzSharp.map");
 
         GnNinja($"{VARIANT}/{arch}", "HarfBuzzSharp",
             $"target_os='linux' " +
-            $"target_cpu='{arch}' " +
+            $"target_cpu='{skiaArch}' " +
             $"visibility_hidden=false " +
             $"extra_asmflags=[] " +
             $"extra_cflags=[] " +

--- a/scripts/cake/native-shared.cake
+++ b/scripts/cake/native-shared.cake
@@ -244,6 +244,7 @@ string ReduceArch(string arch)
             return "arm64";
         case "riscv64":
             return "riscv64";
+        case "loong64":
         case "loongarch64":
             return "loongarch64";
     }


### PR DESCRIPTION
## Problem

`origin/main` still fails when building the native Linux loongarch64 target:

```text
undefined reference to `png_init_filter_functions_lsx`
```

I reproduced this on a clean Ubuntu WSL checkout with:

```bash
bash scripts/Docker/debian/13/build-local.sh loongarch64
```

## Root cause

Our Linux Cake build passes `target_cpu='loongarch64'` straight through to Skia GN, but upstream Skia's LoongArch conditionals key off `loong64` for the relevant optimized source selection.

## Fix

- keep the repo/package-facing architecture name as `loongarch64`
- map only the Skia GN handoff to `loong64`
- teach `ReduceArch()` to recognize both spellings safely

## Validation

- repro confirmed on clean WSL `main`
- the same minimal fix already cleared the loongarch64 Azure jobs on #3560 (build 156620)