### PR TITLE
Add Suggested Repro Platform to auto-triage workflow

### DIFF
--- a/.github/workflows/auto-triage.md
+++ b/.github/workflows/auto-triage.md
@@ -108,6 +108,7 @@ Read the triage JSON and update the issue in the **SkiaSharp Backlog** project (
 | Repro Quality | `evidence.bugSignals.reproQuality` | SINGLE_SELECT: complete, partial, none. Skip if null. |
 | Error Type | `evidence.bugSignals.errorType` | SINGLE_SELECT: crash, exception, wrong-output, etc. Skip if null. |
 | Triage Summary | `analysis.summary` | TEXT: root cause hypothesis. Truncate to 1024 chars. |
+| Suggested Repro Platform | `output.actionability.suggestedReproPlatform` | SINGLE_SELECT: linux, macos, windows. Skip if null. |
 
 The `update-project` safe output auto-creates missing SINGLE_SELECT options — no need to pre-create values.
 


### PR DESCRIPTION
## Summary

The auto-triage workflow already produces `suggestedReproPlatform` in the triage JSON (`output.actionability.suggestedReproPlatform`), but the workflow instructions didn't include it in the Step 3 project board update table. This means triaged issues were missing the "Suggested Repro Platform" field on the project board.

## Changes

- Added `Suggested Repro Platform` row to the project-fields table in `.github/workflows/auto-triage.md`
- Maps `output.actionability.suggestedReproPlatform` → SINGLE_SELECT: `linux`, `macos`, `windows`
- Future triage runs will now write this field automatically

## Backfill

Existing ~199 triaged issues will be backfilled separately using a script that downloads artifacts from past workflow runs and updates the project field via GraphQL.