### PR TITLE
Update libjpeg-turbo to 3.1.4.1

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29,7 +29,7 @@
         "type": "other",
         "other": {
           "name": "libjpeg-turbo",
-          "version": "3.1.0",
+          "version": "3.1.4.1",
           "downloadUrl": "https://github.com/libjpeg-turbo/libjpeg-turbo"
         }
       }


### PR DESCRIPTION
Bumps libjpeg-turbo from 3.1.0 to 3.1.4.1.

Chromium's libjpeg-turbo fork hasn't rolled past 3.1.0, so the skia-side PR ([mono/skia#237](https://github.com/mono/skia/pull/237)) switches DEPS to point directly at the upstream GitHub repo at tag 3.1.4.1. Since upstream uses CMake and Skia uses GN, we provide pre-baked config headers (`jconfig.h`, `jconfigint.h`, `jversion.h`, `neon-compat.h`) that replicate what CMake's `configure_file()` would generate.

During review we also hardened several platform-conditional defines that Chromium shipped with latent issues:

- `HAVE_BUILTIN_CTZL` now gated on `sizeof(long) == sizeof(size_t)` to avoid truncation on LLP64 targets
- `SIZEOF_SIZE_T` uses portable compiler builtins instead of glibc's `__WORDSIZE`
- `HAVE_VLD1_*` NEON intrinsics gated on Clang/MSVC (GCC < 12 lacks them)
- Defensive `#undef` of arith/SIMD flags for non-8-bit JSAMPLE builds

Upstream compare: https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.1.0...3.1.4.1

---

**This PR:**
- Updates `externals/skia` submodule to the merged skia commit (`db59ba6c04`)
- Bumps `cgmanifest.json` version to 3.1.4.1

Fixes #3689