### PR TITLE
Add animated WebP encoding support (SKWebpEncoder)

### DIFF
--- a/binding/SkiaSharp/Definitions.cs
+++ b/binding/SkiaSharp/Definitions.cs
@@ -601,6 +601,17 @@ namespace SkiaSharp
 		public float Quality => fQuality;
 	}
 
+	public unsafe partial struct SKWebpEncoderFrame
+	{
+		public SKWebpEncoderFrame (SKPixmap pixmap, int duration)
+		{
+			this.pixmap = pixmap?.Handle ?? throw new ArgumentNullException (nameof (pixmap));
+			this.duration = duration;
+		}
+
+		public int Duration => duration;
+	}
+
 	public partial struct SKCubicResampler
 	{
 		public static readonly SKCubicResampler Mitchell = new (1 / 3.0f, 1 / 3.0f);

--- a/binding/SkiaSharp/Definitions.cs
+++ b/binding/SkiaSharp/Definitions.cs
@@ -609,6 +609,20 @@ namespace SkiaSharp
 			Duration = duration;
 		}
 
+		public SKWebpEncoderFrame (SKBitmap bitmap, TimeSpan duration)
+		{
+			_ = bitmap ?? throw new ArgumentNullException (nameof (bitmap));
+			Pixmap = bitmap.PeekPixels () ?? throw new ArgumentException ("Unable to peek pixels from bitmap.", nameof (bitmap));
+			Duration = duration;
+		}
+
+		public SKWebpEncoderFrame (SKImage image, TimeSpan duration)
+		{
+			_ = image ?? throw new ArgumentNullException (nameof (image));
+			Pixmap = image.PeekPixels () ?? throw new ArgumentException ("Unable to peek pixels from image. Ensure the image is raster-backed.", nameof (image));
+			Duration = duration;
+		}
+
 		public SKPixmap Pixmap { readonly get; set; }
 
 		public TimeSpan Duration { readonly get; set; }

--- a/binding/SkiaSharp/Definitions.cs
+++ b/binding/SkiaSharp/Definitions.cs
@@ -601,15 +601,17 @@ namespace SkiaSharp
 		public float Quality => fQuality;
 	}
 
-	public unsafe partial struct SKWebpEncoderFrame
+	public struct SKWebpEncoderFrame
 	{
 		public SKWebpEncoderFrame (SKPixmap pixmap, int duration)
 		{
-			this.pixmap = pixmap?.Handle ?? throw new ArgumentNullException (nameof (pixmap));
-			this.duration = duration;
+			Pixmap = pixmap ?? throw new ArgumentNullException (nameof (pixmap));
+			Duration = duration;
 		}
 
-		public int Duration => duration;
+		public SKPixmap Pixmap { readonly get; set; }
+
+		public int Duration { readonly get; set; }
 	}
 
 	public partial struct SKCubicResampler

--- a/binding/SkiaSharp/Definitions.cs
+++ b/binding/SkiaSharp/Definitions.cs
@@ -603,7 +603,7 @@ namespace SkiaSharp
 
 	public struct SKWebpEncoderFrame
 	{
-		public SKWebpEncoderFrame (SKPixmap pixmap, int duration)
+		public SKWebpEncoderFrame (SKPixmap pixmap, TimeSpan duration)
 		{
 			Pixmap = pixmap ?? throw new ArgumentNullException (nameof (pixmap));
 			Duration = duration;
@@ -611,7 +611,7 @@ namespace SkiaSharp
 
 		public SKPixmap Pixmap { readonly get; set; }
 
-		public int Duration { readonly get; set; }
+		public TimeSpan Duration { readonly get; set; }
 	}
 
 	public partial struct SKCubicResampler

--- a/binding/SkiaSharp/SKWebpEncoder.cs
+++ b/binding/SkiaSharp/SKWebpEncoder.cs
@@ -5,12 +5,51 @@ namespace SkiaSharp;
 
 public static unsafe class SKWebpEncoder
 {
+	// single-frame encoding
+
+	public static bool Encode (SKWStream dst, SKPixmap src, SKWebpEncoderOptions options)
+	{
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+		_ = src ?? throw new ArgumentNullException (nameof (src));
+
+		return SkiaApi.sk_webpencoder_encode (dst.Handle, src.Handle, &options);
+	}
+
+	public static bool Encode (Stream dst, SKPixmap src, SKWebpEncoderOptions options)
+	{
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+		_ = src ?? throw new ArgumentNullException (nameof (src));
+
+		using var wrapped = new SKManagedWStream (dst);
+		return Encode (wrapped, src, options);
+	}
+
+	public static SKData? Encode (SKPixmap src, SKWebpEncoderOptions options)
+	{
+		_ = src ?? throw new ArgumentNullException (nameof (src));
+
+		using var stream = new SKDynamicMemoryWStream ();
+		var result = Encode (stream, src, options);
+		return result ? stream.DetachAsData () : null;
+	}
+
+	// animated encoding
+
 	public static bool EncodeAnimated (SKWStream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
 	{
 		_ = dst ?? throw new ArgumentNullException (nameof (dst));
 
-		fixed (SKWebpEncoderFrame* f = frames) {
-			return SkiaApi.sk_webpencoder_encode_animated (dst.Handle, f, frames.Length, &options);
+		var nativeFrames = new SKWebpEncoderFrameNative[frames.Length];
+		for (var i = 0; i < frames.Length; i++) {
+			var pixmap = frames[i].Pixmap ?? throw new ArgumentNullException ($"frames[{i}].Pixmap");
+			nativeFrames[i] = new SKWebpEncoderFrameNative {
+				pixmap = pixmap.Handle,
+				duration = frames[i].Duration,
+			};
+		}
+
+		fixed (SKWebpEncoderFrameNative* f = nativeFrames) {
+			return SkiaApi.sk_webpencoder_encode_animated (dst.Handle, f, nativeFrames.Length, &options);
 		}
 	}
 

--- a/binding/SkiaSharp/SKWebpEncoder.cs
+++ b/binding/SkiaSharp/SKWebpEncoder.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+
+namespace SkiaSharp;
+
+public static unsafe class SKWebpEncoder
+{
+	public static bool EncodeAnimated (SKWStream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
+	{
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+
+		fixed (SKWebpEncoderFrame* f = frames) {
+			return SkiaApi.sk_webpencoder_encode_animated (dst.Handle, f, frames.Length, &options);
+		}
+	}
+
+	public static bool EncodeAnimated (Stream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
+	{
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+
+		using var wrapped = new SKManagedWStream (dst);
+		return EncodeAnimated (wrapped, frames, options);
+	}
+
+	public static SKData? EncodeAnimated (ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
+	{
+		using var stream = new SKDynamicMemoryWStream ();
+		var result = EncodeAnimated (stream, frames, options);
+		return result ? stream.DetachAsData () : null;
+	}
+}

--- a/binding/SkiaSharp/SKWebpEncoder.cs
+++ b/binding/SkiaSharp/SKWebpEncoder.cs
@@ -44,7 +44,7 @@ public static unsafe class SKWebpEncoder
 			var pixmap = frames[i].Pixmap ?? throw new ArgumentNullException ($"frames[{i}].Pixmap");
 			nativeFrames.Span[i] = new SKWebpEncoderFrameNative {
 				pixmap = pixmap.Handle,
-				duration = frames[i].Duration,
+				duration = (int)frames[i].Duration.TotalMilliseconds,
 			};
 		}
 

--- a/binding/SkiaSharp/SKWebpEncoder.cs
+++ b/binding/SkiaSharp/SKWebpEncoder.cs
@@ -39,17 +39,17 @@ public static unsafe class SKWebpEncoder
 	{
 		_ = dst ?? throw new ArgumentNullException (nameof (dst));
 
-		var nativeFrames = new SKWebpEncoderFrameNative[frames.Length];
+		using var nativeFrames = Utils.RentArray<SKWebpEncoderFrameNative> (frames.Length);
 		for (var i = 0; i < frames.Length; i++) {
 			var pixmap = frames[i].Pixmap ?? throw new ArgumentNullException ($"frames[{i}].Pixmap");
-			nativeFrames[i] = new SKWebpEncoderFrameNative {
+			nativeFrames.Span[i] = new SKWebpEncoderFrameNative {
 				pixmap = pixmap.Handle,
 				duration = frames[i].Duration,
 			};
 		}
 
-		fixed (SKWebpEncoderFrameNative* f = nativeFrames) {
-			return SkiaApi.sk_webpencoder_encode_animated (dst.Handle, f, nativeFrames.Length, &options);
+		fixed (SKWebpEncoderFrameNative* f = nativeFrames.Span) {
+			return SkiaApi.sk_webpencoder_encode_animated (dst.Handle, f, frames.Length, &options);
 		}
 	}
 

--- a/binding/SkiaSharp/SKWebpEncoder.cs
+++ b/binding/SkiaSharp/SKWebpEncoder.cs
@@ -9,16 +9,16 @@ public static unsafe class SKWebpEncoder
 
 	public static bool Encode (SKWStream dst, SKPixmap src, SKWebpEncoderOptions options)
 	{
-		ArgumentNullException.ThrowIfNull (dst);
-		ArgumentNullException.ThrowIfNull (src);
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+		_ = src ?? throw new ArgumentNullException (nameof (src));
 
 		return SkiaApi.sk_webpencoder_encode (dst.Handle, src.Handle, &options);
 	}
 
 	public static bool Encode (Stream dst, SKPixmap src, SKWebpEncoderOptions options)
 	{
-		ArgumentNullException.ThrowIfNull (dst);
-		ArgumentNullException.ThrowIfNull (src);
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+		_ = src ?? throw new ArgumentNullException (nameof (src));
 
 		using var wrapped = new SKManagedWStream (dst);
 		return Encode (wrapped, src, options);
@@ -26,7 +26,7 @@ public static unsafe class SKWebpEncoder
 
 	public static SKData? Encode (SKPixmap src, SKWebpEncoderOptions options)
 	{
-		ArgumentNullException.ThrowIfNull (src);
+		_ = src ?? throw new ArgumentNullException (nameof (src));
 
 		using var stream = new SKDynamicMemoryWStream ();
 		var result = Encode (stream, src, options);
@@ -37,7 +37,7 @@ public static unsafe class SKWebpEncoder
 
 	public static bool EncodeAnimated (SKWStream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
 	{
-		ArgumentNullException.ThrowIfNull (dst);
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
 
 		using var nativeFrames = Utils.RentArray<SKWebpEncoderFrameNative> (frames.Length);
 		for (var i = 0; i < frames.Length; i++) {
@@ -55,7 +55,7 @@ public static unsafe class SKWebpEncoder
 
 	public static bool EncodeAnimated (Stream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
 	{
-		ArgumentNullException.ThrowIfNull (dst);
+		_ = dst ?? throw new ArgumentNullException (nameof (dst));
 
 		using var wrapped = new SKManagedWStream (dst);
 		return EncodeAnimated (wrapped, frames, options);

--- a/binding/SkiaSharp/SKWebpEncoder.cs
+++ b/binding/SkiaSharp/SKWebpEncoder.cs
@@ -9,16 +9,16 @@ public static unsafe class SKWebpEncoder
 
 	public static bool Encode (SKWStream dst, SKPixmap src, SKWebpEncoderOptions options)
 	{
-		_ = dst ?? throw new ArgumentNullException (nameof (dst));
-		_ = src ?? throw new ArgumentNullException (nameof (src));
+		ArgumentNullException.ThrowIfNull (dst);
+		ArgumentNullException.ThrowIfNull (src);
 
 		return SkiaApi.sk_webpencoder_encode (dst.Handle, src.Handle, &options);
 	}
 
 	public static bool Encode (Stream dst, SKPixmap src, SKWebpEncoderOptions options)
 	{
-		_ = dst ?? throw new ArgumentNullException (nameof (dst));
-		_ = src ?? throw new ArgumentNullException (nameof (src));
+		ArgumentNullException.ThrowIfNull (dst);
+		ArgumentNullException.ThrowIfNull (src);
 
 		using var wrapped = new SKManagedWStream (dst);
 		return Encode (wrapped, src, options);
@@ -26,7 +26,7 @@ public static unsafe class SKWebpEncoder
 
 	public static SKData? Encode (SKPixmap src, SKWebpEncoderOptions options)
 	{
-		_ = src ?? throw new ArgumentNullException (nameof (src));
+		ArgumentNullException.ThrowIfNull (src);
 
 		using var stream = new SKDynamicMemoryWStream ();
 		var result = Encode (stream, src, options);
@@ -37,7 +37,7 @@ public static unsafe class SKWebpEncoder
 
 	public static bool EncodeAnimated (SKWStream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
 	{
-		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+		ArgumentNullException.ThrowIfNull (dst);
 
 		using var nativeFrames = Utils.RentArray<SKWebpEncoderFrameNative> (frames.Length);
 		for (var i = 0; i < frames.Length; i++) {
@@ -55,7 +55,7 @@ public static unsafe class SKWebpEncoder
 
 	public static bool EncodeAnimated (Stream dst, ReadOnlySpan<SKWebpEncoderFrame> frames, SKWebpEncoderOptions options)
 	{
-		_ = dst ?? throw new ArgumentNullException (nameof (dst));
+		ArgumentNullException.ThrowIfNull (dst);
 
 		using var wrapped = new SKManagedWStream (dst);
 		return EncodeAnimated (wrapped, frames, options);

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -12158,6 +12158,28 @@ namespace SkiaSharp
 			(sk_webpencoder_encode_delegate ??= GetSymbol<Delegates.sk_webpencoder_encode> ("sk_webpencoder_encode")).Invoke (dst, src, options);
 		#endif
 
+		// bool sk_webpencoder_encode_animated(sk_wstream_t* dst, const sk_webpencoder_frame_t* src, int count, const sk_webpencoder_options_t* options)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options);
+		}
+		private static Delegates.sk_webpencoder_encode_animated sk_webpencoder_encode_animated_delegate;
+		internal static bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options) =>
+			(sk_webpencoder_encode_animated_delegate ??= GetSymbol<Delegates.sk_webpencoder_encode_animated> ("sk_webpencoder_encode_animated")).Invoke (dst, src, count, options);
+		#endif
+
 		#endregion
 
 		#region sk_region.h
@@ -20653,6 +20675,39 @@ namespace SkiaSharp {
 			hash.Add (pos);
 			hash.Add (utf8text);
 			hash.Add (clusters);
+			return hash.ToHashCode ();
+		}
+
+	}
+
+	// sk_webpencoder_frame_t
+	[StructLayout (LayoutKind.Sequential)]
+	public readonly unsafe partial struct SKWebpEncoderFrame : IEquatable<SKWebpEncoderFrame> {
+		// public const sk_pixmap_t* pixmap
+		private readonly sk_pixmap_t pixmap;
+
+		// public int duration
+		private readonly Int32 duration;
+
+		public readonly bool Equals (SKWebpEncoderFrame obj) =>
+#pragma warning disable CS8909
+			pixmap == obj.pixmap && duration == obj.duration;
+#pragma warning restore CS8909
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKWebpEncoderFrame f && Equals (f);
+
+		public static bool operator == (SKWebpEncoderFrame left, SKWebpEncoderFrame right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKWebpEncoderFrame left, SKWebpEncoderFrame right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (pixmap);
+			hash.Add (duration);
 			return hash.ToHashCode ();
 		}
 

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -12163,20 +12163,20 @@ namespace SkiaSharp
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (SKIA)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options);
+		internal static partial bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrameNative* src, Int32 count, SKWebpEncoderOptions* options);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
 		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options);
+		internal static extern bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrameNative* src, Int32 count, SKWebpEncoderOptions* options);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options);
+			internal delegate bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrameNative* src, Int32 count, SKWebpEncoderOptions* options);
 		}
 		private static Delegates.sk_webpencoder_encode_animated sk_webpencoder_encode_animated_delegate;
-		internal static bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrame* src, Int32 count, SKWebpEncoderOptions* options) =>
+		internal static bool sk_webpencoder_encode_animated (sk_wstream_t dst, SKWebpEncoderFrameNative* src, Int32 count, SKWebpEncoderOptions* options) =>
 			(sk_webpencoder_encode_animated_delegate ??= GetSymbol<Delegates.sk_webpencoder_encode_animated> ("sk_webpencoder_encode_animated")).Invoke (dst, src, count, options);
 		#endif
 
@@ -20682,25 +20682,25 @@ namespace SkiaSharp {
 
 	// sk_webpencoder_frame_t
 	[StructLayout (LayoutKind.Sequential)]
-	public readonly unsafe partial struct SKWebpEncoderFrame : IEquatable<SKWebpEncoderFrame> {
+	internal unsafe partial struct SKWebpEncoderFrameNative : IEquatable<SKWebpEncoderFrameNative> {
 		// public const sk_pixmap_t* pixmap
-		private readonly sk_pixmap_t pixmap;
+		public sk_pixmap_t pixmap;
 
 		// public int duration
-		private readonly Int32 duration;
+		public Int32 duration;
 
-		public readonly bool Equals (SKWebpEncoderFrame obj) =>
+		public readonly bool Equals (SKWebpEncoderFrameNative obj) =>
 #pragma warning disable CS8909
 			pixmap == obj.pixmap && duration == obj.duration;
 #pragma warning restore CS8909
 
 		public readonly override bool Equals (object obj) =>
-			obj is SKWebpEncoderFrame f && Equals (f);
+			obj is SKWebpEncoderFrameNative f && Equals (f);
 
-		public static bool operator == (SKWebpEncoderFrame left, SKWebpEncoderFrame right) =>
+		public static bool operator == (SKWebpEncoderFrameNative left, SKWebpEncoderFrameNative right) =>
 			left.Equals (right);
 
-		public static bool operator != (SKWebpEncoderFrame left, SKWebpEncoderFrame right) =>
+		public static bool operator != (SKWebpEncoderFrameNative left, SKWebpEncoderFrameNative right) =>
 			!left.Equals (right);
 
 		public readonly override int GetHashCode ()

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -206,8 +206,8 @@
         "properties": false
       },
       "sk_webpencoder_frame_t": {
-        "cs": "SKWebpEncoderFrame",
-        "readonly": true,
+        "cs": "SKWebpEncoderFrameNative",
+        "internal": true,
         "properties": false
       },
       "sk_alphatype_t": {

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -205,6 +205,11 @@
         "readonly": true,
         "properties": false
       },
+      "sk_webpencoder_frame_t": {
+        "cs": "SKWebpEncoderFrame",
+        "readonly": true,
+        "properties": false
+      },
       "sk_alphatype_t": {
         "cs": "SKAlphaType"
       },

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -35,7 +35,9 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 	public override string Description => "Encode an animated WebP with letter-by-letter reveal, blink, and fade-out, then play it back.";
 
-	public override string Category => SampleCategories.General;
+	public override string Category => SampleManager.BitmapDecoding;
+
+	public override DateOnly? DateAdded => new DateOnly(2026, 5, 5);
 
 	public override bool IsAnimated => _codec != null && _codec.FrameCount > 1;
 

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -16,6 +16,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 	private int _currentFrame;
 	private SKBitmap? _currentBitmap;
 	private int _frameDurationMs;
+	private SKTypeface? _typeface;
 
 	private static readonly string[] CompressionOptions = { "Lossy", "Lossless" };
 
@@ -61,6 +62,8 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 	protected override Task OnInit()
 	{
+		using var fontStream = SampleMedia.Fonts.InterVariable;
+		_typeface = SKTypeface.FromStream(fontStream);
 		RebuildAnimation();
 		return base.OnInit();
 	}
@@ -105,7 +108,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 			{
 				bitmaps[i] = new SKBitmap(FrameWidth, FrameHeight);
 				using var canvas = new SKCanvas(bitmaps[i]);
-				DrawAnimationFrame(canvas, FrameWidth, FrameHeight, i, totalFrames, letterCount);
+				DrawAnimationFrame(canvas, FrameWidth, FrameHeight, i, totalFrames, letterCount, _typeface);
 				pixmaps[i] = bitmaps[i].PeekPixels();
 				frames[i] = new SKWebpEncoderFrame(pixmaps[i], FrameDuration);
 			}
@@ -136,7 +139,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 	}
 
 	private static void DrawAnimationFrame(
-		SKCanvas canvas, int w, int h, int frame, int totalFrames, int letterCount)
+		SKCanvas canvas, int w, int h, int frame, int totalFrames, int letterCount, SKTypeface? typeface)
 	{
 		// interpolate background gradient across the timeline for subtle motion
 		var t = (float)frame / Math.Max(1, totalFrames - 1);
@@ -158,7 +161,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 			return;
 
 		var fontSize = h * 0.28f;
-		using var font = new SKFont { Size = fontSize };
+		using var font = new SKFont(typeface, fontSize);
 		using var textPaint = new SKPaint
 		{
 			Color = SKColors.White,
@@ -305,5 +308,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 	{
 		base.OnDestroy();
 		DisposeEncoded();
+		_typeface?.Dispose();
+		_typeface = null;
 	}
 }

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -114,7 +114,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 				using var canvas = new SKCanvas(bitmaps[i]);
 				DrawAnimationFrame(canvas, FrameWidth, FrameHeight, i, totalFrames, letterCount, _typeface);
 				pixmaps[i] = bitmaps[i].PeekPixels();
-				frames[i] = new SKWebpEncoderFrame(pixmaps[i], FrameDuration);
+				frames[i] = new SKWebpEncoderFrame(pixmaps[i], TimeSpan.FromMilliseconds(FrameDuration));
 			}
 
 			var compression = _compressionIndex == 1

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SkiaSharp;
+using SkiaSharpSample.Controls;
+
+namespace SkiaSharpSample.Samples;
+
+public class AnimatedWebpEncoderSample : CanvasSampleBase
+{
+	private int _frameCount = 4;
+	private float _quality = 80;
+	private int _compressionIndex;
+	private int _frameDuration = 250;
+
+	private SKData? _encodedData;
+	private SKCodec? _codec;
+	private int _currentFrame;
+	private SKBitmap? _currentBitmap;
+
+	private static readonly string[] CompressionOptions = { "Lossy", "Lossless" };
+
+	private static readonly SKColor[] FrameColors =
+	{
+		SKColors.Red, SKColors.Orange, SKColors.Yellow, SKColors.Green,
+		SKColors.Cyan, SKColors.Blue, SKColors.Purple, SKColors.Magenta,
+	};
+
+	public override string Title => "Animated WebP Encoder";
+
+	public override string Description => "Encode multiple frames as an animated WebP, then decode and play it back.";
+
+	public override string Category => SampleCategories.General;
+
+	public override bool IsAnimated => _codec != null && _codec.FrameCount > 1;
+
+	public override IReadOnlyList<SampleControl> Controls =>
+	[
+		new SliderControl("frames", "Frame Count", 2, 8, _frameCount, 1),
+		new SliderControl("duration", "Frame Duration (ms)", 50, 1000, _frameDuration, 50),
+		new SliderControl("quality", "Quality", 0, 100, _quality, 5),
+		new PickerControl("compression", "Compression", CompressionOptions, _compressionIndex),
+	];
+
+	protected override void OnControlChanged(string id, object value)
+	{
+		switch (id)
+		{
+			case "frames":
+				_frameCount = (int)(float)value;
+				break;
+			case "duration":
+				_frameDuration = (int)(float)value;
+				break;
+			case "quality":
+				_quality = (float)value;
+				break;
+			case "compression":
+				_compressionIndex = (int)value;
+				break;
+		}
+
+		RebuildAnimation();
+	}
+
+	protected override Task OnInit()
+	{
+		RebuildAnimation();
+		return base.OnInit();
+	}
+
+	protected override async Task OnUpdate(CancellationToken token)
+	{
+		await Task.Delay(Math.Max(16, _frameDuration), token);
+		if (_codec != null && _codec.FrameCount > 0)
+			_currentFrame = (_currentFrame + 1) % _codec.FrameCount;
+	}
+
+	private void RebuildAnimation()
+	{
+		_currentFrame = 0;
+		_currentBitmap?.Dispose();
+		_currentBitmap = null;
+		_codec?.Dispose();
+		_codec = null;
+		_encodedData?.Dispose();
+		_encodedData = null;
+
+		var size = 200;
+		var count = Math.Clamp(_frameCount, 2, FrameColors.Length);
+
+		var frames = new SKWebpEncoderFrame[count];
+		var bitmaps = new SKBitmap[count];
+		var pixmaps = new SKPixmap[count];
+
+		try
+		{
+			for (var i = 0; i < count; i++)
+			{
+				bitmaps[i] = new SKBitmap(size, size);
+				using var canvas = new SKCanvas(bitmaps[i]);
+				DrawFrame(canvas, size, size, i, count);
+				pixmaps[i] = bitmaps[i].PeekPixels();
+				frames[i] = new SKWebpEncoderFrame(pixmaps[i], _frameDuration);
+			}
+
+			var compression = _compressionIndex == 1
+				? SKWebpEncoderCompression.Lossless
+				: SKWebpEncoderCompression.Lossy;
+			var options = new SKWebpEncoderOptions(compression, _quality);
+			_encodedData = SKWebpEncoder.EncodeAnimated(frames, options);
+
+			if (_encodedData != null)
+			{
+				_codec = SKCodec.Create(_encodedData);
+				_currentBitmap = new SKBitmap(_codec!.Info);
+			}
+		}
+		finally
+		{
+			for (var i = 0; i < count; i++)
+			{
+				pixmaps[i]?.Dispose();
+				bitmaps[i]?.Dispose();
+			}
+		}
+
+		Refresh();
+	}
+
+	private static void DrawFrame(SKCanvas canvas, int width, int height, int frameIndex, int totalFrames)
+	{
+		var color = FrameColors[frameIndex % FrameColors.Length];
+		canvas.Clear(SKColors.White);
+
+		using var paint = new SKPaint
+		{
+			Color = color,
+			IsAntialias = true,
+			Style = SKPaintStyle.Fill,
+		};
+
+		var cx = width / 2f;
+		var cy = height / 2f;
+		var radius = Math.Min(width, height) * 0.35f;
+		canvas.DrawCircle(cx, cy, radius, paint);
+
+		using var textPaint = new SKPaint
+		{
+			Color = SKColors.White,
+			IsAntialias = true,
+		};
+		using var font = new SKFont { Size = radius * 0.6f };
+		var text = $"{frameIndex + 1}";
+		canvas.DrawText(text, cx, cy + font.Size * 0.35f, SKTextAlign.Center, font, textPaint);
+	}
+
+	protected override void OnDrawSample(SKCanvas canvas, int width, int height)
+	{
+		canvas.Clear(SKColors.White);
+
+		if (_codec == null || _encodedData == null || _currentBitmap == null)
+		{
+			using var errorPaint = new SKPaint { Color = SKColors.Red, IsAntialias = true };
+			using var errorFont = new SKFont { Size = 18 };
+			canvas.DrawText("Encoding failed", width / 2f, height / 2f, SKTextAlign.Center, errorFont, errorPaint);
+			return;
+		}
+
+		var frameIndex = Math.Clamp(_currentFrame, 0, Math.Max(0, _codec.FrameCount - 1));
+		var opts = new SKCodecOptions(frameIndex);
+		_codec.GetPixels(_currentBitmap.Info, _currentBitmap.GetPixels(), opts);
+
+		var scale = Math.Min((width - 20f) / _currentBitmap.Width, (height - 80f) / _currentBitmap.Height);
+		scale = Math.Min(scale, 2f);
+		var dw = _currentBitmap.Width * scale;
+		var dh = _currentBitmap.Height * scale;
+		var destRect = new SKRect(
+			(width - dw) / 2f, 10,
+			(width + dw) / 2f, 10 + dh);
+
+		canvas.DrawBitmap(_currentBitmap, destRect);
+
+		using var infoPaint = new SKPaint { Color = SKColors.Black, IsAntialias = true };
+		using var infoFont = new SKFont { Size = 14 };
+		var infoY = destRect.Bottom + 24;
+		var infoText = $"Frames: {_codec.FrameCount}  |  Size: {_encodedData.Size:N0} bytes  |  Frame: {frameIndex + 1}/{_codec.FrameCount}";
+		canvas.DrawText(infoText, width / 2f, infoY, SKTextAlign.Center, infoFont, infoPaint);
+	}
+
+	protected override void OnDestroy()
+	{
+		base.OnDestroy();
+		_currentBitmap?.Dispose();
+		_currentBitmap = null;
+		_codec?.Dispose();
+		_codec = null;
+		_encodedData?.Dispose();
+		_encodedData = null;
+	}
+}

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -39,6 +39,10 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 	public override bool IsAnimated => _codec != null && _codec.FrameCount > 1;
 
+	public override byte[]? DownloadBytes => _encodedData?.ToArray();
+	public override string DownloadFileName => "SkiaSharp-Animation.webp";
+	public override string DownloadMimeType => "image/webp";
+
 	public override IReadOnlyList<SampleControl> Controls =>
 	[
 		new SliderControl("quality", "Quality", 0, 100, _quality, 5),
@@ -62,7 +66,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 	protected override Task OnInit()
 	{
-		using var fontStream = SampleMedia.Fonts.InterVariable;
+		using var fontStream = SampleMedia.Fonts.Nabla;
 		_typeface = SKTypeface.FromStream(fontStream);
 		RebuildAnimation();
 		return base.OnInit();
@@ -155,9 +159,9 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 		// draw subtle star-like dots that drift
 		DrawStars(canvas, w, h, t);
 
-		// determine how many letters are visible and whether text is "on"
-		var visibleLetters = ComputeVisibleLetters(frame, letterCount);
-		if (visibleLetters <= 0)
+		// determine which letters are visible
+		var (visibleStart, visibleCount) = ComputeVisibleRange(frame, letterCount);
+		if (visibleCount <= 0)
 			return;
 
 		var fontSize = h * 0.28f;
@@ -168,15 +172,18 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 			IsAntialias = true,
 		};
 
-		// measure full text to centre it
-		var fullText = Text.Substring(0, visibleLetters);
-		var fullWidth = font.MeasureText(fullText, textPaint);
+		// measure full text to keep letters in stable positions
 		var totalWidth = font.MeasureText(Text, textPaint);
-		var x = (w - totalWidth) / 2f;
+		var startX = (w - totalWidth) / 2f;
 		var y = h / 2f + fontSize * 0.35f;
 
+		// advance past invisible leading letters
+		var x = startX;
+		for (var i = 0; i < visibleStart; i++)
+			x += font.MeasureText(Text[i].ToString(), textPaint);
+
 		// draw each visible letter with a slight glow
-		for (var i = 0; i < visibleLetters; i++)
+		for (var i = visibleStart; i < visibleStart + visibleCount; i++)
 		{
 			var ch = Text[i].ToString();
 			var charW = font.MeasureText(ch, textPaint);
@@ -196,37 +203,37 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 		}
 	}
 
-	private static int ComputeVisibleLetters(int frame, int letterCount)
+	private static (int start, int count) ComputeVisibleRange(int frame, int letterCount)
 	{
 		var phase = 0;
 
-		// Phase 1: appear
+		// Phase 1: appear (from first to last)
 		if (frame < letterCount)
-			return frame + 1;
+			return (0, frame + 1);
 		phase = frame - letterCount;
 
 		// Phase 2: hold (4)
 		if (phase < 4)
-			return letterCount;
+			return (0, letterCount);
 		phase -= 4;
 
 		// Phase 3-6: blink (off 2, on 2, off 2, on 2)
-		if (phase < 2) return 0;            // blink off
+		if (phase < 2) return (0, 0);            // blink off
 		phase -= 2;
-		if (phase < 2) return letterCount;  // blink on
+		if (phase < 2) return (0, letterCount);  // blink on
 		phase -= 2;
-		if (phase < 2) return 0;            // blink off
+		if (phase < 2) return (0, 0);            // blink off
 		phase -= 2;
-		if (phase < 2) return letterCount;  // blink on
+		if (phase < 2) return (0, letterCount);  // blink on
 		phase -= 2;
 
-		// Phase 7: disappear
+		// Phase 7: disappear (first letter goes first)
 		if (phase < letterCount)
-			return letterCount - phase - 1;
+			return (phase + 1, letterCount - phase - 1);
 		phase -= letterCount;
 
 		// Phase 8: empty pause
-		return 0;
+		return (0, 0);
 	}
 
 	private static void DrawStars(SKCanvas canvas, int w, int h, float t)
@@ -268,7 +275,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 		if (_codec == null || _encodedData == null || _currentBitmap == null)
 		{
 			using var errorPaint = new SKPaint { Color = SKColors.Red, IsAntialias = true };
-			using var errorFont = new SKFont { Size = 18 };
+			using var errorFont = new SKFont(SampleMedia.Fonts.Default, 18);
 			canvas.DrawText("Encoding failed", width / 2f, height / 2f, SKTextAlign.Center, errorFont, errorPaint);
 			return;
 		}
@@ -289,7 +296,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 		// info bar
 		using var infoPaint = new SKPaint { Color = new SKColor(200, 200, 200), IsAntialias = true };
-		using var infoFont = new SKFont { Size = 12 };
+		using var infoFont = new SKFont(SampleMedia.Fonts.Default, 12);
 		var infoText = $"Frames: {_codec.FrameCount}  |  {_encodedData.Size:N0} bytes  |  Frame {frameIndex + 1}/{_codec.FrameCount}";
 		canvas.DrawText(infoText, width / 2f, destRect.Bottom + 18, SKTextAlign.Center, infoFont, infoPaint);
 	}

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -8,27 +8,31 @@ namespace SkiaSharpSample.Samples;
 
 public class AnimatedWebpEncoderSample : CanvasSampleBase
 {
-	private int _frameCount = 4;
 	private float _quality = 80;
 	private int _compressionIndex;
-	private int _frameDuration = 250;
 
 	private SKData? _encodedData;
 	private SKCodec? _codec;
 	private int _currentFrame;
 	private SKBitmap? _currentBitmap;
+	private int _frameDurationMs;
 
 	private static readonly string[] CompressionOptions = { "Lossy", "Lossless" };
 
-	private static readonly SKColor[] FrameColors =
-	{
-		SKColors.Red, SKColors.Orange, SKColors.Yellow, SKColors.Green,
-		SKColors.Cyan, SKColors.Blue, SKColors.Purple, SKColors.Magenta,
-	};
+	private const string Text = "SkiaSharp";
+	private const int FrameWidth = 480;
+	private const int FrameHeight = 240;
+	private const int FrameDuration = 120;
+
+	// gradient colours for a loopable sky-like background
+	private static readonly SKColor TopStart = new SKColor(20, 30, 80);
+	private static readonly SKColor BottomStart = new SKColor(60, 90, 160);
+	private static readonly SKColor TopEnd = new SKColor(40, 50, 120);
+	private static readonly SKColor BottomEnd = new SKColor(80, 120, 200);
 
 	public override string Title => "Animated WebP Encoder";
 
-	public override string Description => "Encode multiple frames as an animated WebP, then decode and play it back.";
+	public override string Description => "Encode an animated WebP with letter-by-letter reveal, blink, and fade-out, then play it back.";
 
 	public override string Category => SampleCategories.General;
 
@@ -36,8 +40,6 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 	public override IReadOnlyList<SampleControl> Controls =>
 	[
-		new SliderControl("frames", "Frame Count", 2, 8, _frameCount, 1),
-		new SliderControl("duration", "Frame Duration (ms)", 50, 1000, _frameDuration, 50),
 		new SliderControl("quality", "Quality", 0, 100, _quality, 5),
 		new PickerControl("compression", "Compression", CompressionOptions, _compressionIndex),
 	];
@@ -46,12 +48,6 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 	{
 		switch (id)
 		{
-			case "frames":
-				_frameCount = (int)(float)value;
-				break;
-			case "duration":
-				_frameDuration = (int)(float)value;
-				break;
 			case "quality":
 				_quality = (float)value;
 				break;
@@ -71,37 +67,47 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 
 	protected override async Task OnUpdate(CancellationToken token)
 	{
-		await Task.Delay(Math.Max(16, _frameDuration), token);
+		await Task.Delay(Math.Max(16, _frameDurationMs), token);
 		if (_codec != null && _codec.FrameCount > 0)
 			_currentFrame = (_currentFrame + 1) % _codec.FrameCount;
 	}
 
 	private void RebuildAnimation()
 	{
-		_currentFrame = 0;
-		_currentBitmap?.Dispose();
-		_currentBitmap = null;
-		_codec?.Dispose();
-		_codec = null;
-		_encodedData?.Dispose();
-		_encodedData = null;
+		DisposeEncoded();
 
-		var size = 200;
-		var count = Math.Clamp(_frameCount, 2, FrameColors.Length);
+		// Phase 1: letters appear one by one  (Text.Length frames)
+		// Phase 2: full text visible           (4 frames)
+		// Phase 3: blink off                   (2 frames)
+		// Phase 4: blink on                    (2 frames)
+		// Phase 5: blink off                   (2 frames)
+		// Phase 6: blink on                    (2 frames)
+		// Phase 7: letters disappear one by one(Text.Length frames)
+		// Phase 8: empty pause                 (4 frames)  <- makes loop seamless
 
-		var frames = new SKWebpEncoderFrame[count];
-		var bitmaps = new SKBitmap[count];
-		var pixmaps = new SKPixmap[count];
+		var letterCount = Text.Length;
+		var totalFrames =
+			letterCount +    // appear
+			4 +              // hold
+			2 + 2 + 2 + 2 + // blink x2
+			letterCount +    // disappear
+			4;               // pause
+
+		var frames = new SKWebpEncoderFrame[totalFrames];
+		var bitmaps = new SKBitmap[totalFrames];
+		var pixmaps = new SKPixmap[totalFrames];
+
+		_frameDurationMs = FrameDuration;
 
 		try
 		{
-			for (var i = 0; i < count; i++)
+			for (var i = 0; i < totalFrames; i++)
 			{
-				bitmaps[i] = new SKBitmap(size, size);
+				bitmaps[i] = new SKBitmap(FrameWidth, FrameHeight);
 				using var canvas = new SKCanvas(bitmaps[i]);
-				DrawFrame(canvas, size, size, i, count);
+				DrawAnimationFrame(canvas, FrameWidth, FrameHeight, i, totalFrames, letterCount);
 				pixmaps[i] = bitmaps[i].PeekPixels();
-				frames[i] = new SKWebpEncoderFrame(pixmaps[i], _frameDuration);
+				frames[i] = new SKWebpEncoderFrame(pixmaps[i], FrameDuration);
 			}
 
 			var compression = _compressionIndex == 1
@@ -114,11 +120,12 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 			{
 				_codec = SKCodec.Create(_encodedData);
 				_currentBitmap = new SKBitmap(_codec!.Info);
+				_currentFrame = 0;
 			}
 		}
 		finally
 		{
-			for (var i = 0; i < count; i++)
+			for (var i = 0; i < totalFrames; i++)
 			{
 				pixmaps[i]?.Dispose();
 				bitmaps[i]?.Dispose();
@@ -128,36 +135,132 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 		Refresh();
 	}
 
-	private static void DrawFrame(SKCanvas canvas, int width, int height, int frameIndex, int totalFrames)
+	private static void DrawAnimationFrame(
+		SKCanvas canvas, int w, int h, int frame, int totalFrames, int letterCount)
 	{
-		var color = FrameColors[frameIndex % FrameColors.Length];
-		canvas.Clear(SKColors.White);
+		// interpolate background gradient across the timeline for subtle motion
+		var t = (float)frame / Math.Max(1, totalFrames - 1);
+		var top = LerpColor(TopStart, TopEnd, t);
+		var bottom = LerpColor(BottomStart, BottomEnd, t);
 
-		using var paint = new SKPaint
-		{
-			Color = color,
-			IsAntialias = true,
-			Style = SKPaintStyle.Fill,
-		};
+		using var bgPaint = new SKPaint();
+		bgPaint.Shader = SKShader.CreateLinearGradient(
+			new SKPoint(0, 0), new SKPoint(0, h),
+			new[] { top, bottom }, null, SKShaderTileMode.Clamp);
+		canvas.DrawRect(0, 0, w, h, bgPaint);
 
-		var cx = width / 2f;
-		var cy = height / 2f;
-		var radius = Math.Min(width, height) * 0.35f;
-		canvas.DrawCircle(cx, cy, radius, paint);
+		// draw subtle star-like dots that drift
+		DrawStars(canvas, w, h, t);
 
+		// determine how many letters are visible and whether text is "on"
+		var visibleLetters = ComputeVisibleLetters(frame, letterCount);
+		if (visibleLetters <= 0)
+			return;
+
+		var fontSize = h * 0.28f;
+		using var font = new SKFont { Size = fontSize };
 		using var textPaint = new SKPaint
 		{
 			Color = SKColors.White,
 			IsAntialias = true,
 		};
-		using var font = new SKFont { Size = radius * 0.6f };
-		var text = $"{frameIndex + 1}";
-		canvas.DrawText(text, cx, cy + font.Size * 0.35f, SKTextAlign.Center, font, textPaint);
+
+		// measure full text to centre it
+		var fullText = Text.Substring(0, visibleLetters);
+		var fullWidth = font.MeasureText(fullText, textPaint);
+		var totalWidth = font.MeasureText(Text, textPaint);
+		var x = (w - totalWidth) / 2f;
+		var y = h / 2f + fontSize * 0.35f;
+
+		// draw each visible letter with a slight glow
+		for (var i = 0; i < visibleLetters; i++)
+		{
+			var ch = Text[i].ToString();
+			var charW = font.MeasureText(ch, textPaint);
+
+			// glow
+			using var glowPaint = new SKPaint
+			{
+				Color = new SKColor(140, 180, 255, 90),
+				IsAntialias = true,
+				MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 6),
+			};
+			canvas.DrawText(ch, x, y, font, glowPaint);
+
+			// letter
+			canvas.DrawText(ch, x, y, font, textPaint);
+			x += charW;
+		}
+	}
+
+	private static int ComputeVisibleLetters(int frame, int letterCount)
+	{
+		var phase = 0;
+
+		// Phase 1: appear
+		if (frame < letterCount)
+			return frame + 1;
+		phase = frame - letterCount;
+
+		// Phase 2: hold (4)
+		if (phase < 4)
+			return letterCount;
+		phase -= 4;
+
+		// Phase 3-6: blink (off 2, on 2, off 2, on 2)
+		if (phase < 2) return 0;            // blink off
+		phase -= 2;
+		if (phase < 2) return letterCount;  // blink on
+		phase -= 2;
+		if (phase < 2) return 0;            // blink off
+		phase -= 2;
+		if (phase < 2) return letterCount;  // blink on
+		phase -= 2;
+
+		// Phase 7: disappear
+		if (phase < letterCount)
+			return letterCount - phase - 1;
+		phase -= letterCount;
+
+		// Phase 8: empty pause
+		return 0;
+	}
+
+	private static void DrawStars(SKCanvas canvas, int w, int h, float t)
+	{
+		// deterministic "random" star positions
+		var seed = 42;
+		using var starPaint = new SKPaint
+		{
+			Color = new SKColor(255, 255, 255, 60),
+			IsAntialias = true,
+		};
+
+		for (var i = 0; i < 30; i++)
+		{
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			var sx = (seed % w) + t * 12f;
+			sx %= w;
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			var sy = seed % h;
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			var sr = 1f + (seed % 20) / 20f;
+			canvas.DrawCircle(sx, sy, sr, starPaint);
+		}
+	}
+
+	private static SKColor LerpColor(SKColor a, SKColor b, float t)
+	{
+		return new SKColor(
+			(byte)(a.Red + (b.Red - a.Red) * t),
+			(byte)(a.Green + (b.Green - a.Green) * t),
+			(byte)(a.Blue + (b.Blue - a.Blue) * t),
+			(byte)(a.Alpha + (b.Alpha - a.Alpha) * t));
 	}
 
 	protected override void OnDrawSample(SKCanvas canvas, int width, int height)
 	{
-		canvas.Clear(SKColors.White);
+		canvas.Clear(SKColors.Black);
 
 		if (_codec == null || _encodedData == null || _currentBitmap == null)
 		{
@@ -171,31 +274,36 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 		var opts = new SKCodecOptions(frameIndex);
 		_codec.GetPixels(_currentBitmap.Info, _currentBitmap.GetPixels(), opts);
 
-		var scale = Math.Min((width - 20f) / _currentBitmap.Width, (height - 80f) / _currentBitmap.Height);
+		var scale = Math.Min((float)width / _currentBitmap.Width, (float)height / _currentBitmap.Height);
 		scale = Math.Min(scale, 2f);
 		var dw = _currentBitmap.Width * scale;
 		var dh = _currentBitmap.Height * scale;
 		var destRect = new SKRect(
-			(width - dw) / 2f, 10,
-			(width + dw) / 2f, 10 + dh);
+			(width - dw) / 2f, (height - dh) / 2f,
+			(width + dw) / 2f, (height + dh) / 2f);
 
 		canvas.DrawBitmap(_currentBitmap, destRect);
 
-		using var infoPaint = new SKPaint { Color = SKColors.Black, IsAntialias = true };
-		using var infoFont = new SKFont { Size = 14 };
-		var infoY = destRect.Bottom + 24;
-		var infoText = $"Frames: {_codec.FrameCount}  |  Size: {_encodedData.Size:N0} bytes  |  Frame: {frameIndex + 1}/{_codec.FrameCount}";
-		canvas.DrawText(infoText, width / 2f, infoY, SKTextAlign.Center, infoFont, infoPaint);
+		// info bar
+		using var infoPaint = new SKPaint { Color = new SKColor(200, 200, 200), IsAntialias = true };
+		using var infoFont = new SKFont { Size = 12 };
+		var infoText = $"Frames: {_codec.FrameCount}  |  {_encodedData.Size:N0} bytes  |  Frame {frameIndex + 1}/{_codec.FrameCount}";
+		canvas.DrawText(infoText, width / 2f, destRect.Bottom + 18, SKTextAlign.Center, infoFont, infoPaint);
 	}
 
-	protected override void OnDestroy()
+	private void DisposeEncoded()
 	{
-		base.OnDestroy();
 		_currentBitmap?.Dispose();
 		_currentBitmap = null;
 		_codec?.Dispose();
 		_codec = null;
 		_encodedData?.Dispose();
 		_encodedData = null;
+	}
+
+	protected override void OnDestroy()
+	{
+		base.OnDestroy();
+		DisposeEncoded();
 	}
 }

--- a/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
+++ b/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
@@ -2,297 +2,287 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace SkiaSharp.Tests
+namespace SkiaSharp.Tests;
+
+public class SKWebpEncoderTest : SKTest
 {
-	public class SKWebpEncoderTest : SKTest
+	private static SKBitmap CreateColorBitmap(SKColor color, int width = 40, int height = 40)
 	{
-		private static SKBitmap CreateColorBitmap(SKColor color, int width = 40, int height = 40)
-		{
-			var bmp = new SKBitmap(width, height);
-			bmp.Erase(color);
-			return bmp;
-		}
+		var bmp = new SKBitmap(width, height);
+		bmp.Erase(color);
+		return bmp;
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpReturnsData()
-		{
-			using var bmp1 = CreateColorBitmap(SKColors.Red);
-			using var bmp2 = CreateColorBitmap(SKColors.Blue);
-			using var pix1 = bmp1.PeekPixels();
-			using var pix2 = bmp2.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpReturnsData()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Blue);
+		using var pix1 = bmp1.PeekPixels();
+		using var pix2 = bmp2.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
-				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(200)),
-			};
+		SKWebpEncoderFrame[] frames =
+		[
+			new(pix1, TimeSpan.FromMilliseconds(100)),
+			new(pix2, TimeSpan.FromMilliseconds(200)),
+		];
 
-			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+		var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
 
-			Assert.NotNull(data);
-			Assert.True(data.Size > 0);
-		}
+		Assert.NotNull(data);
+		Assert.True(data.Size > 0);
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpToStream()
-		{
-			using var bmp1 = CreateColorBitmap(SKColors.Red);
-			using var bmp2 = CreateColorBitmap(SKColors.Green);
-			using var pix1 = bmp1.PeekPixels();
-			using var pix2 = bmp2.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpToStream()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Green);
+		using var pix1 = bmp1.PeekPixels();
+		using var pix2 = bmp2.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
-				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(200)),
-			};
+		SKWebpEncoderFrame[] frames =
+		[
+			new(pix1, TimeSpan.FromMilliseconds(100)),
+			new(pix2, TimeSpan.FromMilliseconds(200)),
+		];
 
-			using var stream = new MemoryStream();
-			var result = SKWebpEncoder.EncodeAnimated(stream, frames, SKWebpEncoderOptions.Default);
+		using var stream = new MemoryStream();
+		var result = SKWebpEncoder.EncodeAnimated(stream, frames, SKWebpEncoderOptions.Default);
 
-			Assert.True(result);
-			Assert.True(stream.Length > 0);
-		}
+		Assert.True(result);
+		Assert.True(stream.Length > 0);
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpWithWStream()
-		{
-			using var bmp1 = CreateColorBitmap(SKColors.Red);
-			using var bmp2 = CreateColorBitmap(SKColors.Blue);
-			using var pix1 = bmp1.PeekPixels();
-			using var pix2 = bmp2.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpWithWStream()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Blue);
+		using var pix1 = bmp1.PeekPixels();
+		using var pix2 = bmp2.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
-				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(200)),
-			};
+		SKWebpEncoderFrame[] frames =
+		[
+			new(pix1, TimeSpan.FromMilliseconds(100)),
+			new(pix2, TimeSpan.FromMilliseconds(200)),
+		];
 
-			using var wstream = new SKDynamicMemoryWStream();
-			var result = SKWebpEncoder.EncodeAnimated(wstream, frames, SKWebpEncoderOptions.Default);
+		using var wstream = new SKDynamicMemoryWStream();
+		var result = SKWebpEncoder.EncodeAnimated(wstream, frames, SKWebpEncoderOptions.Default);
 
-			Assert.True(result);
+		Assert.True(result);
 
-			using var data = wstream.DetachAsData();
-			Assert.NotNull(data);
-			Assert.True(data.Size > 0);
-		}
+		using var data = wstream.DetachAsData();
+		Assert.NotNull(data);
+		Assert.True(data.Size > 0);
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpRoundTrip()
-		{
-			using var bmp1 = CreateColorBitmap(SKColors.Red);
-			using var bmp2 = CreateColorBitmap(SKColors.Blue);
-			using var pix1 = bmp1.PeekPixels();
-			using var pix2 = bmp2.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpRoundTrip()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Blue);
+		using var pix1 = bmp1.PeekPixels();
+		using var pix2 = bmp2.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(150)),
-				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(250)),
-			};
+		SKWebpEncoderFrame[] frames =
+		[
+			new(pix1, TimeSpan.FromMilliseconds(150)),
+			new(pix2, TimeSpan.FromMilliseconds(250)),
+		];
 
-			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
-			Assert.NotNull(data);
+		var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+		Assert.NotNull(data);
 
-			using var codec = SKCodec.Create(data);
-			Assert.NotNull(codec);
-			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
-			Assert.True(codec.FrameCount >= 2, $"Expected at least 2 frames, got {codec.FrameCount}");
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		Assert.True(codec.FrameCount >= 2, $"Expected at least 2 frames, got {codec.FrameCount}");
 
-			var frameInfo = codec.FrameInfo;
-			Assert.True(frameInfo.Length >= 2, $"Expected at least 2 frame infos, got {frameInfo.Length}");
-			Assert.Equal(150, frameInfo[0].Duration);
-			Assert.Equal(250, frameInfo[1].Duration);
-		}
+		var frameInfo = codec.FrameInfo;
+		Assert.True(frameInfo.Length >= 2, $"Expected at least 2 frame infos, got {frameInfo.Length}");
+		Assert.Equal(150, frameInfo[0].Duration);
+		Assert.Equal(250, frameInfo[1].Duration);
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpWithLosslessCompression()
-		{
-			using var bmp1 = CreateColorBitmap(SKColors.Red);
-			using var bmp2 = CreateColorBitmap(SKColors.Green);
-			using var pix1 = bmp1.PeekPixels();
-			using var pix2 = bmp2.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpWithLosslessCompression()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Green);
+		using var pix1 = bmp1.PeekPixels();
+		using var pix2 = bmp2.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
-				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(100)),
-			};
+		SKWebpEncoderFrame[] frames =
+		[
+			new(pix1, TimeSpan.FromMilliseconds(100)),
+			new(pix2, TimeSpan.FromMilliseconds(100)),
+		];
 
-			var options = new SKWebpEncoderOptions(SKWebpEncoderCompression.Lossless, 75);
-			var data = SKWebpEncoder.EncodeAnimated(frames, options);
+		var options = new SKWebpEncoderOptions(SKWebpEncoderCompression.Lossless, 75);
+		var data = SKWebpEncoder.EncodeAnimated(frames, options);
 
-			Assert.NotNull(data);
+		Assert.NotNull(data);
 
-			using var codec = SKCodec.Create(data);
-			Assert.NotNull(codec);
-			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
-			Assert.True(codec.FrameCount >= 2, $"Expected at least 2 frames, got {codec.FrameCount}");
-		}
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		Assert.True(codec.FrameCount >= 2, $"Expected at least 2 frames, got {codec.FrameCount}");
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpWithNullWStreamThrows()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpWithNullWStreamThrows()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(100)),
-			};
+		SKWebpEncoderFrame[] frames = [new(pix, TimeSpan.FromMilliseconds(100))];
 
-			Assert.Throws<ArgumentNullException>(() =>
-				SKWebpEncoder.EncodeAnimated((SKWStream)null!, frames, SKWebpEncoderOptions.Default));
-		}
+		Assert.Throws<ArgumentNullException>(() =>
+			SKWebpEncoder.EncodeAnimated((SKWStream)null!, frames, SKWebpEncoderOptions.Default));
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpWithNullStreamThrows()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpWithNullStreamThrows()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(100)),
-			};
+		SKWebpEncoderFrame[] frames = [new(pix, TimeSpan.FromMilliseconds(100))];
 
-			Assert.Throws<ArgumentNullException>(() =>
-				SKWebpEncoder.EncodeAnimated((Stream)null!, frames, SKWebpEncoderOptions.Default));
-		}
+		Assert.Throws<ArgumentNullException>(() =>
+			SKWebpEncoder.EncodeAnimated((Stream)null!, frames, SKWebpEncoderOptions.Default));
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpFrameWithNullPixmapThrows()
-		{
-			Assert.Throws<ArgumentNullException>(() =>
-				new SKWebpEncoderFrame(null!, TimeSpan.FromMilliseconds(100)));
-		}
+	[SkippableFact]
+	public void EncodeAnimatedWebpFrameWithNullPixmapThrows()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			new SKWebpEncoderFrame(null!, TimeSpan.FromMilliseconds(100)));
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpSingleFrame()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpSingleFrame()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(500)),
-			};
+		SKWebpEncoderFrame[] frames = [new(pix, TimeSpan.FromMilliseconds(500))];
 
-			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
-			Assert.NotNull(data);
+		var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+		Assert.NotNull(data);
 
-			using var codec = SKCodec.Create(data);
-			Assert.NotNull(codec);
-			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
-		}
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpFrameDurationPreserved()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpFrameDurationPreserved()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			var frame = new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(300));
-			Assert.Equal(TimeSpan.FromMilliseconds(300), frame.Duration);
-			Assert.Same(pix, frame.Pixmap);
-		}
+		var frame = new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(300));
+		Assert.Equal(TimeSpan.FromMilliseconds(300), frame.Duration);
+		Assert.Same(pix, frame.Pixmap);
+	}
 
-		[SkippableFact]
-		public void EncodeAnimatedWebpPreservesImageDimensions()
-		{
-			using var bmp1 = CreateColorBitmap(SKColors.Red);
-			using var bmp2 = CreateColorBitmap(SKColors.Blue);
-			using var pix1 = bmp1.PeekPixels();
-			using var pix2 = bmp2.PeekPixels();
+	[SkippableFact]
+	public void EncodeAnimatedWebpPreservesImageDimensions()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Blue);
+		using var pix1 = bmp1.PeekPixels();
+		using var pix2 = bmp2.PeekPixels();
 
-			var frames = new SKWebpEncoderFrame[]
-			{
-				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
-				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(100)),
-			};
+		SKWebpEncoderFrame[] frames =
+		[
+			new(pix1, TimeSpan.FromMilliseconds(100)),
+			new(pix2, TimeSpan.FromMilliseconds(100)),
+		];
 
-			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
-			Assert.NotNull(data);
+		var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+		Assert.NotNull(data);
 
-			using var codec = SKCodec.Create(data);
-			Assert.NotNull(codec);
-			Assert.Equal(bmp1.Width, codec.Info.Width);
-			Assert.Equal(bmp1.Height, codec.Info.Height);
-		}
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(bmp1.Width, codec.Info.Width);
+		Assert.Equal(bmp1.Height, codec.Info.Height);
+	}
 
-		// Single-frame encoding via SKWebpEncoder
+	// Single-frame encoding via SKWebpEncoder
 
-		[SkippableFact]
-		public void EncodeSingleFrameReturnsData()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Green);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeSingleFrameReturnsData()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Green);
+		using var pix = bmp.PeekPixels();
 
-			var data = SKWebpEncoder.Encode(pix, SKWebpEncoderOptions.Default);
+		var data = SKWebpEncoder.Encode(pix, SKWebpEncoderOptions.Default);
 
-			Assert.NotNull(data);
-			Assert.True(data.Size > 0);
+		Assert.NotNull(data);
+		Assert.True(data.Size > 0);
 
-			using var codec = SKCodec.Create(data);
-			Assert.NotNull(codec);
-			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
-		}
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+	}
 
-		[SkippableFact]
-		public void EncodeSingleFrameToStream()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Blue);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeSingleFrameToStream()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Blue);
+		using var pix = bmp.PeekPixels();
 
-			using var stream = new MemoryStream();
-			var result = SKWebpEncoder.Encode(stream, pix, SKWebpEncoderOptions.Default);
+		using var stream = new MemoryStream();
+		var result = SKWebpEncoder.Encode(stream, pix, SKWebpEncoderOptions.Default);
 
-			Assert.True(result);
-			Assert.True(stream.Length > 0);
-		}
+		Assert.True(result);
+		Assert.True(stream.Length > 0);
+	}
 
-		[SkippableFact]
-		public void EncodeSingleFrameWithWStream()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeSingleFrameWithWStream()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			using var wstream = new SKDynamicMemoryWStream();
-			var result = SKWebpEncoder.Encode(wstream, pix, SKWebpEncoderOptions.Default);
+		using var wstream = new SKDynamicMemoryWStream();
+		var result = SKWebpEncoder.Encode(wstream, pix, SKWebpEncoderOptions.Default);
 
-			Assert.True(result);
+		Assert.True(result);
 
-			using var data = wstream.DetachAsData();
-			Assert.NotNull(data);
-			Assert.True(data.Size > 0);
-		}
+		using var data = wstream.DetachAsData();
+		Assert.NotNull(data);
+		Assert.True(data.Size > 0);
+	}
 
-		[SkippableFact]
-		public void EncodeSingleFrameWithNullPixmapThrows()
-		{
-			Assert.Throws<ArgumentNullException>(() =>
-				SKWebpEncoder.Encode((SKPixmap)null!, SKWebpEncoderOptions.Default));
-		}
+	[SkippableFact]
+	public void EncodeSingleFrameWithNullPixmapThrows()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			SKWebpEncoder.Encode((SKPixmap)null!, SKWebpEncoderOptions.Default));
+	}
 
-		[SkippableFact]
-		public void EncodeSingleFrameWithNullWStreamThrows()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeSingleFrameWithNullWStreamThrows()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			Assert.Throws<ArgumentNullException>(() =>
-				SKWebpEncoder.Encode((SKWStream)null!, pix, SKWebpEncoderOptions.Default));
-		}
+		Assert.Throws<ArgumentNullException>(() =>
+			SKWebpEncoder.Encode((SKWStream)null!, pix, SKWebpEncoderOptions.Default));
+	}
 
-		[SkippableFact]
-		public void EncodeSingleFrameWithNullStreamThrows()
-		{
-			using var bmp = CreateColorBitmap(SKColors.Red);
-			using var pix = bmp.PeekPixels();
+	[SkippableFact]
+	public void EncodeSingleFrameWithNullStreamThrows()
+	{
+		using var bmp = CreateColorBitmap(SKColors.Red);
+		using var pix = bmp.PeekPixels();
 
-			Assert.Throws<ArgumentNullException>(() =>
-				SKWebpEncoder.Encode((Stream)null!, pix, SKWebpEncoderOptions.Default));
-		}
+		Assert.Throws<ArgumentNullException>(() =>
+			SKWebpEncoder.Encode((Stream)null!, pix, SKWebpEncoderOptions.Default));
 	}
 }

--- a/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
+++ b/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
@@ -195,6 +195,7 @@ namespace SkiaSharp.Tests
 
 			var frame = new SKWebpEncoderFrame(pix, 300);
 			Assert.Equal(300, frame.Duration);
+			Assert.Same(pix, frame.Pixmap);
 		}
 
 		[SkippableFact]
@@ -218,6 +219,80 @@ namespace SkiaSharp.Tests
 			Assert.NotNull(codec);
 			Assert.Equal(bmp1.Width, codec.Info.Width);
 			Assert.Equal(bmp1.Height, codec.Info.Height);
+		}
+
+		// Single-frame encoding via SKWebpEncoder
+
+		[SkippableFact]
+		public void EncodeSingleFrameReturnsData()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Green);
+			using var pix = bmp.PeekPixels();
+
+			var data = SKWebpEncoder.Encode(pix, SKWebpEncoderOptions.Default);
+
+			Assert.NotNull(data);
+			Assert.True(data.Size > 0);
+
+			using var codec = SKCodec.Create(data);
+			Assert.NotNull(codec);
+			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		}
+
+		[SkippableFact]
+		public void EncodeSingleFrameToStream()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Blue);
+			using var pix = bmp.PeekPixels();
+
+			using var stream = new MemoryStream();
+			var result = SKWebpEncoder.Encode(stream, pix, SKWebpEncoderOptions.Default);
+
+			Assert.True(result);
+			Assert.True(stream.Length > 0);
+		}
+
+		[SkippableFact]
+		public void EncodeSingleFrameWithWStream()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			using var wstream = new SKDynamicMemoryWStream();
+			var result = SKWebpEncoder.Encode(wstream, pix, SKWebpEncoderOptions.Default);
+
+			Assert.True(result);
+
+			using var data = wstream.DetachAsData();
+			Assert.NotNull(data);
+			Assert.True(data.Size > 0);
+		}
+
+		[SkippableFact]
+		public void EncodeSingleFrameWithNullPixmapThrows()
+		{
+			Assert.Throws<ArgumentNullException>(() =>
+				SKWebpEncoder.Encode((SKPixmap)null!, SKWebpEncoderOptions.Default));
+		}
+
+		[SkippableFact]
+		public void EncodeSingleFrameWithNullWStreamThrows()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			Assert.Throws<ArgumentNullException>(() =>
+				SKWebpEncoder.Encode((SKWStream)null!, pix, SKWebpEncoderOptions.Default));
+		}
+
+		[SkippableFact]
+		public void EncodeSingleFrameWithNullStreamThrows()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			Assert.Throws<ArgumentNullException>(() =>
+				SKWebpEncoder.Encode((Stream)null!, pix, SKWebpEncoderOptions.Default));
 		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
+++ b/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
@@ -159,7 +159,7 @@ public class SKWebpEncoderTest : SKTest
 	public void EncodeAnimatedWebpFrameWithNullPixmapThrows()
 	{
 		Assert.Throws<ArgumentNullException>(() =>
-			new SKWebpEncoderFrame(null!, TimeSpan.FromMilliseconds(100)));
+			new SKWebpEncoderFrame((SKPixmap)null!, TimeSpan.FromMilliseconds(100)));
 	}
 
 	[SkippableFact]
@@ -284,5 +284,165 @@ public class SKWebpEncoderTest : SKTest
 
 		Assert.Throws<ArgumentNullException>(() =>
 			SKWebpEncoder.Encode((Stream)null!, pix, SKWebpEncoderOptions.Default));
+	}
+
+	// SKWebpEncoderFrame constructor overloads
+
+	[SkippableFact]
+	public void FrameFromBitmapEncodes()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Red);
+		using var bmp2 = CreateColorBitmap(SKColors.Blue);
+
+		SKWebpEncoderFrame[] frames =
+		[
+			new(bmp1, TimeSpan.FromMilliseconds(100)),
+			new(bmp2, TimeSpan.FromMilliseconds(200)),
+		];
+
+		var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+		Assert.NotNull(data);
+
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		Assert.True(codec.FrameCount >= 2);
+	}
+
+	[SkippableFact]
+	public void FrameFromImageEncodes()
+	{
+		using var bmp1 = CreateColorBitmap(SKColors.Green);
+		using var bmp2 = CreateColorBitmap(SKColors.Yellow);
+		using var img1 = SKImage.FromBitmap(bmp1);
+		using var img2 = SKImage.FromBitmap(bmp2);
+
+		SKWebpEncoderFrame[] frames =
+		[
+			new(img1, TimeSpan.FromMilliseconds(150)),
+			new(img2, TimeSpan.FromMilliseconds(250)),
+		];
+
+		var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+		Assert.NotNull(data);
+
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		Assert.True(codec.FrameCount >= 2);
+	}
+
+	[SkippableFact]
+	public void FrameFromNullBitmapThrows()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			new SKWebpEncoderFrame((SKBitmap)null!, TimeSpan.FromMilliseconds(100)));
+	}
+
+	[SkippableFact]
+	public void FrameFromNullImageThrows()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			new SKWebpEncoderFrame((SKImage)null!, TimeSpan.FromMilliseconds(100)));
+	}
+
+	// Full round-trip: encode → decode → validate pixels and durations
+
+	[SkippableFact]
+	public void FullRoundTripValidatesPixelsAndDurations()
+	{
+		var size = 40;
+		SKColor[] colors = [SKColors.Red, SKColors.Green, SKColors.Blue];
+		int[] durationsMs = [100, 200, 300];
+
+		// encode
+		var srcBitmaps = new SKBitmap[colors.Length];
+		var frames = new SKWebpEncoderFrame[colors.Length];
+		for (var i = 0; i < colors.Length; i++)
+		{
+			srcBitmaps[i] = CreateColorBitmap(colors[i], size, size);
+			frames[i] = new SKWebpEncoderFrame(srcBitmaps[i], TimeSpan.FromMilliseconds(durationsMs[i]));
+		}
+
+		var options = new SKWebpEncoderOptions(SKWebpEncoderCompression.Lossless, 75);
+		var data = SKWebpEncoder.EncodeAnimated(frames, options);
+		Assert.NotNull(data);
+
+		// decode
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		Assert.Equal(colors.Length, codec.FrameCount);
+		Assert.Equal(size, codec.Info.Width);
+		Assert.Equal(size, codec.Info.Height);
+
+		// validate each frame's duration and pixel content
+		var frameInfos = codec.FrameInfo;
+		Assert.Equal(colors.Length, frameInfos.Length);
+
+		for (var i = 0; i < colors.Length; i++)
+		{
+			// duration
+			Assert.Equal(durationsMs[i], frameInfos[i].Duration);
+
+			// decode frame pixels
+			var info = new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var decoded = new SKBitmap(info);
+			var result = codec.GetPixels(info, decoded.GetPixels(), new SKCodecOptions(i));
+			Assert.Equal(SKCodecResult.Success, result);
+
+			// compare center pixel to expected color (lossless should be exact)
+			var actual = decoded.GetPixel(size / 2, size / 2);
+			Assert.Equal(colors[i].Red, actual.Red);
+			Assert.Equal(colors[i].Green, actual.Green);
+			Assert.Equal(colors[i].Blue, actual.Blue);
+		}
+
+		// cleanup source bitmaps
+		foreach (var bmp in srcBitmaps)
+			bmp.Dispose();
+	}
+
+	[SkippableFact]
+	public void LossyRoundTripPreservesApproximateColors()
+	{
+		var size = 40;
+		SKColor[] colors = [SKColors.Red, SKColors.Blue];
+		int[] durationsMs = [150, 250];
+
+		var frames = new SKWebpEncoderFrame[colors.Length];
+		var srcBitmaps = new SKBitmap[colors.Length];
+		for (var i = 0; i < colors.Length; i++)
+		{
+			srcBitmaps[i] = CreateColorBitmap(colors[i], size, size);
+			frames[i] = new SKWebpEncoderFrame(srcBitmaps[i], TimeSpan.FromMilliseconds(durationsMs[i]));
+		}
+
+		var options = new SKWebpEncoderOptions(SKWebpEncoderCompression.Lossy, 100);
+		var data = SKWebpEncoder.EncodeAnimated(frames, options);
+		Assert.NotNull(data);
+
+		using var codec = SKCodec.Create(data);
+		Assert.NotNull(codec);
+		Assert.Equal(colors.Length, codec.FrameCount);
+
+		var frameInfos = codec.FrameInfo;
+		for (var i = 0; i < colors.Length; i++)
+		{
+			Assert.Equal(durationsMs[i], frameInfos[i].Duration);
+
+			var info = new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var decoded = new SKBitmap(info);
+			codec.GetPixels(info, decoded.GetPixels(), new SKCodecOptions(i));
+
+			// lossy at q100 should be close but not necessarily exact
+			var actual = decoded.GetPixel(size / 2, size / 2);
+			Assert.InRange(actual.Red, (byte)Math.Max(0, colors[i].Red - 10), (byte)Math.Min(255, colors[i].Red + 10));
+			Assert.InRange(actual.Green, (byte)Math.Max(0, colors[i].Green - 10), (byte)Math.Min(255, colors[i].Green + 10));
+			Assert.InRange(actual.Blue, (byte)Math.Max(0, colors[i].Blue - 10), (byte)Math.Min(255, colors[i].Blue + 10));
+		}
+
+		foreach (var bmp in srcBitmaps)
+			bmp.Dispose();
 	}
 }

--- a/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
+++ b/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
@@ -23,8 +23,8 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix1, 100),
-				new SKWebpEncoderFrame(pix2, 200),
+				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
+				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(200)),
 			};
 
 			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
@@ -43,8 +43,8 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix1, 100),
-				new SKWebpEncoderFrame(pix2, 200),
+				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
+				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(200)),
 			};
 
 			using var stream = new MemoryStream();
@@ -64,8 +64,8 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix1, 100),
-				new SKWebpEncoderFrame(pix2, 200),
+				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
+				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(200)),
 			};
 
 			using var wstream = new SKDynamicMemoryWStream();
@@ -88,8 +88,8 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix1, 150),
-				new SKWebpEncoderFrame(pix2, 250),
+				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(150)),
+				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(250)),
 			};
 
 			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
@@ -116,8 +116,8 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix1, 100),
-				new SKWebpEncoderFrame(pix2, 100),
+				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
+				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(100)),
 			};
 
 			var options = new SKWebpEncoderOptions(SKWebpEncoderCompression.Lossless, 75);
@@ -139,7 +139,7 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix, 100),
+				new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(100)),
 			};
 
 			Assert.Throws<ArgumentNullException>(() =>
@@ -154,7 +154,7 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix, 100),
+				new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(100)),
 			};
 
 			Assert.Throws<ArgumentNullException>(() =>
@@ -165,7 +165,7 @@ namespace SkiaSharp.Tests
 		public void EncodeAnimatedWebpFrameWithNullPixmapThrows()
 		{
 			Assert.Throws<ArgumentNullException>(() =>
-				new SKWebpEncoderFrame(null!, 100));
+				new SKWebpEncoderFrame(null!, TimeSpan.FromMilliseconds(100)));
 		}
 
 		[SkippableFact]
@@ -176,7 +176,7 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix, 500),
+				new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(500)),
 			};
 
 			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
@@ -193,8 +193,8 @@ namespace SkiaSharp.Tests
 			using var bmp = CreateColorBitmap(SKColors.Red);
 			using var pix = bmp.PeekPixels();
 
-			var frame = new SKWebpEncoderFrame(pix, 300);
-			Assert.Equal(300, frame.Duration);
+			var frame = new SKWebpEncoderFrame(pix, TimeSpan.FromMilliseconds(300));
+			Assert.Equal(TimeSpan.FromMilliseconds(300), frame.Duration);
 			Assert.Same(pix, frame.Pixmap);
 		}
 
@@ -208,8 +208,8 @@ namespace SkiaSharp.Tests
 
 			var frames = new SKWebpEncoderFrame[]
 			{
-				new SKWebpEncoderFrame(pix1, 100),
-				new SKWebpEncoderFrame(pix2, 100),
+				new SKWebpEncoderFrame(pix1, TimeSpan.FromMilliseconds(100)),
+				new SKWebpEncoderFrame(pix2, TimeSpan.FromMilliseconds(100)),
 			};
 
 			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);

--- a/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
+++ b/tests/Tests/SkiaSharp/SKWebpEncoderTest.cs
@@ -1,0 +1,223 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace SkiaSharp.Tests
+{
+	public class SKWebpEncoderTest : SKTest
+	{
+		private static SKBitmap CreateColorBitmap(SKColor color, int width = 40, int height = 40)
+		{
+			var bmp = new SKBitmap(width, height);
+			bmp.Erase(color);
+			return bmp;
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpReturnsData()
+		{
+			using var bmp1 = CreateColorBitmap(SKColors.Red);
+			using var bmp2 = CreateColorBitmap(SKColors.Blue);
+			using var pix1 = bmp1.PeekPixels();
+			using var pix2 = bmp2.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix1, 100),
+				new SKWebpEncoderFrame(pix2, 200),
+			};
+
+			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+
+			Assert.NotNull(data);
+			Assert.True(data.Size > 0);
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpToStream()
+		{
+			using var bmp1 = CreateColorBitmap(SKColors.Red);
+			using var bmp2 = CreateColorBitmap(SKColors.Green);
+			using var pix1 = bmp1.PeekPixels();
+			using var pix2 = bmp2.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix1, 100),
+				new SKWebpEncoderFrame(pix2, 200),
+			};
+
+			using var stream = new MemoryStream();
+			var result = SKWebpEncoder.EncodeAnimated(stream, frames, SKWebpEncoderOptions.Default);
+
+			Assert.True(result);
+			Assert.True(stream.Length > 0);
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpWithWStream()
+		{
+			using var bmp1 = CreateColorBitmap(SKColors.Red);
+			using var bmp2 = CreateColorBitmap(SKColors.Blue);
+			using var pix1 = bmp1.PeekPixels();
+			using var pix2 = bmp2.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix1, 100),
+				new SKWebpEncoderFrame(pix2, 200),
+			};
+
+			using var wstream = new SKDynamicMemoryWStream();
+			var result = SKWebpEncoder.EncodeAnimated(wstream, frames, SKWebpEncoderOptions.Default);
+
+			Assert.True(result);
+
+			using var data = wstream.DetachAsData();
+			Assert.NotNull(data);
+			Assert.True(data.Size > 0);
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpRoundTrip()
+		{
+			using var bmp1 = CreateColorBitmap(SKColors.Red);
+			using var bmp2 = CreateColorBitmap(SKColors.Blue);
+			using var pix1 = bmp1.PeekPixels();
+			using var pix2 = bmp2.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix1, 150),
+				new SKWebpEncoderFrame(pix2, 250),
+			};
+
+			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+			Assert.NotNull(data);
+
+			using var codec = SKCodec.Create(data);
+			Assert.NotNull(codec);
+			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+			Assert.True(codec.FrameCount >= 2, $"Expected at least 2 frames, got {codec.FrameCount}");
+
+			var frameInfo = codec.FrameInfo;
+			Assert.True(frameInfo.Length >= 2, $"Expected at least 2 frame infos, got {frameInfo.Length}");
+			Assert.Equal(150, frameInfo[0].Duration);
+			Assert.Equal(250, frameInfo[1].Duration);
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpWithLosslessCompression()
+		{
+			using var bmp1 = CreateColorBitmap(SKColors.Red);
+			using var bmp2 = CreateColorBitmap(SKColors.Green);
+			using var pix1 = bmp1.PeekPixels();
+			using var pix2 = bmp2.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix1, 100),
+				new SKWebpEncoderFrame(pix2, 100),
+			};
+
+			var options = new SKWebpEncoderOptions(SKWebpEncoderCompression.Lossless, 75);
+			var data = SKWebpEncoder.EncodeAnimated(frames, options);
+
+			Assert.NotNull(data);
+
+			using var codec = SKCodec.Create(data);
+			Assert.NotNull(codec);
+			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+			Assert.True(codec.FrameCount >= 2, $"Expected at least 2 frames, got {codec.FrameCount}");
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpWithNullWStreamThrows()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix, 100),
+			};
+
+			Assert.Throws<ArgumentNullException>(() =>
+				SKWebpEncoder.EncodeAnimated((SKWStream)null!, frames, SKWebpEncoderOptions.Default));
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpWithNullStreamThrows()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix, 100),
+			};
+
+			Assert.Throws<ArgumentNullException>(() =>
+				SKWebpEncoder.EncodeAnimated((Stream)null!, frames, SKWebpEncoderOptions.Default));
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpFrameWithNullPixmapThrows()
+		{
+			Assert.Throws<ArgumentNullException>(() =>
+				new SKWebpEncoderFrame(null!, 100));
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpSingleFrame()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix, 500),
+			};
+
+			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+			Assert.NotNull(data);
+
+			using var codec = SKCodec.Create(data);
+			Assert.NotNull(codec);
+			Assert.Equal(SKEncodedImageFormat.Webp, codec.EncodedFormat);
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpFrameDurationPreserved()
+		{
+			using var bmp = CreateColorBitmap(SKColors.Red);
+			using var pix = bmp.PeekPixels();
+
+			var frame = new SKWebpEncoderFrame(pix, 300);
+			Assert.Equal(300, frame.Duration);
+		}
+
+		[SkippableFact]
+		public void EncodeAnimatedWebpPreservesImageDimensions()
+		{
+			using var bmp1 = CreateColorBitmap(SKColors.Red);
+			using var bmp2 = CreateColorBitmap(SKColors.Blue);
+			using var pix1 = bmp1.PeekPixels();
+			using var pix2 = bmp2.PeekPixels();
+
+			var frames = new SKWebpEncoderFrame[]
+			{
+				new SKWebpEncoderFrame(pix1, 100),
+				new SKWebpEncoderFrame(pix2, 100),
+			};
+
+			var data = SKWebpEncoder.EncodeAnimated(frames, SKWebpEncoderOptions.Default);
+			Assert.NotNull(data);
+
+			using var codec = SKCodec.Create(data);
+			Assert.NotNull(codec);
+			Assert.Equal(bmp1.Width, codec.Info.Width);
+			Assert.Equal(bmp1.Height, codec.Info.Height);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add animated WebP encoding support to SkiaSharp by wrapping `SkWebpEncoder::EncodeAnimated` (available since Skia m107).

Fixes #3768

### New API surface

**`SKWebpEncoderFrame`** — struct holding frame data with three constructor overloads:
```csharp
new SKWebpEncoderFrame(pixmap, TimeSpan.FromMilliseconds(150));
new SKWebpEncoderFrame(bitmap, TimeSpan.FromMilliseconds(150));
new SKWebpEncoderFrame(image, TimeSpan.FromMilliseconds(150));   // raster-backed only
```

**`SKWebpEncoder`** — new static class with 6 methods:

| Method | Returns | Description |
|--------|---------|-------------|
| `Encode(SKWStream, SKPixmap, SKWebpEncoderOptions)` | `bool` | Single-frame encode to stream |
| `Encode(Stream, SKPixmap, SKWebpEncoderOptions)` | `bool` | Single-frame encode to .NET stream |
| `Encode(SKPixmap, SKWebpEncoderOptions)` | `SKData?` | Single-frame encode to data |
| `EncodeAnimated(SKWStream, ReadOnlySpan<SKWebpEncoderFrame>, SKWebpEncoderOptions)` | `bool` | Multi-frame encode to stream |
| `EncodeAnimated(Stream, ReadOnlySpan<SKWebpEncoderFrame>, SKWebpEncoderOptions)` | `bool` | Multi-frame encode to .NET stream |
| `EncodeAnimated(ReadOnlySpan<SKWebpEncoderFrame>, SKWebpEncoderOptions)` | `SKData?` | Multi-frame encode to data |

### Design decisions

- **GC-safe**: Public `SKWebpEncoderFrame` holds the `SKPixmap` instance (not just a handle), preventing GC collection during encoding. Internal `SKWebpEncoderFrameNative` is the P/Invoke struct.
- **Alloc-free**: Frame conversion uses `Utils.RentArray` (pooled arrays).
- **`ReadOnlySpan<T>`** for frames input per API design rules.
- **`TimeSpan`** for duration instead of raw `int` milliseconds.
- **Convenience constructors**: `SKBitmap` and `SKImage` overloads call `PeekPixels()` internally so users pass what they have.
- Reuses existing `SKWebpEncoderOptions` — no new options needed.

### Changes

| Layer | Files |
|-------|-------|
| C API (mono/skia) | `sk_types.h`, `sk_pixmap.h`, `sk_pixmap.cpp` — merged as mono/skia#199 |
| Submodule | `externals/skia` pointed to merged skiasharp tip |
| Bindings config | `libSkiaSharp.json` — `SKWebpEncoderFrameNative` (internal) |
| Generated | `SkiaApi.generated.cs` — P/Invoke + native struct |
| C# wrapper | `Definitions.cs` (frame struct with 3 ctors), `SKWebpEncoder.cs` (static class) |
| Tests | `SKWebpEncoderTest.cs` — 23 tests |
| Gallery | `AnimatedWebpEncoderSample.cs` — Nabla font letter reveal animation with download |

### Tests

23 tests covering:
- Round-trip encode/decode with frame count and duration verification
- Full pixel validation for lossless (exact) and lossy (approximate) modes
- All three stream variants (SKWStream, Stream, SKData)
- Lossless and lossy compression modes
- Null validation for all parameters
- SKBitmap and SKImage constructor overloads
- Single-frame and multi-frame encoding
- Image dimension preservation

<details><summary>Squash commit message</summary>

```
Add animated WebP encoding support (SKWebpEncoder) (#3771)

Context: https://github.com/mono/SkiaSharp/issues/3768
Fixes: https://github.com/mono/SkiaSharp/issues/3768
Changes: https://github.com/mono/skia/pull/199

SkiaSharp can decode animated WebP via SKCodec frame APIs but has no
way to encode them. Skia added SkWebpEncoder::EncodeAnimated in m107,
which accepts an array of frames (pixmap + duration) and writes a
single animated WebP file — widely used for stickers, short animations,
and efficient animated content.

Wrap EncodeAnimated through the full C API → P/Invoke → C# pipeline:

  * C API (mono/skia#199): new sk_webpencoder_frame_t struct and
    sk_webpencoder_encode_animated function with manual conversion
    (pointer-vs-value pixmap mismatch prevents DEF_MAP)
  * SKWebpEncoderFrame: public struct holding SKPixmap + TimeSpan
    duration, with convenience constructors for SKBitmap and SKImage
    that call PeekPixels internally; keeps managed objects alive for
    GC safety. Internal SKWebpEncoderFrameNative is the P/Invoke
    layout struct
  * SKWebpEncoder: new static class with six methods — three
    single-frame Encode and three animated EncodeAnimated overloads
    accepting ReadOnlySpan<SKWebpEncoderFrame> with pooled array
    conversion via Utils.RentArray
  * 23 tests covering round-trip pixel validation (lossless exact,
    lossy approximate), frame durations, all stream variants,
    constructor overloads, null validation, and dimension preservation
  * Gallery: AnimatedWebpEncoderSample with Nabla font letter-reveal
    animation on a night-sky background with download button

Co-authored-by: Matthew Leibowitz <mattleibow@live.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
```

</details>