### PR TITLE
review-skia-update: Add --milestone parameter for explicit milestone input

### DIFF
--- a/.agents/skills/review-skia-update/SKILL.md
+++ b/.agents/skills/review-skia-update/SKILL.md
@@ -39,10 +39,14 @@ running the generator, checking source integrity, auditing DEPS, and analyzing c
 ```bash
 python3 .claude/skills/review-skia-update/scripts/run_review.py \
     --skia-pr {skia_pr_number} \
-    --skiasharp-pr {skiasharp_pr_number}
+    --skiasharp-pr {skiasharp_pr_number} \
+    --milestone {milestone_number}
 ```
 
-Both parameters are required. A Skia update always has a companion SkiaSharp PR.
+All three parameters are required. A Skia update always has a companion SkiaSharp PR.
+Extract the milestone number from the PR title, body, or branch name (e.g. 147 from
+"Bump skia to milestone 147" or "Dev/update skia 147"). The orchestrator validates
+this against cgmanifest.json and the PR title for consistency.
 
 **Output:** `raw-results.json` in the output directory with all check results, including
 mechanically generated file lists and diffs for upstream integrity, interop integrity, DEPS,

--- a/.agents/skills/review-skia-update/scripts/run_review.py
+++ b/.agents/skills/review-skia-update/scripts/run_review.py
@@ -112,6 +112,11 @@ def main():
         help="The SkiaSharp companion PR number.",
     )
     parser.add_argument(
+        "--milestone", type=int, required=True,
+        help="The target Chrome milestone number (e.g. 147). "
+             "AI extracts this from the PR title/body; the orchestrator validates consistency.",
+    )
+    parser.add_argument(
         "--output-dir", default="",
         help="Override output directory. Default: /tmp/skiasharp/skia-review/{timestamp}",
     )
@@ -119,6 +124,7 @@ def main():
 
     skia_pr_number = args.skia_pr
     skiasharp_pr_number = args.skiasharp_pr
+    caller_milestone = f"chrome/m{args.milestone}"
     output_dir = args.output_dir
 
     result = subprocess.run(
@@ -240,29 +246,36 @@ def main():
             f"{companion_base_sha[:12]}:cgmanifest.json"
         )
 
-    # Match both "m122" and "milestone 122" patterns
-    matches = re.findall(r"m(\d{3,})", pr["title"])
-    if not matches:
-        matches = re.findall(r"milestone\s+(\d{2,})", pr["title"], re.IGNORECASE)
-    if not matches:
-        raise RuntimeError(
-            f"Could not extract milestone from PR title: {pr['title']}. Expected 'mNNN' or 'milestone NNN' pattern."
-        )
-    title_milestone = f"chrome/m{matches[-1]}"
+    # 1c. Validate milestone consistency
+    # The caller (AI) provides --milestone; we validate it against PR title,
+    # PR body, branch name, and cgmanifest.json for consistency.
+    eprint(f"▸ Validating milestone {caller_milestone}...")
 
+    # Check PR title for milestone patterns
+    title_milestone = None
+    for pattern in [r"m(\d{3,})", r"milestone\s+(\d{2,})", r"skia[\s\-_]+(\d{2,})"]:
+        m = re.findall(pattern, pr["title"], re.IGNORECASE)
+        if m:
+            title_milestone = f"chrome/m{m[-1]}"
+            break
+    if title_milestone and title_milestone != caller_milestone:
+        eprint(f"   ⚠ PR title implies {title_milestone}, but --milestone says {caller_milestone}")
+    elif not title_milestone:
+        eprint(f"   ⚠ PR title '{pr['title']}' did not match any milestone pattern")
+
+    # Check cgmanifest.json from companion PR head
     companion_head_sha = companion_pr.get("headRefOid", "").strip()
-    new_milestone = title_milestone
+    cgmanifest_milestone = None
     if companion_head_sha and len(companion_head_sha) >= 7:
         new_cgmanifest = load_json_at_git_ref(repo_root, companion_head_sha, "cgmanifest.json")
-        new_milestone_from_cgmanifest = extract_skia_milestone_from_cgmanifest(new_cgmanifest)
-        if new_milestone_from_cgmanifest:
-            if new_milestone_from_cgmanifest != title_milestone:
-                raise RuntimeError(
-                    f"Skia PR title implies {title_milestone}, but companion PR "
-                    f"#{skiasharp_pr_number} cgmanifest.json at {companion_head_sha[:12]} "
-                    f"records {new_milestone_from_cgmanifest}."
-                )
-            new_milestone = new_milestone_from_cgmanifest
+        cgmanifest_milestone = extract_skia_milestone_from_cgmanifest(new_cgmanifest)
+    if cgmanifest_milestone and cgmanifest_milestone != caller_milestone:
+        eprint(
+            f"   ⚠ cgmanifest.json records {cgmanifest_milestone}, "
+            f"but --milestone says {caller_milestone}"
+        )
+
+    new_milestone = caller_milestone
 
     eprint(f"   New upstream: {new_milestone}")
     eprint(f"   Old upstream: {old_milestone}")


### PR DESCRIPTION
The review-skia-update orchestrator tried to extract the milestone number from the skia PR title using fragile regex patterns (`mNNN`, `milestone NNN`). This crashed on titles like `Dev/update skia 147` that didn't match.

**Root cause:** The orchestrator was doing two jobs — fuzzy text extraction (AI's strength) and deterministic validation (script's strength).

**Fix:** Add a required `--milestone` parameter so the AI caller extracts the milestone number from the PR title/body/branch and passes it explicitly. The orchestrator then validates consistency against:
- PR title patterns
- `cgmanifest.json` from the companion PR head

Mismatches produce warnings instead of crashes.

```bash
python3 .../run_review.py --skia-pr 184 --skiasharp-pr 3702 --milestone 147
```

Found while reviewing mono/skia#184 for SkiaSharp PR #3702.