### PR TITLE
Improve security-audit skill: schema enforcement, CG reliability, and report quality

### DIFF
--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -196,6 +196,11 @@ submodules, etc.
 CG scans Docker container images and build-time deps from both ADO pipelines. CG alerts are
 invisible to GitHub Issues and NVD searches alone.
 
+> 🛑 **THIS STEP TAKES 5–7 MINUTES.** The CG script queries 60+ jobs across 8+ builds. This
+> is NORMAL and NON-NEGOTIABLE. Use `initial_wait: 600` (or higher). Do NOT skip, fabricate
+> empty results, or write placeholder data because it's "taking too long." The validator will
+> reject reports with empty `pipelines` or fabricated timestamps.
+
 **See [references/cg-alerts.md](references/cg-alerts.md)** for:
 
 - The one-shot query script (`scripts/query-cg-alerts.py`) — run ONCE, cache to file

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -23,14 +23,20 @@ description: >
 
 # Security Audit Skill
 
-Investigate security status of SkiaSharp's native dependencies. Skia core is a dependency just like libpng or freetype — all are audited together in a unified report.
+Investigate the security status of SkiaSharp's native dependencies. Skia core is treated as
+the product itself (not just a dependency) and gets a deeper, commit-level resolution
+process. Third-party deps and Component Governance alerts are audited alongside it and
+combined into a single unified report.
 
 > ℹ️ This skill is **read-only**. To create PRs and fix issues, use the `native-dependency-update` skill.
 
 ## Key References
 
-- **[documentation/dev/dependencies.md](../../../documentation/dev/dependencies.md)** — Which dependencies to audit, cgmanifest format, known false positives, Skia-specific tracking notes
-- **[references/report-template.md](references/report-template.md)** — Report format templates (markdown)
+- **[references/skia-cve-resolution.md](references/skia-cve-resolution.md)** — Skia core CVE pipeline (NVD → Bug ID → Commit → Branch → Cherry-pick → Reachability). **The Skia process is fine-grained — read this before auditing Skia.**
+- **[references/third-party-deps.md](references/third-party-deps.md)** — Third-party CVE process (libpng, freetype, harfbuzz, etc.): version verification, fix-commit ancestry, known false positives
+- **[references/cg-alerts.md](references/cg-alerts.md)** — Component Governance alerts: ADO pipeline queries, Docker container CVEs, fix locations
+- **[documentation/dev/dependencies.md](../../../documentation/dev/dependencies.md)** — Dependency list, cgmanifest format, Skia-specific tracking notes
+- **[references/report-template.md](references/report-template.md)** — Markdown report format
 - **[references/report-schema.md](references/report-schema.md)** — JSON schema for structured output
 - **[references/security-audit-schema.json](references/security-audit-schema.json)** — Machine-readable JSON Schema (Draft 2020-12)
 - **[scripts/validate-security-audit.py](scripts/validate-security-audit.py)** — Validates report JSON against schema + semantic checks
@@ -39,51 +45,43 @@ Investigate security status of SkiaSharp's native dependencies. Skia core is a d
 
 ## Workflow
 
-```
-1. Search issues/PRs (all deps including Skia)
-2. Get and VERIFY versions from submodule/DEPS (not just cgmanifest.json)
-   ├─ 2a. Verify Skia milestone from SkMilestone.h + find upstream google/skia commit
-   ├─ 2b. Verify dep versions from DEPS commit hashes + header files
-   └─ 2c. Report any cgmanifest.json mismatches as findings
-3. Query CVE databases for ALL dependencies
-   ├─ Third-party deps: web search "{dep} CVE {year}"
-   └─ Skia core: NVD API keywordSearch=Skia
-4. Verify fix commits for each CVE
-   ├─ Fixed? → Mark clean
-   └─ Not fixed? → Flag for action
-5. Check false positives
-6. Query Component Governance alerts from SkiaSharp-Native AND SkiaSharp pipelines
-   ├─ Get latest build IDs (native: 26493, managed: 10789)
-   ├─ Extract ALL CG log IDs from timeline (every job, no sampling)
-   ├─ Parse CVEs from every job's CG log
-   └─ Deduplicate alerts by CVE ID across all jobs/branches/pipelines
-7. Assemble structured JSON report (per report-schema.md)
-8. Validate JSON (validate-security-audit.py) — fix any errors before rendering
-9. Render HTML from JSON (render-security-audit.py)
+1. Search GitHub issues/PRs (all deps including Skia)
+2. Verify dependency versions from submodule/DEPS/headers (NOT cgmanifest.json)
+3. Audit Skia core CVEs — see [Skia CVE Resolution](references/skia-cve-resolution.md)
+4. Audit third-party dependency CVEs — see [Third-Party Deps](references/third-party-deps.md)
+5. Query Component Governance alerts — see [CG Alerts](references/cg-alerts.md)
+6. Check false positives
+7. Assemble structured JSON report
+8. Validate report (`validate-security-audit.py`)
+9. Render HTML (`render-security-audit.py`)
 10. Present markdown summary to user
-```
+
+---
 
 ### Step 1: Search Issues & PRs
 
 Search mono/SkiaSharp open issues for:
+
 - CVE numbers (e.g., "CVE-2024")
 - Keywords: "security", "vulnerability"
 - Dependency names: skia, libpng, expat, zlib, webp, harfbuzz, freetype
 
-Search PRs in both mono/SkiaSharp and mono/skia for dependency updates.
+Search PRs in both `mono/SkiaSharp` and `mono/skia` for dependency updates already in flight.
 
-### Step 2: Get and Verify Dependency Versions
+---
 
-> ⚠️ **CRITICAL: Never trust cgmanifest.json blindly.** Always verify versions against the actual submodule and DEPS file. cgmanifest.json is manually maintained and can drift.
+### Step 2: Verify Dependency Versions
 
-#### 2a. Verify Skia milestone and upstream commit
+> ⚠️ **CRITICAL: Never trust `cgmanifest.json` blindly.** Always verify versions against the
+> actual submodule, DEPS file, and source headers. cgmanifest.json is manually maintained
+> and can drift. Report any mismatches as findings.
 
-> 🛑 **MANDATORY:** Steps 3–5 below (fetching the upstream google/skia branch) are **required**, not optional.
-> Adding a git remote and fetching is a read-only operation — it does not modify any tracked files.
-> Without independent verification of the upstream merge point, the audit would be trusting
-> cgmanifest.json circularly, which defeats the purpose of verification.
+#### 2.1 Verify Skia milestone and upstream commit
 
-The mono/skia fork contains both upstream google/skia code AND custom SkiaSharp C API commits. Track both:
+> 🛑 **MANDATORY:** Fetching the upstream `google/skia` branch is **required**, not optional.
+> Adding a git remote and fetching is read-only — it does not modify any tracked files.
+> Without independent verification of the upstream merge point, the audit would trust
+> cgmanifest.json circularly, defeating the purpose of verification.
 
 ```bash
 # 1. Get the actual submodule commit
@@ -94,22 +92,23 @@ git submodule status externals/skia
 cat externals/skia/include/core/SkMilestone.h
 # Look for: #define SK_MILESTONE NNN
 
-# 3. Find the upstream google/skia merge point (MANDATORY)
+# 3. Find the upstream google/skia merge point
 cd externals/skia
 git log --oneline --merges --grep="chrome/m" -5 HEAD
 # Find the merge commit that brought in chrome/mNNN
 
-# 4. Add the upstream remote and fetch (MANDATORY — this is read-only)
-git remote add upstream https://github.com/google/skia.git 2>/dev/null || git remote set-url upstream https://github.com/google/skia.git
-git fetch upstream chrome/mNNN --depth=1
+# 4. Add the upstream remote and fetch (read-only)
+git remote add upstream https://github.com/google/skia.git 2>/dev/null || \
+  git remote set-url upstream https://github.com/google/skia.git
+git fetch upstream chrome/mNNN
 git log --format="%H %s" -1 FETCH_HEAD
 # This gives the independently-verified upstream_merge_commit
 
-# 5. Confirm upstream is ancestor of our fork (MANDATORY)
+# 5. Confirm upstream is ancestor of our fork
 git merge-base --is-ancestor FETCH_HEAD <merge-parent> && echo "VERIFIED"
 ```
 
-**Compare against cgmanifest.json and report mismatches:**
+Compare against cgmanifest.json and report mismatches:
 
 | Field | Source of truth | cgmanifest.json field |
 |-------|----------------|----------------------|
@@ -117,359 +116,147 @@ git merge-base --is-ancestor FETCH_HEAD <merge-parent> && echo "VERIFIED"
 | Fork commit | `git submodule status` | git entry `commitHash` |
 | Upstream commit | `git fetch upstream chrome/mNNN` tip | `upstream_merge_commit` |
 
-#### 2b. Verify third-party dependency versions
+#### 2.2 Verify third-party dependency versions
 
-Read the DEPS file from the actual submodule commit (NOT from cgmanifest.json):
+See **[references/third-party-deps.md](references/third-party-deps.md)** for the full table of
+header files and the googlesource mirror URL pattern. In short: read pinned commit hashes
+from `externals/skia/DEPS`, then fetch each dependency's version header at that commit and
+parse the version string.
 
-```bash
-cat externals/skia/DEPS
-# Extract commit hashes for each dependency
-```
+#### 2.3 Verify ANGLE and its submodules
 
-Then verify actual versions from the Chromium mirror header files. For each dependency, fetch the version header at the pinned commit:
+ANGLE is a **separate** native component (Windows-only, for WinUI). It is NOT part of the
+Skia submodule.
 
-**Skia DEPS dependencies:**
-
-| Dependency | Version file | Version pattern |
-|------------|-------------|-----------------|
-| libpng | `png.h` line 1-3 | `libpng version X.Y.Z` |
-| freetype | `include/freetype/freetype.h` | `FREETYPE_MAJOR`, `FREETYPE_MINOR`, `FREETYPE_PATCH` |
-| harfbuzz | `src/hb-version.h` | `HB_VERSION_STRING "X.Y.Z"` |
-| libexpat | `expat/lib/expat.h` | `XML_MAJOR_VERSION`, `XML_MINOR_VERSION`, `XML_MICRO_VERSION` |
-| brotli | `c/common/version.h` | `BROTLI_VERSION_MAJOR`, `_MINOR`, `_PATCH` |
-| zlib | `zlib.h` | `ZLIB_VERSION "X.Y.Z"` |
-| libjpeg-turbo | `README.chromium` | `Version: X.Y.Z` |
-| libwebp | `NEWS` line 1 | `version X.Y.Z` |
-
-**Googlesource mirror URL pattern:**
-```
-https://{host}/{path}/+/{commit_sha}/{file}?format=TEXT
-```
-Response is base64-encoded. Decode with `[System.Convert]::FromBase64String()`.
-
-#### 2c. Verify ANGLE dependencies
-
-ANGLE is a **separate** native component (Windows-only, for WinUI). It is NOT part of the Skia submodule — it's cloned separately from `https://github.com/google/angle.git`.
-
-Get the ANGLE version from `scripts/VERSIONS.txt`:
 ```bash
 grep ANGLE scripts/VERSIONS.txt
 # Output: ANGLE    release    chromium/NNNN
 ```
 
-ANGLE has its own submodules that must also be tracked:
-- `third_party/zlib` (separate from Skia's zlib)
-- `third_party/jsoncpp`
-- `third_party/vulkan-deps`
-- `third_party/astc-encoder/src`
+ANGLE has its own submodules (`third_party/zlib`, `jsoncpp`, `vulkan-deps`,
+`astc-encoder/src`) that must also be tracked. See
+[references/third-party-deps.md](references/third-party-deps.md#angle-and-its-submodules)
+for details. Flag any missing from cgmanifest.json as a coverage gap.
 
-Check if these are in cgmanifest.json. If missing, flag as a coverage gap.
+#### 2.4 Build the dependency overview
 
-#### 2d. Build the Dependency Overview
-
-The `versionVerification` array in the JSON must include **ALL** dependencies from ALL sources:
+The `versionVerification` array in the JSON report must include **ALL** dependencies from
+ALL sources:
 
 | Source | What to include |
 |--------|----------------|
 | `"Skia DEPS"` | All deps from `externals/skia/DEPS` + Skia itself |
-| `"ANGLE"` | ANGLE itself (version from VERSIONS.txt) |
+| `"ANGLE"` | ANGLE itself (version from `VERSIONS.txt`) |
 | `"ANGLE submodule"` | ANGLE's submodules (zlib, jsoncpp, vulkan-deps, astc-encoder) |
 | `"GPU/Graphics"` | VulkanMemoryAllocator, SPIRV-Cross, D3D12Allocator from DEPS |
 | `"Supporting"` | piex, wuffs, dng_sdk, buildtools from DEPS |
 
-Each entry must have a `source` field and a `cgmanifestVersion` field (null if missing from cgmanifest.json).
+Each entry must have a `source` field and a `cgmanifestVersion` field (null if missing).
+Report mismatches as findings.
 
-If submodule externals are initialized, read directly from `externals/skia/third_party/externals/{dep}/` instead.
+---
 
-**Report any mismatches** between cgmanifest.json and actual versions as findings in the audit report.
+### Step 3: Audit Skia Core CVEs
 
-### Step 3: Query CVE Databases
+> 🛑 Skia is the product, not just a dependency. Every Skia CVE must be resolved to a
+> specific fix commit, branch, cherry-pick test, and reachability assessment. Classification
+> by milestone alone is INCOMPLETE.
 
-Query CVEs for **all** dependencies in parallel — Skia core and third-party alike.
+**See [references/skia-cve-resolution.md](references/skia-cve-resolution.md) for the full
+process**, including:
 
-#### Third-party dependencies
+- NVD query (`keywordSearch=Skia`)
+- Bug ID extraction from `issues.chromium.org/issues/NNNNN` references
+- `git fetch upstream chrome/mNNN` + `git log --grep=<bug_id>` to find fix commits
+- Branch ancestry verification (our milestone? our tree?)
+- Cherry-pick feasibility test
+- Reachability through SkiaSharp C API
+- Non-Chrome CVEs (Android / vendor bulletins)
+- Required output fields per CVE
 
-```
-"{dependency} CVE {current year}"
-"{dependency} security vulnerability"
-```
+---
 
-#### Skia core
+### Step 4: Audit Third-Party Dependency CVEs
 
-> ⚠️ **Skia CVEs are invisible to Component Governance.** The NVD query is the ONLY way to detect them.
+For libpng, freetype, harfbuzz, libexpat, brotli, zlib, libjpeg-turbo, libwebp, ANGLE
+submodules, etc.
 
-```bash
-curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=Skia&resultsPerPage=200"
-```
+**See [references/third-party-deps.md](references/third-party-deps.md)** for:
 
-> **Note:** No API key is required but rate limit is 5 requests per 30 seconds without one.
+- Web/NVD search queries
+- Version verification (DEPS commit + header files)
+- Fix-commit ancestry check (`git merge-base --is-ancestor`)
+- NVD version range errors (e.g., CVE-2025-27363 / FreeType)
+- Known false positives (MiniZip, FreeType's bundled zlib)
 
-For each Skia CVE returned, extract:
-1. **CVE ID** and **description**
-2. **Severity** (CVSS score from `metrics.cvssMetricV31`)
-3. **Chrome fix version** from `configurations[].nodes[].cpeMatch[]` where `criteria` contains `chrome` and `versionEndExcluding` exists
-4. **Chrome fix milestone** = major version number from `versionEndExcluding` (e.g., `132.0.6834.83` → `132`)
+---
 
-Then classify using the **verified milestone from SkMilestone.h** (not cgmanifest.json):
+### Step 5: Query Component Governance Alerts
 
-| Condition | Classification |
-|-----------|---------------|
-| Fix milestone > our milestone | 🔴 **Potentially affected** — CVE was fixed after our fork point |
-| Fix milestone ≤ our milestone | ✅ **Already fixed** — fix is included in our fork's upstream base |
-| No Chrome version (mentions `SkiaRenderEngine`) | ⚪ **Not applicable** — Android render engine infrastructure, not part of Skia library |
-| No Chrome version (reported via Android/Huawei/other vendor bulletin) | ⚠️ **Code-path verification needed** — see below |
-| No Chrome version (other) | ⚠️ **Manual review needed** — check if affected code path exists in fork |
-| CVSS score not yet published | Use Chromium severity rating (High → treat as HIGH 8.8) |
+CG scans Docker container images and build-time deps from both ADO pipelines. CG alerts are
+invisible to GitHub Issues and NVD searches alone.
 
-> ⚠️ **Newly published CVEs may lack a CVSS score.** If NVD hasn't assigned one yet, check
-> the Chromium severity rating from the Chrome release notes or cvedetails.com. Treat
-> Chromium "High" as HIGH (~8.8) for prioritization purposes.
+**See [references/cg-alerts.md](references/cg-alerts.md)** for:
 
-#### Non-Chrome Skia CVEs (Android/Huawei/vendor bulletins)
+- The one-shot query script (`scripts/query-cg-alerts.py`) — run ONCE, cache to file
+- Manual `az devops` approach for debugging
+- Alert categories (Alpine, Debian, npm, Rust, NuGet)
+- Key Dockerfiles for fixes
+- How to embed the raw `alerts` array in the report (do NOT summarize)
+- Portal links
 
-CVEs reported through Android Security Bulletins or vendor bulletins (Huawei HarmonyOS, etc.)
-reference Skia code that **may also exist in upstream google/skia and therefore in our fork**.
-These forks all diverged from the same upstream, so shared code paths are common.
+---
 
-**Do NOT dismiss a CVE just because it was reported through a vendor bulletin.**
+### Step 6: Check False Positives
 
-Instead, verify whether the vulnerable code exists in our fork:
+Before flagging anything, verify the CVE actually affects SkiaSharp.
 
-```bash
-cd externals/skia
+**General false positives** (apply to any dependency):
 
-# 1. Check if the vulnerable file exists
-find . -name "SkDeflate.cpp" -o -name "TheVulnerableFile.cpp"
+- **NVD version range errors** — When a CVE claims version X is affected but the fix commit
+  is already in version X's tree, classify as false positive and cite the fix commit.
+- **Chrome-only rendering paths** (HTML Canvas, SVG in browser) — May not be reachable through
+  the SkiaSharp C API.
 
-# 2. Check if the vulnerable function exists
-git grep "vulnerable_function_name"
+**Dependency-specific false positives:**
 
-# 3. If a fix commit is referenced (e.g., from AOSP), check if the
-#    vulnerable code pre-fix exists in our fork
-```
+- Skia core → see [references/skia-cve-resolution.md](references/skia-cve-resolution.md#skia-specific-false-positives)
+- Third-party deps → see [references/third-party-deps.md](references/third-party-deps.md#known-third-party-false-positives)
+- Full reference: [dependencies.md](../../../documentation/dev/dependencies.md#known-false-positives)
 
-| If... | Then... |
-|-------|---------|
-| Vulnerable file/function does NOT exist in our fork | ⚪ False positive — vendor-specific code |
-| Vulnerable file/function EXISTS in our fork + fix commit is ancestor of HEAD | ✅ Already fixed |
-| Vulnerable file/function EXISTS in our fork + NOT fixed | 🔴 Needs attention |
-
-### Step 4: Verify Fix Commits (CRITICAL)
-
-> ⚠️ **CVE databases often have WRONG version ranges.** Always verify with the actual commit.
-
-```bash
-cd externals/skia/third_party/externals/{dependency}
-
-# Check if fix commit is ancestor of current HEAD
-git merge-base --is-ancestor {fix_commit} HEAD && echo "FIXED" || echo "VULNERABLE"
-```
-
-**Example:** CVE-2025-27363 claimed FreeType ≤2.13.3 was affected, fix in 2.13.4. Verification
-showed the fix commit (`ef636696...`) was actually in 2.13.1 — SkiaSharp's 2.13.3 was already
-patched. The NVD version range was wrong.
-
-When a CVE's version range says our version is affected but the fix commit is already in our tree,
-classify it as **⚪ False positive (NVD version range incorrect)** — not as a finding. Place it
-in the false positive section with an explanation of why the NVD range is wrong and cite the
-actual fix commit as evidence.
-
-### Step 5: Check False Positives
-
-Before flagging, verify the CVE actually affects SkiaSharp:
-
-- **MiniZip** (in zlib) — Not compiled by Skia, not linked
-- **FreeType's bundled zlib** — Separate from Skia's zlib copy
-- **Android SkiaRenderEngine** (`SkiaRenderEngine.cpp`) — Android OS rendering infrastructure, not part of the Skia library itself. Always a false positive.
-- **Android/vendor Skia forks** — CVEs from Android Security Bulletins or Huawei/Samsung bulletins may reference code in `platform/external/skia` (AOSP's fork) that doesn't exist in upstream `google/skia`. **Verify by checking if the affected file/function exists in our fork** (see Step 3 above). Don't dismiss based solely on which vendor reported it — the code could be shared.
-- **Chrome-specific rendering paths** (HTML Canvas, SVG in browser) — May not be reachable through SkiaSharp's C API
-- **NVD version range errors** — When a CVE claims version X is affected but the fix commit is already in version X's tree, classify as false positive and cite the fix commit (see Step 4)
-
-See [dependencies.md](../../../documentation/dev/dependencies.md#known-false-positives) for details.
-
-### Step 6: Check Component Governance (CG) Alerts
-
-> 🛑 **FIRST ACTION — Run the CG query script ONCE and save to file:**
-> ```bash
-> mkdir -p output/ai && python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > output/ai/cg-alerts-cache.json
-> ```
-> This takes 2-3 minutes. **Do NOT run this script again.** For ALL subsequent CG data needs,
-> read from `output/ai/cg-alerts-cache.json`. The script queries tens of build logs via API — running it
-> multiple times wastes minutes and produces identical results.
-
-> ⚠️ **MANDATORY:** The security audit MUST include CG alerts from BOTH the SkiaSharp-Native
-> (pipeline 26493) and SkiaSharp (pipeline 10789) pipelines — together they make up the shipped build.
-> CG scans Docker container images used for native builds and flags CVEs in OS packages,
-> npm dependencies, Rust crates, and NuGet packages used at build time.
-
-#### Why This Matters
-
-CG alerts are **not visible** from GitHub Issues or NVD searches alone. They come from the
-internal Azure DevOps pipeline and flag vulnerabilities in:
-- **Docker base images** (Debian packages: dpkg, libcap2, sed, rsync)
-- **Cross-compilation sysroots** (Alpine packages: busybox, file, binutils, zlib, freetype, gmp)
-- **Build toolchain dependencies** (npm: minimatch, path-to-regexp, ws, express; Rust: hashbrown, zerovec, time)
-- **NuGet build dependencies** (Microsoft.WindowsAppSDK)
-
-#### How to Query CG Alerts
-
-> 🛑 **CRITICAL — SAVE TO FILE:** This script queries tens of build logs and takes 2-3 minutes.
-> You MUST save the output to a **file** (not a shell variable) so it persists across tool calls.
-> Run it ONCE, save the JSON, then read from that file for the rest of the audit.
-> **NEVER run this script more than once per audit session.**
-
-```bash
-# Run ONCE and save — this is your CG data for the entire audit
-mkdir -p output/ai && python3 .agents/skills/security-audit/scripts/query-cg-alerts.py > output/ai/cg-alerts-cache.json
-
-# Then read from the file whenever you need CG data (fast, no API calls):
-cat output/ai/cg-alerts-cache.json | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
-```
-
-> The output includes a `queriedAt` ISO timestamp so you can verify freshness.
-
-Additional flags:
-
-```bash
-# Human-readable text output (nothing truncated, all CVEs listed)
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --text
-
-# Query only a specific branch
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --branch main
-
-# Query only the native pipeline
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline native
-
-# Query only the managed pipeline
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline managed
-
-# Query a specific build
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 14176611
-```
-
-The script automatically:
-1. Discovers the latest completed build from main AND all active release/* branches for BOTH pipelines
-2. Identifies ALL CG logs in each build (every job, no sampling — this is security)
-3. Parses and deduplicates all CVEs across all builds, pipelines, and jobs
-4. Sorts by severity and reports which branches and pipelines are affected
-
-**Note:** There is no build-independent CG REST API. The `governance.visualstudio.com` service
-does not expose alert data through any documented endpoint. The CG portal UI aggregates from
-build results internally. Our script achieves the same result by enumerating every CG log in
-the latest build of every active branch (no sampling), which reports ALL active registration-level
-alerts regardless of which specific build produced them.
-
-**Manual approach (for debugging):**
-
-```bash
-# 1. Get latest build ID (native pipeline)
-BUILD_ID=$(az pipelines runs list --pipeline-id 26493 \
-  --org https://devdiv.visualstudio.com --project DevDiv \
-  --top 1 --query "[0].id" -o tsv)
-
-# For managed pipeline, use --pipeline-id 10789 instead
-
-# 2. Get timeline to find CG log IDs
-az devops invoke --area build --resource timeline \
-  --route-parameters project=DevDiv buildId=$BUILD_ID \
-  --org https://devdiv.visualstudio.com -o json
-
-# 3. Parse CVEs from a specific CG log
-az devops invoke --area build --resource logs \
-  --route-parameters project=DevDiv buildId=$BUILD_ID logId={LOG_ID} \
-  --org https://devdiv.visualstudio.com -o json
-```
-
-#### CG Alert Categories
-
-> These categories are reference context for understanding where alerts come from and how to fix them.
-> They are **NOT** part of the report JSON — the viewer groups by component automatically.
-
-| Category | Source | Fix Mechanism |
-|----------|--------|---------------|
-| Alpine sysroot packages | `apk add` in alpine Dockerfile | Bump `DISTRO_VERSION` in Dockerfile |
-| Debian base image packages | `apt-get` / base image | Update base image or wait for Debian patches |
-| npm build tooling | .NET SDK / Cake dependencies | Update .NET SDK or pin versions |
-| Rust crate deps | .NET SDK internals | Update .NET SDK |
-| NuGet build deps | Build-time references | Update package version |
-
-> ⚠️ **Do NOT editorialize about whether CG alerts "ship" or not.**
-> A vulnerable build chain means a potentially compromised build artifact.
-> Present all CG alerts at the same importance level as other findings.
-> HIGH severity CG alerts are "needs_attention" just like any other HIGH CVE.
-
-#### Key Files for CG Fixes
-
-| File | Controls |
-|------|----------|
-| `scripts/infra/native/linux/docker/alpine/Dockerfile` (lines 43–47) | Alpine sysroot version (`DISTRO_VERSION`) |
-| `scripts/infra/native/linux/docker/debian/11/Dockerfile` | Debian 11 base image (EOL June 2026) |
-| `scripts/infra/native/linux/docker/debian/13/Dockerfile` | Debian 13 base image |
-| `scripts/infra/native/linux/docker/bionic/Dockerfile` | Bionic/Android cross-compile |
-| `scripts/infra/native/wasm/docker/Dockerfile` | WASM build container |
-
-#### Include in Report
-
-> 🛑 **CRITICAL:** Include the **complete `alerts` array** from the script output in the report.
-> Do NOT summarize or truncate. The viewer needs every individual alert to render correctly.
-> Copy the entire JSON output from `output/ai/cg-alerts-cache.json` as the `cgAlerts` value.
-
-```bash
-# The cgAlerts section of your report MUST be the raw script output:
-cat output/ai/cg-alerts-cache.json
-# Copy this entire JSON object as the value of "cgAlerts" in the report.
-```
-
-The script output has this structure (include ALL fields as-is):
-
-```json
-{
-  "cgAlerts": {
-    "queriedAt": "2026-05-24T12:34:56+00:00",
-    "pipelines": [...],
-    "builds": [...],
-    "totalAlerts": 121,
-    "bySeverity": {"High": 7, "Medium": 110, "Low": 4},
-    "alerts": [
-      {
-        "id": "CVE-2024-XXXXX",
-        "component": "busybox 1.35.0-r31",
-        "severity": "Medium",
-        "sources": ["Alpine 3.17"],
-        "branches": ["main"],
-        "pipelines": ["SkiaSharp-Native"],
-        "paths": ["/some/path/to/manifest"]
-      }
-    ]
-  }
-}
-```
-
-**Do NOT:**
-- Summarize alerts into categories (the viewer does grouping itself)
-- Omit the `alerts` array
-- Replace `alerts` with `uniqueCVEs` or `categories`
-- Write `totalAlerts: N` without including the actual N alerts
-
-#### CG Portal Links
-
-- **Registration:** https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321
-- **Pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493
-- **Alert type filter:** Append `?_a=alerts&typeId={typeId}&alerts-view-option=active` to registration URL
+---
 
 ### Step 7: Assemble Structured JSON Report
 
-> 🛑 **MANDATORY:** The audit MUST produce a JSON file conforming to [references/report-schema.md](references/report-schema.md). This is the machine-readable output used by dashboards and CI.
+> 🛑 **MANDATORY:** The audit MUST produce a JSON file conforming to
+> [references/report-schema.md](references/report-schema.md). This is the machine-readable
+> output used by dashboards and CI.
 
 Build the JSON object with these top-level keys:
 
 1. **`meta`** — Date, schema version, Skia commit hashes, milestone, upstream verification status
 2. **`summary`** — Counts by status category, total CVEs, highest severity
 3. **`versionVerification`** — One entry per dependency with DEPS commit, verified version, cgmanifest version, match boolean
-4. **`findings`** — Array of finding objects sorted by priority then severity. Each has `dependency`, `status`, `cves[]`, `nonChromeCves[]`, `action`, `notes`
-5. **`nextSteps`** — Prioritized action items with severity, command, and reason
+4. **`findings`** — Array of finding objects sorted by priority then severity. **ONE object per dependency** (e.g., one "skia" finding containing ALL Skia CVEs regardless of status). Each has `dependency`, `status`, `cves[]`, `nonChromeCves[]`, `action`, `notes`. The `status` reflects the WORST-case status among the CVEs.
+5. **`cgAlerts`** — The complete raw JSON from `query-cg-alerts.py` (full `alerts` array, do not summarize)
+6. **`nextSteps`** — Prioritized action items with severity, command, and reason
 
-Save as `output/ai/security-audit-{date}.json` in the repo (same pattern as other AI outputs).
+> 🛑 **COMPLETENESS REQUIREMENT:** The `findings` array MUST include **every CVE returned
+> by the NVD query** (Step 3 of skia-cve-resolution.md). CVEs that are verified as already
+> fixed in our tree are classified as `"already_fixed"` or `"false_positive"` — they are
+> NOT dropped from the report. An audit that finds 15 CVEs in NVD but only reports 7 in the
+> JSON is INCOMPLETE and will fail review. The total CVE count in `summary.totalCves` must
+> match the number of CVE objects across all findings.
+
+> 🛑 **ONE FINDING PER DEPENDENCY:** Do NOT create multiple finding objects for the same
+> dependency. All CVEs for "skia" go in ONE finding. All CVEs for "libpng" go in ONE
+> finding. Use each CVE's `assessment` field to distinguish affected/fixed/false_positive.
+> The finding's top-level `status` reflects the worst-case among its CVEs (e.g., if 3 CVEs
+> are already_fixed but 2 are needs_attention, the finding status is `"needs_attention"`).
+
+Save as `output/ai/security-audit-{date}.json`.
+
+---
 
 ### Step 8: Validate Report
 
@@ -480,8 +267,10 @@ python3 .agents/skills/security-audit/scripts/validate-security-audit.py \
   output/ai/security-audit-{date}.json
 ```
 
-Exit codes: 0=valid, 1=fixable errors (fix and retry), 2=fatal.
+Exit codes: `0` = valid, `1` = fixable errors (fix and retry), `2` = fatal.
 Warnings are informational — errors must be fixed before proceeding.
+
+---
 
 ### Step 9: Render HTML Report
 
@@ -492,27 +281,35 @@ python3 .agents/skills/security-audit/scripts/render-security-audit.py \
   output/ai/security-audit-{date}.json
 ```
 
-This produces a self-contained HTML file (Bootstrap 5, no external dependencies except CDN CSS) alongside the JSON. The HTML renders:
+This produces a self-contained HTML file (Bootstrap 5, CDN CSS only) alongside the JSON.
+The HTML renders:
+
 - Summary cards with status counts
-- Collapsible findings with CVE tables, severity badges, and NVD links
+- Collapsible findings with CVE tables, severity badges, NVD links
 - Version verification table with match/mismatch indicators
 - Skia upstream verification details with commit links
 - Prioritized next steps with severity-coded borders
 
 Present the output path to the user:
+
 ```
 ✅ security-audit-2026-04-10.html (45 KB)
    m132 • 2026-04-10 • 12 CVEs • Highest: HIGH
    🔴 3 attention · 🆕 2 undiscovered · ⚪ 4 FP · ✅ 5 clean
 ```
 
+---
+
 ### Step 10: Present Markdown Summary
 
-After generating JSON and HTML, present a concise markdown summary to the user in the conversation (using the report-template.md format). This is in ADDITION to the JSON+HTML files, not instead of them.
+After generating JSON and HTML, present a concise markdown summary to the user in the
+conversation (using the report-template.md format). This is in ADDITION to the JSON+HTML
+files, not instead of them.
 
-**Priority order (applies equally to Skia core and third-party deps):**
+**Priority order** (applies equally to Skia core and third-party deps):
+
 1. 🔴 User-reported + no PR
-2. ✅ User-reported + PR ready  
+2. ✅ User-reported + PR ready
 3. 🟡 User-reported + PR needs work
 4. 🆕 Undiscovered CVEs (proactively found, no user-filed issue)
 5. ⚪ False positives
@@ -521,25 +318,33 @@ Within each priority level, sort by severity (CRITICAL > HIGH > MEDIUM > LOW).
 
 #### Report quality rules
 
-1. **Skia bump recommendations must target the highest-severity CVE**, not the lowest. If there are HIGH CVEs at m146 and a MEDIUM at m133, recommend m146 as the target, not m133.
+1. **Skia bump recommendations must target the highest-severity CVE**, not the lowest. If
+   there are HIGH CVEs at m146 and a MEDIUM at m133, recommend m146 as the target.
+2. **Don't include already-closed GitHub issues** unless directly relevant to an open
+   vulnerability.
+3. **CVEs with NVD version range errors** go in the ⚪ false positive section with the fix
+   commit as evidence — not in findings with a "but it's actually fixed" note.
+4. **CVEs without a CVSS score** should use the vendor severity rating (e.g., Chromium
+   "High" → HIGH ~8.8) and note that the official CVSS is pending.
+5. **"Undiscovered"** means a CVE found proactively by the audit (via NVD/web search) that
+   has no corresponding user-filed GitHub issue. It does NOT mean the CVE is unknown to the
+   world.
 
-2. **Don't include already-closed GitHub issues** in the report unless they are directly relevant to an open vulnerability. If a CVE is fixed and the tracking issue is closed, omit it.
-
-3. **CVEs with NVD version range errors** go in the ⚪ false positive section with the fix commit as evidence — not in the findings section with a "but it's actually fixed" note.
-
-4. **CVEs without a CVSS score** should use the vendor severity rating (e.g., Chromium "High" → HIGH ~8.8) and note that the official CVSS is pending.
-
-5. **"Undiscovered"** means a CVE found proactively by the audit (via NVD/web search) that has no corresponding user-filed GitHub issue. It does NOT mean the CVE is unknown to the world.
+---
 
 ## Handoff
 
-After audit, use `native-dependency-update` skill:
+After audit, use the `native-dependency-update` skill to act on findings:
+
 - "Merge PR #3458"
 - "Update libwebp to 1.6.0"
 - "Bump libpng to fix CVE-2024-XXXXX"
 
-For Skia core CVEs, the fix requires merging a newer upstream milestone into the fork.
-This is a significant undertaking — flag it in the report with the milestone gap.
+For Skia core CVEs, the fix typically requires merging a newer upstream milestone into the
+fork (or cherry-picking specific fix commits, per the resolution pipeline). This is a
+significant undertaking — flag it in the report with the milestone gap and the list of
+required commits.
 
-For CG container alerts, the fix is updating Dockerfiles under `scripts/infra/native/linux/docker/`.
-This does not require a Skia submodule update — only Docker image rebuilds.
+For CG container alerts, the fix is updating Dockerfiles under
+`scripts/infra/native/linux/docker/`. This does not require a Skia submodule update — only
+Docker image rebuilds.

--- a/.agents/skills/security-audit/references/cg-alerts.md
+++ b/.agents/skills/security-audit/references/cg-alerts.md
@@ -58,20 +58,29 @@ The output includes a `queriedAt` ISO timestamp so you can verify freshness.
 ### Additional Flags
 
 ```bash
-# Human-readable text output (nothing truncated, all CVEs listed)
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --text
+# Also print human-readable text summary alongside JSON
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  --text --output output/ai/cg-alerts-cache.json
+
+# With per-job verbose progress (shows each CG log being parsed)
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  --verbose --output output/ai/cg-alerts-cache.json
 
 # Query only a specific branch
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --branch main
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  --branch main --output output/ai/cg-alerts-cache.json
 
 # Query only the native pipeline
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline native
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  --pipeline native --output output/ai/cg-alerts-cache.json
 
 # Query only the managed pipeline
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline managed
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  --pipeline managed --output output/ai/cg-alerts-cache.json
 
 # Query a specific build
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 14176611
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  --build-id 14176611 --output output/ai/cg-alerts-cache.json
 ```
 
 ### What the Script Does
@@ -136,13 +145,13 @@ az devops invoke --area build --resource logs \
 
 > 🛑 **CRITICAL:** Include the **complete `alerts` array** from the script output in the
 > report. Do NOT summarize or truncate. The viewer needs every individual alert to render
-> correctly. Copy the entire JSON output from `output/ai/cg-alerts-cache.json` as the
-> `cgAlerts` value.
+> correctly. Read the JSON from `output/ai/cg-alerts-cache.json` and embed it as the
+> `cgAlerts` value in your report.
 
 ```bash
-# The cgAlerts section of your report MUST be the raw script output:
-cat output/ai/cg-alerts-cache.json
-# Copy this entire JSON object as the value of "cgAlerts" in the report.
+# Read the cached CG data (the script already wrote it with --output):
+python3 -c "import json; d=json.load(open('output/ai/cg-alerts-cache.json')); print(f'{d[\"totalAlerts\"]} alerts, {len(d[\"pipelines\"])} pipelines')"
+# Use the entire contents of this file as the "cgAlerts" value in the report JSON.
 ```
 
 The script output has this structure (include ALL fields as-is):

--- a/.agents/skills/security-audit/references/cg-alerts.md
+++ b/.agents/skills/security-audit/references/cg-alerts.md
@@ -44,13 +44,13 @@ internal Azure DevOps pipeline and flag vulnerabilities in:
 ```bash
 # Run ONCE and save — this is your CG data for the entire audit
 # ⚠️ Takes 5-7 minutes! Use initial_wait: 600 (or mode: sync with 600s wait)
+# Using --output writes JSON to file while progress prints to stdout (agent sees activity)
 mkdir -p output/ai
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
-  > output/ai/cg-alerts-cache.json
+  --output output/ai/cg-alerts-cache.json
 
 # Then read from the file (fast, no API calls):
-cat output/ai/cg-alerts-cache.json | \
-  python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
+python3 -c "import json; d=json.load(open('output/ai/cg-alerts-cache.json')); print(f'{d[\"totalAlerts\"]} alerts')"
 ```
 
 The output includes a `queriedAt` ISO timestamp so you can verify freshness.

--- a/.agents/skills/security-audit/references/cg-alerts.md
+++ b/.agents/skills/security-audit/references/cg-alerts.md
@@ -30,8 +30,20 @@ internal Azure DevOps pipeline and flag vulnerabilities in:
 > Run it ONCE, save the JSON, then read from that file for the rest of the audit.
 > **NEVER run this script more than once per audit session.**
 
+> 🛑 **TAKES 5–7 MINUTES — YOU MUST WAIT:** This script queries 60+ CG jobs across 8+ builds.
+> It is NORMAL for it to take 5–7 minutes with no intermediate output. You MUST use a long
+> timeout (initial_wait of 600 seconds or more). Do NOT:
+> - Give up after 30 seconds and write empty/fake data
+> - Fabricate a `queriedAt` timestamp without actually running the script
+> - Write `"totalAlerts": 0` because you didn't wait
+> - Skip CG because "it's taking too long"
+>
+> **Empty CG results with `pipelines: []` will fail validation.** This is a security audit —
+> every step is mandatory regardless of how long it takes.
+
 ```bash
 # Run ONCE and save — this is your CG data for the entire audit
+# ⚠️ Takes 5-7 minutes! Use initial_wait: 600 (or mode: sync with 600s wait)
 mkdir -p output/ai
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
   > output/ai/cg-alerts-cache.json

--- a/.agents/skills/security-audit/references/cg-alerts.md
+++ b/.agents/skills/security-audit/references/cg-alerts.md
@@ -1,0 +1,173 @@
+# Component Governance (CG) Alerts
+
+CG scans Docker container images and build-time dependencies used by the SkiaSharp-Native
+and SkiaSharp Azure DevOps pipelines. It flags CVEs in OS packages, npm dependencies, Rust
+crates, and NuGet packages used during the build.
+
+> ⚠️ **MANDATORY:** The audit MUST include CG alerts from BOTH the **SkiaSharp-Native**
+> (pipeline 26493) and **SkiaSharp** (pipeline 10789) pipelines — together they make up the
+> shipped build.
+
+## Why This Matters
+
+CG alerts are **not visible** from GitHub Issues or NVD searches alone. They come from the
+internal Azure DevOps pipeline and flag vulnerabilities in:
+
+- **Docker base images** (Debian packages: dpkg, libcap2, sed, rsync)
+- **Cross-compilation sysroots** (Alpine packages: busybox, file, binutils, zlib, freetype, gmp)
+- **Build toolchain dependencies** (npm: minimatch, path-to-regexp, ws, express; Rust: hashbrown, zerovec, time)
+- **NuGet build dependencies** (Microsoft.WindowsAppSDK)
+
+> ⚠️ **Do NOT editorialize about whether CG alerts "ship" or not.**
+> A vulnerable build chain means a potentially compromised build artifact.
+> Present all CG alerts at the same importance level as other findings.
+> HIGH severity CG alerts are `needs_attention` just like any other HIGH CVE.
+
+## Run the Script (ONCE per audit)
+
+> 🛑 **CRITICAL — SAVE TO FILE:** This script queries tens of build logs and takes 2–3 minutes.
+> Save the output to a **file** (not a shell variable) so it persists across tool calls.
+> Run it ONCE, save the JSON, then read from that file for the rest of the audit.
+> **NEVER run this script more than once per audit session.**
+
+```bash
+# Run ONCE and save — this is your CG data for the entire audit
+mkdir -p output/ai
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
+  > output/ai/cg-alerts-cache.json
+
+# Then read from the file (fast, no API calls):
+cat output/ai/cg-alerts-cache.json | \
+  python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['totalAlerts'])"
+```
+
+The output includes a `queriedAt` ISO timestamp so you can verify freshness.
+
+### Additional Flags
+
+```bash
+# Human-readable text output (nothing truncated, all CVEs listed)
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --text
+
+# Query only a specific branch
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --branch main
+
+# Query only the native pipeline
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline native
+
+# Query only the managed pipeline
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --pipeline managed
+
+# Query a specific build
+python3 .agents/skills/security-audit/scripts/query-cg-alerts.py --build-id 14176611
+```
+
+### What the Script Does
+
+1. Discovers the latest completed build from `main` AND all active `release/*` branches for BOTH pipelines.
+2. Identifies ALL CG logs in each build (every job, no sampling — this is security).
+3. Parses and deduplicates all CVEs across builds, pipelines, and jobs.
+4. Sorts by severity and reports which branches and pipelines are affected.
+
+> **Note:** There is no build-independent CG REST API. The `governance.visualstudio.com`
+> service does not expose alert data through any documented endpoint. The CG portal UI
+> aggregates from build results internally. Our script achieves the same result by
+> enumerating every CG log in the latest build of every active branch (no sampling), which
+> reports ALL active registration-level alerts.
+
+## Manual Approach (for Debugging)
+
+```bash
+# 1. Get latest build ID (native pipeline)
+BUILD_ID=$(az pipelines runs list --pipeline-id 26493 \
+  --org https://devdiv.visualstudio.com --project DevDiv \
+  --top 1 --query "[0].id" -o tsv)
+
+# For managed pipeline, use --pipeline-id 10789 instead
+
+# 2. Get timeline to find CG log IDs
+az devops invoke --area build --resource timeline \
+  --route-parameters project=DevDiv buildId=$BUILD_ID \
+  --org https://devdiv.visualstudio.com -o json
+
+# 3. Parse CVEs from a specific CG log
+az devops invoke --area build --resource logs \
+  --route-parameters project=DevDiv buildId=$BUILD_ID logId={LOG_ID} \
+  --org https://devdiv.visualstudio.com -o json
+```
+
+## CG Alert Categories
+
+> These categories are reference context for understanding where alerts come from and how to
+> fix them. They are **NOT** part of the report JSON — the viewer groups by component
+> automatically.
+
+| Category | Source | Fix Mechanism |
+|----------|--------|---------------|
+| Alpine sysroot packages | `apk add` in alpine Dockerfile | Bump `DISTRO_VERSION` in Dockerfile |
+| Debian base image packages | `apt-get` / base image | Update base image or wait for Debian patches |
+| npm build tooling | .NET SDK / Cake dependencies | Update .NET SDK or pin versions |
+| Rust crate deps | .NET SDK internals | Update .NET SDK |
+| NuGet build deps | Build-time references | Update package version |
+
+## Key Files for CG Fixes
+
+| File | Controls |
+|------|----------|
+| `scripts/infra/native/linux/docker/alpine/Dockerfile` (lines 43–47) | Alpine sysroot version (`DISTRO_VERSION`) |
+| `scripts/infra/native/linux/docker/debian/11/Dockerfile` | Debian 11 base image (EOL June 2026) |
+| `scripts/infra/native/linux/docker/debian/13/Dockerfile` | Debian 13 base image |
+| `scripts/infra/native/linux/docker/bionic/Dockerfile` | Bionic/Android cross-compile |
+| `scripts/infra/native/wasm/docker/Dockerfile` | WASM build container |
+
+## Including CG Data in the Report
+
+> 🛑 **CRITICAL:** Include the **complete `alerts` array** from the script output in the
+> report. Do NOT summarize or truncate. The viewer needs every individual alert to render
+> correctly. Copy the entire JSON output from `output/ai/cg-alerts-cache.json` as the
+> `cgAlerts` value.
+
+```bash
+# The cgAlerts section of your report MUST be the raw script output:
+cat output/ai/cg-alerts-cache.json
+# Copy this entire JSON object as the value of "cgAlerts" in the report.
+```
+
+The script output has this structure (include ALL fields as-is):
+
+```json
+{
+  "cgAlerts": {
+    "queriedAt": "2026-05-24T12:34:56+00:00",
+    "pipelines": [...],
+    "builds": [...],
+    "totalAlerts": 121,
+    "bySeverity": {"High": 7, "Medium": 110, "Low": 4},
+    "alerts": [
+      {
+        "id": "CVE-2024-XXXXX",
+        "component": "busybox 1.35.0-r31",
+        "severity": "Medium",
+        "sources": ["Alpine 3.17"],
+        "branches": ["main"],
+        "pipelines": ["SkiaSharp-Native"],
+        "paths": ["/some/path/to/manifest"]
+      }
+    ]
+  }
+}
+```
+
+**Do NOT:**
+
+- Summarize alerts into categories (the viewer does grouping itself)
+- Omit the `alerts` array
+- Replace `alerts` with `uniqueCVEs` or `categories`
+- Write `totalAlerts: N` without including the actual N alerts
+
+## CG Portal Links
+
+- **Registration:** https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321
+- **Native pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493
+- **Managed pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=10789
+- **Alert type filter:** Append `?_a=alerts&typeId={typeId}&alerts-view-option=active` to the registration URL

--- a/.agents/skills/security-audit/references/report-schema.md
+++ b/.agents/skills/security-audit/references/report-schema.md
@@ -67,7 +67,14 @@ Array of objects, one per dependency:
 
 ## `findings` — Individual Dependency Findings
 
-Array of finding objects, sorted by priority then severity:
+Array of finding objects, sorted by priority then severity.
+
+> 🛑 **ONE finding per dependency.** Every dependency (e.g., "skia", "libpng", "freetype")
+> must appear as exactly ONE object in this array. All CVEs for that dependency — regardless
+> of their status (affected, already_fixed, false_positive) — go inside that single finding's
+> `cves[]` array. Use each CVE object's `assessment` field to distinguish affected vs. fixed
+> vs. false positive. **Do NOT create multiple finding objects for the same dependency split
+> by status, milestone, or category.** The validator enforces this as an error.
 
 ```json
 {
@@ -128,6 +135,47 @@ Array of finding objects, sorted by priority then severity:
 | `false_positive` | Does not affect SkiaSharp (reason in `evidence`) |
 | `needs_review` | Cannot determine without manual analysis |
 | `nvd_range_error` | NVD version range is wrong; fix commit already in our tree |
+
+### CVE Fields — "Value OR Note" Principle
+
+> **Every essential CVE field must be either a concrete value OR a `*Note` field explaining
+> why it's missing.** Silent nulls ("we couldn't find it so we left it blank") are forbidden
+> and are rejected by the validator. This forces every CVE to be fully investigated.
+
+Examples:
+
+| ✅ Valid | ❌ Invalid |
+|---------|------------|
+| `"bugId": "496526419"` | `"bugId": null` |
+| `"bugId": null, "bugIdNote": "CVE has no issues.chromium.org reference URL in NVD"` | (no note) |
+| `"fixCommit": "4320748a..."` | `"fixCommit": null` |
+| `"fixCommit": null, "fixCommitNote": "Bug NNN has no matching commit on chrome/m147 or chrome/m148 branches after full fetch"` | (no note) |
+| `"severity": "HIGH", "cvss": 8.3` | `"severity": null` (severity is always required) |
+| `"severity": "HIGH", "cvss": null, "severityNote": "CVSS not yet assigned by NVD; using Chromium 'High' rating"` | `"cvss": null` (no note) |
+
+### CVE Object Fields
+
+| Field | Type | Required | Note Fallback | Description |
+|-------|------|----------|---------------|-------------|
+| `id` | string | ✅ Always | — | CVE ID, e.g., `CVE-2026-8579` |
+| `severity` | enum | ✅ Always | — | `CRITICAL` / `HIGH` / `MEDIUM` / `LOW`. Use Chromium rating if NVD CVSS pending. |
+| `description` | string | ✅ Always | — | What the vulnerability is |
+| `source` | string | ✅ Always | — | Where this CVE came from |
+| `assessment` | enum | ✅ Always | — | See assessment table above |
+| `bugId` | string\|null | Value or note | `bugIdNote` | Chromium bug ID |
+| `bugUrl` | string\|null | Required when `bugId` set | — | `https://issues.chromium.org/issues/{bugId}` |
+| `fixCommit` | string\|null | Value or note | `fixCommitNote` | Upstream Skia commit SHA that fixes the CVE |
+| `fixCommitTitle` | string\|null | Optional | — | Subject of the fix commit |
+| `fixMilestone` | string\|null | Optional | — | Chrome milestone, e.g., `m148` |
+| `cvss` | number\|null | Value or note | `severityNote` | CVSS score |
+| `filesModified` | string[]\|null | Optional | — | Files changed by the fix commit |
+| `onUpstreamMilestone` | bool\|null | Value or note (when `affected`) | `branchNote` | Is fix on `upstream/chrome/m{OUR}`? |
+| `inOurTree` | bool\|null | ✅ When `affected` (never null) | — | Is fix in our fork's HEAD? |
+| `cherryPicksCleanly` | bool\|null | Value or note (when `affected`) | `cherryPickNote` | Did `git cherry-pick --no-commit` succeed? |
+| `reachability` | enum\|null | Value or note (when `affected`) | `reachabilityNote` | `REACHABLE` / `COMPILED_NOT_EXPOSED` / `NOT_REACHABLE` |
+| `evidence` | string | Optional | — | Freeform summary/evidence |
+
+When `assessment == "affected"`, the resolution fields (`cherryPicksCleanly`, `reachability`, `onUpstreamMilestone`, `inOurTree`) are strictly enforced — each requires either a value or its note counterpart (with `inOurTree` always requiring a boolean).
 
 ### CVE `source` Values
 

--- a/.agents/skills/security-audit/references/security-audit-schema.json
+++ b/.agents/skills/security-audit/references/security-audit-schema.json
@@ -189,40 +189,119 @@
             "type": "array",
             "items": {
               "type": "object",
+              "description": "CVE finding. Pattern: every essential field either has a concrete value OR a *Note field explaining why it's missing. Silent nulls are not allowed — the Python validator enforces 'value OR note' for fields marked (V|N) below.",
               "required": [
                 "id",
-                "severity"
+                "severity",
+                "description",
+                "source",
+                "assessment"
               ],
               "properties": {
                 "id": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "CVE ID, e.g., 'CVE-2026-8579'"
                 },
                 "severity": {
-                  "type": "string"
-                },
-                "cvss": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "fixedIn": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string",
+                  "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+                  "description": "Always required. Use Chromium severity rating if NVD CVSS is not yet assigned."
                 },
                 "description": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Vulnerability description"
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Where this CVE came from, e.g., 'NVD (Chrome CPE)', 'Android Security Bulletin'"
                 },
                 "assessment": {
-                  "type": "string"
+                  "type": "string",
+                  "enum": [
+                    "affected",
+                    "already_fixed",
+                    "false_positive",
+                    "needs_review",
+                    "nvd_range_error"
+                  ]
+                },
+                "cvss": {
+                  "type": ["number", "null"],
+                  "description": "CVSS score (V|N). If null, severityNote must explain why."
+                },
+                "severityNote": {
+                  "type": "string",
+                  "description": "Required when cvss is null. Explains the severity source (e.g., 'CVSS not yet assigned by NVD; using Chromium High rating')."
+                },
+                "bugId": {
+                  "type": ["string", "null"],
+                  "description": "Chromium bug ID (V|N). If null, bugIdNote must explain why."
+                },
+                "bugIdNote": {
+                  "type": "string",
+                  "description": "Required when bugId is null. Explains why no bug ID is available."
+                },
+                "bugUrl": {
+                  "type": ["string", "null"],
+                  "description": "https://issues.chromium.org/issues/{bugId}. May be null only when bugId is null."
+                },
+                "fixCommit": {
+                  "type": ["string", "null"],
+                  "description": "Upstream Skia commit SHA that fixes this CVE (V|N). If null, fixCommitNote must explain why."
+                },
+                "fixCommitNote": {
+                  "type": "string",
+                  "description": "Required when fixCommit is null. Explains why the fix commit could not be located."
+                },
+                "fixCommitTitle": {
+                  "type": ["string", "null"],
+                  "description": "Subject of the fix commit"
+                },
+                "fixMilestone": {
+                  "type": ["string", "null"],
+                  "description": "Chrome milestone containing the fix, e.g., 'm148'"
+                },
+                "filesModified": {
+                  "type": ["array", "null"],
+                  "items": { "type": "string" },
+                  "description": "Files changed by the fix commit (from git diff-tree --name-only)"
+                },
+                "onUpstreamMilestone": {
+                  "type": ["boolean", "null"],
+                  "description": "Is the fix commit on upstream/chrome/m{OUR} (V|N). If null, branchNote must explain."
+                },
+                "branchNote": {
+                  "type": "string",
+                  "description": "Required when onUpstreamMilestone is null. Explains the branch ancestry investigation."
+                },
+                "inOurTree": {
+                  "type": ["boolean", "null"],
+                  "description": "Is the fix commit an ancestor of HEAD in our fork. Always required (must be non-null)."
+                },
+                "cherryPicksCleanly": {
+                  "type": ["boolean", "null"],
+                  "description": "Did `git cherry-pick --no-commit` succeed (V|N). If null, cherryPickNote must explain (e.g., already fixed)."
+                },
+                "cherryPickNote": {
+                  "type": "string",
+                  "description": "Required when cherryPicksCleanly is null. Explains why the cherry-pick test wasn't run or wasn't needed."
+                },
+                "reachability": {
+                  "type": ["string", "null"],
+                  "enum": ["REACHABLE", "COMPILED_NOT_EXPOSED", "NOT_REACHABLE", null],
+                  "description": "Whether the vulnerable code is reachable via the SkiaSharp C API (V|N). If null, reachabilityNote must explain."
+                },
+                "reachabilityNote": {
+                  "type": "string",
+                  "description": "Required when reachability is null. Explains why reachability could not be determined."
+                },
+                "fixedIn": {
+                  "type": ["string", "null"],
+                  "description": "Legacy field — prefer fixMilestone"
                 },
                 "evidence": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Freeform evidence/summary text"
                 }
               },
               "additionalProperties": true

--- a/.agents/skills/security-audit/references/skia-cve-resolution.md
+++ b/.agents/skills/security-audit/references/skia-cve-resolution.md
@@ -1,0 +1,328 @@
+# Skia Core CVE Resolution
+
+> **Skia is the product, not just a dependency.** If a CVE exists in libpng or freetype, we
+> simply bump past it. For Skia itself, we need fine-grained resolution: find the actual fix
+> commit, verify which branches contain it, test cherry-pick feasibility, and assess whether
+> the vulnerable code is reachable through the SkiaSharp C API.
+>
+> **Every Skia CVE must be resolved to a fix commit.** Classification by milestone alone is
+> only the first pass — it is NEVER a final answer. A CVE without a verified fix commit is an
+> INCOMPLETE finding.
+
+## Why Skia is Different
+
+- **Invisible to Component Governance.** CG scans build-time dependencies (Docker, npm, NuGet)
+  and third-party libraries vendored via DEPS, but the Skia source tree itself is not in any
+  CG manifest. The NVD query is the **only** automated way to detect Skia CVEs.
+- **We carry a fork.** `mono/skia` diverges from upstream `google/skia` with the SkiaSharp
+  C API and other patches, so "upstream fixed it" doesn't necessarily mean "we have the fix".
+- **Reachability matters.** A Skia CVE might affect code that isn't exposed through our C API,
+  or code that's compiled out by our build flags (Graphite, Vulkan, Dawn). This affects
+  prioritization.
+
+## Pipeline (run for EVERY Skia CVE)
+
+```
+NVD CVE
+  → Bug URL (issues.chromium.org/issues/NNNNN)
+  → Bug ID
+  → Fetch upstream chrome/mNNN branches
+  → git log --grep="<bug_id>"
+  → Fix commit SHA
+  → Branch ancestry check (our milestone? our tree?)
+  → Cherry-pick test (--no-commit)
+  → Reachability assessment (C API / build flags)
+  → Structured finding
+```
+
+## Step 1: Query NVD for Skia CVEs
+
+```bash
+curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=Skia&resultsPerPage=200"
+```
+
+> No API key is required, but the rate limit is 5 requests per 30 seconds without one.
+
+> 🛑 **Process ALL CVEs returned by the query.** Do not filter by keywords in the description
+> (e.g., "print file", "extension"). The `keywordSearch=Skia` query already filters to Skia-related
+> CVEs. Sub-filtering by description keywords will miss CVEs like CVE-2026-6364 whose description
+> mentions "print file" but is actually about SKP lattice validation.
+
+> 🛑 **Scope: Recent CVEs (last 2 years).** From the full NVD results, process every CVE with
+> a 2024, 2025, or 2026 ID (or whatever the current and prior 2 years are). Older CVEs are
+> historical and already addressed. This typically yields 15-25 CVEs. If you find fewer than 10
+> recent Skia CVEs, something is wrong — re-check your query and pagination.
+
+> 🛑 **Every processed CVE must appear in the final JSON report** — as `affected`,
+> `already_fixed`, `false_positive`, or `needs_review`. Do NOT silently drop CVEs that are
+> "likely fixed" by milestone ordering. They must be verified and reported.
+
+> 🛑 **All Skia CVEs go in ONE finding object.** In the final report JSON, there must be
+> exactly ONE finding with `"dependency": "skia"`. Put ALL CVEs (affected, already_fixed,
+> false_positive) in that single finding's `cves[]` array. Use each CVE's `assessment` field
+> to distinguish status. Do NOT split Skia into multiple findings by milestone or category.
+
+For each CVE returned, extract:
+
+1. **CVE ID** and **description**
+2. **Severity** — CVSS score from `metrics.cvssMetricV31`
+3. **Chrome fix version** — from `configurations[].nodes[].cpeMatch[]` where `criteria`
+   contains `chrome` and `versionEndExcluding` exists
+4. **Chrome fix milestone** — major version from `versionEndExcluding` (e.g., `132.0.6834.83` → `132`)
+5. **Bug ID** — from `references[]`, look for `issues.chromium.org/issues/NNNNN`:
+
+   ```python
+   bug_id = None
+   for ref in cve['references']:
+       if 'issues.chromium.org/issues/' in ref['url']:
+           bug_id = ref['url'].rstrip('/').split('/')[-1]
+   ```
+
+> **The bug ID is the critical link** between the NVD CVE and the actual fix commit in the
+> Skia git repo. Every Chrome-reported Skia CVE has one. If a CVE has no bug URL, flag it
+> for manual investigation but do NOT skip it.
+
+## Step 2: First-Pass Classification (by milestone)
+
+Use the **verified milestone from `SkMilestone.h`** (not cgmanifest.json):
+
+| Condition | First-pass classification |
+|-----------|---------------------------|
+| Fix milestone > our milestone | 🔴 **Potentially affected** — proceed to commit resolution |
+| Fix milestone ≤ our milestone | 🟡 **Likely fixed** — verify with commit ancestry then classify as ⚪ false positive or 🔴 affected |
+| No Chrome version, mentions `SkiaRenderEngine` | ⚪ **Not applicable** — Android render engine, not Skia library |
+| No Chrome version, reported via Android/Huawei/vendor bulletin | ⚠️ **Code-path verification needed** (see below) |
+| No Chrome version, other | ⚠️ **Manual review** — check fork for affected code |
+| CVSS score not yet published | Use Chromium severity (High → treat as HIGH ~8.8) |
+
+> 🛑 **ALL CVEs must appear in the final report.** Do NOT drop CVEs from the report because
+> they are "likely fixed." Every CVE — regardless of classification — must be carried through
+> commit resolution and included in the JSON output (as `affected`, `false_positive`, or
+> `already_fixed`). Silently dropping CVEs is the #1 cause of incomplete audits.
+
+> 🛑 **EVERY CVE classified as 🔴 or 🟡 must proceed through commit resolution below.**
+> For 🟡 (fix milestone ≤ ours): verify the fix commit IS in our tree with
+> `git merge-base --is-ancestor`. If confirmed, classify as `false_positive` with evidence.
+> If NOT in our tree (fork diverged before the fix), reclassify as 🔴 affected.
+
+> 💡 **Milestone ordering hint:** If a CVE says "fixed in Chrome N" and N ≤ our milestone,
+> the fix SHOULD be in our tree (because m147 includes all of m146). If you can't find the
+> commit in Skia's git, it likely means the fix is in Chrome's integration layer (`chromium/src`),
+> not in the Skia library itself. See Step 4 fallback #3 (Chromium Gerrit search).
+
+## Step 3: Fetch Upstream Branches
+
+```bash
+cd externals/skia
+git remote add upstream https://github.com/google/skia.git 2>/dev/null || true
+
+# Full fetch — simple and reliable. Do NOT use --depth or --deepen.
+git fetch upstream chrome/m${OUR_MILESTONE}
+git fetch upstream chrome/m${OUR_MILESTONE+1}
+```
+
+> Fetching is read-only and does not modify any tracked files. Full fetches are necessary
+> because fix commits may be deep in branch history, not just at the tip as cherry-picks.
+
+## Step 4: Resolve Bug ID → Fix Commit
+
+```bash
+# Search the fix milestone branch for the bug ID
+git log upstream/chrome/m${FIX_MILESTONE} --oneline --grep="<BUG_ID>"
+
+# Bug IDs in commit messages appear as any of:
+#   Bug: NNNNNNNNN
+#   Bug: b/NNNNNNNNN
+#   Bug: chromium:NNNNNNNNN
+# A plain --grep="NNNNNNNNN" matches all three.
+```
+
+If grep returns empty:
+
+1. Try the next milestone branch (`m${OUR_MILESTONE+2}`, etc.).
+2. Try `git log --all --grep="<BUG_ID>"` after fetching more branches.
+3. **Search Chromium's Gerrit** — the fix may be in `chromium/src` (Chrome's integration
+   layer), not the standalone Skia library:
+   ```bash
+   # Query Chromium's code review system for the bug ID
+   curl -s "https://chromium-review.googlesource.com/changes/?q=bug:<BUG_ID>&n=5&o=CURRENT_REVISION" \
+     | tail -n +2 | python3 -c "
+   import json, sys
+   changes = json.load(sys.stdin)
+   for c in changes:
+       rev = list(c.get('revisions', {}).keys())[0] if c.get('revisions') else 'unknown'
+       print(f\"  {c['project']}  CL#{c['_number']}  {c['subject']}  commit={rev[:12]}\")
+   "
+   ```
+   If the result shows `project: "chromium/src"`, fetch the commit details:
+   ```bash
+   curl -s "https://chromium.googlesource.com/chromium/src/+/<COMMIT_SHA>?format=JSON" \
+     | tail -n +2 | python3 -c "
+   import json, sys
+   data = json.load(sys.stdin)
+   print(f\"Subject: {data['message'].splitlines()[0]}\")
+   for f in data.get('tree_diff', []):
+       print(f\"  {f['new_path']}\")
+   "
+   ```
+4. **Classify the result:**
+   - If modified files are under `skia/ext/` → **Chrome integration layer** (see
+     [Chrome Integration Layer False Positives](#chrome-integration-layer) below)
+   - If modified files are under `third_party/skia/` → the fix IS in Skia, search
+     harder in the Skia repo (it may have landed under a different bug ID)
+   - If modified files are elsewhere in `chromium/src` → not Skia at all
+5. Only after exhausting ALL of the above (Skia branches, `--all`, and Chromium Gerrit)
+   may you mark a CVE as "commit not found" — and you MUST include a detailed note
+   explaining every search attempted.
+
+## Step 5: Branch Ancestry Verification
+
+For each fix commit, determine where it lives:
+
+```bash
+COMMIT_SHA=<sha from previous step>
+
+# Is it on our milestone's upstream branch? (best case — Google backported)
+git merge-base --is-ancestor "$COMMIT_SHA" upstream/chrome/m${OUR_MILESTONE} \
+    && echo "ON_OUR_MILESTONE" || echo "NOT_ON_OUR_MILESTONE"
+
+# Is it in our actual fork tree?
+git merge-base --is-ancestor "$COMMIT_SHA" HEAD \
+    && echo "IN_OUR_TREE" || echo "NOT_IN_OUR_TREE"
+```
+
+| On `upstream/chrome/m${OUR}` | In our tree (HEAD) | Status |
+|------------------------------|--------------------|--------|
+| YES                          | YES                | ✅ Already fixed |
+| YES                          | NO                 | 🔴 VULNERABLE — upstream has backport for our milestone but our fork doesn't |
+| NO                           | NO                 | 🔴 VULNERABLE — fix only on newer milestone, needs cherry-pick |
+| NO                           | YES                | ✅ Fixed via fork-specific patch (rare; verify carefully) |
+
+## Step 6: Cherry-Pick Feasibility Test
+
+For EVERY commit classified as VULNERABLE:
+
+```bash
+git cherry-pick --no-commit "$COMMIT_SHA"
+if [ $? -eq 0 ]; then
+    echo "APPLIES_CLEANLY"
+    git checkout -- . && git clean -fd --quiet
+else
+    echo "CONFLICTS"
+    git cherry-pick --abort
+fi
+```
+
+Record `cherryPicksCleanly: true | false` in the report.
+
+## Step 7: Reachability Assessment
+
+Check whether the affected code is reachable from SkiaSharp:
+
+```bash
+# Files modified by the fix
+git diff-tree --no-commit-id --name-only -r "$COMMIT_SHA"
+
+# Check the C API for references to affected functions/classes
+grep -r "<relevant_symbol>" src/c/ include/c/
+
+# Check that the file is compiled into our library
+grep "<filename>" gn/*.gni BUILD.gn
+```
+
+| Category | Meaning |
+|----------|---------|
+| **REACHABLE** | Code is in the C API or called by C API functions (SkRuntimeEffect, SkRegion, SkPath, SkMaskFilter, etc.) |
+| **COMPILED_NOT_EXPOSED** | Code is in the library binary but not callable from SkiaSharp C API (e.g., `include/private/chromium/`). Still include as defense-in-depth. |
+| **NOT_REACHABLE** | Code is behind a compile flag we don't use (Graphite, Vulkan, Dawn) |
+
+## Non-Chrome Skia CVEs (Android / Vendor Bulletins)
+
+CVEs reported via Android Security Bulletins, Huawei HarmonyOS bulletins, or other vendor
+bulletins reference Skia code that **may also exist in upstream `google/skia`** and therefore
+in our fork. Vendor forks diverged from the same upstream, so shared code paths are common.
+
+**Do NOT dismiss a CVE just because it was reported through a vendor bulletin.** Verify:
+
+```bash
+cd externals/skia
+
+# Check if the vulnerable file exists
+find . -name "TheVulnerableFile.cpp"
+
+# Check if the vulnerable function exists
+git grep "vulnerable_function_name"
+
+# If a fix commit is referenced (e.g., from AOSP), check ancestry against HEAD
+git merge-base --is-ancestor "<fix_commit>" HEAD && echo "FIXED" || echo "VULNERABLE"
+```
+
+| Result | Status |
+|--------|--------|
+| Vulnerable file/function does NOT exist in our fork | ⚪ False positive — vendor-specific code |
+| Vulnerable code EXISTS + fix commit is ancestor of HEAD | ✅ Already fixed |
+| Vulnerable code EXISTS + NOT fixed | 🔴 Needs attention |
+
+## Skia-Specific False Positives
+
+| Pattern | Why it's a false positive |
+|---------|---------------------------|
+| `SkiaRenderEngine.cpp` (Android) | Android OS rendering infrastructure, not the Skia library itself. Always a false positive. |
+| AOSP `platform/external/skia` paths not in upstream | Android-specific code in AOSP's fork that doesn't exist in `google/skia`. Verify by file/function existence (above). |
+| Chrome-only rendering paths (HTML Canvas, SVG-in-browser) | May not be reachable through the SkiaSharp C API. Verify with reachability check. |
+| NVD version range errors | NVD ranges are sometimes wrong — verify with commit ancestry. If our tree contains the fix commit, classify as ⚪ False positive (NVD version range incorrect) and cite the commit. |
+| **`chromium/src/skia/ext/` (Chrome integration layer)** | See below. |
+
+### Chrome Integration Layer
+
+<a id="chrome-integration-layer"></a>
+
+Chrome has its own Skia extension code under `chromium/src/skia/ext/` (image_operations,
+convolver, benchmarking utilities). This is **NOT part of the standalone Skia library** —
+it's Chrome-specific wrapper code that uses Skia types.
+
+**How to identify:** The fix commit is in `chromium/src` and modifies files under `skia/ext/`.
+
+**Why it's a false positive for SkiaSharp:**
+- SkiaSharp uses the standalone Skia library (`skia.googlesource.com/skia`)
+- The `skia/ext/` directory does NOT exist in the Skia library — it's Chrome-specific
+- Our submodule at `externals/skia/` has no `ext/` directory
+- These files are never compiled into SkiaSharp's native binary
+
+**However**, you SHOULD still inspect the fix to determine if the **underlying Skia code
+being called** has the same vulnerability. For example, if Chrome's `skia/ext/image_operations.cc`
+adds an overflow check before calling `SkBitmap::tryAllocPixels()`, ask: "Does the same
+overflow exist when SkiaSharp calls `tryAllocPixels` directly?"
+
+**Assessment template for Chrome integration layer CVEs:**
+
+```
+assessment: "false_positive"
+fixCommitNote: "Fix is in chromium/src/skia/ext/ (Chrome integration layer, CL#NNNNN).
+  This code does not exist in the standalone Skia library. Inspected the fix — it adds
+  overflow checks for [specific scenario]. Verified that SkiaSharp's equivalent code path
+  [is/is not] vulnerable to the same overflow because [reason]."
+reachability: "NOT_REACHABLE"
+reachabilityNote: "chromium/src/skia/ext/ is Chrome-specific code not compiled into SkiaSharp"
+```
+
+## Required Output Fields (per Skia CVE)
+
+| Field | Required | Source |
+|-------|----------|--------|
+| CVE ID | ✅ | NVD |
+| Description | ✅ | NVD |
+| Bug ID | ✅ | NVD reference URL |
+| Bug URL | ✅ | `https://issues.chromium.org/issues/{bug_id}` |
+| Fix commit SHA | ✅ | `git log --grep` |
+| Fix commit title | ✅ | `git log --format` |
+| Files modified | ✅ | `git diff-tree --name-only` |
+| On `upstream/chrome/m${OUR}` | ✅ | `git merge-base --is-ancestor` |
+| In our tree (HEAD) | ✅ | `git merge-base --is-ancestor` |
+| Cherry-picks cleanly | ✅ | `git cherry-pick --no-commit` test |
+| Reachability | ✅ | C API + `.gni` check (REACHABLE / COMPILED_NOT_EXPOSED / NOT_REACHABLE) |
+| CVSS score | ✅ | NVD (or Chromium severity if pending) |
+| Fix milestone | ✅ | NVD `versionEndExcluding` |
+
+> 🛑 **Never report a Skia CVE as just "potentially affected" without resolving it to a commit.**
+> The bug ID → commit → branch verification pipeline is MANDATORY for every single CVE.

--- a/.agents/skills/security-audit/references/third-party-deps.md
+++ b/.agents/skills/security-audit/references/third-party-deps.md
@@ -1,0 +1,127 @@
+# Third-Party Dependency CVEs
+
+Third-party dependencies (libpng, freetype, harfbuzz, libexpat, brotli, zlib, libjpeg-turbo,
+libwebp, ANGLE submodules, etc.) are vendored into Skia via `externals/skia/DEPS`. Their CVE
+process is much simpler than Skia core: verify the version, check whether the fix commit is in
+our pinned tree, and recommend a DEPS bump if not.
+
+## Query CVE Databases
+
+Search the web for each dependency in parallel:
+
+```
+"{dependency} CVE {current year}"
+"{dependency} security vulnerability"
+```
+
+## Verify Versions From Source
+
+> ⚠️ **Never trust cgmanifest.json blindly.** Always verify against the actual DEPS file and
+> source headers. cgmanifest.json is manually maintained and drifts.
+
+### Read the Pinned Commit From DEPS
+
+```bash
+cat externals/skia/DEPS
+# Extract commit hashes for each dependency
+```
+
+### Read the Real Version From a Header File
+
+Each dependency exposes its version in a header. Fetch the header at the pinned commit from
+the Chromium git mirror:
+
+| Dependency | Version file | Version pattern |
+|------------|-------------|-----------------|
+| libpng | `png.h` lines 1–3 | `libpng version X.Y.Z` |
+| freetype | `include/freetype/freetype.h` | `FREETYPE_MAJOR`, `FREETYPE_MINOR`, `FREETYPE_PATCH` |
+| harfbuzz | `src/hb-version.h` | `HB_VERSION_STRING "X.Y.Z"` |
+| libexpat | `expat/lib/expat.h` | `XML_MAJOR_VERSION`, `XML_MINOR_VERSION`, `XML_MICRO_VERSION` |
+| brotli | `c/common/version.h` | `BROTLI_VERSION_MAJOR`, `_MINOR`, `_PATCH` |
+| zlib | `zlib.h` | `ZLIB_VERSION "X.Y.Z"` |
+| libjpeg-turbo | `README.chromium` | `Version: X.Y.Z` |
+| libwebp | `NEWS` line 1 | `version X.Y.Z` |
+
+### Googlesource Mirror URL Pattern
+
+```
+https://{host}/{path}/+/{commit_sha}/{file}?format=TEXT
+```
+
+Response is base64-encoded. Decode with:
+
+- Python: `base64.b64decode(text)`
+- PowerShell: `[System.Convert]::FromBase64String($text)`
+
+If the submodule externals are initialized locally, you can read directly from
+`externals/skia/third_party/externals/{dep}/` instead.
+
+## Verify Fix Commits
+
+> ⚠️ **CVE databases often have WRONG version ranges.** Always verify with the actual commit
+> in the vendored tree.
+
+```bash
+cd externals/skia/third_party/externals/{dependency}
+
+# Check if the fix commit is ancestor of current HEAD
+git merge-base --is-ancestor {fix_commit} HEAD && echo "FIXED" || echo "VULNERABLE"
+```
+
+### Example: CVE-2025-27363 (FreeType)
+
+CVE-2025-27363 claimed FreeType ≤ 2.13.3 was affected, with the fix in 2.13.4. Verification
+showed the fix commit (`ef636696...`) was actually merged into 2.13.1 — SkiaSharp's pinned
+2.13.3 was already patched. The published NVD version range was simply wrong.
+
+When this happens, classify the CVE as **⚪ False positive (NVD version range incorrect)** in
+the false positive section, citing the actual fix commit as evidence. Do NOT place it in
+findings with a "but it's actually fixed" note.
+
+## Known Third-Party False Positives
+
+| Pattern | Why |
+|---------|-----|
+| **MiniZip** (inside zlib) | Not compiled by Skia, not linked |
+| **FreeType's bundled zlib** | Separate copy from Skia's zlib — Skia's zlib build excludes it |
+| **NVD version range errors** | NVD ranges are sometimes wrong (see CVE-2025-27363 above). Verify with `git merge-base --is-ancestor`. |
+
+## ANGLE and Its Submodules
+
+ANGLE is a **separate** native component (Windows-only, for WinUI). It is **not** part of the
+Skia submodule — it's cloned separately from `https://github.com/google/angle.git`.
+
+```bash
+# Read the ANGLE version pin
+grep ANGLE scripts/VERSIONS.txt
+# Output: ANGLE    release    chromium/NNNN
+```
+
+ANGLE has its own submodules that must also be tracked:
+
+- `third_party/zlib` (separate from Skia's zlib)
+- `third_party/jsoncpp`
+- `third_party/vulkan-deps`
+- `third_party/astc-encoder/src`
+
+Check that all of these are in `cgmanifest.json`. If missing, flag as a coverage gap.
+
+## Reporting Third-Party Dep Findings
+
+For each third-party CVE, include:
+
+| Field | Source |
+|-------|--------|
+| CVE ID, description, CVSS | NVD / vendor advisory |
+| Affected dependency | Dependency name |
+| Affected version range | NVD (verify against actual!) |
+| Fix commit / version | Vendor changelog or commit log |
+| Our pinned commit | DEPS file |
+| Our pinned version | Header file (verified) |
+| Fix included? | `git merge-base --is-ancestor` |
+| Recommended action | Bump DEPS commit to ≥ {fix_version} |
+
+> Status priority for third-party CVEs:
+> - ✅ Already fixed (fix commit ancestor of HEAD)
+> - 🔴 Needs attention (fix commit not in HEAD; recommend DEPS bump)
+> - ⚪ False positive (NVD range error, code not compiled, etc.)

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -13,36 +13,30 @@ Prerequisites:
   - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
 
 Usage:
-  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--text] [--verbose] [--pipeline PIPELINE] [--output FILE]
+  python3 query-cg-alerts.py --output FILE [--branch BRANCH] [--text] [--verbose] [--pipeline PIPELINE] [--build-id BUILD_ID]
 
-  # Query all branches and both pipelines — write JSON to file (RECOMMENDED for AI agents)
+  # Standard usage — query all branches, write JSON to file (progress on stdout)
   python3 query-cg-alerts.py --output output/ai/cg-alerts-cache.json
 
-  # Same but with per-job progress (useful for debugging)
+  # With per-job progress (shows each CG log being parsed)
   python3 query-cg-alerts.py --verbose --output output/ai/cg-alerts-cache.json
 
-  # Query all branches — outputs JSON to stdout (legacy, progress goes to stderr)
-  python3 query-cg-alerts.py
-
-  # Human-readable text output (lists every CVE, nothing truncated)
-  python3 query-cg-alerts.py --text
+  # Also print human-readable text summary
+  python3 query-cg-alerts.py --text --output output/ai/cg-alerts-cache.json
 
   # Query only a specific branch
-  python3 query-cg-alerts.py --branch main
+  python3 query-cg-alerts.py --branch main --output output/ai/cg-alerts-cache.json
 
   # Query only the native pipeline
-  python3 query-cg-alerts.py --pipeline native
+  python3 query-cg-alerts.py --pipeline native --output output/ai/cg-alerts-cache.json
 
   # Query a specific build
-  python3 query-cg-alerts.py --build-id 14176611
+  python3 query-cg-alerts.py --build-id 14176611 --output output/ai/cg-alerts-cache.json
 
 Output:
-  With --output: writes JSON to specified file, prints progress to stdout.
-  Without --output: writes JSON to stdout (no progress visible to agent!).
-  With --text: human-readable grouped listing to stdout.
-
-  Progress messages always go to stdout when --output is used, so the calling
-  agent sees activity and knows the script is working (prevents timeout abandonment).
+  JSON is always written to the --output file.
+  Progress messages print to stdout so the calling agent sees activity.
+  This prevents agents from abandoning the 5-7 minute query.
 """
 
 import argparse
@@ -239,9 +233,9 @@ def main():
     parser.add_argument("--branch", type=str, help="Query only this branch (e.g., 'main' or 'release/3.119.x')")
     parser.add_argument("--pipeline", type=str, choices=["native", "managed", "both"], default="both",
                         help="Which pipeline to query (default: both)")
-    parser.add_argument("--text", action="store_true", help="Output as human-readable text instead of JSON (default is JSON for AI consumption)")
-    parser.add_argument("--output", "-o", type=str, help="Write JSON output to this file instead of stdout (progress is always printed to stdout)")
-    parser.add_argument("--verbose", "-v", action="store_true", help="Show progress messages to stderr")
+    parser.add_argument("--text", action="store_true", help="Also print human-readable text summary to stdout")
+    parser.add_argument("--output", "-o", type=str, required=True, help="Write JSON output to this file (required). Progress prints to stdout.")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show per-job progress (each CG log parsed)")
     args = parser.parse_args()
 
     token = get_token()
@@ -359,9 +353,9 @@ def main():
     if by_sev:
         print(f"[CG] Severity: {', '.join(f'{s}={c}' for s, c in by_sev.items())}")
 
-    # Output — write JSON to file if --output specified, otherwise stdout
+    # Output — write JSON to file, progress already printed to stdout
     if args.text:
-        # Text mode: full listing, grouped by component
+        # Text mode: also print grouped listing to stdout
         branches_str = ", ".join(sorted(set(b for _, b, _, _ in builds_to_query)))
         pipelines_str = ", ".join(pi["name"] for _, pi in pipelines_to_query)
         print(f"\nCG ALERTS — {pipelines_str}")
@@ -380,7 +374,6 @@ def main():
             branches = set()
             for a in comp_alerts:
                 branches.update(a["branches"])
-            # Collect all unique paths for this component
             all_paths = set()
             for a in comp_alerts:
                 all_paths.update(a.get("paths", []))
@@ -391,14 +384,11 @@ def main():
             for a in comp_alerts:
                 print(f"    - {a['id']} ({a['severity']})")
         print()
-    elif args.output:
-        # Write JSON to file, progress already went to stdout
-        with open(args.output, "w") as f:
-            json.dump(output, f, indent=2)
-        print(f"[CG] JSON written to: {args.output}")
-    else:
-        # No --output flag: write JSON to stdout (legacy behavior for piping)
-        print(json.dumps(output, indent=2))
+
+    # Always write JSON to the output file
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"[CG] JSON written to: {args.output}")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -13,9 +13,15 @@ Prerequisites:
   - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
 
 Usage:
-  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--text] [--verbose] [--pipeline PIPELINE]
+  python3 query-cg-alerts.py [--build-id BUILD_ID] [--branch BRANCH] [--text] [--verbose] [--pipeline PIPELINE] [--output FILE]
 
-  # Query all branches and both pipelines — outputs JSON (default, for AI)
+  # Query all branches and both pipelines — write JSON to file (RECOMMENDED for AI agents)
+  python3 query-cg-alerts.py --output output/ai/cg-alerts-cache.json
+
+  # Same but with per-job progress (useful for debugging)
+  python3 query-cg-alerts.py --verbose --output output/ai/cg-alerts-cache.json
+
+  # Query all branches — outputs JSON to stdout (legacy, progress goes to stderr)
   python3 query-cg-alerts.py
 
   # Human-readable text output (lists every CVE, nothing truncated)
@@ -31,9 +37,12 @@ Usage:
   python3 query-cg-alerts.py --build-id 14176611
 
 Output:
-  Default: JSON with every alert fully enumerated (id, component, severity,
-  source jobs, branches, pipelines). Designed for AI consumption.
-  With --text: grouped listing with all CVEs shown per component.
+  With --output: writes JSON to specified file, prints progress to stdout.
+  Without --output: writes JSON to stdout (no progress visible to agent!).
+  With --text: human-readable grouped listing to stdout.
+
+  Progress messages always go to stdout when --output is used, so the calling
+  agent sees activity and knows the script is working (prevents timeout abandonment).
 """
 
 import argparse
@@ -231,6 +240,7 @@ def main():
     parser.add_argument("--pipeline", type=str, choices=["native", "managed", "both"], default="both",
                         help="Which pipeline to query (default: both)")
     parser.add_argument("--text", action="store_true", help="Output as human-readable text instead of JSON (default is JSON for AI consumption)")
+    parser.add_argument("--output", "-o", type=str, help="Write JSON output to this file instead of stdout (progress is always printed to stdout)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show progress messages to stderr")
     args = parser.parse_args()
 
@@ -275,30 +285,31 @@ def main():
         print("ERROR: No builds found to query", file=sys.stderr)
         sys.exit(1)
 
-    if args.verbose:
-        print(f"Querying {len(builds_to_query)} build(s) across {len(pipelines_to_query)} pipeline(s):", file=sys.stderr)
-        for bid, branch, bnum, ptype in builds_to_query:
-            print(f"  [{PIPELINES[ptype]['name']}] {branch}: build {bid} ({bnum})", file=sys.stderr)
+    # Always print progress to stdout so the calling agent sees activity
+    print(f"[CG] Querying {len(builds_to_query)} build(s) across {len(pipelines_to_query)} pipeline(s)...")
+    for bid, branch, bnum, ptype in builds_to_query:
+        print(f"  [{PIPELINES[ptype]['name']}] {branch}: build {bid} ({bnum})")
+    sys.stdout.flush()
 
     # Collect alerts from all builds
     all_alerts = {}  # id -> {component, severity, branches, sources, pipelines}
 
     for build_id, branch, build_num, ptype in builds_to_query:
-        if args.verbose:
-            print(f"\n--- [{PIPELINES[ptype]['name']}] {branch} (build {build_id}) ---", file=sys.stderr)
+        print(f"\n[CG] --- [{PIPELINES[ptype]['name']}] {branch} (build {build_id}) ---")
+        sys.stdout.flush()
 
         reps = get_cg_log_ids(token, build_id)
         if not reps:
-            if args.verbose:
-                print(f"  WARNING: No CG logs found in build {build_id}", file=sys.stderr)
+            print(f"  WARNING: No CG logs found in build {build_id}")
             continue
 
-        if args.verbose:
-            print(f"  Checking {len(reps)} CG job(s): {', '.join(sorted(reps.keys())[:5])}{'...' if len(reps) > 5 else ''}", file=sys.stderr)
+        print(f"  Checking {len(reps)} CG job(s)...")
+        sys.stdout.flush()
 
         for category, (job_name, log_id) in sorted(reps.items()):
             if args.verbose:
-                print(f"    Parsing {category} (log {log_id})...", file=sys.stderr)
+                print(f"    Parsing {category} (log {log_id})...")
+                sys.stdout.flush()
             alerts = parse_cg_log(token, build_id, log_id)
             for alert in alerts:
                 key = alert["id"]
@@ -323,33 +334,37 @@ def main():
                         if p not in all_alerts[key]["paths"]:
                             all_alerts[key]["paths"].append(p)
 
-    # Output — always structured for AI consumption.
-    # Default is JSON since this script is consumed by the security-audit skill.
-    # Use --text for a human-readable summary.
-    if not args.text:
-        output = {
-            "queriedAt": datetime.now(timezone.utc).isoformat(),
-            "pipelines": [{"type": pt, "name": pi["name"], "id": pi["id"]} for pt, pi in pipelines_to_query],
-            "builds": [{"id": bid, "branch": br, "number": num, "pipeline": PIPELINES[pt]["name"]} 
-                       for bid, br, num, pt in builds_to_query],
-            "totalAlerts": len(all_alerts),
-            "bySeverity": {
-                sev: len([a for a in all_alerts.values() if a["severity"] == sev])
-                for sev in ["Critical", "High", "Medium", "Low"]
-                if any(a["severity"] == sev for a in all_alerts.values())
-            },
-            "alerts": sorted(all_alerts.values(), key=lambda a: (
-                {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(a["severity"], 9),
-                a["component"],
-                a["id"]
-            ))
-        }
-        print(json.dumps(output, indent=2))
-    else:
+    # Build the JSON output structure
+    output = {
+        "queriedAt": datetime.now(timezone.utc).isoformat(),
+        "pipelines": [{"type": pt, "name": pi["name"], "id": pi["id"]} for pt, pi in pipelines_to_query],
+        "builds": [{"id": bid, "branch": br, "number": num, "pipeline": PIPELINES[pt]["name"]} 
+                   for bid, br, num, pt in builds_to_query],
+        "totalAlerts": len(all_alerts),
+        "bySeverity": {
+            sev: len([a for a in all_alerts.values() if a["severity"] == sev])
+            for sev in ["Critical", "High", "Medium", "Low"]
+            if any(a["severity"] == sev for a in all_alerts.values())
+        },
+        "alerts": sorted(all_alerts.values(), key=lambda a: (
+            {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}.get(a["severity"], 9),
+            a["component"],
+            a["id"]
+        ))
+    }
+
+    # Always print completion summary to stdout (agent sees this)
+    print(f"\n[CG] ✅ Complete: {len(all_alerts)} unique alerts across {len(builds_to_query)} builds")
+    by_sev = output["bySeverity"]
+    if by_sev:
+        print(f"[CG] Severity: {', '.join(f'{s}={c}' for s, c in by_sev.items())}")
+
+    # Output — write JSON to file if --output specified, otherwise stdout
+    if args.text:
         # Text mode: full listing, grouped by component
         branches_str = ", ".join(sorted(set(b for _, b, _, _ in builds_to_query)))
         pipelines_str = ", ".join(pi["name"] for _, pi in pipelines_to_query)
-        print(f"CG ALERTS — {pipelines_str}")
+        print(f"\nCG ALERTS — {pipelines_str}")
         print(f"Branches: {branches_str}")
         print(f"Total: {len(all_alerts)} unique alerts")
         print()
@@ -376,6 +391,14 @@ def main():
             for a in comp_alerts:
                 print(f"    - {a['id']} ({a['severity']})")
         print()
+    elif args.output:
+        # Write JSON to file, progress already went to stdout
+        with open(args.output, "w") as f:
+            json.dump(output, f, indent=2)
+        print(f"[CG] JSON written to: {args.output}")
+    else:
+        # No --output flag: write JSON to stdout (legacy behavior for piping)
+        print(json.dumps(output, indent=2))
 
 
 if __name__ == "__main__":

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -81,8 +81,8 @@ elif cg:
     total_alerts = cg.get("totalAlerts", 0)
     all_alerts = cg.get("alerts", [])
 
-    if not all_alerts:
-        errors.append("cgAlerts missing 'alerts' array — include the raw query-cg-alerts.py output")
+    if "alerts" not in cg:
+        errors.append("cgAlerts missing 'alerts' key — include the raw query-cg-alerts.py output")
 
     # Count must match totalAlerts
     if all_alerts and len(all_alerts) != total_alerts:
@@ -111,11 +111,15 @@ elif cg:
     if not cg.get("pipelines"):
         warnings.append("cgAlerts.pipelines is empty — should list scanned pipelines")
 
-# 4. Findings must have unique dependencies
+# 4. Findings must have unique dependencies — ONE finding per dependency, all CVEs inside it
 deps = [f.get("dependency") for f in findings]
 dupes = [d for d in set(deps) if deps.count(d) > 1]
 if dupes:
-    warnings.append(f"Duplicate finding dependencies: {dupes}")
+    errors.append(
+        f"Duplicate finding dependencies: {dupes} — each dependency MUST have exactly ONE "
+        "finding object. Put all CVEs (affected, already_fixed, false_positive) in a single "
+        "finding's cves[] array. Use each CVE's 'assessment' field to distinguish status."
+    )
 
 # 5. Every finding with status != clean/false_positive should have CVEs or action
 for f in findings:
@@ -131,12 +135,86 @@ if priorities != sorted(priorities):
 # 7. Meta validation
 if not meta.get("date"):
     errors.append("meta.date is required")
-if not meta.get("skiaMilestone"):
+skia_milestone = meta.get("skiaMilestone")
+if skia_milestone is None:
     errors.append("meta.skiaMilestone is required")
+elif not isinstance(skia_milestone, int) or skia_milestone <= 0:
+    errors.append(f"meta.skiaMilestone must be an integer > 0 (got {skia_milestone!r})")
+skia_sha = meta.get("skiaSubmoduleCommit")
+if not skia_sha:
+    errors.append("meta.skiaSubmoduleCommit is required")
+elif not (isinstance(skia_sha, str) and len(skia_sha) >= 7 and all(c in "0123456789abcdefABCDEF" for c in skia_sha)):
+    errors.append(f"meta.skiaSubmoduleCommit must look like a git SHA (got {skia_sha!r})")
 
 # 8. versionVerification should have entries
 if not versions:
     warnings.append("versionVerification is empty — should list verified dependencies")
+
+# 9. Skia CVE completeness — every CVE in a skia finding must be fully resolved.
+#    Pattern: each essential field is either a concrete value OR has an accompanying
+#    *Note field explaining why it's missing. Silent nulls are forbidden.
+def _has_note(cve, key):
+    v = cve.get(key)
+    return isinstance(v, str) and v.strip() != ""
+
+for f in findings:
+    if f.get("dependency") != "skia":
+        continue
+    if f.get("status") == "clean":
+        continue
+    for j, cve in enumerate(f.get("cves", [])):
+        cid = cve.get("id", f"cves[{j}]")
+        loc = f"finding 'skia' / {cid}"
+
+        # Always-required basics
+        if not cve.get("description"):
+            errors.append(f"{loc}: missing 'description'")
+        if not cve.get("source"):
+            errors.append(f"{loc}: missing 'source'")
+        if not cve.get("assessment"):
+            errors.append(f"{loc}: missing 'assessment'")
+        sev = cve.get("severity")
+        if sev not in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
+            errors.append(f"{loc}: severity must be CRITICAL/HIGH/MEDIUM/LOW (got {sev!r})")
+
+        # Value OR Note pairs (errors)
+        if cve.get("bugId") in (None, "") and not _has_note(cve, "bugIdNote"):
+            errors.append(f"{loc}: bugId is null but bugIdNote is missing — explain why no bug ID was found")
+        if cve.get("fixCommit") in (None, "") and not _has_note(cve, "fixCommitNote"):
+            errors.append(f"{loc}: fixCommit is null but fixCommitNote is missing — explain why no fix commit was located")
+
+        # Value OR Note pair (warning — CVSS often pending)
+        if cve.get("cvss") is None and not _has_note(cve, "severityNote"):
+            warnings.append(f"{loc}: cvss is null but severityNote is missing — explain the severity source")
+
+        # bugUrl can only be null if bugId is null
+        if cve.get("bugId") and not cve.get("bugUrl"):
+            warnings.append(f"{loc}: bugId is set but bugUrl is missing — derive from issues.chromium.org/issues/{cve.get('bugId')}")
+
+        # Assessment == affected requires complete resolution
+        if cve.get("assessment") == "affected":
+            if cve.get("cherryPicksCleanly") is None and not _has_note(cve, "cherryPickNote"):
+                errors.append(f"{loc}: assessment='affected' requires cherryPicksCleanly or cherryPickNote")
+            if cve.get("reachability") is None and not _has_note(cve, "reachabilityNote"):
+                errors.append(f"{loc}: assessment='affected' requires reachability or reachabilityNote")
+            if cve.get("onUpstreamMilestone") is None and not _has_note(cve, "branchNote"):
+                errors.append(f"{loc}: assessment='affected' requires onUpstreamMilestone or branchNote")
+            if cve.get("inOurTree") is None:
+                errors.append(f"{loc}: assessment='affected' requires inOurTree (boolean, never null)")
+
+# 10. Minimum CVE count check — the NVD "Skia" query typically returns 15+ recent CVEs.
+#     If the report has significantly fewer, the agent may have dropped "already fixed" ones.
+skia_cve_count = 0
+for f in findings:
+    if f.get("dependency") == "skia":
+        skia_cve_count += len(f.get("cves", []))
+        skia_cve_count += len(f.get("nonChromeCves", []))
+
+if skia_cve_count < 10:
+    warnings.append(
+        f"Only {skia_cve_count} Skia CVEs in report — NVD typically returns 15+ recent CVEs. "
+        "Verify that 'already_fixed' and 'false_positive' CVEs were not silently dropped."
+    )
 
 # --- Output ---
 if warnings:

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -107,9 +107,28 @@ elif cg:
             if actual != count:
                 warnings.append(f"cgAlerts.bySeverity.{sev} ({count}) != actual ({actual})")
 
-    # Pipelines should be present
+    # Pipelines should be present — empty means script wasn't run or agent fabricated data
     if not cg.get("pipelines"):
-        warnings.append("cgAlerts.pipelines is empty — should list scanned pipelines")
+        errors.append(
+            "cgAlerts.pipelines is empty — the CG query script was not run successfully. "
+            "The script takes 5-7 minutes and MUST complete. Empty/fabricated CG data is "
+            "unacceptable in a security audit. Re-run with initial_wait >= 600 seconds."
+        )
+
+    # Builds should be present
+    if not cg.get("builds"):
+        errors.append(
+            "cgAlerts.builds is empty — no builds were queried. "
+            "The CG script must discover and query builds from both pipelines."
+        )
+
+    # Detect fabricated timestamps (midnight UTC = clearly fake)
+    queried_at = cg.get("queriedAt", "")
+    if queried_at and "T00:00:00" in queried_at:
+        errors.append(
+            f"cgAlerts.queriedAt '{queried_at}' appears fabricated (midnight UTC). "
+            "This timestamp must come from the actual script execution, not be invented."
+        )
 
 # 4. Findings must have unique dependencies — ONE finding per dependency, all CVEs inside it
 deps = [f.get("dependency") for f in findings]

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -127,6 +127,19 @@ const SEV_CLASS = { CRITICAL: 'sev-critical', HIGH: 'sev-high', MEDIUM: 'sev-med
 function sevClass(s) { return SEV_CLASS[(s||'').toUpperCase()] || 'sev-unknown'; }
 function esc(s) { const d = document.createElement('div'); d.textContent = s||''; return d.innerHTML; }
 
+const ASSESSMENT_LABELS = {
+  affected: ['🔴 Affected', 'badge bg-danger'],
+  already_fixed: ['✅ Fixed', 'badge bg-success'],
+  false_positive: ['⚪ False Positive', 'badge bg-secondary'],
+  needs_review: ['🟡 Needs Review', 'badge bg-warning text-dark'],
+  not_in_tree: ['➖ Not In Tree', 'badge bg-light text-dark border'],
+};
+function assessmentBadge(val) {
+  const entry = ASSESSMENT_LABELS[val];
+  if (entry) return `<span class="${entry[1]}">${entry[0]}</span>`;
+  return esc(val);
+}
+
 function renderSummary(s, cgAlerts) {
   const cgCount = cgAlerts ? (cgAlerts.totalAlerts || 0) : 0;
   const cgHigh = cgAlerts ? ((cgAlerts.bySeverity || {}).High || 0) + ((cgAlerts.bySeverity || {}).Critical || 0) : 0;
@@ -291,6 +304,9 @@ function renderCveTable(cves, columns) {
       if (c.key === 'id') {
         const url = val.startsWith('GHSA-') ? `https://github.com/advisories/${esc(val)}` : `https://nvd.nist.gov/vuln/detail/${esc(val)}`;
         return `<td><a href="${url}" target="_blank">${esc(val)}</a></td>`;
+      }
+      if (c.key === 'assessment') {
+        return `<td>${assessmentBadge(String(val))}</td>`;
       }
       return `<td>${esc(String(val))}</td>`;
     }).join('');


### PR DESCRIPTION
## Summary

Refactors and improves the security-audit skill for better report quality and reliability.

### Changes

**Schema & validation improvements:**
- Enforce one finding per dependency (validator rejects duplicates as errors)
- Add structured completeness checks to ensure all NVD results are reported
- Strengthen CG alert validation (reject empty/incomplete results)

**CG query script reliability:**
- Make `--output` required — JSON always writes to file
- Print progress to stdout so long-running queries show visible activity
- Add `--verbose` flag for per-job detail

**Skill instruction improvements:**
- Add Chromium Gerrit fallback for resolving CVEs fixed in Chrome's integration layer
- Add milestone-ordering guidance for assessing fix applicability
- Clarify consolidation rules in report-schema.md and SKILL.md
- Add timing guidance for long-running CG queries

**New reference files (multi-file architecture):**
- `references/skia-cve-resolution.md` — Dedicated Skia CVE pipeline docs
- `references/third-party-deps.md` — Third-party dependency audit process  
- `references/cg-alerts.md` — Component Governance integration guide
