### PR TITLE
Fix debian/13 Docker build for non-loong64/riscv64 architectures

### DIFF
--- a/scripts/Docker/debian/13/Dockerfile
+++ b/scripts/Docker/debian/13/Dockerfile
@@ -62,7 +62,7 @@ RUN . /etc/skia-env \
     && case "${TOOLCHAIN_ARCH_SHORT}" in \
          loong64) FC_VERSION=2.17.1-5   ; FC_DEV_PKG=libfontconfig-dev  ; FC_RT_PKG=libfontconfig1 ; APT_REPO=http://deb.debian.org/debian ;; \
          riscv64) FC_VERSION=2.15.0-2.3 ; FC_DEV_PKG=libfontconfig-dev  ; FC_RT_PKG=libfontconfig1 ; APT_REPO=http://deb.debian.org/debian ;; \
-         *)       FC_VERSION=2.13.1-4.2 ; FC_DEV_PKG=libfontconfig1-dev ; FC_RT_PKG=libfontconfig1 ; APT_REPO=http://deb.debian.org/debian ;; \
+         *)       FC_VERSION=2.15.0-2.3 ; FC_DEV_PKG=libfontconfig-dev  ; FC_RT_PKG=libfontconfig1 ; APT_REPO=http://deb.debian.org/debian ;; \
        esac \
     && TOOLCHAIN_ARCH=$(echo ${TOOLCHAIN_ARCH} | sed 's/x86-64/x86_64/g') \
     && FC_DEV_URL=${APT_REPO}/pool/main/f/fontconfig/${FC_DEV_PKG}_${FC_VERSION}_${TOOLCHAIN_ARCH_SHORT}.deb \


### PR DESCRIPTION
## Problem

The debian/13 `build-local.sh` Docker build fails on Mac (arm64) with:

```
cp: cannot stat 'usr/lib/*/*': No such file or directory
```

The fontconfig dev package fallback (`*`) case was downloading `libfontconfig1-dev` version `2.13.1-4.2` (from Debian 11 Bullseye). In Debian 11+, that package name became a **transitional dummy** containing only documentation — no headers or libraries.

## Fix

Updated the `*` case to use `libfontconfig-dev` version `2.15.0-2.3` (the correct Debian 13 Trixie package), matching what the `riscv64` case already uses.

## Context

- debian/13 is used in CI only for `loongarch64` builds, which already had the correct `libfontconfig-dev` package name
- debian/10 is unaffected — it correctly uses `libfontconfig1-dev 2.13.1-2` from `archive.debian.org` where that was still the real package
- The `loong64` and `riscv64` cases were already correct; only the `*` fallback was stale