### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -223,7 +223,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e09e6c1349c2e1bab47ed32675d03be951250f8e"
+          "commitHash": "6bc1a329b06b87d0e251bcf3fce565b8db302756"
         }
       }
     },
@@ -238,7 +238,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/230

# mono/SkiaSharp PR: [skia-sync] Merge upstream chrome/m147 bug fixes

## Summary

Same-milestone sync (`m147` → `m147`). No breaking changes. 3 upstream bug-fix commits merged.

## Breaking Change Analysis

**Risk level: None.** All 3 upstream commits are internal C++ implementation fixes:
- SkRP (Raster Pipeline) bug fixes — no public API changes
- SkRegion validation — no API signature changes

No C API modifications were required.

## Version / Binding Updates

| File | Change |
|------|--------|
| `cgmanifest.json` | `upstream_merge_commit` updated to `dcbd374c13430f81daa04d28f8d00dee65679b17` |
| `externals/skia` | Submodule pointer updated to new merge commit |

No changes to:
- `scripts/VERSIONS.txt` (milestone/version unchanged — still 4.147.0)
- `SkiaApi.generated.cs` (no C API changes → no binding changes)

## C# Changes

None required. No new generated functions. No C API additions or removals.

## Build Results

| Phase | Result |
|-------|--------|
| Native build (Linux x64) | ✅ Success |
| C# build | ✅ 0 errors, 87 warnings (pre-existing) |
| Smoke tests | ✅ Included in full suite |
| Full test suite | ✅ Passed: 5471, Skipped: 171 (GPU, no hardware), Failed: 0 |

## Items Needing Human Attention

None. Routine upstream bug-fix sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).