### PR TITLE
Update libpng to 1.6.57

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8,7 +8,7 @@
         "type": "other",
         "other": {
           "name": "libpng",
-          "version": "1.6.54",
+          "version": "1.6.57",
           "downloadUrl": "https://github.com/glennrp/libpng"
         }
       }


### PR DESCRIPTION
Update libpng from 1.6.54 to 1.6.57 to fix critical security vulnerabilities:

- **CVE-2026-25646** (CRITICAL) — Heap buffer overflow in \png_set_quantize()\, 30-year-old bug
- **CVE-2026-33416** (HIGH) — Use-after-free between \png_struct\ and \png_info\
- **CVE-2026-33636** (HIGH) — ARM/AArch64 NEON palette expansion OOB read/write

**Analysis:** Patch-level update (1.6.54 → 1.6.57). No BUILD.gn changes needed. No breaking API changes. All 20 BUILD.gn source files verified present.

**Changes:**
- \xternals/skia\ submodule → points to \dev/update-libpng\ branch with updated DEPS
- \cgmanifest.json\ → libpng version 1.6.54 → 1.6.57

Required skia PR: https://github.com/mono/skia/pull/182