### PR TITLE
fix: replace obsolete SKPath methods with SKPathBuilder in FillPathSample

### DIFF
--- a/samples/Gallery/Shared/Samples/FillPathSample.cs
+++ b/samples/Gallery/Shared/Samples/FillPathSample.cs
@@ -128,23 +128,23 @@ new ToggleControl("showOriginal", "Show Original Path", showOriginal),
 
 	private static SKPath CreateRoundedRectPath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var rect = new SKRect(cx - size, cy - size * 0.6f, cx + size, cy + size * 0.6f);
 		var rrect = new SKRoundRect(rect, size * 0.2f);
-		path.AddRoundRect(rrect);
-		return path;
+		builder.AddRoundRect(rrect);
+		return builder.Detach();
 	}
 
 	private static SKPath CreateCirclePath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
-		path.AddCircle(cx, cy, size);
-		return path;
+		using var builder = new SKPathBuilder();
+		builder.AddCircle(cx, cy, size);
+		return builder.Detach();
 	}
 
 	private static SKPath CreateSpiralPath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var turns = 4;
 		var pointsPerTurn = 60;
 		var totalPoints = turns * pointsPerTurn;
@@ -158,35 +158,35 @@ new ToggleControl("showOriginal", "Show Original Path", showOriginal),
 			var y = cy + radius * (float)Math.Sin(angle);
 
 			if (i == 0)
-				path.MoveTo(x, y);
+				builder.MoveTo(x, y);
 			else
-				path.LineTo(x, y);
+				builder.LineTo(x, y);
 		}
 
-		return path;
+		return builder.Detach();
 	}
 
 	private static SKPath CreateArrowPath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var shaftWidth = size * 0.3f;
 		var headWidth = size * 0.8f;
 
-		path.MoveTo(cx - size, cy + shaftWidth / 2);
-		path.LineTo(cx - size, cy - shaftWidth / 2);
-		path.LineTo(cx, cy - shaftWidth / 2);
-		path.LineTo(cx, cy - headWidth / 2);
-		path.LineTo(cx + size * 0.7f, cy);
-		path.LineTo(cx, cy + headWidth / 2);
-		path.LineTo(cx, cy + shaftWidth / 2);
-		path.Close();
+		builder.MoveTo(cx - size, cy + shaftWidth / 2);
+		builder.LineTo(cx - size, cy - shaftWidth / 2);
+		builder.LineTo(cx, cy - shaftWidth / 2);
+		builder.LineTo(cx, cy - headWidth / 2);
+		builder.LineTo(cx + size * 0.7f, cy);
+		builder.LineTo(cx, cy + headWidth / 2);
+		builder.LineTo(cx, cy + shaftWidth / 2);
+		builder.Close();
 
-		return path;
+		return builder.Detach();
 	}
 
 	private static SKPath CreateStarPath(float cx, float cy, float outerRadius, float innerRadius, int points)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var totalPoints = points * 2;
 		for (var i = 0; i < totalPoints; i++)
 		{
@@ -196,11 +196,11 @@ new ToggleControl("showOriginal", "Show Original Path", showOriginal),
 			var y = cy + radius * (float)Math.Sin(angle);
 
 			if (i == 0)
-				path.MoveTo(x, y);
+				builder.MoveTo(x, y);
 			else
-				path.LineTo(x, y);
+				builder.LineTo(x, y);
 		}
-		path.Close();
-		return path;
+		builder.Close();
+		return builder.Detach();
 	}
 }

--- a/samples/_UnoPlatformSamples.targets
+++ b/samples/_UnoPlatformSamples.targets
@@ -10,6 +10,7 @@
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" ExcludeAssets="all" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.Views.WPF" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.2" ExcludeAssets="all" />
@@ -20,6 +21,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" ExcludeAssets="all" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.1" ExcludeAssets="all" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.1" ExcludeAssets="all" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.1" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/_UnoPlatformSamples.targets
+++ b/samples/_UnoPlatformSamples.targets
@@ -4,8 +4,38 @@
     <ProjectReference Remove="@(ProjectReference)" />
   </ItemGroup>
 
+  <!-- The Uno SDK injects PackageReferences for SkiaSharp packages through
+       Uno.Implicit.Packages (gated on UnoFeatures containing SkiaRenderer).
+       Those NuGet packages conflict with the in-tree ProjectReferences below
+       in three ways:
+
+       1. Duplicate assemblies (CS1704 error): the NuGet package and the
+          in-tree ProjectReference both produce the same assembly name.
+          Affects: SkiaSharp, SkiaSharp.Views.Uno.WinUI, SkiaSharp.HarfBuzz,
+          HarfBuzzSharp, and all Views/Desktop packages.
+
+       2. Version conflicts (MSB3243/MSB3277 warning): the Uno SDK pins
+          packages at 3.x while in-tree builds produce 4.x. The resolver
+          either picks 3.x (wrong) or gives up. Affects: SkiaSharp.Skottie,
+          SkiaSharp.Resources, SkiaSharp.SceneGraph — packages that the Uno
+          SDK injects as direct references and that also flow in transitively
+          from in-tree at a higher version.
+
+       3. Duplicate native symbols (wasm-ld error): NativeAssets NuGet
+          packages supply a pre-built libSkiaSharp.a / libHarfBuzzSharp.a,
+          but IncludeNativeAssets.*.targets also adds the locally-built copy.
+          The linker sees both and fails with duplicate symbols.
+          Affects: SkiaSharp.NativeAssets.WebAssembly,
+          HarfBuzzSharp.NativeAssets.WebAssembly, and all other
+          platform-specific NativeAssets packages.
+
+       ExcludeAssets="all" keeps each package in the graph (satisfying the
+       Uno SDK's direct reference) but prevents it from contributing any
+       assets — the real code comes from the ProjectReferences below and
+       the locally-built natives from IncludeNativeAssets.*.targets. -->
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.119.2" ExcludeAssets="all" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.Views.WinUI" Version="3.119.2" ExcludeAssets="all" Condition="$(TargetFramework.Contains('-windows'))" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" ExcludeAssets="all" />
@@ -26,6 +56,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\binding\SkiaSharp\SkiaSharp.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\binding\SkiaSharp.Skottie\SkiaSharp.Skottie.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\source\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Problem

The `build-site.yml` workflow is failing because `FillPathSample.cs` uses obsolete `SKPath` mutation methods (`MoveTo`, `LineTo`, `Close`, `AddRoundRect`, `AddCircle`) that now produce `CS0618` errors.

## Fix

Migrated all five path-building helper methods to use `SKPathBuilder` and `Detach()` instead of mutating `SKPath` directly, matching the pattern already used by other gallery samples (e.g. `PathBuilderSample.cs`).