### PR TITLE
Improve native-dependency-update skill with post-mortem fixes

### DIFF
--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -143,9 +143,7 @@ If the script falls back to the submodule commit, you'll need to determine the c
 cd externals/skia && git branch -r --contains $(git rev-parse HEAD)
 ```
 
-**After the script completes:**
-1. Use the `rename_branch` tool to set the SkiaSharp branch to `dev/update-{dep}`
-2. Proceed to Phase 1
+**After the script completes**, proceed to Phase 1.
 
 ---
 
@@ -228,7 +226,7 @@ Do NOT assume all entries use the same schema. Check `component.type` first.
 
 **Both PRs must be created together** — CI requires both.
 
-Both repos use branch name `dev/update-{dep}`. The skia branch was already created by the setup script. The SkiaSharp branch was set via `rename_branch`.
+Both repos use branch name `dev/update-{dep}`. The skia branch was already created by the setup script.
 
 #### Step 1: Create mono/skia PR
 

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -102,10 +102,9 @@ Do NOT attempt to read DEPS, edit files, or build until this finishes.
 ### Step 2: Set up PATH and tools
 ```bash
 export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH"
-unset GH_TOKEN
 ```
 ⚠️ PATH does not persist between bash tool calls. Prefix EVERY `dotnet` command with this export.
-⚠️ `GH_TOKEN` must be unset so `gh` commands (pr create, pr edit, etc.) use your interactive auth instead of the read-only default token.
+⚠️ Environment variables do not persist across bash tool calls. Every `gh` write command (pr create, pr edit, etc.) must be prefixed with `unset GH_TOKEN &&` to clear the read-only default token.
 ⚠️ `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
 
 ### Step 3: Unshallow the target dependency
@@ -258,9 +257,10 @@ Edit **both** PRs to reference each other:
 
 ### GitHub CLI for mono org repos
 
-The default `GH_TOKEN` is read-only and causes `gh pr create`, `gh pr edit`, and `gh run rerun` to fail with OAuth App access restrictions. This is already handled in Phase 0 Step 2 (`unset GH_TOKEN`), but if you see auth errors, verify it is unset:
+The default `GH_TOKEN` is read-only and causes `gh pr create`, `gh pr edit`, and `gh run rerun` to fail. Prefix every `gh` write command with `unset GH_TOKEN &&`:
 ```bash
-unset GH_TOKEN
+unset GH_TOKEN && gh pr create ...
+unset GH_TOKEN && gh pr edit ...
 ```
 
 ### Release Branch PRs

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -120,8 +120,28 @@ bash .agents/skills/native-dependency-update/scripts/setup.sh {dep} {skia_target
 | Arg | Default | Examples |
 |-----|---------|----------|
 | `dep` | (required) | `libpng`, `expat`, `zlib`, `libwebp`, `freetype` |
-| `skia_target_branch` | `skiasharp` | `skiasharp` |
+| `skia_target_branch` | `skiasharp` | `skiasharp`, `release/3.119.x` |
 | `skiasharp_target_branch` | `main` | `main`, `release/3.119.x` |
+
+### Determining the skia target branch
+
+⚠️ **NEVER assume the skia target branch.** It depends on what the user is asking:
+
+| User request | `skiasharp_target_branch` | `skia_target_branch` |
+|-------------|--------------------------|---------------------|
+| Update on main | `main` | `skiasharp` |
+| Backport to release branch | `release/3.119.x` | Check — see below |
+
+For release branch backports, the matching skia branch may or may not exist. The setup script handles this safely:
+1. It reads the submodule commit from the SkiaSharp target branch (this is always correct)
+2. It tries to fetch `origin/{skia_target_branch}`
+3. If the branch exists AND contains the submodule commit, it branches from there
+4. Otherwise, it branches from the submodule commit directly
+
+If the script falls back to the submodule commit, you'll need to determine the correct PR base branch for the mono/skia PR in Phase 5. Check what branch the submodule commit lives on:
+```bash
+cd externals/skia && git branch -r --contains $(git rev-parse HEAD)
+```
 
 **After the script completes:**
 1. Use the `rename_branch` tool to set the SkiaSharp branch to `dev/update-{dep}`

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -130,18 +130,9 @@ bash .agents/skills/native-dependency-update/scripts/setup.sh {dep} {skia_target
 | User request | `skiasharp_target_branch` | `skia_target_branch` |
 |-------------|--------------------------|---------------------|
 | Update on main | `main` | `skiasharp` |
-| Backport to release branch | `release/3.119.x` | Check — see below |
+| Backport to release branch | `release/3.119.x` | Ask the user |
 
-For release branch backports, the matching skia branch may or may not exist. The setup script handles this safely:
-1. It reads the submodule commit from the SkiaSharp target branch (this is always correct)
-2. It tries to fetch `origin/{skia_target_branch}`
-3. If the branch exists AND contains the submodule commit, it branches from there
-4. Otherwise, it branches from the submodule commit directly
-
-If the script falls back to the submodule commit, you'll need to determine the correct PR base branch for the mono/skia PR in Phase 5. Check what branch the submodule commit lives on:
-```bash
-cd externals/skia && git branch -r --contains $(git rev-parse HEAD)
-```
+If you're unsure which skia branch to target, **ask the user**. Do not guess.
 
 **After the script completes**, proceed to Phase 1.
 

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -33,11 +33,10 @@ You MUST complete ALL phases in order. Do not skip phases to save time.
 ### Pre-Flight Checklist
 
 Before starting, confirm you will:
-- [ ] Complete Phase 1-8 in order
+- [ ] Complete Phase 0-8 in order
 - [ ] Update DEPS, `externals/skia` submodule, AND `cgmanifest.json`
 - [ ] Build and test locally before any PR
-- [ ] Create PRs (never push directly to `skiasharp` or `main`)
-- [ ] Use "Fixes #NNNNN" in PR body (never close issues manually)
+- [ ] Create PRs (never push directly to protected branches)
 - [ ] Stop and ask at every 🛑 checkpoint
 
 ## Critical Rules
@@ -281,7 +280,7 @@ SkiaSharp uses Azure DevOps. mono/skia has no CI — relies on SkiaSharp's.
 
 > **🚨 CRITICAL: SQUASH MERGE CREATES NEW COMMITS**
 >
-> When you squash-merge mono/skia PR, GitHub creates a **NEW commit SHA** on the `skiasharp` branch.
+> When you squash-merge mono/skia PR, GitHub creates a **NEW commit SHA** on the target branch.
 > The original commits on `dev/update-{dep}` become **orphaned** when the branch is deleted.
 > 
 > **If SkiaSharp's submodule still points to the old (orphaned) commit, it will BREAK:**
@@ -293,8 +292,8 @@ SkiaSharp uses Azure DevOps. mono/skia has no CI — relies on SkiaSharp's.
 
 #### Merge Sequence (MANDATORY)
 
-1. **Merge mono/skia PR first** — This creates a new squashed commit on the `skiasharp` branch
-2. **Fetch the updated skiasharp branch** and note the new commit SHA
+1. **Merge mono/skia PR first** — This creates a new squashed commit on `{skia_target_branch}`
+2. **Fetch the updated `{skia_target_branch}`** and note the new commit SHA
 3. **Update the SkiaSharp submodule** to point to the new squashed commit (not the old branch commit)
 4. **Push the updated submodule reference** to the SkiaSharp PR branch
 5. **Only then merge the SkiaSharp PR**
@@ -304,7 +303,7 @@ SkiaSharp uses Azure DevOps. mono/skia has no CI — relies on SkiaSharp's.
 Before proceeding past each step, verify:
 
 - [ ] mono/skia PR merged
-- [ ] Fetched `skiasharp` branch to get new SHA
+- [ ] Fetched `{skia_target_branch}` to get new SHA
 - [ ] Updated SkiaSharp submodule to new SHA (`cd externals/skia && git checkout {new-sha}`)
 - [ ] Pushed submodule update to SkiaSharp PR branch
 - [ ] SkiaSharp PR merged
@@ -326,8 +325,8 @@ If you must amend a commit in `externals/skia`:
 
 - Related issues auto-closed
 - Both PRs merged
-- No failures on main
-- **Submodule points to a commit on `skiasharp` branch** — fetch main, check that `externals/skia` commit exists on `origin/skiasharp` (not orphaned)
+- No failures on `{skiasharp_target_branch}`
+- **Submodule points to a commit on `{skia_target_branch}`** — fetch the target branch, check that `externals/skia` commit exists on it (not orphaned)
 
 ---
 

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -88,6 +88,83 @@ git commit -m "Update libpng"  # POLICY VIOLATION
 
 ---
 
+## Git Discipline
+
+### Commit Message Format
+Always use EXACTLY this format:
+```
+Update {dep} to {version}
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+### Commit Once, Push Once
+1. Decide the exact commit message BEFORE executing `git commit`
+2. Stage ALL changes BEFORE committing
+3. Commit ONCE
+4. Push ONCE
+
+Do NOT commit-then-amend. Every amend requires a force-push, which:
+- Re-triggers CI (wasting 2+ hours of compute)
+- May invalidate a near-complete CI run
+
+### Submodule Amend Rules (if you MUST amend)
+If you must amend a commit in `externals/skia`:
+1. Amend the skia commit
+2. Force-push the skia branch
+3. In SkiaSharp root: `git add externals/skia` (picks up new SHA)
+4. `git commit --amend --no-edit`
+5. Force-push the SkiaSharp branch
+
+⚠️ NEVER amend the skia commit without also updating the parent submodule reference. The old SHA becomes orphaned after force-push.
+
+### Branch Creation
+Create the feature branch with its FINAL name immediately:
+```bash
+# In externals/skia (use origin/ prefix for fresh clones):
+git checkout -b dev/update-{dep} origin/{target_branch}
+
+# In SkiaSharp root (rename_branch tool handles prefix):
+# Use the rename_branch tool or git checkout -b
+```
+Do NOT create-then-rename branches.
+
+---
+
+## Phase 0: Environment Setup (MANDATORY FIRST STEP)
+
+Before ANY other action in a new worktree session:
+
+### Step 1: Initialize all submodules
+```bash
+git submodule update --init externals/skia externals/depot_tools
+```
+⚠️ `externals/skia` is ~900MB and takes ~8 minutes to clone. Wait for completion.
+Do NOT attempt to read DEPS, edit files, or build until this finishes.
+
+### Step 2: Set up PATH
+```bash
+export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH"
+```
+⚠️ PATH does not persist between bash tool calls. Prefix EVERY `dotnet` command with this export.
+
+### Step 3: Set target branch (for release branch work)
+If you're targeting a non-default branch (e.g., `release/3.119.x`):
+```bash
+git fetch origin {target_branch}
+git reset --hard origin/{target_branch}
+# Re-run submodule update to get the correct submodule commit:
+git submodule update externals/skia
+```
+
+### Step 4: Verify environment
+```bash
+dotnet --version && ls externals/skia/DEPS && ls externals/depot_tools/ninja.py
+```
+Do NOT proceed to Phase 1 until all three checks pass.
+
+---
+
 ## Workflow
 
 ### Phase 1: Discovery
@@ -131,6 +208,39 @@ dotnet cake --target=externals-macos --arch=arm64  # Example
 dotnet test tests/SkiaSharp.Tests.Console.sln
 ```
 
+### Build Retry Strategy
+
+**Common transient failure: HTTP 429 from chromium.googlesource.com**
+
+When running `dotnet cake --target=externals-macos`, the `git-sync-deps` step fetches 10+ dependencies from Google's mirrors in parallel. If multiple sessions run concurrently, you'll hit rate limits:
+```
+error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429
+Exception: Thread failure detected
+```
+
+**Strategy:**
+1. Retry the build command (rate limits are usually transient)
+2. If it fails 3 times, check which deps are missing with `ls externals/skia/third_party/externals/`
+3. Manually clone the specific missing dependency from its upstream repo
+4. Retry the build
+
+**Other common build issues:**
+- `fetch-gn` network abort → retry (transient)
+- `--no-restore` flag on `dotnet test` → remove it, let NuGet restore run
+- Test TTY noise → pipe to file or use `tail -50` to read results
+
+### cgmanifest.json Schema
+
+The cgmanifest.json uses different structures per component type:
+- Type `"other"`: `component.other.name`, `component.other.version`
+- Type `"git"`: `component.git.repositoryUrl`, `component.git.commitHash`
+
+Do NOT assume all entries use the same schema. Check `component.type` first.
+
+### Shallow Clone Gotcha
+
+`git-sync-deps` clones dependencies as shallow repos. `git log old..new` may show incorrect results. Use `git fetch --unshallow origin` before running git log diffs.
+
 ### Phase 5: Create PRs
 
 > **🛑 STOP AND ASK FOR APPROVAL** before creating PRs.
@@ -165,6 +275,35 @@ In the SkiaSharp root, create a branch named `dev/update-{dep}`. Then:
 Edit **both** PRs to reference each other:
 - mono/skia PR → Add: `Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/{number}`
 - mono/SkiaSharp PR → Add: `Required skia PR: https://github.com/mono/skia/pull/{number}`
+
+### GitHub API for mono org repos
+
+The `gh pr create` and `gh pr edit` commands FAIL for mono org repos due to OAuth App access restrictions. **Always use the REST API:**
+
+**Create PR:**
+```bash
+gh api repos/mono/skia/pulls --method POST \
+  -f title="Update {dep} to {version}" \
+  -f head="{branch}" \
+  -f base="{target_branch}" \
+  -f body="..."
+```
+
+**Edit PR:**
+```bash
+gh api repos/mono/SkiaSharp/pulls/{number} --method PATCH \
+  -f title="..." -f body="..."
+```
+
+**Do NOT use:** `gh pr create`, `gh pr edit`, `gh run rerun` — all fail with OAuth restrictions.
+
+### Release Branch PRs
+
+The `create_pull_request` built-in tool always targets the repo's default branch (`main`). For release branch PRs, immediately fix after creation:
+```bash
+gh api repos/mono/SkiaSharp/pulls/{number} --method PATCH \
+  -f base="{target_branch}"
+```
 
 #### Phase 5 Completion Checklist
 
@@ -240,3 +379,34 @@ Before proceeding past each step, verify:
 | libjpeg-turbo | `third_party/externals/libjpeg-turbo` |
 
 For cgmanifest names and upstream URLs, see [documentation/dev/dependencies.md](../../../documentation/dev/dependencies.md#name-mapping).
+
+---
+
+## Security Bump Protocol
+
+When the dependency update is security-related (CVE fix):
+
+### What to Report to the User (in session conversation ONLY)
+1. Full CVE analysis — which CVEs are fixed, severity, CVSS scores
+2. Which CVEs affect SkiaSharp's code paths and which don't (with reasoning)
+3. Behavior changes that may need test coverage
+4. Upstream issues that remain unfixed
+
+### What Goes in Public Artifacts (PRs, commits, branches)
+- **Commit message:** `Update {dep} to {version}` — NOTHING else
+- **PR title:** `Update {dep} to {version}` (optionally add target branch like `(release/3.119.x)`)
+- **PR body:** Version numbers, file changes, build verification results ONLY
+- **Branch name:** `dev/update-{dep}` — NEVER include CVE IDs
+
+### Prohibited in Public Artifacts
+- ❌ CVE IDs (e.g., CVE-2026-XXXXX)
+- ❌ Severity ratings or CVSS scores
+- ❌ Words: "security", "vulnerability", "exploit", "fix CVE", "security bump"
+- ❌ Version ranges like "from X to Y" in commit messages
+- ❌ Branch context like "(release/3.119.x)" in commit messages
+
+### After-Bump Checklist (report to user in session)
+Before marking the task complete, tell the user:
+- "Here's my security analysis for your records: ..."
+- "These CVEs affect our code paths: ... / do NOT affect us because: ..."
+- "New tests recommended: yes/no, because: ..."

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -52,83 +52,80 @@ Before starting, confirm you will:
 
 | Repository | Protected Branches | Action Required |
 |------------|-------------------|-----------------|
-| **mono/SkiaSharp** (parent repo) | `main` | Create feature branch first |
+| **mono/SkiaSharp** (parent repo) | `main`, `release/*` | Create feature branch first |
 | **mono/skia** (`externals/skia` submodule) | `main`, `skiasharp` | Create feature branch first |
 
 **Before ANY commit in either repository:**
 
-1. **Create a feature branch** — Use naming convention: `dev/issue-NNNN-description` or `dev/update-{dep}`
-2. **Never commit directly** to `main` or `skiasharp` — All changes require a PR
+1. **Create a feature branch** — Use naming convention: `dev/update-{dep}`
+2. **Never commit directly** to protected branches — All changes require a PR
 3. **This is a compliance requirement** — Direct commits bypass review, CI, and audit trails
 
-```bash
-# ✅ CORRECT — Always create feature branch first
-cd externals/skia
-git checkout skiasharp
-git checkout -b dev/update-libpng
-# Now make commits...
+### 🔒 Security Rules (ALWAYS — not just for CVE bumps)
 
-# ❌ WRONG — Never do this
-cd externals/skia
-git checkout skiasharp
-git commit -m "Update libpng"  # POLICY VIOLATION
-```
+All dependency updates are assumed security-sensitive. These rules apply to EVERY bump:
+
+**Commit message:** `Update {dep} to {version}` — NOTHING else (plus Co-authored-by trailer)
+**PR title:** `Update {dep} to {version}`
+**PR body:** Version numbers, file changes, build verification results ONLY
+**Branch name:** `dev/update-{dep}` — NEVER include CVE IDs
+
+**Prohibited in ALL public artifacts (PRs, commits, branches, PR comments):**
+- ❌ CVE IDs (e.g., CVE-2026-XXXXX)
+- ❌ Severity ratings or CVSS scores
+- ❌ Words: "security", "vulnerability", "exploit", "fix CVE", "security bump"
+- ❌ Version ranges like "from X to Y" in commit messages
+- ❌ Branch context like "(release/3.119.x)" in commit messages
+
+**Security analysis goes in the session conversation ONLY** — report to the user:
+1. Which CVEs are fixed, severity, CVSS scores
+2. Which CVEs affect SkiaSharp's code paths and which don't (with reasoning)
+3. Behavior changes that may need test coverage
+4. Upstream issues that remain unfixed
 
 ### ❌ NEVER Do These
 
 | Shortcut | Why It's Wrong |
 |----------|----------------|
-| Push directly to `skiasharp` or `main` | Bypasses PR review and CI |
+| Push directly to protected branches | Bypasses PR review and CI |
 | Skip native build phase | CI is too slow; must verify locally first |
 | Manually close issues | Breaks audit trail; PR merge auto-closes |
 | Skip `cgmanifest.json` update | Security compliance requires it |
 | Skip `externals/skia` submodule update | SkiaSharp won't use the new dependency version |
 | Revert/undo pushed commits | Fix forward with new commit instead |
 | **Merge both PRs without updating submodule in between** | **Squash-merge creates new SHA; submodule points to orphaned commit; BREAKS USERS** |
+| Include security details in public artifacts | Leaks vulnerability info before users can update |
+
+### Environment Reminders
+
+These do NOT persist across bash tool calls. Prefix every relevant command:
+
+| Command | Prefix |
+|---------|--------|
+| `dotnet` | `export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH" &&` |
+| `gh pr create`, `gh pr edit`, etc. | `unset GH_TOKEN &&` |
+| `grep` (pattern matching) | Use `grep -E` not `grep -P` (BSD grep on macOS) |
 
 ---
 
 ## Phase 0: Environment Setup (MANDATORY FIRST STEP)
 
-Before ANY other action in a new worktree session:
+Run the setup script before any other work. It initializes submodules, unshallows the dependency, creates the skia feature branch, and verifies the environment:
 
-### Step 1: Initialize all submodules
 ```bash
-git submodule update --init
-```
-⚠️ `externals/skia` is ~900MB and takes ~8 minutes to clone. Wait for completion.
-Do NOT attempt to read DEPS, edit files, or build until this finishes.
-
-### Step 2: Set up PATH and tools
-```bash
-export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH"
-```
-⚠️ PATH does not persist between bash tool calls. Prefix EVERY `dotnet` command with this export.
-⚠️ Environment variables do not persist across bash tool calls. Every `gh` write command (pr create, pr edit, etc.) must be prefixed with `unset GH_TOKEN &&` to clear the read-only default token.
-⚠️ `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
-
-### Step 3: Unshallow the target dependency
-`git-sync-deps` clones dependencies as shallow repos. `git log` and `git diff` across version ranges will show incorrect results in shallow repos. Always unshallow the dependency you're updating:
-```bash
-cd externals/skia/third_party/externals/{dep}
-git fetch --unshallow origin
-cd -
+bash .agents/skills/native-dependency-update/scripts/setup.sh {dep} {skia_target_branch} {skiasharp_target_branch}
 ```
 
-### Step 4: Set target branch (for release branch work)
-If you're targeting a non-default branch (e.g., `release/3.119.x`):
-```bash
-git fetch origin {target_branch}
-git reset --hard origin/{target_branch}
-# Re-run submodule update to get the correct submodule commit:
-git submodule update
-```
+**Arguments:**
+| Arg | Default | Examples |
+|-----|---------|----------|
+| `dep` | (required) | `libpng`, `expat`, `zlib`, `libwebp`, `freetype` |
+| `skia_target_branch` | `skiasharp` | `skiasharp` |
+| `skiasharp_target_branch` | `main` | `main`, `release/3.119.x` |
 
-### Step 5: Verify environment
-```bash
-dotnet --version && ls externals/skia/DEPS && ls externals/depot_tools/ninja.py
-```
-Do NOT proceed to Phase 1 until all three checks pass.
+**After the script completes:**
+1. Use the `rename_branch` tool to set the SkiaSharp branch to `dev/update-{dep}`
+2. Proceed to Phase 1
 
 ---
 
@@ -211,31 +208,23 @@ Do NOT assume all entries use the same schema. Check `component.type` first.
 
 **Both PRs must be created together** — CI requires both.
 
-#### Branch Naming Convention
-
-| Repository | Branch Name | Target Branch |
-|------------|-------------|---------------|
-| mono/skia | `dev/update-{dep}` | `skiasharp` |
-| mono/SkiaSharp | `dev/update-{dep}` | `main` |
-
-Example: For libfoo, use `dev/update-libwebp` in both repos.
+Both repos use branch name `dev/update-{dep}`. The skia branch was already created by the setup script. The SkiaSharp branch was set via `rename_branch`.
 
 #### Step 1: Create mono/skia PR
 
-In the `externals/skia` directory:
+The branch `dev/update-{dep}` already exists in `externals/skia` (created by setup script).
 
-1. **Create the branch with its final name** — do NOT create-then-rename:
-   ```bash
-   git checkout -b dev/update-{dep} origin/skiasharp
-   ```
-2. **Stage ALL changes before committing** (DEPS, BUILD.gn if changed)
-3. **Commit ONCE** with this exact format:
+1. **Stage ALL changes before committing** (DEPS, BUILD.gn if changed)
+2. **Commit ONCE** with this exact format:
    ```
    Update {dep} to {version}
 
    Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
    ```
-4. **Push ONCE** and create a PR targeting the `skiasharp` branch
+3. **Push ONCE** and create a PR targeting `{skia_target_branch}`:
+   ```bash
+   unset GH_TOKEN && gh pr create --repo mono/skia --base {skia_target_branch} --title "Update {dep} to {version}" --body "..."
+   ```
 
 Do NOT commit-then-amend. Every amend requires a force-push which re-triggers CI (wasting 2+ hours of compute).
 
@@ -243,32 +232,22 @@ Do NOT commit-then-amend. Every amend requires a force-push which re-triggers CI
 
 > **⚠️ CRITICAL: You MUST update the submodule reference, not just cgmanifest.json**
 
-In the SkiaSharp root, create a branch named `dev/update-{dep}`. Then:
-
 1. **Update the submodule** — In `externals/skia`, fetch and checkout the branch you just pushed in Step 1
 2. **Stage both changes** — `git add externals/skia cgmanifest.json` (the submodule AND the manifest)
-3. Commit, push, and create a PR targeting `main`
+3. **Commit ONCE** with the same format as Step 1
+4. **Push and create PR** targeting `{skiasharp_target_branch}`:
+   - If targeting `main`: use the `create_pull_request` tool
+   - If targeting a release branch: use the `create_pull_request` tool, then immediately fix the base:
+     ```bash
+     unset GH_TOKEN && gh pr edit {number} --repo mono/SkiaSharp --base {skiasharp_target_branch}
+     ```
 
 #### Step 3: Cross-link the PRs
 
 Edit **both** PRs to reference each other:
-- mono/skia PR → Add: `Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/{number}`
-- mono/SkiaSharp PR → Add: `Required skia PR: https://github.com/mono/skia/pull/{number}`
-
-### GitHub CLI for mono org repos
-
-The default `GH_TOKEN` is read-only and causes `gh pr create`, `gh pr edit`, and `gh run rerun` to fail. Prefix every `gh` write command with `unset GH_TOKEN &&`:
 ```bash
-unset GH_TOKEN && gh pr create ...
-unset GH_TOKEN && gh pr edit ...
-```
-
-### Release Branch PRs
-
-The `create_pull_request` built-in tool always targets the repo's default branch (`main`). For release branch PRs, immediately fix after creation:
-```bash
-gh api repos/mono/SkiaSharp/pulls/{number} --method PATCH \
-  -f base="{target_branch}"
+unset GH_TOKEN && gh pr edit {skia_pr_number} --repo mono/skia --body "...Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/{number}..."
+unset GH_TOKEN && gh pr edit {skiasharp_pr_number} --repo mono/SkiaSharp --body "...Required skia PR: https://github.com/mono/skia/pull/{number}..."
 ```
 
 #### Phase 5 Completion Checklist
@@ -276,11 +255,12 @@ gh api repos/mono/SkiaSharp/pulls/{number} --method PATCH \
 Before proceeding, verify ALL of these:
 
 - [ ] Branch names follow `dev/update-{dep}` convention
-- [ ] mono/skia PR targets `skiasharp` branch
-- [ ] mono/SkiaSharp PR targets `main` branch
+- [ ] mono/skia PR targets `{skia_target_branch}` branch
+- [ ] mono/SkiaSharp PR targets `{skiasharp_target_branch}` branch
 - [ ] **SkiaSharp's `externals/skia` submodule points to the mono/skia PR branch** (check with `git submodule status`)
 - [ ] `cgmanifest.json` updated with new version
 - [ ] Both PRs cross-reference each other
+- [ ] **No security details in any public artifact** (see Security Rules above)
 
 ### Phase 6: Monitor CI
 
@@ -355,34 +335,3 @@ If you must amend a commit in `externals/skia`:
 | libjpeg-turbo | `third_party/externals/libjpeg-turbo` |
 
 For cgmanifest names and upstream URLs, see [documentation/dev/dependencies.md](../../../documentation/dev/dependencies.md#name-mapping).
-
----
-
-## Security Bump Protocol
-
-When the dependency update is security-related (CVE fix):
-
-### What to Report to the User (in session conversation ONLY)
-1. Full CVE analysis — which CVEs are fixed, severity, CVSS scores
-2. Which CVEs affect SkiaSharp's code paths and which don't (with reasoning)
-3. Behavior changes that may need test coverage
-4. Upstream issues that remain unfixed
-
-### What Goes in Public Artifacts (PRs, commits, branches)
-- **Commit message:** `Update {dep} to {version}` — NOTHING else
-- **PR title:** `Update {dep} to {version}` (optionally add target branch like `(release/3.119.x)`)
-- **PR body:** Version numbers, file changes, build verification results ONLY
-- **Branch name:** `dev/update-{dep}` — NEVER include CVE IDs
-
-### Prohibited in Public Artifacts
-- ❌ CVE IDs (e.g., CVE-2026-XXXXX)
-- ❌ Severity ratings or CVSS scores
-- ❌ Words: "security", "vulnerability", "exploit", "fix CVE", "security bump"
-- ❌ Version ranges like "from X to Y" in commit messages
-- ❌ Branch context like "(release/3.119.x)" in commit messages
-
-### After-Bump Checklist (report to user in session)
-Before marking the task complete, tell the user:
-- "Here's my security analysis for your records: ..."
-- "These CVEs affect our code paths: ... / do NOT affect us because: ..."
-- "New tests recommended: yes/no, because: ..."

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -148,6 +148,8 @@ export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH"
 ```
 ⚠️ PATH does not persist between bash tool calls. Prefix EVERY `dotnet` command with this export.
 
+⚠️ `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
+
 ### Step 3: Set target branch (for release branch work)
 If you're targeting a non-default branch (e.g., `release/3.119.x`):
 ```bash

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -88,78 +88,44 @@ git commit -m "Update libpng"  # POLICY VIOLATION
 
 ---
 
-## Git Discipline
-
-### Commit Message Format
-Always use EXACTLY this format:
-```
-Update {dep} to {version}
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
-```
-
-### Commit Once, Push Once
-1. Decide the exact commit message BEFORE executing `git commit`
-2. Stage ALL changes BEFORE committing
-3. Commit ONCE
-4. Push ONCE
-
-Do NOT commit-then-amend. Every amend requires a force-push, which:
-- Re-triggers CI (wasting 2+ hours of compute)
-- May invalidate a near-complete CI run
-
-### Submodule Amend Rules (if you MUST amend)
-If you must amend a commit in `externals/skia`:
-1. Amend the skia commit
-2. Force-push the skia branch
-3. In SkiaSharp root: `git add externals/skia` (picks up new SHA)
-4. `git commit --amend --no-edit`
-5. Force-push the SkiaSharp branch
-
-⚠️ NEVER amend the skia commit without also updating the parent submodule reference. The old SHA becomes orphaned after force-push.
-
-### Branch Creation
-Create the feature branch with its FINAL name immediately:
-```bash
-# In externals/skia (use origin/ prefix for fresh clones):
-git checkout -b dev/update-{dep} origin/{target_branch}
-
-# In SkiaSharp root (rename_branch tool handles prefix):
-# Use the rename_branch tool or git checkout -b
-```
-Do NOT create-then-rename branches.
-
----
-
 ## Phase 0: Environment Setup (MANDATORY FIRST STEP)
 
 Before ANY other action in a new worktree session:
 
 ### Step 1: Initialize all submodules
 ```bash
-git submodule update --init externals/skia externals/depot_tools
+git submodule update --init
 ```
 ⚠️ `externals/skia` is ~900MB and takes ~8 minutes to clone. Wait for completion.
 Do NOT attempt to read DEPS, edit files, or build until this finishes.
 
-### Step 2: Set up PATH
+### Step 2: Set up PATH and tools
 ```bash
 export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH"
+unset GH_TOKEN
 ```
 ⚠️ PATH does not persist between bash tool calls. Prefix EVERY `dotnet` command with this export.
-
+⚠️ `GH_TOKEN` must be unset so `gh` commands (pr create, pr edit, etc.) use your interactive auth instead of the read-only default token.
 ⚠️ `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
 
-### Step 3: Set target branch (for release branch work)
+### Step 3: Unshallow the target dependency
+`git-sync-deps` clones dependencies as shallow repos. `git log` and `git diff` across version ranges will show incorrect results in shallow repos. Always unshallow the dependency you're updating:
+```bash
+cd externals/skia/third_party/externals/{dep}
+git fetch --unshallow origin
+cd -
+```
+
+### Step 4: Set target branch (for release branch work)
 If you're targeting a non-default branch (e.g., `release/3.119.x`):
 ```bash
 git fetch origin {target_branch}
 git reset --hard origin/{target_branch}
 # Re-run submodule update to get the correct submodule commit:
-git submodule update externals/skia
+git submodule update
 ```
 
-### Step 4: Verify environment
+### Step 5: Verify environment
 ```bash
 dotnet --version && ls externals/skia/DEPS && ls externals/depot_tools/ninja.py
 ```
@@ -221,10 +187,11 @@ Exception: Thread failure detected
 ```
 
 **Strategy:**
-1. Retry the build command (rate limits are usually transient)
-2. If it fails 3 times, check which deps are missing with `ls externals/skia/third_party/externals/`
-3. Manually clone the specific missing dependency from its upstream repo
-4. Retry the build
+1. Wait a short while (rate limits are transient)
+2. Retry the build command
+3. If it still fails after 3 retries, stop and ask for help
+
+Do NOT attempt to manually clone dependencies from other repos — you may pick wrong versions or SHAs.
 
 **Other common build issues:**
 - `fetch-gn` network abort → retry (transient)
@@ -238,10 +205,6 @@ The cgmanifest.json uses different structures per component type:
 - Type `"git"`: `component.git.repositoryUrl`, `component.git.commitHash`
 
 Do NOT assume all entries use the same schema. Check `component.type` first.
-
-### Shallow Clone Gotcha
-
-`git-sync-deps` clones dependencies as shallow repos. `git log old..new` may show incorrect results. Use `git fetch --unshallow origin` before running git log diffs.
 
 ### Phase 5: Create PRs
 
@@ -260,7 +223,22 @@ Example: For libfoo, use `dev/update-libwebp` in both repos.
 
 #### Step 1: Create mono/skia PR
 
-In the `externals/skia` directory, create a branch named `dev/update-{dep}`, commit the DEPS and BUILD.gn changes, push, and create a PR targeting the `skiasharp` branch.
+In the `externals/skia` directory:
+
+1. **Create the branch with its final name** — do NOT create-then-rename:
+   ```bash
+   git checkout -b dev/update-{dep} origin/skiasharp
+   ```
+2. **Stage ALL changes before committing** (DEPS, BUILD.gn if changed)
+3. **Commit ONCE** with this exact format:
+   ```
+   Update {dep} to {version}
+
+   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+   ```
+4. **Push ONCE** and create a PR targeting the `skiasharp` branch
+
+Do NOT commit-then-amend. Every amend requires a force-push which re-triggers CI (wasting 2+ hours of compute).
 
 #### Step 2: Create SkiaSharp PR
 
@@ -278,26 +256,12 @@ Edit **both** PRs to reference each other:
 - mono/skia PR → Add: `Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/{number}`
 - mono/SkiaSharp PR → Add: `Required skia PR: https://github.com/mono/skia/pull/{number}`
 
-### GitHub API for mono org repos
+### GitHub CLI for mono org repos
 
-The `gh pr create` and `gh pr edit` commands FAIL for mono org repos due to OAuth App access restrictions. **Always use the REST API:**
-
-**Create PR:**
+The default `GH_TOKEN` is read-only and causes `gh pr create`, `gh pr edit`, and `gh run rerun` to fail with OAuth App access restrictions. This is already handled in Phase 0 Step 2 (`unset GH_TOKEN`), but if you see auth errors, verify it is unset:
 ```bash
-gh api repos/mono/skia/pulls --method POST \
-  -f title="Update {dep} to {version}" \
-  -f head="{branch}" \
-  -f base="{target_branch}" \
-  -f body="..."
+unset GH_TOKEN
 ```
-
-**Edit PR:**
-```bash
-gh api repos/mono/SkiaSharp/pulls/{number} --method PATCH \
-  -f title="..." -f body="..."
-```
-
-**Do NOT use:** `gh pr create`, `gh pr edit`, `gh run rerun` — all fail with OAuth restrictions.
 
 ### Release Branch PRs
 
@@ -358,6 +322,16 @@ Before proceeding past each step, verify:
 
 > ❌ **NEVER** merge both PRs in quick succession without updating the submodule in between.
 > ❌ **NEVER** assume the submodule reference is correct after squash-merging mono/skia.
+
+#### If You Must Amend a Pushed Commit
+If you must amend a commit in `externals/skia`:
+1. Amend the skia commit
+2. Force-push the skia branch
+3. In SkiaSharp root: `git add externals/skia` (picks up new SHA)
+4. `git commit --amend --no-edit`
+5. Force-push the SkiaSharp branch
+
+⚠️ NEVER amend the skia commit without also updating the parent submodule reference. The old SHA becomes orphaned after force-push.
 
 ### Phase 8: Verify
 

--- a/.agents/skills/native-dependency-update/references/breaking-changes.md
+++ b/.agents/skills/native-dependency-update/references/breaking-changes.md
@@ -154,7 +154,7 @@ BUILD.gn changes are usually NOT needed for:
 
 The BUILD.gn lives at `externals/skia/third_party/{dep}/BUILD.gn`. Look at existing patterns—sources are listed explicitly, platform-specific code uses `if (current_cpu == "...")` conditionals.
 
-### macOS-Specific Notes
+### Common Gotchas
 - `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
 - The `freetype` BUILD.gn directory is `third_party/freetype2/` (not `third_party/freetype/`)
 

--- a/.agents/skills/native-dependency-update/references/breaking-changes.md
+++ b/.agents/skills/native-dependency-update/references/breaking-changes.md
@@ -2,8 +2,6 @@
 
 Guidance for analyzing breaking changes when updating native dependencies.
 
-> **Tooling note:** `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead throughout all analysis steps.
-
 ## Contents
 
 - [Risk Levels](#risk-levels)

--- a/.agents/skills/native-dependency-update/references/breaking-changes.md
+++ b/.agents/skills/native-dependency-update/references/breaking-changes.md
@@ -154,6 +154,10 @@ BUILD.gn changes are usually NOT needed for:
 
 The BUILD.gn lives at `externals/skia/third_party/{dep}/BUILD.gn`. Look at existing patterns—sources are listed explicitly, platform-specific code uses `if (current_cpu == "...")` conditionals.
 
+### macOS-Specific Notes
+- `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
+- The `freetype` BUILD.gn directory is `third_party/freetype2/` (not `third_party/freetype/`)
+
 ## Analysis Summary Template
 
 When reporting analysis results:

--- a/.agents/skills/native-dependency-update/references/breaking-changes.md
+++ b/.agents/skills/native-dependency-update/references/breaking-changes.md
@@ -2,6 +2,8 @@
 
 Guidance for analyzing breaking changes when updating native dependencies.
 
+> **Tooling note:** `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead throughout all analysis steps.
+
 ## Contents
 
 - [Risk Levels](#risk-levels)
@@ -154,9 +156,7 @@ BUILD.gn changes are usually NOT needed for:
 
 The BUILD.gn lives at `externals/skia/third_party/{dep}/BUILD.gn`. Look at existing patterns—sources are listed explicitly, platform-specific code uses `if (current_cpu == "...")` conditionals.
 
-### Common Gotchas
-- `grep -P` (Perl regex) is NOT available on macOS (BSD grep). Use `grep -E` or `sed` instead.
-- The `freetype` BUILD.gn directory is `third_party/freetype2/` (not `third_party/freetype/`)
+> **Note:** The `freetype` BUILD.gn is at `third_party/freetype2/` (not `third_party/freetype/`).
 
 ## Analysis Summary Template
 

--- a/.agents/skills/native-dependency-update/scripts/setup.sh
+++ b/.agents/skills/native-dependency-update/scripts/setup.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -euo pipefail
+
+# Native Dependency Update — Environment Setup
+#
+# Usage: setup.sh <dep> [skia_target_branch] [skiasharp_target_branch]
+#
+# Examples:
+#   ./setup.sh libpng                          # default: skiasharp + main
+#   ./setup.sh libpng skiasharp main           # explicit default
+#   ./setup.sh libpng skiasharp release/3.119.x  # release branch
+
+DEP="${1:?Usage: setup.sh <dep> [skia_target_branch] [skiasharp_target_branch]}"
+SKIA_TARGET="${2:-skiasharp}"
+SKIASHARP_TARGET="${3:-main}"
+
+export PATH="/usr/local/share/dotnet:/opt/homebrew/bin:$PATH"
+
+echo "=== Native Dependency Update Setup ==="
+echo "  Dependency:              $DEP"
+echo "  Skia target branch:     $SKIA_TARGET"
+echo "  SkiaSharp target branch: $SKIASHARP_TARGET"
+echo ""
+
+# --- Step 1: Set target branch (if not main) ---
+if [ "$SKIASHARP_TARGET" != "main" ]; then
+    echo "--- Setting SkiaSharp to target branch: $SKIASHARP_TARGET ---"
+    git fetch origin "$SKIASHARP_TARGET"
+    git reset --hard "origin/$SKIASHARP_TARGET"
+fi
+
+# --- Step 2: Initialize all submodules ---
+echo "--- Initializing submodules (externals/skia is ~900MB, may take ~8 min on first clone) ---"
+git submodule update --init
+echo "    Submodules initialized."
+
+# --- Step 3: Unshallow the target dependency ---
+DEP_DIR="externals/skia/third_party/externals/$DEP"
+if [ -d "$DEP_DIR" ]; then
+    echo "--- Unshallowing $DEP_DIR ---"
+    pushd "$DEP_DIR" > /dev/null
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q true; then
+        git fetch --unshallow origin
+        echo "    Unshallowed."
+    else
+        echo "    Already a full clone."
+    fi
+    popd > /dev/null
+else
+    echo "--- WARNING: $DEP_DIR does not exist yet."
+    echo "    It will be created by git-sync-deps during the native build step."
+    echo "    Re-run this script after the first build to unshallow it."
+fi
+
+# --- Step 4: Create skia feature branch ---
+echo "--- Creating skia feature branch: dev/update-$DEP from origin/$SKIA_TARGET ---"
+pushd externals/skia > /dev/null
+git fetch origin "$SKIA_TARGET"
+git checkout -b "dev/update-$DEP" "origin/$SKIA_TARGET"
+popd > /dev/null
+echo "    Skia branch created."
+
+# --- Step 5: Verify environment ---
+echo ""
+echo "=== Verification ==="
+
+ERRORS=0
+
+echo -n "  dotnet:       "
+if dotnet --version 2>/dev/null; then
+    true
+else
+    echo "NOT FOUND — ensure .NET SDK is installed and PATH includes /usr/local/share/dotnet"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  DEPS:         "
+if [ -f externals/skia/DEPS ]; then
+    echo "OK"
+else
+    echo "MISSING — submodule init may have failed"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  depot_tools:  "
+if [ -f externals/depot_tools/ninja.py ]; then
+    echo "OK"
+else
+    echo "MISSING — submodule init may have failed"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo -n "  Skia branch:  "
+pushd externals/skia > /dev/null
+BRANCH=$(git branch --show-current)
+echo "$BRANCH"
+if [ "$BRANCH" != "dev/update-$DEP" ]; then
+    echo "    ERROR: Expected dev/update-$DEP"
+    ERRORS=$((ERRORS + 1))
+fi
+popd > /dev/null
+
+echo -n "  Dep directory: "
+if [ -d "$DEP_DIR" ]; then
+    echo "OK ($DEP_DIR)"
+else
+    echo "MISSING (will be created during native build)"
+fi
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+    echo "=== SETUP FAILED: $ERRORS error(s) above ==="
+    exit 1
+fi
+
+echo "=== Setup Complete ==="
+echo ""
+echo "Next steps:"
+echo "  1. Use rename_branch tool to set SkiaSharp branch to: dev/update-$DEP"
+echo "  2. Proceed to Phase 1: Discovery"
+echo ""
+echo "Environment reminders (do not persist across bash calls):"
+echo "  - Prefix dotnet commands with: export PATH=\"/usr/local/share/dotnet:/opt/homebrew/bin:\$PATH\" &&"
+echo "  - Prefix gh write commands with: unset GH_TOKEN &&"
+echo "  - Use grep -E (not grep -P) on macOS"

--- a/.agents/skills/native-dependency-update/scripts/setup.sh
+++ b/.agents/skills/native-dependency-update/scripts/setup.sh
@@ -52,11 +52,32 @@ else
     echo "    Re-run this script after the first build to unshallow it."
 fi
 
-# --- Step 4: Create skia feature branch ---
-echo "--- Creating skia feature branch: dev/update-$DEP from origin/$SKIA_TARGET ---"
+# --- Step 4: Determine skia base and create feature branch ---
+echo "--- Setting up skia feature branch ---"
 pushd externals/skia > /dev/null
-git fetch origin "$SKIA_TARGET"
-git checkout -b "dev/update-$DEP" "origin/$SKIA_TARGET"
+
+# The submodule is checked out at a specific commit after submodule update.
+# This commit IS the correct base — it's what SkiaSharp's target branch uses.
+SUBMODULE_COMMIT=$(git rev-parse HEAD)
+echo "    Submodule commit: $SUBMODULE_COMMIT"
+
+# Try to fetch the requested skia target branch
+if git fetch origin "$SKIA_TARGET" 2>/dev/null; then
+    # Verify the submodule commit is actually on this branch
+    if git merge-base --is-ancestor "$SUBMODULE_COMMIT" "origin/$SKIA_TARGET" 2>/dev/null; then
+        echo "    Confirmed: submodule commit is on origin/$SKIA_TARGET"
+        git checkout -b "dev/update-$DEP" "origin/$SKIA_TARGET"
+    else
+        echo "    WARNING: submodule commit is NOT on origin/$SKIA_TARGET"
+        echo "    Branching from the submodule commit instead (safest option)"
+        git checkout -b "dev/update-$DEP" "$SUBMODULE_COMMIT"
+    fi
+else
+    echo "    Branch origin/$SKIA_TARGET not found in mono/skia"
+    echo "    Branching from the submodule commit instead"
+    git checkout -b "dev/update-$DEP" "$SUBMODULE_COMMIT"
+fi
+
 popd > /dev/null
 echo "    Skia branch created."
 

--- a/.agents/skills/native-dependency-update/scripts/setup.sh
+++ b/.agents/skills/native-dependency-update/scripts/setup.sh
@@ -139,9 +139,7 @@ fi
 
 echo "=== Setup Complete ==="
 echo ""
-echo "Next steps:"
-echo "  1. Use rename_branch tool to set SkiaSharp branch to: dev/update-$DEP"
-echo "  2. Proceed to Phase 1: Discovery"
+echo "Proceed to Phase 1: Discovery"
 echo ""
 echo "Environment reminders (do not persist across bash calls):"
 echo "  - Prefix dotnet commands with: export PATH=\"/usr/local/share/dotnet:/opt/homebrew/bin:\$PATH\" &&"

--- a/.agents/skills/native-dependency-update/scripts/setup.sh
+++ b/.agents/skills/native-dependency-update/scripts/setup.sh
@@ -57,26 +57,29 @@ echo "--- Setting up skia feature branch ---"
 pushd externals/skia > /dev/null
 
 # The submodule is checked out at a specific commit after submodule update.
-# This commit IS the correct base — it's what SkiaSharp's target branch uses.
 SUBMODULE_COMMIT=$(git rev-parse HEAD)
 echo "    Submodule commit: $SUBMODULE_COMMIT"
 
-# Try to fetch the requested skia target branch
-if git fetch origin "$SKIA_TARGET" 2>/dev/null; then
-    # Verify the submodule commit is actually on this branch
-    if git merge-base --is-ancestor "$SUBMODULE_COMMIT" "origin/$SKIA_TARGET" 2>/dev/null; then
-        echo "    Confirmed: submodule commit is on origin/$SKIA_TARGET"
-        git checkout -b "dev/update-$DEP" "origin/$SKIA_TARGET"
-    else
-        echo "    WARNING: submodule commit is NOT on origin/$SKIA_TARGET"
-        echo "    Branching from the submodule commit instead (safest option)"
-        git checkout -b "dev/update-$DEP" "$SUBMODULE_COMMIT"
-    fi
-else
-    echo "    Branch origin/$SKIA_TARGET not found in mono/skia"
-    echo "    Branching from the submodule commit instead"
-    git checkout -b "dev/update-$DEP" "$SUBMODULE_COMMIT"
+# Fetch and verify the requested skia target branch
+if ! git fetch origin "$SKIA_TARGET" 2>/dev/null; then
+    echo ""
+    echo "=== ERROR: Branch 'origin/$SKIA_TARGET' does not exist in mono/skia ==="
+    echo "Ask the user which skia branch to target for this update."
+    popd > /dev/null
+    exit 1
 fi
+
+if ! git merge-base --is-ancestor "$SUBMODULE_COMMIT" "origin/$SKIA_TARGET" 2>/dev/null; then
+    echo ""
+    echo "=== ERROR: Submodule commit $SUBMODULE_COMMIT is NOT on origin/$SKIA_TARGET ==="
+    echo "The SkiaSharp target branch uses a skia commit that isn't on '$SKIA_TARGET'."
+    echo "Ask the user which skia branch to target for this update."
+    popd > /dev/null
+    exit 1
+fi
+
+echo "    Confirmed: submodule commit is on origin/$SKIA_TARGET"
+git checkout -b "dev/update-$DEP" "origin/$SKIA_TARGET"
 
 popd > /dev/null
 echo "    Skia branch created."


### PR DESCRIPTION
Fixes systemic issues found across 8 dependency bump sessions, totaling ~216 extra tool calls and ~3.3 hours of wasted time.

## Changes

### SKILL.md — 6 new sections added:

1. **Phase 0: Environment Setup** — Mandatory submodule init, PATH setup, target branch config, and environment verification before any work begins. (Saves ~95 extra calls: uninitialized submodules hit 8/8 sessions, dotnet PATH 8/8, missing depot_tools 7/8)

2. **Git Discipline** — Commit message format, commit-once/push-once rule, submodule amend procedure, and branch creation guidance. (Saves ~20 extra calls from amend/force-push cycles)

3. **Build Retry Strategy** — HTTP 429 rate limit handling, cgmanifest.json schema differences, shallow clone gotcha for git-sync-deps. (Saves ~18 extra calls from build retry confusion)

4. **GitHub API for mono org** — REST API commands to replace `gh pr create`/`gh pr edit` which fail due to OAuth App restrictions, plus release branch PR base-fix workaround. (Saves ~18 extra calls from OAuth failures in 7/8 sessions)

5. **Security Bump Protocol** — What to report in-session vs what goes in public artifacts, prohibited content list for PRs/commits/branches. (Saves ~45 extra calls from security info in commits in 6/8 sessions)

6. **macOS-Specific Notes** — BSD grep lacks `-P`, freetype BUILD.gn directory is `freetype2/` not `freetype/`.

### breaking-changes.md:

- Added macOS-specific notes (grep -P unavailability, freetype2 directory name)