### PR TITLE
Fix YAML syntax error in build-site workflow

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -275,9 +275,8 @@ jobs:
           git config --local user.name "GitHub Action"
           git add .nojekyll staging/$PR_NUMBER
           if ! git diff --cached --quiet; then
-            git commit -m "Deploy staging docs for PR #$PR_NUMBER
-
-https://mono.github.io/SkiaSharp/staging/$PR_NUMBER/"
+            git commit -m "Deploy staging docs for PR #$PR_NUMBER" \
+              -m "https://mono.github.io/SkiaSharp/staging/$PR_NUMBER/"
             git push origin docs-live
           else
             echo "No changes to commit"


### PR DESCRIPTION
The multi-line `git commit -m` in the staging deploy step had the URL body at column 1 (no indentation), which broke the YAML `run: |` block scalar parser — the `:` in `https:` was interpreted as a YAML key.

**Fix:** Use separate `-m` flags for the commit subject and body. Git joins multiple `-m` values with a blank line, preserving the original commit message format.

**CI annotation:** `Invalid workflow file: .github/workflows/build-site.yml#L280 — You have an error in your yaml syntax on line 280`