### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "48f5bec0953579f82ab68afbd1049cb4e36cb4eb"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/223

# mono/SkiaSharp PR Summary — Skia m147 Bug-Fix Sync

## Branch: `skia-sync/m147`
## Target: `main`

## Changes

### Submodule Update
- `externals/skia` bumped from `d89d82d57d` → `48f5bec095`
- Merges 3 upstream m147 bug-fix commits (SkRP, SkRegion)

### cgmanifest.json
- `commitHash`: updated to `48f5bec0953579f82ab68afbd1049cb4e36cb4eb`
- `upstream_merge_commit`: updated to `dcbd374c13430f81daa04d28f8d00dee65679b17`
- `chrome_milestone`: unchanged (147)

## Breaking Change Analysis

**None.** The upstream commits are internal bug fixes with no API surface changes.

## Version/Binding Updates

- Version files unchanged (milestone remains 147)
- `SkiaApi.generated.cs`: no changes (C API signatures unchanged)
- `HarfBuzzApi.generated.cs`: unchanged (reverted as per standard process)

## Build Results

| Step | Result |
|------|--------|
| Native build (Linux x64) | ✅ Success |
| C# build | ✅ 0 errors, 87 warnings (pre-existing) |

## Test Results

- **Total**: 5642 tests
- **Passed**: 5425
- **Skipped**: 171 (GPU/hardware not available in CI — expected)
- **Failed**: 46

### Test Failures

All 46 failures are **pre-existing** on `origin/main` and are unrelated to this sync:
- `SKFontTest` and `SKPaintTest` — font/typeface tests that require system fonts not available in the CI environment
- `SKTypefaceTest.DefaultIsNotEmpty` — `SKTypeface.Default` returns empty typeface in headless CI
- Verified pre-existing by running the same tests against `origin/main` (same failures)

## Items Needing Human Attention

- **Pre-existing test failures** (46): Font/typeface tests fail in headless CI due to missing system fonts. These are not caused by this sync. Tracked separately.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).