### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "c00877ea9fa7e69d3985801a82c96f7d6fcdda30"
+          "commitHash": "8044793ff0a6e338b24c1d270bea4c45159d3c0c"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 147,
-      "upstream_merge_commit": "f8cd2da0256752afb0059bf17e4bf2bec422967e"
+      "upstream_merge_commit": "dcbd374c13430f81daa04d28f8d00dee65679b17"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.

**Companion skia PR:** https://github.com/mono/skia/pull/242

# mono/SkiaSharp PR Summary — [skia-sync] Update skia to milestone 147

## Overview

Same-milestone sync (m147 → m147): picks up 3 upstream Skia bug-fix commits. No version bump — only the upstream commit hash in `cgmanifest.json` changes.

## Breaking Change Analysis

**Risk: 🟢 LOW** — No public API changes.

All 3 upstream commits are internal bug fixes:
- SkRP optimizer correctness fix
- SkRuntimeEffect threading safety (const private members)
- SkRegion malformed-data rejection

## Version Changes

None — same milestone (147), version numbers unchanged.

## Binding Changes

None — `SkiaApi.generated.cs` is unchanged.

## cgmanifest.json Changes

- `commitHash`: updated to `8044793ff0a6e338b24c1d270bea4c45159d3c0c`
- `upstream_merge_commit`: updated to `dcbd374c13430f81daa04d28f8d00dee65679b17`

## C# Wrapper Changes

None required.

## Build Results

| Step | Result |
|------|--------|
| Native Linux x64 | ✅ Clean |
| C# Build | ✅ 0 errors |
| Smoke Tests | ✅ 32/32 passed |
| Full Test Suite | ✅ 5504 passed, 171 skipped (GPU/hardware), 0 failed |

## Items Needing Human Attention

None.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).