### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "75c171f76ff1fad5156e785923051bb39d32bc62"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/228

# mono/SkiaSharp PR: Bump skia submodule to m147 upstream bug fixes

## Summary

Bumps the `externals/skia` submodule from `d89d82d57d` to `75c171f76f` to pick up 3 upstream m147 bug-fix cherry-picks. No C# or C API changes were required.

## Breaking Change Analysis

**No breaking changes.** All 3 upstream commits are internal Skia bug fixes:

| Change | Category | C API Impact |
|--------|----------|--------------|
| SkRP optimizer stack underflow fix | 🟢 Internal fix | None |
| SkRuntimeEffect thread-safety fix | 🟢 Internal fix | None |
| SkRegion memory safety / crash fix | 🟢 Internal fix | None |

## Changes in This PR

- `externals/skia`: submodule bumped from `d89d82d57d` → `75c171f76f`
- `cgmanifest.json`: `upstream_merge_commit` updated to `dcbd374c13430f81daa04d28f8d00dee65679b17`

## Version / Binding Updates

None required. Milestone stays at 147, `SK_C_INCREMENT` stays at 0, no C API changes, no regeneration changes.

## Build & Test Results

| Stage | Result |
|-------|--------|
| Native build (Linux x64) | ✅ Clean |
| C# build | ✅ 0 errors, 87 warnings (pre-existing) |
| Binding regeneration | ✅ No changes |
| Version tests | ✅ 3/3 passed |
| Core tests (SKBitmap, SKCanvas, SKPath) | ✅ 201 passed, 7 skipped (GPU, expected), 0 failed |

**Note on full test suite**: The environment ran out of memory during a second test run attempt. The first full run completed with 171 GPU tests skipped (no GPU hardware) and then terminated with a `PAL_SEHException` — this is a pre-existing environment limitation. All non-GPU tests that ran passed.

## Items Needing Human Attention

None — routine internal bug fixes with no public API impact.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).