### PR TITLE
Fix docs deploy race condition by serializing Go Live deployments

### DIFF
--- a/.github/workflows/build-site-go-live.yml
+++ b/.github/workflows/build-site-go-live.yml
@@ -12,10 +12,13 @@ on:
 # Default to no permissions — each job declares only what it needs.
 permissions: {}
 
-# Ensure go-live runs one at a time (latest wins)
+# Serialize go-live deployments: each must complete before the next starts.
+# cancel-in-progress must be false — cancelling a running deploy-pages action
+# orphans the in-progress GitHub Pages deployment, which then blocks all
+# subsequent deployments with "due to in progress deployment" errors.
 concurrency:
   group: "docs-go-live"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
## Problem

The "Docs - Go Live!" workflow has `cancel-in-progress: true` on its concurrency group. When multiple docs deploys trigger close together (e.g. pushing to multiple PRs), the newer Go Live run cancels the older one mid-flight. However, the cancelled `deploy-pages` action has already created a deployment at the GitHub Pages API level — that deployment is now orphaned and remains "in progress" indefinitely, blocking all subsequent deployments with:

> `Deployment request failed due to in progress deployment. Please cancel [X] first or wait for it to complete.`

This has been causing intermittent failures across both the "Docs - Go Live!" and "pages build and deployment" workflows. Recent examples:
- https://github.com/mono/SkiaSharp/actions/runs/24424688470
- https://github.com/mono/SkiaSharp/actions/runs/24424497375
- https://github.com/mono/SkiaSharp/actions/runs/24423007756

## Fix

Change `cancel-in-progress` from `true` to `false` on the `docs-go-live` concurrency group. This ensures each GitHub Pages deployment completes fully before the next one starts. GitHub Actions concurrency still skips stale pending runs (only the latest pending run is kept), so we don't waste time on outdated deploys — they just aren't cancelled mid-flight.

## Note

There is also a secondary race between the custom "Docs - Go Live!" workflow and the built-in "pages build and deployment" workflow. If GitHub Pages is configured to "Deploy from a branch" (`docs-live`), both workflows will try to create deployments simultaneously. To fully resolve this, the Pages source should be set to **"GitHub Actions"** in **Settings → Pages → Source**, which disables the built-in workflow.