### PR TITLE
[build] Split Tizen native CI into per-architecture jobs

### DIFF
--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -33,7 +33,7 @@ Task("libSkiaSharp")
 
     void Build(string outputDir, string skiaArch, string tizenArch, string rootstrap, string profile, string ncliVersion)
     {
-        if (Skip(outputDir)) return;
+        if (Skip(skiaArch)) return;
 
         GnNinja($"tizen/{outputDir}", "skia modules/skottie",
            $"target_os='tizen' " +
@@ -73,14 +73,14 @@ Task("libSkiaSharp")
 Task("libHarfBuzzSharp")
     .Does(() =>
 {
-    Build("armel", "arm",     "mobile-6.0-device.core",     "mobile-6.0");
-    Build("i586",  "x86",     "mobile-6.0-emulator.core",   "mobile-6.0");
-    Build("x86_64","x86_64",  "tizen-8.0-emulator64.core",  "tizen-8.0");
-    Build("aarch64","aarch64","tizen-8.0-device64.core",     "tizen-8.0");
+    Build("armel", "arm",   "arm",     "mobile-6.0-device.core",     "mobile-6.0");
+    Build("i586",  "x86",  "x86",     "mobile-6.0-emulator.core",   "mobile-6.0");
+    Build("x86_64","x64",  "x86_64",  "tizen-8.0-emulator64.core",  "tizen-8.0");
+    Build("aarch64","arm64","aarch64", "tizen-8.0-device64.core",     "tizen-8.0");
 
-    void Build(string outputDir, string tizenArch, string rootstrap, string profile)
+    void Build(string outputDir, string skiaArch, string tizenArch, string rootstrap, string profile)
     {
-        if (Skip(outputDir)) return;
+        if (Skip(skiaArch)) return;
 
         SetProjectProfile("libHarfBuzzSharp", profile);
 

--- a/scripts/azure-templates-stages-native-linux.yml
+++ b/scripts/azure-templates-stages-native-linux.yml
@@ -54,13 +54,3 @@ stages:
                 variant: bionic
                 docker: scripts/Docker/bionic
 
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen (Linux)
-        parameters:
-          name: native_tizen_linux
-          displayName: Tizen
-          buildAgent: ${{ parameters.buildAgentLinuxNative }}
-          buildExternals: ${{ parameters.buildExternals }}
-          use1ESPipelineTemplates: ${{ parameters.use1ESPipelineTemplates }}
-          packages: $(TIZEN_LINUX_PACKAGES)
-          target: externals-tizen
-          condition: false # https://github.com/mono/SkiaSharp/issues/2933

--- a/scripts/azure-templates-stages-native-macos.yml
+++ b/scripts/azure-templates-stages-native-macos.yml
@@ -72,33 +72,33 @@ stages:
           target: externals-tvos
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|arm (macOS)
         parameters:
-          name: native_tizen_armel_macos
+          name: native_tizen_arm_macos
           displayName: Tizen arm
           buildAgent: ${{ parameters.buildAgentMacNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=armel
+          additionalArgs: --buildarch=arm
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|x86 (macOS)
         parameters:
-          name: native_tizen_i586_macos
+          name: native_tizen_x86_macos
           displayName: Tizen x86
           buildAgent: ${{ parameters.buildAgentMacNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=i586
+          additionalArgs: --buildarch=x86
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|x64 (macOS)
         parameters:
-          name: native_tizen_x86_64_macos
+          name: native_tizen_x64_macos
           displayName: Tizen x64
           buildAgent: ${{ parameters.buildAgentMacNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=x86_64
+          additionalArgs: --buildarch=x64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|arm64 (macOS)
         parameters:
-          name: native_tizen_aarch64_macos
+          name: native_tizen_arm64_macos
           displayName: Tizen arm64
           buildAgent: ${{ parameters.buildAgentMacNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=aarch64
+          additionalArgs: --buildarch=arm64

--- a/scripts/azure-templates-stages-native-macos.yml
+++ b/scripts/azure-templates-stages-native-macos.yml
@@ -70,10 +70,35 @@ stages:
           buildAgent: ${{ parameters.buildAgentMacNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tvos
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen (macOS)
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|arm (macOS)
         parameters:
-          name: native_tizen_macos
-          displayName: Tizen
+          name: native_tizen_armel_macos
+          displayName: Tizen arm
           buildAgent: ${{ parameters.buildAgentMacNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
+          additionalArgs: --buildarch=armel
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|x86 (macOS)
+        parameters:
+          name: native_tizen_i586_macos
+          displayName: Tizen x86
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          buildExternals: ${{ parameters.buildExternals }}
+          target: externals-tizen
+          additionalArgs: --buildarch=i586
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|x64 (macOS)
+        parameters:
+          name: native_tizen_x86_64_macos
+          displayName: Tizen x64
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          buildExternals: ${{ parameters.buildExternals }}
+          target: externals-tizen
+          additionalArgs: --buildarch=x86_64
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Tizen|arm64 (macOS)
+        parameters:
+          name: native_tizen_aarch64_macos
+          displayName: Tizen arm64
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          buildExternals: ${{ parameters.buildExternals }}
+          target: externals-tizen
+          additionalArgs: --buildarch=aarch64

--- a/scripts/azure-templates-stages-native-merge.yml
+++ b/scripts/azure-templates-stages-native-merge.yml
@@ -25,10 +25,10 @@ stages:
             - name: native_android_arm_windows
             - name: native_android_arm64_windows
             # Tizen
-            - name: native_tizen_armel_windows
-            - name: native_tizen_i586_windows
-            - name: native_tizen_x86_64_windows
-            - name: native_tizen_aarch64_windows
+            - name: native_tizen_arm_windows
+            - name: native_tizen_x86_windows
+            - name: native_tizen_x64_windows
+            - name: native_tizen_arm64_windows
             # Win32
             - name: native_win32_x86_windows
             - name: native_win32_x64_windows

--- a/scripts/azure-templates-stages-native-merge.yml
+++ b/scripts/azure-templates-stages-native-merge.yml
@@ -25,7 +25,10 @@ stages:
             - name: native_android_arm_windows
             - name: native_android_arm64_windows
             # Tizen
-            - name: native_tizen_windows
+            - name: native_tizen_armel_windows
+            - name: native_tizen_i586_windows
+            - name: native_tizen_x86_64_windows
+            - name: native_tizen_aarch64_windows
             # Win32
             - name: native_win32_x86_windows
             - name: native_win32_x64_windows

--- a/scripts/azure-templates-stages-native-windows.yml
+++ b/scripts/azure-templates-stages-native-windows.yml
@@ -41,13 +41,38 @@ stages:
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-android
           additionalArgs: --buildarch=arm64
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen (Win)
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|arm (Win)
         parameters:
-          name: native_tizen_windows
-          displayName: Tizen
+          name: native_tizen_armel_windows
+          displayName: Tizen arm
           buildAgent: ${{ parameters.buildAgentWindowsNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
+          additionalArgs: --buildarch=armel
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|x86 (Win)
+        parameters:
+          name: native_tizen_i586_windows
+          displayName: Tizen x86
+          buildAgent: ${{ parameters.buildAgentWindowsNative }}
+          buildExternals: ${{ parameters.buildExternals }}
+          target: externals-tizen
+          additionalArgs: --buildarch=i586
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|x64 (Win)
+        parameters:
+          name: native_tizen_x86_64_windows
+          displayName: Tizen x64
+          buildAgent: ${{ parameters.buildAgentWindowsNative }}
+          buildExternals: ${{ parameters.buildExternals }}
+          target: externals-tizen
+          additionalArgs: --buildarch=x86_64
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|arm64 (Win)
+        parameters:
+          name: native_tizen_aarch64_windows
+          displayName: Tizen arm64
+          buildAgent: ${{ parameters.buildAgentWindowsNative }}
+          buildExternals: ${{ parameters.buildExternals }}
+          target: externals-tizen
+          additionalArgs: --buildarch=aarch64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Win32|x86 (Win)
         parameters:
           name: native_win32_x86_windows

--- a/scripts/azure-templates-stages-native-windows.yml
+++ b/scripts/azure-templates-stages-native-windows.yml
@@ -43,36 +43,36 @@ stages:
           additionalArgs: --buildarch=arm64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|arm (Win)
         parameters:
-          name: native_tizen_armel_windows
+          name: native_tizen_arm_windows
           displayName: Tizen arm
           buildAgent: ${{ parameters.buildAgentWindowsNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=armel
+          additionalArgs: --buildarch=arm
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|x86 (Win)
         parameters:
-          name: native_tizen_i586_windows
+          name: native_tizen_x86_windows
           displayName: Tizen x86
           buildAgent: ${{ parameters.buildAgentWindowsNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=i586
+          additionalArgs: --buildarch=x86
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|x64 (Win)
         parameters:
-          name: native_tizen_x86_64_windows
+          name: native_tizen_x64_windows
           displayName: Tizen x64
           buildAgent: ${{ parameters.buildAgentWindowsNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=x86_64
+          additionalArgs: --buildarch=x64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Tizen|arm64 (Win)
         parameters:
-          name: native_tizen_aarch64_windows
+          name: native_tizen_arm64_windows
           displayName: Tizen arm64
           buildAgent: ${{ parameters.buildAgentWindowsNative }}
           buildExternals: ${{ parameters.buildExternals }}
           target: externals-tizen
-          additionalArgs: --buildarch=aarch64
+          additionalArgs: --buildarch=arm64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Win32|x86 (Win)
         parameters:
           name: native_win32_x86_windows

--- a/scripts/cake/native-shared.cake
+++ b/scripts/cake/native-shared.cake
@@ -261,7 +261,7 @@ bool Skip(string arch)
 
     arch = ReduceArch(arch);
 
-    if (BUILD_ARCH.Contains(arch))
+    if (BUILD_ARCH.Select(ReduceArch).Contains(arch))
         return false;
 
     Warning($"Skipping architecture: {arch}");


### PR DESCRIPTION
## Problem

After #3620 added x64 and arm64 Tizen build support, the single Tizen CI job now builds 4 architectures sequentially (arm, x86, x64, arm64), hitting the 3-hour AzDO worker timeout. This has been the sole failure in 5 of the last 6 main builds.

## Solution

Split the single Tizen native job into 4 parallel per-architecture jobs, matching the existing pattern used by Android, Win32, WinUI, and ANGLE.

The cake build already supports `--buildarch` filtering via the `Skip()` function, so no build script changes are needed.

## Files Changed

- `azure-templates-stages-native-windows.yml` — split active Tizen job into 4
- `azure-templates-stages-native-macos.yml` — split Tizen job into 4
- `azure-templates-stages-native-linux.yml` — split disabled jobs, kept consistent
- `azure-templates-stages-native-merge.yml` — reference 4 per-arch artifacts instead of 1