### PR TITLE
Fix cgmanifest.json Skia milestone mismatch on release/3.119.x

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "8c99e432ff06e61c42cf99aa8f2cbe248d301b9a"
+          "commitHash": "330baf49f60f4354d6e3fdb6ce526c08926c7c37"
         }
       }
     },
@@ -233,12 +233,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m132",
+          "version": "chrome/m119",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 132,
-      "upstream_merge_commit": "9ab7c2064b2b1ab22f856a7f0a8c3b3ae4cb89c7"
+      "chrome_milestone": 119,
+      "upstream_merge_commit": "fcb55886b914028a99f35fb0ba28e66ff82027e3"
     }
   ]
 }


### PR DESCRIPTION
## Problem
The `cgmanifest.json` on `release/3.119.x` incorrectly declared Skia at `chrome/m132` with a commit hash from `main`, but the actual submodule on this release branch points to `chrome/m119` (`330baf49f6`). This mismatch prevented Component Governance from properly detecting Skia CVEs for this release branch.

## Changes
Updated the Skia entries in `cgmanifest.json` to match the actual submodule state:

| Field | Before | After |
|-------|--------|-------|
| `skia` version | `chrome/m132` | `chrome/m119` |
| `chrome_milestone` | `132` | `119` |
| mono/skia `commitHash` | `8c99e432ff...` | `330baf49f6...` (matches submodule) |
| `upstream_merge_commit` | `9ab7c2064b...` | `fcb55886b9...` (chrome/m119 branch tip) |

## Verification
```
$ git submodule status externals/skia
-330baf49f60f4354d6e3fdb6ce526c08926c7c37 externals/skia
```
Commit hash in cgmanifest.json now matches the submodule.