### PR TITLE
Fix x86 .NET Framework threading test OOM failures (#3608)

### DIFF
--- a/tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs
+++ b/tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs
@@ -13,9 +13,16 @@ namespace SkiaSharp.Tests
 	{
 		[SkippableTheory]
 		[InlineData(10, 10)]
+		[InlineData(10, 100)]
 		[InlineData(100, 1000)]
 		public static void ImageScalingMultipleThreadsTest(int numThreads, int numIterationsPerThread)
 		{
+			// The (100, 1000) variant creates 100K undisposed native allocations to stress
+			// GC finalizer throughput. On x86 (2GB address space), the GC can't keep up and
+			// Skia's native allocator fails. See #3608.
+			if (IntPtr.Size == 4 && numThreads >= 100 && numIterationsPerThread >= 1000)
+				throw new SkipException("Stress test skipped on x86 due to address space limit.");
+
 			var referenceFile = Path.Combine(PathToImages, "baboon.jpg");
 
 			var tasks = new List<Task>();

--- a/tests/Tests/SkiaSharp/SKObjectTest.cs
+++ b/tests/Tests/SkiaSharp/SKObjectTest.cs
@@ -242,9 +242,16 @@ namespace SkiaSharp.Tests
 
 		[SkippableTheory]
 		[InlineData(1)]
+		[InlineData(100)]
 		[InlineData(1000)]
 		public async Task EnsureMultithreadingDoesNotThrow(int iterations)
 		{
+			// 1000 concurrent bitmap decodes exceed x86's 2GB address space.
+			// The (100) variant still validates concurrent GC/finalizer behavior.
+			// See #3608.
+			if (IntPtr.Size == 4 && iterations >= 1000)
+				throw new SkipException("Stress test skipped on x86 due to address space limit.");
+
 			var imagePath = Path.Combine(PathToImages, "baboon.jpg");
 
 			var tasks = new Task[iterations];


### PR DESCRIPTION
## Investigation: Fix x86 .NET Framework threading test OOM (#3608)

### Problem
Two multithreading tests fail consistently on Windows .NET Framework x86 (net472-x86) with `Unable to allocate pixels for the bitmap` due to x86 2GB address space exhaustion. Hits 8/15 recent main builds (53%).

### Related Issues
- #3608 (known-issue label)
- #3609 (GC lifecycle flakiness, separate root cause)

Fixes #3608