### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "41793833b451ac6cc30c66d6b2d601f2ae671d8b"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/229

# mono/SkiaSharp PR: Sync Skia m147 upstream bug fixes

## Branch: `skia-sync/m147` → target: `main`

## Summary

Same-milestone (m147 → m147) bug-fix sync. Merges 3 upstream Skia bug-fix commits into the `skiasharp` branch of the submodule, then updates `cgmanifest.json` in the parent repo.

## Breaking Change Analysis

**Risk level: 🟢 NONE** — All 3 upstream commits are pure bug fixes:

1. **SkRegion validation** (`6e0fbe154c`): Adds input validation to reject malformed regions with multiple empty slices. No API change.
2. **SkRP program copy** (`4eda6e72ad`): Internal optimization for SkRasterPipeline program handling. No API change.
3. **SkRP stack entries** (`dcbd374c13`): Fix for stack entry counting during discard_stack. No API change.

None of these touch the C API shim layer or any public SkiaSharp APIs.

## Version / Binding Updates

- `cgmanifest.json`: Updated `commitHash` and `upstream_merge_commit` to reflect new submodule SHA
- `scripts/VERSIONS.txt`: No changes (version stays at `4.147.0`)
- `SkiaApi.generated.cs`: No changes (C API unchanged)

## C# Changes

None.

## Build & Test Results

| Check | Result |
|-------|--------|
| Native build (Linux x64) | ✅ Passed |
| C# build | ✅ 0 errors, 87 warnings (pre-existing) |
| Smoke tests | ✅ 32/32 passed |
| Full test suite | ✅ 5471 passed, 171 skipped, 0 failed |

## Items Needing Human Attention

None. This is a routine upstream bug-fix sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).