### PR TITLE
Bump skia to milestone 133 (Opus 4.6)

### DIFF
--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -19894,9 +19894,15 @@ namespace SkiaSharp {
 		// public const char* fICCProfileDescription
 		private readonly /* char */ void* fICCProfileDescription;
 
+		// public const void* fGainmap
+		private readonly void* fGainmap;
+
+		// public const void* fGainmapInfo
+		private readonly void* fGainmapInfo;
+
 		public readonly bool Equals (SKPngEncoderOptions obj) =>
 #pragma warning disable CS8909
-			fFilterFlags == obj.fFilterFlags && fZLibLevel == obj.fZLibLevel && fComments == obj.fComments && fICCProfile == obj.fICCProfile && fICCProfileDescription == obj.fICCProfileDescription;
+			fFilterFlags == obj.fFilterFlags && fZLibLevel == obj.fZLibLevel && fComments == obj.fComments && fICCProfile == obj.fICCProfile && fICCProfileDescription == obj.fICCProfileDescription && fGainmap == obj.fGainmap && fGainmapInfo == obj.fGainmapInfo;
 #pragma warning restore CS8909
 
 		public readonly override bool Equals (object obj) =>
@@ -19916,6 +19922,8 @@ namespace SkiaSharp {
 			hash.Add (fComments);
 			hash.Add (fICCProfile);
 			hash.Add (fICCProfileDescription);
+			hash.Add (fGainmap);
+			hash.Add (fGainmapInfo);
 			return hash.ToHashCode ();
 		}
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "8c99e432ff06e61c42cf99aa8f2cbe248d301b9a"
+          "commitHash": "2510afc6f734578021e0f703e9e2928224a4c885"
         }
       }
     },
@@ -233,12 +233,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m132",
+          "version": "chrome/m133",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 132,
-      "upstream_merge_commit": "9ab7c2064b2b1ab22f856a7f0a8c3b3ae4cb89c7"
+      "chrome_milestone": 133,
+      "upstream_merge_commit": "f7d1434fdf0276eb2820dea2a2922c44baf92807"
     }
   ]
 }

--- a/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-lskia",
+					"-ljsonreader",
 					"-lskottie",
 					"-lsksg",
 					"-lskshaper",
@@ -458,6 +459,7 @@
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-lskia",
+					"-ljsonreader",
 					"-lskottie",
 					"-lsksg",
 					"-lskshaper",

--- a/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				OTHER_LDFLAGS = (
 					"-lskia",
+					"-ljsonreader",
 					"-lskottie",
 					"-lsksg",
 					"-lskshaper",
@@ -408,6 +409,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				OTHER_LDFLAGS = (
 					"-lskia",
+					"-ljsonreader",
 					"-lskottie",
 					"-lsksg",
 					"-lskshaper",

--- a/native/tizen/libSkiaSharp/project_def.prop
+++ b/native/tizen/libSkiaSharp/project_def.prop
@@ -5,7 +5,7 @@ skia_root = $(abspath ../../../externals/skia)
 
 USER_LIB_DIRS = $(skia_root)/out/tizen/$(BUILD_ARCH)
 
-USER_LIBS = skia skresources skottie sksg skshaper
+USER_LIBS = skia jsonreader skresources skottie sksg skshaper
 
 USER_LINK_OPTS = -Wl,--gc-sections
 

--- a/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-lskia",
+					"-ljsonreader",
 					"-lskottie",
 					"-lsksg",
 					"-lskshaper",
@@ -456,6 +457,7 @@
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-lskia",
+					"-ljsonreader",
 					"-lskottie",
 					"-lsksg",
 					"-lskshaper",

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     8.3.1
-skia                                            release     m132
+skia                                            release     m133
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -49,18 +49,18 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   132
+libSkiaSharp            milestone   133
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      132.0.0
+libSkiaSharp            soname      133.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.60831.0
 
 # SkiaSharp.dll
-SkiaSharp               assembly    3.132.0.0
-SkiaSharp               file        3.132.0.0
+SkiaSharp               assembly    3.133.0.0
+SkiaSharp               file        3.133.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -68,36 +68,36 @@ HarfBuzzSharp           file        8.3.1.5
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       3.132.0
-SkiaSharp.NativeAssets.Linux                    nuget       3.132.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       3.132.0
-SkiaSharp.NativeAssets.NanoServer               nuget       3.132.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       3.132.0
-SkiaSharp.NativeAssets.Android                  nuget       3.132.0
-SkiaSharp.NativeAssets.iOS                      nuget       3.132.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       3.132.0
-SkiaSharp.NativeAssets.macOS                    nuget       3.132.0
-SkiaSharp.NativeAssets.Tizen                    nuget       3.132.0
-SkiaSharp.NativeAssets.tvOS                     nuget       3.132.0
-SkiaSharp.NativeAssets.Win32                    nuget       3.132.0
-SkiaSharp.NativeAssets.WinUI                    nuget       3.132.0
-SkiaSharp.Views                                 nuget       3.132.0
-SkiaSharp.Views.Desktop.Common                  nuget       3.132.0
-SkiaSharp.Views.Gtk3                            nuget       3.132.0
-SkiaSharp.Views.Gtk4                            nuget       3.132.0
-SkiaSharp.Views.WindowsForms                    nuget       3.132.0
-SkiaSharp.Views.WPF                             nuget       3.132.0
-SkiaSharp.Views.Uno.WinUI                       nuget       3.132.0
-SkiaSharp.Views.WinUI                           nuget       3.132.0
-SkiaSharp.Views.Maui.Core                       nuget       3.132.0
-SkiaSharp.Views.Maui.Controls                   nuget       3.132.0
-SkiaSharp.Views.Blazor                          nuget       3.132.0
-SkiaSharp.HarfBuzz                              nuget       3.132.0
-SkiaSharp.Skottie                               nuget       3.132.0
-SkiaSharp.SceneGraph                            nuget       3.132.0
-SkiaSharp.Resources                             nuget       3.132.0
-SkiaSharp.Vulkan.SharpVk                        nuget       3.132.0
-SkiaSharp.Direct3D.Vortice                      nuget       3.132.0
+SkiaSharp                                       nuget       3.133.0
+SkiaSharp.NativeAssets.Linux                    nuget       3.133.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       3.133.0
+SkiaSharp.NativeAssets.NanoServer               nuget       3.133.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       3.133.0
+SkiaSharp.NativeAssets.Android                  nuget       3.133.0
+SkiaSharp.NativeAssets.iOS                      nuget       3.133.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       3.133.0
+SkiaSharp.NativeAssets.macOS                    nuget       3.133.0
+SkiaSharp.NativeAssets.Tizen                    nuget       3.133.0
+SkiaSharp.NativeAssets.tvOS                     nuget       3.133.0
+SkiaSharp.NativeAssets.Win32                    nuget       3.133.0
+SkiaSharp.NativeAssets.WinUI                    nuget       3.133.0
+SkiaSharp.Views                                 nuget       3.133.0
+SkiaSharp.Views.Desktop.Common                  nuget       3.133.0
+SkiaSharp.Views.Gtk3                            nuget       3.133.0
+SkiaSharp.Views.Gtk4                            nuget       3.133.0
+SkiaSharp.Views.WindowsForms                    nuget       3.133.0
+SkiaSharp.Views.WPF                             nuget       3.133.0
+SkiaSharp.Views.Uno.WinUI                       nuget       3.133.0
+SkiaSharp.Views.WinUI                           nuget       3.133.0
+SkiaSharp.Views.Maui.Core                       nuget       3.133.0
+SkiaSharp.Views.Maui.Controls                   nuget       3.133.0
+SkiaSharp.Views.Blazor                          nuget       3.133.0
+SkiaSharp.HarfBuzz                              nuget       3.133.0
+SkiaSharp.Skottie                               nuget       3.133.0
+SkiaSharp.SceneGraph                            nuget       3.133.0
+SkiaSharp.Resources                             nuget       3.133.0
+SkiaSharp.Vulkan.SharpVk                        nuget       3.133.0
+SkiaSharp.Direct3D.Vortice                      nuget       3.133.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       8.3.1.5
 HarfBuzzSharp.NativeAssets.Android              nuget       8.3.1.5


### PR DESCRIPTION
## Summary

Update Skia from milestone 132 to 133.

**Depends on**: mono/skia PR (link below — must be merged first to update submodule)

🔗 **mono/skia PR**: https://github.com/mono/skia/compare/skiasharp...dev/update-skia-m133

## Changes

### Submodule & Versions
- Updated `externals/skia` submodule to `dev/update-skia-m133` branch
- Updated `scripts/VERSIONS.txt`: milestone 132→133, all version numbers
- Updated `cgmanifest.json`: commit hash, chrome_milestone, upstream_merge_commit

### Regenerated Bindings
- `binding/SkiaSharp/SkiaApi.generated.cs`: Added `fGainmap` and `fGainmapInfo` fields to `SKPngEncoderOptions` struct (matching upstream `SkPngEncoder::Options` change)

### Platform Build Configs
- Added `-ljsonreader` to Apple Xcode projects (macOS, iOS, tvOS) — upstream moved `SkJSON` to `modules/jsonreader` in m133
- Added `jsonreader` to Tizen `project_def.prop` link libraries

## Breaking Changes Handled (m132 → m133)

| Change | Risk | Action |
|--------|------|--------|
| `SkJSON.h` → `modules/jsonreader/SkJSONReader.h` | 🔴 | Updated include + link configs |
| `SkPngEncoder::Options` gained gainmap fields | 🔴 | Updated C struct + regenerated |
| `-fstrict-aliasing` extracted to GN config | 🔴 | Added config blocks in skia |
| `SkMaskFilter::approximateFilteredBounds` removed | 🟢 | Not wrapped — no action |
| `GrContextOptions` fields reordered | 🟢 | Field-by-field copy — no action |

## Testing
- ✅ Native build succeeds (macOS arm64)
- ✅ C# build succeeds (0 errors)
- ✅ 5,369 tests passed, 12 skipped (no GPU hardware), 1 flaky GC test (passes on retry)