### PR TITLE
Unify ANGLE dependency into Skia DEPS file

### DIFF
--- a/native/winui-angle/build.cake
+++ b/native/winui-angle/build.cake
@@ -1,8 +1,7 @@
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../.."));
-DirectoryPath ANGLE_PATH = ROOT_PATH.Combine("externals/angle");
+DirectoryPath ANGLE_PATH = ROOT_PATH.Combine("externals/skia/third_party/externals/angle2");
 DirectoryPath WINAPPSDK_PATH = ROOT_PATH.Combine("externals/winappsdk");
 DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native/winui"));
-string ANGLE_VERSION = GetVersion("ANGLE", "release");
 
 var VERIFY_EXCLUDED = new[] { "VCRUNTIME", "MSVCP" };
 
@@ -25,78 +24,10 @@ string GetSpectreLibPath(string arch)
 }
 
 Task("sync-ANGLE")
+    .IsDependentOn("git-sync-deps")
     .WithCriteria(IsRunningOnWindows())
     .Does(() =>
 {
-    // sync ANGLE
-    if (!DirectoryExists(ANGLE_PATH)) {
-        RunProcess("git", $"clone https://github.com/google/angle.git --branch {ANGLE_VERSION} --depth 1 --single-branch --shallow-submodules {ANGLE_PATH}");
-    }
-
-    // sync submodules
-    var submodules = new[] {
-        "build",
-        "testing",
-        "third_party/zlib",
-        "third_party/jsoncpp",
-        "third_party/vulkan-deps",
-        "third_party/astc-encoder/src",
-        "tools/clang",
-    };
-    foreach (var submodule in submodules) {
-        var sub = ANGLE_PATH.Combine(submodule);
-        if (FileExists(sub.CombineWithFilePath("BUILD.gn")) || FileExists(sub.CombineWithFilePath(".gitignore")))
-            continue;
-
-        RunProcess("git", new ProcessSettings {
-            Arguments = $"submodule update --init --recursive --depth 1 --single-branch {submodule}",
-            WorkingDirectory = ANGLE_PATH.FullPath,
-        });
-    }
-
-    // patch the output filenames
-    {
-        var toolchain = ANGLE_PATH.CombineWithFilePath("build/toolchain/win/toolchain.gni");
-        var contents = System.IO.File.ReadAllText(toolchain.FullPath);
-        var newContents = contents
-            .Replace("\"${dllname}.lib\"", "\"{{output_dir}}/{{target_output_name}}.lib\"")
-            .Replace("\"${dllname}.pdb\"", "\"{{output_dir}}/{{target_output_name}}.pdb\"");
-        if (contents != newContents)
-            System.IO.File.WriteAllText(toolchain.FullPath, newContents);
-    }
-
-    // set build args
-    if (!FileExists(ANGLE_PATH.CombineWithFilePath("build/config/gclient_args.gni"))) {
-        var lines = new[] {
-            "checkout_angle_internal = false",
-            "checkout_angle_mesa = false",
-            "checkout_angle_restricted_traces = false",
-            "generate_location_tags = false"
-        };
-        System.IO.File.WriteAllLines(ANGLE_PATH.CombineWithFilePath("build/config/gclient_args.gni").FullPath, lines);
-    }
-
-    // set version numbers
-    if (!FileExists(ANGLE_PATH.CombineWithFilePath("build/util/LASTCHANGE"))) {
-        var lastchange = ANGLE_PATH.CombineWithFilePath("build/util/LASTCHANGE");
-        RunPython(ANGLE_PATH, ANGLE_PATH.CombineWithFilePath("build/util/lastchange.py"), $"-o {lastchange}");
-    }
-
-    // download rc.exe
-    var rc_exe = "build/toolchain/win/rc/win/rc.exe";
-    var rcPath = ANGLE_PATH.CombineWithFilePath(rc_exe);
-    if (!FileExists(rcPath)) {
-        var shaPath = ANGLE_PATH.CombineWithFilePath($"{rc_exe}.sha1");
-        var sha = System.IO.File.ReadAllText(shaPath.FullPath);
-        var url = $"https://storage.googleapis.com/download/storage/v1/b/chromium-browser-clang/o/rc%2F{sha}?alt=media";
-        DownloadFile(url, rcPath);
-    }
-
-    // download llvm
-    if (!FileExists(ANGLE_PATH.CombineWithFilePath("third_party/llvm-build/Release+Asserts/cr_build_revision"))) {
-        RunPython(ANGLE_PATH, ANGLE_PATH.CombineWithFilePath("tools/clang/scripts/update.py"));
-    }
-
     // generate Windows App SDK files
     if (!FileExists(WINAPPSDK_PATH.CombineWithFilePath("Microsoft.WindowsAppSDK.nuspec"))) {
         var setup = ANGLE_PATH.CombineWithFilePath("scripts/winappsdk_setup.py");

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,7 +1,7 @@
 # native sources
 harfbuzz                                        release     8.3.1
 skia                                            release     m132
-ANGLE                                           release     chromium/6275
+ANGLE                                           release     chromium/6275       # pinned in externals/skia/DEPS deps_os["win"]
 
 # product dependencies
 AtkSharp                                        release     3.24.24.95

--- a/scripts/cake/externals.cake
+++ b/scripts/cake/externals.cake
@@ -79,7 +79,7 @@ Task("clean-externals")
     CleanDirectories("externals/skia/xcodebuild");
 
     // angle
-    CleanDirectories("externals/angle");
+    CleanDirectories("externals/skia/third_party/externals/angle2/out");
 
     // all
     CleanDirectories("output/native");

--- a/scripts/cake/native-shared.cake
+++ b/scripts/cake/native-shared.cake
@@ -38,9 +38,101 @@ Task("git-sync-deps")
     if (actualIncrement != expectedIncrement)
         throw new Exception($"The libSkiaSharp C API version did not match the expected '{expectedIncrement}', instead was '{actualIncrement}'.");
 
-    RunPython(SKIA_PATH, SKIA_PATH.CombineWithFilePath("tools/git-sync-deps"),
+    // pass the current OS so that deps_os entries (e.g. ANGLE on Windows) are synced
+    var osArg = IsRunningOnWindows() ? "win" : (IsRunningOnMacOs() ? "mac" : "unix");
+    RunPython(SKIA_PATH, SKIA_PATH.CombineWithFilePath("tools/git-sync-deps"), osArg,
         envVars: new Dictionary<string, string> { ["GIT_SYNC_DEPS_SKIP_EMSDK"] = "1" });
+
+    // sync ANGLE submodules and run post-checkout setup (Windows only via deps_os)
+    var anglePath = SKIA_PATH.Combine("third_party/externals/angle2");
+    if (DirectoryExists(anglePath)) {
+        SyncAngle(anglePath);
+    }
 });
+
+void SyncAngle(DirectoryPath anglePath)
+{
+    // init only the submodules required for building ANGLE
+    var submodules = new[] {
+        "build",
+        "testing",
+        "third_party/zlib",
+        "third_party/jsoncpp",
+        "third_party/astc-encoder/src",
+        "tools/clang",
+    };
+    foreach (var submodule in submodules) {
+        var sub = anglePath.Combine(submodule);
+        if (FileExists(sub.CombineWithFilePath("BUILD.gn")) || FileExists(sub.CombineWithFilePath(".gitignore")))
+            continue;
+
+        RunProcess("git", new ProcessSettings {
+            Arguments = $"submodule update --init --recursive --depth 1 --single-branch {submodule}",
+            WorkingDirectory = anglePath.FullPath,
+        });
+    }
+
+    // vulkan-deps needs special handling: init non-recursively first, then set
+    // core.longpaths and recursively init its children (some have very long filenames)
+    var vulkanDeps = anglePath.Combine("third_party/vulkan-deps");
+    if (!FileExists(vulkanDeps.CombineWithFilePath("README.chromium"))) {
+        RunProcess("git", new ProcessSettings {
+            Arguments = "submodule update --init --depth 1 --single-branch third_party/vulkan-deps",
+            WorkingDirectory = anglePath.FullPath,
+        });
+        RunProcess("git", new ProcessSettings {
+            Arguments = "config core.longpaths true",
+            WorkingDirectory = vulkanDeps.FullPath,
+        });
+        RunProcess("git", new ProcessSettings {
+            Arguments = "submodule update --init --recursive --depth 1 --single-branch",
+            WorkingDirectory = vulkanDeps.FullPath,
+        });
+    }
+
+    // patch the output filenames
+    {
+        var toolchain = anglePath.CombineWithFilePath("build/toolchain/win/toolchain.gni");
+        var contents = System.IO.File.ReadAllText(toolchain.FullPath);
+        var newContents = contents
+            .Replace("\"${dllname}.lib\"", "\"{{output_dir}}/{{target_output_name}}.lib\"")
+            .Replace("\"${dllname}.pdb\"", "\"{{output_dir}}/{{target_output_name}}.pdb\"");
+        if (contents != newContents)
+            System.IO.File.WriteAllText(toolchain.FullPath, newContents);
+    }
+
+    // set build args
+    if (!FileExists(anglePath.CombineWithFilePath("build/config/gclient_args.gni"))) {
+        var lines = new[] {
+            "checkout_angle_internal = false",
+            "checkout_angle_mesa = false",
+            "checkout_angle_restricted_traces = false",
+            "generate_location_tags = false"
+        };
+        System.IO.File.WriteAllLines(anglePath.CombineWithFilePath("build/config/gclient_args.gni").FullPath, lines);
+    }
+
+    // set version numbers
+    if (!FileExists(anglePath.CombineWithFilePath("build/util/LASTCHANGE"))) {
+        var lastchange = anglePath.CombineWithFilePath("build/util/LASTCHANGE");
+        RunPython(anglePath, anglePath.CombineWithFilePath("build/util/lastchange.py"), $"-o {lastchange}");
+    }
+
+    // download rc.exe
+    var rc_exe = "build/toolchain/win/rc/win/rc.exe";
+    var rcPath = anglePath.CombineWithFilePath(rc_exe);
+    if (!FileExists(rcPath)) {
+        var shaPath = anglePath.CombineWithFilePath($"{rc_exe}.sha1");
+        var sha = System.IO.File.ReadAllText(shaPath.FullPath);
+        var url = $"https://storage.googleapis.com/download/storage/v1/b/chromium-browser-clang/o/rc%2F{sha}?alt=media";
+        DownloadFile(url, rcPath);
+    }
+
+    // download llvm
+    if (!FileExists(anglePath.CombineWithFilePath("third_party/llvm-build/Release+Asserts/cr_build_revision"))) {
+        RunPython(anglePath, anglePath.CombineWithFilePath("tools/clang/scripts/update.py"));
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // HELPERS


### PR DESCRIPTION
Move ANGLE from a standalone `git clone` in `winui-angle/build.cake` into the Skia DEPS file using the `deps_os["win"]` conditional section. This means `git-sync-deps` handles ANGLE checkout alongside all other dependencies, but only on Windows where it's needed for WinUI builds.

**Companion PR:** mono/skia#183 — adds the `deps_os["win"]` entry to DEPS

### What changed

| File | Change |
|------|--------|
| `externals/skia` | Points to skia commit with `deps_os["win"]` ANGLE entry |
| `scripts/cake/native-shared.cake` | Passes OS arg to `git-sync-deps`; adds `SyncAngle()` for submodule init + setup |
| `native/winui-angle/build.cake` | Removes clone/setup logic from `sync-ANGLE`; updates `ANGLE_PATH` to new location; keeps WinAppSDK setup + build tasks |
| `scripts/cake/externals.cake` | Updates clean path to new ANGLE location |
| `scripts/VERSIONS.txt` | Notes that DEPS is the source of truth for ANGLE pin |

### How it works

1. `git-sync-deps` in the DEPS file now has a `deps_os` section:
   ```python
   deps_os = {
       "win": {
           "third_party/externals/angle2": "https://github.com/google/angle.git@ea1cea...",
       },
   }
   ```
2. The cake `git-sync-deps` task passes `"win"` / `"mac"` / `"unix"` as a CLI arg so platform-conditional deps are synced
3. After sync, `SyncAngle()` inits only the 7 required submodules and runs post-checkout setup (patches, gclient_args, LASTCHANGE, rc.exe, LLVM)
4. `sync-ANGLE` in the ANGLE build file now only handles WinAppSDK generation — all other setup moved to shared sync

### Benefits
- **Single DEPS file** is the source of truth for all native dependencies including ANGLE
- **Single sync task** (`git-sync-deps`) handles everything
- **Zero cost on non-Windows CI** — `deps_os["win"]` entries are only fetched when OS arg is `"win"`
- ANGLE version pin is visible alongside all other dependency pins