### PR TITLE
[release/3.119.x] Update FreeType to 2.14.3

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -48,7 +48,7 @@
         "type": "other",
         "other": {
           "name": "freetype",
-          "version": "2.13.3",
+          "version": "2.14.3",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
       }


### PR DESCRIPTION
Bump FreeType from 2.13.3 to 2.14.3.

### Changes
- Updated `externals/skia` submodule with new FreeType DEPS entry
- Updated `cgmanifest.json` to version 2.14.3

### Verification
- Native build succeeded (macOS ARM64)
- All 5363 tests passed (0 failures)

Required skia PR: https://github.com/mono/skia/pull/193