### PR TITLE
[samples] Fix Skottie package downgrade NU1605 in Uno gallery

### DIFF
--- a/binding/IncludeNativeAssets.HarfBuzzSharp.targets
+++ b/binding/IncludeNativeAssets.HarfBuzzSharp.targets
@@ -63,8 +63,13 @@
     <NativeReference Include="$(MSBuildThisFileDirectory)..\output\native\tvos\libHarfBuzzSharp.framework" Kind="Framework" Condition="!$(RuntimeIdentifier.StartsWith('tvossimulator'))" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
+    <_HarfBuzzSharpNativeBinaryType Condition="'$(WasmEnableThreads)' == 'True'">mt</_HarfBuzzSharpNativeBinaryType>
+    <_HarfBuzzSharpNativeBinaryType Condition="'$(WasmEnableThreads)' != 'True'">st</_HarfBuzzSharpNativeBinaryType>
+    <_HarfBuzzSharpNativeBinaryType Condition="'$(WasmEnableSIMD)' == 'True'">$(_HarfBuzzSharpNativeBinaryType),simd</_HarfBuzzSharpNativeBinaryType>
+  </PropertyGroup>
   <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
-    <Content Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libHarfBuzzSharp.a\**\*.a" Visible="false" />
+    <Content Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libHarfBuzzSharp.a\*\$(_HarfBuzzSharpNativeBinaryType)\*.a" Visible="false" />
   </ItemGroup>
 
   <PropertyGroup Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true')">

--- a/binding/IncludeNativeAssets.SkiaSharp.targets
+++ b/binding/IncludeNativeAssets.SkiaSharp.targets
@@ -63,10 +63,13 @@
     <NativeReference Include="$(MSBuildThisFileDirectory)..\output\native\tvos\libSkiaSharp.framework" Kind="Framework" Condition="!$(RuntimeIdentifier.StartsWith('tvossimulator'))" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
+    <_SkiaSharpNativeBinaryType Condition="'$(WasmEnableThreads)' == 'True'">mt</_SkiaSharpNativeBinaryType>
+    <_SkiaSharpNativeBinaryType Condition="'$(WasmEnableThreads)' != 'True'">st</_SkiaSharpNativeBinaryType>
+    <_SkiaSharpNativeBinaryType Condition="'$(WasmEnableSIMD)' == 'True'">$(_SkiaSharpNativeBinaryType),simd</_SkiaSharpNativeBinaryType>
+  </PropertyGroup>
   <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
-    <Content Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\**\*.a" Visible="false" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly'">
+    <Content Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\*\$(_SkiaSharpNativeBinaryType)\*.a" Visible="false" />
     <WasmShellExtraEmccFlags Include="-s USE_WEBGL2=1"/>
     <WasmShellExtraEmccFlags Condition="'$(WasmShellEnableThreads)'=='True'" Include="-s OFFSCREEN_FRAMEBUFFER=1" />
   </ItemGroup>

--- a/samples/Gallery/Shared/Samples/FillPathSample.cs
+++ b/samples/Gallery/Shared/Samples/FillPathSample.cs
@@ -128,23 +128,23 @@ new ToggleControl("showOriginal", "Show Original Path", showOriginal),
 
 	private static SKPath CreateRoundedRectPath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var rect = new SKRect(cx - size, cy - size * 0.6f, cx + size, cy + size * 0.6f);
 		var rrect = new SKRoundRect(rect, size * 0.2f);
-		path.AddRoundRect(rrect);
-		return path;
+		builder.AddRoundRect(rrect);
+		return builder.Detach();
 	}
 
 	private static SKPath CreateCirclePath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
-		path.AddCircle(cx, cy, size);
-		return path;
+		using var builder = new SKPathBuilder();
+		builder.AddCircle(cx, cy, size);
+		return builder.Detach();
 	}
 
 	private static SKPath CreateSpiralPath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var turns = 4;
 		var pointsPerTurn = 60;
 		var totalPoints = turns * pointsPerTurn;
@@ -158,35 +158,35 @@ new ToggleControl("showOriginal", "Show Original Path", showOriginal),
 			var y = cy + radius * (float)Math.Sin(angle);
 
 			if (i == 0)
-				path.MoveTo(x, y);
+				builder.MoveTo(x, y);
 			else
-				path.LineTo(x, y);
+				builder.LineTo(x, y);
 		}
 
-		return path;
+		return builder.Detach();
 	}
 
 	private static SKPath CreateArrowPath(float cx, float cy, float size)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var shaftWidth = size * 0.3f;
 		var headWidth = size * 0.8f;
 
-		path.MoveTo(cx - size, cy + shaftWidth / 2);
-		path.LineTo(cx - size, cy - shaftWidth / 2);
-		path.LineTo(cx, cy - shaftWidth / 2);
-		path.LineTo(cx, cy - headWidth / 2);
-		path.LineTo(cx + size * 0.7f, cy);
-		path.LineTo(cx, cy + headWidth / 2);
-		path.LineTo(cx, cy + shaftWidth / 2);
-		path.Close();
+		builder.MoveTo(cx - size, cy + shaftWidth / 2);
+		builder.LineTo(cx - size, cy - shaftWidth / 2);
+		builder.LineTo(cx, cy - shaftWidth / 2);
+		builder.LineTo(cx, cy - headWidth / 2);
+		builder.LineTo(cx + size * 0.7f, cy);
+		builder.LineTo(cx, cy + headWidth / 2);
+		builder.LineTo(cx, cy + shaftWidth / 2);
+		builder.Close();
 
-		return path;
+		return builder.Detach();
 	}
 
 	private static SKPath CreateStarPath(float cx, float cy, float outerRadius, float innerRadius, int points)
 	{
-		var path = new SKPath();
+		using var builder = new SKPathBuilder();
 		var totalPoints = points * 2;
 		for (var i = 0; i < totalPoints; i++)
 		{
@@ -196,11 +196,11 @@ new ToggleControl("showOriginal", "Show Original Path", showOriginal),
 			var y = cy + radius * (float)Math.Sin(angle);
 
 			if (i == 0)
-				path.MoveTo(x, y);
+				builder.MoveTo(x, y);
 			else
-				path.LineTo(x, y);
+				builder.LineTo(x, y);
 		}
-		path.Close();
-		return path;
+		builder.Close();
+		return builder.Detach();
 	}
 }

--- a/samples/Gallery/Uno/SkiaSharpSample.Uno.csproj
+++ b/samples/Gallery/Uno/SkiaSharpSample.Uno.csproj
@@ -41,6 +41,23 @@
     <ProjectReference Include="..\Shared\SkiaSharpSample.Shared.csproj" />
   </ItemGroup>
 
+  <!-- Pin SkiaSharp.Skottie because Uno.Sdk's Uno.Implicit.Packages.ProjectSystem.Uno.targets
+       (gated on the SkiaRenderer UnoFeature above) injects SkiaSharp.Skottie as a *direct*
+       PackageReference. SkiaSharpSample.Shared brings Skottie 4.x in transitively; the Uno
+       SDK's direct ref pegs the floor at 3.x, so NuGet's resolver fires NU1605 (downgrade
+       of a direct ref against a transitive higher version). Other SkiaSharp packages
+       (SkiaSharp itself, HarfBuzzSharp, SkiaSharp.HarfBuzz) reach the gallery only
+       transitively from both directions, so the resolver picks the higher version and no
+       NU1605 fires — Skottie is the only one with this asymmetry.
+       Re-stating Skottie here as a direct ref puts samples-generate's version-substitution
+       in charge of the floor (it bumps to whatever VERSIONS.txt has — currently 4.147.0),
+       lining up with what Shared asks for. ExcludeAssets="all" keeps the package from
+       contributing assets — the actual Skottie code keeps coming from Shared in the
+       generated build, and from _UnoPlatformSamples.targets's project reference in-tree. -->
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp.Skottie" Version="3.119.2" ExcludeAssets="all" />
+  </ItemGroup>
+
   <Import Project="..\..\..\binding\IncludeNativeAssets.SkiaSharp.targets" />
   <Import Project="..\..\..\binding\IncludeNativeAssets.HarfBuzzSharp.targets" />
   <Import Project="..\..\..\binding\IncludeNativeAssets.SkiaSharp.WinUI.targets" Condition="$(TargetFramework.Contains('-windows'))" />

--- a/samples/_UnoPlatformSamples.targets
+++ b/samples/_UnoPlatformSamples.targets
@@ -10,6 +10,7 @@
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" ExcludeAssets="all" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.Views.WPF" Version="3.119.2" ExcludeAssets="all" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.2" ExcludeAssets="all" />
@@ -20,6 +21,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" ExcludeAssets="all" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.1" ExcludeAssets="all" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.1" ExcludeAssets="all" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.1" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/_UnoPlatformSamples.targets
+++ b/samples/_UnoPlatformSamples.targets
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\binding\SkiaSharp\SkiaSharp.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\binding\SkiaSharp.Skottie\SkiaSharp.Skottie.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\binding\HarfBuzzSharp\HarfBuzzSharp.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\source\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz.csproj" />
   </ItemGroup>


### PR DESCRIPTION
After bumping SkiaSharp to 4.147.0, the generated samples flow (`dotnet cake --target=samples-generate`) fails restore on `output/samples/Gallery/Uno/SkiaSharpSample.Uno.csproj` with:

    Error NU1605: Detected package downgrade: SkiaSharp.Skottie from
    4.147.0 to 3.119.2.
      SkiaSharpSample.Uno -> SkiaSharpSample.Shared -> SkiaSharp.Skottie (>= 4.147.0)
      SkiaSharpSample.Uno -> SkiaSharp.Skottie (>= 3.119.2)

`SkiaSharpSample.Shared` brings in Skottie 4.147.0 (its in-tree ProjectReference is rewritten to a PackageReference 4.147.0 by samples-generate). The Uno gallery csproj has no direct Skottie ref; the only "near" Skottie in its closure comes from Uno.WinUI.Lottie at 3.119.2, which NuGet's resolver flags as a downgrade against the deeper 4.147.0 ask from Shared.

The targets file is the right place to declare the Skottie ProjectReference (matching the SkiaSharp / HarfBuzzSharp pattern), but samples-generate strips imports of `samples/_UnoPlatformSamples.targets` along with the file itself — so a PackageReference there alone would not propagate to the generated csproj. The direct PackageReference in the gallery csproj is what actually fixes the generated build: samples-generate's version-substitution bumps it to whatever's in VERSIONS.txt, putting the floor at 4.x and shadowing Lottie's transitive 3.x.

Two changes:
- `samples/_UnoPlatformSamples.targets`: add the in-tree `SkiaSharp.Skottie` ProjectReference next to the existing SkiaSharp / HarfBuzzSharp ones.
- `samples/Gallery/Uno/SkiaSharpSample.Uno.csproj`: pin Skottie with `ExcludeAssets="all"` so the package only constrains the version floor; the actual Skottie code keeps coming from Shared (in the generated build) or the in-tree project ref via the targets file (in the local build). A duplicate PackageReference here AND in the targets file trips NU1504 (and Uno.Implicit.Packages chokes on it), so the targets file holds only the ProjectReference.

**Description of Change**

<!-- Describe your changes here. -->

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
