### PR TITLE
Bump skia to milestone 133 (GPT 5.4)

### DIFF
--- a/binding/SkiaSharp/SKColorSpace.cs
+++ b/binding/SkiaSharp/SKColorSpace.cs
@@ -110,6 +110,11 @@ namespace SkiaSharp
 		public static SKColorSpace CreateRgb (SKColorSpaceTransferFn transferFn, SKColorSpaceXyz toXyzD50) =>
 			GetObject (SkiaApi.sk_colorspace_new_rgb (&transferFn, &toXyzD50));
 
+		// CreateCicp
+
+		public static SKColorSpace CreateCicp (SKColorspacePrimariesCicp colorPrimaries, SKColorspaceTransferFnCicp transferCharacteristics) =>
+			GetObject (SkiaApi.sk_colorspace_new_cicp (colorPrimaries, transferCharacteristics));
+
 		// GetNumericalTransferFunction
 
 		public SKColorSpaceTransferFn GetNumericalTransferFunction () =>

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -4447,6 +4447,25 @@ namespace SkiaSharp
 			(sk_colorspace_make_srgb_gamma_delegate ??= GetSymbol<Delegates.sk_colorspace_make_srgb_gamma> ("sk_colorspace_make_srgb_gamma")).Invoke (colorspace);
 		#endif
 
+		// sk_colorspace_t* sk_colorspace_new_cicp(sk_colorspace_primaries_cicp_t colorPrimaries, sk_colorspace_transfer_fn_cicp_t transferCharacteristics)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_colorspace_t sk_colorspace_new_cicp (SKColorspacePrimariesCicp colorPrimaries, SKColorspaceTransferFnCicp transferCharacteristics);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_colorspace_t sk_colorspace_new_cicp (SKColorspacePrimariesCicp colorPrimaries, SKColorspaceTransferFnCicp transferCharacteristics);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_colorspace_t sk_colorspace_new_cicp (SKColorspacePrimariesCicp colorPrimaries, SKColorspaceTransferFnCicp transferCharacteristics);
+		}
+		private static Delegates.sk_colorspace_new_cicp sk_colorspace_new_cicp_delegate;
+		internal static sk_colorspace_t sk_colorspace_new_cicp (SKColorspacePrimariesCicp colorPrimaries, SKColorspaceTransferFnCicp transferCharacteristics) =>
+			(sk_colorspace_new_cicp_delegate ??= GetSymbol<Delegates.sk_colorspace_new_cicp> ("sk_colorspace_new_cicp")).Invoke (colorPrimaries, transferCharacteristics);
+		#endif
+
 		// sk_colorspace_t* sk_colorspace_new_icc(const sk_colorspace_icc_profile_t* profile)
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
@@ -19894,9 +19913,15 @@ namespace SkiaSharp {
 		// public const char* fICCProfileDescription
 		private readonly /* char */ void* fICCProfileDescription;
 
+		// public const void* fGainmap
+		private readonly void* fGainmap;
+
+		// public const void* fGainmapInfo
+		private readonly void* fGainmapInfo;
+
 		public readonly bool Equals (SKPngEncoderOptions obj) =>
 #pragma warning disable CS8909
-			fFilterFlags == obj.fFilterFlags && fZLibLevel == obj.fZLibLevel && fComments == obj.fComments && fICCProfile == obj.fICCProfile && fICCProfileDescription == obj.fICCProfileDescription;
+			fFilterFlags == obj.fFilterFlags && fZLibLevel == obj.fZLibLevel && fComments == obj.fComments && fICCProfile == obj.fICCProfile && fICCProfileDescription == obj.fICCProfileDescription && fGainmap == obj.fGainmap && fGainmapInfo == obj.fGainmapInfo;
 #pragma warning restore CS8909
 
 		public readonly override bool Equals (object obj) =>
@@ -19916,6 +19941,8 @@ namespace SkiaSharp {
 			hash.Add (fComments);
 			hash.Add (fICCProfile);
 			hash.Add (fICCProfileDescription);
+			hash.Add (fGainmap);
+			hash.Add (fGainmapInfo);
 			return hash.ToHashCode ();
 		}
 
@@ -20600,6 +20627,66 @@ namespace SkiaSharp {
 		B = 2,
 		// A_SK_COLOR_CHANNEL = 3
 		A = 3,
+	}
+
+	// sk_colorspace_primaries_cicp_t
+	public enum SKColorspacePrimariesCicp {
+		// UNKNOWN_SK_COLORSPACE_PRIMARIES_CICP = 0
+		Unknown = 0,
+		// REC709_SK_COLORSPACE_PRIMARIES_CICP = 1
+		Rec709 = 1,
+		// REC470_SYSTEM_M_SK_COLORSPACE_PRIMARIES_CICP = 4
+		Rec470SystemM = 4,
+		// REC470_SYSTEM_BG_SK_COLORSPACE_PRIMARIES_CICP = 5
+		Rec470SystemBg = 5,
+		// REC601_SK_COLORSPACE_PRIMARIES_CICP = 6
+		Rec601 = 6,
+		// SMPTE_ST240_SK_COLORSPACE_PRIMARIES_CICP = 7
+		SmpteSt240 = 7,
+		// GENERIC_FILM_SK_COLORSPACE_PRIMARIES_CICP = 8
+		GenericFilm = 8,
+		// REC2020_SK_COLORSPACE_PRIMARIES_CICP = 9
+		Rec2020 = 9,
+		// SMPTE_ST428_1_SK_COLORSPACE_PRIMARIES_CICP = 10
+		SmpteSt4281 = 10,
+		// SMPTE_RP431_2_SK_COLORSPACE_PRIMARIES_CICP = 11
+		SmpteRp4312 = 11,
+		// SMPTE_EG432_1_SK_COLORSPACE_PRIMARIES_CICP = 12
+		SmpteEg4321 = 12,
+		// ITU_T_H273_VALUE22_SK_COLORSPACE_PRIMARIES_CICP = 22
+		ItuTH273Value22 = 22,
+	}
+
+	// sk_colorspace_transfer_fn_cicp_t
+	public enum SKColorspaceTransferFnCicp {
+		// UNKNOWN_SK_COLORSPACE_TRANSFER_FN_CICP = 0
+		Unknown = 0,
+		// REC709_SK_COLORSPACE_TRANSFER_FN_CICP = 1
+		Rec709 = 1,
+		// REC470_SYSTEM_M_SK_COLORSPACE_TRANSFER_FN_CICP = 4
+		Rec470SystemM = 4,
+		// REC470_SYSTEM_BG_SK_COLORSPACE_TRANSFER_FN_CICP = 5
+		Rec470SystemBg = 5,
+		// REC601_SK_COLORSPACE_TRANSFER_FN_CICP = 6
+		Rec601 = 6,
+		// SMPTE_ST240_SK_COLORSPACE_TRANSFER_FN_CICP = 7
+		SmpteSt240 = 7,
+		// LINEAR_SK_COLORSPACE_TRANSFER_FN_CICP = 8
+		Linear = 8,
+		// IEC61966_2_4_SK_COLORSPACE_TRANSFER_FN_CICP = 11
+		Iec6196624 = 11,
+		// IEC61966_2_1_SK_COLORSPACE_TRANSFER_FN_CICP = 13
+		Iec6196621 = 13,
+		// REC2020_10BIT_SK_COLORSPACE_TRANSFER_FN_CICP = 14
+		Rec202010bit = 14,
+		// REC2020_12BIT_SK_COLORSPACE_TRANSFER_FN_CICP = 15
+		Rec202012bit = 15,
+		// PQ_SK_COLORSPACE_TRANSFER_FN_CICP = 16
+		Pq = 16,
+		// SMPTE_ST428_1_SK_COLORSPACE_TRANSFER_FN_CICP = 17
+		SmpteSt4281 = 17,
+		// HLG_SK_COLORSPACE_TRANSFER_FN_CICP = 18
+		Hlg = 18,
 	}
 
 	// sk_colortype_t

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "8c99e432ff06e61c42cf99aa8f2cbe248d301b9a"
+          "commitHash": "74ddd4ca19723824d4261e863eaf487c199ca537"
         }
       }
     },
@@ -233,12 +233,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m132",
+          "version": "chrome/m133",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 132,
-      "upstream_merge_commit": "9ab7c2064b2b1ab22f856a7f0a8c3b3ae4cb89c7"
+      "chrome_milestone": 133,
+      "upstream_merge_commit": "f7d1434fdf0276eb2820dea2a2922c44baf92807"
     }
   ]
 }

--- a/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 					"-lsksg",
 					"-lskshaper",
 					"-lskresources",
+					"-ljsonreader",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.libSkiaSharp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -462,6 +463,7 @@
 					"-lsksg",
 					"-lskshaper",
 					"-lskresources",
+					"-ljsonreader",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.libSkiaSharp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 					"-lsksg",
 					"-lskshaper",
 					"-lskresources",
+					"-ljsonreader",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -412,6 +413,7 @@
 					"-lsksg",
 					"-lskshaper",
 					"-lskresources",
+					"-ljsonreader",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/native/tizen/libSkiaSharp/project_def.prop
+++ b/native/tizen/libSkiaSharp/project_def.prop
@@ -5,7 +5,7 @@ skia_root = $(abspath ../../../externals/skia)
 
 USER_LIB_DIRS = $(skia_root)/out/tizen/$(BUILD_ARCH)
 
-USER_LIBS = skia skresources skottie sksg skshaper
+USER_LIBS = skia skresources skottie sksg skshaper jsonreader
 
 USER_LINK_OPTS = -Wl,--gc-sections
 

--- a/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 					"-lsksg",
 					"-lskshaper",
 					"-lskresources",
+					"-ljsonreader",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.libSkiaSharp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -460,6 +461,7 @@
 					"-lsksg",
 					"-lskshaper",
 					"-lskresources",
+					"-ljsonreader",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.libSkiaSharp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     8.3.1
-skia                                            release     m132
+skia                                            release     m133
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -49,18 +49,18 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   132
+libSkiaSharp            milestone   133
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      132.0.0
+libSkiaSharp            soname      133.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.60831.0
 
 # SkiaSharp.dll
-SkiaSharp               assembly    3.132.0.0
-SkiaSharp               file        3.132.0.0
+SkiaSharp               assembly    3.133.0.0
+SkiaSharp               file        3.133.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -68,36 +68,36 @@ HarfBuzzSharp           file        8.3.1.5
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       3.132.0
-SkiaSharp.NativeAssets.Linux                    nuget       3.132.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       3.132.0
-SkiaSharp.NativeAssets.NanoServer               nuget       3.132.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       3.132.0
-SkiaSharp.NativeAssets.Android                  nuget       3.132.0
-SkiaSharp.NativeAssets.iOS                      nuget       3.132.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       3.132.0
-SkiaSharp.NativeAssets.macOS                    nuget       3.132.0
-SkiaSharp.NativeAssets.Tizen                    nuget       3.132.0
-SkiaSharp.NativeAssets.tvOS                     nuget       3.132.0
-SkiaSharp.NativeAssets.Win32                    nuget       3.132.0
-SkiaSharp.NativeAssets.WinUI                    nuget       3.132.0
-SkiaSharp.Views                                 nuget       3.132.0
-SkiaSharp.Views.Desktop.Common                  nuget       3.132.0
-SkiaSharp.Views.Gtk3                            nuget       3.132.0
-SkiaSharp.Views.Gtk4                            nuget       3.132.0
-SkiaSharp.Views.WindowsForms                    nuget       3.132.0
-SkiaSharp.Views.WPF                             nuget       3.132.0
-SkiaSharp.Views.Uno.WinUI                       nuget       3.132.0
-SkiaSharp.Views.WinUI                           nuget       3.132.0
-SkiaSharp.Views.Maui.Core                       nuget       3.132.0
-SkiaSharp.Views.Maui.Controls                   nuget       3.132.0
-SkiaSharp.Views.Blazor                          nuget       3.132.0
-SkiaSharp.HarfBuzz                              nuget       3.132.0
-SkiaSharp.Skottie                               nuget       3.132.0
-SkiaSharp.SceneGraph                            nuget       3.132.0
-SkiaSharp.Resources                             nuget       3.132.0
-SkiaSharp.Vulkan.SharpVk                        nuget       3.132.0
-SkiaSharp.Direct3D.Vortice                      nuget       3.132.0
+SkiaSharp                                       nuget       3.133.0
+SkiaSharp.NativeAssets.Linux                    nuget       3.133.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       3.133.0
+SkiaSharp.NativeAssets.NanoServer               nuget       3.133.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       3.133.0
+SkiaSharp.NativeAssets.Android                  nuget       3.133.0
+SkiaSharp.NativeAssets.iOS                      nuget       3.133.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       3.133.0
+SkiaSharp.NativeAssets.macOS                    nuget       3.133.0
+SkiaSharp.NativeAssets.Tizen                    nuget       3.133.0
+SkiaSharp.NativeAssets.tvOS                     nuget       3.133.0
+SkiaSharp.NativeAssets.Win32                    nuget       3.133.0
+SkiaSharp.NativeAssets.WinUI                    nuget       3.133.0
+SkiaSharp.Views                                 nuget       3.133.0
+SkiaSharp.Views.Desktop.Common                  nuget       3.133.0
+SkiaSharp.Views.Gtk3                            nuget       3.133.0
+SkiaSharp.Views.Gtk4                            nuget       3.133.0
+SkiaSharp.Views.WindowsForms                    nuget       3.133.0
+SkiaSharp.Views.WPF                             nuget       3.133.0
+SkiaSharp.Views.Uno.WinUI                       nuget       3.133.0
+SkiaSharp.Views.WinUI                           nuget       3.133.0
+SkiaSharp.Views.Maui.Core                       nuget       3.133.0
+SkiaSharp.Views.Maui.Controls                   nuget       3.133.0
+SkiaSharp.Views.Blazor                          nuget       3.133.0
+SkiaSharp.HarfBuzz                              nuget       3.133.0
+SkiaSharp.Skottie                               nuget       3.133.0
+SkiaSharp.SceneGraph                            nuget       3.133.0
+SkiaSharp.Resources                             nuget       3.133.0
+SkiaSharp.Vulkan.SharpVk                        nuget       3.133.0
+SkiaSharp.Direct3D.Vortice                      nuget       3.133.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       8.3.1.5
 HarfBuzzSharp.NativeAssets.Android              nuget       8.3.1.5

--- a/tests/Tests/SkiaSharp/SKColorSpaceTest.cs
+++ b/tests/Tests/SkiaSharp/SKColorSpaceTest.cs
@@ -292,6 +292,21 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		public void CicpSrgbColorSpaceIsCorrect()
+		{
+			var colorspace = SKColorSpace.CreateCicp(
+				SKColorspacePrimariesCicp.Rec709,
+				SKColorspaceTransferFnCicp.Iec6196621);
+
+			Assert.NotNull(colorspace);
+			Assert.True(colorspace.IsSrgb);
+			Assert.True(colorspace.GammaIsCloseToSrgb);
+			Assert.False(colorspace.GammaIsLinear);
+			Assert.Equal(SKColorSpaceTransferFn.Srgb, colorspace.GetNumericalTransferFunction());
+			Assert.Equal(SKColorSpaceXyz.Srgb, colorspace.ToColorSpaceXyz());
+		}
+
+		[SkippableFact]
 		public void SameColorSpaceCreatedDifferentWaysAreTheSameObject()
 		{
 			// the instance is static, so all instances in .NET are the same instance


### PR DESCRIPTION
## Summary
- bump SkiaSharp from m132 to m133
- link Apple and Tizen native projects against the new `jsonreader` library
- regenerate bindings and add `SKColorSpace.CreateCicp(...)` plus coverage

## Validation
- `dotnet cake --target=externals-macos --arch=arm64`
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj`
- `dotnet test tests/SkiaSharp.Tests.Console.sln --filter "Category=Smoke"`
- `dotnet test tests/SkiaSharp.Tests.Console.sln`

Skia submodule PR branch: `dev/update-skia-133-fresh`