### PR TITLE
[main] Update libpng to 1.6.58

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8,7 +8,7 @@
         "type": "other",
         "other": {
           "name": "libpng",
-          "version": "1.6.54",
+          "version": "1.6.58",
           "downloadUrl": "https://github.com/glennrp/libpng"
         }
       }


### PR DESCRIPTION
Update libpng from 1.6.54 to 1.6.58.

## Changes
- `externals/skia/DEPS`: updated libpng commit hash to v1.6.58
- `cgmanifest.json`: updated version to 1.6.58
- No BUILD.gn changes needed

## Verification
- ✅ Native build succeeded (macOS arm64)
- ✅ C# build succeeded
- ✅ All 5380 tests passed (0 failures, 12 skipped for hardware)

Supersedes #3673.

Required skia PR: https://github.com/mono/skia/pull/188

Fixes #3685