### PR TITLE
[release/3.119.x] Update libexpat to 2.7.5

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -68,7 +68,7 @@
         "type": "other",
         "other": {
           "name": "libexpat",
-          "version": "2.7.3",
+          "version": "2.7.5",
           "downloadUrl": "https://github.com/libexpat/libexpat"
         }
       }


### PR DESCRIPTION
Bumps libexpat from 2.7.3 to 2.7.5.

## Changes
- `externals/skia` submodule: updated DEPS expat commit hash
- `cgmanifest.json`: version bumped to 2.7.5
- No BUILD.gn changes required

Required skia PR: https://github.com/mono/skia/pull/191