### PR TITLE
[main] Update FreeType to 2.14.3

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -48,7 +48,7 @@
         "type": "other",
         "other": {
           "name": "freetype",
-          "version": "2.14.1",
+          "version": "2.14.3",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
       }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -48,7 +48,7 @@
         "type": "other",
         "other": {
           "name": "freetype",
-          "version": "2.13.3",
+          "version": "2.14.3",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
       }


### PR DESCRIPTION
Update freetype from 2.13.3 to 2.14.3.

Fixes #3687

## Changes

- `externals/skia/DEPS`: Updated freetype commit hash
- `cgmanifest.json`: Updated version to 2.14.3

Required skia PR: https://github.com/mono/skia/pull/194