### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/220

# Skia m147 Upstream Sync — mono/SkiaSharp PR Summary

## Changes

- Updated `externals/skia` submodule to include 3 upstream bug-fix commits from `upstream/chrome/m147`
- Updated `cgmanifest.json` `upstream_merge_commit` from `f8cd2da0256752afb0059bf17e4bf2bec422967e` to `dcbd374c13430f81daa04d28f8d00dee65679b17`

## Breaking Change Analysis

No breaking changes. All 3 upstream commits are bug fixes:
1. **SkRegion**: Reject regions with multiple empty slices in a row (defensive validation)
2. **SkRuntimeEffect**: Internal optimization — local copy of SkRP program
3. **SkRasterPipelineBuilder**: Fix stack entry removal during discard_stack

## Version/Binding Updates

- No milestone version bump (staying at m147)
- No C API changes required
- No binding regeneration needed (no generated file changes)
- No C# wrapper changes needed

## Build Results

- ✅ Native build (Linux x64): **PASS**
- ✅ C# build: **PASS** (0 errors, 87 pre-existing warnings)

## Test Results

- **Passed**: 5425
- **Failed**: 46 (pre-existing failures on `main` — font/typeface tests failing due to missing system fonts in CI environment, confirmed by running the same tests on unmodified `main`)
- **Skipped**: 171 (GPU tests skipped — no GPU in CI)
- **Total**: 5642

### Pre-existing Failures (Not Caused by This PR)

All 46 failures are in `SKFontTest`, `SKPaintTest`, and `SKTypefaceTest` — font measurement/rendering tests that require system fonts not available in the CI container. Confirmed pre-existing by testing against unmodified `main`.

## Items Needing Human Attention

- Pre-existing test failures (font/typeface) should be investigated separately

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).