### PR TITLE
Add FillPath and TextToPath gallery samples

### DIFF
--- a/samples/Gallery/Shared/Samples/FillPathSample.cs
+++ b/samples/Gallery/Shared/Samples/FillPathSample.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using SkiaSharp;
+using SkiaSharpSample.Controls;
+
+namespace SkiaSharpSample.Samples;
+
+public class FillPathSample : CanvasSampleBase
+{
+	private int shapeType;
+	private float strokeWidth = 8f;
+	private int capType;
+	private int joinType;
+	private float resScale = 1f;
+	private bool showOriginal = true;
+
+	private static readonly string[] ShapeTypes = { "Star", "Rounded Rect", "Circle", "Spiral", "Arrow" };
+	private static readonly string[] CapTypes = { "Butt", "Round", "Square" };
+	private static readonly string[] JoinTypes = { "Miter", "Round", "Bevel" };
+
+	public override string Title => "Fill Path";
+
+	public override string Description =>
+	"Compute the filled outline of a stroked path using SKPaint.GetFillPath, with adjustable stroke parameters.";
+
+	public override string Category => SampleCategories.Paths;
+
+	public override IReadOnlyList<SampleControl> Controls =>
+	[
+	new PickerControl("shape", "Shape", ShapeTypes, shapeType),
+new SliderControl("strokeWidth", "Stroke Width", 1, 40, strokeWidth),
+new PickerControl("cap", "Stroke Cap", CapTypes, capType),
+new PickerControl("join", "Stroke Join", JoinTypes, joinType),
+new SliderControl("resScale", "Resolution Scale", 0.25f, 4f, resScale, 0.25f),
+new ToggleControl("showOriginal", "Show Original Path", showOriginal),
+];
+
+	protected override void OnControlChanged(string id, object value)
+	{
+		switch (id)
+		{
+			case "shape":
+				shapeType = (int)value;
+				break;
+			case "strokeWidth":
+				strokeWidth = (float)value;
+				break;
+			case "cap":
+				capType = (int)value;
+				break;
+			case "join":
+				joinType = (int)value;
+				break;
+			case "resScale":
+				resScale = (float)value;
+				break;
+			case "showOriginal":
+				showOriginal = (bool)value;
+				break;
+		}
+	}
+
+	protected override void OnDrawSample(SKCanvas canvas, int width, int height)
+	{
+		canvas.Clear(SKColors.White);
+
+		var cx = width / 2f;
+		var cy = height / 2f;
+		var size = Math.Min(width, height) * 0.3f;
+
+		using var srcPath = CreateShape(shapeType, cx, cy, size);
+
+		using var paint = new SKPaint
+		{
+			IsStroke = true,
+			StrokeWidth = strokeWidth,
+			StrokeCap = (SKStrokeCap)capType,
+			StrokeJoin = (SKStrokeJoin)joinType,
+			IsAntialias = true,
+		};
+
+		var cullRect = new SKRect(0, 0, width, height);
+		using var fillPath = paint.GetFillPath(srcPath, cullRect, resScale);
+
+		if (fillPath != null)
+		{
+			using var fillPaint = new SKPaint
+			{
+				Color = SKColors.CornflowerBlue.WithAlpha(100),
+				IsAntialias = true,
+			};
+			canvas.DrawPath(fillPath, fillPaint);
+
+			using var outlinePaint = new SKPaint
+			{
+				Color = SKColors.CornflowerBlue,
+				IsStroke = true,
+				StrokeWidth = 1,
+				IsAntialias = true,
+			};
+			canvas.DrawPath(fillPath, outlinePaint);
+		}
+
+		if (showOriginal)
+		{
+			using var originalPaint = new SKPaint
+			{
+				Color = SKColors.Red,
+				IsStroke = true,
+				StrokeWidth = 2,
+				IsAntialias = true,
+			};
+			canvas.DrawPath(srcPath, originalPaint);
+		}
+	}
+
+	private static SKPath CreateShape(int type, float cx, float cy, float size)
+	{
+		return type switch
+		{
+			0 => CreateStarPath(cx, cy, size, size * 0.45f, 5),
+			1 => CreateRoundedRectPath(cx, cy, size),
+			2 => CreateCirclePath(cx, cy, size),
+			3 => CreateSpiralPath(cx, cy, size),
+			4 => CreateArrowPath(cx, cy, size),
+			_ => CreateStarPath(cx, cy, size, size * 0.45f, 5),
+		};
+	}
+
+	private static SKPath CreateRoundedRectPath(float cx, float cy, float size)
+	{
+		var path = new SKPath();
+		var rect = new SKRect(cx - size, cy - size * 0.6f, cx + size, cy + size * 0.6f);
+		var rrect = new SKRoundRect(rect, size * 0.2f);
+		path.AddRoundRect(rrect);
+		return path;
+	}
+
+	private static SKPath CreateCirclePath(float cx, float cy, float size)
+	{
+		var path = new SKPath();
+		path.AddCircle(cx, cy, size);
+		return path;
+	}
+
+	private static SKPath CreateSpiralPath(float cx, float cy, float size)
+	{
+		var path = new SKPath();
+		var turns = 4;
+		var pointsPerTurn = 60;
+		var totalPoints = turns * pointsPerTurn;
+
+		for (var i = 0; i < totalPoints; i++)
+		{
+			var t = (float)i / totalPoints;
+			var angle = (float)(t * turns * 2 * Math.PI);
+			var radius = size * t;
+			var x = cx + radius * (float)Math.Cos(angle);
+			var y = cy + radius * (float)Math.Sin(angle);
+
+			if (i == 0)
+				path.MoveTo(x, y);
+			else
+				path.LineTo(x, y);
+		}
+
+		return path;
+	}
+
+	private static SKPath CreateArrowPath(float cx, float cy, float size)
+	{
+		var path = new SKPath();
+		var shaftWidth = size * 0.3f;
+		var headWidth = size * 0.8f;
+
+		path.MoveTo(cx - size, cy + shaftWidth / 2);
+		path.LineTo(cx - size, cy - shaftWidth / 2);
+		path.LineTo(cx, cy - shaftWidth / 2);
+		path.LineTo(cx, cy - headWidth / 2);
+		path.LineTo(cx + size * 0.7f, cy);
+		path.LineTo(cx, cy + headWidth / 2);
+		path.LineTo(cx, cy + shaftWidth / 2);
+		path.Close();
+
+		return path;
+	}
+
+	private static SKPath CreateStarPath(float cx, float cy, float outerRadius, float innerRadius, int points)
+	{
+		var path = new SKPath();
+		var totalPoints = points * 2;
+		for (var i = 0; i < totalPoints; i++)
+		{
+			var angle = (float)(i * Math.PI / points - Math.PI / 2);
+			var radius = i % 2 == 0 ? outerRadius : innerRadius;
+			var x = cx + radius * (float)Math.Cos(angle);
+			var y = cy + radius * (float)Math.Sin(angle);
+
+			if (i == 0)
+				path.MoveTo(x, y);
+			else
+				path.LineTo(x, y);
+		}
+		path.Close();
+		return path;
+	}
+}

--- a/samples/Gallery/Shared/Samples/TextToPathSample.cs
+++ b/samples/Gallery/Shared/Samples/TextToPathSample.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using SkiaSharp;
+using SkiaSharpSample.Controls;
+
+namespace SkiaSharpSample.Samples;
+
+public class TextToPathSample : CanvasSampleBase
+{
+	private int textIndex;
+	private float textSize = 64f;
+	private float strokeWidth = 3f;
+	private bool showFillPath = true;
+	private bool showOutline = true;
+	private bool showOriginalText;
+
+	private SKTypeface? typeface;
+
+	private static readonly string[] TextOptions =
+	{
+		"SkiaSharp",
+		"The Quick Brown Fox",
+		"Hello World!",
+		"AaBbCcDdEeFf",
+		"0123456789",
+	};
+
+	public override string Title => "Text to Path";
+
+	public override string Description =>
+		"Convert text to an SKPath using SKFont.GetTextPath, then compute the stroked outline with GetFillPath.";
+
+	public override string Category => SampleCategories.Text;
+
+	public override IReadOnlyList<SampleControl> Controls =>
+	[
+		new PickerControl("text", "Text", TextOptions, textIndex),
+		new SliderControl("textSize", "Text Size", 16, 120, textSize),
+		new SliderControl("strokeWidth", "Stroke Width", 0.5f, 20, strokeWidth, 0.5f),
+		new ToggleControl("showFillPath", "Show Stroke Outline", showFillPath),
+		new ToggleControl("showOutline", "Show Glyph Outlines", showOutline),
+		new ToggleControl("showOriginalText", "Show Original Text", showOriginalText),
+	];
+
+	protected override void OnControlChanged(string id, object value)
+	{
+		switch (id)
+		{
+			case "text":
+				textIndex = (int)value;
+				break;
+			case "textSize":
+				textSize = (float)value;
+				break;
+			case "strokeWidth":
+				strokeWidth = (float)value;
+				break;
+			case "showFillPath":
+				showFillPath = (bool)value;
+				break;
+			case "showOutline":
+				showOutline = (bool)value;
+				break;
+			case "showOriginalText":
+				showOriginalText = (bool)value;
+				break;
+		}
+	}
+
+	protected override void OnDrawSample(SKCanvas canvas, int width, int height)
+	{
+		canvas.Clear(SKColors.White);
+
+		if (typeface == null)
+			return;
+
+		var text = TextOptions[textIndex];
+
+		using var font = new SKFont(typeface, textSize);
+		var textWidth = font.MeasureText(text);
+		var metrics = font.Metrics;
+		var textHeight = metrics.Descent - metrics.Ascent;
+
+		var x = (width - textWidth) / 2f;
+		var y = height * 0.45f;
+
+		using var textPath = font.GetTextPath(text, new SKPoint(x, y));
+		if (textPath == null || textPath.PointCount == 0)
+			return;
+
+		// Show the original rendered text faintly for reference
+		if (showOriginalText)
+		{
+			using var textPaint = new SKPaint
+			{
+				Color = SKColors.Black.WithAlpha(40),
+				IsAntialias = true,
+			};
+			canvas.DrawText(text, x, y, font, textPaint);
+		}
+
+		// Draw the glyph outlines (the raw text path)
+		if (showOutline)
+		{
+			using var outlinePaint = new SKPaint
+			{
+				Color = SKColors.Red,
+				IsStroke = true,
+				StrokeWidth = 1,
+				IsAntialias = true,
+			};
+			canvas.DrawPath(textPath, outlinePaint);
+		}
+
+		// Compute and draw the stroked fill path
+		if (showFillPath)
+		{
+			using var strokePaint = new SKPaint
+			{
+				IsStroke = true,
+				StrokeWidth = strokeWidth,
+				StrokeCap = SKStrokeCap.Round,
+				StrokeJoin = SKStrokeJoin.Round,
+				IsAntialias = true,
+			};
+
+			using var fillPath = strokePaint.GetFillPath(textPath);
+			if (fillPath != null)
+			{
+				using var fillBrush = new SKPaint
+				{
+					Color = SKColors.CornflowerBlue.WithAlpha(80),
+					IsAntialias = true,
+				};
+				canvas.DrawPath(fillPath, fillBrush);
+
+				using var fillOutline = new SKPaint
+				{
+					Color = SKColors.CornflowerBlue,
+					IsStroke = true,
+					StrokeWidth = 1,
+					IsAntialias = true,
+				};
+				canvas.DrawPath(fillPath, fillOutline);
+			}
+		}
+
+		// Draw info
+		using var infoFont = new SKFont(typeface, 13);
+		using var infoPaint = new SKPaint
+		{
+			Color = new SKColor(0x99, 0x99, 0x99),
+			IsAntialias = true,
+		};
+		var info = $"Path points: {textPath.PointCount}   Text size: {textSize:F0}   Stroke: {strokeWidth:F1}";
+		canvas.DrawText(info, 12, height - 12, infoFont, infoPaint);
+	}
+
+	protected override System.Threading.Tasks.Task OnInit()
+	{
+		using var stream = SampleMedia.Fonts.InterVariable;
+		using var data = SKData.Create(stream);
+		typeface = SKTypeface.FromData(data);
+		return base.OnInit();
+	}
+
+	protected override void OnDestroy()
+	{
+		typeface?.Dispose();
+		typeface = null;
+		base.OnDestroy();
+	}
+}


### PR DESCRIPTION
## Summary

Add two new interactive gallery samples demonstrating `SKPaint.GetFillPath` and `SKFont.GetTextPath`.

### Fill Path Sample (Paths & Geometry)
Demonstrates computing the filled outline of a stroked path using `SKPaint.GetFillPath`, with interactive controls for:
- **Shape selector** — Star, Rounded Rect, Circle, Spiral, Arrow
- **Stroke Width** — adjustable from 1 to 40
- **Stroke Cap** — Butt, Round, Square
- **Stroke Join** — Miter, Round, Bevel
- **Resolution Scale** — 0.25x to 4x
- **Show Original Path** toggle — overlay the source path in red

### Text to Path Sample (Text & Typography)
Demonstrates converting text strings to paths using `SKFont.GetTextPath`, then computing the stroked outline with `GetFillPath`:
- **Text selector** — SkiaSharp, The Quick Brown Fox, Hello World!, AaBbCcDdEeFf, 0123456789
- **Text Size** — 16 to 120
- **Stroke Width** — 0.5 to 20
- **Toggle layers** — Show Stroke Outline, Show Glyph Outlines, Show Original Text
- Uses the Inter variable font via `SampleMedia`
- Displays path point count and parameters

### No API changes
These samples use existing APIs (`SKPaint.GetFillPath`, `SKFont.GetTextPath`). No native code, binding, or test changes.