### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "c00877ea9fa7e69d3985801a82c96f7d6fcdda30"
+          "commitHash": "3c9cff2c0d2f578ae3f46943c38fae68cd573a0f"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/238

# mono/SkiaSharp PR Summary — Update Skia to milestone 147 (bug fixes)

**Type:** Same-milestone sync (m147 → m147)  
**Branch:** `skia-sync/m147`  
**Target:** `main`

---

## Summary

This is a same-milestone bug-fix sync: upstream `chrome/m147` had 3 new commits after our last sync. No version number changes — only `cgmanifest.json` was updated with the new commit hashes.

---

## Changes

### `cgmanifest.json`
- Updated `commitHash` to submodule HEAD: `be7f8554cf0c2d867bcb0f256656286418f9f704`
- Updated `upstream_merge_commit` to upstream tip: `dcbd374c13430f81daa04d28f8d00dee65679b17`
- `chrome_milestone` remains `147`

### `externals/skia` submodule
- Bumped submodule pointer to `be7f8554cf0c2d867bcb0f256656286418f9f704` (on `skia-sync/m147` in mono/skia)

---

## Breaking Change Analysis

| Change | Risk | Impact on C API |
|--------|------|----------------|
| `SkFont::breakText()` removed | 🟡 MEDIUM | Fixed in mono/skia: re-implemented `sk_font_break_text` |
| `SkRefCntBase::getRefCount()` removed | 🟡 MEDIUM | Fixed in mono/skia: re-implemented via direct atomic access |
| `SkNVRefCnt::getRefCount()` removed | 🟡 MEDIUM | Fixed in mono/skia: re-implemented via direct atomic access |
| SkRegion iterator doc improvements | 🟢 NONE | Documentation only, behavior fix for edge case |
| SkRP bug fixes | 🟢 NONE | Runtime improvement, no API change |

**No C# wrapper changes required** — all affected functions have existing C# bindings that continue to work unchanged.

---

## Version Files

No version changes (same-milestone sync):
- `scripts/VERSIONS.txt`: unchanged (still `4.147.0`)
- `SK_C_INCREMENT`: remains `0`

---

## Bindings

- `SkiaApi.generated.cs`: **no changes** (C API signatures unchanged)
- `HarfBuzzApi.generated.cs`: unchanged (reverted, separate update track)

---

## Build & Test Results

| Step | Result |
|------|--------|
| Native build (Linux x64) | ✅ Success |
| C# build (0 errors) | ✅ Success |
| Smoke tests (32/32) | ✅ Passed |
| Full test suite | ✅ **Failed: 0, Passed: 5504, Skipped: 171, Total: 5675** |

Skipped tests are all GPU/hardware-specific (no GPU driver available in CI environment) — expected behavior.

---

## Items Needing Human Attention

- **⚠️ `sk_refcnt_get_ref_count` uses memory layout assumption** (documented in mono/skia PR): reads `fRefCnt` by offsetting past vtable pointer in `SkRefCntBase`. Works correctly but is technically implementation-dependent. Only affects `SKObject.GetReferenceCount()` debug helper.

- **⚠️ `sk_font_break_text` uses internal Skia headers:** Uses `src/base/SkUTF.h` and `src/core/SkStrikeSpec.h`. Monitor for changes in future milestones.

- **Merge order:** Merge the mono/skia PR first, then update the submodule pointer in this PR to point to the squashed SHA on `skiasharp`, then merge this PR.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).