### PR TITLE
[skia-sync] Update skia to milestone 147

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "5247a6856dcd9c02a104aa9cbb1b6c70e8322feb"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated Skia milestone bump from m147 to m147.

**Companion skia PR:** https://github.com/mono/skia/pull/216

# mono/SkiaSharp PR Summary — m147 Upstream Bug Fix Sync

## Overview

This is a **same-milestone sync** (m147 → m147). No milestone bump.
Updates the `externals/skia` submodule pointer to include 3 upstream
bug-fix commits that arrived after the previous m147 merge.

## Breaking Change Analysis

**No breaking changes.** The 3 upstream commits are bug fixes only:
- SkRP (SkSL Raster Pipeline) stack management fix
- SkRuntimeEffect optimization (local copy of compiled program)
- SkRegion validation (reject malformed regions)

None of these touch the C API or any public SkiaSharp surface.

## Version / Binding Updates

| File | Change |
|------|--------|
| `cgmanifest.json` | Updated `commitHash`, `upstream_merge_commit` |
| `externals/skia` | Submodule bumped to `5247a6856d` |
| `scripts/VERSIONS.txt` | No change (same milestone 147) |
| `SkiaApi.generated.cs` | No change (C API unchanged) |

## C# Changes

None required. No new or removed C API functions.

## Build Results

- **Native build (Linux x64)**: ✅ Passed (libSkiaSharp: 7m08s)
- **C# build**: ✅ Passed (0 errors, 87 warnings — pre-existing)

## Test Results

- **Smoke tests**: ✅ 32/32 passed
- **Full suite**: ✅ 5424 passed, 171 skipped (GPU/hardware)
- **Known pre-existing failures**: 47 font/typeface tests fail due to
  missing `fontconfig` in this CI environment — **unrelated to this change**.
  All failing tests are `SKFontManagerTest`, `SKTypefaceTest`, `SKFontTest`,
  `SKPaintTest` (text methods). These test the OS font stack, not Skia rendering.

## Items Needing Human Attention

- **Pre-existing test failures (47)**: Font-related tests fail on Linux CI
  due to missing fontconfig. These are not introduced by this PR.
  Affected: SKFontManagerTest, SKTypefaceTest, SKFontTest (text methods), SKPaintTest (text methods).

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).