### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "0c717501e29a5cb16c6fb0a74ebcc275c3b50056"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/222

# mono/SkiaSharp PR: skia-sync/m147

## Summary

Updates the `externals/skia` submodule to include 3 upstream bug-fix cherry-picks from `upstream/chrome/m147`. No milestone change (current = target = m147).

## Changes

### Submodule Update
- `externals/skia`: `d89d82d57d` → `0c717501e2` (branch `skia-sync/m147`)

### cgmanifest.json
- `commitHash` for `mono/skia`: `e09e6c1349` → `0c717501e2`
- `upstream_merge_commit`: `f8cd2da025` → `dcbd374c13` (latest upstream chrome/m147 HEAD)

## Breaking Change Analysis

All 3 upstream fixes are internal bug fixes with no public API changes and no C API impact:
- **SkRegion crash fix** — malformed serialized region data no longer crashes
- **SkRuntimeEffect thread safety** — concurrent GPU/CPU usage no longer races
- **SkRP stack optimizer fix** — certain SKSL programs no longer corrupt memory

## Version Files

No changes needed — milestone unchanged (147), increment unchanged (0), `SK_C_INCREMENT` = 0.

## Binding Changes

None. No new C API functions. `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` confirmed: "No changes to bindings".

## C# Wrapper Changes

None required.

## Build Results

| Step | Result |
|------|--------|
| Native build (`externals-linux --arch=x64`) | ✅ Passed (libSkiaSharp: 13:57, libHarfBuzzSharp: 1:06) |
| C# build (`dotnet build binding/SkiaSharp/SkiaSharp.csproj`) | ✅ 0 errors, 87 warnings (pre-existing) |
| Smoke tests (`Category=Smoke`) | ✅ 32/32 passed |
| Full test suite | ⚠️ See below |

## Test Results

**Full suite**: 27 failures, all pre-existing font/typeface tests failing due to environment lacking `/etc/fonts/` configuration (confirmed by running same tests against `origin/main` — same failures).

Failing test categories (all pre-existing):
- `SKTypefaceTest.DefaultFamilyNameIsNotNullOrEmpty` — empty family name in headless container
- `SKPaintTest.*` font measurement tests — depend on default typeface having glyphs
- `SKFontTest.*` text bounds/measurement tests — same root cause

The `PAL_SEHException` at process exit is non-deterministic and unrelated to the changes.

## Items Needing Human Attention

1. **Pre-existing font test failures** — 27 tests fail due to missing fontconfig in CI environment. These failures existed before this PR and are not caused by this update.
2. No other items.

## Branch Info

- Branch: `skia-sync/m147`
- Base: `origin/main`
- Head: `4c443d62fd`
- Target PR base: `main`
- Submodule points to: `mono/skia@0c717501e2` (branch `skia-sync/m147`)

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).