### PR TITLE
Run stale staging sweep daily instead of weekly

### DIFF
--- a/.github/workflows/build-site-cleanup-stale.yml
+++ b/.github/workflows/build-site-cleanup-stale.yml
@@ -2,8 +2,8 @@ name: "Docs - PR Staging - Sweep Stale"
 
 on:
   schedule:
-    # Every Monday at 06:00 UTC
-    - cron: "0 6 * * 1"
+    # Every day at 06:00 UTC
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 # Default to no permissions — each job declares only what it needs.


### PR DESCRIPTION
## Problem

The `build-site-go-live.yml` workflow has been failing since ~19:29 UTC today with:

> Artifact could not be deployed. Please ensure the content does not contain any hard links, symlinks and total size is less than 10GB.

The `docs-live` branch accumulated **19 PR staging directories** (~519 MB each = ~10.3 GB total), exceeding GitHub Pages' 10 GB deployment limit.

## Root Cause

Each PR staging deploy copies the full site (docs + fiddle + gallery-uno + gallery ≈ 519 MB). The weekly Monday sweep (`build-site-cleanup-stale.yml`) wasn't frequent enough to keep up — 9 of the 19 staging dirs belonged to already closed/merged PRs.

## Fix

- **Immediate:** Triggered the stale sweep manually via `workflow_dispatch` to purge closed/merged PR staging dirs (~4.7 GB freed)
- **Preventive:** Changed the sweep schedule from weekly (`0 6 * * 1`) to daily (`0 6 * * *`)

## One-line change

```diff
-    # Every Monday at 06:00 UTC
-    - cron: "0 6 * * 1"
+    # Every day at 06:00 UTC
+    - cron: "0 6 * * *"
```