### PR TITLE
Clean up issue-triage skill: semantic enum ordering, cost labels, schema fixes

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -62,10 +62,9 @@ If `gh` is unavailable or unauthenticated, use the GitHub MCP issue/PR retrieval
 ### 1. Read the issue
 
 ```bash
-mkdir -p /tmp/skiasharp/triage/{timestamp}
 gh issue view {number} --repo mono/SkiaSharp \
   --json number,title,body,labels,comments,state,createdAt,updatedAt,closedAt,author,milestone \
-  > /tmp/skiasharp/triage/{timestamp}/{number}.issue.json
+  > /tmp/{number}.issue.json
 ```
 
 GitHub MCP issue/PR retrieval tools are equally valid if the environment exposes them.
@@ -126,7 +125,7 @@ Read [references/labels.md](references/labels.md) for valid label values and car
 
 ### Classify and generate JSON
 
-Write brief internal analysis (3–5 sentences), classify the type, then read [references/research-by-type.md](references/research-by-type.md) for type-specific research. Conduct the research, then generate the JSON. Write to `/tmp/skiasharp/triage/{timestamp}/{number}.json` where `{timestamp}` is the current UTC time in `yyyyMMdd-HHmmss` format. Create the directory first with `mkdir -p`. Use this exact literal path structure, do NOT substitute `$TMPDIR` or any other variable.
+Write brief internal analysis (3–5 sentences), classify the type, then read [references/research-by-type.md](references/research-by-type.md) for type-specific research. Conduct the research, then generate the JSON. Write to `/tmp/{number}.json`. Use this exact literal path structure, do NOT substitute `$TMPDIR` or any other variable. Do NOT use `mkdir` — write directly to `/tmp/`.
 
 > **⚠️ Schema Compliance:**
 >
@@ -185,7 +184,7 @@ If no proposals contain code, set `validated: "untested"`.
 > **Skipping validation = INVALID triage. The task is incomplete.**
 
 ```bash
-python3 .agents/skills/issue-triage/scripts/validate-triage.py /tmp/skiasharp/triage/{timestamp}/{number}.json
+python3 .agents/skills/issue-triage/scripts/validate-triage.py /tmp/{number}.json
 ```
 
 - **Exit 0** = ✅ valid → proceed to Phase 6
@@ -206,7 +205,7 @@ python3 .agents/skills/issue-triage/scripts/validate-triage.py /tmp/skiasharp/tr
 Copy the validated JSON to `output/ai/` for collection, then render companion Markdown and HTML reports that wrap the same JSON data.
 
 ```bash
-python3 .agents/skills/issue-triage/scripts/persist-triage.py /tmp/skiasharp/triage/{timestamp}/{number}.json
+python3 .agents/skills/issue-triage/scripts/persist-triage.py /tmp/{number}.json
 ```
 
 This produces:

--- a/.agents/skills/issue-triage/references/labels.md
+++ b/.agents/skills/issue-triage/references/labels.md
@@ -43,4 +43,4 @@ Pick the most specific match. SKCanvasView in MAUI → `area/SkiaSharp.Views.Mau
   - **`type/feature-request`**: Adding completely new functionality — e.g., "add PDF export", "support new image format"
   - **Platform parity gap**: API exists cross-platform but a specific platform handler is missing → `type/bug` (the API contract is broken). Only use `type/enhancement` if no platform implements it yet.
 - `question` asks "how?"; `documentation` says "we need docs for X"
-- When behavior is correct but easy to misuse (disposal ordering, threading, etc.), keep `type/bug` and suggest `close-as-by-design` with a workaround. The `status/by-design` label communicates that the behavior is intentional.
+- When behavior is correct but easy to misuse (disposal ordering, threading, etc.), keep `type/bug` and suggest `close-as-not-a-bug` with a workaround. The `status/by-design` label communicates that the behavior is intentional.

--- a/.agents/skills/issue-triage/references/schema-cheatsheet.md
+++ b/.agents/skills/issue-triage/references/schema-cheatsheet.md
@@ -49,12 +49,12 @@ Read this BEFORE generating JSON. Full schema: `references/triage-schema.json`.
 
 | Enum | Values |
 |------|--------|
-| **classifiedType** | `type/bug`, `type/feature-request`, `type/question`, `type/enhancement`, `type/documentation` |
-| **classifiedArea** | `area/Build`, `area/Docs`, `area/HarfBuzzSharp`, `area/libHarfBuzzSharp.native`, `area/libSkiaSharp.native`, `area/SkiaSharp`, `area/SkiaSharp.HarfBuzz`, `area/SkiaSharp.Views`, `area/SkiaSharp.Views.Blazor`, `area/SkiaSharp.Views.Forms`, `area/SkiaSharp.Views.Maui`, `area/SkiaSharp.Views.Uno`, `area/SkiaSharp.Workbooks` |
-| **classifiedPlatform** | `os/Android`, `os/iOS`, `os/macOS`, `os/Linux`, `os/Windows-Classic`, `os/Windows-WinUI`, `os/Windows-Universal-UWP`, `os/Windows-Nano-Server`, `os/WASM`, `os/Tizen`, `os/tvOS`, `os/watchOS` |
-| **classifiedBackend** | `backend/OpenGL`, `backend/Metal`, `backend/Vulkan`, `backend/Raster`, `backend/Direct3D`, `backend/PDF`, `backend/SVG`, `backend/XPS` |
-| **suggestedAction** | `needs-investigation`, `close-as-fixed`, `close-as-by-design`, `close-with-docs`, `close-as-duplicate`, `convert-to-discussion`, `request-info`, `keep-open` |
-| **errorType** | `crash`, `exception`, `wrong-output`, `missing-output`, `performance`, `build-error`, `memory-leak`, `platform-specific`, `other` |
+| **classifiedType** | `type/bug`, `type/documentation`, `type/enhancement`, `type/feature-request`, `type/question` |
+| **classifiedArea** | `area/Build`, `area/Docs`, `area/HarfBuzzSharp`, `area/SkiaSharp`, `area/SkiaSharp.HarfBuzz`, `area/SkiaSharp.Views`, `area/SkiaSharp.Views.Blazor`, `area/SkiaSharp.Views.Forms`, `area/SkiaSharp.Views.Maui`, `area/SkiaSharp.Views.Uno`, `area/SkiaSharp.Workbooks`, `area/libHarfBuzzSharp.native`, `area/libSkiaSharp.native` |
+| **classifiedPlatform** | `os/Android`, `os/Linux`, `os/Tizen`, `os/WASM`, `os/Windows-Classic`, `os/Windows-Nano-Server`, `os/Windows-Universal-UWP`, `os/Windows-WinUI`, `os/iOS`, `os/macOS`, `os/tvOS`, `os/watchOS` |
+| **classifiedBackend** | `backend/Direct3D`, `backend/Metal`, `backend/OpenGL`, `backend/PDF`, `backend/Raster`, `backend/SVG`, `backend/Vulkan`, `backend/XPS` |
+| **suggestedAction** | `needs-info`, `needs-reproduction`, `needs-investigation`, `ready-to-fix`, `keep-open`, `close-as-fixed`, `close-as-duplicate`, `close-as-not-a-bug`, `close-as-external` |
+| **errorType** | `crash`, `exception`, `memory-leak`, `build-error`, `wrong-output`, `missing-output`, `missing-api`, `performance`, `platform-specific`, `other` |
 | **severity** | `critical`, `high`, `medium`, `low` |
 
 ### Severity rubric (bugs only)
@@ -69,31 +69,37 @@ Read this BEFORE generating JSON. Full schema: `references/triage-schema.json`.
 | **reproQuality** | `complete`, `partial`, `none` |
 | **currentRelevance** | `likely`, `unlikely`, `unknown` |
 | **relevance** (codeInvestigation) | `direct`, `related`, `context` |
-| **category** (proposals) | `workaround`, `fix`, `alternative`, `investigation` |
+| **category** (proposals) | `fix`, `workaround`, `alternative`, `investigation` |
 | **validated** (proposals) | `untested`, `yes`, `no` |
+| **effort** (proposals) | `cost/xs`, `cost/s`, `cost/m`, `cost/l`, `cost/xl` |
 | **suggestedReproPlatform** | `linux`, `macos`, `windows` |
-| **actionType** | `update-labels`, `add-comment`, `close-issue`, `convert-to-discussion`, `link-related`, `link-duplicate`, `set-milestone` |
+| **actionType** | `add-comment`, `close-issue`, `convert-to-discussion`, `link-duplicate`, `link-related`, `set-milestone`, `update-labels` |
+| **actionRisk** | `low`, `medium`, `high` |
+| **stateReason** | `completed`, `not_planned` |
 
 ### Choosing `suggestedAction` by issue type
 
 | Type | Common suggestedAction | When |
 |------|----------------------|------|
 | `type/bug` | `needs-investigation` | Repro code provided, bug seems real |
-| `type/bug` | `request-info` | Missing repro, vague description |
-| `type/bug` | `close-as-by-design` | Behavior is correct but confusing |
+| `type/bug` | `needs-info` | Missing repro, vague description |
+| `type/bug` | `needs-reproduction` | Some info but no reliable minimal repro |
+| `type/bug` | `close-as-not-a-bug` | Behavior is correct but confusing |
+| `type/bug` | `close-as-external` | Root cause is in upstream Skia or another dependency |
+| `type/bug` | `ready-to-fix` | Root cause is clear, fix path is known |
 | `type/enhancement` | `needs-investigation` | Well-specified, has clear scope |
 | `type/enhancement` | `keep-open` | Valid but low priority / needs design |
 | `type/feature-request` | `needs-investigation` | Clear request with implementation path |
 | `type/feature-request` | `keep-open` | Valid but requires design discussion |
-| `type/question` | `close-with-docs` | Answer exists in docs |
-| `type/question` | `convert-to-discussion` | Better suited for community Q&A |
+| `type/question` | `close-as-not-a-bug` | Answer exists in docs or is by-design |
+| `type/question` | `needs-info` | Need more context to answer |
 | `type/documentation` | `needs-investigation` | Docs are missing or wrong |
 
-**Distinguishing `request-info` vs `convert-to-discussion`:**
-- Use `request-info` when there IS a signal worth following up (regression claim, partial repro, plausible bug) — give the reporter a chance to provide details.
-- Use `convert-to-discussion` when there is NO actionable signal (empty template, "how do I?" question, vague feature wish).
+**Distinguishing `needs-info` vs `needs-reproduction`:**
+- Use `needs-info` when critical information is missing from the reporter (version, platform, repro steps, etc.).
+- Use `needs-reproduction` when the issue description has enough context but no reliable minimal reproduction case.
 
-**Empty-template heuristic:** If the code/repro sections contain only template placeholders or are completely empty, use `request-info` regardless of type classification. A regression claim in the version fields upgrades priority even with sparse content.
+**Empty-template heuristic:** If the code/repro sections contain only template placeholders or are completely empty, use `needs-info` regardless of type classification. A regression claim in the version fields upgrades priority even with sparse content.
 
 ## Output (required)
 
@@ -112,7 +118,7 @@ Read this BEFORE generating JSON. Full schema: `references/triage-schema.json`.
 }
 ```
 
-`missingInfo` is optional — include when reporter needs to provide more details (pair with `request-info` action).
+`missingInfo` is optional — include when reporter needs to provide more details (pair with `needs-info` action).
 
 ### Action Types & Required Fields
 

--- a/.agents/skills/issue-triage/references/triage-examples.md
+++ b/.agents/skills/issue-triage/references/triage-examples.md
@@ -71,8 +71,8 @@ Bug with bugSignals, codeInvestigation, resolution proposals, and simplified act
     "resolution": {
       "hypothesis": "Android detaches views on a different thread than iOS, causing use-after-free of the native surface.",
       "proposals": [
-        { "title": "Add disposal guard", "description": "Add null/disposed check before accessing native surface in OnDetachedFromWindow.", "codeSnippet": "if (IsDisposed || _surface == null) return;", "confidence": 0.75, "effort": "small" },
-        { "title": "Synchronize with UI thread", "description": "Synchronize disposal with UI thread to ensure surface validity.", "confidence": 0.70, "effort": "medium" }
+        { "title": "Add disposal guard", "description": "Add null/disposed check before accessing native surface in OnDetachedFromWindow.", "codeSnippet": "if (IsDisposed || _surface == null) return;", "confidence": 0.75, "effort": "cost/s" },
+        { "title": "Synchronize with UI thread", "description": "Synchronize disposal with UI thread to ensure surface validity.", "confidence": 0.70, "effort": "cost/m" }
       ],
       "recommendedProposal": "Add disposal guard",
       "recommendedReason": "Simpler fix with high confidence. Matches the pattern already used on iOS."
@@ -82,7 +82,8 @@ Bug with bugSignals, codeInvestigation, resolution proposals, and simplified act
     "actionability": {
       "suggestedAction": "needs-investigation",
       "confidence": 0.80,
-      "reason": "Real bug with stack trace, needs deeper investigation into Android lifecycle threading"
+      "reason": "Real bug with stack trace, needs deeper investigation into Android lifecycle threading",
+      "suggestedReproPlatform": "linux"
     },
     "actions": [
       {
@@ -106,7 +107,7 @@ Bug with bugSignals, codeInvestigation, resolution proposals, and simplified act
 
 ## Question Example
 
-Question with resolution proposals, no bugSignals, close-with-docs action:
+Question with resolution proposals, no bugSignals, close-as-not-a-bug action:
 
 ```json
 {
@@ -133,14 +134,14 @@ Question with resolution proposals, no bugSignals, close-with-docs action:
     "resolution": {
       "hypothesis": "User wants to render text with a custom .ttf font on Linux.",
       "proposals": [
-        { "title": "Load font from file", "description": "Use SKTypeface.FromFile() to load font from path. Simplest approach.", "category": "fix", "confidence": 0.90, "effort": "trivial" },
-        { "title": "Embed font as resource", "description": "Embed font as resource and use SKTypeface.FromData() for portability.", "category": "alternative", "confidence": 0.90, "effort": "small" }
+        { "title": "Load font from file", "description": "Use SKTypeface.FromFile() to load font from path. Simplest approach.", "category": "fix", "confidence": 0.90, "effort": "cost/xs" },
+        { "title": "Embed font as resource", "description": "Embed font as resource and use SKTypeface.FromData() for portability.", "category": "alternative", "confidence": 0.90, "effort": "cost/s" }
       ]
     }
   },
   "output": {
     "actionability": {
-      "suggestedAction": "close-with-docs",
+      "suggestedAction": "close-as-not-a-bug",
       "confidence": 0.85,
       "reason": "Answered by existing API documentation"
     },

--- a/.agents/skills/issue-triage/references/triage-schema.json
+++ b/.agents/skills/issue-triage/references/triage-schema.json
@@ -24,10 +24,10 @@
       "type": "string",
       "enum": [
         "type/bug",
-        "type/feature-request",
-        "type/question",
+        "type/documentation",
         "type/enhancement",
-        "type/documentation"
+        "type/feature-request",
+        "type/question"
       ],
       "description": "Issue type. Pick ONE best fit \u2014 trust issue content over title prefix."
     },
@@ -37,8 +37,6 @@
         "area/Build",
         "area/Docs",
         "area/HarfBuzzSharp",
-        "area/libHarfBuzzSharp.native",
-        "area/libSkiaSharp.native",
         "area/SkiaSharp",
         "area/SkiaSharp.HarfBuzz",
         "area/SkiaSharp.Views",
@@ -46,7 +44,9 @@
         "area/SkiaSharp.Views.Forms",
         "area/SkiaSharp.Views.Maui",
         "area/SkiaSharp.Views.Uno",
-        "area/SkiaSharp.Workbooks"
+        "area/SkiaSharp.Workbooks",
+        "area/libHarfBuzzSharp.native",
+        "area/libSkiaSharp.native"
       ],
       "description": "Component area. Pick MOST SPECIFIC match. Values are actual GitHub labels."
     },
@@ -54,15 +54,15 @@
       "type": "string",
       "enum": [
         "os/Android",
+        "os/Linux",
+        "os/Tizen",
+        "os/WASM",
+        "os/Windows-Classic",
+        "os/Windows-Nano-Server",
+        "os/Windows-Universal-UWP",
+        "os/Windows-WinUI",
         "os/iOS",
         "os/macOS",
-        "os/Linux",
-        "os/Windows-Classic",
-        "os/Windows-WinUI",
-        "os/Windows-Universal-UWP",
-        "os/Windows-Nano-Server",
-        "os/WASM",
-        "os/Tizen",
         "os/tvOS",
         "os/watchOS"
       ],
@@ -74,10 +74,10 @@
         "backend/Direct3D",
         "backend/Metal",
         "backend/OpenGL",
-        "backend/Raster",
-        "backend/Vulkan",
         "backend/PDF",
+        "backend/Raster",
         "backend/SVG",
+        "backend/Vulkan",
         "backend/XPS"
       ],
       "description": "Rendering backend label. Omit backends array entirely if not backend-specific."
@@ -103,27 +103,28 @@
     "suggestedAction": {
       "type": "string",
       "enum": [
+        "needs-info",
+        "needs-reproduction",
         "needs-investigation",
+        "ready-to-fix",
+        "keep-open",
         "close-as-fixed",
-        "close-as-by-design",
-        "close-with-docs",
         "close-as-duplicate",
-        "convert-to-discussion",
-        "request-info",
-        "keep-open"
+        "close-as-not-a-bug",
+        "close-as-external"
       ],
-      "description": "Recommended next action for the maintainer. close-as-by-design=behavior is intentional but may warrant docs/workaround."
+      "description": "Recommended next action for the maintainer. needs-info=missing critical info from reporter. needs-reproduction=need a reliable minimal repro. needs-investigation=requires deeper code/runtime investigation. ready-to-fix=root cause understood, ready to implement. keep-open=valid issue, no immediate action. close-as-fixed=already resolved. close-as-duplicate=duplicate of another issue. close-as-not-a-bug=behavior is intentional/by-design. close-as-external=root cause is upstream Skia or another dependency."
     },
     "actionType": {
       "type": "string",
       "enum": [
-        "update-labels",
         "add-comment",
         "close-issue",
         "convert-to-discussion",
-        "link-related",
         "link-duplicate",
-        "set-milestone"
+        "link-related",
+        "set-milestone",
+        "update-labels"
       ],
       "description": "Type of automatable operation."
     },
@@ -134,7 +135,7 @@
         "medium",
         "high"
       ],
-      "description": "low=reversible/cosmetic. medium=state change. high=irreversible or reputation-sensitive. For add-comment, risk is dynamic based on content type and confidence — see schema-cheatsheet.md."
+      "description": "low=reversible/cosmetic. medium=state change. high=irreversible or reputation-sensitive. For add-comment, risk is dynamic based on content type and confidence \u2014 see schema-cheatsheet.md."
     }
   },
   "properties": {
@@ -399,15 +400,16 @@
               "enum": [
                 "crash",
                 "exception",
+                "memory-leak",
+                "build-error",
                 "wrong-output",
                 "missing-output",
+                "missing-api",
                 "performance",
-                "build-error",
-                "memory-leak",
                 "platform-specific",
                 "other"
               ],
-              "description": "Category of error behavior. crash=segfault/SIGABRT/hard crash. exception=managed .NET exception thrown. wrong-output=produces incorrect results. missing-output=produces no output or empty. performance=works but too slow. build-error=compile/link/restore failure. memory-leak=growing memory or handles. platform-specific=works on some platforms but not others. other=none of the above."
+              "description": "Category of error behavior. crash=segfault/SIGABRT/hard crash. exception=managed .NET exception thrown. memory-leak=growing memory or handles. build-error=compile/link/restore failure. wrong-output=produces incorrect results. missing-output=produces no output or empty. missing-api=requested API not yet exposed in SkiaSharp. performance=works but too slow. platform-specific=works on some platforms but not others. other=none of the above."
             },
             "errorMessage": {
               "type": "string",
@@ -617,7 +619,7 @@
                   "related",
                   "context"
                 ],
-                "description": "How relevant this is to the issue."
+                "description": "How relevant this is to the issue. direct=primary code involved. related=secondary/supporting code. context=background information only."
               }
             },
             "description": "A code investigation finding with file and line reference."
@@ -673,12 +675,12 @@
                   "category": {
                     "type": "string",
                     "enum": [
-                      "workaround",
                       "fix",
+                      "workaround",
                       "alternative",
                       "investigation"
                     ],
-                    "description": "What kind of proposal. workaround=temporary mitigation. fix=root cause fix. alternative=different approach. investigation=needs more research."
+                    "description": "What kind of proposal. fix=root cause fix. workaround=temporary mitigation. alternative=different approach. investigation=needs more research."
                   },
                   "codeSnippet": {
                     "type": "string",
@@ -700,12 +702,13 @@
                   "effort": {
                     "type": "string",
                     "enum": [
-                      "trivial",
-                      "small",
-                      "medium",
-                      "large"
+                      "cost/xs",
+                      "cost/s",
+                      "cost/m",
+                      "cost/l",
+                      "cost/xl"
                     ],
-                    "description": "Estimated effort to implement."
+                    "description": "Estimated effort to implement. cost/xs=~1 day, isolated, well-understood, minimal context needed. cost/s=~2-3 days, self-contained fix, some familiarity required. cost/m=~1 week, small feature or non-trivial fix, some design thinking. cost/l=~2 weeks, cross-cutting change, real design work, multiple components. cost/xl=over a month, architectural, research-heavy, or high coordination cost."
                   }
                 },
                 "description": "A single fix or resolution proposal."
@@ -756,7 +759,11 @@
             },
             "suggestedReproPlatform": {
               "type": "string",
-              "enum": ["linux", "macos", "windows"],
+              "enum": [
+                "linux",
+                "macos",
+                "windows"
+              ],
               "description": "Platform runner for reproduction. Choose based on classification.platforms: macOS for iOS/macOS/tvOS/watchOS bugs, Windows for WPF/WinUI/UWP bugs, Linux for everything else (including WASM, Android, generic). Used by CI to select the correct runner."
             }
           },
@@ -815,7 +822,10 @@
               },
               "stateReason": {
                 "type": "string",
-                "enum": ["completed", "not_planned"],
+                "enum": [
+                  "completed",
+                  "not_planned"
+                ],
                 "description": "Required for close-issue. Maps to GitHub API state_reason."
               },
               "category": {


### PR DESCRIPTION
## Summary

Cleans up the issue-triage skill's JSON schema enums and reference docs for consistency, correctness, and usability.

## Changes

### Schema enum ordering
- **10 value enums** reordered from alphabetical to **semantic priority** — most important/actionable values first:
  - `severity`: critical → high → medium → low
  - `suggestedAction`: needs-info → needs-reproduction → needs-investigation → ready-to-fix → keep-open → close-*
  - `errorType`: crash → exception → memory-leak → ... → other
  - `effort`: cost/xs → cost/s → cost/m → cost/l → cost/xl
  - Plus: actionRisk, reproQuality, currentRelevance, relevance, category, validated
- **7 label enums** kept alphabetical (matches GitHub label lookup)
- All enum **descriptions now match the enum value order**

### Effort enum → cost/* labels
- Converted from plain values (`trivial`, `small`, `medium`, `large`) to repo `cost/*` labels (`cost/xs` through `cost/xl`)
- Added full descriptions from the label definitions

### Reference doc updates
- `schema-cheatsheet.md`: Complete enum table (added missing effort, actionRisk, stateReason)
- `triage-examples.md`: Updated effort values to cost/* labels, added missing suggestedReproPlatform to bug example
- `labels.md`: Minor reference update

### Earlier commits in this branch
- Flat /tmp paths for gh-aw sandbox compatibility
- auto-triage min-integrity fix
- Python rewrite + auto-triage workflow