### PR TITLE
[main] Update zlib to 1.3.2.1-motley

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -18,7 +18,7 @@
         "type": "other",
         "other": {
           "name": "zlib",
-          "version": "1.3.0.1",
+          "version": "1.3.2.1",
           "downloadUrl": "https://github.com/madler/zlib"
         }
       }
@@ -181,7 +181,7 @@
         "type": "other",
         "other": {
           "name": "angle-zlib",
-          "version": "1.3.0.1",
+          "version": "1.3.2.1",
           "downloadUrl": "https://chromium.googlesource.com/chromium/src/third_party/zlib"
         }
       }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -18,7 +18,7 @@
         "type": "other",
         "other": {
           "name": "zlib",
-          "version": "1.3.2.1",
+          "version": "1.3.0.1",
           "downloadUrl": "https://github.com/madler/zlib"
         }
       }
@@ -28,7 +28,7 @@
         "type": "other",
         "other": {
           "name": "libjpeg-turbo",
-          "version": "2.1.5.1",
+          "version": "3.1.0",
           "downloadUrl": "https://github.com/libjpeg-turbo/libjpeg-turbo"
         }
       }
@@ -48,7 +48,7 @@
         "type": "other",
         "other": {
           "name": "freetype",
-          "version": "2.13.3",
+          "version": "2.14.1",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
       }
@@ -176,17 +176,7 @@
       }
     },
     {
-      "comment": "ANGLE submodule dependencies — versions from ANGLE DEPS at chromium/6275",
-      "component": {
-        "type": "other",
-        "other": {
-          "name": "angle-zlib",
-          "version": "1.3.2.1",
-          "downloadUrl": "https://chromium.googlesource.com/chromium/src/third_party/zlib"
-        }
-      }
-    },
-    {
+      "comment": "ANGLE-only: JSON parser used by ANGLE's build system (not used by Skia)",
       "component": {
         "type": "other",
         "other": {
@@ -197,6 +187,7 @@
       }
     },
     {
+      "comment": "ANGLE-only: ASTC texture compression (not used by Skia)",
       "component": {
         "type": "other",
         "other": {
@@ -207,7 +198,7 @@
       }
     },
     {
-      "comment": "ANGLE vulkan-deps is a meta-repo pinning vulkan-headers, spirv-tools, spirv-cross, etc.",
+      "comment": "ANGLE-only: meta-repo pinning vulkan-headers, spirv-tools, spirv-cross, etc. (Skia pulls these individually via DEPS)",
       "component": {
         "type": "other",
         "other": {


### PR DESCRIPTION
## Description

Update Chromium's zlib fork from 1.3.0.1-motley to 1.3.2.1-motley.

Fixes #3914

## Changes

- `externals/skia`: Updated submodule for zlib version bump
- `cgmanifest.json`: Bumped `zlib` and `angle-zlib` versions to 1.3.2.1

## Verification

- Native macOS arm64 build: ✅
- C# build: ✅
- Tests: ✅

Required skia PR: https://github.com/mono/skia/pull/189

---
> ⚠️ **Note:** The merge commit message incorrectly contained `Fixes #3689` (libjpeg-turbo). The correct issue for this PR is #3914 (zlib). Issue #3689 has been reopened.