### PR TITLE
Add gallery sample guidance to api-add-review skill

### DIFF
--- a/.agents/skills/api-add-review/SKILL.md
+++ b/.agents/skills/api-add-review/SKILL.md
@@ -60,15 +60,15 @@ All three references work together:
 
 | File | Purpose | When to read |
 |------|---------|-------------|
-| [references/api-design-rules.md](references/api-design-rules.md) | Naming, properties vs methods, Span patterns, type wrapping, test requirements | Always — before writing or reviewing any API |
-| [references/add-workflow.md](references/add-workflow.md) | Step-by-step add workflow with C API patterns, struct conversion, JSON config | Add mode |
-| [references/review-workflow.md](references/review-workflow.md) | Structured review checklist, test coverage analysis, auto-fix mode | Review mode, and as final phase of add mode |
+| [references/api-design-rules.md](references/api-design-rules.md) | Naming, properties vs methods, Span patterns, type wrapping, test and sample requirements | Always — before writing or reviewing any API |
+| [references/add-workflow.md](references/add-workflow.md) | Step-by-step add workflow with C API patterns, struct conversion, JSON config, gallery samples | Add mode |
+| [references/review-workflow.md](references/review-workflow.md) | Structured review checklist, test coverage analysis, sample review, auto-fix mode | Review mode, and as final phase of add mode |
 | [references/troubleshooting.md](references/troubleshooting.md) | Common errors and fixes | When something goes wrong |
 
 ## Add Mode
 
 1. Read [api-design-rules.md](references/api-design-rules.md)
-2. Follow [add-workflow.md](references/add-workflow.md) phases 1-9
+2. Follow [add-workflow.md](references/add-workflow.md) phases 1-10
 3. Run [review-workflow.md](references/review-workflow.md) on your own changes
 4. Fix any issues identified by the review
 5. Re-run tests to confirm

--- a/.agents/skills/api-add-review/references/add-workflow.md
+++ b/.agents/skills/api-add-review/references/add-workflow.md
@@ -148,7 +148,58 @@ dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj
 
 Tests MUST PASS. Do not skip, do not claim completion if they fail.
 
-## Phase 9: Review
+## Phase 9: Gallery Sample
+
+Every user-facing API should be demonstrated in the Gallery sample app. Decide
+whether the feature needs a new sample or should enhance an existing one:
+
+| Feature scope | Action | Example |
+|--------------|--------|---------|
+| Standalone capability (new drawing mode, new input type, new rendering technique) | Create new sample file | `VariableFontSample.cs`, `ColorFontSample.cs` |
+| Enhancement to existing capability (new overload, new option, extra parameter) | Update existing sample | Adding optical size slider to an existing font sample |
+| Internal/plumbing API (no visible user effect) | No sample needed | ABI-only struct changes |
+
+### Creating a new sample
+
+- [ ] Create `samples/Gallery/Shared/Samples/{FeatureName}Sample.cs`
+- [ ] Extend `CanvasSampleBase` (for drawing) or `DocumentSampleBase` (for PDF/XPS)
+- [ ] Set `Title`, `Description`, and `Category` (use `SampleCategories.*` constants)
+- [ ] Add interactive controls (sliders, pickers, toggles) to let users explore the API
+- [ ] Load fonts/images from `SampleMedia` (add embedded resources to `Media/` if needed)
+- [ ] Register new media in `SampleMedia.cs` if you added assets
+- [ ] Dispose all SkiaSharp objects properly (`using` or override `OnDestroy`)
+
+### Sample quality guidelines
+
+- [ ] **Teach, don't optimize** — clarity over performance; the sample is documentation
+- [ ] **Interactive** — use controls so users can explore parameter ranges
+- [ ] **Self-contained** — no external dependencies beyond embedded assets
+- [ ] **Real assets** — use real fonts/images, never fabricate test data
+- [ ] **Constant data** — use `static readonly` arrays for fixed values (weights, etc.)
+- [ ] **Clean disposal** — `using` for per-frame objects, `OnDestroy` for cached objects
+- [ ] **Reasonable defaults** — controls should show a good result before any interaction
+
+### Updating an existing sample
+
+- [ ] Add new controls for the new API parameters
+- [ ] Integrate naturally — don't bolt on an unrelated section
+- [ ] Keep the sample focused; if it becomes unfocused, split into a new sample instead
+
+### Gallery architecture reference
+
+```
+samples/Gallery/Shared/
+├── Controls/SampleControl.cs      # SliderControl, PickerControl, ToggleControl, GroupControl
+├── SampleBase.cs                  # Base: Title, Description, Category, Controls
+├── CanvasSampleBase.cs            # OnDrawSample(canvas, width, height), IsAnimated
+├── DocumentSampleBase.cs          # For PDF/XPS document output
+├── SampleCategories.cs            # Category constants
+├── SampleMedia.cs                 # Embedded resource loader (Images, Fonts)
+├── Media/                         # Embedded assets (fonts, images, JSON)
+└── Samples/                       # One file per sample
+```
+
+## Phase 10: Review
 
 Run the [review-workflow.md](review-workflow.md) against your changes.
 Fix any issues it identifies. Re-run tests after fixes.

--- a/.agents/skills/api-add-review/references/api-design-rules.md
+++ b/.agents/skills/api-add-review/references/api-design-rules.md
@@ -49,3 +49,12 @@ Every array API needs three members:
 - No `#nullable disable` unless needed
 - No fabricated fonts — use real fonts
 - No early returns that hide test failures
+
+## Gallery Samples
+- Standalone features get a new sample file in `samples/Gallery/Shared/Samples/`
+- Small enhancements update existing samples with new controls
+- Internal/plumbing APIs don't need samples
+- Samples teach the API — clarity over performance
+- Interactive controls (sliders, pickers, toggles) for exploring parameters
+- Real assets only, loaded via `SampleMedia`
+- Dispose everything (`using` or `OnDestroy`)

--- a/.agents/skills/api-add-review/references/review-workflow.md
+++ b/.agents/skills/api-add-review/references/review-workflow.md
@@ -122,13 +122,40 @@ If tests fail, categorize:
 
 ## Step 5: Check Sample Code
 
-If a gallery sample exists:
+Determine whether the new API needs a gallery sample:
+
+### Does a sample exist?
+
+If a gallery sample **already exists** for this feature area, verify:
 - [ ] Uses the new APIs correctly (not deprecated patterns)
 - [ ] No HarfBuzz dependency in SkiaSharp-only samples (unless justified)
 - [ ] Uses real fonts, not fabricated/modified ones
 - [ ] Sample is clear and demonstrates API patterns (not optimized for perf)
-- [ ] static readonly for constant data (weights arrays, etc.)
-- [ ] Slider casts handled correctly ((int)(float)value for int sliders)
+- [ ] `static readonly` for constant data (weights arrays, etc.)
+- [ ] Slider casts handled correctly (`(int)(float)value` for int sliders)
+- [ ] New API parameters exposed via interactive controls where appropriate
+
+### Should a new sample be created?
+
+If no sample exists, evaluate:
+
+| Feature scope | Sample needed? |
+|--------------|---------------|
+| New standalone capability (new drawing mode, rendering technique, font feature) | **Yes** — new sample file |
+| Enhancement to existing capability (new overload, extra option) | **Maybe** — update existing sample with new controls |
+| Internal/plumbing API (no visible user effect) | **No** |
+
+Flag missing samples as "Missing sample: [description]" in the review report.
+
+### New sample checklist
+- [ ] Extends `CanvasSampleBase` or `DocumentSampleBase`
+- [ ] Has `Title`, `Description`, and `Category` (from `SampleCategories`)
+- [ ] Interactive controls (sliders, pickers, toggles) let users explore the API
+- [ ] Assets loaded from `SampleMedia` (new assets added to `Media/` and registered)
+- [ ] All SkiaSharp objects disposed (`using` or `OnDestroy`)
+- [ ] Teaches the API — clarity over performance
+- [ ] Real assets only — no fabricated fonts or images
+- [ ] Reasonable defaults — shows a good result before any user interaction
 
 ## Step 6: Produce Report
 


### PR DESCRIPTION
## Summary

Ensures agents consider gallery samples when adding new APIs. The `api-add-review` skill now includes a dedicated phase for evaluating whether new features need a standalone sample or should enhance an existing one.

### Changes

**`references/add-workflow.md`** — New Phase 9 (Gallery Sample):
- Decision table: standalone feature → new sample, enhancement → update existing, plumbing → skip
- New sample creation checklist (base class, controls, assets, disposal)
- Quality guidelines (teach don't optimize, interactive controls, real assets, reasonable defaults)
- Existing sample update guidance
- Gallery architecture reference showing directory structure and base classes

**`references/review-workflow.md`** — Expanded Step 5:
- Sample creation evaluation with scope table
- Flag missing samples in review reports
- New sample checklist for reviewers

**`references/api-design-rules.md`** — Gallery Samples quick-reference section

**`SKILL.md`** — Updated reference descriptions and phase count (9→10)

---

No code changes — skill documentation only.