### PR TITLE
Fix SkiaSharp references for Uno Platform's Gallery sample

### DIFF
--- a/samples/Gallery/Uno/SkiaSharpSample.Uno.csproj
+++ b/samples/Gallery/Uno/SkiaSharpSample.Uno.csproj
@@ -41,22 +41,11 @@
     <ProjectReference Include="..\Shared\SkiaSharpSample.Shared.csproj" />
   </ItemGroup>
 
-  <!-- Pin SkiaSharp.Skottie because Uno.Sdk's Uno.Implicit.Packages.ProjectSystem.Uno.targets
-       (gated on the SkiaRenderer UnoFeature above) injects SkiaSharp.Skottie as a *direct*
-       PackageReference. SkiaSharpSample.Shared brings Skottie 4.x in transitively; the Uno
-       SDK's direct ref pegs the floor at 3.x, so NuGet's resolver fires NU1605 (downgrade
-       of a direct ref against a transitive higher version). Other SkiaSharp packages
-       (SkiaSharp itself, HarfBuzzSharp, SkiaSharp.HarfBuzz) reach the gallery only
-       transitively from both directions, so the resolver picks the higher version and no
-       NU1605 fires — Skottie is the only one with this asymmetry.
-       Re-stating Skottie here as a direct ref puts samples-generate's version-substitution
-       in charge of the floor (it bumps to whatever VERSIONS.txt has — currently 4.147.0),
-       lining up with what Shared asks for. ExcludeAssets="all" keeps the package from
-       contributing assets — the actual Skottie code keeps coming from Shared in the
-       generated build, and from _UnoPlatformSamples.targets's project reference in-tree. -->
-  <ItemGroup>
-    <PackageReference Include="SkiaSharp.Skottie" Version="3.119.2" ExcludeAssets="all" />
-  </ItemGroup>
+  <PropertyGroup>
+    <!-- samples-generate's version-substitution will override this value so that
+        implicit references from Uno.Sdk match the versions specified in SkiaSharpSample.Shared -->
+    <SkiaSharpVersion>3.119.2</SkiaSharpVersion>
+  </PropertyGroup>
 
   <Import Project="..\..\..\binding\IncludeNativeAssets.SkiaSharp.targets" />
   <Import Project="..\..\..\binding\IncludeNativeAssets.HarfBuzzSharp.targets" />

--- a/scripts/cake/samples.cake
+++ b/scripts/cake/samples.cake
@@ -417,6 +417,17 @@ void CreateSamplesDirectory(DirectoryPath samplesDirPath, DirectoryPath outputDi
                 import.Remove();
             }
 
+            // substitute <SkiaSharpVersion> (used by Uno.Sdk to override the version of its
+            // implicitly-referenced SkiaSharp package; not a <PackageReference> so not handled above)
+            foreach (var ve in xdoc.Descendants().Where(e => e.Name.LocalName == "SkiaSharpVersion").ToArray()) {
+                var skiaVersion = GetVersion("SkiaSharp");
+                if (!string.IsNullOrWhiteSpace(skiaVersion)) {
+                    skiaVersion += string.IsNullOrEmpty(versionSuffix) ? "" : $"-{versionSuffix}";
+                    Debug($"Substituting SkiaSharpVersion for {skiaVersion}.");
+                    ve.Value = skiaVersion;
+                }
+            }
+
             // save the project
             EnsureDirectoryExists(dest.GetDirectory());
             xdoc.Save(dest.FullPath);


### PR DESCRIPTION
This pull request updates how the SkiaSharp version is managed for Uno Gallery samples to resolve version conflicts and improve maintainability. The main change is to use a property (`<SkiaSharpVersion>`) instead of a direct `PackageReference` for SkiaSharp.Skottie, allowing automated tooling to control the version and ensuring consistency across dependencies.

Dependency management improvements:

* Replaced the direct `<PackageReference>` to `SkiaSharp.Skottie` in `SkiaSharpSample.Uno.csproj` with a `<SkiaSharpVersion>` property, allowing samples-generate tooling to control the version and prevent NuGet downgrade warnings due to version mismatches between direct and transitive references.
* Updated the version substitution logic in `scripts/cake/samples.cake` to replace the value of `<SkiaSharpVersion>` with the correct version (and optional suffix), ensuring that the Uno.Sdk's implicit SkiaSharp package references are aligned with the versions specified in `SkiaSharpSample.Shared`.