### PR TITLE
Fix finalizer crash in SKPath when SKPathBuilder is collected first

### DIFF
--- a/binding/SkiaSharp/SKPath.cs
+++ b/binding/SkiaSharp/SKPath.cs
@@ -25,9 +25,17 @@ namespace SkiaSharp
 		// reads path.Handle directly and P/Invokes with it. If mutations have been batched
 		// into _builder but not yet flushed, base.Handle points at a stale native SkPath.
 		// Flushing in the getter keeps every reader — internal or external — honest.
+		//
+		// Skip the flush once disposal has begun. SKPathBuilder is itself an SKObject with
+		// its own finalizer, so on the finalizer thread it may already have been collected
+		// (its Handle is IntPtr.Zero, native pointer freed). Touching it here would call
+		// sk_pathbuilder_detach_path on a null/dangling handle. The pending mutations are
+		// going to be discarded with the path anyway, and DisposeNative cleans up _builder
+		// defensively.
 		public override IntPtr Handle {
 			get {
-				FlushBuilder ();
+				if (!IsDisposed)
+					FlushBuilder ();
 				return base.Handle;
 			}
 			protected set => base.Handle = value;

--- a/tests/Tests/SkiaSharp/SKPathTest.cs
+++ b/tests/Tests/SkiaSharp/SKPathTest.cs
@@ -725,5 +725,31 @@ namespace SkiaSharp.Tests
 		}
 
 #pragma warning restore CS0618
+
+		[SkippableFact]
+		public void PathWithPendingBuilderMutationsSurvivesFinalization()
+		{
+			// Reproduces a finalizer-ordering crash: SKPath holds a private SKPathBuilder
+			// for batched mutations. Both are SKObjects with their own finalizers, and the
+			// CLR may finalize the builder first. When the path's finalizer then accesses
+			// path.Handle, the override calls FlushBuilder, which calls
+			// sk_pathbuilder_detach_path on the builder's already-freed handle.
+			MakeAndAbandon();
+
+			CollectGarbage();
+			CollectGarbage();
+
+			// If the bug is present, the second collect crashes the finalizer thread on
+			// sk_pathbuilder_detach_path(IntPtr.Zero). Reaching here without an unhandled
+			// native exception means the disposal path skipped FlushBuilder correctly.
+
+			static void MakeAndAbandon()
+			{
+				var path = new SKPath();
+				path.MoveTo(0, 0);
+				path.LineTo(10, 10);
+				// drop both references; the builder is private and goes with it
+			}
+		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

<!-- Describe your changes here. -->
Repro from a downstream app on 3.119: the finalizer thread crashed in sk_pathbuilder_detach_path with this stack:

    SkiaApi.sk_pathbuilder_detach_path(IntPtr)
    SKPath.FlushBuilder()
    SKPath.get_Handle()
    SKNativeObject.Dispose(Boolean)
    SKObject.Dispose(Boolean)
    SKPath.Dispose(Boolean)
    SKNativeObject.Finalize()

SKPath holds a private SKPathBuilder for batched mutations and overrides Handle to flush pending mutations on every read. SKPathBuilder is itself an SKObject with its own finalizer and the CLR makes no guarantee about finalization order — when the builder finalizes first, its native pathbuilder is freed and its Handle is set to IntPtr.Zero. The path's finalizer then runs SKNativeObject.Dispose(false), which reads Handle on line 269 to check `!= IntPtr.Zero`. That dispatches into our overridden getter, FlushBuilder calls
sk_pathbuilder_detach_path(_builder.Handle), and the C side dereferences nullptr (or a dangling pointer if the same address was reallocated).

Skip FlushBuilder once disposal has begun. The pending builder mutations are about to be discarded along with the path either way, and DisposeNative still cleans up _builder defensively (the CAS in SKNativeObject.Dispose makes a second Dispose a no-op if the builder already finalized).

Added a regression test that deterministically reproduces the crash without the fix (Test host process crashed) and passes with it.

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation