### PR TITLE
[auto-triage] Upload triage reports (JSON/MD/HTML) to agent artifact

### DIFF
--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"242cefe826e085ec6262797a68cf80e62621f1e5fd5a35763ae85dfeae39ff22","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"010a3609825a9e2d427d0a16aa4d499463b6510f2acf6de54609b10dba98adfe","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -202,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5269e088c684963d_EOF'
+          cat << 'GH_AW_PROMPT_332fcf04a3cee9d7_EOF'
           <system>
-          GH_AW_PROMPT_5269e088c684963d_EOF
+          GH_AW_PROMPT_332fcf04a3cee9d7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5269e088c684963d_EOF'
+          cat << 'GH_AW_PROMPT_332fcf04a3cee9d7_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5269e088c684963d_EOF
+          GH_AW_PROMPT_332fcf04a3cee9d7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5269e088c684963d_EOF'
+          cat << 'GH_AW_PROMPT_332fcf04a3cee9d7_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_5269e088c684963d_EOF
+          GH_AW_PROMPT_332fcf04a3cee9d7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -369,6 +369,13 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Redirect step summary into agent-writable directory
+        run: |-
+          mkdir -p /tmp/gh-aw/agent
+          touch /tmp/gh-aw/agent/step-summary.md
+          rm -f /tmp/gh-aw/agent-step-summary.md
+          ln -s /tmp/gh-aw/agent/step-summary.md /tmp/gh-aw/agent-step-summary.md
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -418,9 +425,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_6fac395f74811209_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_f3148f0f2c76889e_EOF
           {"add_labels":{"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6fac395f74811209_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f3148f0f2c76889e_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -643,7 +650,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3308790ed9b050a7_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_6bd61f2c8c6a8964_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -693,7 +700,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3308790ed9b050a7_EOF
+          GH_AW_MCP_CONFIG_6bd61f2c8c6a8964_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"010a3609825a9e2d427d0a16aa4d499463b6510f2acf6de54609b10dba98adfe","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b81c2fdd5fe171f1beadb8f03b193d47b393c1c1c18b7bef0e747e55366d70f0","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_WRITE_PROJECT_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -52,8 +52,8 @@ name: "Auto-Triage SkiaSharp Issue"
     # issues: read
   # roles: all # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "*/30 * * * *"
-    # Friendly format: every 30m
+  - cron: "*/10 * * * *"
+    # Friendly format: every 10m
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
   # - github-actions # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
@@ -202,14 +202,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_332fcf04a3cee9d7_EOF'
+          cat << 'GH_AW_PROMPT_94a82b25615d57e9_EOF'
           <system>
-          GH_AW_PROMPT_332fcf04a3cee9d7_EOF
+          GH_AW_PROMPT_94a82b25615d57e9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_332fcf04a3cee9d7_EOF'
+          cat << 'GH_AW_PROMPT_94a82b25615d57e9_EOF'
           <safe-output-tools>
           Tools: add_labels(max:10), update_project, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -241,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_332fcf04a3cee9d7_EOF
+          GH_AW_PROMPT_94a82b25615d57e9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_332fcf04a3cee9d7_EOF'
+          cat << 'GH_AW_PROMPT_94a82b25615d57e9_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-triage.md}}
-          GH_AW_PROMPT_332fcf04a3cee9d7_EOF
+          GH_AW_PROMPT_94a82b25615d57e9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -425,9 +425,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_f3148f0f2c76889e_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_e433af223b333fb2_EOF
           {"add_labels":{"max":10,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_project":{"github-token":"${GH_AW_WRITE_PROJECT_TOKEN}","max":1,"project":"https://github.com/orgs/mono/projects/1"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f3148f0f2c76889e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e433af223b333fb2_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -650,7 +650,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_6bd61f2c8c6a8964_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_df587eb831437e09_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -700,7 +700,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6bd61f2c8c6a8964_EOF
+          GH_AW_MCP_CONFIG_df587eb831437e09_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -39,6 +39,13 @@ jobs:
     outputs:
       issue_number: ${{ steps.find-issue.outputs.issue_number }}
 if: needs.pre_activation.outputs.find-issue_result == 'success'
+steps:
+  - name: Redirect step summary into agent-writable directory
+    run: |
+      mkdir -p /tmp/gh-aw/agent
+      touch /tmp/gh-aw/agent/step-summary.md
+      rm -f /tmp/gh-aw/agent-step-summary.md
+      ln -s /tmp/gh-aw/agent/step-summary.md /tmp/gh-aw/agent-step-summary.md
 tools:
   github:
     toolsets: [issues]
@@ -116,9 +123,9 @@ Copy the three triage output files into `/tmp/gh-aw/agent/` so they are included
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.json /tmp/gh-aw/agent/
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md /tmp/gh-aw/agent/
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.html /tmp/gh-aw/agent/
-cat output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md >> /tmp/gh-aw/agent-step-summary.md
+cat output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md >> /tmp/gh-aw/agent/step-summary.md
 ```
 
-**IMPORTANT:** Write to the literal path `/tmp/gh-aw/agent-step-summary.md` — do NOT use `$GITHUB_STEP_SUMMARY` as it resolves to an inaccessible runner path. The literal `/tmp/gh-aw/agent-step-summary.md` is the correct path that gh-aw reads after the agent finishes.
+**IMPORTANT:** Write to the literal path `/tmp/gh-aw/agent/step-summary.md` — this file is symlinked to the step summary. Do NOT use `$GITHUB_STEP_SUMMARY` as it resolves to an inaccessible path.
 
-All three files MUST be copied and the markdown MUST be appended to `/tmp/gh-aw/agent-step-summary.md`. Verify they exist before finishing.
+All three files MUST be copied and the markdown MUST be appended to `/tmp/gh-aw/agent/step-summary.md`. Verify they exist before finishing.

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -107,3 +107,15 @@ The `update-project` safe output auto-creates missing SINGLE_SELECT options — 
 Use `content_type: "issue"` and issue number `${{ needs.pre_activation.outputs.issue_number }}` to identify the item.
 
 Only include fields that have non-null values in the triage JSON. Omit any field where the source value is null or absent.
+
+## Step 4 — Upload triage reports to artifacts
+
+Copy the three triage output files into `/tmp/gh-aw/agent/` so they are included in the workflow's `agent` artifact:
+
+```bash
+cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.json /tmp/gh-aw/agent/
+cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md /tmp/gh-aw/agent/
+cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.html /tmp/gh-aw/agent/
+```
+
+All three files MUST be copied. Verify they exist before finishing.

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -108,14 +108,15 @@ Use `content_type: "issue"` and issue number `${{ needs.pre_activation.outputs.i
 
 Only include fields that have non-null values in the triage JSON. Omit any field where the source value is null or absent.
 
-## Step 4 — Upload triage reports to artifacts
+## Step 4 — Upload triage reports and write step summary
 
-Copy the three triage output files into `/tmp/gh-aw/agent/` so they are included in the workflow's `agent` artifact:
+Copy the three triage output files into `/tmp/gh-aw/agent/` so they are included in the workflow's `agent` artifact, then write the Markdown report to the step summary so it's visible on the Actions run page without downloading artifacts.
 
 ```bash
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.json /tmp/gh-aw/agent/
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md /tmp/gh-aw/agent/
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.html /tmp/gh-aw/agent/
+cat output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md >> "$GITHUB_STEP_SUMMARY"
 ```
 
-All three files MUST be copied. Verify they exist before finishing.
+All three files MUST be copied and the markdown MUST be appended to `$GITHUB_STEP_SUMMARY`. Verify they exist before finishing.

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -1,7 +1,7 @@
 ---
 description: "Triage a SkiaSharp issue: classify, label, and update the backlog project board."
 on:
-  schedule: every 30m
+  schedule: every 10m
   workflow_dispatch:
     inputs:
       issue_number:

--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -116,7 +116,9 @@ Copy the three triage output files into `/tmp/gh-aw/agent/` so they are included
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.json /tmp/gh-aw/agent/
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md /tmp/gh-aw/agent/
 cp output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.html /tmp/gh-aw/agent/
-cat output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md >> "$GITHUB_STEP_SUMMARY"
+cat output/ai/repos/mono-SkiaSharp/ai-triage/${{ needs.pre_activation.outputs.issue_number }}.md >> /tmp/gh-aw/agent-step-summary.md
 ```
 
-All three files MUST be copied and the markdown MUST be appended to `$GITHUB_STEP_SUMMARY`. Verify they exist before finishing.
+**IMPORTANT:** Write to the literal path `/tmp/gh-aw/agent-step-summary.md` — do NOT use `$GITHUB_STEP_SUMMARY` as it resolves to an inaccessible runner path. The literal `/tmp/gh-aw/agent-step-summary.md` is the correct path that gh-aw reads after the agent finishes.
+
+All three files MUST be copied and the markdown MUST be appended to `/tmp/gh-aw/agent-step-summary.md`. Verify they exist before finishing.


### PR DESCRIPTION
## Summary

Add a Step 4 to the auto-triage workflow that copies the three triage output files (`.json`, `.md`, `.html`) into `/tmp/gh-aw/agent/` so they are included in the workflow's `agent` artifact.

## Why

The issue-triage skill already generates all three report files in `output/ai/repos/mono-SkiaSharp/ai-triage/`, but they weren't being uploaded as artifacts. This means downstream workflows and `gh aw logs` couldn't access the structured triage data.

## Change

Added Step 4 to `.github/workflows/auto-triage.md` instructing the agent to:
```bash
cp output/ai/repos/mono-SkiaSharp/ai-triage/{number}.json /tmp/gh-aw/agent/
cp output/ai/repos/mono-SkiaSharp/ai-triage/{number}.md /tmp/gh-aw/agent/
cp output/ai/repos/mono-SkiaSharp/ai-triage/{number}.html /tmp/gh-aw/agent/
```

Files in `/tmp/gh-aw/agent/` are automatically uploaded as part of the `agent` artifact by gh-aw.