### PR TITLE
Fix release notes workflow to always checkout main

### DIFF
--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -59,6 +59,17 @@ fi
 
 ## Step 2 — Generate release notes using the skill
 
+**Important:** The script uses `origin/` remote refs for all git history queries.
+Always run from a `main` checkout to avoid leaking release-branch-specific files
+(like `PREVIEW_LABEL`) into the PR targeting main.
+
+Ensure the working tree is on `main` and all remote refs are fetched:
+
+```bash
+git checkout main
+git fetch origin --quiet
+```
+
 Use the **release-notes** skill (`.agents/skills/release-notes/SKILL.md`) to generate
 polished release notes for the branch determined above. Pass the branch name to the skill.
 
@@ -67,8 +78,14 @@ polished file, and regenerating the TOC.
 
 ## Step 3 — Create or update the pull request
 
-Always use `dev/release-notes-{VERSION}` as the branch name when creating the pull request.
-This ensures each workflow run updates the **same PR** for a given version instead of
-opening duplicates.
+Use a branch name that includes both the version and the release status to avoid collisions
+between release-branch triggers and main-branch triggers:
+
+- For versioned release branches (e.g. `release/4.147.0-preview.3`): use `dev/release-notes-{VERSION}-released`
+- For `main` (unreleased content): use `dev/release-notes-{VERSION}-unreleased`
+
+This ensures each workflow run updates the **same PR** for a given version and status
+instead of opening duplicates, and prevents a main push from force-pushing over a
+release-branch PR (or vice versa).
 
 The PR targets `main` — release notes always live on main for the docs site.

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -63,11 +63,11 @@ fi
 Always run from a `main` checkout to avoid leaking release-branch-specific files
 (like `PREVIEW_LABEL`) into the PR targeting main.
 
-Ensure the working tree is on `main` and all remote refs are fetched:
+Ensure all remote refs are fetched and the working tree is on `main`:
 
 ```bash
-git checkout main
-git fetch origin --quiet
+git fetch origin main --quiet
+git checkout -B main origin/main
 ```
 
 Use the **release-notes** skill (`.agents/skills/release-notes/SKILL.md`) to generate


### PR DESCRIPTION
## Problem

When a push to a release branch (e.g. `release/4.147.0-preview.3`) triggers the `update-release-notes` workflow, the agent checks out that release branch. Since the PR targets `main`, unrelated file diffs (like `PREVIEW_LABEL` in `scripts/azure-templates-variables.yml`) bleed into the PR.

This happened in PR #4053 which was closed due to the extra diff.

Additionally, both released and unreleased triggers used the same PR branch name (`dev/release-notes-{VERSION}`), causing collisions where a main push would force-push over a release-branch PR.

## Fix

1. **Always work from `main` checkout** — Added `git checkout main` + `git fetch origin` in Step 2 so the working tree is always based on main, regardless of the triggering ref. The script only uses `origin/` remote refs so this is safe.

2. **Distinct PR branch names** — Changed Step 3 to use:
   - `dev/release-notes-{VERSION}-released` for release branch triggers
   - `dev/release-notes-{VERSION}-unreleased` for main triggers

   This prevents branch collisions between release and main triggers.