### PR TITLE
Keep raw PR data in release notes files as HTML comment

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -50,8 +50,9 @@ This writes raw PR data to `documentation/docfx/releases/{version}.md` or
 `documentation/docfx/releases/{version}-unreleased.md` depending on the branch type,
 and regenerates TOC/index. All data comes from git history — no API calls or tokens needed.
 
-The file starts with an HTML comment header containing metadata (version, status, branch,
-diff range, PR count), followed by the raw PR list. Read the header to understand context.
+The file starts with an HTML comment block containing both metadata (version, status, branch,
+diff range, PR count) AND the raw PR list. Below the comment is a skeleton heading with a
+placeholder for polished content. The raw data comment must be preserved in the final file.
 
 **IMPORTANT:** The script prints a summary at the end listing ALL files to polish:
 
@@ -72,16 +73,37 @@ Read each file to get its raw data and metadata, then rewrite it with polished c
 Read `documentation/docfx/releases/TEMPLATE.md`. This is a real example of a polished
 release notes page. Match its structure, tone, and formatting exactly.
 
-Determine the version's status from the HTML comment header in the file (`status: unreleased`, `status: preview`, or `status: stable`):
+Determine the version's status from the HTML comment block in the file (`status: unreleased`, `status: preview`, or `status: stable`):
 - **Stable**: header uses `Released {date}` + NuGet link + GitHub Release link
 - **Preview**: header uses `Preview only` + preview NuGet link + GitHub Release link
 - **Unreleased**: header uses `> **Upcoming release** · In development · Not yet available on NuGet`
 
 ### Step 4 — Write polished pages
 
-For **every file** listed in the script's "Files to polish" output, replace the raw content
-with polished release notes. If the file exists, replace its entire content — this is a full
-regeneration. Each file has its own HTML comment header with version, status, branch, and diff range.
+For **every file** listed in the script's "Files to polish" output, write polished release
+notes **below the raw data HTML comment block**. 
+
+**CRITICAL: Preserve the raw data comment.** The `<!-- RAW PR DATA ... -->` comment block at
+the top of the file must remain intact. Replace everything AFTER it (the skeleton heading and
+placeholder) with polished content. When you write the polished content, start with the
+`<!-- Generated: ... -->` timestamp line, then the `# Version X.Y.Z` heading, then the rest.
+
+The final file structure should be:
+
+```markdown
+<!-- RAW PR DATA — Do not remove this comment block. ... -->
+
+<!-- Generated: YYYY-MM-DDTHH:MM:SSZ by {model-name} -->
+
+# Version X.Y.Z
+
+> **theme** · status · links
+
+## Highlights
+...
+```
+
+Each file has its own HTML comment block with version, status, branch, and diff range.
 
 **CRITICAL: Each file is independent.** Only use the raw PR data that is IN THAT FILE.
 Do NOT combine data from other files. For example, if `3.119.4-unreleased.md` has 4 PRs
@@ -112,7 +134,8 @@ Follow these rules:
 7. **PR links** — Every item links to its PR.
 
 8. **Generation timestamp** — Always include `<!-- Generated: YYYY-MM-DDTHH:MM:SSZ by {model-name} -->`
-   as the very first line of the file. Use the current UTC time and your model name.
+   as the first line AFTER the raw data comment block (before the `# Version` heading).
+   Use the current UTC time and your model name.
 
 9. **Rollup at top** — Aggregate ALL changes across all previews into the main sections.
 

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -581,26 +581,33 @@ def get_prs_from_diff(from_ref, to_ref):
 
 def format_pr_list(prs, metadata):
     # type: (list[dict], dict) -> str
-    """Format the PR list as markdown with metadata header."""
+    """Format the PR list as markdown with raw data in an HTML comment.
+
+    The raw PR data is preserved inside an HTML comment block so that AI
+    can regenerate polished notes from it at any time. Below the comment,
+    a skeleton placeholder is written for AI to fill in.
+    """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    version = metadata["version"]
+
+    # Build the raw data comment block
     lines = [
         "<!--",
+        "  RAW PR DATA — Do not remove this comment block.",
+        "  AI uses this data to generate the polished release notes below.",
+        "  Re-run the script to refresh this data from git history.",
+        "",
         "  Generated: {} by generate-release-notes.py".format(now),
-        "",
-        "  This is raw PR data. Rewrite this entire file with polished release",
-        "  notes using documentation/docfx/releases/TEMPLATE.md as the reference.",
-        "",
-        "  version: {}".format(metadata["version"]),
-        "  status:  {}".format(metadata["status"]),
-        "  branch:  {}".format(metadata["branch"]),
-        "  diff:    {}..{}".format(metadata["from"], metadata["to"]),
-        "  prs:     {}".format(len(prs)),
-        "-->",
+        "  version:   {}".format(version),
+        "  status:    {}".format(metadata["status"]),
+        "  branch:    {}".format(metadata["branch"]),
+        "  diff:      {}..{}".format(metadata["from"], metadata["to"]),
+        "  prs:       {}".format(len(prs)),
         "",
     ]
 
     if not prs:
-        lines.append("*No changes found.*")
+        lines.append("  *No changes found.*")
     else:
         for pr in prs:
             title = pr.get("title", "")
@@ -616,10 +623,41 @@ def format_pr_list(prs, metadata):
             skia_pr = pr.get("skiaPr")
             skia_str = " (skia: mono/skia#{})".format(skia_pr) if skia_pr else ""
 
-            lines.append("- {} by @{} in {}{}{}{}".format(
+            lines.append("  - {} by @{} in {}{}{}{}".format(
                 title, author, url, community_str, effort, skia_str))
 
+    lines.append("-->")
     lines.append("")
+
+    # Add skeleton content for AI to polish
+    lines.append("# Version {}".format(version))
+    lines.append("")
+
+    # Status-appropriate header
+    status = metadata["status"]
+    if status == "unreleased":
+        lines.append(
+            "> **Upcoming release** · In development "
+            "· Not yet available on NuGet")
+    elif status == "preview":
+        lines.append(
+            "> **Preview release** · Preview only "
+            "· [NuGet](https://www.nuget.org/packages/SkiaSharp/"
+            "{}-preview)".format(version))
+    else:
+        lines.append(
+            "> [NuGet](https://www.nuget.org/packages/SkiaSharp/{})".format(
+                version))
+    lines.append("")
+
+    lines.append(
+        "<!-- AI: Use the raw PR data in the comment above to write polished")
+    lines.append(
+        "     release notes here. Follow documentation/docfx/releases/"
+        "TEMPLATE.md")
+    lines.append("     for structure and tone. -->")
+    lines.append("")
+
     return "\n".join(lines)
 
 


### PR DESCRIPTION
The `generate-release-notes.py` script now places the raw PR list inside an HTML comment block that persists in the final file. AI polishes content below the comment rather than replacing the entire file.

**Changes:**
- **Script** (`format_pr_list()`): Raw PR bullets are now inside a `<!-- RAW PR DATA ... -->` comment block, followed by a skeleton placeholder for polished content
- **SKILL.md** (Step 4): Instructions updated to preserve the raw data comment and write polished content below it

**Benefits:**
- Source data is always auditable in the `.md` file
- AI can re-polish from embedded data without re-running the script
- Humans can see exactly what PRs the polished notes were derived from