### PR TITLE
Add auto-milestone workflow for PRs

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,0 +1,165 @@
+name: Auto-milestone PRs
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: ['main', 'release/**']
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Log actions without making changes'
+        type: boolean
+        default: true
+      pr-number:
+        description: 'PR number to process (required for manual runs)'
+        type: number
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: auto-milestone-${{ github.event.pull_request.number || github.event.inputs.pr-number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  assign-milestone:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflows/auto-milestone/auto-milestone.js
+            scripts/azure-templates-variables.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Assign milestone
+        uses: actions/github-script@v7
+        env:
+          # Evaluates to 'true' only for workflow_dispatch with dry-run checked.
+          # For pull_request_target: (false && _) || false → 'false'
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { resolveMilestone, findOrCreateMilestone, parsePipelineVariables } = require('./.github/workflows/auto-milestone/auto-milestone.js');
+            const DRY_RUN = process.env.DRY_RUN === 'true';
+
+            if (DRY_RUN) core.info('DRY RUN — no changes will be made');
+
+            // --- Resolve PR ---
+            let pr;
+            if (context.payload.pull_request) {
+              pr = context.payload.pull_request;
+            } else {
+              const prNumber = Number(context.payload.inputs?.['pr-number']);
+              if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+                core.setFailed(`Invalid PR number: ${context.payload.inputs?.['pr-number']}`);
+                return;
+              }
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              pr = data;
+              if (!pr.merged) {
+                core.setFailed(`PR #${prNumber} has not been merged`);
+                return;
+              }
+            }
+
+            // Skip if already milestoned
+            if (pr.milestone) {
+              core.info(`PR #${pr.number} already has milestone "${pr.milestone.title}", skipping`);
+              return;
+            }
+
+            const baseBranch = pr.base.ref;
+            core.info(`PR #${pr.number} merged to ${baseBranch}`);
+
+            // --- Read version from pipeline variables ---
+            let skiaSharpVersion = null;
+            try {
+              const content = fs.readFileSync('scripts/azure-templates-variables.yml', 'utf8');
+              skiaSharpVersion = parsePipelineVariables(content);
+            } catch (e) {
+              core.warning(`Could not read azure-templates-variables.yml: ${e.message}`);
+            }
+
+            // --- Fetch all milestones (single call avoids TOCTOU race) ---
+            const allMilestones = await github.paginate(github.rest.issues.listMilestones, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            });
+            const openMilestones = allMilestones.filter(m => m.state === 'open');
+            const closedMilestones = allMilestones.filter(m => m.state === 'closed');
+
+            // --- Resolve milestone name ---
+            const milestoneName = resolveMilestone(
+              baseBranch,
+              skiaSharpVersion,
+              openMilestones.map(m => m.title)
+            );
+
+            if (!milestoneName) {
+              core.warning(`Could not determine milestone for branch "${baseBranch}"`);
+              return;
+            }
+
+            core.info(`Resolved milestone: "${milestoneName}"`);
+
+            // --- Find or create milestone ---
+            const milestone = await findOrCreateMilestone({
+              milestoneName,
+              openMilestones: openMilestones.map(m => ({ title: m.title, number: m.number })),
+              closedMilestones: closedMilestones.map(m => ({ title: m.title, number: m.number })),
+              createMilestone: async (title) => {
+                const { data } = await github.rest.issues.createMilestone({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                });
+                return { title: data.title, number: data.number };
+              },
+              listMilestones: async () => {
+                const refreshed = await github.paginate(github.rest.issues.listMilestones, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'all',
+                  per_page: 100,
+                });
+                return refreshed.map(m => ({ title: m.title, number: m.number }));
+              },
+              dryRun: DRY_RUN,
+              log: core.info,
+            });
+
+            if (DRY_RUN) {
+              const action = milestone ? `assign existing milestone "${milestoneName}" (#${milestone.number})` : `create and assign milestone "${milestoneName}"`;
+              core.info(`[DRY RUN] Would ${action} to PR #${pr.number}`);
+              return;
+            }
+
+            if (!milestone) {
+              core.setFailed(`Failed to find or create milestone "${milestoneName}"`);
+              return;
+            }
+
+            // --- Apply milestone ---
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              milestone: milestone.number,
+            });
+
+            core.info(`✅ Assigned milestone "${milestoneName}" to PR #${pr.number}`);

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -81,8 +81,7 @@ jobs:
               return;
             }
 
-            const baseBranch = pr.base.ref;
-            core.info(`PR #${pr.number} merged to ${baseBranch}`);
+            core.info(`PR #${pr.number} merged to ${pr.base.ref}`);
 
             // --- Read version from pipeline variables ---
             let skiaSharpVersion = null;
@@ -105,13 +104,12 @@ jobs:
 
             // --- Resolve milestone name ---
             const milestoneName = resolveMilestone(
-              baseBranch,
               skiaSharpVersion,
               openMilestones.map(m => m.title)
             );
 
             if (!milestoneName) {
-              core.warning(`Could not determine milestone for branch "${baseBranch}"`);
+              core.warning(`Could not determine milestone (version: ${skiaSharpVersion})`);
               return;
             }
 

--- a/.github/workflows/auto-milestone/auto-milestone.js
+++ b/.github/workflows/auto-milestone/auto-milestone.js
@@ -1,0 +1,162 @@
+// Auto-milestone logic for SkiaSharp PRs.
+// Used by auto-milestone.yml workflow and testable via auto-milestone.test.js.
+
+'use strict';
+
+/**
+ * Parse a version string into comparable components.
+ * "4.148.0-preview.1" → { major: 4, minor: 148, patch: 0, prerelease: "preview.1" }
+ * "3.119.x" → { major: 3, minor: 119, patch: -1, prerelease: null }
+ */
+function parseVersion(title) {
+  const match = title.match(/^(\d+)\.(\d+)\.(\d+|x)(?:-([a-zA-Z0-9.]+))?$/);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: match[3] === 'x' ? -1 : parseInt(match[3], 10),
+    prerelease: match[4] || null,
+  };
+}
+
+/**
+ * Compare two parsed versions for sorting.
+ * Stable versions (no prerelease) sort AFTER prereleases of the same base version.
+ * This matches semver: 4.148.0-preview.1 < 4.148.0-preview.2 < 4.148.0-rc.1 < 4.148.0
+ */
+function compareVersions(a, b) {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  if (a.patch !== b.patch) return a.patch - b.patch;
+
+  if (!a.prerelease && !b.prerelease) return 0;
+  if (!a.prerelease) return 1;  // stable sorts AFTER prerelease
+  if (!b.prerelease) return -1;
+
+  return a.prerelease.localeCompare(b.prerelease, undefined, { numeric: true });
+}
+
+/**
+ * Check if a milestone's base version (major.minor.patch) matches the target.
+ */
+function isBaseVersionMatch(milestoneVersion, targetVersion) {
+  return milestoneVersion.major === targetVersion.major
+    && milestoneVersion.minor === targetVersion.minor
+    && milestoneVersion.patch === targetVersion.patch;
+}
+
+/**
+ * Derive the milestone name from a branch name and current version.
+ *
+ * @param {string} baseBranch - The PR's base branch (e.g., "main", "release/3.119.x")
+ * @param {string} skiaSharpVersion - Current version from VERSIONS.txt (e.g., "4.147.0")
+ * @param {string[]} openMilestones - Titles of all open milestones
+ * @returns {string|null} The milestone name to assign, or null if undetermined
+ */
+function resolveMilestone(baseBranch, skiaSharpVersion, openMilestones) {
+  // Specific release branches (not servicing) use the branch name directly
+  if (baseBranch.startsWith('release/') && !baseBranch.endsWith('.x')) {
+    const name = baseBranch.slice('release/'.length);
+    return parseVersion(name) ? name : null;
+  }
+
+  // For main and release/*.x branches, use pipeline variables to find the target
+  if (baseBranch === 'main' || (baseBranch.startsWith('release/') && baseBranch.endsWith('.x'))) {
+    if (!skiaSharpVersion) return null;
+
+    const currentVersion = parseVersion(skiaSharpVersion);
+    if (!currentVersion) return null;
+    if (currentVersion.patch === -1) return null;
+
+    // If the version has a specific prerelease (e.g., preview.3, rc.1),
+    // the milestone must be that exact version — no searching.
+    if (currentVersion.prerelease) {
+      return skiaSharpVersion;
+    }
+
+    // Stable target (preview.0) — find lowest open milestone in the same train
+    const candidates = openMilestones
+      .map(title => ({ title, parsed: parseVersion(title) }))
+      .filter(({ parsed }) => {
+        if (!parsed) return false;
+        if (parsed.patch === -1) return false;
+        return isBaseVersionMatch(parsed, currentVersion);
+      })
+      .sort((a, b) => compareVersions(a.parsed, b.parsed));
+
+    if (candidates.length > 0) {
+      return candidates[0].title;
+    }
+
+    // No matching milestone exists — create the base version
+    return skiaSharpVersion;
+  }
+
+  return null;
+}
+
+/**
+ * Find or create a milestone by title.
+ * Handles race conditions (422 on create → re-fetch).
+ */
+async function findOrCreateMilestone({ milestoneName, openMilestones, closedMilestones, createMilestone, listMilestones, dryRun, log }) {
+  let milestone = openMilestones.find(m => m.title === milestoneName);
+
+  if (!milestone) {
+    milestone = closedMilestones.find(m => m.title === milestoneName);
+    if (milestone) {
+      log(`⚠️ Milestone "${milestoneName}" is closed — assigning anyway (late merge or backport)`);
+    }
+  }
+
+  if (!milestone) {
+    if (dryRun) {
+      log(`[DRY RUN] Would create milestone "${milestoneName}"`);
+      return null;
+    }
+
+    log(`Creating milestone "${milestoneName}"`);
+    try {
+      milestone = await createMilestone(milestoneName);
+    } catch (e) {
+      if (e.status === 422) {
+        log(`Milestone "${milestoneName}" was created by another run, re-fetching...`);
+        const refreshed = await listMilestones();
+        milestone = refreshed.find(m => m.title === milestoneName);
+        if (!milestone) throw e;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  return milestone;
+}
+
+/**
+ * Extract SKIASHARP_VERSION and PREVIEW_LABEL from azure-templates-variables.yml content.
+ * Combines them into the effective target version:
+ *   - PREVIEW_LABEL = "preview.0" → base version only (e.g., "4.147.0")
+ *   - PREVIEW_LABEL = "preview.3" → "4.147.0-preview.3"
+ *   - PREVIEW_LABEL = "rc.1" → "4.147.0-rc.1"
+ *
+ * @param {string} content - File content of azure-templates-variables.yml
+ * @returns {string|null} The effective target version, or null if not found
+ */
+function parsePipelineVariables(content) {
+  const versionMatch = content.match(/^\s*SKIASHARP_VERSION:\s*['"]?(\S+?)['"]?\s*$/m);
+  if (!versionMatch) return null;
+  const baseVersion = versionMatch[1];
+
+  const labelMatch = content.match(/^\s*PREVIEW_LABEL:\s*['"]?(\S+?)['"]?\s*$/m);
+  const label = labelMatch ? labelMatch[1] : null;
+
+  // "preview.0" means stable target (no prerelease suffix)
+  if (!label || label === 'preview.0') {
+    return baseVersion;
+  }
+
+  return `${baseVersion}-${label}`;
+}
+
+module.exports = { parseVersion, compareVersions, isBaseVersionMatch, resolveMilestone, findOrCreateMilestone, parsePipelineVariables };

--- a/.github/workflows/auto-milestone/auto-milestone.js
+++ b/.github/workflows/auto-milestone/auto-milestone.js
@@ -46,53 +46,41 @@ function isBaseVersionMatch(milestoneVersion, targetVersion) {
 }
 
 /**
- * Derive the milestone name from a branch name and current version.
+ * Derive the milestone name from the effective version (from pipeline variables).
  *
- * @param {string} baseBranch - The PR's base branch (e.g., "main", "release/3.119.x")
- * @param {string} skiaSharpVersion - Current version from VERSIONS.txt (e.g., "4.147.0")
+ * @param {string} skiaSharpVersion - Effective version (e.g., "4.147.0" or "4.147.0-preview.3")
  * @param {string[]} openMilestones - Titles of all open milestones
  * @returns {string|null} The milestone name to assign, or null if undetermined
  */
-function resolveMilestone(baseBranch, skiaSharpVersion, openMilestones) {
-  // Specific release branches (not servicing) use the branch name directly
-  if (baseBranch.startsWith('release/') && !baseBranch.endsWith('.x')) {
-    const name = baseBranch.slice('release/'.length);
-    return parseVersion(name) ? name : null;
-  }
+function resolveMilestone(skiaSharpVersion, openMilestones) {
+  if (!skiaSharpVersion) return null;
 
-  // For main and release/*.x branches, use pipeline variables to find the target
-  if (baseBranch === 'main' || (baseBranch.startsWith('release/') && baseBranch.endsWith('.x'))) {
-    if (!skiaSharpVersion) return null;
+  const currentVersion = parseVersion(skiaSharpVersion);
+  if (!currentVersion) return null;
+  if (currentVersion.patch === -1) return null;
 
-    const currentVersion = parseVersion(skiaSharpVersion);
-    if (!currentVersion) return null;
-    if (currentVersion.patch === -1) return null;
-
-    // If the version has a specific prerelease (e.g., preview.3, rc.1),
-    // the milestone must be that exact version — no searching.
-    if (currentVersion.prerelease) {
-      return skiaSharpVersion;
-    }
-
-    // Stable target (preview.0) — find lowest open milestone in the same train
-    const candidates = openMilestones
-      .map(title => ({ title, parsed: parseVersion(title) }))
-      .filter(({ parsed }) => {
-        if (!parsed) return false;
-        if (parsed.patch === -1) return false;
-        return isBaseVersionMatch(parsed, currentVersion);
-      })
-      .sort((a, b) => compareVersions(a.parsed, b.parsed));
-
-    if (candidates.length > 0) {
-      return candidates[0].title;
-    }
-
-    // No matching milestone exists — create the base version
+  // If the version has a specific prerelease (e.g., preview.3, rc.1),
+  // the milestone must be that exact version — no searching.
+  if (currentVersion.prerelease) {
     return skiaSharpVersion;
   }
 
-  return null;
+  // Stable target (preview.0) — find lowest open milestone in the same train
+  const candidates = openMilestones
+    .map(title => ({ title, parsed: parseVersion(title) }))
+    .filter(({ parsed }) => {
+      if (!parsed) return false;
+      if (parsed.patch === -1) return false;
+      return isBaseVersionMatch(parsed, currentVersion);
+    })
+    .sort((a, b) => compareVersions(a.parsed, b.parsed));
+
+  if (candidates.length > 0) {
+    return candidates[0].title;
+  }
+
+  // No matching milestone exists — create the base version
+  return skiaSharpVersion;
 }
 
 /**

--- a/.github/workflows/auto-milestone/auto-milestone.test.js
+++ b/.github/workflows/auto-milestone/auto-milestone.test.js
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// Tests for auto-milestone logic.
+// Run: node .github/workflows/auto-milestone/auto-milestone.test.js
+
+'use strict';
+
+const { parseVersion, compareVersions, isBaseVersionMatch, resolveMilestone, findOrCreateMilestone, parsePipelineVariables } = require('./auto-milestone.js');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, msg) {
+  if (condition) { passed++; console.log(`  ✅ ${msg}`); }
+  else { failed++; console.log(`  ❌ ${msg}`); }
+}
+
+function assertEqual(actual, expected, msg) {
+  if (actual === expected) { passed++; console.log(`  ✅ ${msg}`); }
+  else { failed++; console.log(`  ❌ ${msg}: expected "${expected}", got "${actual}"`); }
+}
+
+// --- parseVersion ---
+console.log('\n📋 parseVersion');
+{
+  const v = parseVersion('4.148.0-preview.1');
+  assert(v !== null, 'parses 4.148.0-preview.1');
+  assertEqual(v.major, 4, '  major = 4');
+  assertEqual(v.minor, 148, '  minor = 148');
+  assertEqual(v.patch, 0, '  patch = 0');
+  assertEqual(v.prerelease, 'preview.1', '  prerelease = preview.1');
+}
+{
+  const v = parseVersion('3.119.x');
+  assert(v !== null, 'parses 3.119.x');
+  assertEqual(v.patch, -1, '  patch = -1 (wildcard)');
+  assertEqual(v.prerelease, null, '  prerelease = null');
+}
+{
+  const v = parseVersion('4.147.0');
+  assert(v !== null, 'parses 4.147.0 (stable)');
+  assertEqual(v.prerelease, null, '  prerelease = null');
+}
+{
+  assertEqual(parseVersion('Backlog'), null, 'Backlog returns null');
+}
+{
+  assertEqual(parseVersion('4.148'), null, '2-part version (no patch) returns null');
+}
+{
+  assertEqual(parseVersion('4.148.0-preview.1/foo'), null, 'slash in prerelease returns null');
+}
+
+// --- compareVersions ---
+console.log('\n📋 compareVersions');
+{
+  const a = parseVersion('4.148.0-preview.1');
+  const b = parseVersion('4.148.0-preview.2');
+  assert(compareVersions(a, b) < 0, 'preview.1 < preview.2');
+}
+{
+  const a = parseVersion('4.148.0-preview.2');
+  const b = parseVersion('4.148.0-rc.1');
+  assert(compareVersions(a, b) < 0, 'preview.2 < rc.1');
+}
+{
+  const a = parseVersion('4.148.0-rc.1');
+  const b = parseVersion('4.148.0');
+  assert(compareVersions(a, b) < 0, 'rc.1 < stable (4.148.0)');
+}
+{
+  const a = parseVersion('3.119.0-preview.1');
+  const b = parseVersion('4.147.0-preview.1');
+  assert(compareVersions(a, b) < 0, '3.119 < 4.147');
+}
+{
+  const a = parseVersion('4.147.0-preview.9');
+  const b = parseVersion('4.147.0-preview.10');
+  assert(compareVersions(a, b) < 0, 'preview.9 < preview.10 (numeric)');
+}
+
+// --- isBaseVersionMatch ---
+console.log('\n📋 isBaseVersionMatch');
+{
+  assert(isBaseVersionMatch(parseVersion('4.147.0-preview.3'), parseVersion('4.147.0')), '4.147.0-preview.3 matches 4.147.0 base');
+  assert(isBaseVersionMatch(parseVersion('4.147.0-rc.1'), parseVersion('4.147.0')), '4.147.0-rc.1 matches 4.147.0 base');
+  assert(isBaseVersionMatch(parseVersion('4.147.0'), parseVersion('4.147.0')), '4.147.0 matches 4.147.0 (exact)');
+  assert(!isBaseVersionMatch(parseVersion('4.148.0-preview.1'), parseVersion('4.147.0')), '4.148.0-preview.1 does NOT match 4.147.0');
+  assert(!isBaseVersionMatch(parseVersion('3.119.0'), parseVersion('4.147.0')), '3.119.0 does NOT match 4.147.0');
+}
+
+// --- resolveMilestone ---
+console.log('\n📋 resolveMilestone — release branches (specific)');
+assertEqual(resolveMilestone('release/3.119.4', '4.147.0', []), '3.119.4', 'release/3.119.4 → 3.119.4');
+assertEqual(resolveMilestone('release/4.148.0-preview.1', '4.147.0', []), '4.148.0-preview.1', 'release/4.148.0-preview.1 → 4.148.0-preview.1');
+
+console.log('\n📋 resolveMilestone — release branches (servicing .x)');
+assertEqual(
+  resolveMilestone('release/3.119.x', '3.119.4', ['3.119.4', '3.119.5-preview.1']),
+  '3.119.4',
+  'release/3.119.x uses VERSIONS.txt from that branch, picks lowest match'
+);
+assertEqual(
+  resolveMilestone('release/3.119.x', '3.119.5', ['3.119.4']),
+  '3.119.5',
+  'release/3.119.x with no matching milestone creates VERSIONS.txt version'
+);
+
+console.log('\n📋 resolveMilestone — main branch');
+// Real-world scenario: VERSIONS.txt=4.147.0, multiple milestones for 4.147.0 train
+assertEqual(
+  resolveMilestone('main', '4.147.0', ['4.147.0-preview.3', '4.147.0-rc.1', '4.147.0', '4.148.0-preview.1', 'Backlog']),
+  '4.147.0-preview.3',
+  'picks lowest milestone in the 4.147.0 train (preview.3)'
+);
+assertEqual(
+  resolveMilestone('main', '4.147.0', ['4.147.0-rc.1', '4.147.0', '4.148.0-preview.1']),
+  '4.147.0-rc.1',
+  'picks lowest in train when preview is closed (rc.1)'
+);
+assertEqual(
+  resolveMilestone('main', '4.147.0', ['4.147.0', '4.148.0-preview.1']),
+  '4.147.0',
+  'picks stable milestone when its the only one in the train'
+);
+assertEqual(
+  resolveMilestone('main', '4.147.0', ['4.148.0-preview.1', '4.148.0', 'Backlog']),
+  '4.147.0',
+  'no milestones matching 4.147.0 base → creates 4.147.0'
+);
+assertEqual(
+  resolveMilestone('main', '4.148.0-preview.2', ['4.148.0-preview.2', '4.148.0-rc.1', '4.148.0']),
+  '4.148.0-preview.2',
+  'prerelease version → exact milestone (preview.2)'
+);
+assertEqual(
+  resolveMilestone('main', '4.148.0-preview.2', ['Backlog']),
+  '4.148.0-preview.2',
+  'prerelease version with no match → creates exact (preview.2)'
+);
+assertEqual(
+  resolveMilestone('main', '4.148.0-rc.1', ['4.148.0-preview.2', '4.148.0-rc.1']),
+  '4.148.0-rc.1',
+  'rc version → exact milestone (rc.1)'
+);
+assertEqual(
+  resolveMilestone('main', '4.147.0', ['3.119.x', '4.148.x', 'Backlog']),
+  '4.147.0',
+  'ignores .x milestones and higher versions → creates VERSIONS.txt version'
+);
+
+console.log('\n📋 resolveMilestone — edge cases');
+assertEqual(resolveMilestone('feature/foo', '4.147.0', ['4.148.0-preview.1']), null, 'unknown branch → null');
+assertEqual(resolveMilestone('main', null, ['4.148.0-preview.1']), null, 'null version → null');
+assertEqual(resolveMilestone('release/foo-bar', '4.147.0', []), null, 'invalid release branch → null');
+assertEqual(resolveMilestone('release/not-a-version', '4.147.0', []), null, 'non-version release branch → null');
+assertEqual(resolveMilestone('main', '3.119.x', ['4.148.0-preview.1']), null, 'wildcard VERSIONS.txt → null');
+
+// --- findOrCreateMilestone ---
+console.log('\n📋 findOrCreateMilestone');
+(async () => {
+  // Found in open
+  {
+    const result = await findOrCreateMilestone({
+      milestoneName: '4.148.0-preview.1',
+      openMilestones: [{ title: '4.148.0-preview.1', number: 61 }],
+      closedMilestones: [],
+      createMilestone: async () => { throw new Error('should not create'); },
+      listMilestones: async () => [],
+      dryRun: false,
+      log: () => {},
+    });
+    assertEqual(result.number, 61, 'finds existing open milestone');
+  }
+
+  // Found in closed (with warning)
+  {
+    const logs = [];
+    const result = await findOrCreateMilestone({
+      milestoneName: '3.119.4',
+      openMilestones: [],
+      closedMilestones: [{ title: '3.119.4', number: 50 }],
+      createMilestone: async () => { throw new Error('should not create'); },
+      listMilestones: async () => [],
+      dryRun: false,
+      log: (msg) => logs.push(msg),
+    });
+    assertEqual(result.number, 50, 'finds existing closed milestone');
+    assert(logs[0].includes('closed'), '  warns about closed milestone');
+  }
+
+  // Creates new
+  {
+    const result = await findOrCreateMilestone({
+      milestoneName: '4.149.0-preview.1',
+      openMilestones: [],
+      closedMilestones: [],
+      createMilestone: async (title) => ({ title, number: 99 }),
+      listMilestones: async () => [],
+      dryRun: false,
+      log: () => {},
+    });
+    assertEqual(result.number, 99, 'creates new milestone');
+  }
+
+  // Handles 422 race condition
+  {
+    let createAttempts = 0;
+    const result = await findOrCreateMilestone({
+      milestoneName: '4.149.0-preview.1',
+      openMilestones: [],
+      closedMilestones: [],
+      createMilestone: async () => { createAttempts++; const e = new Error('exists'); e.status = 422; throw e; },
+      listMilestones: async () => [{ title: '4.149.0-preview.1', number: 100 }],
+      dryRun: false,
+      log: () => {},
+    });
+    assertEqual(result.number, 100, 'handles 422 race → re-fetches');
+    assertEqual(createAttempts, 1, '  only tried create once');
+  }
+
+  // Dry run returns null when milestone doesn't exist
+  {
+    const logs = [];
+    const result = await findOrCreateMilestone({
+      milestoneName: '4.149.0-preview.1',
+      openMilestones: [],
+      closedMilestones: [],
+      createMilestone: async () => { throw new Error('should not create'); },
+      listMilestones: async () => [],
+      dryRun: true,
+      log: (msg) => logs.push(msg),
+    });
+    assertEqual(result, null, 'dry-run returns null when milestone missing');
+    assert(logs[0].includes('DRY RUN'), '  logs dry-run message');
+  }
+
+  // Dry run returns milestone object when it already exists (workflow must check DRY_RUN before using it)
+  {
+    const logs = [];
+    const result = await findOrCreateMilestone({
+      milestoneName: '4.148.0-preview.1',
+      openMilestones: [{ title: '4.148.0-preview.1', number: 42 }],
+      closedMilestones: [],
+      createMilestone: async () => { throw new Error('should not create'); },
+      listMilestones: async () => [],
+      dryRun: true,
+      log: (msg) => logs.push(msg),
+    });
+    assertEqual(result?.number, 42, 'dry-run with existing milestone returns it (caller must guard)');
+  }
+
+  // --- parsePipelineVariables ---
+  console.log('\n📋 parsePipelineVariables');
+  assertEqual(
+    parsePipelineVariables("  SKIASHARP_VERSION: 4.147.0\n  PREVIEW_LABEL: 'preview.0'\n"),
+    '4.147.0',
+    'preview.0 means stable target'
+  );
+  assertEqual(
+    parsePipelineVariables("  SKIASHARP_VERSION: 4.147.0\n  PREVIEW_LABEL: 'preview.3'\n"),
+    '4.147.0-preview.3',
+    'preview.3 appends prerelease suffix'
+  );
+  assertEqual(
+    parsePipelineVariables("  SKIASHARP_VERSION: 4.148.0\n  PREVIEW_LABEL: 'rc.1'\n"),
+    '4.148.0-rc.1',
+    'rc.1 appends rc suffix'
+  );
+  assertEqual(
+    parsePipelineVariables("  SKIASHARP_VERSION: 4.147.0\n"),
+    '4.147.0',
+    'missing PREVIEW_LABEL defaults to stable'
+  );
+  assertEqual(
+    parsePipelineVariables("  PREVIEW_LABEL: 'preview.3'\n"),
+    null,
+    'missing SKIASHARP_VERSION returns null'
+  );
+  assertEqual(
+    parsePipelineVariables(''),
+    null,
+    'empty content returns null'
+  );
+
+  // --- Final summary ---
+  console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+})().catch(e => { console.error(e); process.exit(1); });

--- a/.github/workflows/auto-milestone/auto-milestone.test.js
+++ b/.github/workflows/auto-milestone/auto-milestone.test.js
@@ -89,71 +89,65 @@ console.log('\n📋 isBaseVersionMatch');
 }
 
 // --- resolveMilestone ---
-console.log('\n📋 resolveMilestone — release branches (specific)');
-assertEqual(resolveMilestone('release/3.119.4', '4.147.0', []), '3.119.4', 'release/3.119.4 → 3.119.4');
-assertEqual(resolveMilestone('release/4.148.0-preview.1', '4.147.0', []), '4.148.0-preview.1', 'release/4.148.0-preview.1 → 4.148.0-preview.1');
-
-console.log('\n📋 resolveMilestone — release branches (servicing .x)');
+console.log('\n📋 resolveMilestone — stable target (preview.0)');
 assertEqual(
-  resolveMilestone('release/3.119.x', '3.119.4', ['3.119.4', '3.119.5-preview.1']),
-  '3.119.4',
-  'release/3.119.x uses VERSIONS.txt from that branch, picks lowest match'
-);
-assertEqual(
-  resolveMilestone('release/3.119.x', '3.119.5', ['3.119.4']),
-  '3.119.5',
-  'release/3.119.x with no matching milestone creates VERSIONS.txt version'
-);
-
-console.log('\n📋 resolveMilestone — main branch');
-// Real-world scenario: VERSIONS.txt=4.147.0, multiple milestones for 4.147.0 train
-assertEqual(
-  resolveMilestone('main', '4.147.0', ['4.147.0-preview.3', '4.147.0-rc.1', '4.147.0', '4.148.0-preview.1', 'Backlog']),
+  resolveMilestone('4.147.0', ['4.147.0-preview.3', '4.147.0-rc.1', '4.147.0', '4.148.0-preview.1', 'Backlog']),
   '4.147.0-preview.3',
   'picks lowest milestone in the 4.147.0 train (preview.3)'
 );
 assertEqual(
-  resolveMilestone('main', '4.147.0', ['4.147.0-rc.1', '4.147.0', '4.148.0-preview.1']),
+  resolveMilestone('4.147.0', ['4.147.0-rc.1', '4.147.0', '4.148.0-preview.1']),
   '4.147.0-rc.1',
   'picks lowest in train when preview is closed (rc.1)'
 );
 assertEqual(
-  resolveMilestone('main', '4.147.0', ['4.147.0', '4.148.0-preview.1']),
+  resolveMilestone('4.147.0', ['4.147.0', '4.148.0-preview.1']),
   '4.147.0',
-  'picks stable milestone when its the only one in the train'
+  'picks stable milestone when it is the only one in the train'
 );
 assertEqual(
-  resolveMilestone('main', '4.147.0', ['4.148.0-preview.1', '4.148.0', 'Backlog']),
+  resolveMilestone('4.147.0', ['4.148.0-preview.1', '4.148.0', 'Backlog']),
   '4.147.0',
   'no milestones matching 4.147.0 base → creates 4.147.0'
 );
 assertEqual(
-  resolveMilestone('main', '4.148.0-preview.2', ['4.148.0-preview.2', '4.148.0-rc.1', '4.148.0']),
-  '4.148.0-preview.2',
-  'prerelease version → exact milestone (preview.2)'
+  resolveMilestone('3.119.4', ['3.119.4', '3.119.5-preview.1']),
+  '3.119.4',
+  'servicing: picks matching base version'
 );
 assertEqual(
-  resolveMilestone('main', '4.148.0-preview.2', ['Backlog']),
-  '4.148.0-preview.2',
-  'prerelease version with no match → creates exact (preview.2)'
+  resolveMilestone('3.119.5', ['3.119.4']),
+  '3.119.5',
+  'servicing: no match → creates exact version'
 );
 assertEqual(
-  resolveMilestone('main', '4.148.0-rc.1', ['4.148.0-preview.2', '4.148.0-rc.1']),
-  '4.148.0-rc.1',
-  'rc version → exact milestone (rc.1)'
-);
-assertEqual(
-  resolveMilestone('main', '4.147.0', ['3.119.x', '4.148.x', 'Backlog']),
+  resolveMilestone('4.147.0', ['3.119.x', '4.148.x', 'Backlog']),
   '4.147.0',
-  'ignores .x milestones and higher versions → creates VERSIONS.txt version'
+  'ignores .x milestones and higher versions → creates base version'
+);
+
+console.log('\n📋 resolveMilestone — specific prerelease');
+assertEqual(
+  resolveMilestone('4.148.0-preview.2', ['4.148.0-preview.2', '4.148.0-rc.1', '4.148.0']),
+  '4.148.0-preview.2',
+  'prerelease → exact milestone (preview.2)'
+);
+assertEqual(
+  resolveMilestone('4.148.0-preview.2', ['Backlog']),
+  '4.148.0-preview.2',
+  'prerelease with no match → creates exact (preview.2)'
+);
+assertEqual(
+  resolveMilestone('4.148.0-rc.1', ['4.148.0-preview.2', '4.148.0-rc.1']),
+  '4.148.0-rc.1',
+  'rc → exact milestone (rc.1)'
 );
 
 console.log('\n📋 resolveMilestone — edge cases');
-assertEqual(resolveMilestone('feature/foo', '4.147.0', ['4.148.0-preview.1']), null, 'unknown branch → null');
-assertEqual(resolveMilestone('main', null, ['4.148.0-preview.1']), null, 'null version → null');
-assertEqual(resolveMilestone('release/foo-bar', '4.147.0', []), null, 'invalid release branch → null');
-assertEqual(resolveMilestone('release/not-a-version', '4.147.0', []), null, 'non-version release branch → null');
-assertEqual(resolveMilestone('main', '3.119.x', ['4.148.0-preview.1']), null, 'wildcard VERSIONS.txt → null');
+assertEqual(resolveMilestone(null, ['4.148.0-preview.1']), null, 'null version → null');
+assertEqual(resolveMilestone('', ['4.148.0-preview.1']), null, 'empty version → null');
+assertEqual(resolveMilestone('not-a-version', ['4.148.0-preview.1']), null, 'invalid version → null');
+assertEqual(resolveMilestone('3.119.x', ['4.148.0-preview.1']), null, 'wildcard version → null');
 
 // --- findOrCreateMilestone ---
 console.log('\n📋 findOrCreateMilestone');

--- a/documentation/dev/milestones.md
+++ b/documentation/dev/milestones.md
@@ -1,0 +1,75 @@
+# Milestones
+
+This document defines SkiaSharp's milestone naming convention and how milestones are automatically assigned to PRs.
+
+## Naming Convention
+
+**Rule: the milestone name IS the version string, derivable from the branch name.**
+
+| Release type | Milestone name | Branch name | NuGet version |
+|---|---|---|---|
+| Preview | `4.148.0-preview.1` | `release/4.148.0-preview.1` | `4.148.0-preview.1.{build}` |
+| RC | `4.148.0-rc.1` | `release/4.148.0-rc.1` | `4.148.0-rc.1.{build}` |
+| Stable | `4.148.0` | `release/4.148.0` | `4.148.0-stable.{build}` |
+| Servicing | `3.119.x` | `release/3.119.x` | varies |
+| Backlog | `Backlog` | — | — |
+
+### Rules
+
+1. **No `v` prefix** — milestones are `4.148.0`, not `v4.148.0`
+2. **Hyphens and dots only** — no spaces, no "Preview 1", no "RC 1", no "GA", no "Stable"
+3. **Exact version** — `4.148.0-preview.1` not `4.148.x Preview 1`
+4. **Servicing uses `.x`** — `3.119.x` represents a rolling servicing stream
+5. **Derivable from branch** — strip `release/` from the branch name → milestone name
+
+### Why?
+
+- **Predictable** — anyone can look at a branch and know the milestone
+- **Automatable** — the auto-milestone workflow needs zero configuration
+- **Consistent** — matches NuGet package versions and git tags
+- **Grep-friendly** — `gh issue list --milestone 4.148.0-preview.1` just works
+
+## Auto-assignment
+
+When a PR is merged, the milestone is automatically assigned by the [`auto-milestone.yml`](../../.github/workflows/auto-milestone.yml) workflow:
+
+| PR target branch | Milestone assigned | How |
+|---|---|---|
+| `main` | Lowest open milestone for current version | Reads version from `scripts/VERSIONS.txt` (the `SkiaSharp nuget` line), finds lowest open milestone ≥ that version |
+| `release/X.Y.Z-label.N` | `X.Y.Z-label.N` | Strip `release/` prefix |
+| `release/X.Y.x` | `X.Y.x` | Strip `release/` prefix |
+
+No configuration file is needed — release branches are self-describing, and `main` derives its milestone from the repo's version metadata and open milestones.
+
+The logic is in [`.github/workflows/auto-milestone/auto-milestone.js`](../../.github/workflows/auto-milestone/auto-milestone.js) and can be tested locally:
+
+```bash
+# Run unit tests
+node .github/workflows/auto-milestone/auto-milestone.test.js
+
+# Dry-run against a real PR (uses gh CLI — coming soon)
+# node .github/workflows/auto-milestone/auto-milestone.js --dry-run --pr 4046
+```
+
+### Examples
+
+| I merged a PR to... | It gets milestone... |
+|---|---|
+| `main` | `4.148.0-preview.1` (current lowest open) |
+| `release/3.119.x` | `3.119.x` |
+| `release/3.119.4` | `3.119.4` |
+| `release/3.119.4-preview.1` | `3.119.4-preview.1` |
+| `release/2.88.x` | `2.88.x` |
+
+## Lifecycle
+
+1. **Created** — when the `release-branch` skill creates a release branch, it also creates the milestone
+2. **Assigned** — automatically on PR merge by `auto-milestone.yml`
+3. **Closed** — when the `release-publish` skill publishes to NuGet and creates the GitHub release
+
+## Special Milestones
+
+| Milestone | Purpose |
+|---|---|
+| `Backlog` | Issues/PRs not targeting any specific release |
+| `X.Y.x` (e.g., `3.119.x`) | Servicing stream — collects all patches for a major.minor series |


### PR DESCRIPTION
## Summary

Automatically assigns milestones to PRs when they are merged, eliminating manual milestone management.

### How it works

| PR merged to | Milestone assigned |
|---|---|
| `release/X.Y.Z-label.N` | `X.Y.Z-label.N` (strip `release/` prefix) |
| `release/X.Y.x` | `X.Y.x` |
| `main` | Lowest open milestone > current version from `VERSIONS.txt` |

### Files added

- `.github/workflows/auto-milestone.yml` — workflow (triggers on `pull_request_target` + manual dispatch)
- `.github/workflows/auto-milestone/auto-milestone.js` — logic module (testable, `require()`-able)
- `.github/workflows/auto-milestone/auto-milestone.test.js` — 57 unit tests
- `documentation/dev/milestones.md` — naming convention docs

### Design decisions

- **No config file** — release branches are self-describing; `main` reads `VERSIONS.txt`
- **Race-safe milestone creation** — handles 422 (duplicate) by re-fetching
- **Full semver comparison** — `4.147.0-preview.1 < 4.147.0` (prereleases sort before stable)
- **Validates release branch names** — rejects non-version branch suffixes
- **Dry-run support** — manual dispatch defaults to dry-run mode
- **Sparse checkout** — only fetches the JS module and VERSIONS.txt
- **Skips shipped milestones** — stable version matching VERSIONS.txt is excluded from main candidates

### Milestone naming convention

Milestone name = version string = derivable from branch name:
- `4.148.0-preview.1` (not `v4.148.0 Preview 1`)
- `3.119.x` (servicing stream)
- No `v` prefix, no spaces, exact versions

### Testing

```bash
node .github/workflows/auto-milestone/auto-milestone.test.js
# 57 tests: 57 passed, 0 failed
```

### Future work

- Integrate milestone create/close into release-branch and release-publish skills
- Convert to TypeScript when Node 24 is default on runners (June 2026)