### PR TITLE
Add missing API wrappers and fix naming convention violations

### DIFF
--- a/binding/SkiaSharp/GRContext.cs
+++ b/binding/SkiaSharp/GRContext.cs
@@ -150,6 +150,24 @@ namespace SkiaSharp
 		public void Submit (bool synchronous = false) =>
 			SkiaApi.gr_direct_context_submit (Handle, synchronous);
 
+		public void Flush (SKImage image)
+		{
+			if (image == null) {
+				throw new ArgumentNullException (nameof (image));
+			}
+
+			SkiaApi.gr_direct_context_flush_image (Handle, image.Handle);
+		}
+
+		public void Flush (SKSurface surface)
+		{
+			if (surface == null) {
+				throw new ArgumentNullException (nameof (surface));
+			}
+
+			SkiaApi.gr_direct_context_flush_surface (Handle, surface.Handle);
+		}
+
 		public new int GetMaxSurfaceSampleCount (SKColorType colorType) =>
 			base.GetMaxSurfaceSampleCount (colorType);
 

--- a/binding/SkiaSharp/GRDefinitions.cs
+++ b/binding/SkiaSharp/GRDefinitions.cs
@@ -290,4 +290,28 @@ namespace SkiaSharp
 		// Compressed texture sized formats
 		internal const uint COMPRESSED_ETC1_RGB8 = 0x8D64;
 	}
+
+	[Obsolete ("Use GRVkYcbcrConversionInfo instead.")]
+	[StructLayout (LayoutKind.Sequential)]
+	public unsafe partial struct GrVkYcbcrConversionInfo
+	{
+		private GRVkYcbcrConversionInfo inner;
+
+		public UInt32 Format { readonly get => inner.Format; set => inner.Format = value; }
+		public UInt64 ExternalFormat { readonly get => inner.ExternalFormat; set => inner.ExternalFormat = value; }
+		public UInt32 YcbcrModel { readonly get => inner.YcbcrModel; set => inner.YcbcrModel = value; }
+		public UInt32 YcbcrRange { readonly get => inner.YcbcrRange; set => inner.YcbcrRange = value; }
+		public UInt32 XChromaOffset { readonly get => inner.XChromaOffset; set => inner.XChromaOffset = value; }
+		public UInt32 YChromaOffset { readonly get => inner.YChromaOffset; set => inner.YChromaOffset = value; }
+		public UInt32 ChromaFilter { readonly get => inner.ChromaFilter; set => inner.ChromaFilter = value; }
+		public UInt32 ForceExplicitReconstruction { readonly get => inner.ForceExplicitReconstruction; set => inner.ForceExplicitReconstruction = value; }
+		public GRVkYcbcrComponents Components { readonly get => inner.Components; set => inner.Components = value; }
+		[Obsolete ("FormatFeatures is no longer supported in the native API.")]
+		public UInt32 FormatFeatures { readonly get => 0; set { } }
+		public bool SamplerFilterMustMatchChromaFilter { readonly get => inner.SamplerFilterMustMatchChromaFilter; set => inner.SamplerFilterMustMatchChromaFilter = value; }
+		public bool SupportsLinearFilter { readonly get => inner.SupportsLinearFilter; set => inner.SupportsLinearFilter = value; }
+
+		public static implicit operator GRVkYcbcrConversionInfo (GrVkYcbcrConversionInfo value) => value.inner;
+		public static implicit operator GrVkYcbcrConversionInfo (GRVkYcbcrConversionInfo value) => new GrVkYcbcrConversionInfo { inner = value };
+	}
 }

--- a/binding/SkiaSharp/SKDocument.cs
+++ b/binding/SkiaSharp/SKDocument.cs
@@ -73,6 +73,35 @@ namespace SkiaSharp
 			return Referenced (GetObject (SkiaApi.sk_document_create_xps_from_stream (stream.Handle, dpi)), stream);
 		}
 
+		public static SKDocument CreateXps (string path, SKDocumentXpsOptions options)
+		{
+			if (path == null) {
+				throw new ArgumentNullException (nameof (path));
+			}
+
+			var stream = SKFileWStream.OpenStream (path);
+			return Owned (CreateXps (stream, options), stream);
+		}
+
+		public static SKDocument CreateXps (Stream stream, SKDocumentXpsOptions options)
+		{
+			if (stream == null) {
+				throw new ArgumentNullException (nameof (stream));
+			}
+
+			var managed = new SKManagedWStream (stream);
+			return Owned (CreateXps (managed, options), managed);
+		}
+
+		public static SKDocument CreateXps (SKWStream stream, SKDocumentXpsOptions options)
+		{
+			if (stream == null) {
+				throw new ArgumentNullException (nameof (stream));
+			}
+
+			return Referenced (GetObject (SkiaApi.sk_document_create_xps_from_stream_with_options (stream.Handle, &options)), stream);
+		}
+
 		// CreatePdf
 
 		public static SKDocument CreatePdf (string path)

--- a/binding/SkiaSharp/SKMaskFilter.cs
+++ b/binding/SkiaSharp/SKMaskFilter.cs
@@ -62,6 +62,14 @@ namespace SkiaSharp
 			return GetObject (SkiaApi.sk_maskfilter_new_clip (min, max));
 		}
 
+		public static SKMaskFilter CreateShader (SKShader shader)
+		{
+			if (shader == null)
+				throw new ArgumentNullException (nameof (shader));
+
+			return GetObject (SkiaApi.sk_maskfilter_new_shader (shader.Handle));
+		}
+
 		internal static SKMaskFilter GetObject (IntPtr handle) =>
 			GetOrAddObject (handle, (h, o) => new SKMaskFilter (h, o));
 	}

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -18522,7 +18522,7 @@ namespace SkiaSharp {
 
 		// public bool fFullyReceived
 		private Byte fFullyReceived;
-		public bool FullyReceived {
+		public bool FullyRecieved {
 			readonly get => fFullyReceived > 0;
 			set => fFullyReceived = value ? (byte)1 : (byte)0;
 		}

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -18245,8 +18245,8 @@ namespace SkiaSharp {
 		}
 
 		// public gr_vk_ycbcrconversioninfo_t fYcbcrConversionInfo
-		private GrVkYcbcrConversionInfo fYcbcrConversionInfo;
-		public GrVkYcbcrConversionInfo YcbcrConversionInfo {
+		private GRVkYcbcrConversionInfo fYcbcrConversionInfo;
+		public GRVkYcbcrConversionInfo YcbcrConversionInfo {
 			readonly get => fYcbcrConversionInfo;
 			set => fYcbcrConversionInfo = value;
 		}
@@ -18351,7 +18351,7 @@ namespace SkiaSharp {
 
 	// gr_vk_ycbcrconversioninfo_t
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct GrVkYcbcrConversionInfo : IEquatable<GrVkYcbcrConversionInfo> {
+	public unsafe partial struct GRVkYcbcrConversionInfo : IEquatable<GRVkYcbcrConversionInfo> {
 		// public uint32_t fFormat
 		private UInt32 fFormat;
 		public UInt32 Format {
@@ -18429,18 +18429,18 @@ namespace SkiaSharp {
 			set => fSupportsLinearFilter = value ? (byte)1 : (byte)0;
 		}
 
-		public readonly bool Equals (GrVkYcbcrConversionInfo obj) =>
+		public readonly bool Equals (GRVkYcbcrConversionInfo obj) =>
 #pragma warning disable CS8909
 			fFormat == obj.fFormat && fExternalFormat == obj.fExternalFormat && fYcbcrModel == obj.fYcbcrModel && fYcbcrRange == obj.fYcbcrRange && fXChromaOffset == obj.fXChromaOffset && fYChromaOffset == obj.fYChromaOffset && fChromaFilter == obj.fChromaFilter && fForceExplicitReconstruction == obj.fForceExplicitReconstruction && fComponents == obj.fComponents && fSamplerFilterMustMatchChromaFilter == obj.fSamplerFilterMustMatchChromaFilter && fSupportsLinearFilter == obj.fSupportsLinearFilter;
 #pragma warning restore CS8909
 
 		public readonly override bool Equals (object obj) =>
-			obj is GrVkYcbcrConversionInfo f && Equals (f);
+			obj is GRVkYcbcrConversionInfo f && Equals (f);
 
-		public static bool operator == (GrVkYcbcrConversionInfo left, GrVkYcbcrConversionInfo right) =>
+		public static bool operator == (GRVkYcbcrConversionInfo left, GRVkYcbcrConversionInfo right) =>
 			left.Equals (right);
 
-		public static bool operator != (GrVkYcbcrConversionInfo left, GrVkYcbcrConversionInfo right) =>
+		public static bool operator != (GRVkYcbcrConversionInfo left, GRVkYcbcrConversionInfo right) =>
 			!left.Equals (right);
 
 		public readonly override int GetHashCode ()
@@ -18522,7 +18522,7 @@ namespace SkiaSharp {
 
 		// public bool fFullyReceived
 		private Byte fFullyReceived;
-		public bool FullyRecieved {
+		public bool FullyReceived {
 			readonly get => fFullyReceived > 0;
 			set => fFullyReceived = value ? (byte)1 : (byte)0;
 		}
@@ -19079,7 +19079,7 @@ namespace SkiaSharp {
 	public unsafe partial struct SKDocumentXpsOptions : IEquatable<SKDocumentXpsOptions> {
 		// public float fDPI
 		private Single fDPI;
-		public Single DPI {
+		public Single Dpi {
 			readonly get => fDPI;
 			set => fDPI = value;
 		}

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -74,7 +74,7 @@
         "cs": "GRVkImageInfo"
       },
       "gr_vk_ycbcrconversioninfo_t": {
-        "cs": "GrVkYcbcrConversionInfo"
+        "cs": "GRVkYcbcrConversionInfo"
       },
       "gr_pixelconfig_t": {
         "cs": "GRPixelConfigNative",
@@ -226,8 +226,7 @@
       "sk_codec_frameinfo_t": {
         "cs": "SKCodecFrameInfo",
         "members": {
-          // TODO: spelling error
-          "fFullyReceived": "FullyRecieved"
+          "fFullyReceived": "FullyReceived"
         }
       },
       "sk_codecanimation_disposalmethod_t": {
@@ -409,6 +408,11 @@
       "sk_codec_options_t": {
         "cs": "SKCodecOptionsInternal",
         "internal": true
+      },
+      "sk_document_xps_options_t": {
+        "members": {
+          "fDPI": "Dpi"
+        }
       },
       "sk_document_pdf_metadata_t": {
         "cs": "SKDocumentPdfMetadataInternal",

--- a/binding/libSkiaSharp.json
+++ b/binding/libSkiaSharp.json
@@ -226,7 +226,7 @@
       "sk_codec_frameinfo_t": {
         "cs": "SKCodecFrameInfo",
         "members": {
-          "fFullyReceived": "FullyReceived"
+          "fFullyReceived": "FullyRecieved"
         }
       },
       "sk_codecanimation_disposalmethod_t": {

--- a/tests/Tests/SkiaSharp/SKDocumentTest.cs
+++ b/tests/Tests/SkiaSharp/SKDocumentTest.cs
@@ -168,6 +168,45 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[SkippableFact]
+		public void CanCreateXpsWithOptions()
+		{
+			// XPS is only supported on Windows
+
+			var options = new SKDocumentXpsOptions { Dpi = 150, AllowNoPngs = true };
+
+			using (var stream = new MemoryStream())
+			{
+				using (new SKAutoCoInitialize())
+				using (var doc = SKDocument.CreateXps(stream, options))
+				{
+					if (IsWindows)
+					{
+						Assert.NotNull(doc);
+						Assert.NotNull(doc.BeginPage(100, 100));
+
+						doc.EndPage();
+						doc.Close();
+					}
+					else
+					{
+						Assert.Null(doc);
+					}
+				}
+
+				if (IsWindows)
+				{
+					Assert.True(stream.Length > 0);
+					Assert.True(stream.Position > 0);
+				}
+				else
+				{
+					Assert.True(stream.Length == 0);
+					Assert.True(stream.Position == 0);
+				}
+			}
+		}
+
 
 		[SkippableFact]
 		public void StreamIsNotCollectedPrematurely()


### PR DESCRIPTION
## Summary

This PR addresses forgotten/missing public C# APIs and naming convention violations found during an audit of recently-generated bindings.

### New API Wrappers

- **`SKDocument.CreateXps(path/Stream/SKWStream, SKDocumentXpsOptions)`** — The P/Invoke `sk_document_create_xps_from_stream_with_options` existed but was never exposed publicly. Adds 3 overloads following the same pattern as `CreatePdf` with metadata.
- **`GRContext.Flush(SKImage)` / `GRContext.Flush(SKSurface)`** — Per-resource GPU flush methods that were generated but never wrapped.
- **`SKMaskFilter.CreateShader(SKShader)`** — Creates a mask filter from a shader (new Skia feature).

### Naming Fixes

| Change | Approach | Reason |
|--------|----------|--------|
| `SKDocumentXpsOptions.DPI` → `.Dpi` | Direct rename (preview-only) | PascalCase per .NET conventions |
| `GrVkYcbcrConversionInfo` → `GRVkYcbcrConversionInfo` | Generated struct renamed; old name kept as `[Obsolete]` compat shim | Consistent `GR` prefix matching all other Vulkan types |

The compat shim for `GrVkYcbcrConversionInfo` provides implicit conversions in both directions and a no-op `FormatFeatures` property (removed in the v4 native layout) to ease v3 migration.

### Not Changed (Tracked for v4 GA)

- **`SKCodecFrameInfo.FullyRecieved`** — Misspelling shipped in stable v1.68.1 (2019). Cannot break without a major version. Tracked in #4003.
- **`GrVkYcbcrConversionInfo` removal** — The obsolete compat shim should be removed before v4 GA. Tracked in #4002.

### Tests

- Added `CanCreateXpsWithOptions` test
- All existing tests continue to pass

### Audit Findings

A full audit of unused P/Invokes and naming issues was performed. Most unused P/Invokes are intentionally not wrapped (superseded by compat layer, handled by base class ref-counting, or already exposed through higher-level APIs).