### PR TITLE
Update Tizen SDK installer from 6.1 to 10.0

### DIFF
--- a/scripts/infra/native/tizen/install-tizen.ps1
+++ b/scripts/infra/native/tizen/install-tizen.ps1
@@ -3,9 +3,8 @@
 #  - https://developercommunity.visualstudio.com/content/problem/661596/the-updated-path-doesnt-kick-in.html
 
 Param(
-    [string] $Version = "6.1",
-    [string] $InstallDestination = $null,
-    [boolean] $UpgradeLLVM = $true
+    [string] $Version = "10.0",
+    [string] $InstallDestination = $null
 )
 
 $ErrorActionPreference = 'Stop'
@@ -23,7 +22,7 @@ if ($IsMacOS) {
     $ext = "exe"
 }
 
-$url = "http://download.tizen.org/sdk/Installer/tizen-studio_${Version}/web-cli_Tizen_Studio_${Version}_${platform}.${ext}"
+$url = "http://download.tizen.org/sdk/Installer/tizen-sdk_${Version}/web-cli_Tizen_SDK_${Version}_${platform}.${ext}"
 
 $ts = Join-Path "$HOME_DIR" "tizen-studio"
 if ($InstallDestination) {
@@ -67,32 +66,6 @@ if ($IsMacOS -or $IsLinux) {
 } else {
     & "$packMan" install --no-java-check --accept-license "$packages"
 }
-
-function Swap-Tool {
-    param ([string] $OldName, [string] $NewName)
-
-    $tsTools = Join-Path "$ts" "tools"
-    $llvm40 = Join-Path $tsTools $OldName
-    $llvm40OLD = Join-Path $tsTools "$OldName-OLD"
-    $llvm10 = Join-Path $tsTools $NewName
-    if (!(Test-Path $llvm40OLD)) {
-        Copy-Item $llvm40 $llvm40OLD -Recurse -Force
-    }
-    if (Test-Path $llvm40) {
-        Remove-Item $llvm40 -Recurse -Force
-    }
-    Copy-Item $llvm10 $llvm40 -Recurse -Force
-}
-
-# # Upgrade LLVM 4 to LLVM 10 by literally replacing the folder
-# if ($UpgradeLLVM) {
-#     Write-Host "Upgrading LLVM and GCC in place..."
-#     Swap-Tool "llvm-4.0.0" "llvm-10"
-#     Swap-Tool "aarch64-linux-gnu-gcc-6.2" "aarch64-linux-gnu-gcc-9.2"
-#     Swap-Tool "arm-linux-gnueabi-gcc-6.2" "arm-linux-gnueabi-gcc-9.2"
-#     Swap-Tool "i586-linux-gnueabi-gcc-6.2" "i586-linux-gnueabi-gcc-9.2"
-#     Swap-Tool "x86_64-linux-gnu-gcc-6.2" "x86_64-linux-gnu-gcc-9.2"
-# }
 
 # make sure that Tizen Studio is in TIZEN_STUDIO_HOME
 Write-Host "##vso[task.setvariable variable=TIZEN_STUDIO_HOME;]$ts";

--- a/scripts/install-tizen.ps1
+++ b/scripts/install-tizen.ps1
@@ -3,9 +3,8 @@
 #  - https://developercommunity.visualstudio.com/content/problem/661596/the-updated-path-doesnt-kick-in.html
 
 Param(
-    [string] $Version = "6.1",
-    [string] $InstallDestination = $null,
-    [boolean] $UpgradeLLVM = $true
+    [string] $Version = "10.0",
+    [string] $InstallDestination = $null
 )
 
 $ErrorActionPreference = 'Stop'
@@ -23,7 +22,7 @@ if ($IsMacOS) {
     $ext = "exe"
 }
 
-$url = "http://download.tizen.org/sdk/Installer/tizen-studio_${Version}/web-cli_Tizen_Studio_${Version}_${platform}.${ext}"
+$url = "http://download.tizen.org/sdk/Installer/tizen-sdk_${Version}/web-cli_Tizen_SDK_${Version}_${platform}.${ext}"
 
 $ts = Join-Path "$HOME_DIR" "tizen-studio"
 if ($InstallDestination) {
@@ -67,32 +66,6 @@ if ($IsMacOS -or $IsLinux) {
 } else {
     & "$packMan" install --no-java-check --accept-license "$packages"
 }
-
-function Swap-Tool {
-    param ([string] $OldName, [string] $NewName)
-
-    $tsTools = Join-Path "$ts" "tools"
-    $llvm40 = Join-Path $tsTools $OldName
-    $llvm40OLD = Join-Path $tsTools "$OldName-OLD"
-    $llvm10 = Join-Path $tsTools $NewName
-    if (!(Test-Path $llvm40OLD)) {
-        Copy-Item $llvm40 $llvm40OLD -Recurse -Force
-    }
-    if (Test-Path $llvm40) {
-        Remove-Item $llvm40 -Recurse -Force
-    }
-    Copy-Item $llvm10 $llvm40 -Recurse -Force
-}
-
-# # Upgrade LLVM 4 to LLVM 10 by literally replacing the folder
-# if ($UpgradeLLVM) {
-#     Write-Host "Upgrading LLVM and GCC in place..."
-#     Swap-Tool "llvm-4.0.0" "llvm-10"
-#     Swap-Tool "aarch64-linux-gnu-gcc-6.2" "aarch64-linux-gnu-gcc-9.2"
-#     Swap-Tool "arm-linux-gnueabi-gcc-6.2" "arm-linux-gnueabi-gcc-9.2"
-#     Swap-Tool "i586-linux-gnueabi-gcc-6.2" "i586-linux-gnueabi-gcc-9.2"
-#     Swap-Tool "x86_64-linux-gnu-gcc-6.2" "x86_64-linux-gnu-gcc-9.2"
-# }
 
 # make sure that Tizen Studio is in TIZEN_STUDIO_HOME
 Write-Host "##vso[task.setvariable variable=TIZEN_STUDIO_HOME;]$ts";


### PR DESCRIPTION
Update the Tizen SDK CLI installer to version 10.0 (released Nov 4, 2025). Samsung rebranded "Tizen Studio" to "Tizen SDK" starting with 10.0, which changed the download URLs.

### Changes

- **Default version**: `6.1` → `10.0`  
- **Download URL**: Updated for the SDK rebranding (`tizen-studio_` → `tizen-sdk_`, `Tizen_Studio_` → `Tizen_SDK_`)
- **Removed** unused `$UpgradeLLVM` parameter and dead `Swap-Tool` function (LLVM 10 ships natively with SDK 10.0; the old LLVM 4→10 swap is no longer needed)

### What stays the same

- Native build rootstraps unchanged — still using `mobile-6.0` (arm/x86) and `tizen-8.0` (arm64/x64)
- `build.cake` and Skia GN config unchanged
- Installed packages unchanged: `MOBILE-6.0-NativeAppDevelopment`, `TIZEN-8.0-NativeAppDevelopment`

### Verified locally

Installed SDK 10.0 on macOS arm64 and ran a full `dotnet cake --target=externals-tizen` build. All 4 architectures compiled successfully:

| Arch | libSkiaSharp.so | libHarfBuzzSharp.so |
|------|----------------|---------------------|
| armel (arm 32-bit) | 4.4M | 2.4M |
| i586 (x86 32-bit) | 6.9M | 2.8M |
| aarch64 (arm64) | 5.7M | 2.3M |
| x86_64 | 7.4M | 2.5M |

### Research notes (Tizen SDK 10.0)

**Rootstraps available in SDK 10.0:**

| Platform | Rootstraps |
|----------|-----------|
| tizen-10.0 | `device.core` (arm32), `device64.core` (arm64), `emulator64.core` (x64), `riscv64.core` (new!) — no 32-bit x86 emulator |
| tizen-8.0 | `device.core`, `device64.core`, `emulator.core`, `emulator64.core` — all still ship ✅ |
| mobile-6.0 | `device.core`, `emulator.core` — both still ship ✅ |

**Toolchains shipped:**

| Toolchain | Versions |
|-----------|---------|
| GCC | 9.2, **14.2** (new) |
| LLVM | **10 only** (deprecated, still works, still the default compiler) |

**Key SDK 10.0 changes from release notes:**
- GCC updated to 14.2; GCC 6.x removed
- LLVM toolchain "deprecated" but still shipped and still the default (`-c llvm`)
- x86 emulators deprecated for Tizen 10.0+
- RISC-V architecture support added
- No LLVM version beyond 10 is available in the Tizen package repository