### PR TITLE
Add HBColor struct for proper hb_color_t representation

### DIFF
--- a/binding/HarfBuzzSharp/Face.cs
+++ b/binding/HarfBuzzSharp/Face.cs
@@ -186,30 +186,30 @@ namespace HarfBuzzSharp
 
 		public int PaletteCount => (int)HarfBuzzApi.hb_ot_color_palette_get_count (Handle);
 
-		public uint[] GetPaletteColors (int paletteIndex)
+		public HBColor[] GetPaletteColors (int paletteIndex)
 		{
 			if (paletteIndex < 0)
 				throw new ArgumentOutOfRangeException (nameof (paletteIndex));
 
 			var totalColors = (int)HarfBuzzApi.hb_ot_color_palette_get_colors (Handle, (uint)paletteIndex, 0, null, null);
 			if (totalColors == 0)
-				return Array.Empty<uint> ();
+				return Array.Empty<HBColor> ();
 
 			uint count = (uint)totalColors;
-			var colors = new uint[totalColors];
-			fixed (uint* ptr = colors) {
+			var colors = new HBColor[totalColors];
+			fixed (HBColor* ptr = colors) {
 				HarfBuzzApi.hb_ot_color_palette_get_colors (Handle, (uint)paletteIndex, 0, &count, ptr);
 			}
 			return colors;
 		}
 
-		public int GetPaletteColors (int paletteIndex, Span<uint> colors)
+		public int GetPaletteColors (int paletteIndex, Span<HBColor> colors)
 		{
 			if (paletteIndex < 0)
 				throw new ArgumentOutOfRangeException (nameof (paletteIndex));
 
 			uint count = (uint)colors.Length;
-			fixed (uint* ptr = colors) {
+			fixed (HBColor* ptr = colors) {
 				HarfBuzzApi.hb_ot_color_palette_get_colors (Handle, (uint)paletteIndex, 0, &count, ptr);
 			}
 			return (int)count;

--- a/binding/HarfBuzzSharp/HBColor.cs
+++ b/binding/HarfBuzzSharp/HBColor.cs
@@ -1,0 +1,78 @@
+﻿#nullable disable
+
+using System;
+
+namespace HarfBuzzSharp
+{
+	/// <summary>
+	/// Represents a HarfBuzz color value (<c>hb_color_t</c>) with BGRA byte ordering.
+	/// </summary>
+	/// <remarks>
+	/// HarfBuzz stores colors as <c>0xBBGGRRAA</c> (Blue in high byte, Alpha in low byte).
+	/// This differs from <c>SKColor</c> which uses ARGB: <c>0xAARRGGBB</c>.
+	/// Use the named properties (<see cref="Red"/>, <see cref="Green"/>, <see cref="Blue"/>,
+	/// <see cref="Alpha"/>) to correctly access color channels.
+	/// </remarks>
+	public readonly struct HBColor : IEquatable<HBColor>
+	{
+		private readonly uint color;
+
+		/// <summary>
+		/// Creates an <see cref="HBColor"/> from a raw <c>hb_color_t</c> value.
+		/// </summary>
+		public HBColor (uint value)
+		{
+			color = value;
+		}
+
+		/// <summary>
+		/// Creates an <see cref="HBColor"/> from individual RGBA components.
+		/// </summary>
+		public HBColor (byte red, byte green, byte blue, byte alpha)
+		{
+			color = (uint)((blue << 24) | (green << 16) | (red << 8) | alpha);
+		}
+
+		/// <summary>
+		/// Gets the red channel value.
+		/// </summary>
+		public byte Red => (byte)((color >> 8) & 0xFF);
+
+		/// <summary>
+		/// Gets the green channel value.
+		/// </summary>
+		public byte Green => (byte)((color >> 16) & 0xFF);
+
+		/// <summary>
+		/// Gets the blue channel value.
+		/// </summary>
+		public byte Blue => (byte)((color >> 24) & 0xFF);
+
+		/// <summary>
+		/// Gets the alpha channel value.
+		/// </summary>
+		public byte Alpha => (byte)(color & 0xFF);
+
+		/// <summary>
+		/// Gets the raw <c>hb_color_t</c> value (BGRA byte ordering: <c>0xBBGGRRAA</c>).
+		/// </summary>
+		public uint Value => color;
+
+		public static implicit operator uint (HBColor color) => color.color;
+
+		public static explicit operator HBColor (uint value) => new HBColor (value);
+
+		public bool Equals (HBColor other) => color == other.color;
+
+		public override bool Equals (object obj) => obj is HBColor other && Equals (other);
+
+		public override int GetHashCode () => color.GetHashCode ();
+
+		public static bool operator == (HBColor left, HBColor right) => left.Equals (right);
+
+		public static bool operator != (HBColor left, HBColor right) => !left.Equals (right);
+
+		public override string ToString () =>
+			$"#{Alpha:X2}{Red:X2}{Green:X2}{Blue:X2}";
+	}
+}

--- a/binding/HarfBuzzSharp/HarfBuzzApi.generated.cs
+++ b/binding/HarfBuzzSharp/HarfBuzzApi.generated.cs
@@ -1355,18 +1355,18 @@ namespace HarfBuzzSharp
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (HARFBUZZ)]
-		internal static partial Byte hb_color_get_alpha (UInt32 color);
+		internal static partial Byte hb_color_get_alpha (HBColor color);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Byte hb_color_get_alpha (UInt32 color);
+		internal static extern Byte hb_color_get_alpha (HBColor color);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Byte hb_color_get_alpha (UInt32 color);
+			internal delegate Byte hb_color_get_alpha (HBColor color);
 		}
 		private static Delegates.hb_color_get_alpha hb_color_get_alpha_delegate;
-		internal static Byte hb_color_get_alpha (UInt32 color) =>
+		internal static Byte hb_color_get_alpha (HBColor color) =>
 			(hb_color_get_alpha_delegate ??= GetSymbol<Delegates.hb_color_get_alpha> ("hb_color_get_alpha")).Invoke (color);
 		#endif
 
@@ -1374,18 +1374,18 @@ namespace HarfBuzzSharp
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (HARFBUZZ)]
-		internal static partial Byte hb_color_get_blue (UInt32 color);
+		internal static partial Byte hb_color_get_blue (HBColor color);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Byte hb_color_get_blue (UInt32 color);
+		internal static extern Byte hb_color_get_blue (HBColor color);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Byte hb_color_get_blue (UInt32 color);
+			internal delegate Byte hb_color_get_blue (HBColor color);
 		}
 		private static Delegates.hb_color_get_blue hb_color_get_blue_delegate;
-		internal static Byte hb_color_get_blue (UInt32 color) =>
+		internal static Byte hb_color_get_blue (HBColor color) =>
 			(hb_color_get_blue_delegate ??= GetSymbol<Delegates.hb_color_get_blue> ("hb_color_get_blue")).Invoke (color);
 		#endif
 
@@ -1393,18 +1393,18 @@ namespace HarfBuzzSharp
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (HARFBUZZ)]
-		internal static partial Byte hb_color_get_green (UInt32 color);
+		internal static partial Byte hb_color_get_green (HBColor color);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Byte hb_color_get_green (UInt32 color);
+		internal static extern Byte hb_color_get_green (HBColor color);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Byte hb_color_get_green (UInt32 color);
+			internal delegate Byte hb_color_get_green (HBColor color);
 		}
 		private static Delegates.hb_color_get_green hb_color_get_green_delegate;
-		internal static Byte hb_color_get_green (UInt32 color) =>
+		internal static Byte hb_color_get_green (HBColor color) =>
 			(hb_color_get_green_delegate ??= GetSymbol<Delegates.hb_color_get_green> ("hb_color_get_green")).Invoke (color);
 		#endif
 
@@ -1412,18 +1412,18 @@ namespace HarfBuzzSharp
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (HARFBUZZ)]
-		internal static partial Byte hb_color_get_red (UInt32 color);
+		internal static partial Byte hb_color_get_red (HBColor color);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Byte hb_color_get_red (UInt32 color);
+		internal static extern Byte hb_color_get_red (HBColor color);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Byte hb_color_get_red (UInt32 color);
+			internal delegate Byte hb_color_get_red (HBColor color);
 		}
 		private static Delegates.hb_color_get_red hb_color_get_red_delegate;
-		internal static Byte hb_color_get_red (UInt32 color) =>
+		internal static Byte hb_color_get_red (HBColor color) =>
 			(hb_color_get_red_delegate ??= GetSymbol<Delegates.hb_color_get_red> ("hb_color_get_red")).Invoke (color);
 		#endif
 
@@ -4017,18 +4017,18 @@ namespace HarfBuzzSharp
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
 		[LibraryImport (HARFBUZZ)]
-		internal static partial UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, UInt32* colors);
+		internal static partial UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, HBColor* colors);
 		#else // !USE_LIBRARY_IMPORT
 		[DllImport (HARFBUZZ, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, UInt32* colors);
+		internal static extern UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, HBColor* colors);
 		#endif
 		#else
 		private partial class Delegates {
 			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, UInt32* colors);
+			internal delegate UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, HBColor* colors);
 		}
 		private static Delegates.hb_ot_color_palette_get_colors hb_ot_color_palette_get_colors_delegate;
-		internal static UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, UInt32* colors) =>
+		internal static UInt32 hb_ot_color_palette_get_colors (hb_face_t face, UInt32 palette_index, UInt32 start_offset, UInt32* color_count, HBColor* colors) =>
 			(hb_ot_color_palette_get_colors_delegate ??= GetSymbol<Delegates.hb_ot_color_palette_get_colors> ("hb_ot_color_palette_get_colors")).Invoke (face, palette_index, start_offset, color_count, colors);
 		#endif
 

--- a/binding/libHarfBuzzSharp.json
+++ b/binding/libHarfBuzzSharp.json
@@ -45,7 +45,7 @@
         "cs": "UInt32"
       },
       "hb_color_t": {
-        "cs": "UInt32"
+        "cs": "HBColor"
       },
       "hb_mask_t": {
         "cs": "UInt32"

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/ColorExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/ColorExtensions.cs
@@ -1,0 +1,71 @@
+﻿using HarfBuzzSharp;
+
+namespace SkiaSharp.HarfBuzz
+{
+	/// <summary>
+	/// Extension methods for converting between <see cref="HBColor"/> and SkiaSharp color types.
+	/// </summary>
+	public static class ColorExtensions
+	{
+		/// <summary>
+		/// Converts an <see cref="HBColor"/> to an <see cref="SKColor"/>.
+		/// </summary>
+		public static SKColor ToSKColor (this HBColor hbColor)
+		{
+			return new SKColor (hbColor.Red, hbColor.Green, hbColor.Blue, hbColor.Alpha);
+		}
+
+		/// <summary>
+		/// Converts an <see cref="HBColor"/> to an <see cref="SKColorF"/> (normalized 0.0–1.0 channels).
+		/// </summary>
+		public static SKColorF ToSKColorF (this HBColor hbColor)
+		{
+			return new SKColorF (
+				hbColor.Red / 255f,
+				hbColor.Green / 255f,
+				hbColor.Blue / 255f,
+				hbColor.Alpha / 255f);
+		}
+
+		/// <summary>
+		/// Converts an array of <see cref="HBColor"/> values to an array of <see cref="SKColor"/>.
+		/// </summary>
+		public static SKColor[] ToSKColors (this HBColor[] hbColors)
+		{
+			if (hbColors == null)
+				return null;
+
+			var result = new SKColor[hbColors.Length];
+			for (int i = 0; i < hbColors.Length; i++)
+				result[i] = hbColors[i].ToSKColor ();
+			return result;
+		}
+
+		/// <summary>
+		/// Converts an <see cref="SKColor"/> to an <see cref="HBColor"/>.
+		/// </summary>
+		public static HBColor ToHBColor (this SKColor color)
+		{
+			return new HBColor (color.Red, color.Green, color.Blue, color.Alpha);
+		}
+
+		/// <summary>
+		/// Converts an <see cref="SKColorF"/> to an <see cref="HBColor"/> (clamped to 0–255 range).
+		/// </summary>
+		public static HBColor ToHBColor (this SKColorF color)
+		{
+			return new HBColor (
+				ClampToByte (color.Red * 255f),
+				ClampToByte (color.Green * 255f),
+				ClampToByte (color.Blue * 255f),
+				ClampToByte (color.Alpha * 255f));
+		}
+
+		private static byte ClampToByte (float value)
+		{
+			if (value <= 0f) return 0;
+			if (value >= 255f) return 255;
+			return (byte)(value + 0.5f);
+		}
+	}
+}

--- a/tests/Tests/HarfBuzzSharp/ColorExtensionsTest.cs
+++ b/tests/Tests/HarfBuzzSharp/ColorExtensionsTest.cs
@@ -1,0 +1,230 @@
+﻿using System.IO;
+
+using Xunit;
+
+using SkiaSharp.HarfBuzz;
+
+namespace HarfBuzzSharp.Tests
+{
+	public class ColorExtensionsTest : HBTest
+	{
+		// HBColor -> SKColor
+
+		[SkippableFact]
+		public void ToSKColorPreservesChannels ()
+		{
+			var hb = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
+			var sk = hb.ToSKColor ();
+
+			Assert.Equal ((byte)0xAA, sk.Red);
+			Assert.Equal ((byte)0xBB, sk.Green);
+			Assert.Equal ((byte)0xCC, sk.Blue);
+			Assert.Equal ((byte)0xFF, sk.Alpha);
+		}
+
+		[SkippableFact]
+		public void ToSKColorWithOpaqueBlack ()
+		{
+			var hb = new HBColor (0, 0, 0, 255);
+			var sk = hb.ToSKColor ();
+
+			Assert.Equal (SkiaSharp.SKColors.Black, sk);
+		}
+
+		[SkippableFact]
+		public void ToSKColorWithOpaqueWhite ()
+		{
+			var hb = new HBColor (255, 255, 255, 255);
+			var sk = hb.ToSKColor ();
+
+			Assert.Equal (SkiaSharp.SKColors.White, sk);
+		}
+
+		[SkippableFact]
+		public void ToSKColorWithTransparent ()
+		{
+			var hb = new HBColor (0, 0, 0, 0);
+			var sk = hb.ToSKColor ();
+
+			Assert.Equal ((byte)0, sk.Alpha);
+		}
+
+		[SkippableFact]
+		public void ToSKColorWorksWithRealPaletteColors ()
+		{
+			using var blob = Blob.FromFile (Path.Combine (PathToFonts, "test_glyphs-COLRv1.ttf"));
+			using var face = new Face (blob, 0);
+			var colors = face.GetPaletteColors (0);
+			Assert.NotEmpty (colors);
+
+			foreach (var hbColor in colors) {
+				var skColor = hbColor.ToSKColor ();
+
+				Assert.Equal (hbColor.Red, skColor.Red);
+				Assert.Equal (hbColor.Green, skColor.Green);
+				Assert.Equal (hbColor.Blue, skColor.Blue);
+				Assert.Equal (hbColor.Alpha, skColor.Alpha);
+			}
+		}
+
+		// HBColor -> SKColorF
+
+		[SkippableFact]
+		public void ToSKColorFNormalizesChannels ()
+		{
+			var hb = new HBColor (255, 128, 0, 204);
+			var skF = hb.ToSKColorF ();
+
+			Assert.Equal (1.0f, skF.Red, 0.01f);
+			Assert.Equal (128 / 255f, skF.Green, 0.01f);
+			Assert.Equal (0.0f, skF.Blue, 0.01f);
+			Assert.Equal (204 / 255f, skF.Alpha, 0.01f);
+		}
+
+		[SkippableFact]
+		public void ToSKColorFOpaqueWhiteIsAllOnes ()
+		{
+			var hb = new HBColor (255, 255, 255, 255);
+			var skF = hb.ToSKColorF ();
+
+			Assert.Equal (1.0f, skF.Red, 0.001f);
+			Assert.Equal (1.0f, skF.Green, 0.001f);
+			Assert.Equal (1.0f, skF.Blue, 0.001f);
+			Assert.Equal (1.0f, skF.Alpha, 0.001f);
+		}
+
+		[SkippableFact]
+		public void ToSKColorFBlackIsAllZeros ()
+		{
+			var hb = new HBColor (0, 0, 0, 0);
+			var skF = hb.ToSKColorF ();
+
+			Assert.Equal (0.0f, skF.Red);
+			Assert.Equal (0.0f, skF.Green);
+			Assert.Equal (0.0f, skF.Blue);
+			Assert.Equal (0.0f, skF.Alpha);
+		}
+
+		// SKColor -> HBColor
+
+		[SkippableFact]
+		public void SKColorToHBColorRoundtrips ()
+		{
+			var original = new SkiaSharp.SKColor (0xAA, 0xBB, 0xCC, 0xFF);
+			var hbColor = original.ToHBColor ();
+			var converted = hbColor.ToSKColor ();
+
+			Assert.Equal (original, converted);
+		}
+
+		[SkippableFact]
+		public void SKColorToHBColorPreservesChannels ()
+		{
+			var sk = new SkiaSharp.SKColor (10, 20, 30, 40);
+			var hb = sk.ToHBColor ();
+
+			Assert.Equal ((byte)10, hb.Red);
+			Assert.Equal ((byte)20, hb.Green);
+			Assert.Equal ((byte)30, hb.Blue);
+			Assert.Equal ((byte)40, hb.Alpha);
+		}
+
+		// SKColorF -> HBColor
+
+		[SkippableFact]
+		public void SKColorFToHBColorConvertsCorrectly ()
+		{
+			var skF = new SkiaSharp.SKColorF (1.0f, 0.5f, 0.0f, 0.8f);
+			var hb = skF.ToHBColor ();
+
+			Assert.Equal ((byte)255, hb.Red);
+			Assert.Equal ((byte)128, hb.Green);
+			Assert.Equal ((byte)0, hb.Blue);
+			Assert.Equal ((byte)204, hb.Alpha);
+		}
+
+		[SkippableFact]
+		public void SKColorFToHBColorClampsNegativeValues ()
+		{
+			var skF = new SkiaSharp.SKColorF (-0.5f, -1.0f, 0.0f, 1.0f);
+			var hb = skF.ToHBColor ();
+
+			Assert.Equal ((byte)0, hb.Red);
+			Assert.Equal ((byte)0, hb.Green);
+			Assert.Equal ((byte)0, hb.Blue);
+			Assert.Equal ((byte)255, hb.Alpha);
+		}
+
+		[SkippableFact]
+		public void SKColorFToHBColorClampsOverflowValues ()
+		{
+			var skF = new SkiaSharp.SKColorF (2.0f, 1.5f, 1.0f, 0.0f);
+			var hb = skF.ToHBColor ();
+
+			Assert.Equal ((byte)255, hb.Red);
+			Assert.Equal ((byte)255, hb.Green);
+			Assert.Equal ((byte)255, hb.Blue);
+			Assert.Equal ((byte)0, hb.Alpha);
+		}
+
+		[SkippableFact]
+		public void SKColorFToHBColorRoundtrips ()
+		{
+			// Due to 8-bit quantization, use values that map cleanly
+			var original = new SkiaSharp.SKColorF (1.0f, 0.0f, 1.0f, 1.0f);
+			var hb = original.ToHBColor ();
+			var converted = hb.ToSKColorF ();
+
+			Assert.Equal (original.Red, converted.Red, 0.01f);
+			Assert.Equal (original.Green, converted.Green, 0.01f);
+			Assert.Equal (original.Blue, converted.Blue, 0.01f);
+			Assert.Equal (original.Alpha, converted.Alpha, 0.01f);
+		}
+
+		// Batch: ToSKColors
+
+		[SkippableFact]
+		public void ToSKColorsConvertsArray ()
+		{
+			var hbColors = new[] {
+				new HBColor (255, 0, 0, 255),
+				new HBColor (0, 255, 0, 255),
+				new HBColor (0, 0, 255, 128),
+			};
+			var skColors = hbColors.ToSKColors ();
+
+			Assert.Equal (3, skColors.Length);
+
+			Assert.Equal ((byte)255, skColors[0].Red);
+			Assert.Equal ((byte)0, skColors[0].Green);
+			Assert.Equal ((byte)0, skColors[0].Blue);
+
+			Assert.Equal ((byte)0, skColors[1].Red);
+			Assert.Equal ((byte)255, skColors[1].Green);
+			Assert.Equal ((byte)0, skColors[1].Blue);
+
+			Assert.Equal ((byte)0, skColors[2].Red);
+			Assert.Equal ((byte)0, skColors[2].Green);
+			Assert.Equal ((byte)255, skColors[2].Blue);
+			Assert.Equal ((byte)128, skColors[2].Alpha);
+		}
+
+		[SkippableFact]
+		public void ToSKColorsWithNullReturnsNull ()
+		{
+			HBColor[] hbColors = null;
+			var result = hbColors.ToSKColors ();
+
+			Assert.Null (result);
+		}
+
+		[SkippableFact]
+		public void ToSKColorsWithEmptyReturnsEmpty ()
+		{
+			var hbColors = System.Array.Empty<HBColor> ();
+			var result = hbColors.ToSKColors ();
+
+			Assert.Empty (result);
+		}
+	}
+}

--- a/tests/Tests/HarfBuzzSharp/HBColorTest.cs
+++ b/tests/Tests/HarfBuzzSharp/HBColorTest.cs
@@ -1,0 +1,168 @@
+﻿using Xunit;
+
+namespace HarfBuzzSharp.Tests
+{
+	public class HBColorTest : HBTest
+	{
+		// Construction
+
+		[SkippableFact]
+		public void ConstructorFromComponentsRoundtrips ()
+		{
+			var color = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
+
+			Assert.Equal ((byte)0xAA, color.Red);
+			Assert.Equal ((byte)0xBB, color.Green);
+			Assert.Equal ((byte)0xCC, color.Blue);
+			Assert.Equal ((byte)0xFF, color.Alpha);
+		}
+
+		[SkippableFact]
+		public void ConstructorFromRawValuePreservesLayout ()
+		{
+			// hb_color_t layout: 0xBBGGRRAA
+			var color = new HBColor (0xCCBBAA_FFu);
+
+			Assert.Equal ((byte)0xAA, color.Red);
+			Assert.Equal ((byte)0xBB, color.Green);
+			Assert.Equal ((byte)0xCC, color.Blue);
+			Assert.Equal ((byte)0xFF, color.Alpha);
+			Assert.Equal (0xCCBBAA_FFu, color.Value);
+		}
+
+		[SkippableFact]
+		public void ComponentConstructorProducesCorrectRawValue ()
+		{
+			var color = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
+
+			// Verify raw uint layout: 0xBBGGRRAA
+			Assert.Equal (0xCCBBAA_FFu, color.Value);
+		}
+
+		// Well-known colors
+
+		[SkippableFact]
+		public void OpaqueBlack ()
+		{
+			var color = new HBColor (0, 0, 0, 255);
+
+			Assert.Equal ((byte)0, color.Red);
+			Assert.Equal ((byte)0, color.Green);
+			Assert.Equal ((byte)0, color.Blue);
+			Assert.Equal ((byte)255, color.Alpha);
+			Assert.Equal (0x000000_FFu, color.Value);
+		}
+
+		[SkippableFact]
+		public void OpaqueWhite ()
+		{
+			var color = new HBColor (255, 255, 255, 255);
+
+			Assert.Equal ((byte)255, color.Red);
+			Assert.Equal ((byte)255, color.Green);
+			Assert.Equal ((byte)255, color.Blue);
+			Assert.Equal ((byte)255, color.Alpha);
+			Assert.Equal (0xFFFFFF_FFu, color.Value);
+		}
+
+		[SkippableFact]
+		public void TransparentBlack ()
+		{
+			var color = new HBColor (0, 0, 0, 0);
+
+			Assert.Equal ((byte)0, color.Red);
+			Assert.Equal ((byte)0, color.Green);
+			Assert.Equal ((byte)0, color.Blue);
+			Assert.Equal ((byte)0, color.Alpha);
+			Assert.Equal (0x00000000u, color.Value);
+		}
+
+		[SkippableFact]
+		public void PureRedIsDistinctFromPureBlue ()
+		{
+			var red = new HBColor (255, 0, 0, 255);
+			var blue = new HBColor (0, 0, 255, 255);
+
+			Assert.NotEqual (red.Value, blue.Value);
+			Assert.Equal ((byte)255, red.Red);
+			Assert.Equal ((byte)0, red.Blue);
+			Assert.Equal ((byte)0, blue.Red);
+			Assert.Equal ((byte)255, blue.Blue);
+		}
+
+		// Operators
+
+		[SkippableFact]
+		public void ImplicitConversionToUint ()
+		{
+			var color = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
+			uint value = color;
+
+			Assert.Equal (color.Value, value);
+		}
+
+		[SkippableFact]
+		public void ExplicitConversionFromUint ()
+		{
+			uint raw = 0xCCBBAA_FFu;
+			var color = (HBColor)raw;
+
+			Assert.Equal ((byte)0xAA, color.Red);
+			Assert.Equal ((byte)0xBB, color.Green);
+			Assert.Equal ((byte)0xCC, color.Blue);
+			Assert.Equal ((byte)0xFF, color.Alpha);
+		}
+
+		// Equality
+
+		[SkippableFact]
+		public void EqualColorsAreEqual ()
+		{
+			var a = new HBColor (10, 20, 30, 40);
+			var b = new HBColor (10, 20, 30, 40);
+
+			Assert.True (a == b);
+			Assert.False (a != b);
+			Assert.True (a.Equals (b));
+			Assert.True (a.Equals ((object)b));
+			Assert.Equal (a.GetHashCode (), b.GetHashCode ());
+		}
+
+		[SkippableFact]
+		public void DifferentColorsAreNotEqual ()
+		{
+			var a = new HBColor (10, 20, 30, 40);
+			var b = new HBColor (10, 20, 30, 41);
+
+			Assert.False (a == b);
+			Assert.True (a != b);
+			Assert.False (a.Equals (b));
+		}
+
+		[SkippableFact]
+		public void NotEqualToNull ()
+		{
+			var color = new HBColor (1, 2, 3, 4);
+
+			Assert.False (color.Equals (null));
+		}
+
+		// ToString
+
+		[SkippableFact]
+		public void ToStringFormatsAsARGBHex ()
+		{
+			var color = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
+
+			Assert.Equal ("#FFAABBCC", color.ToString ());
+		}
+
+		[SkippableFact]
+		public void ToStringPadsWithZeros ()
+		{
+			var color = new HBColor (0, 0, 0, 0);
+
+			Assert.Equal ("#00000000", color.ToString ());
+		}
+	}
+}

--- a/tests/Tests/HarfBuzzSharp/HBFaceTest.cs
+++ b/tests/Tests/HarfBuzzSharp/HBFaceTest.cs
@@ -366,7 +366,7 @@ namespace HarfBuzzSharp.Tests
 			var arrayResult = face.GetPaletteColors (0);
 			Assert.NotEmpty (arrayResult);
 
-			var spanBuffer = new uint[arrayResult.Length];
+			var spanBuffer = new HBColor[arrayResult.Length];
 			var written = face.GetPaletteColors (0, spanBuffer);
 			Assert.Equal (arrayResult.Length, written);
 
@@ -384,7 +384,7 @@ namespace HarfBuzzSharp.Tests
 			Assert.True (totalColors > 1, $"Need palette with >1 colors, got {totalColors}");
 
 			// HarfBuzz fills what fits
-			var spanBuffer = new uint[1];
+			var spanBuffer = new HBColor[1];
 			var written = face.GetPaletteColors (0, spanBuffer);
 			Assert.Equal (1, written);
 		}
@@ -397,7 +397,7 @@ namespace HarfBuzzSharp.Tests
 
 			var totalColors = face.GetPaletteColors (0).Length;
 
-			var spanBuffer = new uint[totalColors + 5];
+			var spanBuffer = new HBColor[totalColors + 5];
 			var written = face.GetPaletteColors (0, spanBuffer);
 			Assert.Equal (totalColors, written);
 		}
@@ -408,7 +408,7 @@ namespace HarfBuzzSharp.Tests
 			using var face = CreateColorFace ();
 			Assert.True (face.PaletteCount > 0);
 
-			var spanBuffer = new uint[0];
+			var spanBuffer = new HBColor[0];
 			var written = face.GetPaletteColors (0, spanBuffer);
 			Assert.Equal (0, written);
 		}
@@ -516,6 +516,83 @@ namespace HarfBuzzSharp.Tests
 		{
 			using var face = CreateColorFace ();
 			Assert.Throws<ArgumentOutOfRangeException> (() => face.GetPaletteColorNameId (-1));
+		}
+
+		[SkippableFact]
+		public void PaletteColorsHaveCorrectChannels ()
+		{
+			// GetPaletteColors() returns HBColor[] with correct channel accessors.
+			// HBColor properties use the same bit-shift logic as the native
+			// hb_color_get_* macros — no P/Invoke needed.
+			using var face = CreateColorFace ();
+			var colors = face.GetPaletteColors (0);
+			Assert.NotEmpty (colors);
+
+			// Verify at least one color has non-zero alpha (palette colors should be opaque)
+			Assert.Contains (colors, c => c.Alpha > 0);
+		}
+
+		[SkippableFact]
+		public void HBColorCreateRoundtrips ()
+		{
+			var color = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
+			Assert.Equal ((byte)0xAA, color.Red);
+			Assert.Equal ((byte)0xBB, color.Green);
+			Assert.Equal ((byte)0xCC, color.Blue);
+			Assert.Equal ((byte)0xFF, color.Alpha);
+
+			// Verify raw uint layout: 0xBBGGRRAA
+			Assert.Equal (0xCCBBAA_FFu, color.Value);
+		}
+
+		[SkippableFact]
+		public void PaletteColorConversionToSKColorIsCorrect ()
+		{
+			using var face = CreateColorFace ();
+			var colors = face.GetPaletteColors (0);
+			Assert.NotEmpty (colors);
+
+			foreach (var hbColor in colors) {
+				var skColor = SkiaSharp.HarfBuzz.ColorExtensions.ToSKColor (hbColor);
+
+				Assert.Equal (hbColor.Red, skColor.Red);
+				Assert.Equal (hbColor.Green, skColor.Green);
+				Assert.Equal (hbColor.Blue, skColor.Blue);
+				Assert.Equal (hbColor.Alpha, skColor.Alpha);
+			}
+		}
+
+		[SkippableFact]
+		public void PaletteColorConversionToSKColorFIsCorrect ()
+		{
+			var hbColor = new HBColor (255, 128, 0, 204);
+			var skColorF = SkiaSharp.HarfBuzz.ColorExtensions.ToSKColorF (hbColor);
+
+			Assert.Equal (1.0f, skColorF.Red, 0.01f);
+			Assert.Equal (128 / 255f, skColorF.Green, 0.01f);
+			Assert.Equal (0.0f, skColorF.Blue, 0.01f);
+			Assert.Equal (204 / 255f, skColorF.Alpha, 0.01f);
+		}
+
+		[SkippableFact]
+		public void SKColorToHBColorRoundtrips ()
+		{
+			var original = new SkiaSharp.SKColor (0xAA, 0xBB, 0xCC, 0xFF);
+			var hbColor = SkiaSharp.HarfBuzz.ColorExtensions.ToHBColor (original);
+			var converted = SkiaSharp.HarfBuzz.ColorExtensions.ToSKColor (hbColor);
+			Assert.Equal (original, converted);
+		}
+
+		[SkippableFact]
+		public void SKColorFToHBColorRoundtrips ()
+		{
+			var original = new SkiaSharp.SKColorF (1.0f, 0.5f, 0.0f, 0.8f);
+			var hbColor = SkiaSharp.HarfBuzz.ColorExtensions.ToHBColor (original);
+
+			Assert.Equal ((byte)255, hbColor.Red);
+			Assert.Equal ((byte)128, hbColor.Green);
+			Assert.Equal ((byte)0, hbColor.Blue);
+			Assert.Equal ((byte)204, hbColor.Alpha);
 		}
 
 		[SkippableFact]

--- a/tests/Tests/HarfBuzzSharp/HBFaceTest.cs
+++ b/tests/Tests/HarfBuzzSharp/HBFaceTest.cs
@@ -533,69 +533,6 @@ namespace HarfBuzzSharp.Tests
 		}
 
 		[SkippableFact]
-		public void HBColorCreateRoundtrips ()
-		{
-			var color = new HBColor (0xAA, 0xBB, 0xCC, 0xFF);
-			Assert.Equal ((byte)0xAA, color.Red);
-			Assert.Equal ((byte)0xBB, color.Green);
-			Assert.Equal ((byte)0xCC, color.Blue);
-			Assert.Equal ((byte)0xFF, color.Alpha);
-
-			// Verify raw uint layout: 0xBBGGRRAA
-			Assert.Equal (0xCCBBAA_FFu, color.Value);
-		}
-
-		[SkippableFact]
-		public void PaletteColorConversionToSKColorIsCorrect ()
-		{
-			using var face = CreateColorFace ();
-			var colors = face.GetPaletteColors (0);
-			Assert.NotEmpty (colors);
-
-			foreach (var hbColor in colors) {
-				var skColor = SkiaSharp.HarfBuzz.ColorExtensions.ToSKColor (hbColor);
-
-				Assert.Equal (hbColor.Red, skColor.Red);
-				Assert.Equal (hbColor.Green, skColor.Green);
-				Assert.Equal (hbColor.Blue, skColor.Blue);
-				Assert.Equal (hbColor.Alpha, skColor.Alpha);
-			}
-		}
-
-		[SkippableFact]
-		public void PaletteColorConversionToSKColorFIsCorrect ()
-		{
-			var hbColor = new HBColor (255, 128, 0, 204);
-			var skColorF = SkiaSharp.HarfBuzz.ColorExtensions.ToSKColorF (hbColor);
-
-			Assert.Equal (1.0f, skColorF.Red, 0.01f);
-			Assert.Equal (128 / 255f, skColorF.Green, 0.01f);
-			Assert.Equal (0.0f, skColorF.Blue, 0.01f);
-			Assert.Equal (204 / 255f, skColorF.Alpha, 0.01f);
-		}
-
-		[SkippableFact]
-		public void SKColorToHBColorRoundtrips ()
-		{
-			var original = new SkiaSharp.SKColor (0xAA, 0xBB, 0xCC, 0xFF);
-			var hbColor = SkiaSharp.HarfBuzz.ColorExtensions.ToHBColor (original);
-			var converted = SkiaSharp.HarfBuzz.ColorExtensions.ToSKColor (hbColor);
-			Assert.Equal (original, converted);
-		}
-
-		[SkippableFact]
-		public void SKColorFToHBColorRoundtrips ()
-		{
-			var original = new SkiaSharp.SKColorF (1.0f, 0.5f, 0.0f, 0.8f);
-			var hbColor = SkiaSharp.HarfBuzz.ColorExtensions.ToHBColor (original);
-
-			Assert.Equal ((byte)255, hbColor.Red);
-			Assert.Equal ((byte)128, hbColor.Green);
-			Assert.Equal ((byte)0, hbColor.Blue);
-			Assert.Equal ((byte)204, hbColor.Alpha);
-		}
-
-		[SkippableFact]
 		public void ShouldHaveGlyphCount()
 		{
 			using (var face = new Face(Blob, 0))


### PR DESCRIPTION
## Summary

Introduces an `HBColor` readonly struct to properly represent HarfBuzz's `hb_color_t` type, replacing raw `uint` usage. This fixes a byte-order mismatch where `hb_color_t` (BGRA: `0xBBGGRRAA`) was returned as raw `uint` that users would incorrectly cast to `SKColor` (ARGB: `0xAARRGGBB`), getting wrong colors.

## Changes

### New: `HBColor` struct (`binding/HarfBuzzSharp/HBColor.cs`)
- Readonly struct wrapping a single `uint` (blittable, zero-overhead P/Invoke)
- `Red`, `Green`, `Blue`, `Alpha` properties using bit-shift extraction matching HarfBuzz's macros
- Constructor from `(byte r, byte g, byte b, byte a)` or raw `uint`
- Implicit conversion to `uint`, explicit from `uint`

### New: `ColorExtensions` (`source/SkiaSharp.HarfBuzz/`)
- `ToSKColor()` / `ToSKColorF()` — convert HBColor → SkiaSharp color types
- `ToHBColor()` — convert SKColor or SKColorF → HBColor
- `ToSKColors()` — batch array conversion

### Modified: `Face.GetPaletteColors()`
- Return type changed from `uint[]` to `HBColor[]` (and `Span<uint>` to `Span<HBColor>`)
- This is safe because the palette API was only added 3 weeks ago in preview releases (`v4.147.0-preview.1.1` / `.2.1`)

### Generator integration
- Updated `libHarfBuzzSharp.json` to map `hb_color_t` → `HBColor`
- Regenerated `HarfBuzzApi.generated.cs` — all P/Invoke signatures now use `HBColor` directly

## Investigation findings

- `hb_color_get_red/green/blue/alpha` are **pure macros** (bit shifts) — no P/Invoke needed
- HarfBuzz has **no floating-point color type** — `SKColorF` conversion is a convenience we provide
- No byte-order swapping concerns — bit positions are fixed regardless of endianness

## Testing

65 HBFaceTest tests pass, including new tests for:
- HBColor component extraction
- SKColor ↔ HBColor roundtrip
- SKColorF ↔ HBColor conversion
- Palette color validation with real color font