### PR TITLE
fix: skip release notes workflow when only docs/releases change

### DIFF
--- a/.github/workflows/update-release-notes.lock.yml
+++ b/.github/workflows/update-release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"37074e3ccaeae8d416099710ae1388b5706e4fd603fe8a8c65c76cee458b98b2","compiler_version":"v0.71.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"674b0b60d3484f7ffc923d59db46622e0fcde4e9582cf8ffebe35dbbd8aedd94","compiler_version":"v0.71.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f8495a686e66770ae977f82732f34d7340ee42a4","version":"v0.71.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.35"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.35"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.35"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.3"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -54,6 +54,8 @@ name: "Update Release Notes"
     branches:
     - main
     - release/**
+    paths-ignore:
+    - documentation/docfx/releases/**
     tags:
     - v*
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
@@ -194,23 +196,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_939dd78ffcec042e_EOF'
+          cat << 'GH_AW_PROMPT_53297906f9ee98e2_EOF'
           <system>
-          GH_AW_PROMPT_939dd78ffcec042e_EOF
+          GH_AW_PROMPT_53297906f9ee98e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_939dd78ffcec042e_EOF'
+          cat << 'GH_AW_PROMPT_53297906f9ee98e2_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_939dd78ffcec042e_EOF
+          GH_AW_PROMPT_53297906f9ee98e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_939dd78ffcec042e_EOF'
+          cat << 'GH_AW_PROMPT_53297906f9ee98e2_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_939dd78ffcec042e_EOF
+          GH_AW_PROMPT_53297906f9ee98e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_939dd78ffcec042e_EOF'
+          cat << 'GH_AW_PROMPT_53297906f9ee98e2_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -239,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_939dd78ffcec042e_EOF
+          GH_AW_PROMPT_53297906f9ee98e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_939dd78ffcec042e_EOF'
+          cat << 'GH_AW_PROMPT_53297906f9ee98e2_EOF'
           </system>
           {{#runtime-import .github/workflows/update-release-notes.md}}
-          GH_AW_PROMPT_939dd78ffcec042e_EOF
+          GH_AW_PROMPT_53297906f9ee98e2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -432,9 +434,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0ccb326e3c4ffba3_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5bb97ee3e69a95ca_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"draft":false,"labels":["documentation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true,"title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0ccb326e3c4ffba3_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5bb97ee3e69a95ca_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -642,7 +644,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_d5f06a5cc9819973_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f2556535b2cc304b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -683,7 +685,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d5f06a5cc9819973_EOF
+          GH_AW_MCP_CONFIG_f2556535b2cc304b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main, "release/**"]
     tags: ["v*"]
+    paths-ignore:
+      - "documentation/docfx/releases/**"
   workflow_dispatch:
   skip-bots: [github-actions, copilot, dependabot]
 concurrency:


### PR DESCRIPTION
Merging a release notes PR pushes to `main`, which re-triggers the `update-release-notes` workflow, creating another PR — an infinite loop.

Adding `paths-ignore: documentation/docfx/releases/**` breaks the cycle: when a release notes PR merges (only touching files in that directory), the workflow won't re-trigger.

Observed: merging #3837 immediately spawned #3838 (closed as duplicate).