### PR TITLE
Add download button and fix WASM text rendering in gallery

### DIFF
--- a/.agents/skills/pr-commit-message/SKILL.md
+++ b/.agents/skills/pr-commit-message/SKILL.md
@@ -192,12 +192,38 @@ State:
 When one PR contains multiple tightly related changes, organize the body so each part
 has a name and purpose. Use bullets or short section headers instead of a wall of text.
 
+## Co-authored-by trailers
+
+Every commit message **must** end with `Co-authored-by:` trailers listing all people
+who contributed to the PR. This includes:
+
+- commit authors (from `git log`)
+- co-authors already present in commit trailers
+- PR reviewers who approved or left substantive feedback
+
+To collect the full list, run:
+
+```bash
+gh pr view <number> --json commits --jq '[.commits[].authors[]| "Co-authored-by: \(.name) <\(.email)>"] | unique | .[]'
+```
+
+Deduplicate by email. Do not include bots (e.g. `github-actions`) unless they authored
+real code. Always include `Copilot` if any commit has the Copilot co-author trailer.
+
+Place the trailers at the very end of the message, after a blank line, one per line:
+
+```text
+Co-authored-by: Alice Smith <alice@example.com>
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
 ## Output format
 
 When the user asks for a commit message, return:
 
 1. **One polished commit message** in a fenced code block, ready to paste.
-2. **Optional `Missing context:` bullets** only if important context could not be found.
+2. Co-authored-by trailers at the end (see above).
+3. **Optional `Missing context:` bullets** only if important context could not be found.
 
 Do not dump brainstorming notes unless the user explicitly asks for alternatives.
 

--- a/samples/Gallery/Blazor/Pages/SamplePage.razor
+++ b/samples/Gallery/Blazor/Pages/SamplePage.razor
@@ -17,15 +17,7 @@ else if (IsDocument)
     <div class="sample-page">
         <div class="sample-header">
             <a href="" class="text-decoration-none small d-inline-block">&larr; Back to Gallery</a>
-            <div class="d-flex align-items-center gap-2">
-                <h2 class="mb-0">@sample.Title</h2>
-                @if (sample.HasDownload)
-                {
-                    <button class="btn btn-sm btn-outline-primary" @onclick="TriggerDownload" title="Download @sample.DownloadFileName">
-                        ⬇ Download
-                    </button>
-                }
-            </div>
+            <h2>@sample.Title</h2>
             @if (!string.IsNullOrWhiteSpace(sample.Description))
             {
                 <p class="text-muted mb-1">@sample.Description</p>
@@ -72,6 +64,12 @@ else if (IsDocument)
                             </div>
                             <ControlPanel Controls="@sample!.Controls"
                                           OnChanged="@OnControlChanged" />
+                            @if (sample.HasDownload)
+                            {
+                                <button class="btn btn-sm btn-outline-primary w-100 mt-2" @onclick="TriggerDownload" @onclick:stopPropagation="true" title="Download @sample.DownloadFileName">
+                                    ⬇ Download
+                                </button>
+                            }
                         </div>
                     }
                 </div>
@@ -87,15 +85,7 @@ else
     <div class="sample-page">
         <div class="sample-header">
             <a href="" class="text-decoration-none small d-inline-block">&larr; Back to Gallery</a>
-            <div class="d-flex align-items-center gap-2">
-                <h2 class="mb-0">@sample.Title</h2>
-                @if (sample.HasDownload)
-                {
-                    <button class="btn btn-sm btn-outline-primary" @onclick="TriggerDownload" title="Download @sample.DownloadFileName">
-                        ⬇ Download
-                    </button>
-                }
-            </div>
+            <h2>@sample.Title</h2>
             @if (!string.IsNullOrWhiteSpace(sample.Description))
             {
                 <p class="text-muted mb-1">@sample.Description</p>
@@ -147,6 +137,12 @@ else
                             </div>
                             <ControlPanel Controls="@sample.Controls"
                                           OnChanged="@OnControlChanged" />
+                            @if (sample.HasDownload)
+                            {
+                                <button class="btn btn-sm btn-outline-primary w-100 mt-2" @onclick="TriggerDownload" @onclick:stopPropagation="true" title="Download @sample.DownloadFileName">
+                                    ⬇ Download
+                                </button>
+                            }
                         </div>
                     }
                 </div>
@@ -178,7 +174,7 @@ else
 
     // Computed helpers for template branching
     private bool IsDocument => sample is DocumentSampleBase;
-    private bool HasControls => sample is { Controls.Count: > 0 };
+    private bool HasControls => sample is { Controls.Count: > 0 } || (sample?.HasDownload ?? false);
 
     // Control panel layout state
     private bool isPinned = true;

--- a/samples/Gallery/Blazor/Pages/SamplePage.razor
+++ b/samples/Gallery/Blazor/Pages/SamplePage.razor
@@ -17,7 +17,15 @@ else if (IsDocument)
     <div class="sample-page">
         <div class="sample-header">
             <a href="" class="text-decoration-none small d-inline-block">&larr; Back to Gallery</a>
-            <h2>@sample.Title</h2>
+            <div class="d-flex align-items-center gap-2">
+                <h2 class="mb-0">@sample.Title</h2>
+                @if (sample.HasDownload)
+                {
+                    <button class="btn btn-sm btn-outline-primary" @onclick="TriggerDownload" title="Download @sample.DownloadFileName">
+                        ⬇ Download
+                    </button>
+                }
+            </div>
             @if (!string.IsNullOrWhiteSpace(sample.Description))
             {
                 <p class="text-muted mb-1">@sample.Description</p>
@@ -79,7 +87,15 @@ else
     <div class="sample-page">
         <div class="sample-header">
             <a href="" class="text-decoration-none small d-inline-block">&larr; Back to Gallery</a>
-            <h2>@sample.Title</h2>
+            <div class="d-flex align-items-center gap-2">
+                <h2 class="mb-0">@sample.Title</h2>
+                @if (sample.HasDownload)
+                {
+                    <button class="btn btn-sm btn-outline-primary" @onclick="TriggerDownload" title="Download @sample.DownloadFileName">
+                        ⬇ Download
+                    </button>
+                }
+            </div>
             @if (!string.IsNullOrWhiteSpace(sample.Description))
             {
                 <p class="text-muted mb-1">@sample.Description</p>
@@ -154,6 +170,7 @@ else
     private SKGLView? glView;
     private bool previousUseGpu;
     private string? documentBlobUrl;
+    private string? downloadBlobUrl;
 
     private int canvasInfoWidth, canvasInfoHeight;
     private int canvasRawWidth, canvasRawHeight;
@@ -290,11 +307,37 @@ else
             sample = null;
         }
 
-        if (!string.IsNullOrEmpty(documentBlobUrl))
+        RevokeUrl(ref documentBlobUrl);
+        RevokeUrl(ref downloadBlobUrl);
+    }
+
+    private void RevokeUrl(ref string? url)
+    {
+        if (!string.IsNullOrEmpty(url))
         {
-            _ = JS.InvokeVoidAsync("eval", $"URL.revokeObjectURL('{documentBlobUrl}')");
-            documentBlobUrl = null;
+            _ = JS.InvokeVoidAsync("eval", $"URL.revokeObjectURL('{url}')");
+            url = null;
         }
+    }
+
+    private async Task TriggerDownload()
+    {
+        if (sample is null || !sample.HasDownload)
+            return;
+
+        RevokeUrl(ref downloadBlobUrl);
+
+        var base64 = Convert.ToBase64String(sample.DownloadBytes!);
+        var mime = sample.DownloadMimeType;
+        var fileName = sample.DownloadFileName;
+
+        downloadBlobUrl = await JS.InvokeAsync<string>(
+            "eval",
+            $"(() => {{ var b = atob('{base64}'); var a = new Uint8Array(b.length); for(var i=0;i<b.length;i++) a[i]=b.charCodeAt(i); return URL.createObjectURL(new Blob([a], {{type:'{mime}'}})); }})()");
+
+        await JS.InvokeVoidAsync(
+            "eval",
+            $"(() => {{ var a = document.createElement('a'); a.href = '{downloadBlobUrl}'; a.download = '{fileName}'; document.body.appendChild(a); a.click(); document.body.removeChild(a); }})()");
     }
 
     private void OnControlChanged((string id, object value) args)
@@ -307,12 +350,7 @@ else
     {
         if (sample is DocumentSampleBase doc)
         {
-            // Clear old blob
-            if (!string.IsNullOrEmpty(documentBlobUrl))
-            {
-                _ = JS.InvokeVoidAsync("eval", $"URL.revokeObjectURL('{documentBlobUrl}')");
-                documentBlobUrl = null;
-            }
+            RevokeUrl(ref documentBlobUrl);
 
             // Generate the document (calls OnGenerateDocument which populates DocumentBytes)
             using var tempSurface = SKSurface.Create(new SKImageInfo(1, 1));

--- a/samples/Gallery/Blazor/Pages/SamplePage.razor
+++ b/samples/Gallery/Blazor/Pages/SamplePage.razor
@@ -12,74 +12,6 @@
         <a href="">Return to home</a>
     </div>
 }
-else if (IsDocument)
-{
-    <div class="sample-page">
-        <div class="sample-header">
-            <a href="" class="text-decoration-none small d-inline-block">&larr; Back to Gallery</a>
-            <h2>@sample.Title</h2>
-            @if (!string.IsNullOrWhiteSpace(sample.Description))
-            {
-                <p class="text-muted mb-1">@sample.Description</p>
-            }
-        </div>
-        <div class="sample-body">
-            <div class="sample-canvas">
-                @if (!string.IsNullOrEmpty(documentBlobUrl))
-                {
-                    <div class="border rounded" style="width:100%;height:100%;">
-                        <iframe src="@documentBlobUrl" style="width:100%;height:100%;border:none;" />
-                    </div>
-                }
-                else
-                {
-                    <div class="border rounded d-flex align-items-center justify-content-center" style="width:100%;height:100%;background:#f8f8f8;">
-                        <span class="text-muted">Generating document...</span>
-                    </div>
-                }
-            </div>
-
-            @if (HasControls)
-            {
-                @if (!isPinned && showControls)
-                {
-                    <div class="sidebar-backdrop" @onclick="() => showControls = false"></div>
-                }
-
-                <div class="sample-sidebar @(!isPinned && !showControls ? "collapsed" : "")"
-                     @onclick="OnSidebarClick"
-                     @onclick:stopPropagation="true">
-                    @if (!isPinned && !showControls)
-                    {
-                        <span class="sidebar-label">Controls</span>
-                    }
-                    else
-                    {
-                        <div class="sidebar-content" @onclick:stopPropagation="true">
-                            <div class="d-flex justify-content-between align-items-center mb-2">
-                                <small class="fw-bold text-uppercase" style="letter-spacing:0.05em;color:#666;">Controls</small>
-                                <button class="btn btn-sm btn-outline-secondary" @onclick="TogglePin" @onclick:stopPropagation="true">
-                                    @(isPinned ? "◀" : "▶")
-                                </button>
-                            </div>
-                            <ControlPanel Controls="@sample!.Controls"
-                                          OnChanged="@OnControlChanged" />
-                            @if (sample.HasDownload)
-                            {
-                                <button class="btn btn-sm btn-outline-primary w-100 mt-2" @onclick="TriggerDownload" @onclick:stopPropagation="true" title="Download @sample.DownloadFileName">
-                                    ⬇ Download
-                                </button>
-                            }
-                        </div>
-                    }
-                </div>
-            }
-        </div>
-    </div>
-    <div class="sample-debug small text-muted px-2" style="flex-shrink:0;font-size:0.7rem;opacity:0.6;">
-        Canvas: @canvasInfoWidth×@canvasInfoHeight CSS px | @canvasRawWidth×@canvasRawHeight device px | DPI: @canvasDpi
-    </div>
-}
 else
 {
     <div class="sample-page">
@@ -93,23 +25,41 @@ else
         </div>
         <div class="sample-body">
             <div class="sample-canvas">
-                <div class="canvas-wrapper border rounded">
-                    @if (UseGpu)
+                @if (sample is DocumentSampleBase)
+                {
+                    @if (!string.IsNullOrEmpty(documentBlobUrl))
                     {
-                        <SKGLView @ref="glView"
-                                  OnPaintSurface="OnPaintGL"
-                                  EnableRenderLoop="@(sample is CanvasSampleBase cs && cs.IsAnimated)"
-                                  IgnorePixelScaling="true"
-                                  style="width:100%;height:100%;display:block;" />
+                        <div class="border rounded" style="width:100%;height:100%;">
+                            <iframe src="@documentBlobUrl" style="width:100%;height:100%;border:none;" />
+                        </div>
                     }
                     else
                     {
-                        <SKCanvasView @ref="canvasView"
-                                      OnPaintSurface="OnPaintRaster"
+                        <div class="border rounded d-flex align-items-center justify-content-center" style="width:100%;height:100%;background:#f8f8f8;">
+                            <span class="text-muted">Generating document...</span>
+                        </div>
+                    }
+                }
+                else
+                {
+                    <div class="canvas-wrapper border rounded">
+                        @if (UseGpu)
+                        {
+                            <SKGLView @ref="glView"
+                                      OnPaintSurface="OnPaintGL"
+                                      EnableRenderLoop="@(sample is CanvasSampleBase cs && cs.IsAnimated)"
                                       IgnorePixelScaling="true"
                                       style="width:100%;height:100%;display:block;" />
-                    }
-                </div>
+                        }
+                        else
+                        {
+                            <SKCanvasView @ref="canvasView"
+                                          OnPaintSurface="OnPaintRaster"
+                                          IgnorePixelScaling="true"
+                                          style="width:100%;height:100%;display:block;" />
+                        }
+                    </div>
+                }
             </div>
 
             @if (HasControls)
@@ -173,7 +123,6 @@ else
     private string canvasDpi = "?";
 
     // Computed helpers for template branching
-    private bool IsDocument => sample is DocumentSampleBase;
     private bool HasControls => sample is { Controls.Count: > 0 } || (sample?.HasDownload ?? false);
 
     // Control panel layout state

--- a/samples/Gallery/Shared/DocumentSampleBase.cs
+++ b/samples/Gallery/Shared/DocumentSampleBase.cs
@@ -12,6 +12,10 @@ public abstract class DocumentSampleBase : SampleBase
 
 	public override string Category => SampleCategories.Documents;
 
+	public override byte[]? DownloadBytes => DocumentBytes;
+	public override string DownloadFileName => DocumentFileName ?? "document.pdf";
+	public override string DownloadMimeType => DocumentMimeType ?? "application/pdf";
+
 	protected abstract void OnGenerateDocument(SKCanvas previewCanvas, int width, int height);
 
 	public void DrawSample(SKCanvas canvas, int width, int height)

--- a/samples/Gallery/Shared/SampleBase.cs
+++ b/samples/Gallery/Shared/SampleBase.cs
@@ -19,6 +19,12 @@ public abstract class SampleBase
 
 	public virtual IReadOnlyList<SampleControl> Controls => [];
 
+	// Download support — samples that produce downloadable output override these
+	public virtual byte[]? DownloadBytes => null;
+	public virtual string DownloadFileName => "download.bin";
+	public virtual string DownloadMimeType => "application/octet-stream";
+	public bool HasDownload => DownloadBytes is { Length: > 0 };
+
 	public virtual void UpdateControl(string id, object value)
 	{
 		OnControlChanged(id, value);

--- a/samples/Gallery/Shared/SampleMedia.cs
+++ b/samples/Gallery/Shared/SampleMedia.cs
@@ -37,6 +37,16 @@ public static class SampleMedia
 		public static Stream Nabla => Embedded.Load("Nabla.ttf");
 
 		public static string ContentFontPath = string.Empty;
+
+		private static SKTypeface? defaultTypeface;
+
+		public static SKTypeface Default => defaultTypeface ??= LoadDefaultTypeface();
+
+		private static SKTypeface LoadDefaultTypeface()
+		{
+			using var stream = InterVariable;
+			return SKTypeface.FromStream(stream) ?? SKTypeface.CreateDefault();
+		}
 	}
 
 	public static class Embedded

--- a/samples/Gallery/Shared/Samples/BlendModesSample.cs
+++ b/samples/Gallery/Shared/Samples/BlendModesSample.cs
@@ -74,7 +74,7 @@ public class BlendModesSample : CanvasSampleBase
 		canvas.Restore();
 
 		// Draw blend mode name
-		using var textFont = new SKFont { Size = Math.Min(width, height) * 0.06f };
+		using var textFont = new SKFont(SampleMedia.Fonts.Default, Math.Min(width, height) * 0.06f);
 		using var textPaint = new SKPaint
 		{
 			Color = SKColors.Black,

--- a/samples/Gallery/Shared/Samples/CreateXpsSample.cs
+++ b/samples/Gallery/Shared/Samples/CreateXpsSample.cs
@@ -33,7 +33,7 @@ public class CreateXpsSample : DocumentSampleBase
 					IsStroke = true,
 					StrokeWidth = 3,
 				};
-				using var docFont = new SKFont { Size = 64.0f };
+				using var docFont = new SKFont(SampleMedia.Fonts.Default, 64);
 
 				var pageWidth = 840;
 				var pageHeight = 1188;
@@ -52,7 +52,7 @@ public class CreateXpsSample : DocumentSampleBase
 			}
 		}
 
-		using var font = new SKFont { Size = 40 };
+		using var font = new SKFont(SampleMedia.Fonts.Default, 40);
 		using var previewPaint = new SKPaint { IsAntialias = true, Color = 0xFF9CAFB7 };
 
 		previewCanvas.DrawText(

--- a/samples/Gallery/Shared/Samples/GifPlayerSample.cs
+++ b/samples/Gallery/Shared/Samples/GifPlayerSample.cs
@@ -117,7 +117,7 @@ public class GifPlayerSample : CanvasSampleBase
 
 		// Draw frame info
 		using var textPaint = new SKPaint { IsAntialias = true, Color = SKColors.White };
-		using var font = new SKFont(SKTypeface.Default, 14);
+		using var font = new SKFont(SampleMedia.Fonts.Default, 14);
 		var statusText = playing ? "▶" : "⏸";
 		canvas.DrawText($"{statusText} Frame {currentFrame + 1}/{frames.Length}  Speed: {speed:F2}x", 10, height - 10, font, textPaint);
 	}

--- a/samples/Gallery/Shared/Samples/ImageDecoderSample.cs
+++ b/samples/Gallery/Shared/Samples/ImageDecoderSample.cs
@@ -179,7 +179,7 @@ public class ImageDecoderSample : CanvasSampleBase
 			StrokeWidth = 1,
 			IsAntialias = true,
 		};
-		using var font = new SKFont { Size = fontSize };
+		using var font = new SKFont(SampleMedia.Fonts.Default, fontSize);
 		using var textPaint = new SKPaint
 		{
 			Color = SKColors.White,
@@ -298,7 +298,7 @@ public class ImageDecoderSample : CanvasSampleBase
 
 	private static void DrawErrorText(SKCanvas canvas, int width, int height, string message)
 	{
-		using var font = new SKFont { Size = 24 };
+		using var font = new SKFont(SampleMedia.Fonts.Default, 24);
 		using var paint = new SKPaint
 		{
 			Color = SKColors.Red,

--- a/samples/Gallery/Shared/Samples/PathBuilderSample.cs
+++ b/samples/Gallery/Shared/Samples/PathBuilderSample.cs
@@ -182,7 +182,7 @@ public class PathBuilderSample : CanvasSampleBase
 		canvas.DrawCircle(p3, anchorRadius, anchorPaint);
 
 		// Labels
-		using var labelFont = new SKFont { Size = 11 };
+		using var labelFont = new SKFont(SampleMedia.Fonts.Default, 11);
 		using var labelPaint = new SKPaint
 		{
 			IsAntialias = true,

--- a/samples/Gallery/Shared/Samples/PdfComposerSample.cs
+++ b/samples/Gallery/Shared/Samples/PdfComposerSample.cs
@@ -101,7 +101,7 @@ public class PdfComposerSample : DocumentSampleBase
 		}
 
 		// Draw preview
-		using var font = new SKFont { Size = 40 };
+		using var font = new SKFont(SampleMedia.Fonts.Default, 40);
 		using var paint = new SKPaint { IsAntialias = true, Color = 0xFF9CAFB7 };
 
 		if (!isSupported)
@@ -124,7 +124,7 @@ public class PdfComposerSample : DocumentSampleBase
 
 	private static void DrawBackToTocLink(SKCanvas canvas, float pageWidth, float pageHeight)
 	{
-		using var font = new SKFont { Size = 12 };
+		using var font = new SKFont(SampleMedia.Fonts.Default, 12);
 		using var paint = new SKPaint { IsAntialias = true, Color = LinkColor };
 		var text = "\u2190 Back to Contents";
 		var textWidth = font.MeasureText(text);
@@ -141,7 +141,7 @@ public class PdfComposerSample : DocumentSampleBase
 
 	private static void DrawPageTitle(SKCanvas canvas, float pageWidth, string title)
 	{
-		using var font = new SKFont { Size = 28 };
+		using var font = new SKFont(SampleMedia.Fonts.Default, 28);
 		using var paint = new SKPaint { IsAntialias = true, Color = HeadingColor };
 		canvas.DrawText(title, pageWidth / 2, 60, SKTextAlign.Center, font, paint);
 
@@ -154,12 +154,12 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawNamedDestinationAnnotation(new SKPoint(0, 0), "toc")?.Dispose();
 
 		// Title
-		using var titleFont = new SKFont { Size = 48 };
+		using var titleFont = new SKFont(SampleMedia.Fonts.Default, 48);
 		using var titlePaint = new SKPaint { IsAntialias = true, Color = HeadingColor };
 		canvas.DrawText("SkiaSharp PDF Demo", pageWidth / 2, 120, SKTextAlign.Center, titleFont, titlePaint);
 
 		// Subtitle
-		using var subtitleFont = new SKFont { Size = 20 };
+		using var subtitleFont = new SKFont(SampleMedia.Fonts.Default, 20);
 		using var subtitlePaint = new SKPaint { IsAntialias = true, Color = SubtitleColor };
 		canvas.DrawText("Generated with SkiaSharp", pageWidth / 2, 155, SKTextAlign.Center, subtitleFont, subtitlePaint);
 
@@ -168,12 +168,12 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawLine(80, 185, pageWidth - 80, 185, rulePaint);
 
 		// TOC header
-		using var tocHeaderFont = new SKFont { Size = 22 };
+		using var tocHeaderFont = new SKFont(SampleMedia.Fonts.Default, 22);
 		using var tocHeaderPaint = new SKPaint { IsAntialias = true, Color = HeadingColor };
 		canvas.DrawText("Table of Contents", pageWidth / 2, 230, SKTextAlign.Center, tocHeaderFont, tocHeaderPaint);
 
 		// TOC entries
-		using var tocFont = new SKFont { Size = 16 };
+		using var tocFont = new SKFont(SampleMedia.Fonts.Default, 16);
 		using var tocPaint = new SKPaint { IsAntialias = true, Color = LinkColor };
 		using var tocUnderline = new SKPaint { IsAntialias = true, Color = LinkColor, StrokeWidth = 0.5f, IsStroke = true };
 
@@ -197,7 +197,7 @@ public class PdfComposerSample : DocumentSampleBase
 		}
 
 		// Footer URL
-		using var footerFont = new SKFont { Size = 11 };
+		using var footerFont = new SKFont(SampleMedia.Fonts.Default, 11);
 		using var footerPaint = new SKPaint { IsAntialias = true, Color = LinkColor };
 		var url = "https://github.com/mono/SkiaSharp";
 		var urlW = footerFont.MeasureText(url);
@@ -212,7 +212,7 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawNamedDestinationAnnotation(new SKPoint(0, 0), "page-shapes")?.Dispose();
 		DrawPageTitle(canvas, pageWidth, "Shapes & Paths");
 
-		using var labelFont = new SKFont { Size = 12 };
+		using var labelFont = new SKFont(SampleMedia.Fonts.Default, 12);
 		using var labelPaint = new SKPaint { IsAntialias = true, Color = BodyColor };
 
 		// Star
@@ -291,7 +291,7 @@ public class PdfComposerSample : DocumentSampleBase
 		var margin = 60f;
 		var y = 110f;
 
-		using var sectionFont = new SKFont { Size = 14 };
+		using var sectionFont = new SKFont(SampleMedia.Fonts.Default, 14);
 		using var sectionPaint = new SKPaint { IsAntialias = true, Color = AccentColor };
 		using var bodyPaint = new SKPaint { IsAntialias = true, Color = BodyColor };
 
@@ -300,7 +300,7 @@ public class PdfComposerSample : DocumentSampleBase
 		y += 10;
 		foreach (var size in new[] { 12, 24, 36, 48 })
 		{
-			using var sizedFont = new SKFont { Size = size };
+			using var sizedFont = new SKFont(SampleMedia.Fonts.Default, size);
 			y += size + 8;
 			canvas.DrawText($"{size}pt Sample Text", margin, y, sizedFont, bodyPaint);
 		}
@@ -310,7 +310,7 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawText("Text Styles", margin, y, sectionFont, sectionPaint);
 		y += 30;
 
-		using var styleFont = new SKFont { Size = 20 };
+		using var styleFont = new SKFont(SampleMedia.Fonts.Default, 20);
 		canvas.DrawText("Normal text style", margin, y, styleFont, bodyPaint);
 		y += 30;
 
@@ -324,7 +324,7 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawText("Bold text style (stroke)", margin, y, styleFont, boldPaint);
 		y += 30;
 
-		using var italicFont = new SKFont(null, 20, 1, -0.25f);
+		using var italicFont = new SKFont(SampleMedia.Fonts.Default, 20, 1, -0.25f);
 		canvas.DrawText("Italic text style (skew)", margin, y, italicFont, bodyPaint);
 		y += 50;
 
@@ -332,7 +332,7 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawText("Text Alignment", margin, y, sectionFont, sectionPaint);
 		y += 30;
 
-		using var alignFont = new SKFont { Size = 16 };
+		using var alignFont = new SKFont(SampleMedia.Fonts.Default, 16);
 		using var guidePaint = new SKPaint { IsAntialias = true, Color = LightGray, StrokeWidth = 1, IsStroke = true };
 		canvas.DrawLine(pageWidth / 2, y - 16, pageWidth / 2, y + 60, guidePaint);
 
@@ -357,7 +357,7 @@ public class PdfComposerSample : DocumentSampleBase
 		var y = 100f;
 
 		// Description
-		using var descFont = new SKFont { Size = 13 };
+		using var descFont = new SKFont(SampleMedia.Fonts.Default, 13);
 		using var descPaint = new SKPaint { IsAntialias = true, Color = BodyColor };
 		canvas.DrawText("SkiaSharp can decode and embed bitmap images in PDF documents.", margin, y, descFont, descPaint);
 		y += 30;
@@ -374,7 +374,7 @@ public class PdfComposerSample : DocumentSampleBase
 				canvas.DrawBitmap(baboonBitmap, imgRect);
 
 				// Label
-				using var labelFont = new SKFont { Size = 11 };
+				using var labelFont = new SKFont(SampleMedia.Fonts.Default, 11);
 				using var labelPaint = new SKPaint { IsAntialias = true, Color = SubtitleColor };
 				canvas.DrawText($"baboon.png ({baboonBitmap.Width}×{baboonBitmap.Height})", margin, y + imgSize + 16, labelFont, labelPaint);
 
@@ -420,14 +420,14 @@ public class PdfComposerSample : DocumentSampleBase
 				var cwSize = 150f;
 				canvas.DrawBitmap(cwBitmap, SKRect.Create(margin, y, cwSize, cwSize));
 
-				using var cwLabel = new SKFont { Size = 11 };
+				using var cwLabel = new SKFont(SampleMedia.Fonts.Default, 11);
 				using var cwPaint = new SKPaint { IsAntialias = true, Color = SubtitleColor };
 				canvas.DrawText($"color-wheel.png ({cwBitmap.Width}×{cwBitmap.Height})", margin, y + cwSize + 16, cwLabel, cwPaint);
 			}
 		}
 
 		// Page number
-		using var pageFont = new SKFont { Size = 11 };
+		using var pageFont = new SKFont(SampleMedia.Fonts.Default, 11);
 		using var pagePaint = new SKPaint { IsAntialias = true, Color = BodyColor };
 		canvas.DrawText("Page 4 of 5", pageWidth / 2, pageHeight - 60, SKTextAlign.Center, pageFont, pagePaint);
 
@@ -497,7 +497,7 @@ public class PdfComposerSample : DocumentSampleBase
 		canvas.DrawPath(diamondPath, diaPaint);
 
 		// Page number
-		using var pageFont = new SKFont { Size = 11 };
+		using var pageFont = new SKFont(SampleMedia.Fonts.Default, 11);
 		using var pagePaint = new SKPaint { IsAntialias = true, Color = BodyColor };
 		canvas.DrawText($"Page {pageNum} of {totalPages}", pageWidth / 2, pageHeight - 60, SKTextAlign.Center, pageFont, pagePaint);
 

--- a/samples/Gallery/Shared/Samples/ShaderPlaygroundSample.cs
+++ b/samples/Gallery/Shared/Samples/ShaderPlaygroundSample.cs
@@ -191,12 +191,12 @@ half4 main(float2 fragCoord) {
 				Color = SKColors.Red,
 				IsAntialias = true,
 			};
-			using var errorFont = new SKFont { Size = 16 };
+			using var errorFont = new SKFont(SampleMedia.Fonts.Default, 16);
 			canvas.DrawText("Shader compilation failed:", 20, 40, SKTextAlign.Left, errorFont, errorPaint);
 			if (compileError != null)
 			{
 				errorPaint.Color = SKColors.White;
-				using var detailFont = new SKFont { Size = 14 };
+				using var detailFont = new SKFont(SampleMedia.Fonts.Default, 14);
 				canvas.DrawText(compileError, 20, 70, SKTextAlign.Left, detailFont, errorPaint);
 			}
 			return;

--- a/samples/Gallery/Shared/Samples/TextLabSample.cs
+++ b/samples/Gallery/Shared/Samples/TextLabSample.cs
@@ -163,7 +163,7 @@ public class TextLabSample : CanvasSampleBase
 			}
 
 			// Labels
-			using var labelFont = new SKFont { Size = 12 };
+			using var labelFont = new SKFont(SampleMedia.Fonts.Default, 12);
 			using var labelPaint = new SKPaint
 			{
 				IsAntialias = true,

--- a/samples/Gallery/Shared/Samples/ThreeDSample.cs
+++ b/samples/Gallery/Shared/Samples/ThreeDSample.cs
@@ -128,7 +128,7 @@ public class ThreeDSample : CanvasSampleBase
 		canvas.DrawRoundRect(rect, 20, 20, strokePaint);
 
 		// Face label
-		using var labelFont = new SKFont { Size = 20 };
+		using var labelFont = new SKFont(SampleMedia.Fonts.Default, 20);
 		using var labelPaint = new SKPaint { Color = SKColors.White, IsAntialias = true };
 		canvas.DrawText(side ? "FRONT" : "BACK", 0, 7, SKTextAlign.Center, labelFont, labelPaint);
 
@@ -191,7 +191,7 @@ public class ThreeDSample : CanvasSampleBase
 			StrokeWidth = 2,
 			IsAntialias = true,
 		};
-		using var font = new SKFont { Size = 14 };
+		using var font = new SKFont(SampleMedia.Fonts.Default, 14);
 		using var textPaint = new SKPaint { IsAntialias = true };
 
 		// X axis (red) — draw along +X

--- a/samples/Gallery/Uno/Pages/SamplePage.xaml
+++ b/samples/Gallery/Uno/Pages/SamplePage.xaml
@@ -98,7 +98,7 @@
                                         HorizontalAlignment="Stretch"
                                         Visibility="Collapsed"
                                         Margin="0,8,0,0">
-                                    <TextBlock Text="Download document" />
+                                    <TextBlock Text="⬇ Download" />
                                 </Button>
                             </StackPanel>
                         </ScrollViewer>

--- a/samples/Gallery/Uno/Pages/SamplePage.xaml.cs
+++ b/samples/Gallery/Uno/Pages/SamplePage.xaml.cs
@@ -38,14 +38,6 @@ public sealed partial class SamplePage : Page
 
         ControlPanel.SetControls(sample.Controls);
 
-        var hasDownload = sample.HasDownload;
-        DownloadButton.Visibility = hasDownload
-            ? Visibility.Visible
-            : Visibility.Collapsed;
-        ControlsSidebar.Visibility = sample.Controls.Count > 0 || hasDownload
-            ? Visibility.Visible
-            : Visibility.Collapsed;
-
         currentSample = sample;
         if (sample is CanvasSampleBase canvasSample)
         {
@@ -59,6 +51,16 @@ public sealed partial class SamplePage : Page
         {
             GenerateDocument(docSample);
         }
+
+        // Set download/sidebar visibility after init and document generation
+        // so that HasDownload reflects populated DocumentBytes.
+        var hasDownload = sample.HasDownload;
+        DownloadButton.Visibility = hasDownload
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        ControlsSidebar.Visibility = sample.Controls.Count > 0 || hasDownload
+            ? Visibility.Visible
+            : Visibility.Collapsed;
 
         canvasHost.InvalidateRender();
     }

--- a/samples/Gallery/Uno/Pages/SamplePage.xaml.cs
+++ b/samples/Gallery/Uno/Pages/SamplePage.xaml.cs
@@ -37,11 +37,12 @@ public sealed partial class SamplePage : Page
         DescriptionText.Text = sample.Description ?? string.Empty;
 
         ControlPanel.SetControls(sample.Controls);
-        ControlsSidebar.Visibility = sample.Controls.Count > 0
+
+        var hasDownload = sample.HasDownload;
+        DownloadButton.Visibility = hasDownload
             ? Visibility.Visible
             : Visibility.Collapsed;
-
-        DownloadButton.Visibility = sample is DocumentSampleBase
+        ControlsSidebar.Visibility = sample.Controls.Count > 0 || hasDownload
             ? Visibility.Visible
             : Visibility.Collapsed;
 
@@ -142,26 +143,28 @@ public sealed partial class SamplePage : Page
 
     private async void OnDownloadClicked(object sender, RoutedEventArgs e)
     {
-        if (currentSample is not DocumentSampleBase doc) return;
-        if (doc.DocumentBytes is not { Length: > 0 } bytes)
+        if (currentSample is null || !currentSample.HasDownload)
+            return;
+
+        var bytes = currentSample.DownloadBytes;
+        if (bytes is not { Length: > 0 })
         {
-            GenerateDocument(doc);
-            bytes = doc.DocumentBytes ?? System.Array.Empty<byte>();
-            if (bytes.Length == 0) return;
+            if (currentSample is DocumentSampleBase doc)
+                GenerateDocument(doc);
+            bytes = currentSample.DownloadBytes;
+            if (bytes is not { Length: > 0 }) return;
         }
 
-        var extension = (doc.DocumentMimeType ?? "application/pdf") switch
-        {
-            "application/pdf" => ".pdf",
-            "application/oxps" => ".xps",
-            _ => ".bin",
-        };
+        var fileName = currentSample.DownloadFileName;
+        var extension = System.IO.Path.GetExtension(fileName);
+        if (string.IsNullOrEmpty(extension))
+            extension = ".bin";
 
         var picker = new FileSavePicker
         {
-            SuggestedFileName = doc.Title.Replace(' ', '-').ToLowerInvariant() + extension,
+            SuggestedFileName = fileName,
         };
-        picker.FileTypeChoices.Add("Document", new List<string> { extension });
+        picker.FileTypeChoices.Add("File", new List<string> { extension });
 
         var file = await picker.PickSaveFileAsync();
         if (file is null) return;


### PR DESCRIPTION
## Summary

Two independent gallery improvements:

### Download button
- Add virtual `DownloadBytes`/`DownloadFileName`/`DownloadMimeType` on `SampleBase` so any sample can offer a download
- `DocumentSampleBase` bridges its existing document properties to the base
- `SamplePage.razor` shows a ⬇ Download button in the header when a sample has downloadable output
- Works today for PDF Composer and Create XPS; any future sample just overrides three properties

### WASM text rendering fix
- Add `SampleMedia.Fonts.Default` — lazily loads the embedded `InterVariable.ttf` as a shared `SKTypeface`
- Replace all `new SKFont { Size = X }` (default null typeface) with `new SKFont(SampleMedia.Fonts.Default, X)` across 11 samples
- Fixes text not rendering on WASM/Blazor where no system fonts are available

### Files changed
| Area | Files |
|------|-------|
| Infrastructure | `SampleBase.cs`, `DocumentSampleBase.cs`, `SampleMedia.cs`, `SamplePage.razor` |
| Font fixes | `BlendModesSample`, `CreateXpsSample`, `GifPlayerSample`, `ImageDecoderSample`, `PathBuilderSample`, `PdfComposerSample`, `ShaderPlaygroundSample`, `TextLabSample`, `ThreeDSample` |