### PR TITLE
Enhance security-audit skill: CG alerts integration and viewer improvements

### DIFF
--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -56,7 +56,7 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
    ├─ Get latest build IDs (native: 26493, managed: 10789)
    ├─ Extract ALL CG log IDs from timeline (every job, no sampling)
    ├─ Parse CVEs from every job's CG log
-   └─ Categorize by source (container, toolchain, NuGet)
+   └─ Deduplicate alerts by CVE ID across all jobs/branches/pipelines
 7. Assemble structured JSON report (per report-schema.md)
 8. Validate JSON (validate-security-audit.py) — fix any errors before rendering
 9. Render HTML from JSON (render-security-audit.py)
@@ -100,7 +100,7 @@ git log --oneline --merges --grep="chrome/m" -5 HEAD
 # Find the merge commit that brought in chrome/mNNN
 
 # 4. Add the upstream remote and fetch (MANDATORY — this is read-only)
-git remote add upstream https://github.com/google/skia.git 2>/dev/null
+git remote add upstream https://github.com/google/skia.git 
 git fetch upstream chrome/mNNN --depth=1
 git log --format="%H %s" -1 FETCH_HEAD
 # This gives the independently-verified upstream_merge_commit
@@ -291,10 +291,10 @@ See [dependencies.md](../../../documentation/dev/dependencies.md#known-false-pos
 
 > 🛑 **FIRST ACTION — Run the CG query script ONCE and save to file:**
 > ```bash
-> python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > /tmp/cg-alerts-cache.json 2>/dev/null
+> mkdir -p output/ai && python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > output/ai/cg-alerts-cache.json
 > ```
 > This takes 2-3 minutes. **Do NOT run this script again.** For ALL subsequent CG data needs,
-> read from `/tmp/cg-alerts-cache.json`. The script queries 60+ build logs via API — running it
+> read from `output/ai/cg-alerts-cache.json`. The script queries tens of build logs via API — running it
 > multiple times wastes minutes and produces identical results.
 
 > ⚠️ **MANDATORY:** The security audit MUST include CG alerts from BOTH the SkiaSharp-Native
@@ -313,17 +313,17 @@ internal Azure DevOps pipeline and flag vulnerabilities in:
 
 #### How to Query CG Alerts
 
-> 🛑 **CRITICAL — SAVE TO FILE:** This script queries 60+ build logs and takes 2-3 minutes.
+> 🛑 **CRITICAL — SAVE TO FILE:** This script queries tens of build logs and takes 2-3 minutes.
 > You MUST save the output to a **file** (not a shell variable) so it persists across tool calls.
 > Run it ONCE, save the JSON, then read from that file for the rest of the audit.
 > **NEVER run this script more than once per audit session.**
 
 ```bash
-# Run ONCE and save to a temp file — this is your CG data for the entire audit
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > /tmp/cg-alerts-cache.json 2>/dev/null
+# Run ONCE and save — this is your CG data for the entire audit
+mkdir -p output/ai && python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > output/ai/cg-alerts-cache.json
 
 # Then read from the file whenever you need CG data (fast, no API calls):
-cat /tmp/cg-alerts-cache.json | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
+cat output/ai/cg-alerts-cache.json | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
 ```
 
 > The output includes a `queriedAt` ISO timestamp so you can verify freshness.
@@ -351,14 +351,13 @@ The script automatically:
 1. Discovers the latest completed build from main AND all active release/* branches for BOTH pipelines
 2. Identifies ALL CG logs in each build (every job, no sampling — this is security)
 3. Parses and deduplicates all CVEs across all builds, pipelines, and jobs
-4. Categorizes alerts by source and shows "component stacks" (components with many CVEs grouped)
-5. Shows which branches and pipelines are affected
+4. Sorts by severity and reports which branches and pipelines are affected
 
 **Note:** There is no build-independent CG REST API. The `governance.visualstudio.com` service
 does not expose alert data through any documented endpoint. The CG portal UI aggregates from
-build results internally. Our script achieves the same result by sampling the latest build's
-CG logs, which report ALL active registration-level alerts regardless of which specific build
-produced them.
+build results internally. Our script achieves the same result by enumerating every CG log in
+the latest build of every active branch (no sampling), which reports ALL active registration-level
+alerts regardless of which specific build produced them.
 
 **Manual approach (for debugging):**
 
@@ -382,6 +381,9 @@ az devops invoke --area build --resource logs \
 ```
 
 #### CG Alert Categories
+
+> These categories are reference context for understanding where alerts come from and how to fix them.
+> They are **NOT** part of the report JSON — the viewer groups by component automatically.
 
 | Category | Source | Fix Mechanism |
 |----------|--------|---------------|
@@ -410,11 +412,11 @@ az devops invoke --area build --resource logs \
 
 > 🛑 **CRITICAL:** Include the **complete `alerts` array** from the script output in the report.
 > Do NOT summarize or truncate. The viewer needs every individual alert to render correctly.
-> Copy the entire JSON output from `/tmp/cg-alerts-cache.json` as the `cgAlerts` value.
+> Copy the entire JSON output from `output/ai/cg-alerts-cache.json` as the `cgAlerts` value.
 
 ```bash
 # The cgAlerts section of your report MUST be the raw script output:
-cat /tmp/cg-alerts-cache.json
+cat output/ai/cg-alerts-cache.json
 # Copy this entire JSON object as the value of "cgAlerts" in the report.
 ```
 
@@ -504,7 +506,7 @@ Present the output path to the user:
    🔴 3 attention · 🆕 2 undiscovered · ⚪ 4 FP · ✅ 5 clean
 ```
 
-### Step 9: Present Markdown Summary
+### Step 10: Present Markdown Summary
 
 After generating JSON and HTML, present a concise markdown summary to the user in the conversation (using the report-template.md format). This is in ADDITION to the JSON+HTML files, not instead of them.
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: security-audit
 description: >
-  Audit SkiaSharp's native dependencies for security vulnerabilities and CVEs.
+  Audit SkiaSharp's native dependencies for security vulnerabilities and CVEs,
+  including Component Governance (CG) alerts from the SkiaSharp-Native Azure DevOps pipeline.
   Read-only investigation that produces a status report with recommendations.
 
   Use when user asks to:
@@ -10,9 +11,12 @@ description: >
   - Find security-related issues and their PR coverage
   - Get an overview of open vulnerabilities
   - See what security work is pending
+  - Check Component Governance alerts
+  - Review CG alerts from the native build pipeline
 
   Triggers: "security audit", "audit CVEs", "CVE status", "what security issues are open",
-  "check vulnerability status", "security overview", "what CVEs need fixing".
+  "check vulnerability status", "security overview", "what CVEs need fixing",
+  "CG alerts", "component governance", "check container CVEs".
 
   This skill is READ-ONLY. To actually fix issues, use the `native-dependency-update` skill.
 ---
@@ -46,9 +50,14 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
    ├─ Fixed? → Mark clean
    └─ Not fixed? → Flag for action
 5. Check false positives
-6. Assemble structured JSON report (per report-schema.md)
-7. Render HTML from JSON (render-security-audit.py)
-8. Present markdown summary to user
+6. Query Component Governance alerts from SkiaSharp-Native pipeline (Step 9)
+   ├─ Get latest build ID (pipeline 26493)
+   ├─ Extract CG log IDs from timeline
+   ├─ Parse CVEs from representative jobs (alpine, debian, wasm)
+   └─ Categorize by source (container, toolchain, NuGet)
+7. Assemble structured JSON report (per report-schema.md)
+8. Render HTML from JSON (render-security-audit.py)
+9. Present markdown summary to user
 ```
 
 ### Step 1: Search Issues & PRs
@@ -337,6 +346,135 @@ Within each priority level, sort by severity (CRITICAL > HIGH > MEDIUM > LOW).
 
 5. **"Undiscovered"** means a CVE found proactively by the audit (via NVD/web search) that has no corresponding user-filed GitHub issue. It does NOT mean the CVE is unknown to the world.
 
+## Step 9: Check Component Governance (CG) Alerts
+
+> ⚠️ **MANDATORY:** The security audit MUST include CG alerts from the SkiaSharp-Native pipeline.
+> CG scans Docker container images used for native builds and flags CVEs in OS packages,
+> npm dependencies, Rust crates, and NuGet packages used at build time.
+
+### Why This Matters
+
+CG alerts are **not visible** from GitHub Issues or NVD searches alone. They come from the
+internal Azure DevOps pipeline and flag vulnerabilities in:
+- **Docker base images** (Debian packages: dpkg, libcap2, sed, rsync)
+- **Cross-compilation sysroots** (Alpine packages: busybox, file, binutils, zlib, freetype, gmp)
+- **Build toolchain dependencies** (npm: minimatch, path-to-regexp, ws, express; Rust: hashbrown, zerovec, time)
+- **NuGet build dependencies** (Microsoft.WindowsAppSDK)
+
+Even though these don't ship in SkiaSharp NuGet packages, they exist in Docker image layers
+and trigger compliance alerts that block releases (partiallySucceeded builds).
+
+### How to Query CG Alerts
+
+```bash
+# 1. Get the latest SkiaSharp-Native build ID
+BUILD_ID=$(az pipelines runs list --pipeline-id 26493 \
+  --org https://devdiv.visualstudio.com --project DevDiv \
+  --top 1 --query "[0].id" -o tsv)
+
+# 2. Get the build timeline to find CG task log IDs
+az devops invoke --area build --resource timeline \
+  --route-parameters project=DevDiv buildId=$BUILD_ID \
+  --org https://devdiv.visualstudio.com -o json \
+  | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+for r in data.get('records', []):
+    if 'Component Governance' in r.get('name', ''):
+        log_id = r.get('log', {}).get('id') if r.get('log') else None
+        if log_id:
+            print(f'Log {log_id}: {r.get(\"result\",\"\")} - parent job TBD')
+"
+
+# 3. Get CVEs from a specific CG log
+az devops invoke --area build --resource logs \
+  --route-parameters project=DevDiv buildId=$BUILD_ID logId={LOG_ID} \
+  --org https://devdiv.visualstudio.com -o json \
+  | python3 -c "
+import sys, json, re
+from collections import defaultdict
+data = json.loads(sys.stdin.read())
+lines = data if isinstance(data, list) else data.get('value', [])
+by_sev = defaultdict(lambda: defaultdict(list))
+for line in lines:
+    s = str(line)
+    m = re.search(r'\|(CVE-[\d-]+|MVS-[\w-]+|GHSA-[\w-]+)\s*\|([^|]+)\|(\w+)', s)
+    if m:
+        by_sev[m.group(3)][m.group(2).strip()].append(m.group(1))
+for sev in ['Critical','High','Medium','Low']:
+    if sev in by_sev:
+        total = sum(len(v) for v in by_sev[sev].values())
+        print(f'{sev} ({total}):')
+        for comp, cves in sorted(by_sev[sev].items()):
+            print(f'  {comp}: {\", \".join(sorted(cves))}')
+"
+```
+
+### CG Alert Categories
+
+| Category | Source | Ships in NuGet? | Fix Mechanism |
+|----------|--------|-----------------|---------------|
+| Alpine sysroot packages | `apk add` in alpine Dockerfile | No | Bump `DISTRO_VERSION` in Dockerfile |
+| Debian base image packages | `apt-get` / base image | No | Update base image or wait for Debian patches |
+| npm build tooling | .NET SDK / Cake dependencies | No | Update .NET SDK or pin versions |
+| Rust crate deps | .NET SDK internals | No | Update .NET SDK |
+| NuGet build deps | Build-time references | No | Update package version |
+
+### Key Files for CG Fixes
+
+| File | Controls |
+|------|----------|
+| `scripts/infra/native/linux/docker/alpine/Dockerfile` (lines 43–47) | Alpine sysroot version (`DISTRO_VERSION`) |
+| `scripts/infra/native/linux/docker/debian/11/Dockerfile` | Debian 11 base image (EOL June 2026) |
+| `scripts/infra/native/linux/docker/debian/13/Dockerfile` | Debian 13 base image |
+| `scripts/infra/native/linux/docker/bionic/Dockerfile` | Bionic/Android cross-compile |
+| `scripts/infra/native/wasm/docker/Dockerfile` | WASM build container |
+
+### Include in Report
+
+Add a `cgAlerts` section to the JSON report:
+
+```json
+{
+  "cgAlerts": {
+    "buildId": 14176611,
+    "pipelineId": 26493,
+    "scanDate": "2026-05-23",
+    "totalAlerts": 112,
+    "categories": [
+      {
+        "source": "Alpine 3.17 sysroot",
+        "alertCount": 93,
+        "severity": "Medium",
+        "fix": "Bump to Alpine 3.21",
+        "affectedJobs": ["alpine arm64", "alpine x64", "alpine arm", "alpine x86"]
+      },
+      {
+        "source": "Build toolchain (npm/Rust/NuGet)",
+        "alertCount": 13,
+        "severity": "High/Medium/Low",
+        "fix": "Update .NET SDK or suppress",
+        "affectedJobs": ["ALL jobs"]
+      },
+      {
+        "source": "Debian base image",
+        "alertCount": 3,
+        "severity": "Medium",
+        "fix": "Wait for Debian patches or upgrade",
+        "affectedJobs": ["Debian 12-based jobs"]
+      }
+    ],
+    "uniqueCVEs": []
+  }
+}
+```
+
+### CG Portal Links
+
+- **Registration:** https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321
+- **Pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493
+- **Alert type filter:** Append `?_a=alerts&typeId={typeId}&alerts-view-option=active` to registration URL
+
 ## Handoff
 
 After audit, use `native-dependency-update` skill:
@@ -346,3 +484,6 @@ After audit, use `native-dependency-update` skill:
 
 For Skia core CVEs, the fix requires merging a newer upstream milestone into the fork.
 This is a significant undertaking — flag it in the report with the milestone gap.
+
+For CG container alerts, the fix is updating Dockerfiles under `scripts/infra/native/linux/docker/`.
+This does not require a Skia submodule update — only Docker image rebuilds.

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -52,8 +52,8 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
 5. Check false positives
 6. Query Component Governance alerts from SkiaSharp-Native AND SkiaSharp pipelines
    ├─ Get latest build IDs (native: 26493, managed: 10789)
-   ├─ Extract CG log IDs from timeline
-   ├─ Parse CVEs from representative jobs (alpine, debian, wasm, managed-build)
+   ├─ Extract ALL CG log IDs from timeline (every job, no sampling)
+   ├─ Parse CVEs from every job's CG log
    └─ Categorize by source (container, toolchain, NuGet)
 7. Assemble structured JSON report (per report-schema.md)
 8. Render HTML from JSON (render-security-audit.py)
@@ -329,8 +329,8 @@ python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 1417
 
 The script automatically:
 1. Discovers the latest completed build from main AND all active release/* branches for BOTH pipelines
-2. Identifies representative CG logs per build (native: alpine, debian11, debian13, bionic, wasm; managed: build/test stages)
-3. Parses and deduplicates all CVEs across all builds, pipelines, and container types
+2. Identifies ALL CG logs in each build (every job, no sampling — this is security)
+3. Parses and deduplicates all CVEs across all builds, pipelines, and jobs
 4. Categorizes alerts by source and shows "component stacks" (components with many CVEs grouped)
 5. Shows which branches and pipelines are affected
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -308,11 +308,12 @@ and trigger compliance alerts that block releases (partiallySucceeded builds).
 **Automated script (preferred):**
 
 ```bash
-# Get all current CG alerts across main + release branches from both pipelines (default)
+# Get all current CG alerts across main + release branches from both pipelines
+# Default output is JSON (designed for AI consumption)
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py
 
-# JSON output for inclusion in audit report
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --json
+# Human-readable text output (nothing truncated, all CVEs listed)
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --text
 
 # Query only a specific branch
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --branch main

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -307,21 +307,24 @@ and trigger compliance alerts that block releases (partiallySucceeded builds).
 **Automated script (preferred):**
 
 ```bash
-# Get all current CG alerts (auto-discovers latest build, samples all container types)
+# Get all current CG alerts across main + release branches (default)
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py
 
 # JSON output for inclusion in audit report
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --json
+
+# Query only a specific branch
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --branch main
 
 # Query a specific build
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 14176611
 ```
 
 The script automatically:
-1. Finds the latest completed SkiaSharp-Native build (pipeline 26493)
-2. Identifies representative CG logs (one per container type: alpine, debian11, debian13, bionic, wasm)
-3. Parses and deduplicates all CVEs across container types
-4. Categorizes alerts by source (Alpine sysroot, Debian base, npm tooling, Rust crates, NuGet)
+1. Discovers the latest completed build from main AND all active release/* branches
+2. Identifies representative CG logs per build (one per container type: alpine, debian11, debian13, bionic, wasm)
+3. Parses and deduplicates all CVEs across all builds and container types
+4. Categorizes alerts by source and shows which branches are affected
 
 **Note:** There is no build-independent CG REST API. The `governance.visualstudio.com` service
 does not expose alert data through any documented endpoint. The CG portal UI aggregates from

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -305,20 +305,20 @@ internal Azure DevOps pipeline and flag vulnerabilities in:
 
 #### How to Query CG Alerts
 
-> ⚠️ **CACHING:** This script queries 60+ build logs and takes 2-3 minutes to run.
-> **Run it ONCE at the start of the audit**, save the JSON output to a variable or temp file,
-> and reference that cached result for the rest of the skill execution. Do NOT re-run the
-> script each time you need a CG value. The data doesn't change during a single audit session.
-
-**Automated script (preferred):**
+> 🛑 **CRITICAL — SAVE TO FILE:** This script queries 60+ build logs and takes 2-3 minutes.
+> You MUST save the output to a **file** (not a shell variable) so it persists across tool calls.
+> Run it ONCE, save the JSON, then read from that file for the rest of the audit.
+> **NEVER run this script more than once per audit session.**
 
 ```bash
-# Run ONCE and cache the output for the duration of this audit
-CG_DATA=$(python3 .agents/skills/security-audit/scripts/query-cg-alerts.py)
+# Run ONCE and save to a temp file — this is your CG data for the entire audit
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > /tmp/cg-alerts-cache.json 2>/dev/null
 
-# Then parse the cached JSON as needed (no re-running):
-echo "$CG_DATA" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
+# Then read from the file whenever you need CG data (fast, no API calls):
+cat /tmp/cg-alerts-cache.json | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
 ```
+
+> The output includes a `queriedAt` ISO timestamp so you can verify freshness.
 
 Additional flags:
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -300,9 +300,6 @@ internal Azure DevOps pipeline and flag vulnerabilities in:
 - **Build toolchain dependencies** (npm: minimatch, path-to-regexp, ws, express; Rust: hashbrown, zerovec, time)
 - **NuGet build dependencies** (Microsoft.WindowsAppSDK)
 
-Even though these don't ship in SkiaSharp NuGet packages, they exist in Docker image layers
-and trigger compliance alerts that block releases (partiallySucceeded builds).
-
 #### How to Query CG Alerts
 
 > ⚠️ **CACHING:** This script queries 60+ build logs and takes 2-3 minutes to run.
@@ -314,7 +311,7 @@ and trigger compliance alerts that block releases (partiallySucceeded builds).
 
 ```bash
 # Run ONCE and cache the output for the duration of this audit
-CG_DATA=$(python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --quiet)
+CG_DATA=$(python3 .agents/skills/security-audit/scripts/query-cg-alerts.py)
 
 # Then parse the cached JSON as needed (no re-running):
 echo "$CG_DATA" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -383,13 +383,18 @@ az devops invoke --area build --resource logs \
 
 #### CG Alert Categories
 
-| Category | Source | Ships in NuGet? | Fix Mechanism |
-|----------|--------|-----------------|---------------|
-| Alpine sysroot packages | `apk add` in alpine Dockerfile | No | Bump `DISTRO_VERSION` in Dockerfile |
-| Debian base image packages | `apt-get` / base image | No | Update base image or wait for Debian patches |
-| npm build tooling | .NET SDK / Cake dependencies | No | Update .NET SDK or pin versions |
-| Rust crate deps | .NET SDK internals | No | Update .NET SDK |
-| NuGet build deps | Build-time references | No | Update package version |
+| Category | Source | Fix Mechanism |
+|----------|--------|---------------|
+| Alpine sysroot packages | `apk add` in alpine Dockerfile | Bump `DISTRO_VERSION` in Dockerfile |
+| Debian base image packages | `apt-get` / base image | Update base image or wait for Debian patches |
+| npm build tooling | .NET SDK / Cake dependencies | Update .NET SDK or pin versions |
+| Rust crate deps | .NET SDK internals | Update .NET SDK |
+| NuGet build deps | Build-time references | Update package version |
+
+> ⚠️ **Do NOT editorialize about whether CG alerts "ship" or not.**
+> A vulnerable build chain means a potentially compromised build artifact.
+> Present all CG alerts at the same importance level as other findings.
+> HIGH severity CG alerts are "needs_attention" just like any other HIGH CVE.
 
 #### Key Files for CG Fixes
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -403,44 +403,46 @@ az devops invoke --area build --resource logs \
 
 #### Include in Report
 
-Add a `cgAlerts` section to the JSON report:
+> 🛑 **CRITICAL:** Include the **complete `alerts` array** from the script output in the report.
+> Do NOT summarize or truncate. The viewer needs every individual alert to render correctly.
+> Copy the entire JSON output from `/tmp/cg-alerts-cache.json` as the `cgAlerts` value.
+
+```bash
+# The cgAlerts section of your report MUST be the raw script output:
+cat /tmp/cg-alerts-cache.json
+# Copy this entire JSON object as the value of "cgAlerts" in the report.
+```
+
+The script output has this structure (include ALL fields as-is):
 
 ```json
 {
   "cgAlerts": {
-    "pipelines": [
-      {"type": "native", "name": "SkiaSharp-Native", "id": 26493},
-      {"type": "managed", "name": "SkiaSharp", "id": 10789}
-    ],
-    "scanDate": "2026-05-23",
-    "totalAlerts": 112,
-    "categories": [
+    "queriedAt": "2026-05-24T12:34:56+00:00",
+    "pipelines": [...],
+    "builds": [...],
+    "totalAlerts": 121,
+    "bySeverity": {"High": 7, "Medium": 110, "Low": 4},
+    "alerts": [
       {
-        "source": "Alpine 3.17 sysroot",
-        "alertCount": 93,
+        "id": "CVE-2024-XXXXX",
+        "component": "busybox 1.35.0-r31",
         "severity": "Medium",
-        "fix": "Bump to Alpine 3.21",
-        "affectedJobs": ["alpine arm64", "alpine x64", "alpine arm", "alpine x86"]
-      },
-      {
-        "source": "Build toolchain (npm/Rust/NuGet)",
-        "alertCount": 13,
-        "severity": "High/Medium/Low",
-        "fix": "Update .NET SDK or suppress",
-        "affectedJobs": ["ALL jobs"]
-      },
-      {
-        "source": "Debian base image",
-        "alertCount": 3,
-        "severity": "Medium",
-        "fix": "Wait for Debian patches or upgrade",
-        "affectedJobs": ["Debian 12-based jobs"]
+        "sources": ["Alpine 3.17"],
+        "branches": ["main"],
+        "pipelines": ["SkiaSharp-Native"],
+        "paths": ["/some/path/to/manifest"]
       }
-    ],
-    "uniqueCVEs": []
+    ]
   }
 }
 ```
+
+**Do NOT:**
+- Summarize alerts into categories (the viewer does grouping itself)
+- Omit the `alerts` array
+- Replace `alerts` with `uniqueCVEs` or `categories`
+- Write `totalAlerts: N` without including the actual N alerts
 
 #### CG Portal Links
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -305,13 +305,24 @@ and trigger compliance alerts that block releases (partiallySucceeded builds).
 
 #### How to Query CG Alerts
 
+> ⚠️ **CACHING:** This script queries 60+ build logs and takes 2-3 minutes to run.
+> **Run it ONCE at the start of the audit**, save the JSON output to a variable or temp file,
+> and reference that cached result for the rest of the skill execution. Do NOT re-run the
+> script each time you need a CG value. The data doesn't change during a single audit session.
+
 **Automated script (preferred):**
 
 ```bash
-# Get all current CG alerts across main + release branches from both pipelines
-# Default output is JSON (designed for AI consumption)
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py
+# Run ONCE and cache the output for the duration of this audit
+CG_DATA=$(python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --quiet)
 
+# Then parse the cached JSON as needed (no re-running):
+echo "$CG_DATA" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
+```
+
+Additional flags:
+
+```bash
 # Human-readable text output (nothing truncated, all CVEs listed)
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --text
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -50,7 +50,7 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
    ├─ Fixed? → Mark clean
    └─ Not fixed? → Flag for action
 5. Check false positives
-6. Query Component Governance alerts from SkiaSharp-Native pipeline (Step 9)
+6. Query Component Governance alerts from SkiaSharp-Native pipeline
    ├─ Get latest build ID (pipeline 26493)
    ├─ Extract CG log IDs from timeline
    ├─ Parse CVEs from representative jobs (alpine, debian, wasm)
@@ -284,75 +284,13 @@ Before flagging, verify the CVE actually affects SkiaSharp:
 
 See [dependencies.md](../../../documentation/dev/dependencies.md#known-false-positives) for details.
 
-### Step 6: Assemble Structured JSON Report
-
-> 🛑 **MANDATORY:** The audit MUST produce a JSON file conforming to [references/report-schema.md](references/report-schema.md). This is the machine-readable output used by dashboards and CI.
-
-Build the JSON object with these top-level keys:
-
-1. **`meta`** — Date, schema version, Skia commit hashes, milestone, upstream verification status
-2. **`summary`** — Counts by status category, total CVEs, highest severity
-3. **`versionVerification`** — One entry per dependency with DEPS commit, verified version, cgmanifest version, match boolean
-4. **`findings`** — Array of finding objects sorted by priority then severity. Each has `dependency`, `status`, `cves[]`, `nonChromeCves[]`, `action`, `notes`
-5. **`nextSteps`** — Prioritized action items with severity, command, and reason
-
-Save as `output/ai/security-audit-{date}.json` in the repo (same pattern as other AI outputs).
-
-### Step 7: Render HTML Report
-
-> 🛑 **MANDATORY:** Always generate the HTML report. The human needs a readable dashboard.
-
-```bash
-python3 .agents/skills/security-audit/scripts/render-security-audit.py \
-  output/ai/security-audit-{date}.json
-```
-
-This produces a self-contained HTML file (Bootstrap 5, no external dependencies except CDN CSS) alongside the JSON. The HTML renders:
-- Summary cards with status counts
-- Collapsible findings with CVE tables, severity badges, and NVD links
-- Version verification table with match/mismatch indicators
-- Skia upstream verification details with commit links
-- Prioritized next steps with severity-coded borders
-
-Present the output path to the user:
-```
-✅ security-audit-2026-04-10.html (45 KB)
-   m132 • 2026-04-10 • 12 CVEs • Highest: HIGH
-   🔴 3 attention · 🆕 2 undiscovered · ⚪ 4 FP · ✅ 5 clean
-```
-
-### Step 8: Present Markdown Summary
-
-After generating JSON and HTML, present a concise markdown summary to the user in the conversation (using the report-template.md format). This is in ADDITION to the JSON+HTML files, not instead of them.
-
-**Priority order (applies equally to Skia core and third-party deps):**
-1. 🔴 User-reported + no PR
-2. ✅ User-reported + PR ready  
-3. 🟡 User-reported + PR needs work
-4. 🆕 Undiscovered CVEs (proactively found, no user-filed issue)
-5. ⚪ False positives
-
-Within each priority level, sort by severity (CRITICAL > HIGH > MEDIUM > LOW).
-
-#### Report quality rules
-
-1. **Skia bump recommendations must target the highest-severity CVE**, not the lowest. If there are HIGH CVEs at m146 and a MEDIUM at m133, recommend m146 as the target, not m133.
-
-2. **Don't include already-closed GitHub issues** in the report unless they are directly relevant to an open vulnerability. If a CVE is fixed and the tracking issue is closed, omit it.
-
-3. **CVEs with NVD version range errors** go in the ⚪ false positive section with the fix commit as evidence — not in the findings section with a "but it's actually fixed" note.
-
-4. **CVEs without a CVSS score** should use the vendor severity rating (e.g., Chromium "High" → HIGH ~8.8) and note that the official CVSS is pending.
-
-5. **"Undiscovered"** means a CVE found proactively by the audit (via NVD/web search) that has no corresponding user-filed GitHub issue. It does NOT mean the CVE is unknown to the world.
-
-## Step 9: Check Component Governance (CG) Alerts
+### Step 6: Check Component Governance (CG) Alerts
 
 > ⚠️ **MANDATORY:** The security audit MUST include CG alerts from the SkiaSharp-Native pipeline.
 > CG scans Docker container images used for native builds and flags CVEs in OS packages,
 > npm dependencies, Rust crates, and NuGet packages used at build time.
 
-### Why This Matters
+#### Why This Matters
 
 CG alerts are **not visible** from GitHub Issues or NVD searches alone. They come from the
 internal Azure DevOps pipeline and flag vulnerabilities in:
@@ -364,7 +302,7 @@ internal Azure DevOps pipeline and flag vulnerabilities in:
 Even though these don't ship in SkiaSharp NuGet packages, they exist in Docker image layers
 and trigger compliance alerts that block releases (partiallySucceeded builds).
 
-### How to Query CG Alerts
+#### How to Query CG Alerts
 
 **Automated script (preferred):**
 
@@ -410,7 +348,7 @@ az devops invoke --area build --resource logs \
   --org https://devdiv.visualstudio.com -o json
 ```
 
-### CG Alert Categories
+#### CG Alert Categories
 
 | Category | Source | Ships in NuGet? | Fix Mechanism |
 |----------|--------|-----------------|---------------|
@@ -420,7 +358,7 @@ az devops invoke --area build --resource logs \
 | Rust crate deps | .NET SDK internals | No | Update .NET SDK |
 | NuGet build deps | Build-time references | No | Update package version |
 
-### Key Files for CG Fixes
+#### Key Files for CG Fixes
 
 | File | Controls |
 |------|----------|
@@ -430,7 +368,7 @@ az devops invoke --area build --resource logs \
 | `scripts/infra/native/linux/docker/bionic/Dockerfile` | Bionic/Android cross-compile |
 | `scripts/infra/native/wasm/docker/Dockerfile` | WASM build container |
 
-### Include in Report
+#### Include in Report
 
 Add a `cgAlerts` section to the JSON report:
 
@@ -469,11 +407,73 @@ Add a `cgAlerts` section to the JSON report:
 }
 ```
 
-### CG Portal Links
+#### CG Portal Links
 
 - **Registration:** https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321
 - **Pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493
 - **Alert type filter:** Append `?_a=alerts&typeId={typeId}&alerts-view-option=active` to registration URL
+
+### Step 7: Assemble Structured JSON Report
+
+> 🛑 **MANDATORY:** The audit MUST produce a JSON file conforming to [references/report-schema.md](references/report-schema.md). This is the machine-readable output used by dashboards and CI.
+
+Build the JSON object with these top-level keys:
+
+1. **`meta`** — Date, schema version, Skia commit hashes, milestone, upstream verification status
+2. **`summary`** — Counts by status category, total CVEs, highest severity
+3. **`versionVerification`** — One entry per dependency with DEPS commit, verified version, cgmanifest version, match boolean
+4. **`findings`** — Array of finding objects sorted by priority then severity. Each has `dependency`, `status`, `cves[]`, `nonChromeCves[]`, `action`, `notes`
+5. **`nextSteps`** — Prioritized action items with severity, command, and reason
+
+Save as `output/ai/security-audit-{date}.json` in the repo (same pattern as other AI outputs).
+
+### Step 8: Render HTML Report
+
+> 🛑 **MANDATORY:** Always generate the HTML report. The human needs a readable dashboard.
+
+```bash
+python3 .agents/skills/security-audit/scripts/render-security-audit.py \
+  output/ai/security-audit-{date}.json
+```
+
+This produces a self-contained HTML file (Bootstrap 5, no external dependencies except CDN CSS) alongside the JSON. The HTML renders:
+- Summary cards with status counts
+- Collapsible findings with CVE tables, severity badges, and NVD links
+- Version verification table with match/mismatch indicators
+- Skia upstream verification details with commit links
+- Prioritized next steps with severity-coded borders
+
+Present the output path to the user:
+```
+✅ security-audit-2026-04-10.html (45 KB)
+   m132 • 2026-04-10 • 12 CVEs • Highest: HIGH
+   🔴 3 attention · 🆕 2 undiscovered · ⚪ 4 FP · ✅ 5 clean
+```
+
+### Step 9: Present Markdown Summary
+
+After generating JSON and HTML, present a concise markdown summary to the user in the conversation (using the report-template.md format). This is in ADDITION to the JSON+HTML files, not instead of them.
+
+**Priority order (applies equally to Skia core and third-party deps):**
+1. 🔴 User-reported + no PR
+2. ✅ User-reported + PR ready  
+3. 🟡 User-reported + PR needs work
+4. 🆕 Undiscovered CVEs (proactively found, no user-filed issue)
+5. ⚪ False positives
+
+Within each priority level, sort by severity (CRITICAL > HIGH > MEDIUM > LOW).
+
+#### Report quality rules
+
+1. **Skia bump recommendations must target the highest-severity CVE**, not the lowest. If there are HIGH CVEs at m146 and a MEDIUM at m133, recommend m146 as the target, not m133.
+
+2. **Don't include already-closed GitHub issues** in the report unless they are directly relevant to an open vulnerability. If a CVE is fixed and the tracking issue is closed, omit it.
+
+3. **CVEs with NVD version range errors** go in the ⚪ false positive section with the fix commit as evidence — not in the findings section with a "but it's actually fixed" note.
+
+4. **CVEs without a CVSS score** should use the vendor severity rating (e.g., Chromium "High" → HIGH ~8.8) and note that the official CVSS is pending.
+
+5. **"Undiscovered"** means a CVE found proactively by the audit (via NVD/web search) that has no corresponding user-filed GitHub issue. It does NOT mean the CVE is unknown to the world.
 
 ## Handoff
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -32,6 +32,8 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
 - **[documentation/dev/dependencies.md](../../../documentation/dev/dependencies.md)** — Which dependencies to audit, cgmanifest format, known false positives, Skia-specific tracking notes
 - **[references/report-template.md](references/report-template.md)** — Report format templates (markdown)
 - **[references/report-schema.md](references/report-schema.md)** — JSON schema for structured output
+- **[references/security-audit-schema.json](references/security-audit-schema.json)** — Machine-readable JSON Schema (Draft 2020-12)
+- **[scripts/validate-security-audit.py](scripts/validate-security-audit.py)** — Validates report JSON against schema + semantic checks
 - **[scripts/render-security-audit.py](scripts/render-security-audit.py)** — Renders JSON → standalone HTML
 - **[scripts/viewer.html](scripts/viewer.html)** — HTML template (Bootstrap 5)
 
@@ -56,8 +58,9 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
    ├─ Parse CVEs from every job's CG log
    └─ Categorize by source (container, toolchain, NuGet)
 7. Assemble structured JSON report (per report-schema.md)
-8. Render HTML from JSON (render-security-audit.py)
-9. Present markdown summary to user
+8. Validate JSON (validate-security-audit.py) — fix any errors before rendering
+9. Render HTML from JSON (render-security-audit.py)
+10. Present markdown summary to user
 ```
 
 ### Step 1: Search Issues & PRs
@@ -451,7 +454,19 @@ Build the JSON object with these top-level keys:
 
 Save as `output/ai/security-audit-{date}.json` in the repo (same pattern as other AI outputs).
 
-### Step 8: Render HTML Report
+### Step 8: Validate Report
+
+> 🛑 **MANDATORY:** Always validate before rendering. Fix any errors reported.
+
+```bash
+python3 .agents/skills/security-audit/scripts/validate-security-audit.py \
+  output/ai/security-audit-{date}.json
+```
+
+Exit codes: 0=valid, 1=fixable errors (fix and retry), 2=fatal.
+Warnings are informational — errors must be fixed before proceeding.
+
+### Step 9: Render HTML Report
 
 > 🛑 **MANDATORY:** Always generate the HTML report. The human needs a readable dashboard.
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -100,7 +100,7 @@ git log --oneline --merges --grep="chrome/m" -5 HEAD
 # Find the merge commit that brought in chrome/mNNN
 
 # 4. Add the upstream remote and fetch (MANDATORY — this is read-only)
-git remote add upstream https://github.com/google/skia.git 
+git remote add upstream https://github.com/google/skia.git 2>/dev/null || git remote set-url upstream https://github.com/google/skia.git
 git fetch upstream chrome/mNNN --depth=1
 git log --format="%H %s" -1 FETCH_HEAD
 # This gives the independently-verified upstream_merge_commit

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -289,6 +289,14 @@ See [dependencies.md](../../../documentation/dev/dependencies.md#known-false-pos
 
 ### Step 6: Check Component Governance (CG) Alerts
 
+> 🛑 **FIRST ACTION — Run the CG query script ONCE and save to file:**
+> ```bash
+> python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > /tmp/cg-alerts-cache.json 2>/dev/null
+> ```
+> This takes 2-3 minutes. **Do NOT run this script again.** For ALL subsequent CG data needs,
+> read from `/tmp/cg-alerts-cache.json`. The script queries 60+ build logs via API — running it
+> multiple times wastes minutes and produces identical results.
+
 > ⚠️ **MANDATORY:** The security audit MUST include CG alerts from BOTH the SkiaSharp-Native
 > (pipeline 26493) and SkiaSharp (pipeline 10789) pipelines — together they make up the shipped build.
 > CG scans Docker container images used for native builds and flags CVEs in OS packages,

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: security-audit
 description: >
   Audit SkiaSharp's native dependencies for security vulnerabilities and CVEs,
-  including Component Governance (CG) alerts from the SkiaSharp-Native Azure DevOps pipeline.
+  including Component Governance (CG) alerts from the SkiaSharp-Native and SkiaSharp Azure DevOps pipelines.
   Read-only investigation that produces a status report with recommendations.
 
   Use when user asks to:
@@ -50,10 +50,10 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
    ├─ Fixed? → Mark clean
    └─ Not fixed? → Flag for action
 5. Check false positives
-6. Query Component Governance alerts from SkiaSharp-Native pipeline
-   ├─ Get latest build ID (pipeline 26493)
+6. Query Component Governance alerts from SkiaSharp-Native AND SkiaSharp pipelines
+   ├─ Get latest build IDs (native: 26493, managed: 10789)
    ├─ Extract CG log IDs from timeline
-   ├─ Parse CVEs from representative jobs (alpine, debian, wasm)
+   ├─ Parse CVEs from representative jobs (alpine, debian, wasm, managed-build)
    └─ Categorize by source (container, toolchain, NuGet)
 7. Assemble structured JSON report (per report-schema.md)
 8. Render HTML from JSON (render-security-audit.py)
@@ -286,7 +286,8 @@ See [dependencies.md](../../../documentation/dev/dependencies.md#known-false-pos
 
 ### Step 6: Check Component Governance (CG) Alerts
 
-> ⚠️ **MANDATORY:** The security audit MUST include CG alerts from the SkiaSharp-Native pipeline.
+> ⚠️ **MANDATORY:** The security audit MUST include CG alerts from BOTH the SkiaSharp-Native
+> (pipeline 26493) and SkiaSharp (pipeline 10789) pipelines — together they make up the shipped build.
 > CG scans Docker container images used for native builds and flags CVEs in OS packages,
 > npm dependencies, Rust crates, and NuGet packages used at build time.
 
@@ -307,7 +308,7 @@ and trigger compliance alerts that block releases (partiallySucceeded builds).
 **Automated script (preferred):**
 
 ```bash
-# Get all current CG alerts across main + release branches (default)
+# Get all current CG alerts across main + release branches from both pipelines (default)
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py
 
 # JSON output for inclusion in audit report
@@ -316,15 +317,22 @@ python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --json
 # Query only a specific branch
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --branch main
 
+# Query only the native pipeline
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline native
+
+# Query only the managed pipeline
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline managed
+
 # Query a specific build
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 14176611
 ```
 
 The script automatically:
-1. Discovers the latest completed build from main AND all active release/* branches
-2. Identifies representative CG logs per build (one per container type: alpine, debian11, debian13, bionic, wasm)
-3. Parses and deduplicates all CVEs across all builds and container types
-4. Categorizes alerts by source and shows which branches are affected
+1. Discovers the latest completed build from main AND all active release/* branches for BOTH pipelines
+2. Identifies representative CG logs per build (native: alpine, debian11, debian13, bionic, wasm; managed: build/test stages)
+3. Parses and deduplicates all CVEs across all builds, pipelines, and container types
+4. Categorizes alerts by source and shows "component stacks" (components with many CVEs grouped)
+5. Shows which branches and pipelines are affected
 
 **Note:** There is no build-independent CG REST API. The `governance.visualstudio.com` service
 does not expose alert data through any documented endpoint. The CG portal UI aggregates from
@@ -335,10 +343,12 @@ produced them.
 **Manual approach (for debugging):**
 
 ```bash
-# 1. Get latest build ID
+# 1. Get latest build ID (native pipeline)
 BUILD_ID=$(az pipelines runs list --pipeline-id 26493 \
   --org https://devdiv.visualstudio.com --project DevDiv \
   --top 1 --query "[0].id" -o tsv)
+
+# For managed pipeline, use --pipeline-id 10789 instead
 
 # 2. Get timeline to find CG log IDs
 az devops invoke --area build --resource timeline \
@@ -378,8 +388,10 @@ Add a `cgAlerts` section to the JSON report:
 ```json
 {
   "cgAlerts": {
-    "buildId": 14176611,
-    "pipelineId": 26493,
+    "pipelines": [
+      {"type": "native", "name": "SkiaSharp-Native", "id": 26493},
+      {"type": "managed", "name": "SkiaSharp", "id": 10789}
+    ],
     "scanDate": "2026-05-23",
     "totalAlerts": 112,
     "categories": [

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -366,48 +366,48 @@ and trigger compliance alerts that block releases (partiallySucceeded builds).
 
 ### How to Query CG Alerts
 
+**Automated script (preferred):**
+
 ```bash
-# 1. Get the latest SkiaSharp-Native build ID
+# Get all current CG alerts (auto-discovers latest build, samples all container types)
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py
+
+# JSON output for inclusion in audit report
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --json
+
+# Query a specific build
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 14176611
+```
+
+The script automatically:
+1. Finds the latest completed SkiaSharp-Native build (pipeline 26493)
+2. Identifies representative CG logs (one per container type: alpine, debian11, debian13, bionic, wasm)
+3. Parses and deduplicates all CVEs across container types
+4. Categorizes alerts by source (Alpine sysroot, Debian base, npm tooling, Rust crates, NuGet)
+
+**Note:** There is no build-independent CG REST API. The `governance.visualstudio.com` service
+does not expose alert data through any documented endpoint. The CG portal UI aggregates from
+build results internally. Our script achieves the same result by sampling the latest build's
+CG logs, which report ALL active registration-level alerts regardless of which specific build
+produced them.
+
+**Manual approach (for debugging):**
+
+```bash
+# 1. Get latest build ID
 BUILD_ID=$(az pipelines runs list --pipeline-id 26493 \
   --org https://devdiv.visualstudio.com --project DevDiv \
   --top 1 --query "[0].id" -o tsv)
 
-# 2. Get the build timeline to find CG task log IDs
+# 2. Get timeline to find CG log IDs
 az devops invoke --area build --resource timeline \
   --route-parameters project=DevDiv buildId=$BUILD_ID \
-  --org https://devdiv.visualstudio.com -o json \
-  | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-for r in data.get('records', []):
-    if 'Component Governance' in r.get('name', ''):
-        log_id = r.get('log', {}).get('id') if r.get('log') else None
-        if log_id:
-            print(f'Log {log_id}: {r.get(\"result\",\"\")} - parent job TBD')
-"
+  --org https://devdiv.visualstudio.com -o json
 
-# 3. Get CVEs from a specific CG log
+# 3. Parse CVEs from a specific CG log
 az devops invoke --area build --resource logs \
   --route-parameters project=DevDiv buildId=$BUILD_ID logId={LOG_ID} \
-  --org https://devdiv.visualstudio.com -o json \
-  | python3 -c "
-import sys, json, re
-from collections import defaultdict
-data = json.loads(sys.stdin.read())
-lines = data if isinstance(data, list) else data.get('value', [])
-by_sev = defaultdict(lambda: defaultdict(list))
-for line in lines:
-    s = str(line)
-    m = re.search(r'\|(CVE-[\d-]+|MVS-[\w-]+|GHSA-[\w-]+)\s*\|([^|]+)\|(\w+)', s)
-    if m:
-        by_sev[m.group(3)][m.group(2).strip()].append(m.group(1))
-for sev in ['Critical','High','Medium','Low']:
-    if sev in by_sev:
-        total = sum(len(v) for v in by_sev[sev].values())
-        print(f'{sev} ({total}):')
-        for comp, cves in sorted(by_sev[sev].items()):
-            print(f'  {comp}: {\", \".join(sorted(cves))}')
-"
+  --org https://devdiv.visualstudio.com -o json
 ```
 
 ### CG Alert Categories

--- a/.agents/skills/security-audit/references/security-audit-schema.json
+++ b/.agents/skills/security-audit/references/security-audit-schema.json
@@ -271,9 +271,14 @@
     "cgAlerts": {
       "type": "object",
       "required": [
-        "totalAlerts"
+        "totalAlerts",
+        "alerts"
       ],
       "properties": {
+        "queriedAt": {
+          "type": "string",
+          "description": "ISO timestamp of when the CG query was run"
+        },
         "pipelines": {
           "type": "array",
           "items": {
@@ -296,8 +301,12 @@
             "additionalProperties": true
           }
         },
-        "scanDate": {
-          "type": "string"
+        "builds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
         "totalAlerts": {
           "type": "integer",
@@ -309,15 +318,9 @@
             "type": "integer"
           }
         },
-        "branches": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "alerts": {
           "type": "array",
-          "description": "Full alert list from query-cg-alerts.py output (preferred format, key is 'alerts')",
+          "description": "Full alert list from query-cg-alerts.py output, grouped by component in viewer",
           "items": {
             "type": "object",
             "required": [
@@ -360,92 +363,11 @@
                 }
               }
             },
-            "additionalProperties": true
-          }
-        },
-        "allAlerts": {
-          "type": "array",
-          "description": "Full alert list (legacy key name, same schema as 'alerts')",
-          "items": {
-            "type": "object",
-            "required": [
-              "id",
-              "component",
-              "severity"
-            ],
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "component": {
-                "type": "string"
-              },
-              "severity": {
-                "type": "string"
-              },
-              "paths": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "sources": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "pipelines": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "branches": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "additionalProperties": true
-          }
-        },
-        "uniqueCVEs": {
-          "type": "array",
-          "description": "Alternate flat CVE list (legacy format)",
-          "items": {
-            "type": "object",
-            "required": [
-              "id",
-              "severity"
-            ],
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "severity": {
-                "type": "string"
-              },
-              "component": {
-                "type": "string"
-              },
-              "source": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": true
-          }
-        },
-        "categories": {
-          "type": "array",
-          "items": {
-            "type": "object",
             "additionalProperties": true
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "nextSteps": {
       "type": "array",

--- a/.agents/skills/security-audit/references/security-audit-schema.json
+++ b/.agents/skills/security-audit/references/security-audit-schema.json
@@ -53,7 +53,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "summary": {
       "type": "object",
@@ -97,7 +97,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "versionVerification": {
       "type": "array",
@@ -336,7 +336,8 @@
                 "type": "string"
               },
               "severity": {
-                "type": "string"
+                "type": "string",
+                "enum": ["Critical", "High", "Medium", "Low"]
               },
               "paths": {
                 "type": "array",

--- a/.agents/skills/security-audit/references/security-audit-schema.json
+++ b/.agents/skills/security-audit/references/security-audit-schema.json
@@ -315,9 +315,57 @@
             "type": "string"
           }
         },
+        "alerts": {
+          "type": "array",
+          "description": "Full alert list from query-cg-alerts.py output (preferred format, key is 'alerts')",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "component",
+              "severity"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "component": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pipelines": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "branches": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        },
         "allAlerts": {
           "type": "array",
-          "description": "Full alert list from query-cg-alerts.py (preferred format)",
+          "description": "Full alert list (legacy key name, same schema as 'alerts')",
           "items": {
             "type": "object",
             "required": [

--- a/.agents/skills/security-audit/references/security-audit-schema.json
+++ b/.agents/skills/security-audit/references/security-audit-schema.json
@@ -239,6 +239,12 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["number"],
+              "properties": {
+                "number": { "type": "integer" },
+                "url": { "type": "string" },
+                "title": { "type": "string" }
+              },
               "additionalProperties": true
             }
           },
@@ -246,6 +252,12 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["number"],
+              "properties": {
+                "number": { "type": "integer" },
+                "url": { "type": "string" },
+                "title": { "type": "string" }
+              },
               "additionalProperties": true
             }
           },

--- a/.agents/skills/security-audit/references/security-audit-schema.json
+++ b/.agents/skills/security-audit/references/security-audit-schema.json
@@ -1,0 +1,437 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mono/SkiaSharp/security-audit-schema.json",
+  "title": "SkiaSharp Security Audit Report",
+  "description": "Structured security audit output covering native dependencies, Skia upstream verification, and Component Governance alerts from build pipelines.",
+  "type": "object",
+  "required": [
+    "meta",
+    "summary",
+    "versionVerification",
+    "findings",
+    "nextSteps"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": [
+        "date",
+        "schemaVersion",
+        "skiaMilestone"
+      ],
+      "properties": {
+        "date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "schemaVersion": {
+          "type": "string"
+        },
+        "skiaSubmoduleCommit": {
+          "type": "string"
+        },
+        "skiaUpstreamCommit": {
+          "type": "string"
+        },
+        "skiaMilestone": {
+          "type": "integer"
+        },
+        "upstreamVerified": {
+          "type": "boolean"
+        },
+        "upstreamVerificationNote": {
+          "type": "string"
+        },
+        "chromeM147BranchTip": {
+          "type": "string"
+        },
+        "upstreamBehindBy": {
+          "type": "integer"
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "needsAttention",
+        "undiscovered",
+        "falsePositive",
+        "clean",
+        "totalCves",
+        "highestSeverity"
+      ],
+      "properties": {
+        "needsAttention": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "undiscovered": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "falsePositive": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "clean": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalCves": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "highestSeverity": {
+          "type": "string",
+          "enum": [
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW",
+            "NONE"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "versionVerification": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "depsCommit": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "verifiedVersion": {
+            "type": "string"
+          },
+          "cgmanifestVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latestVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "match": {
+            "type": "boolean"
+          },
+          "verificationMethod": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "dependency",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "dependency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "needs_attention",
+              "undiscovered",
+              "false_positive",
+              "clean",
+              "in_progress",
+              "ready_to_merge"
+            ]
+          },
+          "currentVersion": {
+            "type": "string"
+          },
+          "fixVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latestVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cves": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "severity"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "severity": {
+                  "type": "string"
+                },
+                "cvss": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "fixedIn": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "description": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "assessment": {
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "nonChromeCves": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "prs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "action": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "falsePositiveReason": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "cgAlerts": {
+      "type": "object",
+      "required": [
+        "totalAlerts"
+      ],
+      "properties": {
+        "pipelines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "id"
+            ],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "scanDate": {
+          "type": "string"
+        },
+        "totalAlerts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "bySeverity": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "branches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allAlerts": {
+          "type": "array",
+          "description": "Full alert list from query-cg-alerts.py (preferred format)",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "component",
+              "severity"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "component": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pipelines": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "branches": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "uniqueCVEs": {
+          "type": "array",
+          "description": "Alternate flat CVE list (legacy format)",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "severity"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string"
+              },
+              "component": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "nextSteps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "priority",
+          "action"
+        ],
+        "properties": {
+          "priority": {
+            "type": "integer"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "dependency": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "command": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -2,8 +2,8 @@
 """
 Query all Component Governance (CG) alerts for the SkiaSharp-Native pipeline.
 
-No build ID required - automatically uses the latest completed build and extracts
-alerts from representative CG logs (one per container type) to get full coverage.
+Automatically queries the latest builds from main AND active release branches,
+then deduplicates alerts across all builds to give a complete picture.
 
 Prerequisites:
   - az CLI installed and authenticated
@@ -11,10 +11,19 @@ Prerequisites:
   - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
 
 Usage:
-  python3 query-cg-alerts.py [--build-id BUILD_ID] [--json] [--quiet]
+  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--json] [--quiet]
+
+  # Query all branches (default)
+  python3 query-cg-alerts.py
+
+  # Query only a specific branch
+  python3 query-cg-alerts.py --branch main
+
+  # Query a specific build
+  python3 query-cg-alerts.py --build-id 14176611
 
 Output:
-  Prints a summary of all unique CG alerts grouped by severity and component.
+  Prints a summary of all unique CG alerts grouped by severity, component, and branch.
   With --json, outputs structured JSON suitable for the security audit report.
 """
 
@@ -23,11 +32,42 @@ import json
 import re
 import subprocess
 import sys
+import urllib.request
 from collections import defaultdict
 
 ORG = "https://devdiv.visualstudio.com"
 PROJECT = "DevDiv"
 PIPELINE_ID = 26493  # SkiaSharp-Native
+
+# Branches to query by default (main + any active release branches)
+DEFAULT_BRANCHES = ["main", "release/*"]
+
+
+def get_token() -> str:
+    """Get Azure DevOps access token via az CLI."""
+    result = subprocess.run(
+        ["az", "account", "get-access-token",
+         "--resource", "499b84ac-1321-427f-aa17-267ca6975798",
+         "--query", "accessToken", "-o", "tsv"],
+        capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        print("ERROR: Failed to get access token. Run 'az login' first.", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def api_get(token: str, url: str):
+    """Make an authenticated GET request to AzDO REST API."""
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/json")
+    try:
+        resp = urllib.request.urlopen(req, timeout=30)
+        return json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        print(f"ERROR: API request failed: {url}\n  {e}", file=sys.stderr)
+        return None
 
 
 def run_az(args: list[str], parse_json=True):
@@ -38,35 +78,47 @@ def run_az(args: list[str], parse_json=True):
     )
     if result.returncode != 0:
         print(f"ERROR: az {' '.join(args[:5])}... failed: {result.stderr[:200]}", file=sys.stderr)
-        sys.exit(1)
+        return None
     if parse_json:
         return json.loads(result.stdout)
     return result.stdout.strip()
 
 
-def get_latest_build_id() -> tuple[int, str]:
-    """Get the latest completed build ID and number."""
-    builds = run_az([
-        "pipelines", "runs", "list",
-        "--pipeline-id", str(PIPELINE_ID),
-        "--org", ORG, "--project", PROJECT,
-        "--top", "1", "--status", "completed",
-        "-o", "json"
-    ])
-    if not builds:
-        print("ERROR: No completed builds found", file=sys.stderr)
-        sys.exit(1)
-    return builds[0]["id"], builds[0].get("buildNumber", "unknown")
+def get_builds_for_branches(token: str, branches: list[str], top_per_branch: int = 1) -> list[dict]:
+    """Get the latest completed builds for the given branches.
+    
+    Supports wildcards: "release/*" matches any release/X.Y.Z or release/X.Y.x branch.
+    """
+    # Get recent builds (enough to cover all active branches)
+    url = (f"{ORG}/{PROJECT}/_apis/build/builds"
+           f"?definitions={PIPELINE_ID}&statusFilter=completed&$top=20&api-version=7.1")
+    data = api_get(token, url)
+    if not data:
+        return []
+    
+    all_builds = data.get("value", [])
+    
+    # Match branches
+    matched = {}
+    for build in all_builds:
+        branch = build.get("sourceBranch", "").replace("refs/heads/", "")
+        for pattern in branches:
+            if pattern.endswith("*"):
+                prefix = pattern[:-1]
+                if branch.startswith(prefix) and branch not in matched:
+                    matched[branch] = build
+            elif branch == pattern and branch not in matched:
+                matched[branch] = build
+    
+    return list(matched.values())
 
 
-def get_cg_log_ids(build_id: int) -> dict[str, tuple[str, int]]:
+def get_cg_log_ids(token: str, build_id: int) -> dict[str, tuple[str, int]]:
     """Get representative CG log IDs from the build timeline."""
-    timeline = run_az([
-        "devops", "invoke",
-        "--area", "build", "--resource", "timeline",
-        "--route-parameters", f"project={PROJECT}", f"buildId={build_id}",
-        "--org", ORG, "-o", "json"
-    ])
+    url = (f"{ORG}/{PROJECT}/_apis/build/builds/{build_id}/timeline?api-version=7.1")
+    timeline = api_get(token, url)
+    if not timeline:
+        return {}
 
     records = timeline.get("records", [])
     jobs = {r["id"]: r.get("name", "") for r in records}
@@ -100,71 +152,109 @@ def get_cg_log_ids(build_id: int) -> dict[str, tuple[str, int]]:
     return representatives
 
 
-def parse_cg_log(build_id: int, log_id: int) -> list[dict]:
-    """Parse CVEs from a CG log."""
-    log_data = run_az([
-        "devops", "invoke",
-        "--area", "build", "--resource", "logs",
-        "--route-parameters", f"project={PROJECT}", f"buildId={build_id}", f"logId={log_id}",
-        "--org", ORG, "-o", "json"
-    ])
+def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
+    """Parse CVEs from a CG log using REST API directly."""
+    url = f"{ORG}/{PROJECT}/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1"
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    try:
+        resp = urllib.request.urlopen(req, timeout=30)
+        content = resp.read().decode("utf-8")
+    except Exception as e:
+        print(f"  WARNING: Failed to fetch log {log_id}: {e}", file=sys.stderr)
+        return []
 
-    lines = log_data if isinstance(log_data, list) else log_data.get("value", [])
     alerts = []
-
-    for line in lines:
-        s = str(line)
-        m = re.search(r"\|(CVE-[\d-]+|MVS-[\w-]+|GHSA-[\w-]+)\s*\|([^|]+)\|(\w+)", s)
-        if m:
-            alerts.append({
-                "id": m.group(1).strip(),
-                "component": m.group(2).strip(),
-                "severity": m.group(3).strip()
-            })
+    for line in content.split("\n"):
+        # Format: |CVE-XXXX-XXXXX |component |severity |date|
+        parts = [p.strip() for p in line.split("|")]
+        data_parts = [p for p in parts if p and not re.match(r"^\d{4}-\d{2}-\d{2}T", p)]
+        if len(data_parts) >= 3:
+            cve_match = re.search(r"(CVE-\d{4}-\d+|GHSA-[\w-]+)", data_parts[0])
+            if cve_match:
+                alerts.append({
+                    "id": cve_match.group(1),
+                    "component": data_parts[1],
+                    "severity": data_parts[2]
+                })
 
     return alerts
 
 
 def main():
     parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp-Native")
-    parser.add_argument("--build-id", type=int, help="Specific build ID (default: latest)")
+    parser.add_argument("--build-id", type=int, help="Specific build ID (skips branch discovery)")
+    parser.add_argument("--branch", type=str, help="Query only this branch (e.g., 'main' or 'release/3.119.x')")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--quiet", action="store_true", help="Suppress progress messages")
     args = parser.parse_args()
 
-    # Get build ID
+    token = get_token()
+
+    # Determine which builds to query
+    builds_to_query = []  # list of (build_id, branch, build_number)
+
     if args.build_id:
-        build_id = args.build_id
-        build_num = "specified"
+        # Query specific build
+        url = f"{ORG}/{PROJECT}/_apis/build/builds/{args.build_id}?api-version=7.1"
+        build = api_get(token, url)
+        if build:
+            branch = build.get("sourceBranch", "").replace("refs/heads/", "")
+            builds_to_query.append((args.build_id, branch, build.get("buildNumber", "unknown")))
+        else:
+            print(f"ERROR: Build {args.build_id} not found", file=sys.stderr)
+            sys.exit(1)
     else:
-        build_id, build_num = get_latest_build_id()
+        # Discover builds from branches
+        branches = [args.branch] if args.branch else DEFAULT_BRANCHES
+        discovered = get_builds_for_branches(token, branches)
+        if not discovered:
+            print("ERROR: No completed builds found for specified branches", file=sys.stderr)
+            sys.exit(1)
+        for b in discovered:
+            branch = b.get("sourceBranch", "").replace("refs/heads/", "")
+            builds_to_query.append((b["id"], branch, b.get("buildNumber", "unknown")))
 
     if not args.quiet:
-        print(f"Build: {build_id} ({build_num})", file=sys.stderr)
+        print(f"Querying {len(builds_to_query)} build(s):", file=sys.stderr)
+        for bid, branch, bnum in builds_to_query:
+            print(f"  {branch}: build {bid} ({bnum})", file=sys.stderr)
 
-    # Get representative log IDs
-    reps = get_cg_log_ids(build_id)
-    if not args.quiet:
-        print(f"Sampling {len(reps)} container types: {', '.join(sorted(reps.keys()))}", file=sys.stderr)
+    # Collect alerts from all builds
+    all_alerts = {}  # id -> {component, severity, branches, sources}
 
-    # Parse all logs and deduplicate
-    all_alerts = {}  # id -> {component, severity, sources}
-    for category, (job_name, log_id) in sorted(reps.items()):
+    for build_id, branch, build_num in builds_to_query:
         if not args.quiet:
-            print(f"  Parsing {category} (log {log_id}: {job_name})...", file=sys.stderr)
-        alerts = parse_cg_log(build_id, log_id)
-        for alert in alerts:
-            key = alert["id"]
-            if key not in all_alerts:
-                all_alerts[key] = {
-                    "id": alert["id"],
-                    "component": alert["component"],
-                    "severity": alert["severity"],
-                    "sources": [category]
-                }
-            else:
-                if category not in all_alerts[key]["sources"]:
-                    all_alerts[key]["sources"].append(category)
+            print(f"\n--- {branch} (build {build_id}) ---", file=sys.stderr)
+
+        reps = get_cg_log_ids(token, build_id)
+        if not reps:
+            if not args.quiet:
+                print(f"  WARNING: No CG logs found in build {build_id}", file=sys.stderr)
+            continue
+
+        if not args.quiet:
+            print(f"  Sampling {len(reps)} container types: {', '.join(sorted(reps.keys()))}", file=sys.stderr)
+
+        for category, (job_name, log_id) in sorted(reps.items()):
+            if not args.quiet:
+                print(f"    Parsing {category} (log {log_id})...", file=sys.stderr)
+            alerts = parse_cg_log(token, build_id, log_id)
+            for alert in alerts:
+                key = alert["id"]
+                if key not in all_alerts:
+                    all_alerts[key] = {
+                        "id": alert["id"],
+                        "component": alert["component"],
+                        "severity": alert["severity"],
+                        "sources": [category],
+                        "branches": [branch]
+                    }
+                else:
+                    if category not in all_alerts[key]["sources"]:
+                        all_alerts[key]["sources"].append(category)
+                    if branch not in all_alerts[key]["branches"]:
+                        all_alerts[key]["branches"].append(branch)
 
     # Categorize
     for alert in all_alerts.values():
@@ -185,8 +275,7 @@ def main():
     # Output
     if args.json:
         output = {
-            "buildId": build_id,
-            "buildNumber": build_num,
+            "builds": [{"id": bid, "branch": br, "number": num} for bid, br, num in builds_to_query],
             "pipelineId": PIPELINE_ID,
             "totalAlerts": len(all_alerts),
             "alerts": sorted(all_alerts.values(), key=lambda a: (
@@ -202,10 +291,12 @@ def main():
         for alert in all_alerts.values():
             by_sev[alert["severity"]].append(alert)
 
-        print(f"\n{'='*60}")
-        print(f"CG ALERTS SUMMARY — Build {build_id} ({build_num})")
+        branches_str = ", ".join(b for _, b, _ in builds_to_query)
+        print(f"\n{'='*70}")
+        print(f"CG ALERTS SUMMARY — SkiaSharp-Native (pipeline {PIPELINE_ID})")
+        print(f"Branches: {branches_str}")
         print(f"Total unique alerts: {len(all_alerts)}")
-        print(f"{'='*60}")
+        print(f"{'='*70}")
 
         for sev in ["Critical", "High", "Medium", "Low"]:
             if sev not in by_sev:
@@ -224,16 +315,24 @@ def main():
                 # Group by component
                 by_comp = defaultdict(list)
                 for a in cat_alerts:
-                    by_comp[a["component"]].append(a["id"])
+                    by_comp[a["component"]].append(a)
                 for comp in sorted(by_comp.keys()):
-                    cves = sorted(by_comp[comp])
+                    comp_alerts = by_comp[comp]
+                    cves = sorted(a["id"] for a in comp_alerts)
+                    # Show branch info if not all branches
+                    all_branches = set()
+                    for a in comp_alerts:
+                        all_branches.update(a["branches"])
+                    branch_note = ""
+                    if len(builds_to_query) > 1:
+                        branch_note = f" [{', '.join(sorted(all_branches))}]"
                     if len(cves) <= 3:
-                        print(f"    {comp}: {', '.join(cves)}")
+                        print(f"    {comp}: {', '.join(cves)}{branch_note}")
                     else:
-                        print(f"    {comp} ({len(cves)} CVEs): {', '.join(cves[:3])}...")
+                        print(f"    {comp} ({len(cves)} CVEs): {', '.join(cves[:3])}...{branch_note}")
 
         # Summary by category
-        print(f"\n{'='*60}")
+        print(f"\n{'='*70}")
         print("BY CATEGORY:")
         by_cat = defaultdict(list)
         for a in all_alerts.values():
@@ -245,6 +344,24 @@ def main():
                 sevs[a["severity"]] += 1
             sev_str = ", ".join(f"{s}: {c}" for s, c in sorted(sevs.items()))
             print(f"  {cat}: {len(alerts)} alerts ({sev_str})")
+
+        # Branch coverage
+        if len(builds_to_query) > 1:
+            print(f"\nBRANCH COVERAGE:")
+            for _, branch, _ in builds_to_query:
+                branch_alerts = [a for a in all_alerts.values() if branch in a["branches"]]
+                print(f"  {branch}: {len(branch_alerts)} alerts")
+            
+            # Show branch-exclusive alerts
+            for _, branch, _ in builds_to_query:
+                exclusive = [a for a in all_alerts.values() 
+                           if a["branches"] == [branch]]
+                if exclusive:
+                    print(f"\n  Only in {branch} ({len(exclusive)}):")
+                    for a in sorted(exclusive, key=lambda x: x["id"])[:10]:
+                        print(f"    {a['id']} [{a['severity']}] {a['component']}")
+                    if len(exclusive) > 10:
+                        print(f"    ... and {len(exclusive) - 10} more")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -32,7 +32,7 @@ Usage:
 
 Output:
   Default: JSON with every alert fully enumerated (id, component, severity,
-  category, source jobs, branches, pipelines). Designed for AI consumption.
+  source jobs, branches, pipelines). Designed for AI consumption.
   With --text: grouped listing with all CVEs shown per component.
 """
 
@@ -184,47 +184,6 @@ def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
     return alerts
 
 
-def categorize_alert(component: str, source_jobs: list[str]) -> str:
-    """Derive category from the job context and component format.
-    
-    Uses job names (where the alert was found) as the primary signal,
-    falling back to component string patterns only when needed.
-    This approach is resilient to new packages/versions appearing.
-    """
-    # OS-packaged components are labeled "Distro:Version:package" by CG
-    distro_match = re.match(r"^([\w]+):(\d+):", component)
-    
-    if distro_match:
-        distro = distro_match.group(1)  # e.g., "Debian"
-        version = distro_match.group(2)  # e.g., "12", "13"
-        
-        # Check if it came from an alpine job — those "Debian:12:" entries
-        # are actually Alpine sysroot packages (CG mislabels them)
-        alpine_jobs = [s for s in source_jobs if "alpine" in s.lower()]
-        if alpine_jobs:
-            return f"Alpine sysroot (from {distro} {version} label)"
-        
-        return f"{distro} {version} base image"
-    
-    # NuGet packages (Microsoft.*, or other known .NET package patterns)
-    if re.match(r"^(Microsoft\.|System\.|NuGet\.|WindowsAppSDK)", component):
-        return "NuGet dependency"
-    
-    # Non-distro packages: categorize by job context
-    # If found only in "Prepare Build" or "Merge" jobs (not platform-specific),
-    # it's a toolchain/SDK dependency
-    platform_keywords = ["linux", "android", "ios", "wasm", "win", "angle",
-                         "mac", "tizen", "nano", "catalyst"]
-    platform_jobs = [s for s in source_jobs 
-                     if any(x in s.lower() for x in platform_keywords)]
-    non_platform_jobs = [s for s in source_jobs if s not in platform_jobs]
-    
-    if non_platform_jobs and not platform_jobs:
-        return "SDK/toolchain dependency"
-    
-    return "Build toolchain dependency"
-
-
 def main():
     parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp pipelines")
     parser.add_argument("--build-id", type=int, help="Specific build ID (skips branch discovery)")
@@ -320,14 +279,6 @@ def main():
                     if PIPELINES[ptype]["name"] not in all_alerts[key]["pipelines"]:
                         all_alerts[key]["pipelines"].append(PIPELINES[ptype]["name"])
 
-    # Categorize based on job context (source) and component format.
-    # We use the job name the alert was found in — this is stable regardless of
-    # which packages or versions appear in the future.
-    for alert in all_alerts.values():
-        comp = alert["component"]
-        sources = alert["sources"]
-        alert["category"] = categorize_alert(comp, sources)
-
     # Output — always structured for AI consumption.
     # Default is JSON since this script is consumed by the security-audit skill.
     # Use --text for a human-readable summary.
@@ -342,21 +293,6 @@ def main():
                 for sev in ["Critical", "High", "Medium", "Low"]
                 if any(a["severity"] == sev for a in all_alerts.values())
             },
-            "byCategory": {
-                cat: {
-                    "count": len(alerts),
-                    "severities": dict(sorted(
-                        ((s, len([a for a in alerts if a["severity"] == s]))
-                         for s in set(a["severity"] for a in alerts)),
-                        key=lambda x: {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(x[0], 9)
-                    ))
-                }
-                for cat, alerts in sorted(
-                    ((cat, [a for a in all_alerts.values() if a["category"] == cat])
-                     for cat in set(a["category"] for a in all_alerts.values())),
-                    key=lambda x: -x[1].__len__()
-                )
-            },
             "alerts": sorted(all_alerts.values(), key=lambda a: (
                 {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(a["severity"], 9),
                 a["component"],
@@ -365,7 +301,7 @@ def main():
         }
         print(json.dumps(output, indent=2))
     else:
-        # Text mode: full listing, nothing truncated
+        # Text mode: full listing, grouped by component
         branches_str = ", ".join(sorted(set(b for _, b, _, _ in builds_to_query)))
         pipelines_str = ", ".join(pi["name"] for _, pi in pipelines_to_query)
         print(f"CG ALERTS — {pipelines_str}")
@@ -373,30 +309,21 @@ def main():
         print(f"Total: {len(all_alerts)} unique alerts")
         print()
 
-        # Group by category, then component, list ALL CVEs
-        by_cat = defaultdict(list)
+        # Group by component, list ALL CVEs
+        by_comp = defaultdict(list)
         for a in all_alerts.values():
-            by_cat[a["category"]].append(a)
+            by_comp[a["component"]].append(a)
 
-        for cat in sorted(by_cat.keys()):
-            cat_alerts = by_cat[cat]
-            print(f"## {cat} ({len(cat_alerts)} alerts)")
-            
-            # Group by component
-            by_comp = defaultdict(list)
-            for a in cat_alerts:
-                by_comp[a["component"]].append(a)
-            
-            for comp in sorted(by_comp.keys()):
-                comp_alerts = sorted(by_comp[comp], key=lambda a: a["id"])
-                sevs = set(a["severity"] for a in comp_alerts)
-                branches = set()
-                for a in comp_alerts:
-                    branches.update(a["branches"])
-                print(f"  {comp} [{', '.join(sorted(sevs))}] (branches: {', '.join(sorted(branches))})")
-                for a in comp_alerts:
-                    print(f"    - {a['id']} ({a['severity']})")
-            print()
+        for comp in sorted(by_comp.keys()):
+            comp_alerts = sorted(by_comp[comp], key=lambda a: a["id"])
+            sevs = set(a["severity"] for a in comp_alerts)
+            branches = set()
+            for a in comp_alerts:
+                branches.update(a["branches"])
+            print(f"  {comp} [{', '.join(sorted(sevs))}] (branches: {', '.join(sorted(branches))})")
+            for a in comp_alerts:
+                print(f"    - {a['id']} ({a['severity']})")
+        print()
 
 
 if __name__ == "__main__":

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -13,10 +13,13 @@ Prerequisites:
   - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
 
 Usage:
-  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--json] [--quiet] [--pipeline PIPELINE]
+  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--text] [--quiet] [--pipeline PIPELINE]
 
-  # Query all branches and both pipelines (default)
+  # Query all branches and both pipelines — outputs JSON (default, for AI)
   python3 query-cg-alerts.py
+
+  # Human-readable text output (lists every CVE, nothing truncated)
+  python3 query-cg-alerts.py --text
 
   # Query only a specific branch
   python3 query-cg-alerts.py --branch main
@@ -28,9 +31,9 @@ Usage:
   python3 query-cg-alerts.py --build-id 14176611
 
 Output:
-  Prints a summary of all unique CG alerts grouped by severity, component, and branch.
-  Shows "stacks" — components with multiple CVEs grouped together.
-  With --json, outputs structured JSON suitable for the security audit report.
+  Default: JSON with every alert fully enumerated (id, component, severity,
+  category, source jobs, branches, pipelines). Designed for AI consumption.
+  With --text: grouped listing with all CVEs shown per component.
 """
 
 import argparse
@@ -228,7 +231,7 @@ def main():
     parser.add_argument("--branch", type=str, help="Query only this branch (e.g., 'main' or 'release/3.119.x')")
     parser.add_argument("--pipeline", type=str, choices=["native", "managed", "both"], default="both",
                         help="Which pipeline to query (default: both)")
-    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--text", action="store_true", help="Output as human-readable text instead of JSON (default is JSON for AI consumption)")
     parser.add_argument("--quiet", action="store_true", help="Suppress progress messages")
     args = parser.parse_args()
 
@@ -325,119 +328,75 @@ def main():
         sources = alert["sources"]
         alert["category"] = categorize_alert(comp, sources)
 
-    # Output
-    if args.json:
+    # Output — always structured for AI consumption.
+    # Default is JSON since this script is consumed by the security-audit skill.
+    # Use --text for a human-readable summary.
+    if not args.text:
         output = {
             "pipelines": [{"type": pt, "name": pi["name"], "id": pi["id"]} for pt, pi in pipelines_to_query],
             "builds": [{"id": bid, "branch": br, "number": num, "pipeline": PIPELINES[pt]["name"]} 
                        for bid, br, num, pt in builds_to_query],
             "totalAlerts": len(all_alerts),
+            "bySeverity": {
+                sev: len([a for a in all_alerts.values() if a["severity"] == sev])
+                for sev in ["Critical", "High", "Medium", "Low"]
+                if any(a["severity"] == sev for a in all_alerts.values())
+            },
+            "byCategory": {
+                cat: {
+                    "count": len(alerts),
+                    "severities": dict(sorted(
+                        ((s, len([a for a in alerts if a["severity"] == s]))
+                         for s in set(a["severity"] for a in alerts)),
+                        key=lambda x: {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(x[0], 9)
+                    ))
+                }
+                for cat, alerts in sorted(
+                    ((cat, [a for a in all_alerts.values() if a["category"] == cat])
+                     for cat in set(a["category"] for a in all_alerts.values())),
+                    key=lambda x: -x[1].__len__()
+                )
+            },
             "alerts": sorted(all_alerts.values(), key=lambda a: (
                 {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(a["severity"], 9),
-                a["category"],
+                a["component"],
                 a["id"]
             ))
         }
         print(json.dumps(output, indent=2))
     else:
-        # Group by severity
-        by_sev = defaultdict(list)
-        for alert in all_alerts.values():
-            by_sev[alert["severity"]].append(alert)
-
+        # Text mode: full listing, nothing truncated
         branches_str = ", ".join(sorted(set(b for _, b, _, _ in builds_to_query)))
         pipelines_str = ", ".join(pi["name"] for _, pi in pipelines_to_query)
-        print(f"\n{'='*70}")
-        print(f"CG ALERTS SUMMARY — {pipelines_str}")
+        print(f"CG ALERTS — {pipelines_str}")
         print(f"Branches: {branches_str}")
-        print(f"Total unique alerts: {len(all_alerts)}")
-        print(f"{'='*70}")
+        print(f"Total: {len(all_alerts)} unique alerts")
+        print()
 
-        for sev in ["Critical", "High", "Medium", "Low"]:
-            if sev not in by_sev:
-                continue
-            alerts = by_sev[sev]
-            print(f"\n### {sev} ({len(alerts)} alerts)")
-
-            # Group by category
-            by_cat = defaultdict(list)
-            for a in alerts:
-                by_cat[a["category"]].append(a)
-
-            for cat in sorted(by_cat.keys()):
-                cat_alerts = by_cat[cat]
-                print(f"\n  [{cat}]")
-                # Group by component
-                by_comp = defaultdict(list)
-                for a in cat_alerts:
-                    by_comp[a["component"]].append(a)
-                for comp in sorted(by_comp.keys()):
-                    comp_alerts = by_comp[comp]
-                    cves = sorted(a["id"] for a in comp_alerts)
-                    # Show branch info if not all branches
-                    all_branches = set()
-                    for a in comp_alerts:
-                        all_branches.update(a["branches"])
-                    branch_note = ""
-                    if len(builds_to_query) > 1:
-                        branch_note = f" [{', '.join(sorted(all_branches))}]"
-                    if len(cves) <= 3:
-                        print(f"    {comp}: {', '.join(cves)}{branch_note}")
-                    else:
-                        print(f"    {comp} ({len(cves)} CVEs): {', '.join(cves[:3])}...{branch_note}")
-
-        # Summary by category
-        print(f"\n{'='*70}")
-        print("BY CATEGORY:")
+        # Group by category, then component, list ALL CVEs
         by_cat = defaultdict(list)
         for a in all_alerts.values():
             by_cat[a["category"]].append(a)
+
         for cat in sorted(by_cat.keys()):
-            alerts = by_cat[cat]
-            sevs = defaultdict(int)
-            for a in alerts:
-                sevs[a["severity"]] += 1
-            sev_str = ", ".join(f"{s}: {c}" for s, c in sorted(sevs.items()))
-            print(f"  {cat}: {len(alerts)} alerts ({sev_str})")
-
-        # Branch coverage
-        if len(builds_to_query) > 1:
-            print(f"\nBRANCH COVERAGE:")
-            all_branches_seen = sorted(set(b for _, b, _, _ in builds_to_query))
-            for branch in all_branches_seen:
-                branch_alerts = [a for a in all_alerts.values() if branch in a["branches"]]
-                print(f"  {branch}: {len(branch_alerts)} alerts")
+            cat_alerts = by_cat[cat]
+            print(f"## {cat} ({len(cat_alerts)} alerts)")
             
-            # Show branch-exclusive alerts
-            all_branches_seen = sorted(set(b for _, b, _, _ in builds_to_query))
-            for branch in all_branches_seen:
-                exclusive = [a for a in all_alerts.values() 
-                           if a["branches"] == [branch]]
-                if exclusive:
-                    print(f"\n  Only in {branch} ({len(exclusive)}):")
-                    for a in sorted(exclusive, key=lambda x: x["id"])[:10]:
-                        print(f"    {a['id']} [{a['severity']}] {a['component']}")
-                    if len(exclusive) > 10:
-                        print(f"    ... and {len(exclusive) - 10} more")
-
-        # Component stacks (components with many CVEs grouped together)
-        print(f"\n{'='*70}")
-        print("COMPONENT STACKS (most affected first):")
-        by_comp = defaultdict(list)
-        for a in all_alerts.values():
-            by_comp[a["component"]].append(a)
-        stacks = sorted(by_comp.items(), key=lambda x: -len(x[1]))
-        for comp, comp_alerts in stacks[:15]:
-            sevs = defaultdict(int)
-            for a in comp_alerts:
-                sevs[a["severity"]] += 1
-            sev_str = ", ".join(f"{s}: {c}" for s, c in sorted(sevs.items()))
-            cat = comp_alerts[0].get("category", "unknown")
-            print(f"  {comp} — {len(comp_alerts)} CVEs ({sev_str}) [{cat}]")
-            # List CVE IDs for stacks > 5
-            if len(comp_alerts) > 5:
-                ids = sorted(a["id"] for a in comp_alerts)
-                print(f"    {', '.join(ids[:5])}... (+{len(ids)-5} more)")
+            # Group by component
+            by_comp = defaultdict(list)
+            for a in cat_alerts:
+                by_comp[a["component"]].append(a)
+            
+            for comp in sorted(by_comp.keys()):
+                comp_alerts = sorted(by_comp[comp], key=lambda a: a["id"])
+                sevs = set(a["severity"] for a in comp_alerts)
+                branches = set()
+                for a in comp_alerts:
+                    branches.update(a["branches"])
+                print(f"  {comp} [{', '.join(sorted(sevs))}] (branches: {', '.join(sorted(branches))})")
+                for a in comp_alerts:
+                    print(f"    - {a['id']} ({a['severity']})")
+            print()
 
 
 if __name__ == "__main__":

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -156,7 +156,14 @@ def get_cg_log_ids(token: str, build_id: int) -> dict[str, tuple[str, int]]:
 
 
 def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
-    """Parse CVEs from a CG log using REST API directly."""
+    """Parse CVEs and component locations from a CG log using REST API directly.
+    
+    The log has two sections:
+    1. Component manifest (--- Component: --- / --- Found at: --- pairs)
+    2. CVE alert table (|CVE-XXXX|component|severity|date|)
+    
+    We parse both and join them so each alert includes its file path(s).
+    """
     url = f"{ORG}/{PROJECT}/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1"
     req = urllib.request.Request(url)
     req.add_header("Authorization", f"Bearer {token}")
@@ -167,18 +174,50 @@ def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
         print(f"  WARNING: Failed to fetch log {log_id}: {e}", file=sys.stderr)
         return []
 
+    lines = content.split("\n")
+    
+    # Pass 1: Extract component locations (--- Component: --- / --- Found at: ---)
+    # Maps "component_name version" -> set of file paths
+    component_paths: dict[str, set] = {}
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # Strip timestamp prefix
+        text = re.sub(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*", "", line).strip()
+        if text == "--- Component: ---" and i + 1 < len(lines):
+            comp_line = re.sub(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*", "", lines[i + 1]).strip()
+            # Component line format: "name version - Type" (e.g., "minimatch 3.1.2 - Npm")
+            comp_match = re.match(r"^(.+?)\s*-\s*\w+$", comp_line)
+            comp_key = comp_match.group(1).strip() if comp_match else comp_line
+            # Look for "--- Found at: ---" on i+2, path on i+3
+            if i + 3 < len(lines):
+                found_text = re.sub(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*", "", lines[i + 2]).strip()
+                if found_text == "--- Found at: ---":
+                    path_text = re.sub(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*", "", lines[i + 3]).strip()
+                    if path_text:
+                        component_paths.setdefault(comp_key, set()).add(path_text)
+                    i += 4
+                    continue
+            i += 2
+            continue
+        i += 1
+
+    # Pass 2: Extract CVE alerts from table
     alerts = []
-    for line in content.split("\n"):
+    for line in lines:
         # Format: |CVE-XXXX-XXXXX |component |severity |date|
         parts = [p.strip() for p in line.split("|")]
         data_parts = [p for p in parts if p and not re.match(r"^\d{4}-\d{2}-\d{2}T", p)]
         if len(data_parts) >= 3:
             cve_match = re.search(r"(CVE-\d{4}-\d+|GHSA-[\w-]+)", data_parts[0])
             if cve_match:
+                component = data_parts[1]
+                paths = sorted(component_paths.get(component, set()))
                 alerts.append({
                     "id": cve_match.group(1),
-                    "component": data_parts[1],
-                    "severity": data_parts[2]
+                    "component": component,
+                    "severity": data_parts[2],
+                    "paths": paths
                 })
 
     return alerts
@@ -269,7 +308,8 @@ def main():
                         "severity": alert["severity"],
                         "sources": [category],
                         "branches": [branch],
-                        "pipelines": [PIPELINES[ptype]["name"]]
+                        "pipelines": [PIPELINES[ptype]["name"]],
+                        "paths": list(alert.get("paths", []))
                     }
                 else:
                     if category not in all_alerts[key]["sources"]:
@@ -278,6 +318,9 @@ def main():
                         all_alerts[key]["branches"].append(branch)
                     if PIPELINES[ptype]["name"] not in all_alerts[key]["pipelines"]:
                         all_alerts[key]["pipelines"].append(PIPELINES[ptype]["name"])
+                    for p in alert.get("paths", []):
+                        if p not in all_alerts[key]["paths"]:
+                            all_alerts[key]["paths"].append(p)
 
     # Output — always structured for AI consumption.
     # Default is JSON since this script is consumed by the security-audit skill.
@@ -320,7 +363,14 @@ def main():
             branches = set()
             for a in comp_alerts:
                 branches.update(a["branches"])
+            # Collect all unique paths for this component
+            all_paths = set()
+            for a in comp_alerts:
+                all_paths.update(a.get("paths", []))
             print(f"  {comp} [{', '.join(sorted(sevs))}] (branches: {', '.join(sorted(branches))})")
+            if all_paths:
+                for p in sorted(all_paths):
+                    print(f"    path: {p}")
             for a in comp_alerts:
                 print(f"    - {a['id']} ({a['severity']})")
         print()

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -124,11 +124,11 @@ def get_builds_for_branches(token: str, pipeline_id: int, branches: list[str], t
     return list(matched.values())
 
 
-def get_cg_log_ids(token: str, build_id: int, pipeline_type: str = "native") -> dict[str, tuple[str, int]]:
-    """Get representative CG log IDs from the build timeline.
+def get_cg_log_ids(token: str, build_id: int) -> dict[str, tuple[str, int]]:
+    """Get ALL CG log IDs from the build timeline.
     
-    For 'native' pipeline: samples one per container type (alpine, debian11, etc.)
-    For 'managed' pipeline: samples one per job stage (prepare, build, test, etc.)
+    Returns every successful Component Governance task log — no sampling.
+    For security auditing, we must check all jobs to avoid missing alerts.
     """
     url = (f"{ORG}/{PROJECT}/_apis/build/builds/{build_id}/timeline?api-version=7.1")
     timeline = api_get(token, url)
@@ -138,8 +138,8 @@ def get_cg_log_ids(token: str, build_id: int, pipeline_type: str = "native") -> 
     records = timeline.get("records", [])
     jobs = {r["id"]: r.get("name", "") for r in records}
 
-    # Find all CG tasks with their parent job names
-    cg_logs = {}
+    # Find ALL CG tasks with their parent job names
+    all_logs = {}
     for r in records:
         if "Component Governance" in r.get("name", "") and r.get("log"):
             log_id = r["log"]["id"]
@@ -147,41 +147,9 @@ def get_cg_log_ids(token: str, build_id: int, pipeline_type: str = "native") -> 
             job_name = jobs.get(parent, "unknown")
             result = r.get("result", "")
             if result in ("succeeded", "succeededWithIssues"):
-                cg_logs[job_name] = log_id
+                all_logs[job_name] = (job_name, log_id)
 
-    if pipeline_type == "managed":
-        # For managed pipeline, just pick a few representative jobs
-        representatives = {}
-        for job, log_id in cg_logs.items():
-            jl = job.lower()
-            if "prepare" in jl or "build" in jl:
-                representatives.setdefault("managed-build", (job, log_id))
-            elif "test" in jl or "pack" in jl:
-                representatives.setdefault("managed-test", (job, log_id))
-            else:
-                representatives.setdefault("managed-other", (job, log_id))
-        # If we couldn't categorize, just take up to 3
-        if not representatives:
-            for i, (job, log_id) in enumerate(list(cg_logs.items())[:3]):
-                representatives[f"managed-{i}"] = (job, log_id)
-        return representatives
-
-    # Native pipeline: Pick representative jobs (one per container type for full coverage)
-    representatives = {}
-    for job, log_id in cg_logs.items():
-        jl = job.lower()
-        if "alpine" in jl and "arm64" in jl and "nodeps" not in jl:
-            representatives["alpine"] = (job, log_id)
-        elif "loongarch64" in jl and "alpine" not in jl:
-            representatives.setdefault("debian13", (job, log_id))
-        elif "arm)" in jl and "alpine" not in jl and "bionic" not in jl:
-            representatives.setdefault("debian11", (job, log_id))
-        elif "wasm" in jl and "3.1.56" in job and "simd" not in jl and "thread" not in jl:
-            representatives.setdefault("wasm", (job, log_id))
-        elif "bionic" in jl and "arm64" in jl:
-            representatives.setdefault("bionic", (job, log_id))
-
-    return representatives
+    return all_logs
 
 
 def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
@@ -276,14 +244,14 @@ def main():
         if not args.quiet:
             print(f"\n--- [{PIPELINES[ptype]['name']}] {branch} (build {build_id}) ---", file=sys.stderr)
 
-        reps = get_cg_log_ids(token, build_id, ptype)
+        reps = get_cg_log_ids(token, build_id)
         if not reps:
             if not args.quiet:
                 print(f"  WARNING: No CG logs found in build {build_id}", file=sys.stderr)
             continue
 
         if not args.quiet:
-            print(f"  Sampling {len(reps)} job types: {', '.join(sorted(reps.keys()))}", file=sys.stderr)
+            print(f"  Checking {len(reps)} CG job(s): {', '.join(sorted(reps.keys())[:5])}{'...' if len(reps) > 5 else ''}", file=sys.stderr)
 
         for category, (job_name, log_id) in sorted(reps.items()):
             if not args.quiet:

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -181,6 +181,47 @@ def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
     return alerts
 
 
+def categorize_alert(component: str, source_jobs: list[str]) -> str:
+    """Derive category from the job context and component format.
+    
+    Uses job names (where the alert was found) as the primary signal,
+    falling back to component string patterns only when needed.
+    This approach is resilient to new packages/versions appearing.
+    """
+    # OS-packaged components are labeled "Distro:Version:package" by CG
+    distro_match = re.match(r"^([\w]+):(\d+):", component)
+    
+    if distro_match:
+        distro = distro_match.group(1)  # e.g., "Debian"
+        version = distro_match.group(2)  # e.g., "12", "13"
+        
+        # Check if it came from an alpine job — those "Debian:12:" entries
+        # are actually Alpine sysroot packages (CG mislabels them)
+        alpine_jobs = [s for s in source_jobs if "alpine" in s.lower()]
+        if alpine_jobs:
+            return f"Alpine sysroot (from {distro} {version} label)"
+        
+        return f"{distro} {version} base image"
+    
+    # NuGet packages (Microsoft.*, or other known .NET package patterns)
+    if re.match(r"^(Microsoft\.|System\.|NuGet\.|WindowsAppSDK)", component):
+        return "NuGet dependency"
+    
+    # Non-distro packages: categorize by job context
+    # If found only in "Prepare Build" or "Merge" jobs (not platform-specific),
+    # it's a toolchain/SDK dependency
+    platform_keywords = ["linux", "android", "ios", "wasm", "win", "angle",
+                         "mac", "tizen", "nano", "catalyst"]
+    platform_jobs = [s for s in source_jobs 
+                     if any(x in s.lower() for x in platform_keywords)]
+    non_platform_jobs = [s for s in source_jobs if s not in platform_jobs]
+    
+    if non_platform_jobs and not platform_jobs:
+        return "SDK/toolchain dependency"
+    
+    return "Build toolchain dependency"
+
+
 def main():
     parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp pipelines")
     parser.add_argument("--build-id", type=int, help="Specific build ID (skips branch discovery)")
@@ -276,21 +317,13 @@ def main():
                     if PIPELINES[ptype]["name"] not in all_alerts[key]["pipelines"]:
                         all_alerts[key]["pipelines"].append(PIPELINES[ptype]["name"])
 
-    # Categorize
+    # Categorize based on job context (source) and component format.
+    # We use the job name the alert was found in — this is stable regardless of
+    # which packages or versions appear in the future.
     for alert in all_alerts.values():
         comp = alert["component"]
-        if comp.startswith("Debian:12:") and any(x in comp for x in ["busybox", "file", "binutils", "zlib", "freetype", "gmp"]):
-            alert["category"] = "Alpine 3.17 sysroot"
-        elif comp.startswith("Debian:12:"):
-            alert["category"] = "Debian 12 base image"
-        elif comp.startswith("Debian:13:"):
-            alert["category"] = "Debian 13 base image"
-        elif "WindowsAppSDK" in comp or "Microsoft." in comp:
-            alert["category"] = "NuGet dependency"
-        elif any(c in comp for c in ["hashbrown", "zerovec", "time 0."]):
-            alert["category"] = "Rust crate (.NET SDK)"
-        else:
-            alert["category"] = "npm build tooling"
+        sources = alert["sources"]
+        alert["category"] = categorize_alert(comp, sources)
 
     # Output
     if args.json:

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """
-Query all Component Governance (CG) alerts for the SkiaSharp-Native pipeline.
+Query all Component Governance (CG) alerts for SkiaSharp pipelines.
 
-Automatically queries the latest builds from main AND active release branches,
-then deduplicates alerts across all builds to give a complete picture.
+Queries BOTH the SkiaSharp-Native (native libraries) and SkiaSharp (managed C#)
+pipelines since together they make up the shipped build. Automatically queries
+the latest builds from main AND active release branches, then deduplicates
+alerts across all builds to give a complete picture.
 
 Prerequisites:
   - az CLI installed and authenticated
@@ -11,19 +13,23 @@ Prerequisites:
   - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
 
 Usage:
-  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--json] [--quiet]
+  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--json] [--quiet] [--pipeline PIPELINE]
 
-  # Query all branches (default)
+  # Query all branches and both pipelines (default)
   python3 query-cg-alerts.py
 
   # Query only a specific branch
   python3 query-cg-alerts.py --branch main
+
+  # Query only the native pipeline
+  python3 query-cg-alerts.py --pipeline native
 
   # Query a specific build
   python3 query-cg-alerts.py --build-id 14176611
 
 Output:
   Prints a summary of all unique CG alerts grouped by severity, component, and branch.
+  Shows "stacks" — components with multiple CVEs grouped together.
   With --json, outputs structured JSON suitable for the security audit report.
 """
 
@@ -37,7 +43,12 @@ from collections import defaultdict
 
 ORG = "https://devdiv.visualstudio.com"
 PROJECT = "DevDiv"
-PIPELINE_ID = 26493  # SkiaSharp-Native
+
+# Both pipelines together make up the shipped build
+PIPELINES = {
+    "native": {"id": 26493, "name": "SkiaSharp-Native"},
+    "managed": {"id": 10789, "name": "SkiaSharp"},
+}
 
 # Branches to query by default (main + any active release branches)
 DEFAULT_BRANCHES = ["main", "release/*"]
@@ -84,14 +95,14 @@ def run_az(args: list[str], parse_json=True):
     return result.stdout.strip()
 
 
-def get_builds_for_branches(token: str, branches: list[str], top_per_branch: int = 1) -> list[dict]:
+def get_builds_for_branches(token: str, pipeline_id: int, branches: list[str], top_per_branch: int = 1) -> list[dict]:
     """Get the latest completed builds for the given branches.
     
     Supports wildcards: "release/*" matches any release/X.Y.Z or release/X.Y.x branch.
     """
     # Get recent builds (enough to cover all active branches)
     url = (f"{ORG}/{PROJECT}/_apis/build/builds"
-           f"?definitions={PIPELINE_ID}&statusFilter=completed&$top=20&api-version=7.1")
+           f"?definitions={pipeline_id}&statusFilter=completed&$top=20&api-version=7.1")
     data = api_get(token, url)
     if not data:
         return []
@@ -113,8 +124,12 @@ def get_builds_for_branches(token: str, branches: list[str], top_per_branch: int
     return list(matched.values())
 
 
-def get_cg_log_ids(token: str, build_id: int) -> dict[str, tuple[str, int]]:
-    """Get representative CG log IDs from the build timeline."""
+def get_cg_log_ids(token: str, build_id: int, pipeline_type: str = "native") -> dict[str, tuple[str, int]]:
+    """Get representative CG log IDs from the build timeline.
+    
+    For 'native' pipeline: samples one per container type (alpine, debian11, etc.)
+    For 'managed' pipeline: samples one per job stage (prepare, build, test, etc.)
+    """
     url = (f"{ORG}/{PROJECT}/_apis/build/builds/{build_id}/timeline?api-version=7.1")
     timeline = api_get(token, url)
     if not timeline:
@@ -134,7 +149,24 @@ def get_cg_log_ids(token: str, build_id: int) -> dict[str, tuple[str, int]]:
             if result in ("succeeded", "succeededWithIssues"):
                 cg_logs[job_name] = log_id
 
-    # Pick representative jobs (one per container type for full coverage)
+    if pipeline_type == "managed":
+        # For managed pipeline, just pick a few representative jobs
+        representatives = {}
+        for job, log_id in cg_logs.items():
+            jl = job.lower()
+            if "prepare" in jl or "build" in jl:
+                representatives.setdefault("managed-build", (job, log_id))
+            elif "test" in jl or "pack" in jl:
+                representatives.setdefault("managed-test", (job, log_id))
+            else:
+                representatives.setdefault("managed-other", (job, log_id))
+        # If we couldn't categorize, just take up to 3
+        if not representatives:
+            for i, (job, log_id) in enumerate(list(cg_logs.items())[:3]):
+                representatives[f"managed-{i}"] = (job, log_id)
+        return representatives
+
+    # Native pipeline: Pick representative jobs (one per container type for full coverage)
     representatives = {}
     for job, log_id in cg_logs.items():
         jl = job.lower()
@@ -182,17 +214,25 @@ def parse_cg_log(token: str, build_id: int, log_id: int) -> list[dict]:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp-Native")
+    parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp pipelines")
     parser.add_argument("--build-id", type=int, help="Specific build ID (skips branch discovery)")
     parser.add_argument("--branch", type=str, help="Query only this branch (e.g., 'main' or 'release/3.119.x')")
+    parser.add_argument("--pipeline", type=str, choices=["native", "managed", "both"], default="both",
+                        help="Which pipeline to query (default: both)")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--quiet", action="store_true", help="Suppress progress messages")
     args = parser.parse_args()
 
     token = get_token()
 
+    # Determine which pipelines to query
+    if args.pipeline == "both":
+        pipelines_to_query = list(PIPELINES.items())
+    else:
+        pipelines_to_query = [(args.pipeline, PIPELINES[args.pipeline])]
+
     # Determine which builds to query
-    builds_to_query = []  # list of (build_id, branch, build_number)
+    builds_to_query = []  # list of (build_id, branch, build_number, pipeline_type)
 
     if args.build_id:
         # Query specific build
@@ -200,41 +240,50 @@ def main():
         build = api_get(token, url)
         if build:
             branch = build.get("sourceBranch", "").replace("refs/heads/", "")
-            builds_to_query.append((args.build_id, branch, build.get("buildNumber", "unknown")))
+            # Determine pipeline type from definition
+            def_id = build.get("definition", {}).get("id")
+            ptype = "native" if def_id == PIPELINES["native"]["id"] else "managed"
+            builds_to_query.append((args.build_id, branch, build.get("buildNumber", "unknown"), ptype))
         else:
             print(f"ERROR: Build {args.build_id} not found", file=sys.stderr)
             sys.exit(1)
     else:
-        # Discover builds from branches
+        # Discover builds from branches for each pipeline
         branches = [args.branch] if args.branch else DEFAULT_BRANCHES
-        discovered = get_builds_for_branches(token, branches)
-        if not discovered:
-            print("ERROR: No completed builds found for specified branches", file=sys.stderr)
-            sys.exit(1)
-        for b in discovered:
-            branch = b.get("sourceBranch", "").replace("refs/heads/", "")
-            builds_to_query.append((b["id"], branch, b.get("buildNumber", "unknown")))
+        for ptype, pinfo in pipelines_to_query:
+            discovered = get_builds_for_branches(token, pinfo["id"], branches)
+            if not discovered:
+                if not args.quiet:
+                    print(f"WARNING: No completed builds found for {pinfo['name']}", file=sys.stderr)
+                continue
+            for b in discovered:
+                branch = b.get("sourceBranch", "").replace("refs/heads/", "")
+                builds_to_query.append((b["id"], branch, b.get("buildNumber", "unknown"), ptype))
+
+    if not builds_to_query:
+        print("ERROR: No builds found to query", file=sys.stderr)
+        sys.exit(1)
 
     if not args.quiet:
-        print(f"Querying {len(builds_to_query)} build(s):", file=sys.stderr)
-        for bid, branch, bnum in builds_to_query:
-            print(f"  {branch}: build {bid} ({bnum})", file=sys.stderr)
+        print(f"Querying {len(builds_to_query)} build(s) across {len(pipelines_to_query)} pipeline(s):", file=sys.stderr)
+        for bid, branch, bnum, ptype in builds_to_query:
+            print(f"  [{PIPELINES[ptype]['name']}] {branch}: build {bid} ({bnum})", file=sys.stderr)
 
     # Collect alerts from all builds
-    all_alerts = {}  # id -> {component, severity, branches, sources}
+    all_alerts = {}  # id -> {component, severity, branches, sources, pipelines}
 
-    for build_id, branch, build_num in builds_to_query:
+    for build_id, branch, build_num, ptype in builds_to_query:
         if not args.quiet:
-            print(f"\n--- {branch} (build {build_id}) ---", file=sys.stderr)
+            print(f"\n--- [{PIPELINES[ptype]['name']}] {branch} (build {build_id}) ---", file=sys.stderr)
 
-        reps = get_cg_log_ids(token, build_id)
+        reps = get_cg_log_ids(token, build_id, ptype)
         if not reps:
             if not args.quiet:
                 print(f"  WARNING: No CG logs found in build {build_id}", file=sys.stderr)
             continue
 
         if not args.quiet:
-            print(f"  Sampling {len(reps)} container types: {', '.join(sorted(reps.keys()))}", file=sys.stderr)
+            print(f"  Sampling {len(reps)} job types: {', '.join(sorted(reps.keys()))}", file=sys.stderr)
 
         for category, (job_name, log_id) in sorted(reps.items()):
             if not args.quiet:
@@ -248,13 +297,16 @@ def main():
                         "component": alert["component"],
                         "severity": alert["severity"],
                         "sources": [category],
-                        "branches": [branch]
+                        "branches": [branch],
+                        "pipelines": [PIPELINES[ptype]["name"]]
                     }
                 else:
                     if category not in all_alerts[key]["sources"]:
                         all_alerts[key]["sources"].append(category)
                     if branch not in all_alerts[key]["branches"]:
                         all_alerts[key]["branches"].append(branch)
+                    if PIPELINES[ptype]["name"] not in all_alerts[key]["pipelines"]:
+                        all_alerts[key]["pipelines"].append(PIPELINES[ptype]["name"])
 
     # Categorize
     for alert in all_alerts.values():
@@ -265,7 +317,7 @@ def main():
             alert["category"] = "Debian 12 base image"
         elif comp.startswith("Debian:13:"):
             alert["category"] = "Debian 13 base image"
-        elif "WindowsAppSDK" in comp:
+        elif "WindowsAppSDK" in comp or "Microsoft." in comp:
             alert["category"] = "NuGet dependency"
         elif any(c in comp for c in ["hashbrown", "zerovec", "time 0."]):
             alert["category"] = "Rust crate (.NET SDK)"
@@ -275,8 +327,9 @@ def main():
     # Output
     if args.json:
         output = {
-            "builds": [{"id": bid, "branch": br, "number": num} for bid, br, num in builds_to_query],
-            "pipelineId": PIPELINE_ID,
+            "pipelines": [{"type": pt, "name": pi["name"], "id": pi["id"]} for pt, pi in pipelines_to_query],
+            "builds": [{"id": bid, "branch": br, "number": num, "pipeline": PIPELINES[pt]["name"]} 
+                       for bid, br, num, pt in builds_to_query],
             "totalAlerts": len(all_alerts),
             "alerts": sorted(all_alerts.values(), key=lambda a: (
                 {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(a["severity"], 9),
@@ -291,9 +344,10 @@ def main():
         for alert in all_alerts.values():
             by_sev[alert["severity"]].append(alert)
 
-        branches_str = ", ".join(b for _, b, _ in builds_to_query)
+        branches_str = ", ".join(sorted(set(b for _, b, _, _ in builds_to_query)))
+        pipelines_str = ", ".join(pi["name"] for _, pi in pipelines_to_query)
         print(f"\n{'='*70}")
-        print(f"CG ALERTS SUMMARY — SkiaSharp-Native (pipeline {PIPELINE_ID})")
+        print(f"CG ALERTS SUMMARY — {pipelines_str}")
         print(f"Branches: {branches_str}")
         print(f"Total unique alerts: {len(all_alerts)}")
         print(f"{'='*70}")
@@ -348,12 +402,14 @@ def main():
         # Branch coverage
         if len(builds_to_query) > 1:
             print(f"\nBRANCH COVERAGE:")
-            for _, branch, _ in builds_to_query:
+            all_branches_seen = sorted(set(b for _, b, _, _ in builds_to_query))
+            for branch in all_branches_seen:
                 branch_alerts = [a for a in all_alerts.values() if branch in a["branches"]]
                 print(f"  {branch}: {len(branch_alerts)} alerts")
             
             # Show branch-exclusive alerts
-            for _, branch, _ in builds_to_query:
+            all_branches_seen = sorted(set(b for _, b, _, _ in builds_to_query))
+            for branch in all_branches_seen:
                 exclusive = [a for a in all_alerts.values() 
                            if a["branches"] == [branch]]
                 if exclusive:
@@ -362,6 +418,25 @@ def main():
                         print(f"    {a['id']} [{a['severity']}] {a['component']}")
                     if len(exclusive) > 10:
                         print(f"    ... and {len(exclusive) - 10} more")
+
+        # Component stacks (components with many CVEs grouped together)
+        print(f"\n{'='*70}")
+        print("COMPONENT STACKS (most affected first):")
+        by_comp = defaultdict(list)
+        for a in all_alerts.values():
+            by_comp[a["component"]].append(a)
+        stacks = sorted(by_comp.items(), key=lambda x: -len(x[1]))
+        for comp, comp_alerts in stacks[:15]:
+            sevs = defaultdict(int)
+            for a in comp_alerts:
+                sevs[a["severity"]] += 1
+            sev_str = ", ".join(f"{s}: {c}" for s, c in sorted(sevs.items()))
+            cat = comp_alerts[0].get("category", "unknown")
+            print(f"  {comp} — {len(comp_alerts)} CVEs ({sev_str}) [{cat}]")
+            # List CVE IDs for stacks > 5
+            if len(comp_alerts) > 5:
+                ids = sorted(a["id"] for a in comp_alerts)
+                print(f"    {', '.join(ids[:5])}... (+{len(ids)-5} more)")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Query all Component Governance (CG) alerts for the SkiaSharp-Native pipeline.
+
+No build ID required - automatically uses the latest completed build and extracts
+alerts from representative CG logs (one per container type) to get full coverage.
+
+Prerequisites:
+  - az CLI installed and authenticated
+  - az devops extension installed
+  - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
+
+Usage:
+  python3 query-cg-alerts.py [--build-id BUILD_ID] [--json] [--quiet]
+
+Output:
+  Prints a summary of all unique CG alerts grouped by severity and component.
+  With --json, outputs structured JSON suitable for the security audit report.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+ORG = "https://devdiv.visualstudio.com"
+PROJECT = "DevDiv"
+PIPELINE_ID = 26493  # SkiaSharp-Native
+
+
+def run_az(args: list[str], parse_json=True):
+    """Run an az CLI command and return parsed output."""
+    result = subprocess.run(
+        ["az"] + args,
+        capture_output=True, text=True, timeout=60
+    )
+    if result.returncode != 0:
+        print(f"ERROR: az {' '.join(args[:5])}... failed: {result.stderr[:200]}", file=sys.stderr)
+        sys.exit(1)
+    if parse_json:
+        return json.loads(result.stdout)
+    return result.stdout.strip()
+
+
+def get_latest_build_id() -> tuple[int, str]:
+    """Get the latest completed build ID and number."""
+    builds = run_az([
+        "pipelines", "runs", "list",
+        "--pipeline-id", str(PIPELINE_ID),
+        "--org", ORG, "--project", PROJECT,
+        "--top", "1", "--status", "completed",
+        "-o", "json"
+    ])
+    if not builds:
+        print("ERROR: No completed builds found", file=sys.stderr)
+        sys.exit(1)
+    return builds[0]["id"], builds[0].get("buildNumber", "unknown")
+
+
+def get_cg_log_ids(build_id: int) -> dict[str, tuple[str, int]]:
+    """Get representative CG log IDs from the build timeline."""
+    timeline = run_az([
+        "devops", "invoke",
+        "--area", "build", "--resource", "timeline",
+        "--route-parameters", f"project={PROJECT}", f"buildId={build_id}",
+        "--org", ORG, "-o", "json"
+    ])
+
+    records = timeline.get("records", [])
+    jobs = {r["id"]: r.get("name", "") for r in records}
+
+    # Find all CG tasks with their parent job names
+    cg_logs = {}
+    for r in records:
+        if "Component Governance" in r.get("name", "") and r.get("log"):
+            log_id = r["log"]["id"]
+            parent = r.get("parentId", "")
+            job_name = jobs.get(parent, "unknown")
+            result = r.get("result", "")
+            if result in ("succeeded", "succeededWithIssues"):
+                cg_logs[job_name] = log_id
+
+    # Pick representative jobs (one per container type for full coverage)
+    representatives = {}
+    for job, log_id in cg_logs.items():
+        jl = job.lower()
+        if "alpine" in jl and "arm64" in jl and "nodeps" not in jl:
+            representatives["alpine"] = (job, log_id)
+        elif "loongarch64" in jl and "alpine" not in jl:
+            representatives.setdefault("debian13", (job, log_id))
+        elif "arm)" in jl and "alpine" not in jl and "bionic" not in jl:
+            representatives.setdefault("debian11", (job, log_id))
+        elif "wasm" in jl and "3.1.56" in job and "simd" not in jl and "thread" not in jl:
+            representatives.setdefault("wasm", (job, log_id))
+        elif "bionic" in jl and "arm64" in jl:
+            representatives.setdefault("bionic", (job, log_id))
+
+    return representatives
+
+
+def parse_cg_log(build_id: int, log_id: int) -> list[dict]:
+    """Parse CVEs from a CG log."""
+    log_data = run_az([
+        "devops", "invoke",
+        "--area", "build", "--resource", "logs",
+        "--route-parameters", f"project={PROJECT}", f"buildId={build_id}", f"logId={log_id}",
+        "--org", ORG, "-o", "json"
+    ])
+
+    lines = log_data if isinstance(log_data, list) else log_data.get("value", [])
+    alerts = []
+
+    for line in lines:
+        s = str(line)
+        m = re.search(r"\|(CVE-[\d-]+|MVS-[\w-]+|GHSA-[\w-]+)\s*\|([^|]+)\|(\w+)", s)
+        if m:
+            alerts.append({
+                "id": m.group(1).strip(),
+                "component": m.group(2).strip(),
+                "severity": m.group(3).strip()
+            })
+
+    return alerts
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp-Native")
+    parser.add_argument("--build-id", type=int, help="Specific build ID (default: latest)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--quiet", action="store_true", help="Suppress progress messages")
+    args = parser.parse_args()
+
+    # Get build ID
+    if args.build_id:
+        build_id = args.build_id
+        build_num = "specified"
+    else:
+        build_id, build_num = get_latest_build_id()
+
+    if not args.quiet:
+        print(f"Build: {build_id} ({build_num})", file=sys.stderr)
+
+    # Get representative log IDs
+    reps = get_cg_log_ids(build_id)
+    if not args.quiet:
+        print(f"Sampling {len(reps)} container types: {', '.join(sorted(reps.keys()))}", file=sys.stderr)
+
+    # Parse all logs and deduplicate
+    all_alerts = {}  # id -> {component, severity, sources}
+    for category, (job_name, log_id) in sorted(reps.items()):
+        if not args.quiet:
+            print(f"  Parsing {category} (log {log_id}: {job_name})...", file=sys.stderr)
+        alerts = parse_cg_log(build_id, log_id)
+        for alert in alerts:
+            key = alert["id"]
+            if key not in all_alerts:
+                all_alerts[key] = {
+                    "id": alert["id"],
+                    "component": alert["component"],
+                    "severity": alert["severity"],
+                    "sources": [category]
+                }
+            else:
+                if category not in all_alerts[key]["sources"]:
+                    all_alerts[key]["sources"].append(category)
+
+    # Categorize
+    for alert in all_alerts.values():
+        comp = alert["component"]
+        if comp.startswith("Debian:12:") and any(x in comp for x in ["busybox", "file", "binutils", "zlib", "freetype", "gmp"]):
+            alert["category"] = "Alpine 3.17 sysroot"
+        elif comp.startswith("Debian:12:"):
+            alert["category"] = "Debian 12 base image"
+        elif comp.startswith("Debian:13:"):
+            alert["category"] = "Debian 13 base image"
+        elif "WindowsAppSDK" in comp:
+            alert["category"] = "NuGet dependency"
+        elif any(c in comp for c in ["hashbrown", "zerovec", "time 0."]):
+            alert["category"] = "Rust crate (.NET SDK)"
+        else:
+            alert["category"] = "npm build tooling"
+
+    # Output
+    if args.json:
+        output = {
+            "buildId": build_id,
+            "buildNumber": build_num,
+            "pipelineId": PIPELINE_ID,
+            "totalAlerts": len(all_alerts),
+            "alerts": sorted(all_alerts.values(), key=lambda a: (
+                {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(a["severity"], 9),
+                a["category"],
+                a["id"]
+            ))
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        # Group by severity
+        by_sev = defaultdict(list)
+        for alert in all_alerts.values():
+            by_sev[alert["severity"]].append(alert)
+
+        print(f"\n{'='*60}")
+        print(f"CG ALERTS SUMMARY — Build {build_id} ({build_num})")
+        print(f"Total unique alerts: {len(all_alerts)}")
+        print(f"{'='*60}")
+
+        for sev in ["Critical", "High", "Medium", "Low"]:
+            if sev not in by_sev:
+                continue
+            alerts = by_sev[sev]
+            print(f"\n### {sev} ({len(alerts)} alerts)")
+
+            # Group by category
+            by_cat = defaultdict(list)
+            for a in alerts:
+                by_cat[a["category"]].append(a)
+
+            for cat in sorted(by_cat.keys()):
+                cat_alerts = by_cat[cat]
+                print(f"\n  [{cat}]")
+                # Group by component
+                by_comp = defaultdict(list)
+                for a in cat_alerts:
+                    by_comp[a["component"]].append(a["id"])
+                for comp in sorted(by_comp.keys()):
+                    cves = sorted(by_comp[comp])
+                    if len(cves) <= 3:
+                        print(f"    {comp}: {', '.join(cves)}")
+                    else:
+                        print(f"    {comp} ({len(cves)} CVEs): {', '.join(cves[:3])}...")
+
+        # Summary by category
+        print(f"\n{'='*60}")
+        print("BY CATEGORY:")
+        by_cat = defaultdict(list)
+        for a in all_alerts.values():
+            by_cat[a["category"]].append(a)
+        for cat in sorted(by_cat.keys()):
+            alerts = by_cat[cat]
+            sevs = defaultdict(int)
+            for a in alerts:
+                sevs[a["severity"]] += 1
+            sev_str = ", ".join(f"{s}: {c}" for s, c in sorted(sevs.items()))
+            print(f"  {cat}: {len(alerts)} alerts ({sev_str})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 import urllib.request
 from collections import defaultdict
+from datetime import datetime, timezone
 
 ORG = "https://devdiv.visualstudio.com"
 PROJECT = "DevDiv"
@@ -327,6 +328,7 @@ def main():
     # Use --text for a human-readable summary.
     if not args.text:
         output = {
+            "queriedAt": datetime.now(timezone.utc).isoformat(),
             "pipelines": [{"type": pt, "name": pi["name"], "id": pi["id"]} for pt, pi in pipelines_to_query],
             "builds": [{"id": bid, "branch": br, "number": num, "pipeline": PIPELINES[pt]["name"]} 
                        for bid, br, num, pt in builds_to_query],

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -13,7 +13,7 @@ Prerequisites:
   - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
 
 Usage:
-  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--text] [--quiet] [--pipeline PIPELINE]
+  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--text] [--verbose] [--pipeline PIPELINE]
 
   # Query all branches and both pipelines — outputs JSON (default, for AI)
   python3 query-cg-alerts.py
@@ -232,7 +232,7 @@ def main():
     parser.add_argument("--pipeline", type=str, choices=["native", "managed", "both"], default="both",
                         help="Which pipeline to query (default: both)")
     parser.add_argument("--text", action="store_true", help="Output as human-readable text instead of JSON (default is JSON for AI consumption)")
-    parser.add_argument("--quiet", action="store_true", help="Suppress progress messages")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show progress messages to stderr")
     args = parser.parse_args()
 
     token = get_token()
@@ -265,7 +265,7 @@ def main():
         for ptype, pinfo in pipelines_to_query:
             discovered = get_builds_for_branches(token, pinfo["id"], branches)
             if not discovered:
-                if not args.quiet:
+                if args.verbose:
                     print(f"WARNING: No completed builds found for {pinfo['name']}", file=sys.stderr)
                 continue
             for b in discovered:
@@ -276,7 +276,7 @@ def main():
         print("ERROR: No builds found to query", file=sys.stderr)
         sys.exit(1)
 
-    if not args.quiet:
+    if args.verbose:
         print(f"Querying {len(builds_to_query)} build(s) across {len(pipelines_to_query)} pipeline(s):", file=sys.stderr)
         for bid, branch, bnum, ptype in builds_to_query:
             print(f"  [{PIPELINES[ptype]['name']}] {branch}: build {bid} ({bnum})", file=sys.stderr)
@@ -285,20 +285,20 @@ def main():
     all_alerts = {}  # id -> {component, severity, branches, sources, pipelines}
 
     for build_id, branch, build_num, ptype in builds_to_query:
-        if not args.quiet:
+        if args.verbose:
             print(f"\n--- [{PIPELINES[ptype]['name']}] {branch} (build {build_id}) ---", file=sys.stderr)
 
         reps = get_cg_log_ids(token, build_id)
         if not reps:
-            if not args.quiet:
+            if args.verbose:
                 print(f"  WARNING: No CG logs found in build {build_id}", file=sys.stderr)
             continue
 
-        if not args.quiet:
+        if args.verbose:
             print(f"  Checking {len(reps)} CG job(s): {', '.join(sorted(reps.keys())[:5])}{'...' if len(reps) > 5 else ''}", file=sys.stderr)
 
         for category, (job_name, log_id) in sorted(reps.items()):
-            if not args.quiet:
+            if args.verbose:
                 print(f"    Parsing {category} (log {log_id})...", file=sys.stderr)
             alerts = parse_cg_log(token, build_id, log_id)
             for alert in alerts:

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -61,13 +61,13 @@ for f in findings:
         status_counts[s] += 1
 
 if summary.get("needsAttention", 0) != status_counts["needs_attention"]:
-    warnings.append(f"summary.needsAttention ({summary.get('needsAttention')}) != findings count ({status_counts['needs_attention']})")
+    errors.append(f"summary.needsAttention ({summary.get('needsAttention')}) != findings count ({status_counts['needs_attention']}) — fix the count")
 if summary.get("undiscovered", 0) != status_counts["undiscovered"]:
-    warnings.append(f"summary.undiscovered ({summary.get('undiscovered')}) != findings count ({status_counts['undiscovered']})")
+    errors.append(f"summary.undiscovered ({summary.get('undiscovered')}) != findings count ({status_counts['undiscovered']}) — fix the count")
 if summary.get("falsePositive", 0) != status_counts["false_positive"]:
-    warnings.append(f"summary.falsePositive ({summary.get('falsePositive')}) != findings count ({status_counts['false_positive']})")
+    errors.append(f"summary.falsePositive ({summary.get('falsePositive')}) != findings count ({status_counts['false_positive']}) — fix the count")
 if summary.get("clean", 0) != status_counts["clean"]:
-    warnings.append(f"summary.clean ({summary.get('clean')}) != findings count ({status_counts['clean']})")
+    errors.append(f"summary.clean ({summary.get('clean')}) != findings count ({status_counts['clean']}) — fix the count")
 
 # 2. totalCves should match sum of all CVEs across findings
 total_cves = sum(len(f.get("cves", [])) + len(f.get("nonChromeCves", [])) for f in findings)

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -77,26 +77,29 @@ if summary.get("totalCves", 0) != total_cves:
 # 3. CG alerts validation
 if cg:
     total_alerts = cg.get("totalAlerts", 0)
-    all_alerts = cg.get("allAlerts", [])
+    all_alerts = cg.get("alerts", []) or cg.get("allAlerts", [])
     unique_cves = cg.get("uniqueCVEs", [])
     categories = cg.get("categories", [])
 
-    # Must have at least one way to enumerate alerts
-    if not all_alerts and not unique_cves and not categories:
-        errors.append("cgAlerts has totalAlerts but no allAlerts, uniqueCVEs, or categories to enumerate them")
+    # Prefer 'alerts' array — categories alone is insufficient
+    if not all_alerts and not unique_cves:
+        if categories:
+            errors.append("cgAlerts has 'categories' but no 'alerts' array — include the raw script output")
+        else:
+            errors.append("cgAlerts has totalAlerts but no 'alerts' array to enumerate them")
 
-    # If allAlerts present, count must match totalAlerts
+    # If alerts present, count must match totalAlerts
     if all_alerts and len(all_alerts) != total_alerts:
-        warnings.append(f"cgAlerts.totalAlerts ({total_alerts}) != len(allAlerts) ({len(all_alerts)})")
+        warnings.append(f"cgAlerts.totalAlerts ({total_alerts}) != len(alerts) ({len(all_alerts)})")
 
-    # Every alert in allAlerts must have id, component, severity
+    # Every alert must have id, component, severity
     for i, a in enumerate(all_alerts):
         if not a.get("id"):
-            errors.append(f"cgAlerts.allAlerts[{i}] missing 'id'")
+            errors.append(f"cgAlerts.alerts[{i}] missing 'id'")
         if not a.get("component"):
-            errors.append(f"cgAlerts.allAlerts[{i}] missing 'component'")
+            errors.append(f"cgAlerts.alerts[{i}] missing 'component'")
         if not a.get("severity"):
-            errors.append(f"cgAlerts.allAlerts[{i}] missing 'severity'")
+            errors.append(f"cgAlerts.alerts[{i}] missing 'severity'")
 
     # bySeverity counts should match
     by_sev = cg.get("bySeverity", {})

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -75,7 +75,9 @@ if summary.get("totalCves", 0) != total_cves:
     warnings.append(f"summary.totalCves ({summary.get('totalCves')}) != actual CVE count ({total_cves})")
 
 # 3. CG alerts validation
-if cg:
+if not cg:
+    warnings.append("cgAlerts missing — Step 6 is mandatory for a complete security audit")
+elif cg:
     total_alerts = cg.get("totalAlerts", 0)
     all_alerts = cg.get("alerts", [])
 

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -77,18 +77,12 @@ if summary.get("totalCves", 0) != total_cves:
 # 3. CG alerts validation
 if cg:
     total_alerts = cg.get("totalAlerts", 0)
-    all_alerts = cg.get("alerts", []) or cg.get("allAlerts", [])
-    unique_cves = cg.get("uniqueCVEs", [])
-    categories = cg.get("categories", [])
+    all_alerts = cg.get("alerts", [])
 
-    # Prefer 'alerts' array — categories alone is insufficient
-    if not all_alerts and not unique_cves:
-        if categories:
-            errors.append("cgAlerts has 'categories' but no 'alerts' array — include the raw script output")
-        else:
-            errors.append("cgAlerts has totalAlerts but no 'alerts' array to enumerate them")
+    if not all_alerts:
+        errors.append("cgAlerts missing 'alerts' array — include the raw query-cg-alerts.py output")
 
-    # If alerts present, count must match totalAlerts
+    # Count must match totalAlerts
     if all_alerts and len(all_alerts) != total_alerts:
         warnings.append(f"cgAlerts.totalAlerts ({total_alerts}) != len(alerts) ({len(all_alerts)})")
 

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate a security audit JSON report against the schema.
+
+Usage: python3 validate-security-audit.py <report.json>
+Exits: 0=valid, 1=fixable errors (retry), 2=fatal.
+"""
+import json
+import sys
+from pathlib import Path
+
+if len(sys.argv) != 2:
+    print("Usage: python3 validate-security-audit.py <report.json>")
+    sys.exit(2)
+
+path = Path(sys.argv[1])
+if not path.exists():
+    print(f"❌ File not found: {path}")
+    sys.exit(2)
+
+schema_path = Path(__file__).resolve().parent / "../references/security-audit-schema.json"
+if not schema_path.exists():
+    print(f"❌ Schema not found: {schema_path}")
+    sys.exit(2)
+
+try:
+    with open(path) as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    print(f"❌ Invalid JSON: {e}")
+    sys.exit(2)
+
+with open(schema_path) as f:
+    schema = json.load(f)
+
+errors = []
+warnings = []
+
+# --- JSON Schema validation ---
+try:
+    from jsonschema import Draft202012Validator
+    validator = Draft202012Validator(schema)
+    for e in validator.iter_errors(data):
+        p = ".".join(str(x) for x in e.absolute_path) or "(root)"
+        errors.append(f"Schema: {p}: {e.message}")
+except ImportError:
+    warnings.append("jsonschema not installed — run: pip install jsonschema (schema check skipped)")
+
+# --- Semantic checks ---
+meta = data.get("meta", {})
+summary = data.get("summary", {})
+findings = data.get("findings", [])
+cg = data.get("cgAlerts", {})
+next_steps = data.get("nextSteps", [])
+versions = data.get("versionVerification", [])
+
+# 1. Summary counts must match findings
+status_counts = {"needs_attention": 0, "undiscovered": 0, "false_positive": 0, "clean": 0, "in_progress": 0, "ready_to_merge": 0}
+for f in findings:
+    s = f.get("status", "")
+    if s in status_counts:
+        status_counts[s] += 1
+
+if summary.get("needsAttention", 0) != status_counts["needs_attention"]:
+    warnings.append(f"summary.needsAttention ({summary.get('needsAttention')}) != findings count ({status_counts['needs_attention']})")
+if summary.get("undiscovered", 0) != status_counts["undiscovered"]:
+    warnings.append(f"summary.undiscovered ({summary.get('undiscovered')}) != findings count ({status_counts['undiscovered']})")
+if summary.get("falsePositive", 0) != status_counts["false_positive"]:
+    warnings.append(f"summary.falsePositive ({summary.get('falsePositive')}) != findings count ({status_counts['false_positive']})")
+if summary.get("clean", 0) != status_counts["clean"]:
+    warnings.append(f"summary.clean ({summary.get('clean')}) != findings count ({status_counts['clean']})")
+
+# 2. totalCves should match sum of all CVEs across findings
+total_cves = sum(len(f.get("cves", [])) + len(f.get("nonChromeCves", [])) for f in findings)
+if summary.get("totalCves", 0) != total_cves:
+    warnings.append(f"summary.totalCves ({summary.get('totalCves')}) != actual CVE count ({total_cves})")
+
+# 3. CG alerts validation
+if cg:
+    total_alerts = cg.get("totalAlerts", 0)
+    all_alerts = cg.get("allAlerts", [])
+    unique_cves = cg.get("uniqueCVEs", [])
+    categories = cg.get("categories", [])
+
+    # Must have at least one way to enumerate alerts
+    if not all_alerts and not unique_cves and not categories:
+        errors.append("cgAlerts has totalAlerts but no allAlerts, uniqueCVEs, or categories to enumerate them")
+
+    # If allAlerts present, count must match totalAlerts
+    if all_alerts and len(all_alerts) != total_alerts:
+        warnings.append(f"cgAlerts.totalAlerts ({total_alerts}) != len(allAlerts) ({len(all_alerts)})")
+
+    # Every alert in allAlerts must have id, component, severity
+    for i, a in enumerate(all_alerts):
+        if not a.get("id"):
+            errors.append(f"cgAlerts.allAlerts[{i}] missing 'id'")
+        if not a.get("component"):
+            errors.append(f"cgAlerts.allAlerts[{i}] missing 'component'")
+        if not a.get("severity"):
+            errors.append(f"cgAlerts.allAlerts[{i}] missing 'severity'")
+
+    # bySeverity counts should match
+    by_sev = cg.get("bySeverity", {})
+    if all_alerts and by_sev:
+        from collections import Counter
+        actual_sev = Counter(a.get("severity") for a in all_alerts)
+        for sev, count in by_sev.items():
+            actual = actual_sev.get(sev, 0)
+            if actual != count:
+                warnings.append(f"cgAlerts.bySeverity.{sev} ({count}) != actual ({actual})")
+
+    # Pipelines should be present
+    if not cg.get("pipelines"):
+        warnings.append("cgAlerts.pipelines is empty — should list scanned pipelines")
+
+# 4. Findings must have unique dependencies
+deps = [f.get("dependency") for f in findings]
+dupes = [d for d in set(deps) if deps.count(d) > 1]
+if dupes:
+    warnings.append(f"Duplicate finding dependencies: {dupes}")
+
+# 5. Every finding with status != clean/false_positive should have CVEs or action
+for f in findings:
+    if f.get("status") in ("needs_attention", "undiscovered", "in_progress"):
+        if not f.get("cves") and not f.get("nonChromeCves") and not f.get("action"):
+            warnings.append(f"Finding '{f.get('dependency')}' has status={f.get('status')} but no CVEs or action")
+
+# 6. nextSteps should be sorted by priority
+priorities = [s.get("priority", 999) for s in next_steps]
+if priorities != sorted(priorities):
+    warnings.append("nextSteps not sorted by priority")
+
+# 7. Meta validation
+if not meta.get("date"):
+    errors.append("meta.date is required")
+if not meta.get("skiaMilestone"):
+    errors.append("meta.skiaMilestone is required")
+
+# 8. versionVerification should have entries
+if not versions:
+    warnings.append("versionVerification is empty — should list verified dependencies")
+
+# --- Output ---
+if warnings:
+    print(f"⚠️  {len(warnings)} warning(s):")
+    for w in warnings:
+        print(f"   ⚠️  {w}")
+
+if errors:
+    print(f"\n❌ {len(errors)} error(s):")
+    for e in errors:
+        print(f"   ❌ {e}")
+    sys.exit(1)
+else:
+    total_findings = len(findings)
+    cg_count = cg.get("totalAlerts", 0) if cg else 0
+    print(f"✅ Valid security audit report")
+    print(f"   m{meta.get('skiaMilestone', '?')} • {meta.get('date', '?')}")
+    print(f"   {total_findings} findings • {summary.get('totalCves', 0)} CVEs • {cg_count} CG alerts")
+    if warnings:
+        print(f"   ({len(warnings)} warnings — review above)")
+    sys.exit(0)

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -189,13 +189,8 @@ function renderOverview(vers, findings, cgAlerts) {
     });
   }
 
-  // Split into groups: has CVEs vs no CVEs, each sorted by severity then name
-  const sevOrder = { Critical: 0, High: 1, Medium: 2, Low: 3 };
-  const withCves = enriched.filter(e => e.cveTotal > 0).sort((a,b) => {
-    const aSev = a.isCg ? (sevOrder[a.cgSeverity] || 9) : (a.f ? sevOrder[a.f.cves?.[0]?.severity] || 5 : 5);
-    const bSev = b.isCg ? (sevOrder[b.cgSeverity] || 9) : (b.f ? sevOrder[b.f.cves?.[0]?.severity] || 5 : 5);
-    return aSev !== bSev ? aSev - bSev : a.name.localeCompare(b.name);
-  });
+  // Split into groups: has CVEs vs no CVEs, sorted by name within each group
+  const withCves = enriched.filter(e => e.cveTotal > 0).sort((a,b) => a.name.localeCompare(b.name));
   const noCves = enriched.filter(e => e.cveTotal === 0).sort((a,b) => a.name.localeCompare(b.name));
 
   let mismatches = 0;
@@ -245,13 +240,16 @@ function renderOverview(vers, findings, cgAlerts) {
   html += noCves.map(buildRow).join('');
 
   tbody.innerHTML = html;
-  const total = enriched.length;
-  const cgMissing = enriched.filter(v => !v.cgmanifestVersion).length;
+  const nonCgEntries = enriched.filter(v => !v.isCg);
+  const total = nonCgEntries.length;
+  const cgMissing = nonCgEntries.filter(v => !v.cgmanifestVersion).length;
+  const cgTotal = enriched.filter(v => v.isCg).length;
   let statusText = mismatches === 0 && cgMissing === 0
     ? `✅ All ${total} dependencies verified`
     : `${total} deps`;
   if (mismatches > 0) statusText += ` · ❌ ${mismatches} version mismatch${mismatches > 1 ? 'es' : ''}`;
   if (cgMissing > 0) statusText += ` · ⚠️ ${cgMissing} missing from cgmanifest`;
+  if (cgTotal > 0) statusText += ` · 🛡️ ${cgTotal} CG components`;
   document.getElementById('overview-status').textContent = statusText;
 }
 

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -124,16 +124,19 @@ const SEV_CLASS = { CRITICAL: 'sev-critical', HIGH: 'sev-high', MEDIUM: 'sev-med
 function sevClass(s) { return SEV_CLASS[(s||'').toUpperCase()] || 'sev-low'; }
 function esc(s) { const d = document.createElement('div'); d.textContent = s||''; return d.innerHTML; }
 
-function renderSummary(s) {
+function renderSummary(s, cgAlerts) {
+  const cgCount = cgAlerts ? (cgAlerts.totalAlerts || 0) : 0;
+  const cgHigh = cgAlerts ? ((cgAlerts.bySeverity || {}).High || 0) : 0;
   const cards = [
-    ['Needs Attention', s.needsAttention, 'danger', 'exclamation-triangle'],
+    ['Needs Attention', s.needsAttention + cgHigh, 'danger', 'exclamation-triangle'],
+    ['CG Alerts', cgCount, cgHigh > 0 ? 'danger' : 'warning', 'shield-exclamation'],
     ['Undiscovered', s.undiscovered, 'primary', 'search'],
     ['False Positive', s.falsePositive, 'secondary', 'x-circle'],
     ['Clean', s.clean, 'success', 'check-circle'],
   ];
   const el = document.getElementById('summary-cards');
   el.innerHTML = cards.map(([label, count, color, icon]) => `
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md">
       <div class="card text-center p-3">
         <div class="fs-2 text-${color}"><i class="bi bi-${icon}"></i></div>
         <div class="fs-1 fw-bold">${count}</div>
@@ -142,7 +145,7 @@ function renderSummary(s) {
     </div>`).join('');
 }
 
-function renderOverview(vers, findings) {
+function renderOverview(vers, findings, cgAlerts) {
   const tbody = document.querySelector('#overview-table tbody');
   const findingMap = {};
   (findings || []).forEach((f, i) => { findingMap[f.dependency] = { ...f, idx: i }; });
@@ -151,11 +154,44 @@ function renderOverview(vers, findings) {
   const enriched = (vers || []).map(v => {
     const f = findingMap[v.name];
     const cveTotal = f ? (f.cves||[]).length + (f.nonChromeCves||[]).length : 0;
-    return { ...v, f, cveTotal, findingIdx: f ? f.idx : -1 };
+    return { ...v, f, cveTotal, findingIdx: f ? f.idx : -1, isCg: false };
   });
 
-  // Split into groups: has CVEs vs no CVEs, each sorted by name
-  const withCves = enriched.filter(e => e.cveTotal > 0).sort((a,b) => a.name.localeCompare(b.name));
+  // Add CG components as rows (grouped by component)
+  if (cgAlerts && cgAlerts.alerts) {
+    const byComp = {};
+    cgAlerts.alerts.forEach(a => {
+      if (!byComp[a.component]) byComp[a.component] = { alerts: [], severity: 'Low' };
+      byComp[a.component].alerts.push(a);
+      const sevOrder = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+      if ((sevOrder[a.severity] || 9) < (sevOrder[byComp[a.component].severity] || 9)) {
+        byComp[a.component].severity = a.severity;
+      }
+    });
+    Object.entries(byComp).forEach(([comp, data]) => {
+      enriched.push({
+        name: comp,
+        source: 'CG (Build Pipeline)',
+        verifiedVersion: '',
+        cgmanifestVersion: '',
+        latestVersion: '',
+        match: true,
+        f: { status: data.severity === 'High' || data.severity === 'Critical' ? 'needs_attention' : 'in_progress' },
+        cveTotal: data.alerts.length,
+        findingIdx: -1,
+        isCg: true,
+        cgSeverity: data.severity
+      });
+    });
+  }
+
+  // Split into groups: has CVEs vs no CVEs, each sorted by severity then name
+  const sevOrder = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+  const withCves = enriched.filter(e => e.cveTotal > 0).sort((a,b) => {
+    const aSev = a.isCg ? (sevOrder[a.cgSeverity] || 9) : (a.f ? sevOrder[a.f.cves?.[0]?.severity] || 5 : 5);
+    const bSev = b.isCg ? (sevOrder[b.cgSeverity] || 9) : (b.f ? sevOrder[b.f.cves?.[0]?.severity] || 5 : 5);
+    return aSev !== bSev ? aSev - bSev : a.name.localeCompare(b.name);
+  });
   const noCves = enriched.filter(e => e.cveTotal === 0).sort((a,b) => a.name.localeCompare(b.name));
 
   let mismatches = 0;
@@ -163,7 +199,12 @@ function renderOverview(vers, findings) {
   function buildRow(v) {
     if (!v.match) mismatches++;
     const rowCls = v.match ? 'overview-row' : 'overview-row overview-mismatch';
-    const onclick = v.findingIdx >= 0 ? `onclick="document.getElementById('finding-${v.findingIdx}').scrollIntoView({behavior:'smooth',block:'start'}); var col=document.getElementById('finding-${v.findingIdx}'); if(!col.classList.contains('show')){col.previousElementSibling.click();}"` : '';
+    let onclick = '';
+    if (v.isCg) {
+      onclick = `onclick="document.getElementById('cg-section').scrollIntoView({behavior:'smooth',block:'start'})"`;
+    } else if (v.findingIdx >= 0) {
+      onclick = `onclick="document.getElementById('finding-${v.findingIdx}').scrollIntoView({behavior:'smooth',block:'start'}); var col=document.getElementById('finding-${v.findingIdx}'); if(!col.classList.contains('show')){col.previousElementSibling.click();}"`;
+    }
 
     let secBadge = '<span class="status-pill st-clean">✅ Clean</span>';
     let cveCount = '';
@@ -424,8 +465,8 @@ document.addEventListener('DOMContentLoaded', () => {
     `${d.meta.date} · Skia m${d.meta.skiaMilestone} · ${d.summary.totalCves} CVEs analyzed`;
   document.getElementById('header-badges').innerHTML =
     `<span class="badge bg-${d.summary.highestSeverity === 'CRITICAL' ? 'danger' : d.summary.highestSeverity === 'HIGH' ? 'warning' : 'info'}">${d.summary.highestSeverity}</span>`;
-  renderSummary(d.summary);
-  renderOverview(d.versionVerification, d.findings);
+  renderSummary(d.summary, d.cgAlerts);
+  renderOverview(d.versionVerification, d.findings, d.cgAlerts);
   const container = document.getElementById('findings-container');
   container.innerHTML = d.findings.map((f, i) => renderFinding(f, i)).join('');
   renderNextSteps(d.nextSteps);

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -89,20 +89,14 @@
       <span class="ms-auto" id="cg-badge"></span>
     </div>
     <div class="card-body">
-      <div class="alert alert-warning py-2 small mb-3">
-        <i class="bi bi-exclamation-triangle me-1"></i>
-        <strong>Build-chain vulnerabilities matter.</strong> A compromised build toolchain can inject malicious code into shipped artifacts even if the vulnerability isn't in shipped source.
-      </div>
       <div class="row g-3 mb-3" id="cg-severity-cards"></div>
+      <h6 class="mt-3"><i class="bi bi-list-ul me-1"></i>By Category</h6>
       <div id="cg-categories"></div>
-      <div id="cg-high-alerts" style="display:none;">
-        <h6 class="mt-3 text-danger"><i class="bi bi-exclamation-octagon me-1"></i>High Severity Alerts</h6>
-        <table class="table table-sm cve-table" id="cg-high-table">
-          <thead><tr><th>CVE/Advisory</th><th>Component</th><th>Category</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-      <div class="text-muted small mt-3" id="cg-note"></div>
+      <h6 class="mt-3"><i class="bi bi-exclamation-octagon me-1"></i>All Alerts</h6>
+      <table class="table table-sm cve-table" id="cg-all-table">
+        <thead><tr><th>CVE/Advisory</th><th>Severity</th><th>Component</th><th>Category</th><th>Pipelines</th><th>Branches</th></tr></thead>
+        <tbody></tbody>
+      </table>
       <div class="text-muted small" id="cg-pipelines"></div>
     </div>
   </div>
@@ -367,33 +361,28 @@ function renderCgAlerts(cg) {
   // Categories
   const catEl = document.getElementById('cg-categories');
   const cats = cg.categories || [];
-  catEl.innerHTML = `<table class="table table-sm cve-table mb-0">
-    <thead><tr><th>Source</th><th>Alerts</th><th>Severity</th><th>Fix</th><th>Affected Jobs</th></tr></thead>
+  catEl.innerHTML = `<table class="table table-sm cve-table mb-3">
+    <thead><tr><th>Source</th><th>Alerts</th><th>Severity</th><th>Affected Jobs</th></tr></thead>
     <tbody>${cats.map(c => `<tr>
       <td><strong>${esc(c.source)}</strong></td>
       <td><span class="badge bg-secondary">${c.alertCount}</span></td>
       <td class="${sevClass(c.severity)}">${esc(c.severity)}</td>
-      <td class="small">${esc(c.fix)}</td>
       <td class="small text-muted">${(c.affectedJobs||[]).join(', ')}</td>
     </tr>`).join('')}</tbody>
   </table>`;
 
-  // High alerts table
-  const highAlerts = cg.highAlerts || [];
-  if (highAlerts.length > 0) {
-    const highSection = document.getElementById('cg-high-alerts');
-    highSection.style.display = '';
-    const tbody = document.querySelector('#cg-high-table tbody');
-    tbody.innerHTML = highAlerts.map(a => `<tr>
-      <td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank" class="sev-high">${esc(a.id)}</a></td>
+  // ALL alerts table — no filtering, no editorial decisions
+  const allAlerts = cg.allAlerts || cg.highAlerts || [];
+  if (allAlerts.length > 0) {
+    const tbody = document.querySelector('#cg-all-table tbody');
+    tbody.innerHTML = allAlerts.map(a => `<tr>
+      <td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank" class="${sevClass(a.severity)}">${esc(a.id)}</a></td>
+      <td class="${sevClass(a.severity)}">${esc(a.severity)}</td>
       <td>${esc(a.component)}</td>
-      <td class="small text-muted">${esc(a.category)}</td>
+      <td class="small">${esc(a.category)}</td>
+      <td class="small text-muted">${(a.pipelines||[]).join(', ')}</td>
+      <td class="small text-muted">${(a.branches||[]).join(', ')}</td>
     </tr>`).join('');
-  }
-
-  // Note
-  if (cg.note) {
-    document.getElementById('cg-note').innerHTML = `<i class="bi bi-info-circle me-1"></i>${esc(cg.note)}`;
   }
 
   // Pipelines

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -86,13 +86,14 @@
   <div class="card mb-4" id="cg-section" style="display:none;">
     <div class="card-header bg-white d-flex align-items-center">
       <i class="bi bi-shield-exclamation me-2"></i><strong>Component Governance (Build Pipeline)</strong>
+      <a href="https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321?_a=alerts&typeId=29227950&alerts-view-option=active" target="_blank" class="ms-2 small">Open in AzDO</a>
       <span class="ms-auto" id="cg-badge"></span>
     </div>
     <div class="card-body">
       <div class="row g-3 mb-3" id="cg-severity-cards"></div>
       <h6 class="mt-3"><i class="bi bi-exclamation-octagon me-1"></i>All Alerts</h6>
       <table class="table table-sm cve-table" id="cg-all-table">
-        <thead><tr><th>CVE/Advisory</th><th>Severity</th><th>Component</th><th>Pipelines</th><th>Branches</th></tr></thead>
+        <thead><tr><th>CVE/Advisory</th><th>Severity</th><th>Component</th><th>Found At</th><th>Pipelines</th><th>Branches</th></tr></thead>
         <tbody></tbody>
       </table>
       <div class="text-muted small" id="cg-pipelines"></div>
@@ -364,6 +365,7 @@ function renderCgAlerts(cg) {
       <td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank" class="${sevClass(a.severity)}">${esc(a.id)}</a></td>
       <td class="${sevClass(a.severity)}">${esc(a.severity)}</td>
       <td>${esc(a.component)}</td>
+      <td class="small text-muted">${(a.paths||[]).map(p => `<code>${esc(p)}</code>`).join('<br>') || '—'}</td>
       <td class="small text-muted">${(a.pipelines||[]).join(', ')}</td>
       <td class="small text-muted">${(a.branches||[]).join(', ')}</td>
     </tr>`).join('');

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -15,6 +15,7 @@
     .card { border: 1px solid var(--border); box-shadow: 0 1px 2px rgba(16,24,40,0.04); }
     .status-pill { font-size: 0.75rem; font-weight: 600; padding: 2px 8px; border-radius: 12px; }
     .st-attention { background: #fee2e2; color: #991b1b; }
+    .st-cg-tracked { background: #ede9fe; color: #5b21b6; }
     .st-undiscovered { background: #dbeafe; color: #1e40af; }
     .st-false-positive { background: #f3f4f6; color: #6b7280; }
     .st-clean { background: #dcfce7; color: #166534; }
@@ -24,6 +25,7 @@
     .sev-high { color: #991b1b; font-weight: 600; }
     .sev-medium { color: #92400e; }
     .sev-low { color: #6b7280; }
+    .sev-unknown { color: #dc2626; font-style: italic; }
     .version-match { color: #166534; }
     .version-mismatch { color: #991b1b; font-weight: 700; }
     .finding-header { cursor: pointer; }
@@ -112,6 +114,7 @@
 <script>
 const STATUS_LABELS = {
   needs_attention: ['🔴 Needs Attention', 'st-attention'],
+  cg_tracked: ['🛡️ CG Tracked', 'st-cg-tracked'],
   undiscovered: ['🆕 Undiscovered', 'st-undiscovered'],
   false_positive: ['⚪ False Positive', 'st-false-positive'],
   clean: ['✅ Clean', 'st-clean'],
@@ -121,12 +124,12 @@ const STATUS_LABELS = {
 
 const SEV_CLASS = { CRITICAL: 'sev-critical', HIGH: 'sev-high', MEDIUM: 'sev-medium', LOW: 'sev-low' };
 
-function sevClass(s) { return SEV_CLASS[(s||'').toUpperCase()] || 'sev-low'; }
+function sevClass(s) { return SEV_CLASS[(s||'').toUpperCase()] || 'sev-unknown'; }
 function esc(s) { const d = document.createElement('div'); d.textContent = s||''; return d.innerHTML; }
 
 function renderSummary(s, cgAlerts) {
   const cgCount = cgAlerts ? (cgAlerts.totalAlerts || 0) : 0;
-  const cgHigh = cgAlerts ? ((cgAlerts.bySeverity || {}).High || 0) : 0;
+  const cgHigh = cgAlerts ? ((cgAlerts.bySeverity || {}).High || 0) + ((cgAlerts.bySeverity || {}).Critical || 0) : 0;
   const cards = [
     ['Needs Attention', s.needsAttention + cgHigh, 'danger', 'exclamation-triangle'],
     ['CG Alerts', cgCount, cgHigh > 0 ? 'danger' : 'warning', 'shield-exclamation'],
@@ -184,7 +187,7 @@ function renderOverview(vers, findings, cgAlerts) {
       const compName = verMatch ? verMatch[1] : comp;
       const compVersion = verMatch ? verMatch[2] : '';
       // Map CG severity to finding status — all CVEs need attention, severity determines urgency
-      const statusMap = { Critical: 'needs_attention', High: 'needs_attention', Medium: 'undiscovered', Low: 'undiscovered' };
+      const statusMap = { Critical: 'needs_attention', High: 'needs_attention', Medium: 'cg_tracked', Low: 'cg_tracked' };
       enriched.push({
         name: compName,
         source: 'CG (Build Pipeline)',
@@ -286,7 +289,8 @@ function renderCveTable(cves, columns) {
         return `<td class="${sevClass(cve.severity)}">${esc(String(val))}</td>`;
       }
       if (c.key === 'id') {
-        return `<td><a href="https://nvd.nist.gov/vuln/detail/${esc(val)}" target="_blank">${esc(val)}</a></td>`;
+        const url = val.startsWith('GHSA-') ? `https://github.com/advisories/${esc(val)}` : `https://nvd.nist.gov/vuln/detail/${esc(val)}`;
+        return `<td><a href="${url}" target="_blank">${esc(val)}</a></td>`;
       }
       return `<td>${esc(String(val))}</td>`;
     }).join('');
@@ -383,10 +387,17 @@ function renderNextSteps(steps) {
 
 function renderUpstream(meta) {
   const el = document.getElementById('upstream-info');
+  const milestoneNote = meta.upstreamVerified ? ' (verified from SkMilestone.h)' : ' <span class="text-danger">(NOT independently verified)</span>';
+  const forkCommit = meta.skiaSubmoduleCommit
+    ? `<code><a href="https://github.com/mono/skia/commit/${esc(meta.skiaSubmoduleCommit)}" target="_blank">${esc(meta.skiaSubmoduleCommit)}</a></code>`
+    : '<span class="text-muted">not captured</span>';
+  const upstreamCommit = meta.skiaUpstreamCommit
+    ? `<code><a href="https://github.com/google/skia/commit/${esc(meta.skiaUpstreamCommit)}" target="_blank">${esc(meta.skiaUpstreamCommit)}</a></code>`
+    : '<span class="text-muted">not captured</span>';
   el.innerHTML = `<table class="table table-sm meta-table mb-0"><tbody>
-    <tr><th>Milestone</th><td>m${meta.skiaMilestone} (verified from SkMilestone.h)</td></tr>
-    <tr><th>Fork Commit</th><td><code><a href="https://github.com/mono/skia/commit/${meta.skiaSubmoduleCommit}" target="_blank">${meta.skiaSubmoduleCommit}</a></code></td></tr>
-    <tr><th>Upstream Commit</th><td><code><a href="https://github.com/google/skia/commit/${meta.skiaUpstreamCommit}" target="_blank">${meta.skiaUpstreamCommit}</a></code></td></tr>
+    <tr><th>Milestone</th><td>m${esc(String(meta.skiaMilestone))}${milestoneNote}</td></tr>
+    <tr><th>Fork Commit</th><td>${forkCommit}</td></tr>
+    <tr><th>Upstream Commit</th><td>${upstreamCommit}</td></tr>
     <tr><th>Ancestry Verified</th><td>${meta.upstreamVerified ? '✅ Yes' : '❌ No'}</td></tr>
   </tbody></table>`;
 }
@@ -406,12 +417,13 @@ function renderCgAlerts(cg) {
   const sevCards = document.getElementById('cg-severity-cards');
   const sevData = cg.bySeverity || {};
   const sevEntries = [
+    ['Critical', sevData.Critical || 0, 'danger', 'shield-fill-exclamation'],
     ['High', sevData.High || 0, 'danger', 'exclamation-octagon'],
     ['Medium', sevData.Medium || 0, 'warning', 'exclamation-triangle'],
     ['Low', sevData.Low || 0, 'secondary', 'info-circle'],
   ];
-  sevCards.innerHTML = sevEntries.map(([label, count, color, icon]) => `
-    <div class="col-4">
+  sevCards.innerHTML = sevEntries.filter(([,count]) => count > 0).map(([label, count, color, icon]) => `
+    <div class="col-3">
       <div class="card text-center p-2">
         <div class="text-${color}"><i class="bi bi-${icon}"></i></div>
         <div class="fs-4 fw-bold">${count}</div>
@@ -446,9 +458,10 @@ function renderCgAlerts(cg) {
     container.innerHTML = groups.map((g, idx) => {
       const maxSev = g.alerts.reduce((best, a) => (sevOrder[a.severity] ?? 9) < (sevOrder[best] ?? 9) ? a.severity : best, 'Low');
       const collapseId = `cg-comp-${idx}`;
-      const cveRows = g.alerts.map(a =>
-        `<tr><td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank">${esc(a.id)}</a></td><td class="${sevClass(a.severity)}">${esc(a.severity)}</td></tr>`
-      ).join('');
+      const cveRows = g.alerts.map(a => {
+        const cveUrl = a.id.startsWith('GHSA-') ? `https://github.com/advisories/${esc(a.id)}` : `https://nvd.nist.gov/vuln/detail/${esc(a.id)}`;
+        return `<tr><td><a href="${cveUrl}" target="_blank">${esc(a.id)}</a></td><td class="${sevClass(a.severity)}">${esc(a.severity)}</td></tr>`;
+      }).join('');
       const pathList = [...g.paths].sort().map(p => `<code class="small d-block">${esc(p)}</code>`).join('');
       return `
         <div class="card mb-2">
@@ -486,8 +499,10 @@ function renderCgAlerts(cg) {
 document.addEventListener('DOMContentLoaded', () => {
   if (typeof DATA === 'undefined') { document.body.innerHTML = '<p class="p-4 text-danger">No DATA found. JSON not injected.</p>'; return; }
   const d = DATA;
-  document.getElementById('header-subtitle').textContent =
-    `${d.meta.date} · Skia m${d.meta.skiaMilestone} · ${d.summary.totalCves} CVEs analyzed`;
+  const cgTotal = d.cgAlerts ? (d.cgAlerts.totalAlerts || 0) : 0;
+  const subtitleParts = [`${d.meta.date}`, `Skia m${d.meta.skiaMilestone}`, `${d.summary.totalCves} CVEs`];
+  if (cgTotal > 0) subtitleParts.push(`${cgTotal} CG alerts`);
+  document.getElementById('header-subtitle').textContent = subtitleParts.join(' · ');
   document.getElementById('header-badges').innerHTML =
     `<span class="badge bg-${d.summary.highestSeverity === 'CRITICAL' ? 'danger' : d.summary.highestSeverity === 'HIGH' ? 'warning' : 'info'}">${d.summary.highestSeverity}</span>`;
   renderSummary(d.summary, d.cgAlerts);

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -353,60 +353,8 @@ function renderCgAlerts(cg) {
       </div>
     </div>`).join('');
 
-  // Normalize alerts from different schema versions:
-  // v1: cg.alerts = [{id, component, severity, paths, pipelines, branches}] (from query-cg-alerts.py)
-  // v1b: cg.allAlerts = same as above (legacy key name)
-  // v2: cg.uniqueCVEs = [{id, component, severity, source}] + cg.categories = [{source, components, ...}]
-  // v3: cg.categories = [{source, topComponents: [{component, cveCount}]}] (summarized, no individual alerts)
-  let allAlerts = cg.alerts || cg.allAlerts || [];
-  if (allAlerts.length === 0 && cg.uniqueCVEs) {
-    // Build allAlerts from uniqueCVEs + categories
-    allAlerts = cg.uniqueCVEs.map(cve => ({
-      id: cve.id,
-      component: cve.component + (cve.version ? ' ' + cve.version : ''),
-      severity: cve.severity,
-      paths: cve.paths || [],
-      pipelines: cve.pipelines || [],
-      branches: cve.branches || cg.branches || [],
-      source: cve.source || ''
-    }));
-  }
-  if (allAlerts.length === 0 && cg.categories) {
-    // Fallback: synthesize from categories if no flat list exists
-    cg.categories.forEach(cat => {
-      const comps = cat.components || cat.topComponents || [];
-      comps.forEach(comp => {
-        const compName = comp.component || `${comp.name || ''} ${comp.version || ''}`.trim();
-        const cveCount = comp.cveCount || 1;
-        const cves = comp.cves || [];
-        if (cves.length > 0) {
-          cves.forEach(cve => {
-            allAlerts.push({
-              id: cve.id || cve,
-              component: compName,
-              severity: cve.severity || cat.severity || 'Medium',
-              paths: comp.paths || [],
-              pipelines: cat.affectedJobs || [],
-              branches: cg.branches || [],
-              source: cat.source || ''
-            });
-          });
-        } else {
-          for (let i = 0; i < cveCount; i++) {
-            allAlerts.push({
-              id: `${compName} (${i+1}/${cveCount})`,
-              component: compName,
-              severity: cat.severity || 'Medium',
-              paths: comp.paths || [],
-              pipelines: cat.affectedJobs || [],
-              branches: cg.branches || [],
-              source: cat.source || ''
-            });
-          }
-        }
-      });
-    });
-  }
+  // cg.alerts = [{id, component, severity, paths, pipelines, branches, sources}]
+  const allAlerts = cg.alerts || [];
 
   // Group alerts by component, render as collapsible cards
   if (allAlerts.length > 0) {

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -71,7 +71,7 @@
       <table class="table table-sm table-hover mb-0 meta-table" id="overview-table">
         <thead><tr>
           <th>Dependency</th><th>Source</th><th>Current Version</th>
-          <th>Latest</th><th>Security</th><th>CVEs</th>
+          <th>Latest</th><th>Severity</th><th>Status</th><th>CVEs</th>
         </tr></thead>
         <tbody></tbody>
       </table>
@@ -154,7 +154,16 @@ function renderOverview(vers, findings, cgAlerts) {
   const enriched = (vers || []).map(v => {
     const f = findingMap[v.name];
     const cveTotal = f ? (f.cves||[]).length + (f.nonChromeCves||[]).length : 0;
-    return { ...v, f, cveTotal, findingIdx: f ? f.idx : -1, isCg: false };
+    // Derive highest severity from CVEs
+    let maxSev = '';
+    if (f) {
+      const allCves = [...(f.cves||[]), ...(f.nonChromeCves||[])];
+      const sevOrd = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+      allCves.forEach(c => {
+        if (!maxSev || (sevOrd[c.severity] ?? 9) < (sevOrd[maxSev] ?? 9)) maxSev = c.severity;
+      });
+    }
+    return { ...v, f, cveTotal, findingIdx: f ? f.idx : -1, isCg: false, cgSeverity: maxSev };
   });
 
   // Add CG components as rows (grouped by component)
@@ -215,6 +224,10 @@ function renderOverview(vers, findings, cgAlerts) {
     let secBadge = '<span class="status-pill st-clean">✅ Clean</span>';
     let cveCount = '';
     let latest = v.latestVersion || '';
+    let sevBadge = '<span class="text-muted">—</span>';
+    if (v.cgSeverity) {
+      sevBadge = `<span class="${sevClass(v.cgSeverity)}">${esc(v.cgSeverity)}</span>`;
+    }
     if (v.f) {
       const [label, cls] = STATUS_LABELS[v.f.status] || ['?', ''];
       secBadge = `<span class="status-pill ${cls}">${label}</span>`;
@@ -231,13 +244,14 @@ function renderOverview(vers, findings, cgAlerts) {
       <td class="text-muted small">${esc(v.source || 'Skia DEPS')}</td>
       <td>${versionDisplay}</td>
       <td>${latest ? esc(latest) : '<span class="text-muted">—</span>'}</td>
+      <td>${sevBadge}</td>
       <td>${secBadge}</td>
       <td>${cveCount}</td>
     </tr>`;
   }
 
   function groupHeader(label, count) {
-    return `<tr class="table-light"><td colspan="6" class="fw-bold small text-muted py-1 px-2"><i class="bi bi-${count > 0 ? 'exclamation-triangle text-danger' : 'check-circle text-success'} me-1"></i>${label} (${count})</td></tr>`;
+    return `<tr class="table-light"><td colspan="7" class="fw-bold small text-muted py-1 px-2"><i class="bi bi-${count > 0 ? 'exclamation-triangle text-danger' : 'check-circle text-success'} me-1"></i>${label} (${count})</td></tr>`;
   }
 
   let html = '';

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -82,6 +82,31 @@
   <h5 class="mb-3"><i class="bi bi-exclamation-triangle me-2"></i>Findings</h5>
   <div id="findings-container"></div>
 
+  <!-- Component Governance Alerts -->
+  <div class="card mb-4" id="cg-section" style="display:none;">
+    <div class="card-header bg-white d-flex align-items-center">
+      <i class="bi bi-shield-exclamation me-2"></i><strong>Component Governance (Build Pipeline)</strong>
+      <span class="ms-auto" id="cg-badge"></span>
+    </div>
+    <div class="card-body">
+      <div class="alert alert-warning py-2 small mb-3">
+        <i class="bi bi-exclamation-triangle me-1"></i>
+        <strong>Build-chain vulnerabilities matter.</strong> A compromised build toolchain can inject malicious code into shipped artifacts even if the vulnerability isn't in shipped source.
+      </div>
+      <div class="row g-3 mb-3" id="cg-severity-cards"></div>
+      <div id="cg-categories"></div>
+      <div id="cg-high-alerts" style="display:none;">
+        <h6 class="mt-3 text-danger"><i class="bi bi-exclamation-octagon me-1"></i>High Severity Alerts</h6>
+        <table class="table table-sm cve-table" id="cg-high-table">
+          <thead><tr><th>CVE/Advisory</th><th>Component</th><th>Category</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div class="text-muted small mt-3" id="cg-note"></div>
+      <div class="text-muted small" id="cg-pipelines"></div>
+    </div>
+  </div>
+
   <!-- Next Steps -->
   <div class="card mb-4">
     <div class="card-header bg-white"><i class="bi bi-list-check me-2"></i><strong>Next Steps</strong></div>
@@ -227,8 +252,18 @@ function renderFinding(f, idx) {
   if (f.currentVersion) body += `<tr><th>Current</th><td>${esc(f.currentVersion)}</td></tr>`;
   if (f.fixVersion) body += `<tr><th>Min Fix</th><td>${esc(f.fixVersion)}</td></tr>`;
   if (f.latestVersion) body += `<tr><th>Latest</th><td>${esc(f.latestVersion)}</td></tr>`;
-  if (f.issues && f.issues.length) body += `<tr><th>Issues</th><td>${f.issues.map(i => `<a href="https://github.com/mono/SkiaSharp/issues/${i}" target="_blank">#${i}</a>`).join(', ')}</td></tr>`;
-  if (f.prs && f.prs.length) body += `<tr><th>PRs</th><td>${f.prs.map(p => `<a href="https://github.com/mono/SkiaSharp/pull/${p}" target="_blank">#${p}</a>`).join(', ')}</td></tr>`;
+  if (f.issues && f.issues.length) body += `<tr><th>Issues</th><td>${f.issues.map(i => {
+      const num = typeof i === 'object' ? i.number : i;
+      const repo = (typeof i === 'object' && i.repo) ? i.repo : 'mono/SkiaSharp';
+      const state = (typeof i === 'object' && i.state) ? ` (${i.state.toLowerCase()})` : '';
+      return `<a href="https://github.com/${repo}/issues/${num}" target="_blank">#${num}</a>${state}`;
+    }).join(', ')}</td></tr>`;
+  if (f.prs && f.prs.length) body += `<tr><th>PRs</th><td>${f.prs.map(p => {
+      const num = typeof p === 'object' ? p.number : p;
+      const repo = (typeof p === 'object' && p.repo) ? p.repo : 'mono/SkiaSharp';
+      const title = (typeof p === 'object' && p.title) ? ` &mdash; ${esc(p.title)}` : '';
+      return `<a href="https://github.com/${repo}/pull/${num}" target="_blank">#${num}</a>${title}`;
+    }).join('<br>')}</td></tr>`;
   body += `</tbody></table>`;
 
   // Chrome CVEs
@@ -301,6 +336,75 @@ function renderUpstream(meta) {
   </tbody></table>`;
 }
 
+function renderCgAlerts(cg) {
+  if (!cg || !cg.totalAlerts) return;
+  const section = document.getElementById('cg-section');
+  section.style.display = '';
+
+  // Badge
+  const badge = document.getElementById('cg-badge');
+  const highCount = (cg.bySeverity || {}).High || 0;
+  const totalCount = cg.totalAlerts || 0;
+  badge.innerHTML = `<span class="badge bg-${highCount > 0 ? 'danger' : 'warning'}">${totalCount} alerts</span>`;
+
+  // Severity cards
+  const sevCards = document.getElementById('cg-severity-cards');
+  const sevData = cg.bySeverity || {};
+  const sevEntries = [
+    ['High', sevData.High || 0, 'danger', 'exclamation-octagon'],
+    ['Medium', sevData.Medium || 0, 'warning', 'exclamation-triangle'],
+    ['Low', sevData.Low || 0, 'secondary', 'info-circle'],
+  ];
+  sevCards.innerHTML = sevEntries.map(([label, count, color, icon]) => `
+    <div class="col-4">
+      <div class="card text-center p-2">
+        <div class="text-${color}"><i class="bi bi-${icon}"></i></div>
+        <div class="fs-4 fw-bold">${count}</div>
+        <div class="text-muted small">${label}</div>
+      </div>
+    </div>`).join('');
+
+  // Categories
+  const catEl = document.getElementById('cg-categories');
+  const cats = cg.categories || [];
+  catEl.innerHTML = `<table class="table table-sm cve-table mb-0">
+    <thead><tr><th>Source</th><th>Alerts</th><th>Severity</th><th>Fix</th><th>Affected Jobs</th></tr></thead>
+    <tbody>${cats.map(c => `<tr>
+      <td><strong>${esc(c.source)}</strong></td>
+      <td><span class="badge bg-secondary">${c.alertCount}</span></td>
+      <td class="${sevClass(c.severity)}">${esc(c.severity)}</td>
+      <td class="small">${esc(c.fix)}</td>
+      <td class="small text-muted">${(c.affectedJobs||[]).join(', ')}</td>
+    </tr>`).join('')}</tbody>
+  </table>`;
+
+  // High alerts table
+  const highAlerts = cg.highAlerts || [];
+  if (highAlerts.length > 0) {
+    const highSection = document.getElementById('cg-high-alerts');
+    highSection.style.display = '';
+    const tbody = document.querySelector('#cg-high-table tbody');
+    tbody.innerHTML = highAlerts.map(a => `<tr>
+      <td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank" class="sev-high">${esc(a.id)}</a></td>
+      <td>${esc(a.component)}</td>
+      <td class="small text-muted">${esc(a.category)}</td>
+    </tr>`).join('');
+  }
+
+  // Note
+  if (cg.note) {
+    document.getElementById('cg-note').innerHTML = `<i class="bi bi-info-circle me-1"></i>${esc(cg.note)}`;
+  }
+
+  // Pipelines
+  const pipes = cg.pipelines || [];
+  if (pipes.length > 0) {
+    document.getElementById('cg-pipelines').innerHTML = `<i class="bi bi-gear me-1"></i>Scanned: ${pipes.map(p =>
+      `<a href="https://dev.azure.com/devdiv/DevDiv/_build?definitionId=${p.id}" target="_blank">${esc(p.name)}</a>`
+    ).join(', ')}`;
+  }
+}
+
 // Boot
 document.addEventListener('DOMContentLoaded', () => {
   if (typeof DATA === 'undefined') { document.body.innerHTML = '<p class="p-4 text-danger">No DATA found. JSON not injected.</p>'; return; }
@@ -314,6 +418,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('findings-container');
   container.innerHTML = d.findings.map((f, i) => renderFinding(f, i)).join('');
   renderNextSteps(d.nextSteps);
+  if (d.cgAlerts) renderCgAlerts(d.cgAlerts);
   renderUpstream(d.meta);
 });
 </script>

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -173,8 +173,8 @@ function renderOverview(vers, findings, cgAlerts) {
       const verMatch = comp.match(/^(.+?)\s+([\d][\w.\-+:~]*)$/);
       const compName = verMatch ? verMatch[1] : comp;
       const compVersion = verMatch ? verMatch[2] : '';
-      // Map CG severity to finding status
-      const statusMap = { Critical: 'needs_attention', High: 'needs_attention', Medium: 'undiscovered', Low: 'clean' };
+      // Map CG severity to finding status — all CVEs need attention, severity determines urgency
+      const statusMap = { Critical: 'needs_attention', High: 'needs_attention', Medium: 'undiscovered', Low: 'undiscovered' };
       enriched.push({
         name: compName,
         source: 'CG (Build Pipeline)',

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -169,10 +169,14 @@ function renderOverview(vers, findings, cgAlerts) {
       }
     });
     Object.entries(byComp).forEach(([comp, data]) => {
+      // Split "minimatch 3.1.2" or "Debian:12:binutils 2.39-r2" into name + version
+      const verMatch = comp.match(/^(.+?)\s+([\d][\w.\-+:~]*)$/);
+      const compName = verMatch ? verMatch[1] : comp;
+      const compVersion = verMatch ? verMatch[2] : '';
       enriched.push({
-        name: comp,
+        name: compName,
         source: 'CG (Build Pipeline)',
-        verifiedVersion: '',
+        verifiedVersion: compVersion,
         cgmanifestVersion: '',
         latestVersion: '',
         match: true,

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -353,8 +353,42 @@ function renderCgAlerts(cg) {
       </div>
     </div>`).join('');
 
+  // Normalize alerts from different schema versions:
+  // v1: cg.allAlerts = [{id, component, severity, paths, pipelines, branches}]
+  // v2: cg.uniqueCVEs = [{id, component, severity, source}] + cg.categories = [{source, components, ...}]
+  let allAlerts = cg.allAlerts || [];
+  if (allAlerts.length === 0 && cg.uniqueCVEs) {
+    // Build allAlerts from uniqueCVEs + categories
+    allAlerts = cg.uniqueCVEs.map(cve => ({
+      id: cve.id,
+      component: cve.component + (cve.version ? ' ' + cve.version : ''),
+      severity: cve.severity,
+      paths: cve.paths || [],
+      pipelines: cve.pipelines || [],
+      branches: cve.branches || cg.branches || [],
+      source: cve.source || ''
+    }));
+  }
+  if (allAlerts.length === 0 && cg.categories) {
+    // Fallback: synthesize from categories if no flat list exists
+    cg.categories.forEach(cat => {
+      (cat.components || []).forEach(comp => {
+        for (let i = 0; i < (comp.cveCount || 1); i++) {
+          allAlerts.push({
+            id: `${comp.name}@${comp.version} (${i+1}/${comp.cveCount || 1})`,
+            component: `${comp.name} ${comp.version || ''}`.trim(),
+            severity: cat.severity || 'Medium',
+            paths: [],
+            pipelines: [],
+            branches: cg.branches || [],
+            source: cat.source || ''
+          });
+        }
+      });
+    });
+  }
+
   // Group alerts by component, render as collapsible cards
-  const allAlerts = cg.allAlerts || [];
   if (allAlerts.length > 0) {
     const byComp = {};
     allAlerts.forEach(a => {

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -90,11 +90,9 @@
     </div>
     <div class="card-body">
       <div class="row g-3 mb-3" id="cg-severity-cards"></div>
-      <h6 class="mt-3"><i class="bi bi-list-ul me-1"></i>By Category</h6>
-      <div id="cg-categories"></div>
       <h6 class="mt-3"><i class="bi bi-exclamation-octagon me-1"></i>All Alerts</h6>
       <table class="table table-sm cve-table" id="cg-all-table">
-        <thead><tr><th>CVE/Advisory</th><th>Severity</th><th>Component</th><th>Category</th><th>Pipelines</th><th>Branches</th></tr></thead>
+        <thead><tr><th>CVE/Advisory</th><th>Severity</th><th>Component</th><th>Pipelines</th><th>Branches</th></tr></thead>
         <tbody></tbody>
       </table>
       <div class="text-muted small" id="cg-pipelines"></div>
@@ -358,19 +356,6 @@ function renderCgAlerts(cg) {
       </div>
     </div>`).join('');
 
-  // Categories
-  const catEl = document.getElementById('cg-categories');
-  const cats = cg.categories || [];
-  catEl.innerHTML = `<table class="table table-sm cve-table mb-3">
-    <thead><tr><th>Source</th><th>Alerts</th><th>Severity</th><th>Affected Jobs</th></tr></thead>
-    <tbody>${cats.map(c => `<tr>
-      <td><strong>${esc(c.source)}</strong></td>
-      <td><span class="badge bg-secondary">${c.alertCount}</span></td>
-      <td class="${sevClass(c.severity)}">${esc(c.severity)}</td>
-      <td class="small text-muted">${(c.affectedJobs||[]).join(', ')}</td>
-    </tr>`).join('')}</tbody>
-  </table>`;
-
   // ALL alerts table — no filtering, no editorial decisions
   const allAlerts = cg.allAlerts || cg.highAlerts || [];
   if (allAlerts.length > 0) {
@@ -379,7 +364,6 @@ function renderCgAlerts(cg) {
       <td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank" class="${sevClass(a.severity)}">${esc(a.id)}</a></td>
       <td class="${sevClass(a.severity)}">${esc(a.severity)}</td>
       <td>${esc(a.component)}</td>
-      <td class="small">${esc(a.category)}</td>
       <td class="small text-muted">${(a.pipelines||[]).join(', ')}</td>
       <td class="small text-muted">${(a.branches||[]).join(', ')}</td>
     </tr>`).join('');

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -91,12 +91,8 @@
     </div>
     <div class="card-body">
       <div class="row g-3 mb-3" id="cg-severity-cards"></div>
-      <h6 class="mt-3"><i class="bi bi-exclamation-octagon me-1"></i>All Alerts</h6>
-      <table class="table table-sm cve-table" id="cg-all-table">
-        <thead><tr><th>CVE/Advisory</th><th>Severity</th><th>Component</th><th>Found At</th><th>Pipelines</th><th>Branches</th></tr></thead>
-        <tbody></tbody>
-      </table>
-      <div class="text-muted small" id="cg-pipelines"></div>
+      <div id="cg-components"></div>
+      <div class="text-muted small mt-3" id="cg-pipelines"></div>
     </div>
   </div>
 
@@ -357,18 +353,56 @@ function renderCgAlerts(cg) {
       </div>
     </div>`).join('');
 
-  // ALL alerts table — no filtering, no editorial decisions
-  const allAlerts = cg.allAlerts || cg.highAlerts || [];
+  // Group alerts by component, render as collapsible cards
+  const allAlerts = cg.allAlerts || [];
   if (allAlerts.length > 0) {
-    const tbody = document.querySelector('#cg-all-table tbody');
-    tbody.innerHTML = allAlerts.map(a => `<tr>
-      <td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank" class="${sevClass(a.severity)}">${esc(a.id)}</a></td>
-      <td class="${sevClass(a.severity)}">${esc(a.severity)}</td>
-      <td>${esc(a.component)}</td>
-      <td class="small text-muted">${(a.paths||[]).map(p => `<code>${esc(p)}</code>`).join('<br>') || '—'}</td>
-      <td class="small text-muted">${(a.pipelines||[]).join(', ')}</td>
-      <td class="small text-muted">${(a.branches||[]).join(', ')}</td>
-    </tr>`).join('');
+    const byComp = {};
+    allAlerts.forEach(a => {
+      const key = a.component;
+      if (!byComp[key]) byComp[key] = { component: key, alerts: [], paths: new Set(), pipelines: new Set(), branches: new Set() };
+      byComp[key].alerts.push(a);
+      (a.paths || []).forEach(p => byComp[key].paths.add(p));
+      (a.pipelines || []).forEach(p => byComp[key].pipelines.add(p));
+      (a.branches || []).forEach(b => byComp[key].branches.add(b));
+    });
+
+    // Sort: highest severity first, then by alert count desc
+    const sevOrder = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+    const groups = Object.values(byComp).sort((a, b) => {
+      const aMax = Math.min(...a.alerts.map(x => sevOrder[x.severity] ?? 9));
+      const bMax = Math.min(...b.alerts.map(x => sevOrder[x.severity] ?? 9));
+      return aMax !== bMax ? aMax - bMax : b.alerts.length - a.alerts.length;
+    });
+
+    const container = document.getElementById('cg-components');
+    container.innerHTML = groups.map((g, idx) => {
+      const maxSev = g.alerts.reduce((best, a) => (sevOrder[a.severity] ?? 9) < (sevOrder[best] ?? 9) ? a.severity : best, 'Low');
+      const collapseId = `cg-comp-${idx}`;
+      const cveRows = g.alerts.map(a =>
+        `<tr><td><a href="https://nvd.nist.gov/vuln/detail/${esc(a.id)}" target="_blank">${esc(a.id)}</a></td><td class="${sevClass(a.severity)}">${esc(a.severity)}</td></tr>`
+      ).join('');
+      const pathList = [...g.paths].sort().map(p => `<code class="small d-block">${esc(p)}</code>`).join('');
+      return `
+        <div class="card mb-2">
+          <div class="card-header bg-white finding-header d-flex align-items-center py-2" data-bs-toggle="collapse" data-bs-target="#${collapseId}">
+            <span class="status-pill ${sevClass(maxSev)} me-2" style="font-size:0.7rem;padding:1px 6px;">${esc(maxSev)}</span>
+            <strong class="me-2">${esc(g.component)}</strong>
+            <span class="badge bg-secondary me-2">${g.alerts.length} CVE${g.alerts.length > 1 ? 's' : ''}</span>
+            <span class="text-muted small me-auto">${[...g.branches].join(', ')}</span>
+            <i class="bi bi-chevron-down ms-2"></i>
+          </div>
+          <div class="collapse" id="${collapseId}">
+            <div class="card-body py-2">
+              ${pathList ? `<div class="mb-2"><strong class="small">Found at:</strong><br>${pathList}</div>` : ''}
+              <table class="table table-sm cve-table mb-2">
+                <thead><tr><th>CVE/Advisory</th><th>Severity</th></tr></thead>
+                <tbody>${cveRows}</tbody>
+              </table>
+              <div class="text-muted small">Pipelines: ${[...g.pipelines].join(', ')}</div>
+            </div>
+          </div>
+        </div>`;
+    }).join('');
   }
 
   // Pipelines

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -173,6 +173,8 @@ function renderOverview(vers, findings, cgAlerts) {
       const verMatch = comp.match(/^(.+?)\s+([\d][\w.\-+:~]*)$/);
       const compName = verMatch ? verMatch[1] : comp;
       const compVersion = verMatch ? verMatch[2] : '';
+      // Map CG severity to finding status
+      const statusMap = { Critical: 'needs_attention', High: 'needs_attention', Medium: 'undiscovered', Low: 'clean' };
       enriched.push({
         name: compName,
         source: 'CG (Build Pipeline)',
@@ -180,7 +182,7 @@ function renderOverview(vers, findings, cgAlerts) {
         cgmanifestVersion: '',
         latestVersion: '',
         match: true,
-        f: { status: data.severity === 'High' || data.severity === 'Critical' ? 'needs_attention' : 'in_progress' },
+        f: { status: statusMap[data.severity] || 'undiscovered' },
         cveTotal: data.alerts.length,
         findingIdx: -1,
         isCg: true,
@@ -189,8 +191,13 @@ function renderOverview(vers, findings, cgAlerts) {
     });
   }
 
-  // Split into groups: has CVEs vs no CVEs, sorted by name within each group
-  const withCves = enriched.filter(e => e.cveTotal > 0).sort((a,b) => a.name.localeCompare(b.name));
+  // Split into groups: has CVEs vs no CVEs, sorted by severity then name
+  const sevOrder = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+  const withCves = enriched.filter(e => e.cveTotal > 0).sort((a,b) => {
+    const aSev = sevOrder[a.cgSeverity] ?? (a.f?.status === 'needs_attention' ? 1 : a.f?.status === 'undiscovered' ? 2 : 3);
+    const bSev = sevOrder[b.cgSeverity] ?? (b.f?.status === 'needs_attention' ? 1 : b.f?.status === 'undiscovered' ? 2 : 3);
+    return aSev !== bSev ? aSev - bSev : a.name.localeCompare(b.name);
+  });
   const noCves = enriched.filter(e => e.cveTotal === 0).sort((a,b) => a.name.localeCompare(b.name));
 
   let mismatches = 0;

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -354,9 +354,11 @@ function renderCgAlerts(cg) {
     </div>`).join('');
 
   // Normalize alerts from different schema versions:
-  // v1: cg.allAlerts = [{id, component, severity, paths, pipelines, branches}]
+  // v1: cg.alerts = [{id, component, severity, paths, pipelines, branches}] (from query-cg-alerts.py)
+  // v1b: cg.allAlerts = same as above (legacy key name)
   // v2: cg.uniqueCVEs = [{id, component, severity, source}] + cg.categories = [{source, components, ...}]
-  let allAlerts = cg.allAlerts || [];
+  // v3: cg.categories = [{source, topComponents: [{component, cveCount}]}] (summarized, no individual alerts)
+  let allAlerts = cg.alerts || cg.allAlerts || [];
   if (allAlerts.length === 0 && cg.uniqueCVEs) {
     // Build allAlerts from uniqueCVEs + categories
     allAlerts = cg.uniqueCVEs.map(cve => ({
@@ -372,17 +374,35 @@ function renderCgAlerts(cg) {
   if (allAlerts.length === 0 && cg.categories) {
     // Fallback: synthesize from categories if no flat list exists
     cg.categories.forEach(cat => {
-      (cat.components || []).forEach(comp => {
-        for (let i = 0; i < (comp.cveCount || 1); i++) {
-          allAlerts.push({
-            id: `${comp.name}@${comp.version} (${i+1}/${comp.cveCount || 1})`,
-            component: `${comp.name} ${comp.version || ''}`.trim(),
-            severity: cat.severity || 'Medium',
-            paths: [],
-            pipelines: [],
-            branches: cg.branches || [],
-            source: cat.source || ''
+      const comps = cat.components || cat.topComponents || [];
+      comps.forEach(comp => {
+        const compName = comp.component || `${comp.name || ''} ${comp.version || ''}`.trim();
+        const cveCount = comp.cveCount || 1;
+        const cves = comp.cves || [];
+        if (cves.length > 0) {
+          cves.forEach(cve => {
+            allAlerts.push({
+              id: cve.id || cve,
+              component: compName,
+              severity: cve.severity || cat.severity || 'Medium',
+              paths: comp.paths || [],
+              pipelines: cat.affectedJobs || [],
+              branches: cg.branches || [],
+              source: cat.source || ''
+            });
           });
+        } else {
+          for (let i = 0; i < cveCount; i++) {
+            allAlerts.push({
+              id: `${compName} (${i+1}/${cveCount})`,
+              component: compName,
+              severity: cat.severity || 'Medium',
+              paths: comp.paths || [],
+              pipelines: cat.affectedJobs || [],
+              branches: cg.branches || [],
+              source: cat.source || ''
+            });
+          }
         }
       });
     });

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -160,7 +160,8 @@ function renderOverview(vers, findings, cgAlerts) {
       const allCves = [...(f.cves||[]), ...(f.nonChromeCves||[])];
       const sevOrd = { Critical: 0, High: 1, Medium: 2, Low: 3 };
       allCves.forEach(c => {
-        if (!maxSev || (sevOrd[c.severity] ?? 9) < (sevOrd[maxSev] ?? 9)) maxSev = c.severity;
+        const norm = (c.severity||'').charAt(0).toUpperCase() + (c.severity||'').slice(1).toLowerCase();
+        if (!maxSev || (sevOrd[norm] ?? 9) < (sevOrd[maxSev] ?? 9)) maxSev = norm;
       });
     }
     return { ...v, f, cveTotal, findingIdx: f ? f.idx : -1, isCg: false, cgSeverity: maxSev };
@@ -226,7 +227,8 @@ function renderOverview(vers, findings, cgAlerts) {
     let latest = v.latestVersion || '';
     let sevBadge = '<span class="text-muted">—</span>';
     if (v.cgSeverity) {
-      sevBadge = `<span class="${sevClass(v.cgSeverity)}">${esc(v.cgSeverity)}</span>`;
+      const normSev = v.cgSeverity.charAt(0).toUpperCase() + v.cgSeverity.slice(1).toLowerCase();
+      sevBadge = `<span class="${sevClass(v.cgSeverity)}">${esc(normSev)}</span>`;
     }
     if (v.f) {
       const [label, cls] = STATUS_LABELS[v.f.status] || ['?', ''];

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -409,7 +409,7 @@ function renderCgAlerts(cg) {
 
   // Badge
   const badge = document.getElementById('cg-badge');
-  const highCount = (cg.bySeverity || {}).High || 0;
+  const highCount = ((cg.bySeverity || {}).High || 0) + ((cg.bySeverity || {}).Critical || 0);
   const totalCount = cg.totalAlerts || 0;
   badge.innerHTML = `<span class="badge bg-${highCount > 0 ? 'danger' : 'warning'}">${totalCount} alerts</span>`;
 


### PR DESCRIPTION
## Summary

Adds Component Governance (CG) alert querying to the security-audit skill and significantly improves the HTML viewer for presenting security findings.

## Key Changes

### CG Alert Integration
- **New script**: `query-cg-alerts.py` queries AzDO build logs for CG alerts from both SkiaSharp-Native and SkiaSharp pipelines
- CG alerts are elevated to the same importance level as other security findings (not dismissed as build-time only)
- Alerts grouped by component with collapsible detail cards showing CVE IDs and severity

### Viewer Improvements
- **5 summary cards** (was 4): Needs Attention, CG Alerts, Undiscovered, False Positive, Clean
- **New Severity column** in dependency overview table showing highest CVE severity per dep
- **CG components in main table** alongside regular deps, clickable to scroll to CG section
- **Version extraction** from CG component strings (e.g. "minimatch 3.1.2" → name + version)
- **Correct status mapping**: all CVEs = not clean (Low severity → Undiscovered, not Clean)
- **Normalized severity casing** (HIGH → High) for consistent display
- **Sort by severity** first, then alphabetical

### Skill Workflow
- SKILL.md updated: CG cache-to-file instructions (prevents re-running 3-min query)
- JSON Schema requires raw `alerts[]` array (no categories/summaries)
- Validation script checks schema + semantic consistency
- `queriedAt` ISO timestamp for freshness tracking
- Explicit "DO NOT editorialize" instructions to prevent AI from dismissing CG findings

### Schema
- Single format: `cgAlerts.alerts[]` required, `additionalProperties: false`
- No legacy format support — each run produces fresh data