### PR TITLE
Fix skia-analyst and sample-scout: no safe outputs generated

### DIFF
--- a/.agents/skills/sample-scout/SKILL.md
+++ b/.agents/skills/sample-scout/SKILL.md
@@ -40,7 +40,6 @@ Phase 1: Setup (list GM files, list existing Gallery samples)
 Phase 2: Analyze GM files (parallel agents, each handles a chunk)
 Phase 3: Cross-reference with existing Gallery samples
 Phase 4: Validate and render
-Phase 5: Present results
 ```
 
 ### Phase 1: Setup
@@ -142,19 +141,4 @@ python3 .agents/skills/sample-scout/scripts/render-sample-scout.py sample-scout-
 
 This produces a `.md` file with `###`/`####` headers suitable for GitHub issues.
 
-### Phase 5: Present Results
-
-Show the summary with these key metrics:
-- Total samples analyzed
-- 🆕 No existing sample (opportunities)
-- 🔶 Similar sample exists (enhancement opportunities)
-- ✅ Already covered
-- 🎯 **Opportunity count** = high interest + APIs ready + no existing sample
-
-Then present the top opportunities — samples that are high-interest, have all APIs available,
-and have no existing Gallery coverage. These are the ones to build next.
-
-Offer:
-1. "Want me to build Gallery samples for the top opportunities?"
-2. "Should I focus on samples that need new APIs first?"
-3. "Want to filter by a specific category (shaders, image filters, text, etc.)?"
+ 

--- a/.agents/skills/skia-analyst/SKILL.md
+++ b/.agents/skills/skia-analyst/SKILL.md
@@ -54,7 +54,6 @@ Phase 1: Setup (determine scan range, prepare sources)
 Phase 2: Launch dual-model agents (Opus + GPT in parallel)
 Phase 3: Synthesize — merge findings, dedupe, both lenses
 Phase 4: Generate outputs (JSON → validate → Markdown)
-Phase 5: Present results
 ```
 
 ### Phase 1: Setup
@@ -149,16 +148,4 @@ python3 .agents/skills/skia-analyst/scripts/render-skia-analyst.py skia-analyst-
 This produces a GitHub-flavored Markdown file with collapsible details, suitable for pasting
 into a GitHub issue or sharing as a gist.
 
-### Phase 5: Present Results
-
-Show highlights inline:
-
-- **Top gaps** — transformative and significant items
-- **Quick wins** — partial binding status (C API exists, just needs C# wrapper)
-- **Breaking changes** — if any findings have `importance: breaking`
-
-Then offer next steps:
-1. "Want me to investigate any finding in more detail?"
-2. "Should I use the api-add-review skill to start binding a feature?"
-3. "Want to upload the markdown to a gist for sharing?"
-4. "Should I create a GitHub issue with the gap analysis?"
+ 

--- a/.github/workflows/sample-scout.md
+++ b/.github/workflows/sample-scout.md
@@ -8,10 +8,12 @@ concurrency:
   group: sample-scout
   cancel-in-progress: true
 timeout-minutes: 30
+checkout:
+  submodules: recursive
+  fetch-depth: 1
 steps:
-  - name: Init submodule and redirect step summary
+  - name: Prepare working directory
     run: |
-      git submodule update --init --depth=1 externals/skia
       mkdir -p /tmp/gh-aw/agent
       touch /tmp/gh-aw/agent/step-summary.md
       rm -f /tmp/gh-aw/agent-step-summary.md
@@ -20,11 +22,7 @@ permissions:
   contents: read
   issues: read
 tools:
-  github:
-    toolsets: [repos, issues]
-    allowed-repos: ["mono/skiasharp"]
-    min-integrity: none
-  bash: ["python3", "pip3", "gh", "git", "jq", "cat", "grep", "find", "sed", "sort", "head", "tail", "wc", "ls", "cp", "mkdir", "echo", "xargs", "basename"]
+  bash: ["python3", "cat", "grep", "find", "jq", "head", "tail", "wc", "sort", "sed", "ls", "cp", "mkdir", "echo", "xargs", "basename"]
 network:
   allowed:
     - defaults
@@ -42,27 +40,27 @@ safe-outputs:
 
 # Weekly Sample Scout Report
 
-Scan all Skia GM samples from the submodule and publish a report of Gallery opportunities as a GitHub issue.
+Scan Skia GM samples from the submodule and publish a report of Gallery opportunities
+as a GitHub issue using the `create_issue` safe output tool.
 
 ## Step 1 — Run the sample-scout skill
 
-Read and follow the instructions in `.agents/skills/sample-scout/SKILL.md` to run a full scan.
+Read `.agents/skills/sample-scout/SKILL.md` and follow its instructions for a full scan.
 
-Complete all phases (Setup → Analyze → Cross-Reference → Validate & Render).
-The GM files are at `externals/skia/gm/*.cpp` — read them directly, no remote fetching needed.
-
-After Phase 4 completes, the outputs will be:
-- `sample-scout-report.json` — the validated JSON report
-- `sample-scout-report.md` — the rendered Markdown
+The GM files are at `externals/skia/gm/*.cpp` and binding code is in `binding/SkiaSharp/` —
+read them directly from the checkout, no remote fetching needed.
 
 ## Step 2 — Publish as GitHub issue
 
-Create a GitHub issue with the contents of `sample-scout-report.md` as the body.
+**Use the `create_issue` safe output tool** to publish the report. This is the primary deliverable.
+
+Read `sample-scout-report.md` and pass it as the issue body. If larger than 65000 characters,
+generate a condensed summary with the top opportunities instead.
 
 The issue title **must** start with `Sample Scout:` followed by date and key metric
-(e.g. `Sample Scout: 2025-01-15 (42 opportunities)`) so `close-older-issues` matches correctly.
+(e.g. `Sample Scout: 2025-01-15 (42 opportunities)`).
 
-## Step 3 — Upload artifacts and write step summary
+## Step 3 — Upload artifacts
 
 ```bash
 cp sample-scout-report.json /tmp/gh-aw/agent/
@@ -70,5 +68,10 @@ cp sample-scout-report.md /tmp/gh-aw/agent/
 cat sample-scout-report.md >> /tmp/gh-aw/agent/step-summary.md
 ```
 
-**IMPORTANT:** Write to the literal path `/tmp/gh-aw/agent/step-summary.md` — this file is symlinked
-to the step summary. Do NOT use `$GITHUB_STEP_SUMMARY` as it resolves to an inaccessible path.
+Write to `/tmp/gh-aw/agent/step-summary.md` (symlinked to step summary).
+
+## ⚠️ MANDATORY — Safe Output Required
+
+**You MUST call the `create_issue` safe output tool before finishing.** If the full report
+could not be generated, still call `create_issue` with a partial summary. Never exit without
+calling at least one safe output tool.

--- a/.github/workflows/skia-analyst.md
+++ b/.github/workflows/skia-analyst.md
@@ -8,27 +8,33 @@ concurrency:
   group: skia-analyst
   cancel-in-progress: true
 timeout-minutes: 30
+checkout:
+  submodules: recursive
+  fetch-depth: 1
 steps:
-  - name: Redirect step summary into agent-writable directory
+  - name: Prepare external data
+    env:
+      GH_TOKEN: ${{ github.token }}
     run: |
+      set -euo pipefail
       mkdir -p /tmp/gh-aw/agent
       touch /tmp/gh-aw/agent/step-summary.md
       rm -f /tmp/gh-aw/agent-step-summary.md
       ln -s /tmp/gh-aw/agent/step-summary.md /tmp/gh-aw/agent-step-summary.md
+
+      # Pre-fetch upstream release notes (different repo — agent can't access google/skia)
+      gh api repos/google/skia/contents/RELEASE_NOTES.md \
+        -H "Accept: application/vnd.github.raw" > /tmp/gh-aw/agent/skia-release-notes.md
+      echo "Release notes: $(wc -l < /tmp/gh-aw/agent/skia-release-notes.md) lines"
 permissions:
   contents: read
   issues: read
 tools:
-  github:
-    toolsets: [repos, issues]
-    allowed-repos: ["mono/skiasharp", "mono/skia", "google/skia"]
-    min-integrity: none
-  bash: ["python3", "pip3", "gh", "git", "jq", "cat", "grep", "find", "sed", "sort", "head", "tail", "wc", "cp", "mkdir", "echo"]
+  bash: ["python3", "cat", "grep", "find", "jq", "head", "tail", "wc", "sort", "sed", "cp", "mkdir", "echo"]
 network:
   allowed:
     - defaults
     - python
-    - github
 safe-outputs:
   mentions: false
   allowed-github-references: []
@@ -42,26 +48,36 @@ safe-outputs:
 
 # Daily Skia Analyst Report
 
-Run a full skia-analyst scan and publish the results as a GitHub issue.
+Analyze what's new in upstream Skia and what's missing in SkiaSharp, then publish
+a report as a GitHub issue using the `create_issue` safe output tool.
 
 ## Step 1 — Run the skia-analyst skill
 
-Read and follow the instructions in `.agents/skills/skia-analyst/SKILL.md` to run a **full scan**.
+Read `.agents/skills/skia-analyst/SKILL.md` and follow its instructions for a **full scan**.
 
-Complete all phases (Setup → Agents → Synthesize → Generate Outputs). Use `scanMode: full`.
+Key data locations:
+- Upstream release notes have been pre-fetched to `/tmp/gh-aw/agent/skia-release-notes.md`
+- Current milestone: `externals/skia/include/core/SkMilestone.h`
+- C API bindings: `binding/SkiaSharp/SkiaApi.generated.cs`
+- C# wrappers: `binding/SkiaSharp/*.cs`
+- Upstream C++ headers: `externals/skia/include/` (submodule is checked out)
+- Our C API shim: `externals/skia/include/c/` and `externals/skia/src/c/`
 
-After Phase 4 completes, the outputs will be:
-- `skia-analyst-report.json` — the validated JSON report
-- `skia-analyst-report.md` — the rendered Markdown
+Read these files directly — do not fetch anything via MCP or `gh`.
+
+Use a **single analysis agent** to stay within the 30-minute budget.
 
 ## Step 2 — Publish as GitHub issue
 
-Create a GitHub issue with the contents of `skia-analyst-report.md` as the body.
+**Use the `create_issue` safe output tool** to publish the report. This is the primary deliverable.
+
+Read `skia-analyst-report.md` and pass it as the issue body. If larger than 65000 characters,
+generate a condensed summary with top gaps and quick wins instead.
 
 The issue title **must** start with `Skia Analyst:` followed by the milestone and date
-(e.g. `Skia Analyst: m147 (2025-01-15)`) so `close-older-issues` matches correctly.
+(e.g. `Skia Analyst: m147 (2025-01-15)`).
 
-## Step 3 — Upload artifacts and write step summary
+## Step 3 — Upload artifacts
 
 ```bash
 cp skia-analyst-report.json /tmp/gh-aw/agent/
@@ -69,5 +85,10 @@ cp skia-analyst-report.md /tmp/gh-aw/agent/
 cat skia-analyst-report.md >> /tmp/gh-aw/agent/step-summary.md
 ```
 
-**IMPORTANT:** Write to the literal path `/tmp/gh-aw/agent/step-summary.md` — this file is symlinked
-to the step summary. Do NOT use `$GITHUB_STEP_SUMMARY` as it resolves to an inaccessible path.
+Write to `/tmp/gh-aw/agent/step-summary.md` (symlinked to step summary).
+
+## ⚠️ MANDATORY — Safe Output Required
+
+**You MUST call the `create_issue` safe output tool before finishing.** If the full report
+could not be generated, still call `create_issue` with a partial summary. Never exit without
+calling at least one safe output tool.


### PR DESCRIPTION
## Problem

Both `skia-analyst` and `sample-scout` agentic workflows completed their analysis runs but never called the `create_issue` safe output tool, causing **"No Safe Outputs Generated"** failures.

## Root Cause Analysis

From auditing runs [#25132180272](https://github.com/mono/SkiaSharp/actions/runs/25132180272) and [#25132182154](https://github.com/mono/SkiaSharp/actions/runs/25132182154):

1. **SKILL.md Phase 5** told the agent to offer interactive follow-up questions ("Want me to investigate?"), signaling completion before the workflow's issue-creation step ran.

2. **Workflow prompts** said "Create a GitHub issue" without naming the `create_issue` safe output tool. The system prompt mentions it, but after 94-253 turns of skill execution the agent lost track.

3. **skia-analyst wasted 5.3M tokens** fetching files via MCP that were already in the checkout — SkCanvas.h fetched 2× via GitHub API (~64K tokens), SkCodec.h 3× (~35K tokens), RELEASE_NOTES.md via MCP instead of pre-step (~31K tokens). Two sub-agents independently fetched the same headers.

## Fixes

| Change | File |
|--------|------|
| Remove Phase 5 (interactive-mode prompts) | Both `SKILL.md` files |
| Explicit `create_issue` safe output instructions + mandatory reminder | Both workflow `.md` files |
| Pre-fetch only RELEASE_NOTES.md (different repo) in deterministic pre-step | `skia-analyst.md` |
| Use `checkout.submodules: recursive` instead of runtime `git submodule` | Both workflows |
| Remove github MCP tool (all code is on disk) | Both workflows |
| Single agent instead of dual-model (stays within 30-min budget) | `skia-analyst.md` |
