### PR TITLE
fix: reuse same PR for release notes workflow

### DIFF
--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -155,16 +155,11 @@ def compute_pr_effort(pr: dict) -> dict:
     commit_count = len(commits)
     unique_days = set()
 
-    # Collect SkiaSharp PR author logins and names for filtering skia commits
-    pr_author = pr.get("author", {}).get("login", "")
-    pr_authors = {pr_author} if pr_author else set()
+    # Collect SkiaSharp PR author names for filtering skia commits
     pr_author_names = set()
     for c in commits:
         for a in c.get("authors", []):
-            login = a.get("login", "")
             name = a.get("name", "")
-            if login:
-                pr_authors.add(login)
             if name:
                 pr_author_names.add(name)
 
@@ -185,7 +180,7 @@ def compute_pr_effort(pr: dict) -> dict:
     skia_commits = 0
     if skia_pr_num:
         skia_commits, skia_days = _fetch_skia_pr_effort(
-            skia_pr_num, pr_authors, pr_author_names)
+            skia_pr_num, pr_author_names)
         unique_days |= skia_days
 
     return {
@@ -196,70 +191,19 @@ def compute_pr_effort(pr: dict) -> dict:
 
 
 def _fetch_skia_pr_effort(
-    pr_num: str, author_logins: set[str], author_names: set[str]
+    pr_num: str, author_names: set[str]
 ) -> tuple[int, set[str]]:
-    """Fetch effort from a mono/skia PR, filtering to known authors.
+    """Fetch effort from a mono/skia PR using git log on the submodule.
 
-    Large skia merge PRs can have thousands of upstream commits. The GitHub
-    API silently truncates commit lists (gh pr view caps at 100), so we
-    compare the returned count against the PR's actual commit total. When
-    truncated we fall back to git log via the submodule (externals/skia).
+    Uses the skia submodule directly to avoid GitHub API commit truncation
+    (the API caps at 100-250 commits, but skia merge PRs can have thousands).
+    Filters commits by author name to count only work by the SkiaSharp PR
+    contributors, excluding unrelated upstream Skia committers.
 
     Returns (commit_count, set_of_date_strings).
     """
-    try:
-        meta = json.loads(gh(["pr", "view", pr_num, "--repo", SKIA_REPO,
-                               "--json", "commits"]))
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
-        return 0, set()
-
-    api_commits = meta.get("commits", [])
-
-    # Check actual commit count from the REST API
-    try:
-        total_str = gh(["api", f"repos/{SKIA_REPO}/pulls/{pr_num}",
-                         "--jq", ".commits"])
-        total_commits = int(total_str)
-    except (subprocess.CalledProcessError, ValueError):
-        total_commits = len(api_commits)
-
-    # If API returned the full list, use it directly
-    if len(api_commits) >= total_commits:
-        return _filter_skia_commits_api(api_commits, author_logins)
-
-    # Truncated — fall back to git log via submodule for accurate data
-    return _filter_skia_commits_git(pr_num, author_logins, author_names)
-
-
-def _filter_skia_commits_api(
-    commits: list[dict], author_logins: set[str]
-) -> tuple[int, set[str]]:
-    """Filter API commit data by author login."""
-    count = 0
-    days = set()
-    for c in commits:
-        c_authors = {a.get("login", "") for a in c.get("authors", [])}
-        if not c_authors & author_logins:
-            continue
-        count += 1
-        date_str = c.get("committedDate") or c.get("authoredDate", "")
-        if date_str:
-            days.add(date_str[:10])
-    return count, days
-
-
-def _filter_skia_commits_git(
-    pr_num: str, author_logins: set[str], author_names: set[str]
-) -> tuple[int, set[str]]:
-    """Use git log on the submodule for large PRs where the API truncates.
-
-    Fetches the PR head commit, finds the merge base with the PR's base
-    branch, then filters git log by author name.
-    """
     skia_dir = Path("externals/skia")
     if not (skia_dir / ".git").exists():
-        print(f"  Skia submodule not available, skipping git log for skia#{pr_num}",
-              file=sys.stderr)
         return 0, set()
 
     try:
@@ -272,19 +216,14 @@ def _filter_skia_commits_git(
         return 0, set()
 
     # Fetch the head commit into the submodule
-    try:
-        run(["git", "-C", str(skia_dir), "fetch", "origin", head_sha, "--quiet"],
-            check=False)
-    except Exception:
-        return 0, set()
+    run(["git", "-C", str(skia_dir), "fetch", "origin", head_sha, "--quiet"],
+        check=False)
 
-    # Verify we have the commits
+    # Verify we have both commits
     try:
         run(["git", "-C", str(skia_dir), "cat-file", "-e", head_sha])
         run(["git", "-C", str(skia_dir), "cat-file", "-e", base_sha])
     except subprocess.CalledProcessError:
-        print(f"  Cannot resolve commits for skia#{pr_num}, skipping git log",
-              file=sys.stderr)
         return 0, set()
 
     # Get all commits in the PR range with author and date

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -36,8 +36,13 @@ from typing import Optional
 REPO = "mono/SkiaSharp"
 RELEASES_DIR = Path("documentation/docfx/releases")
 
+SKIA_REPO = "mono/skia"
+SKIA_PR_PATTERNS = [
+    re.compile(r"(?:companion|related)\s+(?:skia\s+)?pr[:\s]+https?://github\.com/mono/skia/pull/(\d+)", re.IGNORECASE),
+    re.compile(r"https?://github\.com/mono/skia/pull/(\d+)"),
+]
 
-# ── Helpers ──────────────────────────────────────────────────────────
+
 
 
 def run(args: list[str], check: bool = True) -> str:
@@ -140,15 +145,62 @@ def generate_raw_version_page(base_version: str, releases: list[dict]) -> str:
 
 
 def compute_pr_effort(pr: dict) -> dict:
-    """Compute commit count and unique working days from PR commit data."""
+    """Compute commit count and unique working days from PR commit data.
+
+    If the PR body references a companion mono/skia PR, fetches that PR's
+    commits too and merges the effort (only counting authors from the
+    SkiaSharp PR to exclude unrelated upstream Skia committers).
+    """
     commits = pr.get("commits", [])
     commit_count = len(commits)
     unique_days = set()
+
+    # Collect SkiaSharp PR author logins for filtering skia commits
+    pr_author = pr.get("author", {}).get("login", "")
+    pr_authors = {pr_author} if pr_author else set()
+    for c in commits:
+        for a in c.get("authors", []):
+            login = a.get("login", "")
+            if login:
+                pr_authors.add(login)
+
     for c in commits:
         date_str = c.get("committedDate") or c.get("authoredDate", "")
         if date_str:
             unique_days.add(date_str[:10])  # YYYY-MM-DD
-    return {"commitCount": commit_count, "workingDays": len(unique_days)}
+
+    # Look for companion skia PR in the body
+    skia_pr_num = None
+    body = pr.get("body") or ""
+    for pattern in SKIA_PR_PATTERNS:
+        m = pattern.search(body)
+        if m:
+            skia_pr_num = m.group(1)
+            break
+
+    skia_commits = 0
+    if skia_pr_num:
+        try:
+            raw = gh(["pr", "view", skia_pr_num, "--repo", SKIA_REPO,
+                       "--json", "commits"])
+            skia_pr = json.loads(raw)
+            for c in skia_pr.get("commits", []):
+                # Only count commits from authors on the SkiaSharp PR
+                c_authors = {a.get("login", "") for a in c.get("authors", [])}
+                if not c_authors & pr_authors:
+                    continue
+                skia_commits += 1
+                date_str = c.get("committedDate") or c.get("authoredDate", "")
+                if date_str:
+                    unique_days.add(date_str[:10])
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            pass
+
+    return {
+        "commitCount": commit_count + skia_commits,
+        "workingDays": len(unique_days),
+        "skiaPr": int(skia_pr_num) if skia_pr_num else None,
+    }
 
 
 # ── Unreleased data ─────────────────────────────────────────────────
@@ -215,7 +267,7 @@ def get_unreleased_prs(tag: str) -> list[dict]:
     for i, num in enumerate(pr_numbers, 1):
         try:
             raw = gh(["pr", "view", str(num), "--repo", REPO,
-                      "--json", "title,author,url,number,labels,mergedAt,commits"])
+                      "--json", "title,author,url,number,labels,mergedAt,commits,body"])
             pr = json.loads(raw)
             pr.update(compute_pr_effort(pr))
             prs.append(pr)
@@ -243,8 +295,10 @@ def generate_raw_unreleased(prs: list[dict], tag: str) -> str:
         commits = pr.get("commitCount", 0)
         days = pr.get("workingDays", 0)
         effort = f" ({commits} commit{'s' if commits != 1 else ''}, {days} day{'s' if days != 1 else ''})"
+        skia_pr = pr.get("skiaPr")
+        skia_str = f" (skia: mono/skia#{skia_pr})" if skia_pr else ""
 
-        lines.append(f"- {title} by @{author} in {url}{labels_str}{effort}")
+        lines.append(f"- {title} by @{author} in {url}{labels_str}{effort}{skia_str}")
 
     lines.append("")
     return "\n".join(lines)

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -155,14 +155,18 @@ def compute_pr_effort(pr: dict) -> dict:
     commit_count = len(commits)
     unique_days = set()
 
-    # Collect SkiaSharp PR author logins for filtering skia commits
+    # Collect SkiaSharp PR author logins and names for filtering skia commits
     pr_author = pr.get("author", {}).get("login", "")
     pr_authors = {pr_author} if pr_author else set()
+    pr_author_names = set()
     for c in commits:
         for a in c.get("authors", []):
             login = a.get("login", "")
+            name = a.get("name", "")
             if login:
                 pr_authors.add(login)
+            if name:
+                pr_author_names.add(name)
 
     for c in commits:
         date_str = c.get("committedDate") or c.get("authoredDate", "")
@@ -180,27 +184,131 @@ def compute_pr_effort(pr: dict) -> dict:
 
     skia_commits = 0
     if skia_pr_num:
-        try:
-            raw = gh(["pr", "view", skia_pr_num, "--repo", SKIA_REPO,
-                       "--json", "commits"])
-            skia_pr = json.loads(raw)
-            for c in skia_pr.get("commits", []):
-                # Only count commits from authors on the SkiaSharp PR
-                c_authors = {a.get("login", "") for a in c.get("authors", [])}
-                if not c_authors & pr_authors:
-                    continue
-                skia_commits += 1
-                date_str = c.get("committedDate") or c.get("authoredDate", "")
-                if date_str:
-                    unique_days.add(date_str[:10])
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
-            pass
+        skia_commits, skia_days = _fetch_skia_pr_effort(
+            skia_pr_num, pr_authors, pr_author_names)
+        unique_days |= skia_days
 
     return {
         "commitCount": commit_count + skia_commits,
         "workingDays": len(unique_days),
         "skiaPr": int(skia_pr_num) if skia_pr_num else None,
     }
+
+
+def _fetch_skia_pr_effort(
+    pr_num: str, author_logins: set[str], author_names: set[str]
+) -> tuple[int, set[str]]:
+    """Fetch effort from a mono/skia PR, filtering to known authors.
+
+    Large skia merge PRs can have thousands of upstream commits. The GitHub
+    API silently truncates commit lists (gh pr view caps at 100), so we
+    compare the returned count against the PR's actual commit total. When
+    truncated we fall back to git log via the submodule (externals/skia).
+
+    Returns (commit_count, set_of_date_strings).
+    """
+    try:
+        meta = json.loads(gh(["pr", "view", pr_num, "--repo", SKIA_REPO,
+                               "--json", "commits"]))
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return 0, set()
+
+    api_commits = meta.get("commits", [])
+
+    # Check actual commit count from the REST API
+    try:
+        total_str = gh(["api", f"repos/{SKIA_REPO}/pulls/{pr_num}",
+                         "--jq", ".commits"])
+        total_commits = int(total_str)
+    except (subprocess.CalledProcessError, ValueError):
+        total_commits = len(api_commits)
+
+    # If API returned the full list, use it directly
+    if len(api_commits) >= total_commits:
+        return _filter_skia_commits_api(api_commits, author_logins)
+
+    # Truncated — fall back to git log via submodule for accurate data
+    return _filter_skia_commits_git(pr_num, author_logins, author_names)
+
+
+def _filter_skia_commits_api(
+    commits: list[dict], author_logins: set[str]
+) -> tuple[int, set[str]]:
+    """Filter API commit data by author login."""
+    count = 0
+    days = set()
+    for c in commits:
+        c_authors = {a.get("login", "") for a in c.get("authors", [])}
+        if not c_authors & author_logins:
+            continue
+        count += 1
+        date_str = c.get("committedDate") or c.get("authoredDate", "")
+        if date_str:
+            days.add(date_str[:10])
+    return count, days
+
+
+def _filter_skia_commits_git(
+    pr_num: str, author_logins: set[str], author_names: set[str]
+) -> tuple[int, set[str]]:
+    """Use git log on the submodule for large PRs where the API truncates.
+
+    Fetches the PR head commit, finds the merge base with the PR's base
+    branch, then filters git log by author name.
+    """
+    skia_dir = Path("externals/skia")
+    if not (skia_dir / ".git").exists():
+        print(f"  Skia submodule not available, skipping git log for skia#{pr_num}",
+              file=sys.stderr)
+        return 0, set()
+
+    try:
+        meta = json.loads(
+            gh(["api", f"repos/{SKIA_REPO}/pulls/{pr_num}",
+                "--jq", "{base_sha: .base.sha, head_sha: .head.sha}"]))
+        base_sha = meta["base_sha"]
+        head_sha = meta["head_sha"]
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
+        return 0, set()
+
+    # Fetch the head commit into the submodule
+    try:
+        run(["git", "-C", str(skia_dir), "fetch", "origin", head_sha, "--quiet"],
+            check=False)
+    except Exception:
+        return 0, set()
+
+    # Verify we have the commits
+    try:
+        run(["git", "-C", str(skia_dir), "cat-file", "-e", head_sha])
+        run(["git", "-C", str(skia_dir), "cat-file", "-e", base_sha])
+    except subprocess.CalledProcessError:
+        print(f"  Cannot resolve commits for skia#{pr_num}, skipping git log",
+              file=sys.stderr)
+        return 0, set()
+
+    # Get all commits in the PR range with author and date
+    log_output = run([
+        "git", "-C", str(skia_dir), "log",
+        "--format=%ad\t%an", "--date=short",
+        f"{base_sha}..{head_sha}",
+    ], check=False)
+
+    if not log_output:
+        return 0, set()
+
+    count = 0
+    days = set()
+    for line in log_output.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        date_str, author_name = parts
+        if author_name in author_names:
+            count += 1
+            days.add(date_str)
+
+    return count, days
 
 
 # ── Unreleased data ─────────────────────────────────────────────────

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -139,6 +139,18 @@ def generate_raw_version_page(base_version: str, releases: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def compute_pr_effort(pr: dict) -> dict:
+    """Compute commit count and unique working days from PR commit data."""
+    commits = pr.get("commits", [])
+    commit_count = len(commits)
+    unique_days = set()
+    for c in commits:
+        date_str = c.get("committedDate") or c.get("authoredDate", "")
+        if date_str:
+            unique_days.add(date_str[:10])  # YYYY-MM-DD
+    return {"commitCount": commit_count, "workingDays": len(unique_days)}
+
+
 # ── Unreleased data ─────────────────────────────────────────────────
 
 
@@ -203,8 +215,10 @@ def get_unreleased_prs(tag: str) -> list[dict]:
     for i, num in enumerate(pr_numbers, 1):
         try:
             raw = gh(["pr", "view", str(num), "--repo", REPO,
-                      "--json", "title,author,url,number,labels,mergedAt"])
-            prs.append(json.loads(raw))
+                      "--json", "title,author,url,number,labels,mergedAt,commits"])
+            pr = json.loads(raw)
+            pr.update(compute_pr_effort(pr))
+            prs.append(pr)
         except (subprocess.CalledProcessError, json.JSONDecodeError):
             continue
         if i % 20 == 0:
@@ -226,8 +240,11 @@ def generate_raw_unreleased(prs: list[dict], tag: str) -> str:
         number = pr.get("number", "")
         label_names = [l.get("name", "") for l in pr.get("labels", [])]
         labels_str = f" [{', '.join(label_names)}]" if label_names else ""
+        commits = pr.get("commitCount", 0)
+        days = pr.get("workingDays", 0)
+        effort = f" ({commits} commit{'s' if commits != 1 else ''}, {days} day{'s' if days != 1 else ''})"
 
-        lines.append(f"- {title} by @{author} in {url}{labels_str}")
+        lines.append(f"- {title} by @{author} in {url}{labels_str}{effort}")
 
     lines.append("")
     return "\n".join(lines)

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -117,15 +117,3 @@ No fence markers or placeholders needed — the workflow overwrites the whole fi
 
 Always use `dev/upcoming-release-notes` as the branch name when creating the pull request.
 This ensures each workflow run updates the **same PR** instead of opening a new one.
-
-Before finishing, close any other open documentation PRs with stale release notes:
-
-```bash
-gh pr list --repo mono/SkiaSharp --state open --label documentation --search "[docs]" --json number,headRefName
-```
-
-Close any whose branch is NOT `dev/upcoming-release-notes`:
-
-```bash
-gh pr close {number} --repo mono/SkiaSharp --comment "Superseded by the current release notes PR."
-```

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -112,3 +112,20 @@ The file should follow the template structure exactly — title, blockquote head
 then the polished sections (Highlights, Breaking Changes, New Features, etc.).
 
 No fence markers or placeholders needed — the workflow overwrites the whole file each run.
+
+## Step 6 — Create or update the pull request
+
+Always use `dev/upcoming-release-notes` as the branch name when creating the pull request.
+This ensures each workflow run updates the **same PR** instead of opening a new one.
+
+Before finishing, close any other open documentation PRs with stale release notes:
+
+```bash
+gh pr list --repo mono/SkiaSharp --state open --label documentation --search "[docs]" --json number,headRefName
+```
+
+Close any whose branch is NOT `dev/upcoming-release-notes`:
+
+```bash
+gh pr close {number} --repo mono/SkiaSharp --comment "Superseded by the current release notes PR."
+```


### PR DESCRIPTION
## Summary

Improves the "Update Upcoming Release Notes" agentic workflow and the `generate-release-notes.py` script with two changes: PR reuse and effort metrics.

## PR Reuse

The workflow was creating a new PR on every run because the agent picked a unique branch name each time (e.g., `dev/release-notes-4.147.0-b431d55e1660d280`).

**Fix:** Added Step 6 instructing the agent to always use `dev/upcoming-release-notes` as the branch name. The `create_pull_request` safe-output detects the existing PR on that branch and updates it in place.

## Effort Metrics

Each PR in the unreleased notes output now shows commit count and working days, giving a sense of effort and complexity:

```
- Variable font support by @ramezgerges (24 commits, 6 days) (skia: mono/skia#185)
- Quick typo fix by @contributor (1 commit, 1 day)
```

### How it works

1. **SkiaSharp PR commits** — fetched via `gh pr view --json commits`. All commits counted, unique calendar days collected.
2. **Companion skia PR detection** — parses the PR body for `mono/skia/pull/NNN` links (patterns like "Companion Skia PR:", "Related skia PR:", or bare URLs).
3. **Skia PR effort via git log** — uses `git log` on the `externals/skia` submodule with `base_sha..head_sha` range. Only counts commits by authors who also appear in the SkiaSharp PR (filtering out thousands of unrelated upstream Skia committers). The GitHub API caps at 100 commits per PR, so git log is the only reliable approach for large merge PRs (e.g., skia milestone bumps with 4000+ commits).

### Example impact

| PR | Before | After |
|----|--------|-------|
| #3702 Bump skia m147 | — | 87 commits, 8 days |
| #3560 Bump skia m132 | — | 44 commits, 12 days |
| #3703 Variable fonts | — | 24 commits, 6 days |
| #3742 Color palettes | — | 56 commits, 6 days |

## Changes

- `.github/workflows/update-release-notes.md` — Added Step 6 for fixed branch name
- `.agents/skills/release-notes/scripts/generate-release-notes.py` — Added effort metrics with companion skia PR support