### PR TITLE
Improve update-skia skill from m133 bump analysis

### DIFF
--- a/.github/skills/update-skia/SKILL.md
+++ b/.github/skills/update-skia/SKILL.md
@@ -147,6 +147,11 @@ The workflow follows this shape:
    git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} -- include/core/ include/gpu/ganesh/
    ```
 
+5. **Three mandatory verification checks** (see [breaking-changes-checklist.md](references/breaking-changes-checklist.md) Steps 4a–4c):
+   - **Struct size audit**: Check every `static_assert(sizeof(...))` in `sk_structs.cpp` against the target milestone's C++ struct definitions. Struct field additions cause build failures or silent memory corruption.
+   - **Deleted file audit**: For every deleted file, search the target branch for where it moved. Skia relocates files, it rarely removes them. Never recommend removing code that references a deleted file without finding the replacement.
+   - **Removal verification**: For any symbol you believe was "removed", confirm by grepping the target branch — diff hunks can show `-` lines for symbols that were merely reordered within the file.
+
 👉 See [references/breaking-changes-checklist.md](references/breaking-changes-checklist.md) for detailed analysis template.
 
 > 🛑 **GATE**: Present full breaking change analysis to user. Get approval before proceeding.

--- a/.github/skills/update-skia/SKILL.md
+++ b/.github/skills/update-skia/SKILL.md
@@ -147,12 +147,13 @@ The workflow follows this shape:
    git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} -- include/core/ include/gpu/ganesh/
    ```
 
-5. **Three mandatory verification checks** (see [breaking-changes-checklist.md](references/breaking-changes-checklist.md) Steps 4a–4c):
-   - **Struct size audit**: Check every `static_assert(sizeof(...))` in `sk_structs.cpp` against the target milestone's C++ struct definitions. Struct field additions cause build failures or silent memory corruption.
-   - **Deleted file audit**: For every deleted file, search the target branch for where it moved. Skia relocates files, it rarely removes them. Never recommend removing code that references a deleted file without finding the replacement.
-   - **Removal verification**: For any symbol you believe was "removed", confirm by grepping the target branch — diff hunks can show `-` lines for symbols that were merely reordered within the file.
+5. **Run structural diff on include/ directory**:
+   ```bash
+   git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --stat -- include/
+   git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} -- include/core/ include/gpu/ganesh/
+   ```
 
-👉 See [references/breaking-changes-checklist.md](references/breaking-changes-checklist.md) for detailed analysis template.
+👉 See [references/breaking-changes-checklist.md](references/breaking-changes-checklist.md) for the full analysis template, including verification steps for struct sizes, moved files, and diff-reading traps.
 
 > 🛑 **GATE**: Present full breaking change analysis to user. Get approval before proceeding.
 
@@ -180,38 +181,43 @@ milestone numbers and paste your breaking change analysis table. The default exp
    git checkout -b dev/update-skia-{TARGET}
    ```
 
-2. **Merge upstream**:
+2. **Merge upstream** — use `--no-commit` for manual conflict resolution:
    ```bash
-   git merge upstream/chrome/m{TARGET}
+   git merge --no-commit upstream/chrome/m{TARGET}
    ```
 
-3. **Resolve conflicts** — Common conflicts:
-   - `DEPS` — Keep our dependency pins, accept upstream structure changes
-   - `RELEASE_NOTES.md` — Accept upstream
-   - `infra/bots/jobs.json` — Accept upstream
-   - Source files in `src/` — Carefully resolve (don't lose our C API)
+3. **Resolve conflicts** — each conflict must be resolved individually.
+   Never use `git merge -s ours` or `git read-tree --reset` — this destroys `git blame` attribution.
 
-4. **Verify our C API files survived the merge**:
+   | File Category | Strategy |
+   |--------------|----------|
+   | `BUILD.gn` | **Combine both** — keep upstream structure AND SkiaSharp's platform flags + `skiasharp_build` target |
+   | `DEPS` | **Combine** — keep our dependency pins, accept upstream structure |
+   | `RELEASE_NOTES.md`, `infra/bots/` | **Take upstream** |
+   | C API (`include/c/`, `src/c/`) | **Keep SkiaSharp** — adapt includes/API calls in post-merge commits |
+
+4. **Commit the merge**:
+   ```bash
+   git commit  # Creates proper two-parent merge
+   ```
+
+5. **Verify our C API files survived the merge**:
    ```bash
    ls src/c/*.cpp include/c/*.h  # All files should still exist
    ```
 
-5. **Source file verification** — Check for added/deleted upstream files:
+6. **Source file verification** — Check for added/deleted upstream files:
    ```bash
    git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --diff-filter=AD --name-only -- src/ include/
    ```
    Cross-reference against `BUILD.gn` — new source files may need to be added.
 
-> 🛑 **GATE**: Merge complete, conflicts resolved. Run ALL of these verification commands
-> (from inside `externals/skia`):
+> 🛑 **GATE**: Merge complete, conflicts resolved. Verify:
 > ```bash
-> cd externals/skia
 > ls src/c/*.cpp include/c/*.h                    # C API files intact
-> git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --diff-filter=AD --name-only -- src/ include/
->                                                   # Review added/deleted files
-> git diff --check                                  # Zero conflict markers remain
+> git diff --check                                  # Zero conflict markers
+> git blame src/c/sk_canvas.cpp | head -20         # Attribution shows original commits, not just merge
 > ```
-> All three must produce expected output before proceeding.
 
 ### Phase 5: Fix C API Shim Layer
 

--- a/.github/skills/update-skia/SKILL.md
+++ b/.github/skills/update-skia/SKILL.md
@@ -147,12 +147,6 @@ The workflow follows this shape:
    git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} -- include/core/ include/gpu/ganesh/
    ```
 
-5. **Run structural diff on include/ directory**:
-   ```bash
-   git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --stat -- include/
-   git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} -- include/core/ include/gpu/ganesh/
-   ```
-
 👉 See [references/breaking-changes-checklist.md](references/breaking-changes-checklist.md) for the full analysis template, including verification steps for struct sizes, moved files, and diff-reading traps.
 
 > 🛑 **GATE**: Present full breaking change analysis to user. Get approval before proceeding.
@@ -235,9 +229,10 @@ must be updated when the underlying C++ APIs change.
    |-----------|-------------|
    | Missing type | Add/update typedef in `sk_types.h` |
    | Renamed function | Update call in `*.cpp` |
-   | Removed enum value | Remove from `sk_enums.cpp`, update `sk_types.h` |
+   | Removed enum value | Remove from `sk_enums.cpp` + `sk_types.h`. Flag as a C# breaking change — Phase 8 must add `[Obsolete]` or document removal |
    | Changed signature | Update C wrapper function signature |
    | New header required | Add `#include` in the relevant `.cpp` |
+   | Legacy flag breaks C API | Update C API to use replacement API (see gotcha #6). Do not just comment out the flag without a plan |
 
 3. **Update `sk_types.h`** for any new enums or type changes:
    - **Reset `SK_C_INCREMENT` to `0`** in `externals/skia/include/c/sk_types.h` for the new milestone

--- a/.github/skills/update-skia/references/breaking-changes-checklist.md
+++ b/.github/skills/update-skia/references/breaking-changes-checklist.md
@@ -29,6 +29,13 @@ SkiaSharp uses **Ganesh** (not Graphite). Filter changes:
 | `Dawn*`, `wgpu::` | ❌ No | Dawn/WebGPU — skip |
 | `SkSL`, `SkRuntimeEffect` | ⚠️ Maybe | Only if C API exposes runtime effects |
 | `SkCodec` | ⚠️ Maybe | Only if C API exposes codec APIs |
+| `include/gpu/GpuTypes.h`, `skgpu::` (non-graphite) | ⚠️ Check | Shared GPU types — trace consumers in **both** Ganesh and Graphite before skipping |
+| `SkEncoder::Options` structs | ✅ Yes | Size changes break `static_assert` in `sk_structs.cpp` |
+
+> ⚠️ **Shared GPU headers:** Types in `include/gpu/GpuTypes.h` and `include/gpu/` (outside
+> `ganesh/` and `graphite/`) are shared between backends. Before classifying as "Graphite-only",
+> grep for consumers in `include/gpu/ganesh/` — e.g., `GrFlushInfo` in `GrTypes.h` uses types
+> from `GpuTypes.h`.
 
 ## Step 3: Categorize Each Change
 
@@ -55,6 +62,58 @@ grep -rn "SYMBOL_NAME" src/c/ include/c/
 # Show the C API file that wraps the affected C++ class
 # Example: For SkImage changes, check sk_image.cpp
 cat src/c/sk_image.cpp | grep -A5 "FUNCTION_NAME"
+```
+
+### Step 4a: Verify struct size assertions (MANDATORY)
+
+Every milestone update MUST check `sk_structs.cpp` for `static_assert(sizeof(...))` lines.
+For each asserted struct, compare the C API struct (in `sk_types.h`) against the C++ struct
+in the **target milestone** — not the current branch:
+
+```bash
+# List all size-asserted structs
+grep "static_assert.*sizeof" src/c/sk_structs.cpp
+
+# For each struct, show the C++ definition at the target milestone
+git show upstream/chrome/m{TARGET}:include/encode/SkPngEncoder.h | grep -A30 "struct Options"
+git show upstream/chrome/m{TARGET}:include/encode/SkJpegEncoder.h | grep -A20 "struct Options"
+git show upstream/chrome/m{TARGET}:include/encode/SkWebpEncoder.h | grep -A20 "struct Options"
+# ... repeat for all asserted structs
+```
+
+Any new fields in a C++ struct that the C API mirrors via `reinterpret_cast` (not field-by-field
+copy) will cause either a `static_assert` failure at compile time or silent memory corruption
+at runtime. This check catches both.
+
+### Step 4b: Verify deleted files → search for moves (MANDATORY)
+
+When a file is deleted between milestones, **always search for where it moved** before
+recommending removal of references. Skia rarely deletes functionality outright — it relocates.
+
+```bash
+# Find what was deleted
+git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --diff-filter=D --name-only
+
+# For each deleted file, search for the same content at the new location
+git ls-tree -r upstream/chrome/m{TARGET} --name-only | grep -i "FILENAME_STEM"
+# Example: SkJSON.h deleted → search for "SkJSON" or "skjson" → finds modules/jsonreader/
+```
+
+Then update `#include` paths in our C API files rather than removing code.
+
+### Step 4c: Verify "removed" symbols on target branch (MANDATORY)
+
+When a diff hunk shows a symbol on a `-` line, it may have been **moved within the same
+file** (reordered), not actually removed. Always confirm on the target branch:
+
+```bash
+# WRONG: Trusting the diff alone
+git diff m{CURRENT}..m{TARGET} -- include/gpu/ganesh/GrContextOptions.h
+# Shows "- bool fSuppressPrints" → might conclude "removed"
+
+# RIGHT: Check the target branch directly
+git show upstream/chrome/m{TARGET}:include/gpu/ganesh/GrContextOptions.h | grep "fSuppressPrints"
+# Shows it still exists → it was reordered, not removed
 ```
 
 ### Common C API Patterns
@@ -106,6 +165,27 @@ After applying fixes:
 4. Test: `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj`
 
 ## Historical Examples
+
+### m132 → m133 Changes Required
+
+| Change | C API Fix | C# Fix |
+|--------|-----------|--------|
+| `src/utils/SkJSON.h` moved to `modules/jsonreader/` | Updated `#include` in `sk_linker.cpp` | None |
+| `SkPngEncoder::Options` gained `fGainmap` + `fGainmapInfo` | Added fields to `sk_pngencoder_options_t` | None (null pointers) |
+| `SkColorSpace::MakeCICP` + CICP enums added | New C API function + enum types | New `CreateCicp` factory + enums |
+| `SkTypeface::getResourceName` added | New C API function | New `ResourceName` property |
+| `GrContextOptions` fields reordered (no add/remove) | None (field-by-field copy) | None |
+| `SkMaskFilter::approximateFilteredBounds` removed | None (not wrapped) | None |
+| `SkSL::DebugTrace::writeTrace` removed | None (not wrapped) | None |
+| Shared GPU stats types added (`GpuStatsFlags`, `GpuStats`) | None (additive, safe defaults) | None (callback-based, deferred) |
+
+**Lessons learned:**
+- `SkJSON.h` deletion was a **relocation** to `modules/jsonreader/` — always search for moves before removing references
+- `SkPngEncoder::Options` field addition broke `static_assert` in `sk_structs.cpp` — always audit struct assertions
+- `fSuppressPrints` appeared "removed" in diff but was actually reordered within `GrContextOptions.h` — verify on target branch
+- `GpuTypes.h` changes looked Graphite-only but `GrFlushInfo` (Ganesh) uses those types — trace shared GPU header consumers
+
+**Files changed:** 2 in C API (fixes), 2 in C API (new APIs), ~6 total in SkiaSharp PR
 
 ### m118 → m119 Changes Required
 

--- a/.github/skills/update-skia/references/breaking-changes-checklist.md
+++ b/.github/skills/update-skia/references/breaking-changes-checklist.md
@@ -2,8 +2,9 @@
 
 ## How to Use This Document
 
-When updating Skia to a new milestone, use this checklist to systematically identify
-and categorize all breaking changes that affect SkiaSharp.
+When updating Skia to a new milestone, follow these steps in order. Each step builds
+on the previous one. The goal is to identify every change that affects our C API shim
+layer **before** you start merging.
 
 ## Step 1: Gather Release Notes
 
@@ -28,14 +29,18 @@ SkiaSharp uses **Ganesh** (not Graphite). Filter changes:
 | `SkPath`, `SkPaint` | ✅ Yes | Drawing APIs — always check |
 | `Dawn*`, `wgpu::` | ❌ No | Dawn/WebGPU — skip |
 | `SkSL`, `SkRuntimeEffect` | ⚠️ Maybe | Only if C API exposes runtime effects |
-| `SkCodec` | ⚠️ Maybe | Only if C API exposes codec APIs |
-| `include/gpu/GpuTypes.h`, `skgpu::` (non-graphite) | ⚠️ Check | Shared GPU types — trace consumers in **both** Ganesh and Graphite before skipping |
-| `SkEncoder::Options` structs | ✅ Yes | Size changes break `static_assert` in `sk_structs.cpp` |
+| `SkCodec`, `SkEncoder` | ⚠️ Maybe | Only if C API exposes codec/encoder APIs |
 
-> ⚠️ **Shared GPU headers:** Types in `include/gpu/GpuTypes.h` and `include/gpu/` (outside
-> `ganesh/` and `graphite/`) are shared between backends. Before classifying as "Graphite-only",
-> grep for consumers in `include/gpu/ganesh/` — e.g., `GrFlushInfo` in `GrTypes.h` uses types
-> from `GpuTypes.h`.
+**Two common misclassification traps:**
+
+1. **Shared GPU headers** (`include/gpu/GpuTypes.h`, `include/gpu/*.h`): Types here are
+   shared across Ganesh and Graphite. Before skipping as "Graphite-only", check if
+   `include/gpu/ganesh/` consumes them — e.g., `GrFlushInfo` uses types from `GpuTypes.h`.
+
+2. **Struct field changes in asserted types**: `sk_structs.cpp` has `static_assert(sizeof(...))`
+   for every C API struct mapped via `reinterpret_cast`. A field addition to any of these
+   C++ structs (encoders, lattice, frame info, etc.) is a **build break** even if the
+   release notes don't mention it prominently.
 
 ## Step 3: Categorize Each Change
 
@@ -49,114 +54,59 @@ Create a table for each change:
 | 3 | New `SkVertices::Builder` SK_API | 🟢 LOW | None | None | Optional: wrap later |
 ```
 
-## Step 4: C API Impact Analysis
+## Step 4: Verify the Analysis
+
+The release notes don't cover everything. These checks catch what they miss.
+
+**Check struct sizes:**
+```bash
+# List all asserted structs, then compare each against the target milestone
+grep "static_assert.*sizeof" src/c/sk_structs.cpp
+git show upstream/chrome/m{TARGET}:include/encode/SkPngEncoder.h | grep -A30 "struct Options"
+```
+
+**Check for moved files** (Skia relocates, it rarely deletes):
+```bash
+git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --diff-filter=D --name-only
+# For each deleted file our C API references:
+git ls-tree -r upstream/chrome/m{TARGET} --name-only | grep -i "FILENAME_STEM"
+```
+
+**Confirm removals on the target branch** (diff `-` lines can be reorders, not deletions):
+```bash
+# Don't trust the diff — verify directly
+git show upstream/chrome/m{TARGET}:include/gpu/ganesh/GrContextOptions.h | grep "fSuppressPrints"
+```
+
+## Step 5: C API Impact Analysis
 
 For each HIGH/MEDIUM risk change, check the C API:
 
 ```bash
 cd externals/skia
-
-# Search for affected symbols in C API
 grep -rn "SYMBOL_NAME" src/c/ include/c/
-
-# Show the C API file that wraps the affected C++ class
-# Example: For SkImage changes, check sk_image.cpp
-cat src/c/sk_image.cpp | grep -A5 "FUNCTION_NAME"
 ```
 
-### Step 4a: Verify struct size assertions (MANDATORY)
+### Recurring patterns across milestone bumps
 
-Every milestone update MUST check `sk_structs.cpp` for `static_assert(sizeof(...))` lines.
-For each asserted struct, compare the C API struct (in `sk_types.h`) against the C++ struct
-in the **target milestone** — not the current branch:
+| Pattern | Risk | C API Fix | C# Fix |
+|---------|------|-----------|--------|
+| **Removed static factory** → replaced with context-taking free function | 🔴 HIGH | Update call + add `#include` for new header | Add new overload or update existing |
+| **Header path reorganization** (e.g., `include/gpu/` → `include/gpu/ganesh/`) | 🟡 MED | Update `#include` paths | None |
+| **Factory moved to namespace** (`ClassName::Make*` → `ClassNames::Make*`) | 🔴 HIGH | Update function call + add `#include` | None (auto-generated) |
+| **Type renamed into namespace** (e.g., `GrVkAlloc` → `skgpu::VulkanAlloc`) | 🔴 HIGH | Update type refs in `sk_types_priv.h` | Update managed struct names |
+| **Struct field added/removed** (breaks `static_assert`) | 🔴 HIGH | Update `sk_types.h` struct definition | Update managed struct |
+| **Enum value inserted mid-sequence** (renumbers everything after) | 🟡 MED | Regenerate bindings — never hand-edit | Regenerate + update mappings |
+| **File moved to new module** (e.g., `src/utils/` → `modules/`) | 🟡 MED | Update `#include` path | None |
+
+## Step 6: C# Impact Analysis
 
 ```bash
-# List all size-asserted structs
-grep "static_assert.*sizeof" src/c/sk_structs.cpp
-
-# For each struct, show the C++ definition at the target milestone
-git show upstream/chrome/m{TARGET}:include/encode/SkPngEncoder.h | grep -A30 "struct Options"
-git show upstream/chrome/m{TARGET}:include/encode/SkJpegEncoder.h | grep -A20 "struct Options"
-git show upstream/chrome/m{TARGET}:include/encode/SkWebpEncoder.h | grep -A20 "struct Options"
-# ... repeat for all asserted structs
-```
-
-Any new fields in a C++ struct that the C API mirrors via `reinterpret_cast` (not field-by-field
-copy) will cause either a `static_assert` failure at compile time or silent memory corruption
-at runtime. This check catches both.
-
-### Step 4b: Verify deleted files → search for moves (MANDATORY)
-
-When a file is deleted between milestones, **always search for where it moved** before
-recommending removal of references. Skia rarely deletes functionality outright — it relocates.
-
-```bash
-# Find what was deleted
-git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --diff-filter=D --name-only
-
-# For each deleted file, search for the same content at the new location
-git ls-tree -r upstream/chrome/m{TARGET} --name-only | grep -i "FILENAME_STEM"
-# Example: SkJSON.h deleted → search for "SkJSON" or "skjson" → finds modules/jsonreader/
-```
-
-Then update `#include` paths in our C API files rather than removing code.
-
-### Step 4c: Verify "removed" symbols on target branch (MANDATORY)
-
-When a diff hunk shows a symbol on a `-` line, it may have been **moved within the same
-file** (reordered), not actually removed. Always confirm on the target branch:
-
-```bash
-# WRONG: Trusting the diff alone
-git diff m{CURRENT}..m{TARGET} -- include/gpu/ganesh/GrContextOptions.h
-# Shows "- bool fSuppressPrints" → might conclude "removed"
-
-# RIGHT: Check the target branch directly
-git show upstream/chrome/m{TARGET}:include/gpu/ganesh/GrContextOptions.h | grep "fSuppressPrints"
-# Shows it still exists → it was reordered, not removed
-```
-
-### Common C API Patterns
-
-**Enum removed from C++:**
-```cpp
-// Before (sk_enums.cpp)
-case ENUM_VALUE_FOO:    return CppEnum::kFoo;
-
-// After: Remove the line and the corresponding sk_types.h entry
-```
-
-**Function signature changed:**
-```cpp
-// Before (sk_image.cpp)
-return ToImage(SkImage::MakeOld(args).release());
-
-// After: Update to new API
-return ToImage(SkImages::MakeNew(args).release());
-```
-
-**Header moved:**
-```cpp
-// Before
-#include "include/gpu/GrOldHeader.h"
-
-// After: Update include path
-#include "include/gpu/ganesh/GrNewHeader.h"
-```
-
-## Step 5: C# Impact Analysis
-
-For each C API change, check the C# side:
-
-```bash
-# Search C# wrappers for affected types
 grep -rn "ENUM_NAME\|FUNCTION_NAME" binding/SkiaSharp/
-
-# Check generated bindings
 grep -rn "SYMBOL" binding/SkiaSharp/SkiaApi.generated.cs
 ```
 
-## Step 6: Build & Verify
+## Step 7: Build & Verify
 
 After applying fixes:
 1. Build native: `dotnet cake --target=externals-macos --arch=arm64`
@@ -173,19 +123,15 @@ After applying fixes:
 | `src/utils/SkJSON.h` moved to `modules/jsonreader/` | Updated `#include` in `sk_linker.cpp` | None |
 | `SkPngEncoder::Options` gained `fGainmap` + `fGainmapInfo` | Added fields to `sk_pngencoder_options_t` | None (null pointers) |
 | `SkColorSpace::MakeCICP` + CICP enums added | New C API function + enum types | New `CreateCicp` factory + enums |
-| `SkTypeface::getResourceName` added | New C API function | New `ResourceName` property |
 | `GrContextOptions` fields reordered (no add/remove) | None (field-by-field copy) | None |
 | `SkMaskFilter::approximateFilteredBounds` removed | None (not wrapped) | None |
-| `SkSL::DebugTrace::writeTrace` removed | None (not wrapped) | None |
 | Shared GPU stats types added (`GpuStatsFlags`, `GpuStats`) | None (additive, safe defaults) | None (callback-based, deferred) |
 
 **Lessons learned:**
-- `SkJSON.h` deletion was a **relocation** to `modules/jsonreader/` — always search for moves before removing references
-- `SkPngEncoder::Options` field addition broke `static_assert` in `sk_structs.cpp` — always audit struct assertions
-- `fSuppressPrints` appeared "removed" in diff but was actually reordered within `GrContextOptions.h` — verify on target branch
-- `GpuTypes.h` changes looked Graphite-only but `GrFlushInfo` (Ganesh) uses those types — trace shared GPU header consumers
-
-**Files changed:** 2 in C API (fixes), 2 in C API (new APIs), ~6 total in SkiaSharp PR
+- `SkJSON.h` deletion was a **relocation** to `modules/jsonreader/` — always search for moves
+- `SkPngEncoder::Options` field addition broke `static_assert` — always audit asserted structs
+- `fSuppressPrints` appeared "removed" in diff but was reordered — verify on target branch
+- `GpuTypes.h` changes looked Graphite-only but `GrFlushInfo` (Ganesh) uses them — trace consumers
 
 ### m118 → m119 Changes Required
 
@@ -196,8 +142,6 @@ After applying fixes:
 | `SkImages::MakeWithFilter` API change | Updated `sk_image.cpp` call | None (auto-generated) |
 | `GrDirectContext` API updates | Updated `gr_context.cpp` | Updated `GRDefinitions.cs` |
 
-**Files changed:** 8 in C API, 12 total in SkiaSharp PR
-
 ### m117 → m118 Changes Required
 
 | Change | C API Fix | C# Fix |
@@ -206,8 +150,6 @@ After applying fixes:
 | `SkImage::makeWithFilter` deprecated | Updated to new factory | Auto-regenerated |
 
 ## Risk Assessment Template
-
-Before proceeding with a milestone update, score the risk:
 
 | Factor | Low Risk | Medium Risk | High Risk |
 |--------|----------|-------------|-----------|

--- a/.github/skills/update-skia/references/known-gotchas.md
+++ b/.github/skills/update-skia/references/known-gotchas.md
@@ -2,113 +2,107 @@
 
 Hard-won findings from past Skia milestone updates. Check these proactively — they will save hours of debugging.
 
-## 1. `DEF_STRUCT_MAP` vs Type Aliases
+## C++ ↔ C API Layer
+
+### 1. `DEF_STRUCT_MAP` vs Type Aliases
 
 When upstream changes a C++ type from a `struct` to a `using` alias (e.g., `GrVkYcbcrConversionInfo` → `using VulkanYcbcrConversionInfo`), the `DEF_STRUCT_MAP` macro in `sk_types_priv.h` forward-declares `struct X`, which conflicts with the alias. Fix by switching to `DEF_MAP_WITH_NS(namespace, ActualType, CType)` and wrapping in the appropriate platform guard (e.g., `#if SK_VULKAN`).
 
-## 2. `git-sync-deps` emsdk Failure
+### 2. Struct Size `static_assert` Failures
 
-Upstream m121+ added an `activate-emsdk` call in `tools/git-sync-deps`. Since SkiaSharp comments out emsdk in DEPS, this call fails. Set the environment variable `GIT_SYNC_DEPS_SKIP_EMSDK=1` in `scripts/cake/native-shared.cake` to prevent build failures during dependency sync.
+`sk_structs.cpp` asserts `sizeof(our_c_type) == sizeof(CppType)` for every struct mapped via `reinterpret_cast`. When upstream adds fields (e.g., `SkPngEncoder::Options` gaining gainmap pointers in m133), the assert fires. During analysis, proactively check every asserted struct against the target milestone — don't wait for the build to catch it.
 
-## 3. `BUILD.gn` Legacy Flags
+### 3. Custom Patches May Partially Survive Merges
 
-Upstream may introduce defines like `SK_DEFAULT_TYPEFACE_IS_EMPTY` and `SK_DISABLE_LEGACY_DEFAULT_TYPEFACE` that break SkiaSharp's C API, which still relies on legacy typeface/fontmgr APIs. Comment these defines out in `BUILD.gn` when they cause compilation errors in the C API shim layer.
+SkiaSharp adds custom methods to upstream headers (e.g., `SkTypeface::RefDefault()`). After merge, implementations in `.cpp` files may survive but header declarations can be silently removed by upstream changes. Always verify header declarations match implementations.
 
-## 4. Custom Patches May Partially Survive Merges
+### 4. Fontconfig `#ifdef` Guards
 
-SkiaSharp adds custom methods to upstream headers (e.g., `SkTypeface::RefDefault()`, `SkTypeface::UniqueID()`, `SkFontMgr::MakeDefault()`). After an upstream merge, implementations in `.cpp` files may survive but header declarations can be silently removed by upstream changes. Always verify that header declarations in `include/` still match the implementations in `src/`.
+Platform font manager calls (e.g., `SkFontMgr_New_FontConfig`) must be guarded by feature-availability macros (`SK_FONTMGR_FONTCONFIG_AVAILABLE`), not platform macros (`SK_BUILD_FOR_UNIX`). When `skia_use_fontconfig=false`, platform macros leave the symbol unresolved. The `-Wl,--no-undefined` linker flag catches this at link time.
 
-## 5. Version Compatibility Errors Mean You Missed a Step
+## Build System
 
-If you get `InvalidOperationException: The version of the native libSkiaSharp library (X) is incompatible`, this means the native milestone and C# expected milestone don't match. This is always caused by an incomplete Phase 6 (VERSIONS.txt not fully updated) or a stale build. Go back and fix the root cause — do NOT work around it with `--no-incremental` or by manually copying native libraries.
+### 5. `git-sync-deps` emsdk Failure
 
-## 6. Test Runner
+Upstream m121+ added an `activate-emsdk` call in `tools/git-sync-deps`. Since SkiaSharp comments out emsdk in DEPS, this call fails. Set `GIT_SYNC_DEPS_SKIP_EMSDK=1` in `scripts/cake/native-shared.cake`.
 
-Tests use runtime `Skip.If()` calls to self-skip on unsupported platforms. Run all tests
-with `dotnet test tests/SkiaSharp.Tests.Console.sln` — this runs core, Vulkan, and Direct3D
-test projects. Backend-specific tests self-skip when hardware isn't available. CI handles
-WASM, Android, and iOS testing separately.
+### 6. `BUILD.gn` Legacy Flags
 
-## 7. HarfBuzz Binding Generation Failures
+Upstream may introduce defines like `SK_DEFAULT_TYPEFACE_IS_EMPTY` and `SK_DISABLE_LEGACY_DEFAULT_TYPEFACE` that break SkiaSharp's C API. Comment these out when they cause compilation errors. Also watch for renamed/removed GN flags between milestones — obsolete flags cause `Unknown GN flag` errors. Always diff the target `BUILD.gn` against the current one.
 
-HarfBuzz generated bindings may fail due to system header issues (`inttypes.h` not found). This is independent of SkiaSharp bindings — if it happens, restore the file from git with `git checkout -- binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` and continue. SkiaSharp bindings generate independently.
+### 7. `.gitmodules` Branch Name
 
-## 8. New C API Functions From Upstream
+When the mono/skia target branch name changes, `.gitmodules` must be updated to track the new branch. Easy to forget; causes silent submodule tracking failures.
 
-Upstream may add new C API functions (e.g., `sk_surface_draw_with_sampling`) that weren't in the previous milestone. The regeneration step (`pwsh ./utils/generate.ps1`) picks these up automatically. Always review the diff of `*.generated.cs` files for new functions that may need corresponding C# wrappers in `binding/SkiaSharp/`.
+## Dependencies & Bindings
 
-## 9. DEPS: Fork-Customized Dependencies
+### 8. DEPS: Fork-Customized Dependencies
 
-SkiaSharp's fork often has **newer** dependency versions than upstream Skia (from custom security/bug-fix updates via the `native-dependency-update` skill). When merging upstream and resolving DEPS, do NOT blindly update all hashes to the upstream milestone's versions — you may **downgrade** dependencies and break the build.
+SkiaSharp's fork often has **newer** dependency versions than upstream. When resolving DEPS conflicts, do NOT blindly take upstream's hashes — you may downgrade and break the build.
 
-**Check the skiasharp branch commit log** for custom dependency updates:
 ```bash
 git log --oneline skiasharp | grep -i "update\|bump\|libpng\|zlib\|expat\|brotli\|webp\|harfbuzz\|vulkan"
 ```
 
-For each dep with a custom update, **keep the fork's hash**. Only update deps that the fork hasn't customized. Common fork-customized deps: libwebp, brotli, expat, libpng, zlib, vulkanmemoryallocator, **harfbuzz**.
+Keep fork's hash for customized deps. Common ones: libwebp, brotli, expat, libpng, zlib, vulkanmemoryallocator, **harfbuzz**.
 
-> ⚠️ **HarfBuzz is ALWAYS a fork-customized dep.** HarfBuzz updates require hand-written C# delegate
-> proxies and must be done as a separate task via the `native-dependency-update` skill. During a Skia
-> milestone update, ALWAYS keep the fork's harfbuzz hash in DEPS and ALWAYS revert any changes to
-> `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs`.
+### 9. HarfBuzz — ALWAYS Separate
 
-**Symptoms of getting this wrong**: Build failures referencing missing source files (e.g., `palette.c` in libwebp), or HarfBuzz generated binding errors from a version mismatch.
-
-## 10. HarfBuzz Generated Bindings — ALWAYS Revert
-
-HarfBuzz updates are **always separate** from Skia milestone updates. When the harfbuzz DEPS version changes (even accidentally during a merge), the code generator picks up new APIs (paint/draw/colorline callbacks) that require hand-written delegate proxy implementations in `binding/HarfBuzzSharp/DelegateProxies.*.cs`. This causes `CS8795` errors for missing partial method implementations.
-
-**During a Skia milestone update, ALWAYS:**
-1. Keep the fork's harfbuzz hash in DEPS (do not accept upstream's version)
+HarfBuzz updates require hand-written C# delegate proxies and must be done via the `native-dependency-update` skill. During a milestone update, ALWAYS:
+1. Keep the fork's harfbuzz hash in DEPS
 2. Revert any generated HarfBuzz binding changes: `git checkout HEAD -- binding/HarfBuzzSharp/HarfBuzzApi.generated.cs`
 
-HarfBuzz version bumps should be done separately via the `native-dependency-update` skill, which includes writing the required delegate proxies.
+### 10. Enum Value Renumbering
 
-## 11. Struct Size static_assert Failures
+When upstream inserts new enum values mid-sequence, ALL subsequent values shift. This affects `sk_enums.cpp`, `Definitions.cs`, `EnumMappings.cs`, and any test hardcoding enum integers. Always regenerate bindings — never hand-edit enum values.
 
-`sk_structs.cpp` contains `static_assert(sizeof(our_c_type) == sizeof(CppType))` for every
-C API struct that is mapped via `reinterpret_cast`. When upstream adds fields to a C++ struct
-(e.g., `SkPngEncoder::Options` gaining `fGainmap` and `fGainmapInfo` in m133), the assert
-fires at compile time — but only if you actually build. During the analysis phase, you must
-**proactively check** every asserted struct against the target milestone's definition.
+## Diff Reading Traps
 
-```bash
-# List all asserted structs
-grep "static_assert.*sizeof" src/c/sk_structs.cpp
-# For each, compare C API struct in sk_types.h vs C++ struct at target milestone
-```
+### 11. Deleted Files ≠ Deleted Functionality
 
-**Fix:** Add corresponding fields to the C API struct in `include/c/sk_types.h`. For pointer
-fields that the C API doesn't need to expose, use `void*` defaulting to `nullptr`.
-
-## 12. Deleted Files ≠ Deleted Functionality
-
-Skia almost never removes functionality outright — **it relocates it**. When a file is deleted
-between milestones (e.g., `src/utils/SkJSON.h` → `modules/jsonreader/SkJSONReader.h` in m133),
-always search the target branch for where it moved:
+Skia relocates files, it rarely removes them. Example: `src/utils/SkJSON.h` → `modules/jsonreader/SkJSONReader.h` in m133. Always search the target branch for where content moved before removing references:
 
 ```bash
 git ls-tree -r upstream/chrome/m{TARGET} --name-only | grep -i "FILENAME_STEM"
 ```
 
-**Never recommend "remove references"** to a deleted file without first finding the replacement.
-Code in our C API (especially `sk_linker.cpp` keep-alives) exists for a reason — update the
-`#include` path to the new location instead.
+### 12. Reordered Fields ≠ Removed Fields
 
-## 13. Reordered Fields ≠ Removed Fields
-
-When reading diffs, a symbol appearing on a `-` line may have been **moved within the same
-file**, not removed. Always confirm removals by checking the symbol on the target branch:
+A symbol on a diff `-` line may have been moved within the same file, not removed. Always confirm on the target branch:
 
 ```bash
-# WRONG: "fSuppressPrints is on a minus line, it was removed"
-# RIGHT: Check the target branch directly
-git show upstream/chrome/m{TARGET}:include/gpu/ganesh/GrContextOptions.h | grep "fSuppressPrints"
+git show upstream/chrome/m{TARGET}:FILEPATH | grep "SYMBOL"
 ```
 
-This is especially common during struct reorganizations where fields are reordered into
-logical groups without any actual additions or removals.
+## Merge Strategy
+
+### 13. Genuine Merge Required
+
+Never use a tree-override merge (`git merge -s ours`, `git read-tree --reset`). This destroys `git blame` attribution for all C API files. Always resolve each conflict individually. Use `git merge --no-commit` for manual control.
+
+### 14. Conflict Resolution by File Category
+
+| File Category | Strategy |
+|--------------|----------|
+| `BUILD.gn` | **Combine both** — most complex; keep upstream structure AND SkiaSharp's platform flags/targets |
+| `DEPS` | **Combine** — keep our dependency pins, accept upstream structure |
+| `RELEASE_NOTES.md`, `infra/bots/` | **Take upstream** |
+| C API headers (`include/c/`) | **Keep SkiaSharp** — these don't exist upstream |
+| C API source (`src/c/`) | **Keep SkiaSharp + adapt** — fix includes and API calls in post-merge commits |
+
+## Testing
+
+### 15. Version Compatibility Errors
+
+`InvalidOperationException: The version of the native libSkiaSharp library (X) is incompatible` means VERSIONS.txt wasn't fully updated. Fix the root cause — do NOT work around it.
+
+### 16. Pixel Value Precision
+
+Upstream periodically improves color conversion precision, shifting expected pixel values by ±1. When pixel-exact test assertions break, check if upstream changed the conversion and update expected values.
+
+### 17. Test Runner
+
+Tests use `Skip.If()` for unsupported platforms. Run `dotnet test tests/SkiaSharp.Tests.Console.sln` for the full suite. Backend-specific tests self-skip when hardware isn't available.
 
 ---
 
@@ -118,8 +112,11 @@ logical groups without any actual additions or removals.
 |-------|-------|-----|
 | `EntryPointNotFoundException` | Native lib not rebuilt after C API change | `dotnet cake --target=externals-{platform}` |
 | `error CS0246` missing type | Binding not regenerated | `pwsh ./utils/generate.ps1` |
-| Merge conflict in DEPS | Both forks updated deps independently | Keep our DEPS pins, accept upstream structure |
-| `LNK2001 unresolved external` | C function name mismatch | Verify C API function names match exactly |
-| Build fails after merge | Missing `#include` for moved headers | Check upstream header relocation notes |
-| `static_assert` sizeof failure | Upstream struct gained/lost fields | Update C API struct in `sk_types.h` to match |
-| `#include` file not found | Upstream moved file to new module/path | Search target branch for new location, update path |
+| `static_assert` sizeof failure | Upstream struct gained/lost fields | Update C API struct in `sk_types.h` |
+| `#include` file not found | Upstream moved file to new path | Search target branch, update path |
+| `LNK2001 unresolved external` | C function name mismatch or missing lib | Verify names; check system library linkage |
+| `Unknown GN flag` error | Obsolete build flag | Remove flag; diff target BUILD.gn |
+| `git blame` all from merge commit | Tree-override merge was used | Redo as genuine conflict-resolved merge |
+| Merge conflict in DEPS | Both forks updated deps | Keep our pins, accept upstream structure |
+| Enum values don't match | Mid-sequence insertion | Regenerate bindings — never hand-edit |
+| Pixel mismatch by ±1 | Upstream precision change | Update expected test values |

--- a/.github/skills/update-skia/references/known-gotchas.md
+++ b/.github/skills/update-skia/references/known-gotchas.md
@@ -14,7 +14,12 @@ When upstream changes a C++ type from a `struct` to a `using` alias (e.g., `GrVk
 
 ### 3. Custom Patches May Partially Survive Merges
 
-SkiaSharp adds custom methods to upstream headers (e.g., `SkTypeface::RefDefault()`). After merge, implementations in `.cpp` files may survive but header declarations can be silently removed by upstream changes. Always verify header declarations match implementations.
+SkiaSharp adds custom methods to upstream headers (e.g., `SkTypeface::RefDefault()`). After merge, implementations in `.cpp` files may survive but header declarations can be silently removed by upstream changes.
+
+When header declarations are lost:
+1. **Check if upstream provides a replacement API** — if so, update the C API to use it
+2. **If no replacement exists**, re-add the declaration. But consider moving custom methods out of upstream headers and into our C API layer (`src/c/`) to avoid this recurring conflict
+3. **Never leave a mismatched header/implementation** — it compiles but crashes at runtime on some platforms
 
 ### 4. Fontconfig `#ifdef` Guards
 
@@ -28,7 +33,13 @@ Upstream m121+ added an `activate-emsdk` call in `tools/git-sync-deps`. Since Sk
 
 ### 6. `BUILD.gn` Legacy Flags
 
-Upstream may introduce defines like `SK_DEFAULT_TYPEFACE_IS_EMPTY` and `SK_DISABLE_LEGACY_DEFAULT_TYPEFACE` that break SkiaSharp's C API. Comment these out when they cause compilation errors. Also watch for renamed/removed GN flags between milestones — obsolete flags cause `Unknown GN flag` errors. Always diff the target `BUILD.gn` against the current one.
+Upstream progressively deprecates legacy APIs behind flags (e.g., `SK_DEFAULT_TYPEFACE_IS_EMPTY`, `SK_DISABLE_LEGACY_DEFAULT_TYPEFACE`). When these flags break SkiaSharp's C API:
+
+1. **Check what the flag removes** — read the upstream commit that added it
+2. **If the C API uses the removed behavior**, update the C API to use the replacement API. This is the real fix — upstream is signaling that the old API will be removed entirely in a future milestone.
+3. **Only as a short-term bridge** (with a TODO comment and tracking issue), you may comment out the flag to unblock the build while you work on the proper fix. Never leave a commented-out flag without a plan to address it.
+
+Also watch for renamed/removed GN flags between milestones — obsolete flags cause `Unknown GN flag` errors. Always diff the target `BUILD.gn` against the current one.
 
 ### 7. `.gitmodules` Branch Name
 

--- a/.github/skills/update-skia/references/known-gotchas.md
+++ b/.github/skills/update-skia/references/known-gotchas.md
@@ -65,6 +65,51 @@ HarfBuzz updates are **always separate** from Skia milestone updates. When the h
 
 HarfBuzz version bumps should be done separately via the `native-dependency-update` skill, which includes writing the required delegate proxies.
 
+## 11. Struct Size static_assert Failures
+
+`sk_structs.cpp` contains `static_assert(sizeof(our_c_type) == sizeof(CppType))` for every
+C API struct that is mapped via `reinterpret_cast`. When upstream adds fields to a C++ struct
+(e.g., `SkPngEncoder::Options` gaining `fGainmap` and `fGainmapInfo` in m133), the assert
+fires at compile time — but only if you actually build. During the analysis phase, you must
+**proactively check** every asserted struct against the target milestone's definition.
+
+```bash
+# List all asserted structs
+grep "static_assert.*sizeof" src/c/sk_structs.cpp
+# For each, compare C API struct in sk_types.h vs C++ struct at target milestone
+```
+
+**Fix:** Add corresponding fields to the C API struct in `include/c/sk_types.h`. For pointer
+fields that the C API doesn't need to expose, use `void*` defaulting to `nullptr`.
+
+## 12. Deleted Files ≠ Deleted Functionality
+
+Skia almost never removes functionality outright — **it relocates it**. When a file is deleted
+between milestones (e.g., `src/utils/SkJSON.h` → `modules/jsonreader/SkJSONReader.h` in m133),
+always search the target branch for where it moved:
+
+```bash
+git ls-tree -r upstream/chrome/m{TARGET} --name-only | grep -i "FILENAME_STEM"
+```
+
+**Never recommend "remove references"** to a deleted file without first finding the replacement.
+Code in our C API (especially `sk_linker.cpp` keep-alives) exists for a reason — update the
+`#include` path to the new location instead.
+
+## 13. Reordered Fields ≠ Removed Fields
+
+When reading diffs, a symbol appearing on a `-` line may have been **moved within the same
+file**, not removed. Always confirm removals by checking the symbol on the target branch:
+
+```bash
+# WRONG: "fSuppressPrints is on a minus line, it was removed"
+# RIGHT: Check the target branch directly
+git show upstream/chrome/m{TARGET}:include/gpu/ganesh/GrContextOptions.h | grep "fSuppressPrints"
+```
+
+This is especially common during struct reorganizations where fields are reordered into
+logical groups without any actual additions or removals.
+
 ---
 
 ## Troubleshooting
@@ -76,3 +121,5 @@ HarfBuzz version bumps should be done separately via the `native-dependency-upda
 | Merge conflict in DEPS | Both forks updated deps independently | Keep our DEPS pins, accept upstream structure |
 | `LNK2001 unresolved external` | C function name mismatch | Verify C API function names match exactly |
 | Build fails after merge | Missing `#include` for moved headers | Check upstream header relocation notes |
+| `static_assert` sizeof failure | Upstream struct gained/lost fields | Update C API struct in `sk_types.h` to match |
+| `#include` file not found | Upstream moved file to new module/path | Search target branch for new location, update path |

--- a/.github/skills/update-skia/references/typical-changes.md
+++ b/.github/skills/update-skia/references/typical-changes.md
@@ -2,17 +2,22 @@
 
 | Repository | File | Change |
 |-----------|------|--------|
+| mono/skia | `BUILD.gn` | Merge conflict resolution (most complex) |
 | mono/skia | `DEPS` | Merge conflict resolution |
 | mono/skia | `include/core/SkMilestone.h` | New milestone number (from upstream) |
-| mono/skia | `include/c/sk_types.h` | Enum/type updates |
+| mono/skia | `include/c/sk_types.h` | Enum/type updates, `SK_C_INCREMENT` reset |
 | mono/skia | `src/c/*.cpp` | C API fixes for new C++ APIs |
 | mono/skia | `src/c/sk_enums.cpp` | Enum mapping updates |
+| mono/skia | `src/c/sk_types_priv.h` | Include path + type conversion updates |
+| mono/SkiaSharp | `.gitmodules` | Submodule branch name |
 | mono/SkiaSharp | `externals/skia` | Submodule pointer |
 | mono/SkiaSharp | `scripts/VERSIONS.txt` | All version numbers |
 | mono/SkiaSharp | `cgmanifest.json` | Security tracking |
 | mono/SkiaSharp | `scripts/azure-pipelines-variables.yml` | CI config |
+| mono/SkiaSharp | `native/*/build.cake` | Per-platform GN flag updates |
 | mono/SkiaSharp | `binding/SkiaSharp/SkiaApi.generated.cs` | Regenerated |
-| mono/SkiaSharp | `binding/SkiaSharp/Definitions.cs` | Type definitions |
+| mono/SkiaSharp | `binding/SkiaSharp/Definitions.cs` | Type definitions, new enums |
 | mono/SkiaSharp | `binding/SkiaSharp/EnumMappings.cs` | Enum mappings |
+| mono/SkiaSharp | `binding/SkiaSharp/GRDefinitions.cs` | GPU type changes |
 | mono/SkiaSharp | `binding/libSkiaSharp.json` | Type config |
 | mono/SkiaSharp | `tests/Tests/SkiaSharp/*.cs` | Test updates |

--- a/.github/skills/update-skia/references/validation-prompt.md
+++ b/.github/skills/update-skia/references/validation-prompt.md
@@ -12,8 +12,20 @@ Please validate by (run from externals/skia):
 1. Run: git diff upstream/chrome/m{CURRENT}..upstream/chrome/m{TARGET} --stat -- src/ include/
    Count the files changed and compare to my analysis — did I miss any?
 2. For each HIGH/MEDIUM item I identified, verify the C API impact by grepping src/c/ include/c/
-3. Check for changes I may have filtered as "Graphite-only" that actually affect Ganesh
+3. Check for changes I may have filtered as "Graphite-only" that actually affect Ganesh:
+   - Search shared GPU headers (include/gpu/GpuTypes.h, include/gpu/*.h outside ganesh/ and graphite/)
+   - For each new type, grep include/gpu/ganesh/ to see if Ganesh consumes it
 4. Check for removed/moved headers that our C API includes:
    grep -rh '#include' src/c/*.cpp | sort -u
    Then verify each included header still exists at upstream/chrome/m{TARGET}
-5. Report: missed items, incorrect classifications, and confirmed items
+5. **Struct size audit**: Check every `static_assert(sizeof(...))` in src/c/sk_structs.cpp.
+   For each asserted C++ struct, compare the target milestone's definition against our
+   C API struct in include/c/sk_types.h. Flag any struct that gained or lost fields.
+6. **Deleted file audit**: For each file deleted between milestones
+   (git diff --diff-filter=D --name-only), check if our C API references it (#include
+   or uses its types). For referenced deletions, search the target branch for where the
+   content moved (git ls-tree -r upstream/chrome/m{TARGET} --name-only | grep STEM).
+7. **Removal verification**: For any symbol claimed "removed" in the analysis, verify it
+   is truly absent from the target branch (not just moved within the file):
+   git show upstream/chrome/m{TARGET}:PATH | grep SYMBOL
+8. Report: missed items, incorrect classifications, and confirmed items


### PR DESCRIPTION
## Summary

Improves the `update-skia` skill based on lessons learned during the m132→m133 breaking change analysis, incorporating useful findings from PR #3644 (community contribution).

**Net effect: better quality, less duplication (-50 lines in the consolidation commit).**

## Changes

### Commit 1: Lessons from m133 analysis
- Add verification checks for struct sizes, moved files, and diff-reading traps
- Add m132→m133 historical example to breaking-changes-checklist
- Add gotchas #11-13 from m133 experience

### Commit 2: Consolidate and reduce duplication
- Merge overlapping content from Steps 4a/4b/4c (checklist) and gotchas 11/12/13 into single locations
- Reorganize gotchas from flat numbered list into themed sections (C API, build, deps, diff reading, merge, testing)
- Replace separate "Common C API Patterns" with unified "Recurring patterns" table
- Incorporate merge strategy, conflict resolution table, and `git blame` gate from PR #3644
- Add missing typical-changes entries (BUILD.gn, .gitmodules, native build cakes)
- Remove "MANDATORY" headers that diluted the signal

### Commit 3: Fix guidance that hides issues
- Gotcha #6 (BUILD.gn legacy flags): Replace "comment these out" with proper investigation flow
- Gotcha #3 (custom patches): Add concrete steps for when header declarations diverge
- Phase 5: Flag removed enum values as C# breaking changes requiring `[Obsolete]`
- Fix duplicate step in Phase 2 (copy-paste)

## Motivation

During the m133 analysis, three errors were made that the skill should have prevented:
1. Recommended removing SkJSON references instead of finding the new location (`modules/jsonreader/`)
2. Missed `SkPngEncoder::Options` struct size change (caught by validation agent, not analysis)
3. Misread `fSuppressPrints` as removed when it was reordered within `GrContextOptions.h`

Additionally, the skill had guidance that masked problems rather than solving them (commenting out legacy flags, verifying without action steps, silently removing enum values).