### PR TITLE
Fix integration tests for .NET 10 SDK compatibility

### DIFF
--- a/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
@@ -148,7 +148,7 @@ public class LinuxConsoleTests(ITestOutputHelper output) : PlatformTestBase(outp
         // Build and run in Docker using dotnet publish (resolves RID-specific native assets)
         var dockerfile = Path.Combine(projectDir, "Dockerfile");
         File.WriteAllText(dockerfile, $"""
-            FROM mcr.microsoft.com/dotnet/sdk:8.0
+            FROM mcr.microsoft.com/dotnet/sdk:10.0
             WORKDIR /src
             COPY {projectName}.csproj nuget.config ./
             RUN dotnet restore

--- a/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
@@ -140,7 +140,7 @@ public abstract class MauiTestBase(ITestOutputHelper output) : PlatformTestBase(
         
         // Always run from TestDir (which has global.json) using relative path
         var relativeProjectDir = Path.GetRelativePath(TestDir, projectDir);
-        await Run("dotnet", $"build {relativeProjectDir} -c {BuildConfiguration} -f {TargetFramework}", timeoutSeconds: 600);
+        await Run("dotnet", $"build {relativeProjectDir} -c {BuildConfiguration} -f {TargetFramework} -p:ValidateXcodeVersion=false", timeoutSeconds: 600);
         
         var appPath = FindAppArtifact(projectDir, projectName);
         Assert.NotNull(appPath);
@@ -170,8 +170,13 @@ public abstract class MauiTestBase(ITestOutputHelper output) : PlatformTestBase(
         var projectDir = Path.Combine(TestDir, projectName);
         var relativeProjectDir = projectName;  // Relative to TestDir
         
+        // Extract the .NET version from the TargetFramework (e.g., "net10.0" from "net10.0-maccatalyst")
+        var dotnetVersion = TargetFramework.Contains('-')
+            ? TargetFramework[..TargetFramework.IndexOf('-')]
+            : "net10.0";
+        
         // Create project (run from TestDir to pick up global.json)
-        await Run("dotnet", $"new maui -n {projectName} -o {relativeProjectDir}");
+        await Run("dotnet", $"new maui -n {projectName} -o {relativeProjectDir} --framework {dotnetVersion}");
 
         // Add SkiaSharp package (run from TestDir)
         await Run("dotnet", $"add {relativeProjectDir} package SkiaSharp.Views.Maui.Controls --version {SkiaVersion}");

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -46,12 +46,13 @@ public abstract class PlatformTestBase : IDisposable
             </configuration>
             """);
         
-        // Write global.json to allow latest SDK (prevents inheriting repo's .NET 8 restriction)
+        // Write global.json pinned to .NET 10 SDK (avoids rolling to .NET 11 preview which
+        // may require newer Xcode versions not yet installed)
         File.WriteAllText(Path.Combine(TestDir, "global.json"), """
             {
               "sdk": {
-                "version": "8.0.0",
-                "rollForward": "latestMajor"
+                "version": "10.0.0",
+                "rollForward": "latestFeature"
               }
             }
             """);


### PR DESCRIPTION
Fixes integration test failures caused by .NET 11 preview SDK being picked up:

- **Docker Linux tests**: Updated base image from `sdk:8.0` → `sdk:10.0` (net10.0 target requires .NET 10 SDK)
- **MAUI tests**: Pin `global.json` to .NET 10 SDK with `latestFeature` rollForward (avoids rolling to .NET 11 preview which requires newer Xcode)
- **MAUI tests**: Pass `--framework net10.0` to `dotnet new maui` to ensure templates generate `net10.0-*` TFMs
- **MAUI tests**: Add `ValidateXcodeVersion=false` for Xcode minor version tolerance

All 19 integration tests pass across the full matrix (iOS 16.2/26.3, Android API 23/36, Mac Catalyst, Blazor, Console, Linux Docker).