### PR TITLE
Add gh-aw agent config and actions lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,3 +34,5 @@
 *.vcxitems      text eol=crlf
 
 *.sh            text eol=lf
+
+.github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/.github/agents/agentic-workflows.agent.md
+++ b/.github/agents/agentic-workflows.agent.md
@@ -1,0 +1,178 @@
+---
+description: GitHub Agentic Workflows (gh-aw) - Create, debug, and upgrade AI-powered workflows with intelligent prompt routing
+disable-model-invocation: true
+---
+
+# GitHub Agentic Workflows Agent
+
+This agent helps you work with **GitHub Agentic Workflows (gh-aw)**, a CLI extension for creating AI-powered workflows in natural language using markdown files.
+
+## What This Agent Does
+
+This is a **dispatcher agent** that routes your request to the appropriate specialized prompt based on your task:
+
+- **Creating new workflows**: Routes to `create` prompt
+- **Updating existing workflows**: Routes to `update` prompt
+- **Debugging workflows**: Routes to `debug` prompt  
+- **Upgrading workflows**: Routes to `upgrade-agentic-workflows` prompt
+- **Creating report-generating workflows**: Routes to `report` prompt — consult this whenever the workflow posts status updates, audits, analyses, or any structured output as issues, discussions, or comments
+- **Creating shared components**: Routes to `create-shared-agentic-workflow` prompt
+- **Fixing Dependabot PRs**: Routes to `dependabot` prompt — use this when Dependabot opens PRs that modify generated manifest files (`.github/workflows/package.json`, `.github/workflows/requirements.txt`, `.github/workflows/go.mod`). Never merge those PRs directly; instead update the source `.md` files and rerun `gh aw compile --dependabot` to bundle all fixes
+- **Analyzing test coverage**: Routes to `test-coverage` prompt — consult this whenever the workflow reads, analyzes, or reports on test coverage data from PRs or CI runs
+
+Workflows may optionally include:
+
+- **Project tracking / monitoring** (GitHub Projects updates, status reporting)
+- **Orchestration / coordination** (one workflow assigning agents or dispatching and coordinating other workflows)
+
+## Files This Applies To
+
+- Workflow files: `.github/workflows/*.md` and `.github/workflows/**/*.md`
+- Workflow lock files: `.github/workflows/*.lock.yml`
+- Shared components: `.github/workflows/shared/*.md`
+- Configuration: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/github-agentic-workflows.md
+
+## Problems This Solves
+
+- **Workflow Creation**: Design secure, validated agentic workflows with proper triggers, tools, and permissions
+- **Workflow Debugging**: Analyze logs, identify missing tools, investigate failures, and fix configuration issues
+- **Version Upgrades**: Migrate workflows to new gh-aw versions, apply codemods, fix breaking changes
+- **Component Design**: Create reusable shared workflow components that wrap MCP servers
+
+## How to Use
+
+When you interact with this agent, it will:
+
+1. **Understand your intent** - Determine what kind of task you're trying to accomplish
+2. **Route to the right prompt** - Load the specialized prompt file for your task
+3. **Execute the task** - Follow the detailed instructions in the loaded prompt
+
+## Available Prompts
+
+### Create New Workflow
+**Load when**: User wants to create a new workflow from scratch, add automation, or design a workflow that doesn't exist yet
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/create-agentic-workflow.md
+
+**Use cases**:
+- "Create a workflow that triages issues"
+- "I need a workflow to label pull requests"
+- "Design a weekly research automation"
+
+### Update Existing Workflow  
+**Load when**: User wants to modify, improve, or refactor an existing workflow
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/update-agentic-workflow.md
+
+**Use cases**:
+- "Add web-fetch tool to the issue-classifier workflow"
+- "Update the PR reviewer to use discussions instead of issues"
+- "Improve the prompt for the weekly-research workflow"
+
+### Debug Workflow  
+**Load when**: User needs to investigate, audit, debug, or understand a workflow, troubleshoot issues, analyze logs, or fix errors
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/debug-agentic-workflow.md
+
+**Use cases**:
+- "Why is this workflow failing?"
+- "Analyze the logs for workflow X"
+- "Investigate missing tool calls in run #12345"
+
+### Upgrade Agentic Workflows
+**Load when**: User wants to upgrade workflows to a new gh-aw version or fix deprecations
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/upgrade-agentic-workflows.md
+
+**Use cases**:
+- "Upgrade all workflows to the latest version"
+- "Fix deprecated fields in workflows"
+- "Apply breaking changes from the new release"
+
+### Create a Report-Generating Workflow
+**Load when**: The workflow being created or updated produces reports — recurring status updates, audit summaries, analyses, or any structured output posted as a GitHub issue, discussion, or comment
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/report.md
+
+**Use cases**:
+- "Create a weekly CI health report"
+- "Post a daily security audit to Discussions"
+- "Add a status update comment to open PRs"
+
+### Create Shared Agentic Workflow
+**Load when**: User wants to create a reusable workflow component or wrap an MCP server
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/create-shared-agentic-workflow.md
+
+**Use cases**:
+- "Create a shared component for Notion integration"
+- "Wrap the Slack MCP server as a reusable component"
+- "Design a shared workflow for database queries"
+
+### Fix Dependabot PRs
+**Load when**: User needs to close or fix open Dependabot PRs that update dependencies in generated manifest files (`.github/workflows/package.json`, `.github/workflows/requirements.txt`, `.github/workflows/go.mod`)
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/dependabot.md
+
+**Use cases**:
+- "Fix the open Dependabot PRs for npm dependencies"
+- "Bundle and close the Dependabot PRs for workflow dependencies"
+- "Update @playwright/test to fix the Dependabot PR"
+
+### Analyze Test Coverage
+**Load when**: The workflow reads, analyzes, or reports test coverage — whether triggered by a PR, a schedule, or a slash command. Always consult this prompt before designing the coverage data strategy.
+
+**Prompt file**: https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/test-coverage.md
+
+**Use cases**:
+- "Create a workflow that comments coverage on PRs"
+- "Analyze coverage trends over time"
+- "Add a coverage gate that blocks PRs below a threshold"
+
+## Instructions
+
+When a user interacts with you:
+
+1. **Identify the task type** from the user's request
+2. **Load the appropriate prompt** from the GitHub repository URLs listed above
+3. **Follow the loaded prompt's instructions** exactly
+4. **If uncertain**, ask clarifying questions to determine the right prompt
+
+## Quick Reference
+
+```bash
+# Initialize repository for agentic workflows
+gh aw init
+
+# Generate the lock file for a workflow
+gh aw compile [workflow-name]
+
+# Debug workflow runs
+gh aw logs [workflow-name]
+gh aw audit <run-id>
+
+# Upgrade workflows
+gh aw fix --write
+gh aw compile --validate
+```
+
+## Key Features of gh-aw
+
+- **Natural Language Workflows**: Write workflows in markdown with YAML frontmatter
+- **AI Engine Support**: Copilot, Claude, Codex, or custom engines
+- **MCP Server Integration**: Connect to Model Context Protocol servers for tools
+- **Safe Outputs**: Structured communication between AI and GitHub API
+- **Strict Mode**: Security-first validation and sandboxing
+- **Shared Components**: Reusable workflow building blocks
+- **Repo Memory**: Persistent git-backed storage for agents
+- **Sandboxed Execution**: All workflows run in the Agent Workflow Firewall (AWF) sandbox, enabling full `bash` and `edit` tools by default
+
+## Important Notes
+
+- Always reference the instructions file at https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/github-agentic-workflows.md for complete documentation
+- Use the MCP tool `agentic-workflows` when running in GitHub Copilot Cloud
+- Workflows must be compiled to `.lock.yml` files before running in GitHub Actions
+- **Bash tools are enabled by default** - Don't restrict bash commands unnecessarily since workflows are sandboxed by the AWF
+- Follow security best practices: minimal permissions, explicit network access, no template injection
+- **Network configuration**: Use ecosystem identifiers (`node`, `python`, `go`, etc.) or explicit FQDNs in `network.allowed`. Bare shorthands like `npm` or `pypi` are **not** valid. See https://github.com/github/gh-aw/blob/v0.68.3/.github/aw/network.md for the full list of valid ecosystem identifiers and domain patterns.
+- **Single-file output**: When creating a workflow, produce exactly **one** workflow `.md` file. Do not create separate documentation files (architecture docs, runbooks, usage guides, etc.). If documentation is needed, add a brief `## Usage` section inside the workflow file itself.

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,0 +1,14 @@
+{
+  "entries": {
+    "actions/github-script@v9": {
+      "repo": "actions/github-script",
+      "version": "v9",
+      "sha": "373c709c69115d41ff229c7e5df9f8788daa9553"
+    },
+    "github/gh-aw-actions/setup@v0.68.3": {
+      "repo": "github/gh-aw-actions/setup",
+      "version": "v0.68.3",
+      "sha": "ba90f2186d7ad780ec640f364005fa24e797b360"
+    }
+  }
+}

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a926ef44eaab65a12e4dcd2e5ec6e07e66334ce42633ac4104c9d1194febe803","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7da29c4f033ad5f3b896d02a7e067b7e409be2d074ddb0e22fe0d441c021c442","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,7 +73,7 @@ name: "Auto-Triage SkiaSharp Issue"
       # CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
       # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
         # --state open \
-        # --search "-label:triage/triaged created:<${CUTOFF} sort:created-asc" \
+        # --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
         # --json number --limit 1 --jq '.[0].number')
       # if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
         # echo "::notice::No untriaged issues older than 1 hour"
@@ -202,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF'
+          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
           <system>
-          GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF
+          GH_AW_PROMPT_dbe6d878c23483e6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF'
+          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF
+          GH_AW_PROMPT_dbe6d878c23483e6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF'
+          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF
+          GH_AW_PROMPT_dbe6d878c23483e6_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -418,9 +418,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_c27e3d468de6d6f5_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c27e3d468de6d6f5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -643,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_56d74d9eb3da47cf_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -693,7 +693,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_56d74d9eb3da47cf_EOF
+          GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1247,7 +1247,7 @@ jobs:
           CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
           ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --search "-label:triage/triaged created:<${CUTOFF} sort:created-asc" \
+            --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
             --json number --limit 1 --jq '.[0].number')
           if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
             echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1401e8480287439613cf62358747578a0313771c76d8c366fcdfe3605f483ae9","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7da29c4f033ad5f3b896d02a7e067b7e409be2d074ddb0e22fe0d441c021c442","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,7 +73,7 @@ name: "Auto-Triage SkiaSharp Issue"
       # CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
       # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
         # --state open \
-        # --search "-label:triage/triaged created:<${CUTOFF} sort:reactions-desc" \
+        # --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
         # --json number --limit 1 --jq '.[0].number')
       # if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
         # echo "::notice::No untriaged issues older than 1 hour"
@@ -202,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9c11e23016334056_EOF'
+          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
           <system>
-          GH_AW_PROMPT_9c11e23016334056_EOF
+          GH_AW_PROMPT_dbe6d878c23483e6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9c11e23016334056_EOF'
+          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9c11e23016334056_EOF
+          GH_AW_PROMPT_dbe6d878c23483e6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9c11e23016334056_EOF'
+          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_9c11e23016334056_EOF
+          GH_AW_PROMPT_dbe6d878c23483e6_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -418,9 +418,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_66ad3d68a6d7905a_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_66ad3d68a6d7905a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -643,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3e36543a8aa3f175_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -693,7 +693,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3e36543a8aa3f175_EOF
+          GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1247,7 +1247,7 @@ jobs:
           CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
           ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --search "-label:triage/triaged created:<${CUTOFF} sort:reactions-desc" \
+            --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
             --json number --limit 1 --jq '.[0].number')
           if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
             echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d1823dba4f325c87efc92c4b86c5f69694296347bc882fb14fdac81d7bf1c6f4","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4e6550fbd415a4cc7123fb3b85738f273a719a57f0f94b790140fd97cef3fc39","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,8 +73,7 @@ name: "Auto-Triage SkiaSharp Issue"
         # echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
         # exit 0
       # fi
-      # CUTOFF=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-        # || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
+      # CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
       # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
         # --state open \
         # --search "-label:triage/triaged created:<${CUTOFF}" \
@@ -210,14 +209,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_eee4e37d3207fabf_EOF'
+          cat << 'GH_AW_PROMPT_a686b48d3ec6b514_EOF'
           <system>
-          GH_AW_PROMPT_eee4e37d3207fabf_EOF
+          GH_AW_PROMPT_a686b48d3ec6b514_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_eee4e37d3207fabf_EOF'
+          cat << 'GH_AW_PROMPT_a686b48d3ec6b514_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -249,12 +248,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_eee4e37d3207fabf_EOF
+          GH_AW_PROMPT_a686b48d3ec6b514_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_eee4e37d3207fabf_EOF'
+          cat << 'GH_AW_PROMPT_a686b48d3ec6b514_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_eee4e37d3207fabf_EOF
+          GH_AW_PROMPT_a686b48d3ec6b514_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -426,9 +425,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_ce7a77d3e18a796d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_f2bbc03ab48c484b_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ce7a77d3e18a796d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f2bbc03ab48c484b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -651,7 +650,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_45d55c551ed7a6b9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_fb72979b0b58690b_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -701,7 +700,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_45d55c551ed7a6b9_EOF
+          GH_AW_MCP_CONFIG_fb72979b0b58690b_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1252,8 +1251,7 @@ jobs:
             echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          CUTOFF=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-            || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
+          CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
           ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open \
             --search "-label:triage/triaged created:<${CUTOFF}" \

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"31975ae51b8f95ecd94bb9eb30f71845a53d6d43966b33fe3b280eacb8b078c2","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d1823dba4f325c87efc92c4b86c5f69694296347bc882fb14fdac81d7bf1c6f4","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,15 +73,14 @@ name: "Auto-Triage SkiaSharp Issue"
         # echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
         # exit 0
       # fi
+      # CUTOFF=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        # || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
       # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
         # --state open \
-        # --search "NOT label:triage/triaged" \
+        # --search "-label:triage/triaged created:<${CUTOFF}" \
         # --sort created --order desc \
-        # --json number,createdAt --limit 50 \
-        # | jq --arg cutoff "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-          # || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
-          # '[.[] | select(.createdAt < $cutoff)] | first | .number')
-      # if [ "$ISSUE" = "null" ] || [ -z "$ISSUE" ]; then
+        # --json number --limit 1 --jq '.[0].number')
+      # if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
         # echo "::notice::No untriaged issues older than 1 hour"
         # exit 1
       # fi
@@ -211,14 +210,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0745fc073661e959_EOF'
+          cat << 'GH_AW_PROMPT_eee4e37d3207fabf_EOF'
           <system>
-          GH_AW_PROMPT_0745fc073661e959_EOF
+          GH_AW_PROMPT_eee4e37d3207fabf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0745fc073661e959_EOF'
+          cat << 'GH_AW_PROMPT_eee4e37d3207fabf_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -250,12 +249,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0745fc073661e959_EOF
+          GH_AW_PROMPT_eee4e37d3207fabf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0745fc073661e959_EOF'
+          cat << 'GH_AW_PROMPT_eee4e37d3207fabf_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_0745fc073661e959_EOF
+          GH_AW_PROMPT_eee4e37d3207fabf_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -427,9 +426,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_25e6142d3dbad226_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_ce7a77d3e18a796d_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_25e6142d3dbad226_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ce7a77d3e18a796d_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -652,7 +651,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_a0d231020cae05e9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_45d55c551ed7a6b9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -702,7 +701,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a0d231020cae05e9_EOF
+          GH_AW_MCP_CONFIG_45d55c551ed7a6b9_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1253,15 +1252,14 @@ jobs:
             echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          CUTOFF=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
           ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --search "NOT label:triage/triaged" \
+            --search "-label:triage/triaged created:<${CUTOFF}" \
             --sort created --order desc \
-            --json number,createdAt --limit 50 \
-            | jq --arg cutoff "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-              || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
-              '[.[] | select(.createdAt < $cutoff)] | first | .number')
-          if [ "$ISSUE" = "null" ] || [ -z "$ISSUE" ]; then
+            --json number --limit 1 --jq '.[0].number')
+          if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
             echo "::notice::No untriaged issues older than 1 hour"
             exit 1
           fi

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6a7c2ba73fb004ca52e29e62b67682aeb0223e4a6d700e841047e164cb9dbc42","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"31975ae51b8f95ecd94bb9eb30f71845a53d6d43966b33fe3b280eacb8b078c2","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -24,6 +24,9 @@
 #
 # Triage a SkiaSharp issue: classify, label, and update the backlog project board.
 #
+# Frontmatter env variables:
+#   - ISSUE_NUMBER: (main workflow)
+#
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
@@ -48,6 +51,8 @@
 
 name: "Auto-Triage SkiaSharp Issue"
 "on":
+  # permissions: # Permissions applied to pre-activation job
+    # issues: read
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
   - cron: "21 */1 * * *"
@@ -57,6 +62,30 @@ name: "Auto-Triage SkiaSharp Issue"
   # - copilot # Skip-bots processed as bot check in pre-activation job
   # - dependabot # Skip-bots processed as bot check in pre-activation job
   # skip-if-no-match: is:issue is:open -label:triage/triaged # Skip-if-no-match processed as search check in pre-activation job
+  # steps: # Steps injected into pre-activation job
+  # - env:
+      # GH_TOKEN: ${{ github.token }}
+      # INPUT_ISSUE: ${{ github.event.inputs.issue_number }}
+    # id: find-issue
+    # name: Select issue to triage
+    # run: |
+      # if [ -n "$INPUT_ISSUE" ]; then
+        # echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
+        # exit 0
+      # fi
+      # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+        # --state open \
+        # --search "NOT label:triage/triaged" \
+        # --sort created --order desc \
+        # --json number,createdAt --limit 50 \
+        # | jq --arg cutoff "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+          # || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
+          # '[.[] | select(.createdAt < $cutoff)] | first | .number')
+      # if [ "$ISSUE" = "null" ] || [ -z "$ISSUE" ]; then
+        # echo "::notice::No untriaged issues older than 1 hour"
+        # exit 1
+      # fi
+      # echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
   workflow_dispatch:
     inputs:
       aw_context:
@@ -72,14 +101,17 @@ name: "Auto-Triage SkiaSharp Issue"
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}"
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
 
 run-name: "Auto-Triage SkiaSharp Issue"
+
+env:
+  ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
 
 jobs:
   activation:
     needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
+    if: needs.pre_activation.outputs.activated == 'true' && (needs.pre_activation.outputs.find-issue_result == 'success')
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -166,10 +198,10 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
+          GH_AW_ENV_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
-          GH_AW_GITHUB_EVENT_INPUTS_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
@@ -179,14 +211,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_563240d1080258e3_EOF'
+          cat << 'GH_AW_PROMPT_0745fc073661e959_EOF'
           <system>
-          GH_AW_PROMPT_563240d1080258e3_EOF
+          GH_AW_PROMPT_0745fc073661e959_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_563240d1080258e3_EOF'
+          cat << 'GH_AW_PROMPT_0745fc073661e959_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -218,18 +250,18 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_563240d1080258e3_EOF
+          GH_AW_PROMPT_0745fc073661e959_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_563240d1080258e3_EOF'
+          cat << 'GH_AW_PROMPT_0745fc073661e959_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_563240d1080258e3_EOF
+          GH_AW_PROMPT_0745fc073661e959_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_GITHUB_EVENT_INPUTS_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+          GH_AW_ENV_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -240,10 +272,10 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_ENV_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
-          GH_AW_GITHUB_EVENT_INPUTS_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
@@ -261,10 +293,10 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
+                GH_AW_ENV_ISSUE_NUMBER: process.env.GH_AW_ENV_ISSUE_NUMBER,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
-                GH_AW_GITHUB_EVENT_INPUTS_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_INPUTS_ISSUE_NUMBER,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
@@ -301,8 +333,6 @@ jobs:
     permissions:
       contents: read
       issues: read
-    concurrency:
-      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -397,9 +427,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_d25f541efbc0d0ea_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_25e6142d3dbad226_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d25f541efbc0d0ea_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_25e6142d3dbad226_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -622,7 +652,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_8fd7df5a541917ef_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_a0d231020cae05e9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -672,7 +702,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8fd7df5a541917ef_EOF
+          GH_AW_MCP_CONFIG_a0d231020cae05e9_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1176,8 +1206,12 @@ jobs:
 
   pre_activation:
     runs-on: ubuntu-slim
+    permissions:
+      issues: read
     outputs:
       activated: ${{ steps.check_skip_if_no_match.outputs.skip_no_match_check_ok == 'true' && steps.check_skip_bots.outputs.skip_bots_ok == 'true' }}
+      find-issue_result: ${{ steps.find-issue.outcome }}
+      issue_number: ${{ steps.find-issue.outputs.issue_number }}
       matched_command: ''
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
@@ -1212,6 +1246,29 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_bots.cjs');
             await main();
+      - name: Select issue to triage
+        id: find-issue
+        run: |
+          if [ -n "$INPUT_ISSUE" ]; then
+            echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "NOT label:triage/triaged" \
+            --sort created --order desc \
+            --json number,createdAt --limit 50 \
+            | jq --arg cutoff "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+              || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
+              '[.[] | select(.createdAt < $cutoff)] | first | .number')
+          if [ "$ISSUE" = "null" ] || [ -z "$ISSUE" ]; then
+            echo "::notice::No untriaged issues older than 1 hour"
+            exit 1
+          fi
+          echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_ISSUE: ${{ github.event.inputs.issue_number }}
 
   safe_outputs:
     needs:

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"982342b407e180b6567cb87d1326aa7dd5259ee2f432fa9902cba358195def40","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e67d741aa524e4ace68102a061cb6e7803b9bffd9f792b72654f9ded3bca2ac9","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -49,6 +49,8 @@
 name: "Auto-Triage SkiaSharp Issue"
 "on":
   # roles: all # Roles processed as role check in pre-activation job
+  schedule:
+  - cron: "0 * * * *"
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
   # - github-actions # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
@@ -61,8 +63,8 @@ name: "Auto-Triage SkiaSharp Issue"
         required: false
         type: string
       issue_number:
-        description: Issue number to triage
-        required: true
+        description: Issue number to triage (leave blank for auto-select)
+        required: false
         type: string
 
 permissions: {}
@@ -175,14 +177,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f5f2b4ca85fcf67e_EOF'
+          cat << 'GH_AW_PROMPT_75c43be2533facef_EOF'
           <system>
-          GH_AW_PROMPT_f5f2b4ca85fcf67e_EOF
+          GH_AW_PROMPT_75c43be2533facef_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f5f2b4ca85fcf67e_EOF'
+          cat << 'GH_AW_PROMPT_75c43be2533facef_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -214,12 +216,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f5f2b4ca85fcf67e_EOF
+          GH_AW_PROMPT_75c43be2533facef_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f5f2b4ca85fcf67e_EOF'
+          cat << 'GH_AW_PROMPT_75c43be2533facef_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_f5f2b4ca85fcf67e_EOF
+          GH_AW_PROMPT_75c43be2533facef_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -297,6 +299,8 @@ jobs:
     permissions:
       contents: read
       issues: read
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -391,9 +395,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_93b474f2968d2c7d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_ff2b4d46334b70b3_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_93b474f2968d2c7d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ff2b4d46334b70b3_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -616,7 +620,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_fb8e35e16870c690_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_53c2a012c3c6220e_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -666,7 +670,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fb8e35e16870c690_EOF
+          GH_AW_MCP_CONFIG_53c2a012c3c6220e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c2b809a324aa5ef83e1db6a8cc1dc8308b312c27163d2614b3b0e0282d0cdb79","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6a7c2ba73fb004ca52e29e62b67682aeb0223e4a6d700e841047e164cb9dbc42","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -50,7 +50,8 @@ name: "Auto-Triage SkiaSharp Issue"
 "on":
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "0 * * * *"
+  - cron: "21 */1 * * *"
+    # Friendly format: hourly (scattered)
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
   # - github-actions # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
@@ -178,14 +179,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8e63a0fc7039d0fd_EOF'
+          cat << 'GH_AW_PROMPT_563240d1080258e3_EOF'
           <system>
-          GH_AW_PROMPT_8e63a0fc7039d0fd_EOF
+          GH_AW_PROMPT_563240d1080258e3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8e63a0fc7039d0fd_EOF'
+          cat << 'GH_AW_PROMPT_563240d1080258e3_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -217,12 +218,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8e63a0fc7039d0fd_EOF
+          GH_AW_PROMPT_563240d1080258e3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8e63a0fc7039d0fd_EOF'
+          cat << 'GH_AW_PROMPT_563240d1080258e3_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_8e63a0fc7039d0fd_EOF
+          GH_AW_PROMPT_563240d1080258e3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -396,9 +397,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_a03560d011d9fe4d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_d25f541efbc0d0ea_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a03560d011d9fe4d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d25f541efbc0d0ea_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -621,7 +622,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_7bee9636806cc6a3_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_8fd7df5a541917ef_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -671,7 +672,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7bee9636806cc6a3_EOF
+          GH_AW_MCP_CONFIG_8fd7df5a541917ef_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4e6550fbd415a4cc7123fb3b85738f273a719a57f0f94b790140fd97cef3fc39","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"11ee4557ce4e5fde504961843f9ca9ec1e5883429e2ff30e0ae3238d8f662a42","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -23,9 +23,6 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 # Triage a SkiaSharp issue: classify, label, and update the backlog project board.
-#
-# Frontmatter env variables:
-#   - ISSUE_NUMBER: (main workflow)
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -102,9 +99,6 @@ concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
 
 run-name: "Auto-Triage SkiaSharp Issue"
-
-env:
-  ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
 
 jobs:
   activation:
@@ -196,7 +190,6 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
-          GH_AW_ENV_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -205,18 +198,19 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a686b48d3ec6b514_EOF'
+          cat << 'GH_AW_PROMPT_2827c595979ff0ea_EOF'
           <system>
-          GH_AW_PROMPT_a686b48d3ec6b514_EOF
+          GH_AW_PROMPT_2827c595979ff0ea_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a686b48d3ec6b514_EOF'
+          cat << 'GH_AW_PROMPT_2827c595979ff0ea_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -248,18 +242,18 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a686b48d3ec6b514_EOF
+          GH_AW_PROMPT_2827c595979ff0ea_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a686b48d3ec6b514_EOF'
+          cat << 'GH_AW_PROMPT_2827c595979ff0ea_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_a686b48d3ec6b514_EOF
+          GH_AW_PROMPT_2827c595979ff0ea_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_ENV_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -270,7 +264,6 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_ENV_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -280,6 +273,7 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -291,7 +285,6 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_ENV_ISSUE_NUMBER: process.env.GH_AW_ENV_ISSUE_NUMBER,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -300,7 +293,8 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ISSUE_NUMBER: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ISSUE_NUMBER
               }
             });
       - name: Validate prompt placeholders
@@ -425,9 +419,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_f2bbc03ab48c484b_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_80f4aa52c2aa3a67_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f2bbc03ab48c484b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_80f4aa52c2aa3a67_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -650,7 +644,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_fb72979b0b58690b_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_c31e19f553ba7009_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -700,7 +694,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fb72979b0b58690b_EOF
+          GH_AW_MCP_CONFIG_c31e19f553ba7009_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e67d741aa524e4ace68102a061cb6e7803b9bffd9f792b72654f9ded3bca2ac9","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c2b809a324aa5ef83e1db6a8cc1dc8308b312c27163d2614b3b0e0282d0cdb79","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,6 +55,7 @@ name: "Auto-Triage SkiaSharp Issue"
   # - github-actions # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
   # - dependabot # Skip-bots processed as bot check in pre-activation job
+  # skip-if-no-match: is:issue is:open -label:triage/triaged # Skip-if-no-match processed as search check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -177,14 +178,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_75c43be2533facef_EOF'
+          cat << 'GH_AW_PROMPT_8e63a0fc7039d0fd_EOF'
           <system>
-          GH_AW_PROMPT_75c43be2533facef_EOF
+          GH_AW_PROMPT_8e63a0fc7039d0fd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_75c43be2533facef_EOF'
+          cat << 'GH_AW_PROMPT_8e63a0fc7039d0fd_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -216,12 +217,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_75c43be2533facef_EOF
+          GH_AW_PROMPT_8e63a0fc7039d0fd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_75c43be2533facef_EOF'
+          cat << 'GH_AW_PROMPT_8e63a0fc7039d0fd_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_75c43be2533facef_EOF
+          GH_AW_PROMPT_8e63a0fc7039d0fd_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -395,9 +396,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_ff2b4d46334b70b3_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_a03560d011d9fe4d_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ff2b4d46334b70b3_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a03560d011d9fe4d_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -620,7 +621,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_53c2a012c3c6220e_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_7bee9636806cc6a3_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -670,7 +671,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_53c2a012c3c6220e_EOF
+          GH_AW_MCP_CONFIG_7bee9636806cc6a3_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1175,7 +1176,7 @@ jobs:
   pre_activation:
     runs-on: ubuntu-slim
     outputs:
-      activated: ${{ steps.check_skip_bots.outputs.skip_bots_ok == 'true' }}
+      activated: ${{ steps.check_skip_if_no_match.outputs.skip_no_match_check_ok == 'true' && steps.check_skip_bots.outputs.skip_bots_ok == 'true' }}
       matched_command: ''
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
@@ -1185,6 +1186,19 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
+      - name: Check skip-if-no-match query
+        id: check_skip_if_no_match
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_SKIP_QUERY: "is:issue is:open -label:triage/triaged"
+          GH_AW_WORKFLOW_NAME: "Auto-Triage SkiaSharp Issue"
+          GH_AW_SKIP_MIN_MATCHES: "1"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_no_match.cjs');
+            await main();
       - name: Check skip-bots
         id: check_skip_bots
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"11ee4557ce4e5fde504961843f9ca9ec1e5883429e2ff30e0ae3238d8f662a42","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a926ef44eaab65a12e4dcd2e5ec6e07e66334ce42633ac4104c9d1194febe803","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,8 +73,7 @@ name: "Auto-Triage SkiaSharp Issue"
       # CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
       # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
         # --state open \
-        # --search "-label:triage/triaged created:<${CUTOFF}" \
-        # --sort created --order desc \
+        # --search "-label:triage/triaged created:<${CUTOFF} sort:created-asc" \
         # --json number --limit 1 --jq '.[0].number')
       # if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
         # echo "::notice::No untriaged issues older than 1 hour"
@@ -203,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2827c595979ff0ea_EOF'
+          cat << 'GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF'
           <system>
-          GH_AW_PROMPT_2827c595979ff0ea_EOF
+          GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2827c595979ff0ea_EOF'
+          cat << 'GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -242,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2827c595979ff0ea_EOF
+          GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2827c595979ff0ea_EOF'
+          cat << 'GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_2827c595979ff0ea_EOF
+          GH_AW_PROMPT_7e9f7bdc5e259ec9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -419,9 +418,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_80f4aa52c2aa3a67_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_c27e3d468de6d6f5_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_80f4aa52c2aa3a67_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c27e3d468de6d6f5_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -644,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_c31e19f553ba7009_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_56d74d9eb3da47cf_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -694,7 +693,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c31e19f553ba7009_EOF
+          GH_AW_MCP_CONFIG_56d74d9eb3da47cf_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1248,8 +1247,7 @@ jobs:
           CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
           ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --search "-label:triage/triaged created:<${CUTOFF}" \
-            --sort created --order desc \
+            --search "-label:triage/triaged created:<${CUTOFF} sort:created-asc" \
             --json number --limit 1 --jq '.[0].number')
           if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
             echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7da29c4f033ad5f3b896d02a7e067b7e409be2d074ddb0e22fe0d441c021c442","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1401e8480287439613cf62358747578a0313771c76d8c366fcdfe3605f483ae9","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,7 +73,7 @@ name: "Auto-Triage SkiaSharp Issue"
       # CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
       # ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
         # --state open \
-        # --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
+        # --search "-label:triage/triaged created:<${CUTOFF} sort:reactions-desc" \
         # --json number --limit 1 --jq '.[0].number')
       # if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
         # echo "::notice::No untriaged issues older than 1 hour"
@@ -202,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
+          cat << 'GH_AW_PROMPT_9c11e23016334056_EOF'
           <system>
-          GH_AW_PROMPT_dbe6d878c23483e6_EOF
+          GH_AW_PROMPT_9c11e23016334056_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
+          cat << 'GH_AW_PROMPT_9c11e23016334056_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_dbe6d878c23483e6_EOF
+          GH_AW_PROMPT_9c11e23016334056_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
+          cat << 'GH_AW_PROMPT_9c11e23016334056_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_dbe6d878c23483e6_EOF
+          GH_AW_PROMPT_9c11e23016334056_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -418,9 +418,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_66ad3d68a6d7905a_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_66ad3d68a6d7905a_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -643,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_3e36543a8aa3f175_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -693,7 +693,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF
+          GH_AW_MCP_CONFIG_3e36543a8aa3f175_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1247,7 +1247,7 @@ jobs:
           CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
           ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
+            --search "-label:triage/triaged created:<${CUTOFF} sort:reactions-desc" \
             --json number --limit 1 --jq '.[0].number')
           if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
             echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7da29c4f033ad5f3b896d02a7e067b7e409be2d074ddb0e22fe0d441c021c442","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"07842c46369f1bf6ad0da87866ca4d0e9cfaaaf87d9f17223021dfb9d312f838","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -52,8 +52,8 @@ name: "Auto-Triage SkiaSharp Issue"
     # issues: read
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "21 */1 * * *"
-    # Friendly format: hourly (scattered)
+  - cron: "*/30 * * * *"
+    # Friendly format: every 30m
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
   # - github-actions # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
@@ -202,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
+          cat << 'GH_AW_PROMPT_f1c2ae4fd199c1fc_EOF'
           <system>
-          GH_AW_PROMPT_dbe6d878c23483e6_EOF
+          GH_AW_PROMPT_f1c2ae4fd199c1fc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
+          cat << 'GH_AW_PROMPT_f1c2ae4fd199c1fc_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_dbe6d878c23483e6_EOF
+          GH_AW_PROMPT_f1c2ae4fd199c1fc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbe6d878c23483e6_EOF'
+          cat << 'GH_AW_PROMPT_f1c2ae4fd199c1fc_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_dbe6d878c23483e6_EOF
+          GH_AW_PROMPT_f1c2ae4fd199c1fc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -418,9 +418,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_23dc703aaf409dbf_EOF
           {"add_labels":{"allowed":["type/*","area/*","os/*","backend/*","tenet/*","partner/*","triage/triaged"],"blocked":["~*"],"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_841f5173e4d9906d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_23dc703aaf409dbf_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -643,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_a892f1933a85c299_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -693,7 +693,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_158a4a0afc2cee2d_EOF
+          GH_AW_MCP_CONFIG_a892f1933a85c299_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -24,15 +24,14 @@ on:
           echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
           exit 0
         fi
+        CUTOFF=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+          || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
         ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open \
-          --search "NOT label:triage/triaged" \
+          --search "-label:triage/triaged created:<${CUTOFF}" \
           --sort created --order desc \
-          --json number,createdAt --limit 50 \
-          | jq --arg cutoff "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-            || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
-            '[.[] | select(.createdAt < $cutoff)] | first | .number')
-        if [ "$ISSUE" = "null" ] || [ -z "$ISSUE" ]; then
+          --json number --limit 1 --jq '.[0].number')
+        if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
           echo "::notice::No untriaged issues older than 1 hour"
           exit 1
         fi

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -1,7 +1,7 @@
 ---
 description: "Triage a SkiaSharp issue: classify, label, and update the backlog project board."
 on:
-  schedule: hourly
+  schedule: every 30m
   workflow_dispatch:
     inputs:
       issue_number:

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -9,6 +9,7 @@ on:
         description: "Issue number to triage (leave blank for auto-select)"
         required: false
         type: string
+  skip-if-no-match: "is:issue is:open -label:triage/triaged"
   skip-bots: [github-actions, copilot, dependabot]
   roles: all
 tools:

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -40,8 +40,6 @@ jobs:
     outputs:
       issue_number: ${{ steps.find-issue.outputs.issue_number }}
 if: needs.pre_activation.outputs.find-issue_result == 'success'
-env:
-  ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
 tools:
   github:
     toolsets: [issues]
@@ -76,15 +74,15 @@ safe-outputs:
 
 # Auto-Triage SkiaSharp Issue
 
-Triage issue **#${{ env.ISSUE_NUMBER }}**, apply labels, and update the backlog project board.
+Triage issue **#${{ needs.pre_activation.outputs.issue_number }}** using the issue-triage skill, then apply labels and update the SkiaSharp Backlog project board.
 
 ## Step 1 — Run the issue-triage skill
 
-Read and follow the instructions in `.agents/skills/issue-triage/SKILL.md` to triage the selected issue.
+Read and follow the instructions in `.agents/skills/issue-triage/SKILL.md` to triage issue #${{ needs.pre_activation.outputs.issue_number }}.
 
 Complete all phases (Setup → Investigate → Analyze → Workarounds → Validate → Persist).
 
-After Phase 6 completes, the triage JSON will be at `issue-triage-workspace/<issue_number>.json`.
+After Phase 6 completes, the triage JSON will be at `issue-triage-workspace/${{ needs.pre_activation.outputs.issue_number }}.json`.
 
 ## Step 2 — Apply labels from classification
 
@@ -116,6 +114,6 @@ Read the triage JSON and update the issue in the **SkiaSharp Backlog** project (
 
 The `update-project` safe output auto-creates missing SINGLE_SELECT options — no need to pre-create values.
 
-Use `content_type: "issue"` and the selected issue number to identify the item.
+Use `content_type: "issue"` and issue number `${{ needs.pre_activation.outputs.issue_number }}` to identify the item.
 
 Only include fields that have non-null values in the triage JSON. Omit any field where the source value is null or absent.

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -1,8 +1,7 @@
 ---
 description: "Triage a SkiaSharp issue: classify, label, and update the backlog project board."
 on:
-  schedule:
-    - cron: "0 * * * *"
+  schedule: hourly
   workflow_dispatch:
     inputs:
       issue_number:

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -11,6 +11,39 @@ on:
   skip-if-no-match: "is:issue is:open -label:triage/triaged"
   skip-bots: [github-actions, copilot, dependabot]
   roles: all
+  permissions:
+    issues: read
+  steps:
+    - name: Select issue to triage
+      id: find-issue
+      env:
+        INPUT_ISSUE: ${{ github.event.inputs.issue_number }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ -n "$INPUT_ISSUE" ]; then
+          echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+          --state open \
+          --search "NOT label:triage/triaged" \
+          --sort created --order desc \
+          --json number,createdAt --limit 50 \
+          | jq --arg cutoff "$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
+            '[.[] | select(.createdAt < $cutoff)] | first | .number')
+        if [ "$ISSUE" = "null" ] || [ -z "$ISSUE" ]; then
+          echo "::notice::No untriaged issues older than 1 hour"
+          exit 1
+        fi
+        echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
+jobs:
+  pre-activation:
+    outputs:
+      issue_number: ${{ steps.find-issue.outputs.issue_number }}
+if: needs.pre_activation.outputs.find-issue_result == 'success'
+env:
+  ISSUE_NUMBER: ${{ needs.pre_activation.outputs.issue_number }}
 tools:
   github:
     toolsets: [issues]
@@ -45,33 +78,7 @@ safe-outputs:
 
 # Auto-Triage SkiaSharp Issue
 
-Triage a single SkiaSharp issue, apply labels, and update the backlog project board.
-
-## Step 0 — Select which issue to triage
-
-If `${{ github.event.inputs.issue_number }}` is provided and non-empty, use that issue number.
-
-Otherwise (scheduled run), find the **newest** open issue that:
-1. Does **not** have the `triage/triaged` label
-2. Was created **more than 1 hour ago** (so reporters have time to edit)
-
-Run this command to find it:
-
-```bash
-gh issue list --repo mono/SkiaSharp \
-  --state open \
-  --label "" \
-  --search "NOT label:triage/triaged" \
-  --sort created --order desc \
-  --json number,createdAt \
-  --limit 50 \
-  | jq --arg cutoff "$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" \
-    '[.[] | select(.createdAt < $cutoff)] | first | .number'
-```
-
-If the result is `null` or empty, there are no untriaged issues older than 1 hour — exit successfully with a message "No untriaged issues found" and skip all remaining steps.
-
-Store the selected issue number for the rest of the workflow.
+Triage issue **#${{ env.ISSUE_NUMBER }}**, apply labels, and update the backlog project board.
 
 ## Step 1 — Run the issue-triage skill
 

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -27,7 +27,7 @@ on:
         CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
         ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open \
-          --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
+          --search "-label:triage/triaged created:<${CUTOFF} sort:reactions-desc" \
           --json number --limit 1 --jq '.[0].number')
         if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
           echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -27,8 +27,7 @@ on:
         CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
         ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open \
-          --search "-label:triage/triaged created:<${CUTOFF}" \
-          --sort created --order desc \
+          --search "-label:triage/triaged created:<${CUTOFF} sort:created-asc" \
           --json number --limit 1 --jq '.[0].number')
         if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
           echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -1,11 +1,13 @@
 ---
 description: "Triage a SkiaSharp issue: classify, label, and update the backlog project board."
 on:
+  schedule:
+    - cron: "0 * * * *"
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to triage"
-        required: true
+        description: "Issue number to triage (leave blank for auto-select)"
+        required: false
         type: string
   skip-bots: [github-actions, copilot, dependabot]
   roles: all
@@ -43,15 +45,41 @@ safe-outputs:
 
 # Auto-Triage SkiaSharp Issue
 
-Triage issue **#${{ github.event.inputs.issue_number }}** using the issue-triage skill, then apply labels and update the SkiaSharp Backlog project board.
+Triage a single SkiaSharp issue, apply labels, and update the backlog project board.
+
+## Step 0 — Select which issue to triage
+
+If `${{ github.event.inputs.issue_number }}` is provided and non-empty, use that issue number.
+
+Otherwise (scheduled run), find the **newest** open issue that:
+1. Does **not** have the `triage/triaged` label
+2. Was created **more than 1 hour ago** (so reporters have time to edit)
+
+Run this command to find it:
+
+```bash
+gh issue list --repo mono/SkiaSharp \
+  --state open \
+  --label "" \
+  --search "NOT label:triage/triaged" \
+  --sort created --order desc \
+  --json number,createdAt \
+  --limit 50 \
+  | jq --arg cutoff "$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" \
+    '[.[] | select(.createdAt < $cutoff)] | first | .number'
+```
+
+If the result is `null` or empty, there are no untriaged issues older than 1 hour — exit successfully with a message "No untriaged issues found" and skip all remaining steps.
+
+Store the selected issue number for the rest of the workflow.
 
 ## Step 1 — Run the issue-triage skill
 
-Read and follow the instructions in `.agents/skills/issue-triage/SKILL.md` to triage issue #${{ github.event.inputs.issue_number }}.
+Read and follow the instructions in `.agents/skills/issue-triage/SKILL.md` to triage the selected issue.
 
 Complete all phases (Setup → Investigate → Analyze → Workarounds → Validate → Persist).
 
-After Phase 6 completes, the triage JSON will be at `issue-triage-workspace/${{ github.event.inputs.issue_number }}.json`.
+After Phase 6 completes, the triage JSON will be at `issue-triage-workspace/<issue_number>.json`.
 
 ## Step 2 — Apply labels from classification
 
@@ -83,6 +111,6 @@ Read the triage JSON and update the issue in the **SkiaSharp Backlog** project (
 
 The `update-project` safe output auto-creates missing SINGLE_SELECT options — no need to pre-create values.
 
-Use `content_type: "issue"` and `content_number: ${{ github.event.inputs.issue_number }}` to identify the item.
+Use `content_type: "issue"` and the selected issue number to identify the item.
 
 Only include fields that have non-null values in the triage JSON. Omit any field where the source value is null or absent.

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -27,7 +27,7 @@ on:
         CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
         ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open \
-          --search "-label:triage/triaged created:<${CUTOFF} sort:reactions-desc" \
+          --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
           --json number --limit 1 --jq '.[0].number')
         if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
           echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -27,7 +27,7 @@ on:
         CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
         ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open \
-          --search "-label:triage/triaged created:<${CUTOFF} sort:created-asc" \
+          --search "-label:triage/triaged created:<${CUTOFF} sort:comments-desc" \
           --json number --limit 1 --jq '.[0].number')
         if [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
           echo "::notice::No untriaged issues older than 1 hour"

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -24,8 +24,7 @@ on:
           echo "issue_number=$INPUT_ISSUE" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        CUTOFF=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-          || date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
+        CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
         ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open \
           --search "-label:triage/triaged created:<${CUTOFF}" \


### PR DESCRIPTION
Adds the agentic-workflows agent definition and actions lock file generated by `gh aw init/upgrade`. Updates `.gitattributes` to mark `lock.yml` files as generated.

## Files
- `.github/agents/agentic-workflows.agent.md` — gh-aw agent definition
- `.github/aw/actions-lock.json` — pinned action versions
- `.gitattributes` — mark `*.lock.yml` as linguist-generated