### PR TITLE
Fix integration tests for .NET 10 migration

### DIFF
--- a/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
@@ -148,7 +148,7 @@ public class LinuxConsoleTests(ITestOutputHelper output) : PlatformTestBase(outp
         // Build and run in Docker using dotnet publish (resolves RID-specific native assets)
         var dockerfile = Path.Combine(projectDir, "Dockerfile");
         File.WriteAllText(dockerfile, $"""
-            FROM mcr.microsoft.com/dotnet/sdk:8.0
+            FROM mcr.microsoft.com/dotnet/sdk:10.0
             WORKDIR /src
             COPY {projectName}.csproj nuget.config ./
             RUN dotnet restore

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -46,12 +46,13 @@ public abstract class PlatformTestBase : IDisposable
             </configuration>
             """);
         
-        // Write global.json to allow latest SDK (prevents inheriting repo's .NET 8 restriction)
+        // Write global.json to pin to .NET 10 SDK (where MAUI workloads are installed)
         File.WriteAllText(Path.Combine(TestDir, "global.json"), """
             {
               "sdk": {
-                "version": "8.0.0",
-                "rollForward": "latestMajor"
+                "version": "10.0.100",
+                "allowPrerelease": false,
+                "rollForward": "latestFeature"
               }
             }
             """);


### PR DESCRIPTION
## Summary

Two hardcoded .NET 8 references in the integration tests were broken after the repo migrated to .NET 10.

## Changes

### `LinuxConsoleTests.cs`
- Updated Docker image from `mcr.microsoft.com/dotnet/sdk:8.0` to `mcr.microsoft.com/dotnet/sdk:10.0`
- The generated test project targets `net10.0`, so the Docker image must also be .NET 10

### `PlatformTestBase.cs`
- Updated the temp `global.json` from `8.0.0`/`latestMajor` to `10.0.100`/`latestFeature`
- The old config rolled forward all the way to .NET 11 preview SDK, which doesn't have MAUI workloads installed
- Now matches the repo's own `global.json` so MAUI builds use the correct SDK

## Testing

All integration tests verified against `3.119.4-preview.1.1` during release testing:
- ✅ SmokeTests, ConsoleTests, LinuxConsoleTests, BlazorTests
- ✅ MauiMacCatalystTests
- ✅ MauiiOSTests (iPhone 14 Pro / iOS 16.2, iPhone 16 Pro / iOS 18.5)
- ✅ MauiAndroidTests (API 23, API 36)