### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "cdec43f19725e09932ac2ffecf3dfedfe3281657"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/226

# mono/SkiaSharp PR Summary: m147 Bug-Fix Sync

## Overview

Syncs 3 upstream Skia `chrome/m147` bug-fix commits. No milestone version bump
(both current and target are m147). No C# wrapper changes needed.

## Changes Made

### `cgmanifest.json`
- `commitHash`: `e09e6c1349...` → `cdec43f197...` (new submodule merge SHA)
- `upstream_merge_commit`: `f8cd2da025...` → `dcbd374c13...` (upstream tip SHA)
- `chrome_milestone`: unchanged (147)

### `externals/skia` (submodule)
- Pointer updated to `cdec43f19725e09932ac2ffecf3dfedfe3281657`

## Breaking Change Analysis

**Risk level: NONE.** The 3 upstream commits are internal bug fixes:

| Change | Category | C API Impact |
|--------|----------|-------------|
| SkRP discard_stack fix | 🟢 Internal fix | None |
| SkRuntimeEffect const fields | 🟢 Private only | None |
| SkRegion RLE validation | 🟢 Internal fix | None |

## Binding Updates

- No changes to `SkiaApi.generated.cs` — C API signatures unchanged
- HarfBuzz bindings untouched

## Build Results

- **Native build (Linux x64):** ✅ Success
- **C# build:** ✅ 0 errors, 87 warnings (pre-existing warnings only)

## Test Results

- **Smoke tests (32/32):** ✅ All passed
- **Full test suite:** 46 pre-existing failures in font/typeface tests
  (e.g., `SKTypefaceTest.DefaultIsNotEmpty`, `SKFontTest.*`) — these are
  environment-specific failures unrelated to the 3 SkRP/SkRegion/SkRuntimeEffect commits.
  The same tests fail on `origin/main` builds in this CI environment (no system fonts).

## Items Needing Human Attention

- **Pre-existing font test failures (46 tests):** Font-related tests fail in this headless
  CI environment. These are not regressions from this sync. Recommend reviewing
  whether these tests should use `Skip` conditions for environments without system fonts.
  Full test output saved to workflow artifacts (`test-output.txt`).

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).