### PR TITLE
Add release-notes-audit skill for Skia API gap analysis

### DIFF
--- a/.github/skills/release-notes-audit/SKILL.md
+++ b/.github/skills/release-notes-audit/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: release-notes-audit
+description: >
+  Audit Skia release notes against SkiaSharp bindings to find new APIs to add,
+  deprecated APIs to mark, and missing bindings. Produces structured JSON and
+  a standalone HTML report with binding coverage.
+
+  Use when user asks to:
+  - Review Skia release notes for binding gaps
+  - Check what APIs were added/removed since a milestone
+  - Find missing SkiaSharp bindings for new Skia features
+  - Audit API coverage between Skia and SkiaSharp
+  - Check deprecation alignment between Skia and SkiaSharp
+  - Plan work for a Skia milestone bump
+
+  Triggers: "release notes audit", "what APIs are missing", "check release notes",
+  "binding coverage", "what's new in skia", "skia API changes", "milestone audit",
+  "what did we miss", "audit API gaps", "check deprecations", "plan milestone bump",
+  "review skia changes since m119", "new features from skia".
+
+  Always use this skill when the user mentions reviewing, auditing, or comparing
+  Skia release notes against SkiaSharp, even if they don't use the word "audit".
+  Also trigger when they ask about API gaps between Skia versions.
+---
+
+# Release Notes Audit Skill
+
+Compare Skia upstream release notes against SkiaSharp's C API shim and C# bindings to identify new features to add, deprecated APIs to mark, and missing bindings. Produces a structured JSON report and standalone HTML dashboard.
+
+## Key References
+
+- **[references/report-schema.md](references/report-schema.md)** — JSON schema for structured output
+- **[scripts/render-release-notes-audit.py](scripts/render-release-notes-audit.py)** — Renders JSON → standalone HTML
+- **[scripts/viewer.html](scripts/viewer.html)** — HTML template (Bootstrap 5)
+
+## Workflow
+
+```
+1. Determine milestone range (current vs previous)
+2. Fetch Skia release notes from upstream
+3. Classify each change (new feature, deprecation, removal, behavior change, internal)
+4. Check C API (mono/skia include/c/) for each relevant item
+5. Check C# bindings (binding/SkiaSharp/) for each relevant item
+6. Cross-validate findings with a second model
+7. Assemble structured JSON report (per report-schema.md)
+8. Render HTML from JSON (render-release-notes-audit.py)
+9. Present markdown summary to user
+```
+
+### Step 1: Determine Milestone Range
+
+Find the current and previous SkiaSharp milestones. The user may specify these or you can detect them:
+
+```bash
+# Check current milestone from submodule (if checked out)
+cat externals/skia/include/core/SkMilestone.h 2>/dev/null
+# Or check git log for milestone references
+git --no-pager log --oneline -20 | grep -i milestone
+```
+
+If the submodule isn't checked out, ask the user or check recent PRs/issues for milestone references.
+
+### Step 2: Fetch Skia Release Notes
+
+Get the release notes from upstream Google Skia:
+
+```
+https://raw.githubusercontent.com/google/skia/main/RELEASE_NOTES.md
+```
+
+This file is large — paginate with start_index if needed (content may exceed 20K chars). Parse each milestone section between `Milestone NNN` headers.
+
+### Step 3: Classify Each Change
+
+For each entry in the release notes within the milestone range, classify it:
+
+| Category | Description | Example |
+|----------|------------|---------|
+| `new_feature` | New public API added | `SkColorSpace::MakeCICP` |
+| `deprecation` | API marked deprecated | `SkTypeface::MakeDefault()` |
+| `removal` | API removed from public surface | `SkDrawLooper` removed |
+| `behavior_change` | Existing API changed behavior | `kRec709` transfer fn changed |
+| `header_reorg` | Headers moved/renamed (usually N/A for SkiaSharp) | `include/gpu/` → `include/gpu/ganesh/` |
+| `internal` | Build system, Graphite-only, Dawn-only | Precompile context threading |
+
+**Filter out items irrelevant to SkiaSharp's C API surface:**
+- Graphite-only APIs (SkiaSharp uses Ganesh for GPU)
+- Dawn-only changes (SkiaSharp uses GL/Vulkan/Metal)
+- Build system / GN flag changes
+- SkSL language specification changes (unless they affect runtime effects)
+
+### Step 4: Check C API
+
+For each relevant item, check if the C API shim in mono/skia exposes it.
+
+If the submodule is checked out:
+```bash
+grep -rn "function_name" externals/skia/include/c/
+grep -rn "function_name" externals/skia/src/c/
+```
+
+If NOT checked out, use the GitHub API:
+```
+github-mcp-server-get_file_contents owner=mono repo=skia path=include/c/sk_<relevant>.h
+```
+
+Key C API header files to check:
+- `sk_types.h` — enums, structs
+- `sk_image.h`, `sk_canvas.h`, `sk_path.h`, `sk_codec.h` — core APIs
+- `sk_colorspace.h`, `sk_font.h`, `sk_typeface.h` — specialized APIs
+- `sk_imagefilter.h`, `sk_shader.h`, `sk_paint.h` — effects
+
+### Step 5: Check C# Bindings
+
+For each relevant item, check the C# wrappers:
+
+```bash
+grep -rn "MethodName\|method_name" binding/SkiaSharp/
+```
+
+Key C# files to check:
+- `Definitions.cs` — enums (SKColorType, SKAlphaType, etc.)
+- `SkiaApi.generated.cs` — P/Invoke declarations (DO NOT EDIT but check for presence)
+- `SK*.cs` files — wrapper classes
+
+**Binding status classification:**
+
+| Status | Meaning |
+|--------|---------|
+| `full` | C API + C# wrapper both exist and cover the feature |
+| `partial` | C API exists but C# wrapper is incomplete, or vice versa |
+| `missing` | Neither C API nor C# wrapper exists |
+| `not_applicable` | Skia change doesn't require a binding (header reorg, internal, etc.) |
+| `correctly_absent` | Skia removed this and SkiaSharp never wrapped it |
+| `action_needed` | SkiaSharp wraps something Skia deprecated/removed without marking `[Obsolete]` |
+
+### Step 6: Cross-Validate
+
+For accuracy, use a second model (via `task` tool with `model` parameter) to independently verify the key findings. At minimum, validate:
+- All items marked `full` (confirm they actually exist)
+- All items marked `action_needed` (confirm the deprecation status)
+- All items marked `missing` that are high priority
+
+### Step 7: Assemble Structured JSON Report
+
+> 🛑 **MANDATORY:** The audit MUST produce a JSON file conforming to [references/report-schema.md](references/report-schema.md).
+
+Save as `output/ai/release-notes-audit-{date}.json` in the repo.
+
+### Step 8: Render HTML Report
+
+> 🛑 **MANDATORY:** Always generate the HTML report.
+
+```bash
+python3 .github/skills/release-notes-audit/scripts/render-release-notes-audit.py \
+  output/ai/release-notes-audit-{date}.json
+```
+
+This produces a self-contained HTML file alongside the JSON. Present the output path:
+```
+✅ release-notes-audit-2026-04-15.html (52 KB)
+   m119 → m133 • 52 items • 6 missing • 5 action needed
+```
+
+### Step 9: Present Markdown Summary
+
+After generating JSON and HTML, present a concise markdown summary in the conversation. Group items by urgency:
+
+1. 🔴 **Critical** — APIs that will break on next Skia bump
+2. ⚠️ **Action Needed** — Deprecated APIs missing `[Obsolete]` markers
+3. ❌ **Missing (High)** — New features in current milestone window with no binding
+4. 🔶 **Missing (Medium)** — Useful features to plan for
+5. 🟢 **Missing (Low)** — Nice-to-have features
+6. ✅ **Full** — Features already bound
+7. 🚫 **N/A** — Items correctly absent
+
+## Priority Classification
+
+When classifying priority, use these guidelines:
+
+| Priority | Criteria |
+|----------|----------|
+| 🔴 Critical | Will cause compile/link/runtime failures on next Skia bump. E.g., removed headers, immutable SkPath. |
+| ⚠️ Action Needed | SkiaSharp wraps something Skia deprecated. Should add `[Obsolete]`. |
+| 🔶 High | New API in current milestone window (between previous and current). Commonly requested. |
+| 🟡 Medium | New API in future milestones. Useful but not urgent. |
+| 🟢 Low | Niche feature, or C# already has equivalent functionality. |
+
+## Handoff
+
+After the audit, the user may want to:
+- **Add new APIs** → Use the `add-api` skill for each missing binding
+- **Mark deprecations** → Edit `binding/SkiaSharp/SK*.cs` to add `[Obsolete]` attributes
+- **Plan a Skia bump** → Use the `update-skia` skill
+- **Check security** → Use the `security-audit` skill
+
+## Tips for Accuracy
+
+1. **Don't trust file absence as evidence of API absence.** A grep returning no results might mean the submodule isn't checked out. Always verify via GitHub API fallback.
+
+2. **Check both C API AND C# bindings.** Sometimes the C API has a function but the C# wrapper wasn't created. This is `partial` status.
+
+3. **Enum ordering matters.** The C API `sk_types.h` may reorder enum values vs upstream Skia. Compare by name, not by ordinal.
+
+4. **Generated files reflect C API.** `SkiaApi.generated.cs` is auto-generated from C API headers. If a function is in the C API, it will be in the generated file.
+
+5. **The mono/skia fork may retain deprecated APIs** that upstream removed. This isn't a bug — it's intentional for backward compatibility. Flag it but don't classify as broken.

--- a/.github/skills/release-notes-audit/SKILL.md
+++ b/.github/skills/release-notes-audit/SKILL.md
@@ -16,11 +16,15 @@ description: >
   Triggers: "release notes audit", "what APIs are missing", "check release notes",
   "binding coverage", "what's new in skia", "skia API changes", "milestone audit",
   "what did we miss", "audit API gaps", "check deprecations", "plan milestone bump",
-  "review skia changes since m119", "new features from skia".
+  "review skia changes since m119", "new features from skia",
+  "generate a report", "report of the release notes", "release notes between",
+  "release notes report", "between milestones", "milestone report",
+  "report between m88 and m119", "changes between milestones".
 
-  Always use this skill when the user mentions reviewing, auditing, or comparing
-  Skia release notes against SkiaSharp, even if they don't use the word "audit".
-  Also trigger when they ask about API gaps between Skia versions.
+  Always use this skill when the user mentions reviewing, auditing, generating a
+  report of, or comparing Skia release notes — even if they don't use the word
+  "audit". Also trigger when they ask about API gaps between Skia versions, or
+  ask to generate/create any kind of report involving release notes or milestones.
 ---
 
 # Release Notes Audit Skill

--- a/.github/skills/release-notes-audit/SKILL.md
+++ b/.github/skills/release-notes-audit/SKILL.md
@@ -1,30 +1,16 @@
 ---
 name: release-notes-audit
 description: >
-  Audit Skia release notes against SkiaSharp bindings to find new APIs to add,
-  deprecated APIs to mark, and missing bindings. Produces structured JSON and
-  a standalone HTML report with binding coverage.
-
-  Use when user asks to:
-  - Review Skia release notes for binding gaps
-  - Check what APIs were added/removed since a milestone
-  - Find missing SkiaSharp bindings for new Skia features
-  - Audit API coverage between Skia and SkiaSharp
-  - Check deprecation alignment between Skia and SkiaSharp
-  - Plan work for a Skia milestone bump
-
-  Triggers: "release notes audit", "what APIs are missing", "check release notes",
-  "binding coverage", "what's new in skia", "skia API changes", "milestone audit",
-  "what did we miss", "audit API gaps", "check deprecations", "plan milestone bump",
-  "review skia changes since m119", "new features from skia",
-  "generate a report", "report of the release notes", "release notes between",
-  "release notes report", "between milestones", "milestone report",
-  "report between m88 and m119", "changes between milestones".
-
-  Always use this skill when the user mentions reviewing, auditing, generating a
-  report of, or comparing Skia release notes — even if they don't use the word
-  "audit". Also trigger when they ask about API gaps between Skia versions, or
-  ask to generate/create any kind of report involving release notes or milestones.
+  Compare Skia upstream release notes against SkiaSharp C# bindings to produce a
+  structured report (JSON + HTML) of new, missing, deprecated, and removed APIs
+  across milestone ranges. Use this skill whenever the user mentions Skia release
+  notes, milestone changes, API gaps, binding coverage, or wants a report of what
+  changed between Skia milestones. Trigger on: "release notes", "what changed
+  between milestones", "what's new in skia", "generate a report", "missing APIs",
+  "deprecated APIs", "milestone bump", "binding audit", "API coverage", "what
+  should we add", "what should we deprecate". DO NOT use for: fixing bugs, adding
+  a single specific API binding, updating the skia submodule, security audits, or
+  writing documentation.
 ---
 
 # Release Notes Audit Skill

--- a/.github/skills/release-notes-audit/references/report-schema.md
+++ b/.github/skills/release-notes-audit/references/report-schema.md
@@ -1,0 +1,181 @@
+# Release Notes Audit Report Schema
+
+JSON schema for the release notes audit report. The AI generates this JSON as structured output, then `render-release-notes-audit.py` injects it into `viewer.html` to produce a standalone HTML report.
+
+## Top-Level Structure
+
+```json
+{
+  "meta": { ... },
+  "summary": { ... },
+  "items": [ ... ],
+  "deprecations": [ ... ],
+  "nextSteps": [ ... ]
+}
+```
+
+## `meta` — Audit Metadata
+
+```json
+{
+  "date": "2026-04-15",
+  "schemaVersion": "1.0",
+  "previousMilestone": 119,
+  "currentMilestone": 133,
+  "latestUpstreamMilestone": 148,
+  "skiaSubmoduleCommit": "0c28aa73beebf4747af531a893b4e8d94690f5cf",
+  "releaseNotesSource": "https://raw.githubusercontent.com/google/skia/main/RELEASE_NOTES.md"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `date` | string | Yes | ISO date of the audit |
+| `schemaVersion` | string | Yes | Always `"1.0"` |
+| `previousMilestone` | integer | Yes | The milestone SkiaSharp was on before this bump |
+| `currentMilestone` | integer | Yes | The milestone SkiaSharp is now on |
+| `latestUpstreamMilestone` | integer | Yes | Latest milestone in upstream release notes |
+| `skiaSubmoduleCommit` | string | No | mono/skia fork commit if available |
+| `releaseNotesSource` | string | Yes | URL where release notes were fetched |
+
+## `summary` — Overview Counts
+
+```json
+{
+  "totalItems": 52,
+  "full": 3,
+  "partial": 1,
+  "missing": 14,
+  "actionNeeded": 5,
+  "correctlyAbsent": 12,
+  "notApplicable": 17,
+  "critical": 2,
+  "high": 6,
+  "medium": 8,
+  "low": 10
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalItems` | integer | Total items cataloged |
+| `full` | integer | Count with full binding |
+| `partial` | integer | Count with partial binding |
+| `missing` | integer | Count with no binding |
+| `actionNeeded` | integer | Count needing `[Obsolete]` or other fix |
+| `correctlyAbsent` | integer | Removed by Skia, never wrapped (correct) |
+| `notApplicable` | integer | Internal/header-only changes |
+| `critical` | integer | Critical priority items |
+| `high` | integer | High priority items |
+| `medium` | integer | Medium priority items |
+| `low` | integer | Low priority items |
+
+## `items` — Individual API Change Items
+
+Array of objects, one per release notes entry:
+
+```json
+{
+  "id": 1,
+  "milestone": 133,
+  "category": "new_feature",
+  "skiaApi": "SkColorSpace::MakeCICP",
+  "description": "Create SkColorSpace from CICP code points (Rec. ITU-T H.273)",
+  "cApiStatus": "present",
+  "cApiFunction": "sk_colorspace_new_cicp",
+  "cApiFile": "sk_colorspace.h",
+  "csharpStatus": "present",
+  "csharpMethod": "SKColorSpace.CreateCicp()",
+  "csharpFile": "SKColorSpace.cs",
+  "bindingStatus": "full",
+  "priority": "low",
+  "notes": "Already fully bound"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | Yes | Sequential identifier |
+| `milestone` | integer | Yes | Skia milestone where this appeared |
+| `category` | string | Yes | One of: `new_feature`, `deprecation`, `removal`, `behavior_change`, `header_reorg`, `internal` |
+| `skiaApi` | string | Yes | Upstream Skia API name or description |
+| `description` | string | Yes | What changed and why it matters |
+| `cApiStatus` | string | Yes | `"present"`, `"missing"`, `"not_applicable"` |
+| `cApiFunction` | string | No | C API function name if present |
+| `cApiFile` | string | No | C API header file if present |
+| `csharpStatus` | string | Yes | `"present"`, `"missing"`, `"not_applicable"` |
+| `csharpMethod` | string | No | C# method/property name if present |
+| `csharpFile` | string | No | C# file if present |
+| `bindingStatus` | string | Yes | `"full"`, `"partial"`, `"missing"`, `"not_applicable"`, `"correctly_absent"`, `"action_needed"` |
+| `priority` | string | Yes | `"critical"`, `"high"`, `"medium"`, `"low"`, `"none"` |
+| `notes` | string | No | Additional context |
+
+### `category` Values
+
+| Value | Description |
+|-------|-------------|
+| `new_feature` | New public API added to Skia |
+| `deprecation` | API marked deprecated in Skia |
+| `removal` | API removed from Skia public surface |
+| `behavior_change` | Existing API changed behavior silently |
+| `header_reorg` | Headers moved/renamed |
+| `internal` | Build system, backend-specific, or irrelevant to SkiaSharp |
+
+### `bindingStatus` Values
+
+| Value | Badge | Description |
+|-------|-------|-------------|
+| `full` | ✅ Full | C API + C# wrapper both exist |
+| `partial` | 🟡 Partial | C API exists but C# incomplete, or vice versa |
+| `missing` | ❌ Missing | No C API or C# wrapper |
+| `not_applicable` | 🚫 N/A | Change doesn't need a binding |
+| `correctly_absent` | 🚫 N/A | Skia removed this; SkiaSharp never wrapped it |
+| `action_needed` | ⚠️ Action | SkiaSharp wraps deprecated/removed Skia API |
+
+## `deprecations` — APIs Needing [Obsolete] Markers
+
+Array of objects for APIs that Skia deprecated but SkiaSharp still exposes without `[Obsolete]`:
+
+```json
+{
+  "id": 1,
+  "skiaApi": "SkTypeface::MakeFromName",
+  "deprecatedSince": 120,
+  "skiasharpApi": "SKTypeface.FromFamilyName()",
+  "skiasharpFile": "SKTypeface.cs",
+  "replacement": "SKFontManager.CreateTypeface()",
+  "obsoleteMessage": "Use SKFontManager.CreateTypeface() instead."
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | Yes | Sequential identifier |
+| `skiaApi` | string | Yes | Upstream Skia API that was deprecated |
+| `deprecatedSince` | integer | Yes | Milestone when deprecated |
+| `skiasharpApi` | string | Yes | SkiaSharp method/property name |
+| `skiasharpFile` | string | Yes | C# file containing the API |
+| `replacement` | string | No | What users should migrate to |
+| `obsoleteMessage` | string | Yes | Suggested `[Obsolete("...")]` text |
+
+## `nextSteps` — Prioritized Action Items
+
+```json
+{
+  "priority": 1,
+  "severity": "critical",
+  "action": "Create SKPathBuilder bindings",
+  "milestone": 143,
+  "reason": "SkPath is going immutable. All edit methods will be removed.",
+  "skillToUse": "add-api"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `priority` | integer | Yes | 1 = highest |
+| `severity` | string | Yes | `"critical"`, `"high"`, `"medium"`, `"low"` |
+| `action` | string | Yes | What to do |
+| `milestone` | integer | No | Which Skia milestone drives this |
+| `reason` | string | Yes | Why (cite impact) |
+| `skillToUse` | string | No | Recommended SkiaSharp skill for follow-up |

--- a/.github/skills/release-notes-audit/scripts/render-release-notes-audit.py
+++ b/.github/skills/release-notes-audit/scripts/render-release-notes-audit.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Render a release-notes-audit JSON report as a self-contained HTML file.
+
+Usage:
+    python3 render-release-notes-audit.py <path-to-json> [output.html]
+
+If output path is omitted, writes to the same directory as the JSON
+with a .html extension.
+
+Exit codes: 0=success, 1=error.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 render-release-notes-audit.py <path-to-json> [output.html]")
+        sys.exit(1)
+
+    json_path = Path(sys.argv[1])
+    if not json_path.exists():
+        print(f"❌ JSON file not found: {json_path}")
+        sys.exit(1)
+
+    # Determine output path
+    if len(sys.argv) >= 3:
+        output_path = Path(sys.argv[2])
+    else:
+        output_path = json_path.with_suffix(".html")
+
+    # Load JSON data
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"❌ Invalid JSON: {e}")
+        sys.exit(1)
+
+    # Validate required fields
+    for key in ("meta", "summary", "items"):
+        if key not in data:
+            print(f"❌ Missing required key: {key}")
+            sys.exit(1)
+
+    # Ensure optional keys have defaults
+    data.setdefault("deprecations", [])
+    data.setdefault("nextSteps", [])
+
+    # Load HTML template
+    template_path = Path(__file__).parent / "viewer.html"
+    if not template_path.exists():
+        print(f"❌ Template not found: {template_path}")
+        sys.exit(1)
+
+    with open(template_path, encoding="utf-8") as f:
+        template = f.read()
+
+    # Serialize JSON for injection (escape </script> tags)
+    json_str = json.dumps(data, ensure_ascii=False)
+    json_str = json_str.replace("</script>", "<\\/script>")
+    json_str = json_str.replace("</Script>", "<\\/Script>")
+    json_str = json_str.replace("</SCRIPT>", "<\\/SCRIPT>")
+
+    data_script = f"<script>const DATA = {json_str};</script>"
+
+    marker = "<!--INJECT_DATA_HERE-->"
+    if marker not in template:
+        print(f"❌ Injection marker '{marker}' not found in template")
+        sys.exit(1)
+
+    html = template.replace(marker, data_script)
+
+    # Update title
+    meta = data.get("meta", {})
+    prev_ms = meta.get("previousMilestone", "?")
+    curr_ms = meta.get("currentMilestone", "?")
+    date = meta.get("date", "?")
+    html = html.replace(
+        "<title>Release Notes Audit</title>",
+        f"<title>Release Notes Audit — m{prev_ms}→m{curr_ms} ({date})</title>"
+    )
+
+    # Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    size_kb = os.path.getsize(output_path) / 1024
+    summary = data.get("summary", {})
+    total = summary.get("totalItems", "?")
+    missing = summary.get("missing", 0)
+    action = summary.get("actionNeeded", 0)
+    full = summary.get("full", 0)
+
+    print(f"✅ {output_path.name} ({size_kb:.0f} KB)")
+    print(f"   m{prev_ms} → m{curr_ms} • {date} • {total} items")
+    print(f"   ❌ {missing} missing · ⚠️ {action} action needed · ✅ {full} full")
+    print(f"   Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/release-notes-audit/scripts/viewer.html
+++ b/.github/skills/release-notes-audit/scripts/viewer.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Release Notes Audit</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <style>
+    :root { --bg: #f6f8fa; --border: #d0d7de; --muted: #57606a; --surface: #fff; }
+    body { background: var(--bg); color: #1f2328; }
+    .page-shell { max-width: 1200px; }
+    .sticky-header { position: sticky; top: 0; z-index: 1030; backdrop-filter: blur(10px);
+      background: rgba(255,255,255,0.94); border-bottom: 1px solid var(--border); }
+    .card { border: 1px solid var(--border); box-shadow: 0 1px 2px rgba(16,24,40,0.04); }
+    .status-pill { font-size: 0.75rem; font-weight: 600; padding: 2px 8px; border-radius: 12px; white-space: nowrap; }
+    .st-full { background: #dcfce7; color: #166534; }
+    .st-partial { background: #fef3c7; color: #92400e; }
+    .st-missing { background: #fee2e2; color: #991b1b; }
+    .st-action-needed { background: #fce7f3; color: #9d174d; }
+    .st-not-applicable { background: #f3f4f6; color: #6b7280; }
+    .st-correctly-absent { background: #f3f4f6; color: #6b7280; }
+    .pri-critical { color: #7f1d1d; font-weight: 700; }
+    .pri-high { color: #991b1b; font-weight: 600; }
+    .pri-medium { color: #92400e; }
+    .pri-low { color: #6b7280; }
+    .cat-pill { font-size: 0.7rem; font-weight: 500; padding: 1px 6px; border-radius: 8px; }
+    .cat-new_feature { background: #dbeafe; color: #1e40af; }
+    .cat-deprecation { background: #fef3c7; color: #92400e; }
+    .cat-removal { background: #fee2e2; color: #991b1b; }
+    .cat-behavior_change { background: #fce7f3; color: #9d174d; }
+    .cat-header_reorg { background: #f3f4f6; color: #6b7280; }
+    .cat-internal { background: #f3f4f6; color: #6b7280; }
+    .finding-header { cursor: pointer; }
+    .finding-header:hover { background: #f3f4f6; }
+    .milestone-badge { font-size: 0.75rem; font-weight: 600; padding: 2px 8px;
+      border-radius: 12px; background: #e0e7ff; color: #3730a3; }
+    .next-step { border-left: 3px solid; padding-left: 12px; margin-bottom: 12px; }
+    .ns-critical { border-color: #dc2626; }
+    .ns-high { border-color: #f97316; }
+    .ns-medium { border-color: #f59e0b; }
+    .ns-low { border-color: #6b7280; }
+    .meta-table td, .meta-table th { font-size: 0.85rem; padding: 4px 8px; }
+    code { font-size: 0.8rem; }
+    .filter-btn { font-size: 0.8rem; }
+    .filter-btn.active { font-weight: 700; }
+    .depr-table td, .depr-table th { font-size: 0.85rem; }
+    .window-marker { border-left: 3px solid #3b82f6; background: #eff6ff; }
+    .future-marker { border-left: 3px solid #d1d5db; background: #fafafa; }
+    .ms-range { font-size: 0.85rem; padding: 4px 12px; border-radius: 8px; }
+    .ms-current { background: #dbeafe; color: #1e40af; }
+    .ms-future { background: #f3f4f6; color: #6b7280; }
+  </style>
+</head>
+<body>
+<!--INJECT_DATA_HERE-->
+<div class="page-shell mx-auto px-3 py-4">
+
+  <!-- Header -->
+  <div class="sticky-header py-2 px-3 mb-4">
+    <div class="d-flex align-items-center justify-content-between">
+      <div>
+        <h4 class="mb-0"><i class="bi bi-journal-code me-2"></i>Release Notes Audit</h4>
+        <small class="text-muted" id="header-subtitle"></small>
+      </div>
+      <div id="header-badges" class="d-flex gap-2 align-items-center"></div>
+    </div>
+  </div>
+
+  <!-- Summary Cards -->
+  <div class="row g-3 mb-4" id="summary-cards"></div>
+
+  <!-- Filter Bar -->
+  <div class="card mb-4">
+    <div class="card-body py-2 d-flex flex-wrap gap-2 align-items-center">
+      <strong class="small me-2">Filter:</strong>
+      <button class="btn btn-sm btn-outline-secondary filter-btn active" data-filter="all">All</button>
+      <button class="btn btn-sm btn-outline-danger filter-btn" data-filter="missing">❌ Missing</button>
+      <button class="btn btn-sm btn-outline-warning filter-btn" data-filter="action_needed">⚠️ Action</button>
+      <button class="btn btn-sm btn-outline-success filter-btn" data-filter="full">✅ Full</button>
+      <button class="btn btn-sm btn-outline-info filter-btn" data-filter="partial">🟡 Partial</button>
+      <button class="btn btn-sm btn-outline-secondary filter-btn" data-filter="not_applicable">🚫 N/A</button>
+      <span class="ms-auto small text-muted" id="filter-count"></span>
+    </div>
+  </div>
+
+  <!-- Milestone Sections -->
+  <div id="items-container"></div>
+
+  <!-- Deprecations -->
+  <div class="card mb-4" id="deprecations-section">
+    <div class="card-header bg-white"><i class="bi bi-exclamation-diamond me-2"></i><strong>Deprecation Action Items</strong></div>
+    <div class="card-body p-0">
+      <table class="table table-sm table-hover mb-0 depr-table" id="deprecations-table">
+        <thead><tr><th>SkiaSharp API</th><th>Deprecated In</th><th>Replacement</th><th>File</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Next Steps -->
+  <div class="card mb-4">
+    <div class="card-header bg-white"><i class="bi bi-list-check me-2"></i><strong>Next Steps</strong></div>
+    <div class="card-body" id="next-steps"></div>
+  </div>
+
+  <!-- Meta -->
+  <div class="card mb-4">
+    <div class="card-header bg-white"><i class="bi bi-info-circle me-2"></i><strong>Audit Details</strong></div>
+    <div class="card-body" id="audit-meta"></div>
+  </div>
+</div>
+
+<script>
+const STATUS_MAP = {
+  full: ['✅ Full', 'st-full'],
+  partial: ['🟡 Partial', 'st-partial'],
+  missing: ['❌ Missing', 'st-missing'],
+  action_needed: ['⚠️ Action Needed', 'st-action-needed'],
+  not_applicable: ['🚫 N/A', 'st-not-applicable'],
+  correctly_absent: ['🚫 N/A', 'st-correctly-absent'],
+};
+
+const CAT_LABELS = {
+  new_feature: 'New Feature',
+  deprecation: 'Deprecation',
+  removal: 'Removal',
+  behavior_change: 'Behavior Change',
+  header_reorg: 'Header Reorg',
+  internal: 'Internal',
+};
+
+const PRI_CLASS = { critical: 'pri-critical', high: 'pri-high', medium: 'pri-medium', low: 'pri-low' };
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+
+function renderSummary(s) {
+  const cards = [
+    ['Missing', s.missing, 'danger', 'x-circle'],
+    ['Action Needed', s.actionNeeded, 'warning', 'exclamation-triangle'],
+    ['Full', s.full, 'success', 'check-circle'],
+    ['N/A', (s.notApplicable || 0) + (s.correctlyAbsent || 0), 'secondary', 'dash-circle'],
+  ];
+  document.getElementById('summary-cards').innerHTML = cards.map(([label, count, color, icon]) => `
+    <div class="col-6 col-md-3">
+      <div class="card text-center p-3">
+        <div class="fs-2 text-${color}"><i class="bi bi-${icon}"></i></div>
+        <div class="fs-1 fw-bold">${count}</div>
+        <div class="text-muted small">${label}</div>
+      </div>
+    </div>`).join('');
+}
+
+function renderItem(item) {
+  const [statusLabel, statusCls] = STATUS_MAP[item.bindingStatus] || ['?', ''];
+  const catCls = `cat-${item.category}`;
+  const priCls = PRI_CLASS[item.priority] || 'pri-low';
+
+  let body = '<table class="table table-sm meta-table mb-2"><tbody>';
+  if (item.cApiFunction) body += `<tr><th>C API</th><td><code>${esc(item.cApiFunction)}</code> (${esc(item.cApiFile || '')})</td></tr>`;
+  else if (item.cApiStatus === 'missing') body += `<tr><th>C API</th><td class="text-danger">Not in C API</td></tr>`;
+  if (item.csharpMethod) body += `<tr><th>C# Binding</th><td><code>${esc(item.csharpMethod)}</code> (${esc(item.csharpFile || '')})</td></tr>`;
+  else if (item.csharpStatus === 'missing') body += `<tr><th>C# Binding</th><td class="text-danger">Not in C# bindings</td></tr>`;
+  if (item.notes) body += `<tr><th>Notes</th><td>${esc(item.notes)}</td></tr>`;
+  body += '</tbody></table>';
+
+  const inWindow = item.milestone >= (DATA.meta.previousMilestone + 1) && item.milestone <= DATA.meta.currentMilestone;
+  const rowCls = inWindow ? 'window-marker' : 'future-marker';
+
+  return `
+    <div class="card mb-2 item-card" data-status="${item.bindingStatus}" data-milestone="${item.milestone}">
+      <div class="card-header bg-white finding-header d-flex align-items-center py-2 ${rowCls}" data-bs-toggle="collapse" data-bs-target="#item-${item.id}">
+        <span class="milestone-badge me-2">m${item.milestone}</span>
+        <span class="cat-pill ${catCls} me-2">${CAT_LABELS[item.category] || item.category}</span>
+        <span class="status-pill ${statusCls} me-2">${statusLabel}</span>
+        <strong class="me-auto small">${esc(item.skiaApi)}</strong>
+        <span class="${priCls} small me-2">${item.priority !== 'none' ? item.priority.toUpperCase() : ''}</span>
+        <i class="bi bi-chevron-down"></i>
+      </div>
+      <div class="collapse" id="item-${item.id}">
+        <div class="card-body py-2">
+          <p class="small text-muted mb-2">${esc(item.description)}</p>
+          ${body}
+        </div>
+      </div>
+    </div>`;
+}
+
+function renderItems(items) {
+  // Group by milestone
+  const grouped = {};
+  items.forEach(item => {
+    const ms = item.milestone;
+    if (!grouped[ms]) grouped[ms] = [];
+    grouped[ms].push(item);
+  });
+
+  const milestones = Object.keys(grouped).map(Number).sort((a, b) => a - b);
+  const container = document.getElementById('items-container');
+
+  container.innerHTML = milestones.map(ms => {
+    const inWindow = ms >= (DATA.meta.previousMilestone + 1) && ms <= DATA.meta.currentMilestone;
+    const rangeCls = inWindow ? 'ms-current' : 'ms-future';
+    const rangeLabel = inWindow ? 'Current Window' : 'Future';
+
+    return `
+      <div class="mb-4 ms-group" data-milestone="${ms}">
+        <div class="d-flex align-items-center mb-2">
+          <h5 class="mb-0 me-2">Milestone ${ms}</h5>
+          <span class="ms-range ${rangeCls}">${rangeLabel}</span>
+          <span class="ms-auto text-muted small">${grouped[ms].length} items</span>
+        </div>
+        ${grouped[ms].map(renderItem).join('')}
+      </div>`;
+  }).join('');
+}
+
+function renderDeprecations(deps) {
+  const tbody = document.querySelector('#deprecations-table tbody');
+  if (!deps || deps.length === 0) {
+    document.getElementById('deprecations-section').style.display = 'none';
+    return;
+  }
+  tbody.innerHTML = deps.map(d => `
+    <tr>
+      <td><code>${esc(d.skiasharpApi)}</code></td>
+      <td><span class="milestone-badge">m${d.deprecatedSince}</span></td>
+      <td>${d.replacement ? `<code>${esc(d.replacement)}</code>` : '<span class="text-muted">—</span>'}</td>
+      <td class="text-muted small">${esc(d.skiasharpFile)}</td>
+    </tr>`).join('');
+}
+
+function renderNextSteps(steps) {
+  const el = document.getElementById('next-steps');
+  if (!steps || steps.length === 0) { el.innerHTML = '<p class="text-muted">No action items.</p>'; return; }
+  el.innerHTML = steps.map(s => {
+    const cls = s.severity === 'critical' ? 'ns-critical' : s.severity === 'high' ? 'ns-high' : s.severity === 'medium' ? 'ns-medium' : 'ns-low';
+    return `<div class="next-step ${cls}">
+      <div class="d-flex align-items-center">
+        <span class="badge bg-secondary me-2">${s.priority}</span>
+        <strong>${esc(s.action)}</strong>
+        <span class="ms-2 ${PRI_CLASS[s.severity] || ''} small">${(s.severity || '').toUpperCase()}</span>
+        ${s.milestone ? `<span class="milestone-badge ms-2">m${s.milestone}</span>` : ''}
+      </div>
+      <div class="text-muted small">${esc(s.reason)}</div>
+      ${s.skillToUse ? `<span class="small text-info">→ Use <code>${esc(s.skillToUse)}</code> skill</span>` : ''}
+    </div>`;
+  }).join('');
+}
+
+function renderMeta(meta) {
+  document.getElementById('audit-meta').innerHTML = `
+    <table class="table table-sm meta-table mb-0"><tbody>
+      <tr><th>Date</th><td>${meta.date}</td></tr>
+      <tr><th>Milestone Range</th><td>m${meta.previousMilestone} → m${meta.currentMilestone}</td></tr>
+      <tr><th>Latest Upstream</th><td>m${meta.latestUpstreamMilestone}</td></tr>
+      ${meta.skiaSubmoduleCommit ? `<tr><th>Submodule</th><td><code><a href="https://github.com/mono/skia/commit/${meta.skiaSubmoduleCommit}" target="_blank">${meta.skiaSubmoduleCommit.slice(0, 12)}</a></code></td></tr>` : ''}
+      <tr><th>Source</th><td><a href="${meta.releaseNotesSource}" target="_blank">Skia RELEASE_NOTES.md</a></td></tr>
+    </tbody></table>`;
+}
+
+// Filtering
+let currentFilter = 'all';
+function applyFilter(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.filter-btn').forEach(b => b.classList.toggle('active', b.dataset.filter === filter));
+  let shown = 0, total = 0;
+  document.querySelectorAll('.item-card').forEach(card => {
+    total++;
+    const match = filter === 'all' || card.dataset.status === filter;
+    card.style.display = match ? '' : 'none';
+    if (match) shown++;
+  });
+  // Hide empty milestone groups
+  document.querySelectorAll('.ms-group').forEach(g => {
+    const visible = g.querySelectorAll('.item-card:not([style*="display: none"])').length;
+    g.style.display = visible > 0 ? '' : 'none';
+  });
+  document.getElementById('filter-count').textContent = filter === 'all' ? `${total} items` : `${shown} of ${total}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof DATA === 'undefined') { document.body.innerHTML = '<p class="p-4 text-danger">No DATA found.</p>'; return; }
+  const d = DATA;
+
+  document.getElementById('header-subtitle').textContent =
+    `${d.meta.date} · m${d.meta.previousMilestone} → m${d.meta.currentMilestone} · ${d.summary.totalItems} items`;
+  document.getElementById('header-badges').innerHTML =
+    `<span class="ms-range ms-current">m${d.meta.previousMilestone}→m${d.meta.currentMilestone}</span>` +
+    `<span class="ms-range ms-future">→ m${d.meta.latestUpstreamMilestone}</span>`;
+
+  renderSummary(d.summary);
+  renderItems(d.items);
+  renderDeprecations(d.deprecations);
+  renderNextSteps(d.nextSteps);
+  renderMeta(d.meta);
+
+  // Wire up filter buttons
+  document.querySelectorAll('.filter-btn').forEach(btn => {
+    btn.addEventListener('click', () => applyFilter(btn.dataset.filter));
+  });
+  applyFilter('all');
+});
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

New skill that audits Skia upstream release notes against SkiaSharp's C API and C# bindings to produce a structured report of API coverage gaps. Follows the same JSON + HTML pattern as the `security-audit` skill.

## What it does

When invoked (e.g., *"generate a report of the release notes between m119 and m133"*), the skill:

1. Fetches Skia `RELEASE_NOTES.md` from upstream
2. Classifies each change (new feature, deprecation, removal, behavior change, internal)
3. Checks the C API (`mono/skia include/c/`) for each item
4. Checks C# bindings (`binding/SkiaSharp/`) for each item
5. Cross-validates findings with a second model
6. Produces **structured JSON** conforming to `references/report-schema.md`
7. Renders a **standalone HTML dashboard** (Bootstrap 5, filterable, collapsible)
8. Presents a markdown summary

## Files

```
.github/skills/release-notes-audit/
├── SKILL.md                           # 9-step workflow + classification guide
├── references/
│   └── report-schema.md               # JSON schema (items, deprecations, nextSteps)
└── scripts/
    ├── render-release-notes-audit.py   # JSON → HTML renderer
    └── viewer.html                     # Bootstrap 5 template with filtering
```

## HTML Report Features

- **Summary cards** — Missing / Action Needed / Full / N/A counts
- **Filter bar** — Click to show only items by binding status
- **Milestone grouping** — Items grouped by Skia milestone with current/future markers
- **Collapsible details** — Each item shows C API function, C# method, file, and notes
- **Deprecation table** — APIs needing `[Obsolete]` markers
- **Next steps** — Prioritized actions with skill handoff recommendations

## Motivation

This was built during an actual audit of Skia m119→m133 release notes, which identified:
- 14 missing bindings (including `SKBitmap.SetColorSpace`, `SKImage.MakeScaled`, `SaveLayerRec.TileMode`)
- 5 APIs needing `[Obsolete]` markers (SKTypeface factory methods)
- 2 critical future items (SKPathBuilder for m143, gradient header removal in m146)

The skill codifies this workflow so future milestone bumps can be audited consistently.