### PR TITLE
[WASM] Drop native builds for pre-.NET 8 Emscripten versions

### DIFF
--- a/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
@@ -27,4 +27,10 @@
     <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.56\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>
 
+  <!-- Error when targeting unsupported WASM TFMs -->
+  <Target Name="_HarfBuzzSharpCheckWasmTfm" BeforeTargets="PrepareForBuild"
+          Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '8.0'))">
+    <Error Text="HarfBuzzSharp WebAssembly native assets require .NET 8.0 or later. Please update your project to target net8.0 or newer." />
+  </Target>
+
 </Project>

--- a/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
@@ -29,7 +29,7 @@
 
   <!-- Error when targeting unsupported WASM TFMs -->
   <Target Name="_HarfBuzzSharpCheckWasmTfm" BeforeTargets="PrepareForBuild"
-          Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '8.0'))">
+          Condition="(('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') or ('$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly')) and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '8.0'))">
     <Error Text="HarfBuzzSharp WebAssembly native assets require .NET 8.0 or later. Please update your project to target net8.0 or newer." />
   </Target>
 

--- a/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
+++ b/binding/HarfBuzzSharp.NativeAssets.WebAssembly/buildTransitive/HarfBuzzSharp.targets
@@ -21,10 +21,6 @@
     <_HarfBuzzSharpNativeBinaryType Condition="'$(WasmEnableSIMD)' != 'True'">$(_HarfBuzzSharpNativeBinaryType)</_HarfBuzzSharpNativeBinaryType>
   </PropertyGroup>
   <ItemGroup Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True'">
-    <!-- net6.0 (only has st and non-simd) -->
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\2.0.23\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))" />
-    <!-- net7.0 -->
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.12\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))" />
     <!-- net8.0 -->
     <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.34\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
     <!-- net9.0+ -->

--- a/binding/IncludeNativeAssets.HarfBuzzSharp.targets
+++ b/binding/IncludeNativeAssets.HarfBuzzSharp.targets
@@ -80,8 +80,6 @@
     <_HarfBuzzSharpNativeBinaryType Condition="'$(WasmEnableSIMD)' != 'True'">$(_HarfBuzzSharpNativeBinaryType)</_HarfBuzzSharpNativeBinaryType>
   </PropertyGroup>
   <ItemGroup Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != ''">
-    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libHarfBuzzSharp.a\2.0.23\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))" />
-    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libHarfBuzzSharp.a\3.1.12\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))" />
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libHarfBuzzSharp.a\3.1.34\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libHarfBuzzSharp.a\3.1.56\$(_HarfBuzzSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>

--- a/binding/IncludeNativeAssets.SkiaSharp.targets
+++ b/binding/IncludeNativeAssets.SkiaSharp.targets
@@ -83,8 +83,6 @@
     <_SkiaSharpNativeBinaryType Condition="'$(WasmEnableSIMD)' != 'True'">$(_SkiaSharpNativeBinaryType)</_SkiaSharpNativeBinaryType>
   </PropertyGroup>
   <ItemGroup Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != ''">
-    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\2.0.23\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))" />
-    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\3.1.12\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))" />
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\3.1.34\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\output\native\wasm\libSkiaSharp.a\3.1.56\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>

--- a/binding/SkiaSharp.NativeAssets.WebAssembly/buildTransitive/SkiaSharp.targets
+++ b/binding/SkiaSharp.NativeAssets.WebAssembly/buildTransitive/SkiaSharp.targets
@@ -10,9 +10,8 @@
     <Content Include="@(SkiaSharpStaticLibrary)" Visible="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly' and '$(ShouldIncludeNativeSkiaSharp)' == 'True'">
-    <!-- Include the GL symbol when running under net7 (https://github.com/dotnet/runtime/issues/76077) -->
     <WasmShellEmccExportedRuntimeMethod Include="GL" />
-    <!-- Include the emscripten_gl* symbols in net8 -->
+    <!-- Include the emscripten_gl* symbols -->
     <WasmShellExtraEmccFlags Include="-s USE_WEBGL2=1"/>
     <!-- Enable GLCtx when threading is available -->
     <WasmShellExtraEmccFlags Condition="'$(WasmShellEnableThreads)'=='True'" Include="-s OFFSCREEN_FRAMEBUFFER=1" />
@@ -30,10 +29,6 @@
     <_SkiaSharpNativeBinaryType Condition="'$(WasmEnableSIMD)' != 'True'">$(_SkiaSharpNativeBinaryType)</_SkiaSharpNativeBinaryType>
   </PropertyGroup>
   <ItemGroup Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'True'">
-    <!-- net6.0 (only has st and non-simd) -->
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\2.0.23\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0'))" />
-    <!-- net7.0 -->
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.12\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))" />
     <!-- net8.0 -->
     <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0'))" />
     <!-- net9.0+ -->

--- a/binding/SkiaSharp.NativeAssets.WebAssembly/buildTransitive/SkiaSharp.targets
+++ b/binding/SkiaSharp.NativeAssets.WebAssembly/buildTransitive/SkiaSharp.targets
@@ -37,7 +37,7 @@
 
   <!-- Error when targeting unsupported WASM TFMs -->
   <Target Name="_SkiaSharpCheckWasmTfm" BeforeTargets="PrepareForBuild"
-          Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'True' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '8.0'))">
+          Condition="(('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') or ('$(IsUnoHead)' == 'True' and '$(UnoRuntimeIdentifier)' == 'WebAssembly')) and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'True' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '8.0'))">
     <Error Text="SkiaSharp WebAssembly native assets require .NET 8.0 or later. Please update your project to target net8.0 or newer." />
   </Target>
 

--- a/binding/SkiaSharp.NativeAssets.WebAssembly/buildTransitive/SkiaSharp.targets
+++ b/binding/SkiaSharp.NativeAssets.WebAssembly/buildTransitive/SkiaSharp.targets
@@ -35,6 +35,12 @@
     <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.56\$(_SkiaSharpNativeBinaryType)\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))" />
   </ItemGroup>
 
+  <!-- Error when targeting unsupported WASM TFMs -->
+  <Target Name="_SkiaSharpCheckWasmTfm" BeforeTargets="PrepareForBuild"
+          Condition="('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true') and '$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'True' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '8.0'))">
+    <Error Text="SkiaSharp WebAssembly native assets require .NET 8.0 or later. Please update your project to target net8.0 or newer." />
+  </Target>
+
   <!-- Workaround for https://github.com/dotnet/runtime/issues/109289 -->
   <Target Name="_SkiaSharpRuntimeIssue109289Workaround" AfterTargets="_BrowserWasmWriteRspForLinking">
     <ItemGroup>

--- a/documentation/dev/packages.md
+++ b/documentation/dev/packages.md
@@ -48,7 +48,7 @@ Platform-specific UI controls for rendering SkiaSharp content. These provide rea
 | **SkiaSharp.Views.WPF** | WPF control: `SKElement`. net462+ and net6.0-windows+. Depends on OpenTK. |
 | **SkiaSharp.Views.WinUI** | WinUI 3 controls: `SKXamlCanvas`, `SKSwapChainPanel`. net6.0-windows+. Depends on Microsoft.WindowsAppSDK. Auto-includes SkiaSharp.NativeAssets.WinUI. |
 | **SkiaSharp.Views.Gtk3** | GTK# 3 control: `SKDrawingArea`. netstandard2.0+. For Linux desktop apps. Depends on GtkSharp. |
-| **SkiaSharp.Views.Blazor** | Blazor WebAssembly controls: `SKCanvasView`, `SKGLView`. net6.0+. Auto-includes SkiaSharp.NativeAssets.WebAssembly. |
+| **SkiaSharp.Views.Blazor** | Blazor WebAssembly controls: `SKCanvasView`, `SKGLView`. net6.0+ (WASM native assets require net8.0+). Auto-includes SkiaSharp.NativeAssets.WebAssembly. |
 | **SkiaSharp.Views.Maui.Core** | .NET MAUI shared view infrastructure. net8.0+. Depends on Microsoft.Maui.Core. |
 | **SkiaSharp.Views.Maui.Controls** | .NET MAUI controls: `SKCanvasView`, `SKGLView`. net8.0+. Depends on SkiaSharp.Views.Maui.Core and Microsoft.Maui.Controls. |
 | **SkiaSharp.Views.Uno.WinUI** | Uno Platform controls: `SKXamlCanvas`, `SKSwapChainPanel`. net8.0+. Depends on Uno.WinUI. Auto-includes SkiaSharp.NativeAssets.WebAssembly for WASM targets and SkiaSharp.Views.WinUI for Windows targets. |
@@ -92,7 +92,7 @@ Both follow the same platform matrix and architectures. HarfBuzzSharp does **not
 | **SkiaSharp.NativeAssets.MacCatalyst**<br/>**HarfBuzzSharp.NativeAssets.MacCatalyst** | Mac Catalyst universal framework bundle. Auto-included. |
 | **SkiaSharp.NativeAssets.tvOS**<br/>**HarfBuzzSharp.NativeAssets.tvOS** | Apple tvOS framework bundle (arm64, device only). Auto-included. |
 | **SkiaSharp.NativeAssets.Tizen**<br/>**HarfBuzzSharp.NativeAssets.Tizen** | Samsung Tizen (armel, x86). Auto-included. |
-| **SkiaSharp.NativeAssets.WebAssembly**<br/>**HarfBuzzSharp.NativeAssets.WebAssembly** | Emscripten static library (`.a`). **Static linking, not P/Invoke** — linked into `dotnet.wasm` at build time via MSBuild `NativeFileReference`. Includes multiple Emscripten versions with threading (st/mt) and SIMD variants. **Must add manually** (or use SkiaSharp.Views.Blazor / SkiaSharp.Views.Uno.WinUI). |
+| **SkiaSharp.NativeAssets.WebAssembly**<br/>**HarfBuzzSharp.NativeAssets.WebAssembly** | Emscripten static library (`.a`). **Static linking, not P/Invoke** — linked into `dotnet.wasm` at build time via MSBuild `NativeFileReference`. Includes Emscripten 3.1.34 (net8.0) and 3.1.56 (net9.0+) with threading (st/mt) and SIMD variants. **Requires net8.0+.** Must add manually (or use SkiaSharp.Views.Blazor / SkiaSharp.Views.Uno.WinUI). |
 
 > **⚠️ WASM is NOT dynamic loading.** Unlike all other platforms, WebAssembly uses static linking at compile time. The `.a` files are passed to the Emscripten linker which embeds them into the final `dotnet.wasm` binary. `DllImport("libSkiaSharp")` still works — the .NET WASM runtime resolves it to statically linked symbols.
 

--- a/scripts/azure-templates-stages-native-merge.yml
+++ b/scripts/azure-templates-stages-native-merge.yml
@@ -75,12 +75,6 @@ stages:
             - name: native_linux_x64_bionic_linux
             - name: native_linux_arm64_bionic_linux            
             # WASM
-            - name: native_wasm_2_0_23_linux
-            - name: native_wasm_2_0_6_linux
-            - name: native_wasm_3_1_12_linux
-            - name: native_wasm_3_1_12_SIMD_linux
-            - name: native_wasm_3_1_12_Threading_linux
-            - name: native_wasm_3_1_12_Threading_SIMD_linux
             - name: native_wasm_3_1_34_linux
             - name: native_wasm_3_1_34_SIMD_linux
             - name: native_wasm_3_1_34_SIMD_Threading_linux
@@ -89,7 +83,6 @@ stages:
             - name: native_wasm_3_1_56_SIMD_linux
             - name: native_wasm_3_1_56_SIMD_Threading_linux
             - name: native_wasm_3_1_56_Threading_linux
-            - name: native_wasm_3_1_7_linux
 
       - template: /scripts/azure-templates-jobs-merger.yml@self   # Merge Native Linux Artifacts
         parameters:
@@ -129,12 +122,6 @@ stages:
           displayName: Merge Native WASM Artifacts
           buildAgent: ${{ parameters.buildAgentHost }}
           requiredArtifacts:
-            - name: native_wasm_2_0_23_linux
-            - name: native_wasm_2_0_6_linux
-            - name: native_wasm_3_1_12_linux
-            - name: native_wasm_3_1_12_SIMD_linux
-            - name: native_wasm_3_1_12_Threading_linux
-            - name: native_wasm_3_1_12_Threading_SIMD_linux
             - name: native_wasm_3_1_34_linux
             - name: native_wasm_3_1_34_SIMD_linux
             - name: native_wasm_3_1_34_SIMD_Threading_linux
@@ -143,7 +130,6 @@ stages:
             - name: native_wasm_3_1_56_SIMD_linux
             - name: native_wasm_3_1_56_SIMD_Threading_linux
             - name: native_wasm_3_1_56_Threading_linux
-            - name: native_wasm_3_1_7_linux
 
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - template: /scripts/azure-templates-jobs-merger.yml@self # Merge Native MSVC Artifacts

--- a/scripts/azure-templates-stages-native-wasm.yml
+++ b/scripts/azure-templates-stages-native-wasm.yml
@@ -19,39 +19,6 @@ stages:
           buildAgent: ${{ parameters.buildAgentLinuxNative }}
           use1ESPipelineTemplates: ${{ parameters.use1ESPipelineTemplates }}
           emscripten:
-            - 2.0.6:
-              displayName: 2.0.6
-              version: 2.0.6
-              features: none
-            - 2.0.23:
-              displayName: 2.0.23
-              version: 2.0.23
-              features: none
-
-            # .NET 6
-            - 3.1.7:
-              displayName: 3.1.7
-              version: 3.1.7
-              features: none
-
-            # .NET 7
-            - 3.1.12:
-              displayName: 3.1.12
-              version: 3.1.12
-              features: st
-            - 3.1.12:
-              displayName: '3.1.12_SIMD'
-              version: 3.1.12
-              features: st,simd
-            - 3.1.12:
-              displayName: '3.1.12_Threading'
-              version: 3.1.12
-              features: mt
-            - 3.1.12:
-              displayName: '3.1.12_Threading_SIMD'
-              version: 3.1.12
-              features: mt,simd
-
             # .NET 8
             - 3.1.34:
               displayName: 3.1.34


### PR DESCRIPTION
## Summary

The WASM native build for Emscripten 2.0.6 was intermittently hanging in CI, and the older Emscripten versions target EOL runtimes. This PR removes all WASM native build jobs and NuGet package assets for Emscripten versions below 3.1.34 (.NET 8):

| Emscripten | .NET Version | Reason for removal |
|------------|--------------|-------------------|
| 2.0.6 | None (legacy) | No .NET release, intermittent CI hangs |
| 2.0.23 | .NET 6 (EOL) | Runtime EOL Nov 2024 |
| 3.1.7 | None (legacy) | No .NET release |
| 3.1.12 | .NET 7 (EOL) | Runtime EOL May 2024 |

Retained: Emscripten 3.1.34 (.NET 8) and 3.1.56 (.NET 9/10/11) with all st/mt/simd variants.

## Changes

### CI Pipeline
- Removed 7 build jobs from `azure-templates-stages-native-wasm.yml` (15 → 8 jobs, ~47% reduction)
- Removed corresponding artifact names from `azure-templates-stages-native-merge.yml`

### NuGet Package Targets
- Removed old `NativeFileReference` entries from `SkiaSharp.NativeAssets.WebAssembly` and `HarfBuzzSharp.NativeAssets.WebAssembly` buildTransitive targets
- Added MSBuild error guard: consumers targeting `< net8.0` on Blazor WASM **or Uno Platform WASM** now get a clear build error instead of silently getting no native library

### Internal Targets
- Cleaned `IncludeNativeAssets.SkiaSharp.targets` and `IncludeNativeAssets.HarfBuzzSharp.targets`

### Documentation
- Updated `documentation/dev/packages.md` to reflect net8.0+ WASM native requirement

## What's NOT changed
- `SkiaSharp.Views.Blazor.csproj` still ships managed assemblies for net6.0 (via `TFMBase`) — the managed code compiles fine, only native WASM linking requires net8.0+
- All net8+ builds (3.1.34, 3.1.56 with st/mt/simd variants) are unchanged