### PR TITLE
Add staging URL to docs deploy commit message

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -275,7 +275,9 @@ jobs:
           git config --local user.name "GitHub Action"
           git add .nojekyll staging/$PR_NUMBER
           if ! git diff --cached --quiet; then
-            git commit -m "Deploy staging docs for PR #$PR_NUMBER"
+            git commit -m "Deploy staging docs for PR #$PR_NUMBER
+
+https://mono.github.io/SkiaSharp/staging/$PR_NUMBER/"
             git push origin docs-live
           else
             echo "No changes to commit"


### PR DESCRIPTION
Include the GitHub Pages preview URL in the commit body of staging doc deploys, so reviewers can click through directly from the git log.

**Before:**
```
Deploy staging docs for PR #123
```

**After:**
```
Deploy staging docs for PR #123

https://mono.github.io/SkiaSharp/staging/123/
```