### PR TITLE
Fix UnicodeEncodeError on Windows CI in repo-deps.py

### DIFF
--- a/scripts/infra/caching/repo-deps.py
+++ b/scripts/infra/caching/repo-deps.py
@@ -413,20 +413,20 @@ def cmd_validate(config, args):
         print(f"{job_path:<30} {count:>4} files{sub_str}")
 
     if overlaps:
-        print(f"\nℹ️  {len(overlaps)} files match both include and exclude (include wins):")
+        print(f"\n[info] {len(overlaps)} files match both include and exclude (include wins):")
         for f in overlaps[:10]:
             print(f"  {f}")
         if len(overlaps) > 10:
             print(f"  ... +{len(overlaps) - 10} more")
 
     if uncovered:
-        print(f"\n❌ UNCOVERED FILES:")
+        print(f"\n[FAIL] UNCOVERED FILES:")
         for f in uncovered:
             print(f"{f}")
         print(f"\nAdd to a job or exclude list in repo-deps.json")
         return 1
 
-    print("\n✅ All files covered!")
+    print("\n[PASS] All files covered!")
     return 0
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace emoji characters (ℹ️, ❌, ✅) with ASCII-safe labels (`[info]`, `[FAIL]`, `[PASS]`) in print statements. Windows CI uses cp1252 encoding for stdout which cannot encode these Unicode characters, causing the validate step to fail with:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 2-3: character maps to <undefined>
```