### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "e946b5cf6d834cb9b50a845bde863fd41a3b04d5"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/219

# mono/SkiaSharp PR Summary — m147 Upstream Sync

## Overview

Bumped `externals/skia` submodule to pick up 3 upstream bug-fix commits from `chrome/m147`.
Updated `cgmanifest.json` to reflect new commit hashes.

## Changes

### Submodule (`externals/skia`)
- Advanced from `d89d82d57d` → `e946b5cf6d` (merge commit)
- Picks up 3 upstream cherry-picks: SkRP stack fix, SkRuntimeEffect thread safety, SkRegion validation

### `cgmanifest.json`
- `commitHash`: updated to `e946b5cf6d834cb9b50a845bde863fd41a3b04d5`
- `upstream_merge_commit`: updated to `dcbd374c13430f81daa04d28f8d00dee65679b17`
- `chrome_milestone`: 147 (unchanged)

## Breaking Change Analysis

**Risk: 🟢 NONE** — all 3 commits are internal bug fixes:
- SkRP optimization correctness (no API change)
- SkRuntimeEffect thread safety (internal mutability fix)
- SkRegion memory validation (OOB read fix, CVE-class)

No C API changes. No binding regeneration needed. No C# wrapper changes needed.

## Build Results

| Step | Result |
|------|--------|
| Native build (Linux x64) | ✅ Success |
| C# build (0 errors) | ✅ Success |
| Smoke tests (32/32) | ✅ Pass |
| Full test suite | 5425 passed, 46 failed (pre-existing font failures on CI — confirmed same failures on `origin/main`) |

## Items Needing Human Attention

- The 46 font-related test failures (`SKFontTest`, `SKPaintTest`, `SKTypefaceTest`) are **pre-existing** failures on `origin/main` due to missing system fonts in the CI environment. They are not caused by this change.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).