### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "ffcbdd9a204ac1833a2cae11db2da87b1a475816"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/217

# mono/SkiaSharp — Skia m147 Bug Fix Sync

## Summary

Updated `externals/skia` submodule pointer and `cgmanifest.json` to include 3 upstream m147 bug fixes.

## Changes

### Submodule Update
- **Previous SHA**: `d89d82d57d` (head of `origin/skiasharp`)
- **New SHA**: `ffcbdd9a20` (merge commit on `skia-sync/m147`)

### cgmanifest.json
- `commitHash`: updated to `ffcbdd9a204ac1833a2cae11db2da87b1a475816`
- `upstream_merge_commit`: updated to `dcbd374c13430f81daa04d28f8d00dee65679b17`
- `chrome_milestone`: unchanged (147)

## Breaking Change Analysis

**No breaking changes.** All 3 upstream commits are internal bug fixes:
- SkRegion crash fix (memory safety — reject invalid consecutive empty slices)
- SkRuntimeEffect thread safety fix (race condition in GPU+CPU concurrent use)
- SkRP optimizer fix (stack underflow in discard_stack optimization)

## Binding Changes

None — `SkiaApi.generated.cs` is unchanged. No new C API functions were added.

## C# Wrapper Changes

None — no new functions to wrap.

## Build Results

| Step | Result |
|------|--------|
| Native build (Linux x64) | ✅ Success (13m 06s) |
| C# build | ✅ Success (0 errors, 87 warnings) |
| Tests | ✅ 5425 passed, 171 skipped, 46 failed (pre-existing) |

## Test Failures

46 pre-existing failures in `SKPaintTest`, `SKFontTest`, `SKTypefaceTest` (confirmed to exist on `origin/main` before this change). These are not caused by the upstream merge.

## Items Needing Human Attention

- **Pre-existing test failures (46)**: `SKPaintTest`, `SKFontTest`, `SKTypefaceTest` failures exist on `main` and are unrelated to this sync. Should be investigated separately.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).