### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "e8e5063a8b0769c6469998e80ec809d646cd90b1"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/225

# mono/SkiaSharp PR: Bump skia submodule to m147 upstream bug fixes

## Branch
`skia-sync/m147` → targets `main`

## Summary

Same-milestone sync (m147 → m147). Updates the `externals/skia` submodule pointer
and `cgmanifest.json` to include 3 upstream bug-fix commits from `chrome/m147`.

## Breaking Change Analysis

**Risk: LOW** — None of the 3 upstream commits affect the public C++ API or C API:

| Category | Changes | C API Impact |
|----------|---------|--------------|
| 🟢 Internal fix | SkSL raster pipeline stack overflow fix | None |
| 🟢 Internal fix | SkRuntimeEffect private member `const` change | None |
| 🟢 Validation fix | SkRegion rejects invalid regions with multiple empty slices | None — header only adds doc comments and a private comment |

## Changes Made

### externals/skia (submodule)
- Bumped from `d89d82d57d` to `e8e5063a8b`
- Merge commit: `e8e5063a8b`

### cgmanifest.json
- `commitHash`: `e09e6c1...` → `e8e5063a8b...`
- `upstream_merge_commit`: `f8cd2da...` → `dcbd374c13...`

### binding/SkiaSharp/SkiaApi.generated.cs
- No changes (C API signatures unchanged, regeneration produced identical output)

## Build Results

| Step | Result |
|------|--------|
| Native build (Linux x64) | ✅ Success — `libSkiaSharp` + `libHarfBuzzSharp` |
| Binding regeneration | ✅ No changes — C API identical |
| C# build | ✅ 0 errors, 87 warnings (pre-existing) |
| Smoke tests (32) | ✅ 32/32 passed |
| Full test suite | ⚠️ 5425 passed, 46 failed, 171 skipped |

## Full Test Suite Notes

46 failures are **pre-existing environment issues** unrelated to this sync:
- All failures are in `SKFontTest`, `SKTypefaceTest`, `SKPaintTest` (font text measurement)
- Root cause: CI environment default font is `Alexander_hint.ttf` (ancient scripts, no Latin glyphs)
- These tests require a system font with Latin character glyphs
- The 3 upstream commits do NOT touch any font/typeface code
- Smoke tests (which include basic typeface tests) pass 32/32

## New C API Functions (from earlier PRs — not from this sync)

These functions were added to the mono/skia `skiasharp` branch in prior PRs
but do not yet have C# wrappers in SkiaSharp:

- `sk_webpencoder_encode_animated` — animated WebP encoder (added in mono/skia PR #199)
  - Struct: `SKWebpEncoderFrameNative` already mapped in `SkiaApi.generated.cs`
  - **⚠️ Needs C# wrapper** (e.g., `SKWebpEncoder.EncodeAnimated(...)`)

## Items Requiring Human Attention

1. **C# wrapper for `sk_webpencoder_encode_animated`** — The animated WebP C API was added
   in mono/skia PR #199 but the C# wrapper was never implemented. Tracked separately.

2. **Font test failures in CI environment** — The 46 font-related test failures exist in
   the automated workflow environment due to missing Latin fonts. These are environment issues
   not caused by this sync and should be addressed separately.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).