### PR TITLE
Fix Alpine CI failures caused by transient GitLab 500 errors

### DIFF
--- a/scripts/infra/native/linux/docker/alpine/Dockerfile
+++ b/scripts/infra/native/linux/docker/alpine/Dockerfile
@@ -46,7 +46,7 @@ RUN . /etc/skia-env \
          *)           DISTRO_VERSION=3.17 ;; \
          esac \
     && APK_DIR="$(mktemp -d)" \
-    && curl -SLO --create-dirs --output-dir "$APK_DIR" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.12.14/$MACHINE_ARCH/apk.static" \
+    && curl -SLO --fail --retry 5 --retry-delay 10 --retry-all-errors --create-dirs --output-dir "$APK_DIR" "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.12.14/$MACHINE_ARCH/apk.static" \
     && chmod +x "$APK_DIR/apk.static" \
     && "$APK_DIR/apk.static" \
         -X "http://dl-cdn.alpinelinux.org/alpine/v$DISTRO_VERSION/main" \


### PR DESCRIPTION
## Problem

All Alpine native builds are failing in CI because the `apk.static` download from GitLab (`gitlab.alpinelinux.org`) encounters transient HTTP 500 errors. 

Without `--fail`, `curl` silently saves the 39-byte JSON error response (`{message:500 Internal Server Error}`) as the `apk.static` file. The script then `chmod +x` and tries to execute it, resulting in exit code 127 ("not found").

**CI build:** https://dev.azure.com/xamarin/public/_build/results?buildId=157756&view=results

## Fix

Added resilience flags to the `curl` command in the Alpine Dockerfile:

- `--fail` — return non-zero exit code on HTTP 4xx/5xx instead of saving the error body
- `--retry 5` — retry up to 5 times on failure
- `--retry-delay 10` — wait 10 seconds between retries
- `--retry-all-errors` — retry on all errors including HTTP 5xx (works with `--fail`)

## Verification

- Confirmed the GitLab URL is currently responding (transient issue)
- Built the Docker image locally with `--no-cache` — succeeds with the new flags