### PR TITLE
Fix docs deploy race condition with retry loop

### DIFF
--- a/.github/workflows/build-site-cleanup-stale.yml
+++ b/.github/workflows/build-site-cleanup-stale.yml
@@ -78,7 +78,19 @@ jobs:
           git add -A
           if ! git diff --cached --quiet; then
             git commit -m "Sweep stale staging docs for ${#stale_dirs[@]} closed PR(s)"
-            git push origin docs-live
+            # Retry push with rebase in case another workflow pushed in the meantime
+            for attempt in 1 2 3 4 5; do
+              if git push origin docs-live; then
+                break
+              fi
+              echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
+              git pull --rebase origin docs-live
+              if [ $attempt -eq 5 ]; then
+                echo "Failed to push after 5 attempts"
+                exit 1
+              fi
+              sleep $((attempt * 2))
+            done
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/build-site-cleanup.yml
+++ b/.github/workflows/build-site-cleanup.yml
@@ -52,7 +52,19 @@ jobs:
             git add -A
             if ! git diff --cached --quiet; then
               git commit -m "Remove staging docs for PR #$PR_NUMBER"
-              git push origin docs-live
+              # Retry push with rebase in case another workflow pushed in the meantime
+              for attempt in 1 2 3 4 5; do
+                if git push origin docs-live; then
+                  break
+                fi
+                echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
+                git pull --rebase origin docs-live
+                if [ $attempt -eq 5 ]; then
+                  echo "Failed to push after 5 attempts"
+                  exit 1
+                fi
+                sleep $((attempt * 2))
+              done
               echo "Removed staging directory for PR #$PR_NUMBER"
             else
               echo "No changes to commit for PR #$PR_NUMBER"

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -376,7 +376,19 @@ jobs:
           git add .
           if ! git diff --cached --quiet; then
             git commit -m "Deploy main documentation from commit ${{ github.sha }}"
-            git push origin docs-live
+            # Retry push with rebase in case another workflow pushed in the meantime
+            for attempt in 1 2 3 4 5; do
+              if git push origin docs-live; then
+                break
+              fi
+              echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
+              git pull --rebase origin docs-live
+              if [ $attempt -eq 5 ]; then
+                echo "Failed to push after 5 attempts"
+                exit 1
+              fi
+              sleep $((attempt * 2))
+            done
           else
             echo "No changes to commit"
           fi
@@ -407,7 +419,19 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "Deploy staging docs for PR #$PR_NUMBER" \
               -m "https://mono.github.io/SkiaSharp/staging/$PR_NUMBER/"
-            git push origin docs-live
+            # Retry push with rebase in case another workflow pushed in the meantime
+            for attempt in 1 2 3 4 5; do
+              if git push origin docs-live; then
+                break
+              fi
+              echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
+              git pull --rebase origin docs-live
+              if [ $attempt -eq 5 ]; then
+                echo "Failed to push after 5 attempts"
+                exit 1
+              fi
+              sleep $((attempt * 2))
+            done
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
## Problem

The "Docs - Deploy" workflow fails intermittently when multiple PRs trigger it concurrently. Each run fetches `docs-live`, commits its changes, and pushes — but if another run pushes between the fetch and push, the push is rejected with:

```
! [rejected] docs-live -> docs-live (fetch first)
error: failed to push some refs
```

Recent failures:
- `mattleibow/fix-alpine-ci-failures` — [run 26168098740](https://github.com/mono/SkiaSharp/actions/runs/26168098740)
- `main` — [run 26129208219](https://github.com/mono/SkiaSharp/actions/runs/26129208219)
- `mattleibow/dev-update-zlib-cve-2026-27171` — [run 26115002465](https://github.com/mono/SkiaSharp/actions/runs/26115002465)
- `mattleibow/dev-update-tizen-sdk-10` — [run 26081419859](https://github.com/mono/SkiaSharp/actions/runs/26081419859)

## Fix

Added a retry loop (up to 5 attempts with exponential backoff) that does `git pull --rebase` before retrying the push. Applied to all three workflows that push to `docs-live`:

- `build-site.yml` (main deploy + staging deploy)
- `build-site-cleanup.yml` (PR close cleanup)
- `build-site-cleanup-stale.yml` (stale staging sweep)