### PR TITLE
Free disk space on Linux CI agents

### DIFF
--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -96,7 +96,7 @@ jobs:
 
       # free disk space on hosted linux agents by removing pre-installed tools
       - ${{ if and(eq(parameters.buildAgent.pool.os, 'linux'), eq(parameters.buildAgent.pool.name, 'Azure Pipelines')) }}:
-        - bash: ./scripts/free-disk-space-linux.sh
+        - bash: bash ./scripts/free-disk-space-linux.sh
           displayName: Free disk space on Linux
 
       # # checkout required skia PR

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -94,6 +94,11 @@ jobs:
         displayName: Get the volume information after the checkout
         condition: always()
 
+      # free disk space on linux by removing pre-installed Android SDK components
+      - ${{ if eq(parameters.buildAgent.pool.os, 'linux') }}:
+        - bash: ./scripts/free-disk-space-linux.sh
+          displayName: Free disk space on Linux
+
       # # checkout required skia PR
       # - pwsh: .\scripts\checkout-skia.ps1 -GitHubToken $(GitHub.Token.PublicAccess)
       #   displayName: Checkout required skia PR

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -94,8 +94,8 @@ jobs:
         displayName: Get the volume information after the checkout
         condition: always()
 
-      # free disk space on linux by removing pre-installed Android SDK components
-      - ${{ if eq(parameters.buildAgent.pool.os, 'linux') }}:
+      # free disk space on hosted linux agents by removing pre-installed tools
+      - ${{ if and(eq(parameters.buildAgent.pool.os, 'linux'), eq(parameters.buildAgent.pool.name, 'Azure Pipelines')) }}:
         - bash: ./scripts/free-disk-space-linux.sh
           displayName: Free disk space on Linux
 

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -216,8 +216,6 @@ stages:
             requiredArtifacts:
               - name: native
             preBuildSteps:
-              - bash: bash ./scripts/free-disk-space-linux.sh
-                displayName: Free disk space for emulator
               - script: |
                   echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
                   sudo udevadm control --reload-rules

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -216,7 +216,7 @@ stages:
             requiredArtifacts:
               - name: native
             preBuildSteps:
-              - bash: ./scripts/free-disk-space-linux.sh
+              - bash: bash ./scripts/free-disk-space-linux.sh
                 displayName: Free disk space for emulator
               - script: |
                   echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -216,13 +216,7 @@ stages:
             requiredArtifacts:
               - name: native
             preBuildSteps:
-              - script: |
-                  sudo rm -rf /usr/local/lib/android/sdk/ndk
-                  sudo rm -rf /usr/local/lib/android/sdk/cmake
-                  sudo rm -rf /usr/local/lib/android/sdk/build-tools/33.*
-                  sudo rm -rf /usr/local/lib/android/sdk/build-tools/34.*
-                  sudo rm -rf /usr/local/lib/android/sdk/platforms/android-3[0-4]
-                  df -h /
+              - bash: ./scripts/free-disk-space-linux.sh
                 displayName: Free disk space for emulator
               - script: |
                   echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 # Free disk space on Linux CI agents by removing pre-installed Android SDK
-# components. The CI pipeline reinstalls only the specific components it needs.
+# components that are not needed by CI builds.
+#
+# Components we KEEP (relied on by managed builds and the emulator tests):
+#   cmdline-tools   - sdkmanager, used by install-android-package.ps1
+#   platform-tools  - adb, used to communicate with the emulator
+#   build-tools     - aapt/d8/etc, used to build .NET Android projects
+#   platforms       - android.jar, used to build .NET Android projects
+#
+# Components we REMOVE (large, never used or explicitly reinstalled):
+#   ndk             - native builds use Docker or install-android-ndk.ps1
+#   cmake           - native builds use Docker
+#   system-images   - emulator tests reinstall the exact image they need
+#   sources         - source code jars, never needed in CI
+#   extras          - support libraries, not needed
+#   emulator        - emulator tests reinstall this explicitly
 
 set -euo pipefail
 
@@ -9,11 +23,9 @@ ANDROID_SDK="${ANDROID_HOME:-/usr/local/lib/android/sdk}"
 free_before=$(df --output=avail / | tail -1)
 
 if [ -d "$ANDROID_SDK" ]; then
-    echo "Removing pre-installed Android SDK components from $ANDROID_SDK..."
+    echo "Removing unused Android SDK components from $ANDROID_SDK..."
     sudo rm -rf "$ANDROID_SDK/ndk"
     sudo rm -rf "$ANDROID_SDK/cmake"
-    sudo rm -rf "$ANDROID_SDK/build-tools"
-    sudo rm -rf "$ANDROID_SDK/platforms"
     sudo rm -rf "$ANDROID_SDK/system-images"
     sudo rm -rf "$ANDROID_SDK/sources"
     sudo rm -rf "$ANDROID_SDK/extras"

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -29,16 +29,20 @@ free_before=$(df --output=avail / | tail -1)
 # Remove pre-installed toolchains that SkiaSharp never uses
 # -----------------------------------------------------------------------
 echo "Removing unused toolchains..."
-sudo rm -rf /usr/share/swift              # ~3.3 GB - Swift toolchain
-sudo rm -rf /usr/local/.ghcup             # ~3.7 GB - Haskell toolchain
-sudo rm -rf /usr/local/julia*             # ~1.0 GB - Julia
-sudo rm -rf /usr/share/miniconda          # ~858 MB - Conda
-sudo rm -rf /usr/local/aws-cli            # ~255 MB - AWS CLI
-sudo rm -rf /usr/local/aws-sam-cli        # ~260 MB - AWS SAM CLI
-sudo rm -rf /opt/hostedtoolcache/go       # ~1.1 GB - Go
-sudo rm -rf /opt/hostedtoolcache/CodeQL   # ~1.7 GB - CodeQL
-sudo rm -rf /opt/hostedtoolcache/PyPy     # ~524 MB - PyPy
-sudo rm -rf /opt/hostedtoolcache/Ruby     # ~312 MB - Ruby
+sudo rm -rf /usr/share/dotnet              # ~4.6 GB - pre-installed .NET (we install our own via UseDotNet@2)
+sudo rm -rf /usr/share/swift               # ~3.3 GB - Swift toolchain
+sudo rm -rf /usr/local/.ghcup              # ~3.7 GB - Haskell toolchain
+sudo rm -rf /usr/local/julia*              # ~1.0 GB - Julia
+sudo rm -rf /usr/share/miniconda           # ~858 MB - Conda
+sudo rm -rf /usr/local/share/powershell    # ~178 MB - PowerShell modules (binary is at /opt/microsoft/powershell)
+sudo rm -rf /usr/local/share/chromium      #          - Chromium browser
+sudo rm -rf /usr/local/aws-cli             # ~255 MB - AWS CLI
+sudo rm -rf /usr/local/aws-sam-cli         # ~260 MB - AWS SAM CLI
+sudo rm -rf /opt/hostedtoolcache/go        # ~1.1 GB - Go
+sudo rm -rf /opt/hostedtoolcache/CodeQL    # ~1.7 GB - CodeQL
+sudo rm -rf /opt/hostedtoolcache/Python    # ~1.7 GB - Python (native builds use Docker)
+sudo rm -rf /opt/hostedtoolcache/PyPy      # ~524 MB - PyPy
+sudo rm -rf /opt/hostedtoolcache/Ruby      # ~312 MB - Ruby
 
 # -----------------------------------------------------------------------
 # Clean up Android SDK

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Free disk space on Linux CI agents by removing pre-installed Android SDK
+# components. The CI pipeline reinstalls only the specific components it needs.
+
+set -euo pipefail
+
+ANDROID_SDK="${ANDROID_HOME:-/usr/local/lib/android/sdk}"
+
+echo "Disk space before cleanup:"
+df -h /
+
+if [ -d "$ANDROID_SDK" ]; then
+    echo "Removing pre-installed Android SDK components from $ANDROID_SDK..."
+    sudo rm -rf "$ANDROID_SDK/ndk"
+    sudo rm -rf "$ANDROID_SDK/cmake"
+    sudo rm -rf "$ANDROID_SDK/build-tools"
+    sudo rm -rf "$ANDROID_SDK/platforms"
+    sudo rm -rf "$ANDROID_SDK/system-images"
+    sudo rm -rf "$ANDROID_SDK/sources"
+    sudo rm -rf "$ANDROID_SDK/extras"
+    sudo rm -rf "$ANDROID_SDK/emulator"
+else
+    echo "Android SDK not found at $ANDROID_SDK, skipping."
+fi
+
+echo ""
+echo "Disk space after cleanup:"
+df -h /

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -2,11 +2,11 @@
 # Free disk space on Linux CI agents by removing pre-installed Android SDK
 # components that are not needed by CI builds.
 #
-# Components we KEEP (relied on by managed builds and the emulator tests):
-#   cmdline-tools   - sdkmanager, used by install-android-package.ps1
-#   platform-tools  - adb, used to communicate with the emulator
-#   build-tools     - aapt/d8/etc, used to build .NET Android projects
-#   platforms       - android.jar, used to build .NET Android projects
+# Components we KEEP:
+#   cmdline-tools    - sdkmanager, used by install-android-package.ps1
+#   platform-tools   - adb, used to communicate with the emulator
+#   build-tools/NN.* - latest version only (used by .NET Android builds)
+#   platforms/android-{21,35,36} - ANDROID_PLATFORM_VERSIONS from variables
 #
 # Components we REMOVE (large, never used or explicitly reinstalled):
 #   ndk             - native builds use Docker or install-android-ndk.ps1
@@ -15,10 +15,15 @@
 #   sources         - source code jars, never needed in CI
 #   extras          - support libraries, not needed
 #   emulator        - emulator tests reinstall this explicitly
+#   old build-tools - only latest version needed
+#   old platforms   - only 21, 35, 36 needed (ANDROID_PLATFORM_VERSIONS)
 
 set -euo pipefail
 
 ANDROID_SDK="${ANDROID_HOME:-/usr/local/lib/android/sdk}"
+
+# Platforms to keep (must match ANDROID_PLATFORM_VERSIONS in variables.yml)
+KEEP_PLATFORMS="21 35 36"
 
 free_before=$(df --output=avail / | tail -1)
 
@@ -30,6 +35,39 @@ if [ -d "$ANDROID_SDK" ]; then
     sudo rm -rf "$ANDROID_SDK/sources"
     sudo rm -rf "$ANDROID_SDK/extras"
     sudo rm -rf "$ANDROID_SDK/emulator"
+
+    # Keep only the latest build-tools version
+    if [ -d "$ANDROID_SDK/build-tools" ]; then
+        latest_bt=$(ls -1 "$ANDROID_SDK/build-tools" | sort -V | tail -1)
+        echo "Keeping build-tools/$latest_bt, removing older versions..."
+        for bt in "$ANDROID_SDK/build-tools"/*/; do
+            bt_name=$(basename "$bt")
+            if [ "$bt_name" != "$latest_bt" ]; then
+                echo "  Removing build-tools/$bt_name"
+                sudo rm -rf "$bt"
+            fi
+        done
+    fi
+
+    # Keep only the platforms we need
+    if [ -d "$ANDROID_SDK/platforms" ]; then
+        echo "Keeping platforms: $KEEP_PLATFORMS, removing others..."
+        for plat in "$ANDROID_SDK/platforms"/*/; do
+            plat_name=$(basename "$plat")
+            api_level="${plat_name#android-}"
+            keep=false
+            for k in $KEEP_PLATFORMS; do
+                if [ "$api_level" = "$k" ]; then
+                    keep=true
+                    break
+                fi
+            done
+            if [ "$keep" = false ]; then
+                echo "  Removing platforms/$plat_name"
+                sudo rm -rf "$plat"
+            fi
+        done
+    fi
 else
     echo "Android SDK not found at $ANDROID_SDK, skipping."
 fi

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -1,22 +1,20 @@
 #!/usr/bin/env bash
-# Free disk space on Linux CI agents by removing pre-installed Android SDK
-# components that are not needed by CI builds.
+# Free disk space on Linux CI agents by removing tools and SDK components
+# that are not needed by SkiaSharp CI builds.
 #
-# Components we KEEP:
+# The hosted agents ship with many pre-installed toolchains (Swift, Haskell,
+# Julia, Miniconda, AWS CLI, etc.) that SkiaSharp never uses. Removing them
+# before the build starts prevents the agent from running out of disk space.
+#
+# Android SDK — components we KEEP:
 #   cmdline-tools    - sdkmanager, used by install-android-package.ps1
 #   platform-tools   - adb, used to communicate with the emulator
 #   build-tools/NN.* - latest version only (used by .NET Android builds)
 #   platforms/android-{21,35,36} - ANDROID_PLATFORM_VERSIONS from variables
 #
-# Components we REMOVE (large, never used or explicitly reinstalled):
-#   ndk             - native builds use Docker or install-android-ndk.ps1
-#   cmake           - native builds use Docker
-#   system-images   - emulator tests reinstall the exact image they need
-#   sources         - source code jars, never needed in CI
-#   extras          - support libraries, not needed
-#   emulator        - emulator tests reinstall this explicitly
-#   old build-tools - only latest version needed
-#   old platforms   - only 21, 35, 36 needed (ANDROID_PLATFORM_VERSIONS)
+# Android SDK — components we REMOVE:
+#   ndk, cmake, system-images, sources, extras, emulator, old build-tools,
+#   and platforms not in ANDROID_PLATFORM_VERSIONS.
 
 set -euo pipefail
 
@@ -27,6 +25,20 @@ KEEP_PLATFORMS="21 35 36"
 
 free_before=$(df --output=avail / | tail -1)
 
+# -----------------------------------------------------------------------
+# Remove pre-installed toolchains that SkiaSharp never uses
+# -----------------------------------------------------------------------
+echo "Removing unused toolchains..."
+sudo rm -rf /usr/share/swift              # ~3.3 GB - Swift toolchain
+sudo rm -rf /usr/local/.ghcup             # ~3.7 GB - Haskell toolchain
+sudo rm -rf /usr/local/julia*             # ~1.0 GB - Julia
+sudo rm -rf /usr/share/miniconda          # ~858 MB - Conda
+sudo rm -rf /usr/local/aws-cli            # ~255 MB - AWS CLI
+sudo rm -rf /usr/local/aws-sam-cli        # ~260 MB - AWS SAM CLI
+
+# -----------------------------------------------------------------------
+# Clean up Android SDK
+# -----------------------------------------------------------------------
 if [ -d "$ANDROID_SDK" ]; then
     echo "Removing unused Android SDK components from $ANDROID_SDK..."
     sudo rm -rf "$ANDROID_SDK/ndk"

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -35,6 +35,10 @@ sudo rm -rf /usr/local/julia*             # ~1.0 GB - Julia
 sudo rm -rf /usr/share/miniconda          # ~858 MB - Conda
 sudo rm -rf /usr/local/aws-cli            # ~255 MB - AWS CLI
 sudo rm -rf /usr/local/aws-sam-cli        # ~260 MB - AWS SAM CLI
+sudo rm -rf /opt/hostedtoolcache/go       # ~1.1 GB - Go
+sudo rm -rf /opt/hostedtoolcache/CodeQL   # ~1.7 GB - CodeQL
+sudo rm -rf /opt/hostedtoolcache/PyPy     # ~524 MB - PyPy
+sudo rm -rf /opt/hostedtoolcache/Ruby     # ~312 MB - Ruby
 
 # -----------------------------------------------------------------------
 # Clean up Android SDK

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 
 ANDROID_SDK="${ANDROID_HOME:-/usr/local/lib/android/sdk}"
 
-# Platforms to keep (must match ANDROID_PLATFORM_VERSIONS in variables.yml)
-KEEP_PLATFORMS="21 35 36"
+# Platforms to keep (from ANDROID_PLATFORM_VERSIONS pipeline variable, comma-separated)
+KEEP_PLATFORMS="${ANDROID_PLATFORM_VERSIONS:-21,35,36}"
 
 free_before=$(df --output=avail / | tail -1)
 
@@ -72,11 +72,12 @@ if [ -d "$ANDROID_SDK" ]; then
     # Keep only the platforms we need
     if [ -d "$ANDROID_SDK/platforms" ]; then
         echo "Keeping platforms: $KEEP_PLATFORMS, removing others..."
+        IFS=',' read -ra keep_array <<< "$KEEP_PLATFORMS"
         for plat in "$ANDROID_SDK/platforms"/*/; do
             plat_name=$(basename "$plat")
             api_level="${plat_name#android-}"
             keep=false
-            for k in $KEEP_PLATFORMS; do
+            for k in "${keep_array[@]}"; do
                 if [ "$api_level" = "$k" ]; then
                     keep=true
                     break

--- a/scripts/free-disk-space-linux.sh
+++ b/scripts/free-disk-space-linux.sh
@@ -6,8 +6,7 @@ set -euo pipefail
 
 ANDROID_SDK="${ANDROID_HOME:-/usr/local/lib/android/sdk}"
 
-echo "Disk space before cleanup:"
-df -h /
+free_before=$(df --output=avail / | tail -1)
 
 if [ -d "$ANDROID_SDK" ]; then
     echo "Removing pre-installed Android SDK components from $ANDROID_SDK..."
@@ -23,6 +22,8 @@ else
     echo "Android SDK not found at $ANDROID_SDK, skipping."
 fi
 
-echo ""
-echo "Disk space after cleanup:"
+free_after=$(df --output=avail / | tail -1)
+freed_kb=$((free_after - free_before))
+freed_mb=$((freed_kb / 1024))
+echo "Freed ${freed_mb} MB of disk space"
 df -h /


### PR DESCRIPTION
## Summary

Linux hosted agents ship at **93% disk usage** (~5.4 GB free on a 72 GB disk), which causes Android emulator tests to run out of space and get abandoned. This PR adds a reusable cleanup script that frees ~22 GB by removing unused toolchains and Android SDK components.

## Changes

- **New `scripts/free-disk-space-linux.sh`** — reusable script that:
  - Removes unused toolchains: Swift (3.3G), Haskell (3.7G), Go (1.1G), CodeQL (1.7G), Julia (1G), Miniconda (858M), PyPy (524M), Ruby (312M), AWS CLI/SAM (515M)
  - Removes unused Android SDK components: NDK (6.5G), cmake, system-images, sources, extras, emulator
  - Prunes old `build-tools` versions (keeps only latest)
  - Prunes old `platforms` (keeps only 21, 35, 36 per `ANDROID_PLATFORM_VERSIONS`)
  - Preserves `cmdline-tools`, `platform-tools`, latest `build-tools`, and required `platforms` (needed by managed builds that skip Android SDK install on Linux)
  - Logs how much space was freed in MB
- **`azure-templates-stages-test.yml`** — replaced inline `rm -rf` block with a call to the script
- **`azure-templates-jobs-bootstrapper.yml`** — added the script for all Linux builds, running early after checkout

## Why

The bootstrapper skips Android SDK installation on Linux (`ne(buildAgent.pool.os, 'linux')`), relying on the pre-installed SDK. So we keep the components managed builds need (`cmdline-tools`, `platform-tools`, `build-tools`, `platforms`) while removing everything else. The Android emulator test job already explicitly reinstalls `emulator` and `system-images` in its `preBuildSteps`. Native Android builds use Docker containers or install their own NDK to `~/android-ndk`.
