### PR TITLE
Update SKIASHARP version to 4.147.0

### DIFF
--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.133.0
+  SKIASHARP_VERSION: 4.147.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
This pull request updates the SkiaSharp dependency version in the Azure pipeline variables file to ensure the build uses the latest compatible version.

Dependency version update:

* Updated `SKIASHARP_VERSION` in `scripts/azure-templates-variables.yml` from `4.133.0` to `4.147.0` to match the latest SkiaSharp NuGet version.