### PR TITLE
[samples] Add Hero Image gallery sample

### DIFF
--- a/samples/Gallery/Shared/Media/skiasharp-logo.svg
+++ b/samples/Gallery/Shared/Media/skiasharp-logo.svg
@@ -1,0 +1,1247 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1024"
+   height="1024"
+   viewBox="0 0 1024 1024"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   sodipodi:docname="NewSkiaSharpLogo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2305">
+      <stop
+         style="stop-color:#070705;stop-opacity:1;"
+         offset="0"
+         id="stop2301" />
+      <stop
+         id="stop2309"
+         offset="0.4778702"
+         style="stop-color:#20201f;stop-opacity:1" />
+      <stop
+         style="stop-color:#070807;stop-opacity:1"
+         offset="1"
+         id="stop2303" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2297">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop2293" />
+      <stop
+         style="stop-color:#070705;stop-opacity:1"
+         offset="1"
+         id="stop2295" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2281">
+      <stop
+         style="stop-color:#3c3a42;stop-opacity:1;"
+         offset="0"
+         id="stop2277" />
+      <stop
+         id="stop2311"
+         offset="0.49087396"
+         style="stop-color:#2f2f2f;stop-opacity:1" />
+      <stop
+         style="stop-color:#333333;stop-opacity:1"
+         offset="1"
+         id="stop2279" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1972">
+      <stop
+         style="stop-color:#1d2a60;stop-opacity:1"
+         offset="0"
+         id="stop1968" />
+      <stop
+         id="stop1976"
+         offset="0.51409215"
+         style="stop-color:#2b3f90;stop-opacity:1" />
+      <stop
+         style="stop-color:#2f459d;stop-opacity:1"
+         offset="1"
+         id="stop1970" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1954">
+      <stop
+         style="stop-color:#b54935;stop-opacity:1"
+         offset="0"
+         id="stop1950" />
+      <stop
+         id="stop1958"
+         offset="0.51787269"
+         style="stop-color:#bf4d38;stop-opacity:1" />
+      <stop
+         style="stop-color:#c04e38;stop-opacity:1"
+         offset="1"
+         id="stop1952" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1936">
+      <stop
+         style="stop-color:#76a142;stop-opacity:1"
+         offset="0"
+         id="stop1932" />
+      <stop
+         id="stop1940"
+         offset="0.66958076"
+         style="stop-color:#7ba745;stop-opacity:1" />
+      <stop
+         style="stop-color:#6f983e;stop-opacity:1"
+         offset="1"
+         id="stop1934" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1785">
+      <stop
+         style="stop-color:#101734;stop-opacity:1"
+         offset="0"
+         id="stop1781" />
+      <stop
+         id="stop1791"
+         offset="0.30385667"
+         style="stop-color:#2e4398;stop-opacity:1" />
+      <stop
+         style="stop-color:#141d41;stop-opacity:1"
+         offset="0.68230569"
+         id="stop1793" />
+      <stop
+         id="stop1795"
+         offset="0.74748218"
+         style="stop-color:#2a3e8e;stop-opacity:1;" />
+      <stop
+         style="stop-color:#2f459d;stop-opacity:1"
+         offset="1"
+         id="stop1783" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1777">
+      <stop
+         style="stop-color:#b24834;stop-opacity:1"
+         offset="0"
+         id="stop1773" />
+      <stop
+         style="stop-color:#cc523b;stop-opacity:1"
+         offset="1"
+         id="stop1775" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1771">
+      <stop
+         style="stop-color:#cf523c;stop-opacity:1"
+         offset="0"
+         id="stop1767" />
+      <stop
+         style="stop-color:#d9573f;stop-opacity:1"
+         offset="1"
+         id="stop1769" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1757">
+      <stop
+         style="stop-color:#567630;stop-opacity:1"
+         offset="0"
+         id="stop1753" />
+      <stop
+         style="stop-color:#7ba745;stop-opacity:1"
+         offset="1"
+         id="stop1755" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1741">
+      <stop
+         style="stop-color:#76a142;stop-opacity:1"
+         offset="0"
+         id="stop1737" />
+      <stop
+         style="stop-color:#54732f;stop-opacity:1"
+         offset="1"
+         id="stop1739" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1733">
+      <stop
+         style="stop-color:#54732f;stop-opacity:1"
+         offset="0"
+         id="stop1729" />
+      <stop
+         style="stop-color:#7ba745;stop-opacity:1"
+         offset="1"
+         id="stop1731" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1551">
+      <stop
+         style="stop-color:#d89e6c;stop-opacity:1"
+         offset="0"
+         id="stop1547" />
+      <stop
+         id="stop1555"
+         offset="0.20815833"
+         style="stop-color:#ce7737;stop-opacity:1" />
+      <stop
+         style="stop-color:#d39468;stop-opacity:1"
+         offset="1"
+         id="stop1549" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1543">
+      <stop
+         style="stop-color:#c69670;stop-opacity:1"
+         offset="0"
+         id="stop1539" />
+      <stop
+         style="stop-color:#d09369;stop-opacity:1"
+         offset="1"
+         id="stop1541" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1535">
+      <stop
+         style="stop-color:#d7b398;stop-opacity:1"
+         offset="0"
+         id="stop1531" />
+      <stop
+         style="stop-color:#d2a178;stop-opacity:1"
+         offset="1"
+         id="stop1533" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1527">
+      <stop
+         style="stop-color:#f7c9a5;stop-opacity:1"
+         offset="0"
+         id="stop1523" />
+      <stop
+         style="stop-color:#f7d6c5;stop-opacity:1"
+         offset="1"
+         id="stop1525" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1507">
+      <stop
+         style="stop-color:#eec197;stop-opacity:1"
+         offset="0"
+         id="stop1503" />
+      <stop
+         style="stop-color:#f6c0a2;stop-opacity:1"
+         offset="1"
+         id="stop1505" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1497">
+      <stop
+         style="stop-color:#a55930;stop-opacity:1"
+         offset="0"
+         id="stop1493" />
+      <stop
+         style="stop-color:#f3be99;stop-opacity:1"
+         offset="1"
+         id="stop1495" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1256">
+      <stop
+         style="stop-color:#c4734b;stop-opacity:1"
+         offset="0"
+         id="stop1252" />
+      <stop
+         id="stop1260"
+         offset="0.11108784"
+         style="stop-color:#f4c094;stop-opacity:1" />
+      <stop
+         style="stop-color:#e4c3a8;stop-opacity:1"
+         offset="0.22403972"
+         id="stop1262" />
+      <stop
+         id="stop1264"
+         offset="0.36538956"
+         style="stop-color:#dbae86;stop-opacity:1" />
+      <stop
+         style="stop-color:#ca8961;stop-opacity:1"
+         offset="0.49608418"
+         id="stop1266" />
+      <stop
+         id="stop1268"
+         offset="0.6344502"
+         style="stop-color:#c98451;stop-opacity:1" />
+      <stop
+         style="stop-color:#d89b66;stop-opacity:1"
+         offset="0.81895697"
+         id="stop1270" />
+      <stop
+         style="stop-color:#d4976b;stop-opacity:1"
+         offset="1"
+         id="stop1254" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1223">
+      <stop
+         style="stop-color:#0d0c0f;stop-opacity:1"
+         offset="0"
+         id="stop1219" />
+      <stop
+         id="stop1231"
+         offset="0.24620566"
+         style="stop-color:#0e0e11;stop-opacity:1" />
+      <stop
+         id="stop1227"
+         offset="0.49692184"
+         style="stop-color:#786e6d;stop-opacity:1" />
+      <stop
+         style="stop-color:#151415;stop-opacity:1"
+         offset="0.65391636"
+         id="stop1229" />
+      <stop
+         style="stop-color:#4c3e43;stop-opacity:1"
+         offset="1"
+         id="stop1221" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1185">
+      <stop
+         style="stop-color:#837b82;stop-opacity:1"
+         offset="0"
+         id="stop1181" />
+      <stop
+         style="stop-color:#6e686f;stop-opacity:1"
+         offset="1"
+         id="stop1183" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1177">
+      <stop
+         style="stop-color:#605f6d;stop-opacity:1"
+         offset="0"
+         id="stop1173" />
+      <stop
+         style="stop-color:#6c6670;stop-opacity:1"
+         offset="1"
+         id="stop1175" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1167">
+      <stop
+         style="stop-color:#bbb9c6;stop-opacity:1"
+         offset="0"
+         id="stop1163" />
+      <stop
+         style="stop-color:#9b989f;stop-opacity:1"
+         offset="1"
+         id="stop1165" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1159">
+      <stop
+         style="stop-color:#82797b;stop-opacity:1"
+         offset="0"
+         id="stop1155" />
+      <stop
+         style="stop-color:#867c6f;stop-opacity:1"
+         offset="1"
+         id="stop1157" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1153"
+       inkscape:collect="always">
+      <stop
+         id="stop1145"
+         offset="0"
+         style="stop-color:#a7a29a;stop-opacity:1" />
+      <stop
+         style="stop-color:#978b84;stop-opacity:1"
+         offset="0.28820509"
+         id="stop1147" />
+      <stop
+         style="stop-color:#998d84;stop-opacity:1"
+         offset="0.66103727"
+         id="stop1149" />
+      <stop
+         id="stop1151"
+         offset="1"
+         style="stop-color:#91886e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1066">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop1062" />
+      <stop
+         style="stop-color:#333333;stop-opacity:0"
+         offset="1"
+         id="stop1064" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient980">
+      <stop
+         style="stop-color:#ead0be;stop-opacity:1"
+         offset="0"
+         id="stop976" />
+      <stop
+         style="stop-color:#ca8a5e;stop-opacity:1"
+         offset="1"
+         id="stop978" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient980"
+       id="linearGradient982"
+       x1="-785.13031"
+       y1="1036.1376"
+       x2="-710.35596"
+       y2="1132.0746"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1e-5)"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1066"
+       id="linearGradient1068"
+       x1="98.424477"
+       y1="770.53687"
+       x2="175.27051"
+       y2="691.22675"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.2986442,3.9904473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1153"
+       id="linearGradient1143"
+       x1="-693.83899"
+       y1="1042.8849"
+       x2="-491.15979"
+       y2="1009.3665"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1159"
+       id="linearGradient1161"
+       x1="-1112.3372"
+       y1="1080.7942"
+       x2="-807.56677"
+       y2="1201.5052"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1167"
+       id="linearGradient1169"
+       x1="-1079.9148"
+       y1="1044.8801"
+       x2="-453.91339"
+       y2="740.60852"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1177"
+       id="linearGradient1179"
+       x1="-916.6908"
+       y1="1110.9119"
+       x2="-579.50092"
+       y2="754.67578"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1185"
+       id="linearGradient1187"
+       x1="-1014.0385"
+       y1="1068.2341"
+       x2="-610.89203"
+       y2="734.21869"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1223"
+       id="linearGradient1225"
+       x1="-896.16711"
+       y1="1193.4619"
+       x2="-945.82593"
+       y2="1144.3466"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1256"
+       id="linearGradient1258"
+       x1="-692.85065"
+       y1="888.19672"
+       x2="-1065.595"
+       y2="794.1059"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1223"
+       id="linearGradient1272"
+       gradientUnits="userSpaceOnUse"
+       x1="-896.16711"
+       y1="1193.4619"
+       x2="-945.82593"
+       y2="1144.3466"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1159"
+       id="linearGradient1274"
+       gradientUnits="userSpaceOnUse"
+       x1="-1112.3372"
+       y1="1080.7942"
+       x2="-807.56677"
+       y2="1201.5052"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1153"
+       id="linearGradient1276"
+       gradientUnits="userSpaceOnUse"
+       x1="-693.83899"
+       y1="1042.8849"
+       x2="-491.15979"
+       y2="1009.3665"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1185"
+       id="linearGradient1278"
+       gradientUnits="userSpaceOnUse"
+       x1="-1014.0385"
+       y1="1068.2341"
+       x2="-610.89203"
+       y2="734.21869"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1177"
+       id="linearGradient1280"
+       gradientUnits="userSpaceOnUse"
+       x1="-916.6908"
+       y1="1110.9119"
+       x2="-579.50092"
+       y2="754.67578"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1167"
+       id="linearGradient1282"
+       gradientUnits="userSpaceOnUse"
+       x1="-1079.9148"
+       y1="1044.8801"
+       x2="-453.91339"
+       y2="740.60852" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1167"
+       id="linearGradient1362"
+       x1="-1164.0432"
+       y1="1113.4855"
+       x2="-471.03217"
+       y2="794.84869"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1167"
+       id="linearGradient1404"
+       gradientUnits="userSpaceOnUse"
+       x1="-1079.9148"
+       y1="1044.8801"
+       x2="-453.91339"
+       y2="740.60852"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1167"
+       id="linearGradient1406"
+       gradientUnits="userSpaceOnUse"
+       x1="-1164.0432"
+       y1="1113.4855"
+       x2="-471.03217"
+       y2="794.84869"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1497"
+       id="linearGradient1501"
+       x1="-744.58344"
+       y1="1001.6044"
+       x2="-797.61646"
+       y2="963.42065"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1507"
+       id="linearGradient1509"
+       x1="-769.86249"
+       y1="916.92841"
+       x2="-817.23865"
+       y2="893.94745"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1527"
+       id="linearGradient1529"
+       x1="-805.21783"
+       y1="852.93524"
+       x2="-830.14337"
+       y2="841.79828"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1535"
+       id="linearGradient1537"
+       x1="-835.97699"
+       y1="837.73242"
+       x2="-918.88525"
+       y2="828.18646"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1543"
+       id="linearGradient1545"
+       x1="-930.37579"
+       y1="859.29919"
+       x2="-983.93909"
+       y2="856.82434"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1551"
+       id="linearGradient1553"
+       x1="-1000.0257"
+       y1="901.54883"
+       x2="-1135.967"
+       y2="912.33221"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1733"
+       id="linearGradient1735"
+       x1="-651.5"
+       y1="865.26971"
+       x2="-681.5"
+       y2="817.51971"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1741"
+       id="linearGradient1743"
+       x1="-681.75"
+       y1="798.01971"
+       x2="-738.5"
+       y2="748.76971"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1757"
+       id="linearGradient1751"
+       x1="-740.625"
+       y1="719.51971"
+       x2="-772.5"
+       y2="699.14471"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1771"
+       id="linearGradient1765"
+       x1="-792.66669"
+       y1="712.04419"
+       x2="-884.7674"
+       y2="700.90723"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1777"
+       id="linearGradient1779"
+       x1="-898.38269"
+       y1="704.93884"
+       x2="-973.50922"
+       y2="699.31628"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1785"
+       id="linearGradient1787"
+       x1="-985"
+       y1="722.51971"
+       x2="-1156.1656"
+       y2="796.36713"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1507"
+       id="linearGradient1804"
+       gradientUnits="userSpaceOnUse"
+       x1="-769.86249"
+       y1="916.92841"
+       x2="-817.23865"
+       y2="893.94745"
+       gradientTransform="scale(0.9375)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1543"
+       id="linearGradient1806"
+       gradientUnits="userSpaceOnUse"
+       x1="-930.37579"
+       y1="859.29919"
+       x2="-983.93909"
+       y2="856.82434"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1551"
+       id="linearGradient1808"
+       gradientUnits="userSpaceOnUse"
+       x1="-1000.0257"
+       y1="901.54883"
+       x2="-1135.967"
+       y2="912.33221"
+       gradientTransform="scale(0.9375)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1497"
+       id="linearGradient1810"
+       gradientUnits="userSpaceOnUse"
+       x1="-744.58344"
+       y1="1001.6044"
+       x2="-797.61646"
+       y2="963.42065"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1936"
+       id="linearGradient1938"
+       x1="-369.90524"
+       y1="677.15369"
+       x2="-321.18115"
+       y2="738.80457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-367.55308,234.92121)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1954"
+       id="linearGradient1956"
+       x1="-421.94388"
+       y1="627.10376"
+       x2="-389.79263"
+       y2="669.86163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-367.55308,234.92121)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1972"
+       id="linearGradient1974"
+       x1="-283.06369"
+       y1="771.28729"
+       x2="-310.90601"
+       y2="735.15851"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,737.5412,-690.87293)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1757"
+       id="linearGradient2009"
+       gradientUnits="userSpaceOnUse"
+       x1="-740.625"
+       y1="719.51971"
+       x2="-772.5"
+       y2="699.14471"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1777"
+       id="linearGradient2011"
+       gradientUnits="userSpaceOnUse"
+       x1="-898.38269"
+       y1="704.93884"
+       x2="-973.50922"
+       y2="699.31628"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1771"
+       id="linearGradient2013"
+       gradientUnits="userSpaceOnUse"
+       x1="-792.66669"
+       y1="712.04419"
+       x2="-884.7674"
+       y2="700.90723"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1785"
+       id="linearGradient2015"
+       gradientUnits="userSpaceOnUse"
+       x1="-985"
+       y1="722.51971"
+       x2="-1156.1656"
+       y2="796.36713"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1507"
+       id="linearGradient2017"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)"
+       x1="-769.86249"
+       y1="916.92841"
+       x2="-817.23865"
+       y2="893.94745" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1733"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       x1="-651.5"
+       y1="865.26971"
+       x2="-681.5"
+       y2="817.51971"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1551"
+       id="linearGradient2021"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)"
+       x1="-1000.0257"
+       y1="901.54883"
+       x2="-1135.967"
+       y2="912.33221" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1954"
+       id="linearGradient2111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,737.5412,-690.87293)"
+       x1="-421.94388"
+       y1="627.10376"
+       x2="-389.79263"
+       y2="669.86163" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1936"
+       id="linearGradient2113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44519945,0,0,0.44519945,737.5412,-690.87293)"
+       x1="-369.90524"
+       y1="677.15369"
+       x2="-321.18115"
+       y2="738.80457" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2281"
+       id="linearGradient2283"
+       x1="-534.6875"
+       y1="889.01971"
+       x2="-556.5625"
+       y2="878.26971"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9375,0,0,0.9375,995.69471,-829.96656)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2297"
+       id="linearGradient2299"
+       x1="-561.5"
+       y1="883.39471"
+       x2="-584.6875"
+       y2="876.01971"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9375,0,0,0.9375,995.69471,-829.96656)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2305"
+       id="linearGradient2307"
+       x1="-587.3125"
+       y1="877.48846"
+       x2="-622.5"
+       y2="878.70721"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9375,0,0,0.9375,995.69471,-829.96656)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1543"
+       id="linearGradient1084"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)"
+       x1="-930.37579"
+       y1="859.29919"
+       x2="-983.93909"
+       y2="856.82434" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1785"
+       id="linearGradient1086"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41737448,0,0,0.41737448,860.20475,-460.14863)"
+       x1="-985"
+       y1="722.51971"
+       x2="-1156.1656"
+       y2="796.36713" />
+    <filter
+       id="mask-powermask-path-effect21_inverse"
+       inkscape:label="filtermask-powermask-path-effect21"
+       style="color-interpolation-filters:sRGB"
+       height="100"
+       width="100"
+       x="-50"
+       y="-50">
+      <feColorMatrix
+         id="mask-powermask-path-effect21_primitive1"
+         values="1"
+         type="saturate"
+         result="fbSourceGraphic" />
+      <feColorMatrix
+         id="mask-powermask-path-effect21_primitive2"
+         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0 "
+         in="fbSourceGraphic" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.629607;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect34"
+         width="417.1875"
+         height="417.1875"
+         x="313.20047"
+         y="-191.96841"
+         inkscape:export-xdpi="110.45"
+         inkscape:export-ydpi="110.45"
+         transform="rotate(-36.242581)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         id="path36"
+         d="M -83.999992,417.85001 Q 19.191203,464.9337 30.744315,573.56517 L 67.012308,546.66798 Q 55.680255,438.33656 -47.31001,391.54293 Z"
+         style="fill:#a8a8a8;fill-opacity:1;stroke:none;stroke-width:1.0026" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.33946538"
+     inkscape:cx="257.75824"
+     inkscape:cy="524.35391"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1512"
+     inkscape:window-height="861"
+     inkscape:window-x="0"
+     inkscape:window-y="33"
+     inkscape:window-maximized="0"
+     showguides="false"
+     inkscape:lockguides="false"
+     units="px"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,822.63786)">
+    <g
+       id="g37"
+       inkscape:label="pencil-sharpener"
+       transform="matrix(1.0172537,0,0,1.0172537,24.106767,66.712626)">
+      <g
+         id="g1"
+         clip-path="url(#clipPath33)"
+         inkscape:label="pencil"
+         transform="matrix(2.4369657,0,0,2.4369657,-705.84298,448.47687)">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path1898"
+           d="m 486.53457,-370.45925 239.42873,-172.68689 55.0695,-5.00631 -288.1569,212.40369 z"
+           style="fill:url(#linearGradient2111);fill-opacity:1;stroke:none;stroke-width:0.472px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path1900"
+           d="m 537.43213,-317.55916 285.52507,-214.71715 28.56951,4.54794 -325.18422,242.62065 z"
+           style="fill:url(#linearGradient1974);fill-opacity:1;stroke:none;stroke-width:0.472px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path1902"
+           d="m 526.47335,-322.03296 10.95878,4.4738 285.52507,-214.71715 -36.04548,-21.19341 -294.03581,217.72096 z"
+           style="fill:url(#linearGradient2113);fill-opacity:1;stroke:none;stroke-width:0.472px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         id="g36"
+         transform="matrix(1.2564161,-0.08309827,-0.07715833,1.2025728,805.28698,-1099.1551)"
+         inkscape:label="eraser-ferrule">
+        <g
+           id="g34"
+           transform="translate(0.03807858,0.58138762)">
+          <path
+             id="eraser-body"
+             d="M -47.51,391.53 C 20.803333,422.70333 58.73,474.4 66.27,546.62 l 43.47762,-34.16076 C 157.10253,477.38682 57.965008,321.03051 -0.93643806,357.62423 Z"
+             style="fill:#e8a0a0;fill-opacity:1;stroke:none"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             id="eraser-highlight"
+             d="m -47.51,391.53 c 23.913333,10.90667 39.0833333,31.58667 45.51,62.04 L 67.61564,404.41428 C 96.24483,386.94777 28.86526,336.89306 -0.29357938,358.11282 Z"
+             style="fill:#f0baba;fill-opacity:0.5;stroke:none"
+             sodipodi:nodetypes="ccccc" />
+        </g>
+        <g
+           id="g35"
+           clip-path="url(#clipPath35)"
+           inkscape:label="ferrule-clip">
+          <path
+             id="ferrule"
+             d="M -84,417.85 Q 19.191202,464.93369 30.744309,573.56518 l 36.267998,-26.8972 Q 55.680249,438.33656 -47.310006,391.54293 Z"
+             style="fill:#a8a8a8;fill-opacity:1;stroke:none;stroke-width:1.0026" />
+          <path
+             id="ferrule-highlight"
+             d="m -84,417.85 c 35.933333,16.46667 51.330611,29.30227 65.375813,45.96563 l 36.35,-26.53 C 5.7812212,424.39168 -11.643333,407.89667 -47.51,391.53 Z"
+             style="fill:#c8c8c8;fill-opacity:0.6;stroke:none"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             id="ferrule-groove"
+             d="m -67.21,405.74 c 65.3466667,33.33333 103.733014,85.39264 114.386347,155.66597 l 2.89,-2.15 C 39.419681,488.99597 1.04,436.95333 -64.3,403.64 Z"
+             style="fill:#707070;fill-opacity:0.5;stroke:none"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             id="ferrule-near-edge"
+             d="m -84,417.85 c 68.446667,31.36667 106.513333,83.26 114.2,155.68"
+             style="fill:none;stroke:#909090;stroke-width:1.5;stroke-opacity:0.5"
+             sodipodi:nodetypes="cc" />
+          <path
+             id="ferrule-far-edge"
+             d="M -47.51,391.53 Q 54.96,438.29 66.27,546.62"
+             style="fill:none;stroke:#909090;stroke-width:1.5;stroke-opacity:0.5" />
+        </g>
+      </g>
+      <g
+         id="sharpener"
+         transform="matrix(1.9727634,0.21239995,-0.21239995,1.9727634,-678.9377,-311.74698)">
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path1209"
+           d="m 504.17373,5.5243481 -47.87443,40.9189999 0.90776,4.46695 c 22.22863,37.14299 -17.14463,27.57174 -21.72498,-4.0108 l 34.88156,-50.8535799 z"
+           style="fill:url(#linearGradient1272);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path1085"
+           d="m 435.48204,46.899498 -45.66709,-18.67064 54.80409,-57.88546 55.07287,6.66206 z"
+           style="fill:#c9cad4;fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:#3a2838;fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 389.81495,28.228858 -2.07089,-8.95065 172.74012,-181.439438 56.7809,17.17419 -172.64599,115.330438 z"
+           id="path1171"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           style="fill:url(#linearGradient1274);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 510.61181,101.31017 -14.91744,-39.256482 -39.39507,-15.61034 0.90776,4.46695 c 22.22863,37.14299 -17.14463,27.57174 -21.72498,-4.0108 l -45.66713,-18.67064 -2.07089,-8.95065 -27.59208,-10.9334299 14.91747,39.2564899 z"
+           id="path981"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path983"
+           d="M 495.69437,62.053688 551.308,4.1431681 c -4.11458,-14.9045201 40.2603,-73.3060601 78.39005,-84.1638001 l 50.3983,-53.951418 15.02966,96.308488 -47.79362,35.9975401 c -30.99935,5.90544 -76.9488,43.0432199 -81.70277,61.5374699 l -55.01781,41.438722 z"
+           style="fill:url(#linearGradient1276);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:url(#linearGradient1278);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 604.65496,-140.80303 c -12.50993,-10.18638 -38.00681,-11.60743 -61.66841,8.31934 L 394.64501,16.551008 442.73176,35.650502 Z"
+           id="path1002"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:url(#linearGradient1280);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 442.29226,35.464991 20.90803,8.251147 141.56544,-152.257418 c 11.33068,-12.14604 8.81158,-25.2471 -0.53012,-32.85789 z"
+           id="path1083"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:#696164;fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 395.49943,21.686558 47.16172,18.48713 20.53914,3.54245 -20.42811,-8.09466 -48.12717,-19.07047 z"
+           id="path1207"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           style="fill:#b5afab;fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 495.69437,62.053688 551.308,4.1431681 565.62962,59.871448 510.61185,101.31017 Z"
+           id="path1103"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:#c4bdb6;fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 629.69805,-80.020632 50.3983,-53.951418 15.02966,96.308488 -47.79362,35.9975401 z"
+           id="path1105"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           id="path1013"
+           style="fill:url(#linearGradient1404);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 456.2993,46.443348 602.26148,-110.21078 c 26.50179,-28.40888 -20.43969,-58.75672 -61.77917,-23.94241 L 387.74401,19.278208 360.15193,8.3447781 546.42251,-177.73063 l 133.67384,43.75858 -50.3983,53.951418 C 591.5683,-69.162892 547.19342,-10.761352 551.308,4.1431681 L 495.69437,62.053688 Z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccc" />
+        <path
+           sodipodi:nodetypes="ccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path1063"
+           d="m 380.47978,-129.40415 8.94054,-25.75068 9.11549,2.69797 13.73538,-18.86959 11.39245,15.0917 14.0261,3.31495 15.24207,-11.78396 9.54895,19.98613 23.78521,-27.11785 9.79668,19.95384 19.15928,-15.04281 8.94723,12.87068 11.70157,-19.51181 0.73823,13.22469 15.37042,1.40572 5.38559,26.84634 17.35841,5.1831 8.35115,32.575152 -61.05205,104.659704 -48.75754,-19.657041 -63.74723,4.2662542"
+           style="opacity:1;fill:url(#linearGradient1084);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           style="fill:url(#linearGradient1743);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 556.73155,-164.00314 c -1.11852,23.27189 2.02935,24.78541 5.01366,27.13304 4.59335,1.21461 5.20474,2.66345 19.09785,3.33102 -0.072,1.38957 -0.12758,2.73281 -0.16697,4.03009 l -9.48228,12.94642 -32.51143,-17.41374 z"
+           id="path1611"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="fill:url(#linearGradient2009);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 538.3433,-175.76405 c -0.76352,4.07069 -0.72518,7.74044 1.63923,10.24717 6.69998,-3.38849 15.28739,-8.55339 17.32133,-7.55033 -0.25346,3.34107 -0.44191,6.35049 -0.57231,9.06407 l -8.47065,24.60348 -18.93719,-12.93674 z"
+           id="path1616"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="fill:url(#linearGradient2011);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 451.83123,-178.46028 c 0.3713,-0.4452 0.73845,-0.86955 1.10058,-1.26896 2.46128,6.16792 6.48282,14.10834 10.65928,16.21097 6.38936,3.40041 16.27355,-13.04581 24.8716,-22.42888 0.2534,0.84161 0.50864,1.70916 0.76489,2.5908 l -6.74292,33.26824 -32.89341,13.90575 z"
+           id="path1626"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="fill:url(#linearGradient2013);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 488.9691,-184.26172 c 2.4076,8.28332 5.1624,18.71426 7.0439,19.63311 2.58002,0.2419 8.15739,-2.08538 23.09513,-12.43581 0.81493,5.03248 -0.028,12.55183 2.88685,14.43442 3.9568,-0.18842 11.11767,-19.10533 19.76411,-27.09231 -0.7429,4.45489 -2.57062,9.45222 -3.41579,13.95826 l -12.5173,32.89774 -46.60805,3.9109 z"
+           id="path1621"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           style="fill:url(#linearGradient1086);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 451.1417,-159.90684 c -2.17821,11.62141 -57.29574,47.48667 -71.10913,52.32162 v 0 c -0.0254,-4.14379 -0.9458,-6.19625 -2.3819,-20.18009 2.9068,-9.22291 5.78087,-24.46286 8.66069,-38.63985 3.20023,4.57401 7.4607,6.6738 12.43585,7.10618 4.23322,-6.16507 3.73411,-2.33974 12.87993,-18.87579 6.88412,11.79173 13.76824,20.20907 20.65236,20.2082 4.61013,2.70448 12.7758,-12.36885 19.55173,-20.49371"
+           id="path1624"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           style="fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 580.75435,-131.61542 c -0.38034,12.52518 0.67302,22.87291 3.19767,27.16727 10.39935,6.496838 19.4093,6.567848 26.86889,4.833358 l -22.18276,26.14282 c -7.1341,-9.08995 -22.13431,-22.940691 -30.72492,-29.232518"
+           id="path1246"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1529);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 472.89526,4.3841481 -4.73086,-1.55926 65.40141,-167.4490081 2.34537,-4.1879 c -1.414,8.47937 -4.79654,11.4846 0.18516,16.76614 5.47114,-2.86621 12.04257,-6.58554 15.88304,-6.88929 z"
+           id="path1473"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="opacity:1;fill:url(#linearGradient2017);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 478.95261,10.342064 470.85732,4.3841481 551.57474,-158.57843 c 0.24504,-0.31901 0.43451,-0.39244 0.42874,-0.34553 -2.02637,16.46486 0.64059,29.57638 3.96794,32.19389 4.59334,1.21461 3.53925,2.88551 17.43236,3.55309 -0.008,0.16109 -0.0165,0.32167 -0.0249,0.48172 l -0.2634,3.11531 z"
+           id="path1468"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccsccccc" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1537);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 468.31849,2.9420756 -13.61639,-5.3740175 29.65233,-162.1408481 0.94049,-1.35235 c 2.63406,8.74893 7.74802,16.63777 9.82982,17.65442 2.58002,0.2419 8.04631,-6.85984 20.09719,-18.65373 0.81494,5.03249 1.41543,20.43526 4.33033,22.31785 3.07463,-0.14641 11.14786,-16.13479 16.35892,-24.20542 z"
+           id="path1478"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1806);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 449.86866,-160.87406 c 0.87321,-1.22872 2.0724,-2.73696 3.06315,-3.8297 2.46128,6.16792 6.03868,18.2166 9.54895,19.98613 7.03971,2.35806 14.91022,-11.85499 22.81416,-21.20751 l -30.39234,163.4931981 -9.0904,-1.63535 z"
+           id="path1483"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="opacity:1;fill:url(#linearGradient2021);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 446.58937,-4.0465759 c -10.71199,-1.17586 -23.55796,0.234074 -37.405,5.080774 v 0 C 394.72122,-38.688002 383.8353,-70.655592 378.79461,-118.03364 c 2.9068,-9.22292 7.7459,-22.94421 10.62571,-37.12119 3.20014,4.57401 4.35169,10.44895 9.32684,10.88133 4.23323,-6.16507 5.28866,-7.89145 14.43444,-24.42749 6.88412,11.79172 15.23154,22.31378 22.15704,19.95128 3.42593,3.98022 9.681,-5.52109 15.12855,-12.9377 z"
+           id="path1481"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           style="opacity:1;fill:url(#linearGradient1810);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 573.38969,-122.93361 c -0.74691,14.55045 -0.93221,25.059174 1.82362,29.746774 10.39933,6.49684 21.85339,2.73383 29.31297,0.99929 L 500.70943,32.134754 C 493.6596,23.152234 486.87126,15.288184 477.31728,8.8200644 Z"
+           id="path1248"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           style="fill:url(#linearGradient2283);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 473.26494,-9.327915 c 6.96385,-8.109741 6.48875,-9.008597 20.87411,-15.808116 21.34867,-10.090875 14.49861,43.044403 6.53742,57.2598 -3.72355,-5.343768 -8.40995,-10.741891 -12.25084,-14.135028 -3.82196,-3.376423 -6.79695,-4.753312 -11.0914,-7.859445 -2.8376,-2.0524065 -6.30175,-5.0303378 -9.33238,-6.6640954"
+           id="path1250"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cscssc" />
+        <path
+           style="fill:url(#linearGradient2299);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 445.81813,-9.8249494 c 5.11628,-1.9241996 10.64506,-1.9063126 13.315,0.8411625 2.39984,2.4695344 7.09961,-0.57225 11.12695,3.0619219 1.147,-1.2651844 2.19269,-2.3919938 3.06345,-3.40605 l -5.20449,12.7931156 c -1.94073,-0.9892374 -4.26099,-1.2573407 -5.98476,-1.9884058 -3.59536,-1.52482594 -5.66765,-1.45843405 -8.18617,-2.6247062 -2.36365,-1.0945533 -5.96015,-2.2837871 -8.25315,-2.6210599 z"
+           id="path2275"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccsscc" />
+        <path
+           style="fill:url(#linearGradient2307);fill-opacity:1;stroke:none;stroke-width:0.417374px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 445.75355,-3.7689713 c -0.98211,-0.1244771 -3.34223,-0.5166553 -4.3462,-0.5958233 -3.27374,-0.2581513 -6.46474,1.1622499 -9.8015,1.0906442 -3.35603,-0.072019 -6.6336,1.7773153 -10.41031,1.7995178 -1.63754,0.00963 -3.14799,1.61458802 -4.90704,2.13972537 -1.65459,0.49395593 -3.4598,1.15292533 -5.21444,1.42480743 -0.61125,0.094712 -1.21636,-0.4764193 -1.80683,-0.268494 l -0.0829,-0.7872087 c 6.41574,-43.6186785 21.30604,-30.1001905 28.82693,-17.4142315 1.81699,3.064838 4.37427,5.690944 4.92743,7.9012127 0.95005,-0.5190843 1.93725,-0.9697593 2.93799,-1.3461281"
+           id="path2273"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csssssccscc" />
+        <path
+           style="fill:url(#linearGradient1406);fill-opacity:1;stroke:none;stroke-width:0.417374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 614.65014,-155.39609 65.44621,21.42404 -50.3983,53.951368 C 591.5683,-69.162892 547.19342,-10.761352 551.308,4.1431681 L 495.69437,62.053688 456.2993,46.443348 v 0 L 602.26148,-110.21078 c 11.18245,-11.98714 9.28888,-24.31951 0.25758,-31.95611 z"
+           id="path1354"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/samples/Gallery/Shared/SampleManager.cs
+++ b/samples/Gallery/Shared/SampleManager.cs
@@ -78,6 +78,7 @@ public static class SampleManager
 		["Fill Path"]             = ("bi-paint-bucket",        "\uf4ba"),
 		["GIF Player"]            = ("bi-film",                "\uf3c3"),
 		["Gradient"]              = ("bi-rainbow",             "\uf50d"),
+		["Hero Image"]            = ("bi-image",               "\uf39b"),
 		["Image Decoder"]         = ("bi-file-image",          "\uf39b"),
 		["Lottie Player"]         = ("bi-play-circle",         "\uf4f3"),
 		["Nine-Patch Scaler"]     = ("bi-grid-3x3",            "\uf3fa"),

--- a/samples/Gallery/Shared/SampleMedia.cs
+++ b/samples/Gallery/Shared/SampleMedia.cs
@@ -28,6 +28,7 @@ public static class SampleMedia
 		public static Stream AnimatedHeartGif => Embedded.Load("animated-heart.gif");
 		public static Stream OpacitySvg => Embedded.Load("opacity.svg");
 		public static Stream LottieLogo => Embedded.Load("LottieLogo1.json");
+		public static Stream SkiaSharpLogoSvg => Embedded.Load("skiasharp-logo.svg");
 	}
 
 	public static class Fonts

--- a/samples/Gallery/Shared/Samples/HeroImageSample.cs
+++ b/samples/Gallery/Shared/Samples/HeroImageSample.cs
@@ -1,0 +1,338 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Svg.Skia;
+using SkiaSharp;
+using SkiaSharpSample.Controls;
+
+namespace SkiaSharpSample.Samples;
+
+public class HeroImageSample : CanvasSampleBase
+{
+	private float curveIntensity = 1f;
+	private float glowSize = 1f;
+	private int colorScheme;
+
+	private SKSvg? skiaSharpSvg;
+
+	private static readonly string[] ColorSchemes = { "Default", "Cool Blue", "Warm Sunset", "Monochrome" };
+
+	public override string Title => "Hero Image";
+
+	public override DateOnly? DateAdded => new DateOnly(2026, 4, 29);
+
+	public override string Description =>
+		"Generate a stylized SkiaSharp banner with flowing Bézier curves, gradient text, and a frosted glass logo card.";
+
+	public override string Category => SampleManager.General;
+
+	public override IReadOnlyList<SampleControl> Controls =>
+	[
+		new PickerControl("colorScheme", "Color Scheme", ColorSchemes, colorScheme),
+		new SliderControl("curveIntensity", "Curve Intensity", 0f, 2f, curveIntensity, 0.1f),
+		new SliderControl("glowSize", "Glow Size", 0f, 2f, glowSize, 0.1f),
+	];
+
+	protected override void OnControlChanged(string id, object value)
+	{
+		switch (id)
+		{
+			case "colorScheme":
+				colorScheme = (int)value;
+				break;
+			case "curveIntensity":
+				curveIntensity = (float)value;
+				break;
+			case "glowSize":
+				glowSize = (float)value;
+				break;
+		}
+	}
+
+	protected override Task OnInit()
+	{
+		skiaSharpSvg = new SKSvg();
+		using (var stream = SampleMedia.Images.SkiaSharpLogoSvg)
+			skiaSharpSvg.Load(stream);
+
+		return base.OnInit();
+	}
+
+	protected override void OnDestroy()
+	{
+		skiaSharpSvg?.Dispose();
+		skiaSharpSvg = null;
+		base.OnDestroy();
+	}
+
+	protected override void OnDrawSample(SKCanvas canvas, int width, int height)
+	{
+		var colors = GetColorScheme();
+
+		DrawBackground(canvas, width, height, colors);
+		DrawDecorativeCurves(canvas, width, height, colors);
+		DrawCenterGlow(canvas, width, height, colors);
+
+		// Frosted glass card with logo
+		float scale = Math.Min(width, height) / 1080f;
+		var skiaCard = GetCardRect(width * 0.16f, height * 0.46f, 280 * scale, 280 * scale);
+
+		using var bgSnapshot = canvas.Surface?.Snapshot();
+		if (bgSnapshot != null)
+		{
+			DrawFrostedCard(canvas, bgSnapshot, skiaCard);
+		}
+
+		DrawSkiaSharpIcon(canvas, skiaCard);
+		DrawText(canvas, width, height, skiaCard);
+	}
+
+	private static SKRect GetCardRect(float cx, float cy, float w, float h)
+		=> new(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2);
+
+	private (SKColor bg1, SKColor bg2, SKColor accent1, SKColor accent2, SKColor accent3, SKColor accent4, SKColor accent5) GetColorScheme()
+	{
+		return colorScheme switch
+		{
+			1 => (new SKColor(0x0A, 0x14, 0x28), new SKColor(0x0C, 0x1A, 0x38),
+			      new SKColor(0x15, 0x9B, 0xFF), new SKColor(0x3B, 0x82, 0xF6),
+			      new SKColor(0x67, 0xE5, 0xAD), new SKColor(0x06, 0xB6, 0xD4),
+			      new SKColor(0x81, 0x8C, 0xF8)),
+			2 => (new SKColor(0x1A, 0x0A, 0x14), new SKColor(0x28, 0x0C, 0x10),
+			      new SKColor(0xFF, 0x6B, 0x35), new SKColor(0xF6, 0x3B, 0x5C),
+			      new SKColor(0xFF, 0xC1, 0x07), new SKColor(0xE5, 0x67, 0x67),
+			      new SKColor(0xF8, 0x81, 0xCF)),
+			3 => (new SKColor(0x12, 0x12, 0x12), new SKColor(0x1A, 0x1A, 0x1A),
+			      new SKColor(0xAA, 0xAA, 0xAA), new SKColor(0x88, 0x88, 0x88),
+			      new SKColor(0xCC, 0xCC, 0xCC), new SKColor(0x66, 0x66, 0x66),
+			      new SKColor(0x99, 0x99, 0x99)),
+			_ => (new SKColor(0x0B, 0x10, 0x26), new SKColor(0x12, 0x0C, 0x30),
+			      new SKColor(0x2F, 0x45, 0x9D), new SKColor(0xD9, 0x57, 0x3F),
+			      new SKColor(0x7B, 0xA7, 0x45), new SKColor(0x7A, 0x67, 0xF8),
+			      new SKColor(0x15, 0x9B, 0xFF)),
+		};
+	}
+
+	private void DrawBackground(SKCanvas canvas, int width, int height,
+		(SKColor bg1, SKColor bg2, SKColor accent1, SKColor accent2, SKColor accent3, SKColor accent4, SKColor accent5) colors)
+	{
+		var bgColors = new SKColor[] { colors.bg1, colors.bg2, colors.bg1 };
+		using var bgShader = SKShader.CreateRadialGradient(
+			new SKPoint(width * 0.5f, height * 0.45f),
+			width * 0.8f,
+			bgColors, new float[] { 0f, 0.5f, 1f },
+			SKShaderTileMode.Clamp);
+		using var bgPaint = new SKPaint { Shader = bgShader };
+		canvas.DrawRect(0, 0, width, height, bgPaint);
+
+		using var dotPaint = new SKPaint
+		{
+			Color = new SKColor(255, 255, 255, 8),
+			IsAntialias = true
+		};
+		var rng = new Random(42);
+		for (int i = 0; i < 150; i++)
+		{
+			float x = (float)(rng.NextDouble() * width);
+			float y = (float)(rng.NextDouble() * height);
+			float r = (float)(rng.NextDouble() * 1.5 + 0.3);
+			canvas.DrawCircle(x, y, r, dotPaint);
+		}
+	}
+
+	private void DrawDecorativeCurves(SKCanvas canvas, int width, int height,
+		(SKColor bg1, SKColor bg2, SKColor accent1, SKColor accent2, SKColor accent3, SKColor accent4, SKColor accent5) colors)
+	{
+		var intensity = curveIntensity;
+		var curves = new[]
+		{
+			(Color: colors.accent1.WithAlpha(50), StrokeWidth: 3f,
+			 P0: new SKPoint(-100, height * 0.85f),
+			 C1: new SKPoint(width * 0.2f, height * (0.5f - 0.2f * intensity)),
+			 C2: new SKPoint(width * 0.6f, height * (0.5f + 0.4f * intensity)),
+			 P3: new SKPoint(width + 100, height * 0.15f)),
+
+			(Color: colors.accent2.WithAlpha(40), StrokeWidth: 2.5f,
+			 P0: new SKPoint(-50, height * 0.7f),
+			 C1: new SKPoint(width * 0.3f, height * (0.5f - 0.4f * intensity)),
+			 C2: new SKPoint(width * 0.7f, height * (0.5f + 0.45f * intensity)),
+			 P3: new SKPoint(width + 50, height * 0.25f)),
+
+			(Color: colors.accent3.WithAlpha(40), StrokeWidth: 2f,
+			 P0: new SKPoint(-80, height * 0.95f),
+			 C1: new SKPoint(width * 0.15f, height * 0.5f),
+			 C2: new SKPoint(width * 0.5f, height * (0.5f + 0.2f * intensity)),
+			 P3: new SKPoint(width + 80, height * 0.05f)),
+
+			(Color: colors.accent4.WithAlpha(35), StrokeWidth: 2f,
+			 P0: new SKPoint(width * 0.1f, -50),
+			 C1: new SKPoint(width * 0.35f, height * (0.5f + 0.3f * intensity)),
+			 C2: new SKPoint(width * 0.65f, height * (0.5f - 0.3f * intensity)),
+			 P3: new SKPoint(width * 0.9f, height + 50)),
+
+			(Color: colors.accent5.WithAlpha(30), StrokeWidth: 1.8f,
+			 P0: new SKPoint(-100, height * 0.4f),
+			 C1: new SKPoint(width * 0.25f, height * (0.5f - 0.45f * intensity)),
+			 C2: new SKPoint(width * 0.75f, height * (0.5f + 0.35f * intensity)),
+			 P3: new SKPoint(width + 100, height * 0.5f)),
+		};
+
+		foreach (var curve in curves)
+		{
+			using var builder = new SKPathBuilder();
+			builder.MoveTo(curve.P0);
+			builder.CubicTo(curve.C1, curve.C2, curve.P3);
+			using var path = builder.Detach();
+
+			using var paint = new SKPaint
+			{
+				Style = SKPaintStyle.Stroke,
+				Color = curve.Color,
+				StrokeWidth = curve.StrokeWidth,
+				IsAntialias = true,
+				StrokeCap = SKStrokeCap.Round,
+			};
+			canvas.DrawPath(path, paint);
+
+			using var glowPaint = new SKPaint
+			{
+				Style = SKPaintStyle.Stroke,
+				Color = curve.Color.WithAlpha((byte)(curve.Color.Alpha / 2)),
+				StrokeWidth = curve.StrokeWidth * 6 * glowSize,
+				IsAntialias = true,
+				StrokeCap = SKStrokeCap.Round,
+				MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 12 * glowSize),
+			};
+			canvas.DrawPath(path, glowPaint);
+		}
+	}
+
+	private void DrawCenterGlow(SKCanvas canvas, int width, int height,
+		(SKColor bg1, SKColor bg2, SKColor accent1, SKColor accent2, SKColor accent3, SKColor accent4, SKColor accent5) colors)
+	{
+		using var glowShader = SKShader.CreateRadialGradient(
+			new SKPoint(width * 0.5f, height * 0.46f),
+			Math.Min(width, height) * 0.4f * glowSize,
+			new SKColor[] { colors.accent1.WithAlpha(30), new SKColor(0, 0, 0, 0) },
+			new float[] { 0f, 1f },
+			SKShaderTileMode.Clamp);
+		using var glowPaint = new SKPaint { Shader = glowShader };
+		canvas.DrawRect(0, 0, width, height, glowPaint);
+	}
+
+	private void DrawText(SKCanvas canvas, int width, int height, SKRect logoCard)
+	{
+		float scale = Math.Min(width, height) / 1080f;
+		var baseTypeface = SampleMedia.Fonts.Default;
+
+		// Create a bold variant using variable font weight axis
+		var boldPosition = new[]
+		{
+			new SKFontVariationPositionCoordinate { Axis = SKFourByteTag.Parse("wght"), Value = 700 },
+		};
+		using var boldTypeface = baseTypeface.Clone(boldPosition) ?? baseTypeface;
+
+		// Layout: [margin | logo | gap | text | margin]
+		float leftMargin = logoCard.Left;
+		float textAreaLeft = logoCard.Right + leftMargin;
+		float textAreaRight = width - leftMargin;
+		float textCenterX = (textAreaLeft + textAreaRight) / 2;
+
+		// "SkiaSharp" in large bold gradient text
+		using var titleFont = new SKFont(boldTypeface, 170 * scale);
+		var titleText = "SkiaSharp";
+		float titleWidth = titleFont.MeasureText(titleText);
+		float titleX = textCenterX - titleWidth / 2;
+		float titleY = height * 0.54f;
+
+		using var titleShader = SKShader.CreateLinearGradient(
+			new SKPoint(titleX, titleY - 140 * scale),
+			new SKPoint(titleX + titleWidth, titleY),
+			new SKColor[]
+			{
+				new(0x15, 0x9B, 0xFF),
+				new(0x67, 0xE5, 0xAD),
+				new(0x7B, 0xA7, 0x45),
+			},
+			new float[] { 0f, 0.5f, 1f },
+			SKShaderTileMode.Clamp);
+		using var titlePaint = new SKPaint
+		{
+			Shader = titleShader,
+			IsAntialias = true,
+		};
+		canvas.DrawText(titleText, titleX, titleY, titleFont, titlePaint);
+	}
+
+	private static void DrawFrostedCard(SKCanvas canvas, SKImage bgSnapshot, SKRect cardRect)
+	{
+		float cornerRadius = 24;
+		var roundRect = new SKRoundRect(cardRect, cornerRadius, cornerRadius);
+
+		canvas.Save();
+		canvas.ClipRoundRect(roundRect, antialias: true);
+
+		using var blurPaint = new SKPaint
+		{
+			ImageFilter = SKImageFilter.CreateBlur(20, 20),
+			IsAntialias = true,
+		};
+		canvas.DrawImage(bgSnapshot, 0, 0, blurPaint);
+
+		using var glassPaint = new SKPaint
+		{
+			Color = new SKColor(255, 255, 255, 12),
+			IsAntialias = true,
+		};
+		canvas.DrawRoundRect(roundRect, glassPaint);
+
+		using var innerGradient = SKShader.CreateLinearGradient(
+			new SKPoint(cardRect.Left, cardRect.Top),
+			new SKPoint(cardRect.Left, cardRect.Bottom),
+			new SKColor[] { new(255, 255, 255, 10), new(255, 255, 255, 0) },
+			new float[] { 0f, 1f },
+			SKShaderTileMode.Clamp);
+		using var innerPaint = new SKPaint { Shader = innerGradient, IsAntialias = true };
+		canvas.DrawRoundRect(roundRect, innerPaint);
+
+		canvas.Restore();
+
+		using var borderPaint = new SKPaint
+		{
+			Style = SKPaintStyle.Stroke,
+			Color = new SKColor(255, 255, 255, 30),
+			StrokeWidth = 1f,
+			IsAntialias = true,
+		};
+		canvas.DrawRoundRect(roundRect, borderPaint);
+	}
+
+	private void DrawSkiaSharpIcon(SKCanvas canvas, SKRect cardRect)
+	{
+		DrawSvgInCard(canvas, skiaSharpSvg, cardRect);
+	}
+
+	private static void DrawSvgInCard(SKCanvas canvas, SKSvg? svg, SKRect cardRect)
+	{
+		if (svg?.Picture == null) return;
+
+		var svgBounds = svg.Picture.CullRect;
+		if (svgBounds.IsEmpty) return;
+
+		float padding = cardRect.Width * 0.12f;
+		float availW = cardRect.Width - padding * 2;
+		float availH = cardRect.Height - padding * 2;
+		float scale = Math.Min(availW / svgBounds.Width, availH / svgBounds.Height);
+
+		float drawW = svgBounds.Width * scale;
+		float drawH = svgBounds.Height * scale;
+		float drawX = cardRect.MidX - drawW / 2;
+		float drawY = cardRect.MidY - drawH / 2;
+
+		canvas.Save();
+		canvas.Translate(drawX - svgBounds.Left * scale, drawY - svgBounds.Top * scale);
+		canvas.Scale(scale);
+		canvas.DrawPicture(svg.Picture);
+		canvas.Restore();
+	}
+}

--- a/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
+++ b/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\..\binding\SkiaSharp.Skottie\SkiaSharp.Skottie.csproj" />
     <ProjectReference Include="..\..\..\binding\SkiaSharp\SkiaSharp.csproj" />
     <ProjectReference Include="..\..\..\source\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz\SkiaSharp.HarfBuzz.csproj" />
+    <PackageReference Include="Svg.Skia" Version="2.0.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds an interactive Hero Image sample to the gallery that renders a stylized SkiaSharp banner — entirely with SkiaSharp drawing primitives.

The sample showcases several SkiaSharp capabilities working together: radial and linear gradients for the background, cubic Bézier curves with glow effects for the flowing decorative lines, frosted-glass card rendering using backdrop blur and image filters, SVG loading and rendering via Svg.Skia, and variable font weight control using the embedded Inter typeface.

Three interactive controls let viewers experiment with different color schemes (Default, Cool Blue, Warm Sunset, Monochrome), adjust the curve intensity to see how the Bézier control points affect the flow, and dial the glow size up or down.

The SkiaSharp pencil-sharpener logo is loaded as an embedded SVG resource and rendered inside a frosted-glass card, with the bold gradient "SkiaSharp" wordmark positioned alongside it.