### PR TITLE
Bump SkiaSharpGenerator to CppAst 0.21.4 and make it work on Linux

### DIFF
--- a/binding/SkiaSharp/SKStream.cs
+++ b/binding/SkiaSharp/SKStream.cs
@@ -149,7 +149,8 @@ namespace SkiaSharp
 			return SkiaApi.sk_stream_seek (Handle, (IntPtr)position);
 		}
 
-		public bool Move (long offset) => Move ((int)offset);
+		[Obsolete ("The native stream move offset is capped at a 32-bit int. Use Move(int) instead.")]
+		public bool Move (long offset) => Move (checked ((int)offset));
 
 		public bool Move (int offset)
 		{

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -14397,7 +14397,7 @@ namespace SkiaSharp
 			(sk_stream_is_at_end_delegate ??= GetSymbol<Delegates.sk_stream_is_at_end> ("sk_stream_is_at_end")).Invoke (cstream);
 		#endif
 
-		// bool sk_stream_move(sk_stream_t* cstream, int offset)
+		// bool sk_stream_move(sk_stream_t* cstream, int32_t offset)
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (SKIA)]
@@ -17533,7 +17533,7 @@ namespace SkiaSharp {
 	[return: MarshalAs (UnmanagedType.I1)]
 	internal unsafe delegate bool SKManagedStreamIsAtEndProxyDelegate(sk_stream_managedstream_t s, void* context);
 
-	// typedef bool (*)(sk_stream_managedstream_t* s, void* context, int offset)* sk_managedstream_move_proc
+	// typedef bool (*)(sk_stream_managedstream_t* s, void* context, int32_t offset)* sk_managedstream_move_proc
 	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 	[return: MarshalAs (UnmanagedType.I1)]
 	internal unsafe delegate bool SKManagedStreamMoveProxyDelegate(sk_stream_managedstream_t s, void* context, Int32 offset);

--- a/utils/SkiaSharpGenerator/BaseTool.cs
+++ b/utils/SkiaSharpGenerator/BaseTool.cs
@@ -225,18 +225,16 @@ namespace SkiaSharpGenerator
 				{ "signed int",           nameof(Int32) },
 				{ "unsigned",             nameof(UInt32) },
 				{ "unsigned int",         nameof(UInt32) },
-				// C `long` is 32-bit on Windows (LLP64) and 64-bit on Linux/macOS
-				// (LP64). The checked-in bindings settled on Int32 historically
-				// (older CppAst silently collapsed `long` to `int`). Keep that to
-				// avoid ABI churn across the supported platforms.
-				{ "long",                 nameof(Int32) },
-				{ "long int",             nameof(Int32) },
+				// NOTE: C `long` / `unsigned long` / `signed long` (and the
+				// equivalent `long int` spellings) are intentionally omitted.
+				// Their size is platform-dependent (32-bit on Windows LLP64,
+				// 64-bit on Linux/macOS LP64), so no single managed type maps
+				// correctly on all platforms. GetType() below rejects them with
+				// a diagnostic pointing at int32_t / int64_t.
 				{ "long long",            nameof(Int64) },
 				{ "long long int",        nameof(Int64) },
-				{ "signed long",          nameof(Int32) },
-				{ "signed long int",      nameof(Int32) },
-				{ "unsigned long",        nameof(UInt32) },
-				{ "unsigned long int",    nameof(UInt32) },
+				{ "unsigned long long",   nameof(UInt64) },
+				{ "unsigned long long int", nameof(UInt64) },
 				{ "float",                nameof(Single) },
 				{ "double",               nameof(Double) },
 				// TODO: long double, wchar_t ?
@@ -354,6 +352,16 @@ namespace SkiaSharpGenerator
 			return null;
 		}
 
+		// C types whose sizes differ between LLP64 (Windows) and LP64 (Linux/macOS)
+		// platforms. There is no single managed mapping that is correct on both,
+		// so we refuse to generate bindings for them instead of silently picking
+		// one and propagating the platform-dependent bug.
+		private static readonly HashSet<string> PlatformDependentLongTypes = new()
+		{
+			"long", "signed long", "unsigned long",
+			"long int", "signed long int", "unsigned long int",
+		};
+
 		protected string GetType(CppType type)
 		{
 			var typeName = GetCppType(type);
@@ -362,6 +370,15 @@ namespace SkiaSharpGenerator
 			var pointerIndex = typeName.IndexOf("*");
 			var pointers = pointerIndex == -1 ? "" : typeName.Substring(pointerIndex);
 			var noPointers = pointerIndex == -1 ? typeName : typeName.Substring(0, pointerIndex);
+
+			if (PlatformDependentLongTypes.Contains(noPointers.TrimEnd()))
+			{
+				throw new InvalidOperationException(
+					$"C type '{noPointers.TrimEnd()}' has a platform-dependent size " +
+					$"(32-bit on Windows LLP64, 64-bit on Linux/macOS LP64). " +
+					$"Use int32_t or int64_t explicitly in the C header, " +
+					$"or add an explicit type override in the JSON config.");
+			}
 
 			if (skiaTypes.TryGetValue(noPointers, out var isStruct))
 			{

--- a/utils/SkiaSharpGenerator/BaseTool.cs
+++ b/utils/SkiaSharpGenerator/BaseTool.cs
@@ -115,6 +115,39 @@ namespace SkiaSharpGenerator
 				}
 			}
 
+			if (OperatingSystem.IsLinux())
+			{
+				var process = new System.Diagnostics.Process
+				{
+					StartInfo = new System.Diagnostics.ProcessStartInfo
+					{
+						FileName = "clang",
+						Arguments = "-print-resource-dir",
+						RedirectStandardOutput = true,
+						UseShellExecute = false,
+						CreateNoWindow = true,
+					}
+				};
+				try
+				{
+					process.Start();
+					var resourceDir = process.StandardOutput.ReadToEnd().Trim();
+					process.WaitForExit();
+					if (!string.IsNullOrEmpty(resourceDir))
+					{
+						var include = Path.Combine(resourceDir, "include");
+						if (Directory.Exists(include))
+							options.SystemIncludeFolders.Add(include);
+					}
+				}
+				catch { }
+				foreach (var sys in new[] { "/usr/include/x86_64-linux-gnu", "/usr/include" })
+				{
+					if (Directory.Exists(sys))
+						options.SystemIncludeFolders.Add(sys);
+				}
+			}
+
 			foreach (var header in config.IncludeDirs)
 			{
 				var path = Path.Combine(SkiaRoot, header);
@@ -192,14 +225,18 @@ namespace SkiaSharpGenerator
 				{ "signed int",           nameof(Int32) },
 				{ "unsigned",             nameof(UInt32) },
 				{ "unsigned int",         nameof(UInt32) },
-				{ "long",                 nameof(Int64) },
-				{ "long int",             nameof(Int64) },
+				// C `long` is 32-bit on Windows (LLP64) and 64-bit on Linux/macOS
+				// (LP64). The checked-in bindings settled on Int32 historically
+				// (older CppAst silently collapsed `long` to `int`). Keep that to
+				// avoid ABI churn across the supported platforms.
+				{ "long",                 nameof(Int32) },
+				{ "long int",             nameof(Int32) },
 				{ "long long",            nameof(Int64) },
 				{ "long long int",        nameof(Int64) },
-				{ "signed long",          nameof(Int64) },
-				{ "signed long int",      nameof(Int64) },
-				{ "unsigned long",        nameof(UInt64) },
-				{ "unsigned long int",    nameof(UInt64) },
+				{ "signed long",          nameof(Int32) },
+				{ "signed long int",      nameof(Int32) },
+				{ "unsigned long",        nameof(UInt32) },
+				{ "unsigned long int",    nameof(UInt32) },
 				{ "float",                nameof(Single) },
 				{ "double",               nameof(Double) },
 				// TODO: long double, wchar_t ?
@@ -352,8 +389,12 @@ namespace SkiaSharpGenerator
 		{
 			var typeName = type.GetDisplayName();
 
-			// remove the const
-			typeName = typeName.Replace("const ", "");
+			// remove the const (both prefix and suffix forms — CppAst switched between them)
+			typeName = typeName.Replace("const ", "").Replace(" const", "");
+
+			// normalize whitespace around pointer/reference sigils: newer CppAst emits
+			// "T *" instead of "T*", which breaks the pointer/name split downstream
+			typeName = typeName.Replace(" *", "*").Replace(" &", "&");
 
 			// replace the [] with a *
 			int start;

--- a/utils/SkiaSharpGenerator/Generate/Generator.cs
+++ b/utils/SkiaSharpGenerator/Generate/Generator.cs
@@ -120,7 +120,7 @@ namespace SkiaSharpGenerator
 			functionMappings.TryGetValue(name, out var map);
 			name = map?.CsType ?? CleanName(name);
 
-			writer.WriteLine($"\t// {del}");
+			writer.WriteLine($"\t// {FormatCppSignature(del.ToString())}");
 			writer.WriteLine($"\t[UnmanagedFunctionPointer (CallingConvention.Cdecl)]");
 
 			var (paramsList, returnType) = GetManagedFunctionArguments(function, map);
@@ -193,7 +193,7 @@ namespace SkiaSharpGenerator
 				var funcPointerType = GetFunctionPointerType(field.Type);
 				var cppT = GetCppType(field.Type);
 
-				writer.WriteLine($"\t\t// {field}");
+				writer.WriteLine($"\t\t// {FormatCppSignature(field.ToString())}");
 
 				var fieldName = field.Name;
 				var isPrivate = fieldName.StartsWith("_private_", StringComparison.OrdinalIgnoreCase);
@@ -540,7 +540,7 @@ namespace SkiaSharpGenerator
 					}
 
 					writer.WriteLine();
-					writer.WriteLine($"\t\t// {function}");
+					writer.WriteLine($"\t\t// {FormatCppSignature(function)}");
 					writer.WriteLine($"\t\t#if !USE_DELEGATES");
 					writer.WriteLine($"\t\t#if USE_LIBRARY_IMPORT");
 					writer.WriteLine($"\t\t[LibraryImport ({config.DllName})]");
@@ -652,6 +652,18 @@ namespace SkiaSharpGenerator
 				writer.WriteLine($"\tprivate static partial {returnType} {implName}({string.Join(",", paramsList)});");
 				writer.WriteLine();
 			}
+		}
+
+		// Normalize CppAst's ToString() output to the historical style the checked-in
+		// generated files use: "const T*" instead of "T const *", no space before *.
+		private static string FormatCppSignature(CppFunction function) =>
+			FormatCppSignature(function.ToString());
+
+		private static string FormatCppSignature(string s)
+		{
+			s = System.Text.RegularExpressions.Regex.Replace(s, @"(\w+)\s+const\b", "const $1");
+			s = s.Replace(" *", "*").Replace(" &", "&");
+			return s;
 		}
 
 		private void WriteDocIfAny(TextWriter writer, string key, string indent)

--- a/utils/SkiaSharpGenerator/SkiaSharpGenerator.csproj
+++ b/utils/SkiaSharpGenerator/SkiaSharpGenerator.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CppAst" Version="0.13.0" />
+    <PackageReference Include="CppAst" Version="0.21.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />


### PR DESCRIPTION
**Description of Change**

<!-- Describe your changes here. -->

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

https://github.com/mono/skia/pull/186

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
