### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "4becae04746c8914a655450cf7aa9c925275ee08"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/224

# mono/SkiaSharp PR Summary — m147 Upstream Bug Fixes

## Branch
`skia-sync/m147` in mono/SkiaSharp

## Overview
Same-milestone sync (m147→m147). Updates the `externals/skia` submodule to include 3 upstream bug-fix commits from `upstream/chrome/m147`, and updates `cgmanifest.json` accordingly.

## Changes

### externals/skia
Submodule updated from `d89d82d57d` to `4becae04746c8914a655450cf7aa9c925275ee08`.

New merge commit includes 3 upstream bug fixes:
- SkRP discard_stack fix
- SkRuntimeEffect local optimized copy
- SkRegion validation for multiple empty slices

### cgmanifest.json
- `commitHash` updated to `4becae04746c8914a655450cf7aa9c925275ee08`
- `upstream_merge_commit` updated to `dcbd374c13430f81daa04d28f8d00dee65679b17`
- `chrome_milestone` remains `147`

## Breaking Change Analysis
**None.** The 3 upstream commits are pure bug fixes:
- No C API changes
- No removed/renamed public APIs
- No struct size changes
- No enum removals

## Version/Binding Updates
- No version bump (same milestone 147)
- Bindings regenerated: **no changes** (C API signatures unchanged)
- No new C# wrappers needed

## Build Results
- ✅ Native Linux x64 build: **SUCCESS**
- ✅ C# build: **0 errors, 87 warnings** (all pre-existing)

## Test Results
- ✅ Passed: 5425
- ⚠️ Failed: 46 (all font/typeface tests — pre-existing CI environment issue, no system fonts)
- ⏭️ Skipped: 171 (GPU tests — no GPU in CI)

### Known Pre-existing Font Failures
The 46 failures are all in `SKTypefaceTest`, `SKFontTest`, and `SKPaintTest` for operations requiring a default typeface (font measuring, glyph operations). These fail because the CI container has no system fonts loaded via fontconfig, unrelated to this Skia update.

## Items Needing Human Attention
- The font test failures should be investigated separately (pre-existing environment issue)
- No action required for this PR

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).