### PR TITLE
Update harfbuzz to 14.2.0

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -59,7 +59,7 @@
         "type": "other",
         "other": {
           "name": "harfbuzz",
-          "version": "8.3.1",
+          "version": "14.2.0",
           "downloadUrl": "https://github.com/harfbuzz/harfbuzz"
         }
       }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,5 +1,5 @@
 # native sources
-harfbuzz                                        release     8.3.1
+harfbuzz                                        release     14.2.0
 skia                                            release     m147
 ANGLE                                           release     chromium/6275
 
@@ -69,7 +69,7 @@ libSkiaSharp            increment   0
 # <milestone>.<increment>.0
 libSkiaSharp            soname      147.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
-HarfBuzz                soname      0.60831.0
+HarfBuzz                soname      0.61420.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
@@ -78,7 +78,7 @@ SkiaSharp               file        4.147.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        8.3.1.6
+HarfBuzzSharp           file        14.2.0
 
 # nuget versions
 # SkiaSharp
@@ -113,13 +113,13 @@ SkiaSharp.Resources                             nuget       4.147.0
 SkiaSharp.Vulkan.SharpVk                        nuget       4.147.0
 SkiaSharp.Direct3D.Vortice                      nuget       4.147.0
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.Android              nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.iOS                  nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.Linux                nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.macOS                nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.Tizen                nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       8.3.1.6
-HarfBuzzSharp.NativeAssets.Win32                nuget       8.3.1.6
+HarfBuzzSharp                                   nuget       14.2.0
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.0
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.0
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.0
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.0
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.0
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.0
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.0
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.0
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.0


### PR DESCRIPTION
Update harfbuzz native dependency from 8.3.1 to 14.2.0.

Fixes #3686

Changes:
- Updated `externals/skia` submodule (points to mono/skia dev/update-harfbuzz-14 branch)
- Updated `cgmanifest.json` with new version

Required skia PR: https://github.com/mono/skia/pull/241

Build verified: macOS arm64 native build succeeds.
Tests verified: All 5663 tests pass (12 skipped for hardware reasons).