### PR TITLE
docs: force-push docs-live to prevent repo size bloat

### DIFF
--- a/.github/workflows/build-site-cleanup-stale.yml
+++ b/.github/workflows/build-site-cleanup-stale.yml
@@ -21,10 +21,9 @@ jobs:
       contents: write        # push to docs-live
       pull-requests: read    # check PR state
     steps:
-      - name: Checkout docs-live branch
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: docs-live
           fetch-depth: 1
 
       - name: Find and remove stale staging directories
@@ -32,6 +31,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          # Switch to docs-live branch; exit cleanly if it doesn't exist yet
+          if ! git fetch --depth=1 origin docs-live:docs-live 2>/dev/null; then
+            echo "docs-live branch does not exist, nothing to sweep"
+            exit 0
+          fi
+          if ! git checkout docs-live 2>/dev/null; then
+            echo "Failed to checkout docs-live, nothing to sweep"
+            exit 0
+          fi
+
           if [ ! -d staging ]; then
             echo "No staging directory found, nothing to do"
             exit 0
@@ -77,14 +86,31 @@ jobs:
           git config --local user.name "GitHub Action"
           git add -A
           if ! git diff --cached --quiet; then
-            git commit -m "Sweep stale staging docs for ${#stale_dirs[@]} closed PR(s)"
-            # Retry push with rebase in case another workflow pushed in the meantime
+            # Amend the single commit to prevent history accumulation
+            git commit --amend -m "docs-live"
+            # Force-push with lease: fails atomically if another workflow pushed
             for attempt in 1 2 3 4 5; do
-              if git push origin docs-live; then
+              if git push --force-with-lease origin docs-live; then
                 break
               fi
-              echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
-              git pull --rebase origin docs-live
+              echo "Push failed (attempt $attempt), re-fetching and retrying..."
+              git fetch --depth=1 origin docs-live
+              git reset --hard origin/docs-live
+              # Re-check which dirs are still stale after re-fetch
+              removed_any=false
+              for d in "${stale_dirs[@]}"; do
+                if [ -d "$d" ]; then
+                  rm -rf "$d"
+                  removed_any=true
+                fi
+              done
+              if [ "$removed_any" = true ]; then
+                git add -A
+                git commit --amend -m "docs-live"
+              else
+                echo "Stale directories already removed by another workflow"
+                break
+              fi
               if [ $attempt -eq 5 ]; then
                 echo "Failed to push after 5 attempts"
                 exit 1

--- a/.github/workflows/build-site-cleanup.yml
+++ b/.github/workflows/build-site-cleanup.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Remove staging directory from docs-live
         env:
@@ -36,7 +36,7 @@ jobs:
           fi
 
           # Switch to docs-live branch; exit cleanly if it doesn't exist yet
-          if ! git fetch origin docs-live:docs-live 2>/dev/null; then
+          if ! git fetch --depth=1 origin docs-live:docs-live 2>/dev/null; then
             echo "docs-live branch does not exist, nothing to clean up"
             exit 0
           fi
@@ -51,14 +51,24 @@ jobs:
             git config --local user.name "GitHub Action"
             git add -A
             if ! git diff --cached --quiet; then
-              git commit -m "Remove staging docs for PR #$PR_NUMBER"
-              # Retry push with rebase in case another workflow pushed in the meantime
+              # Amend the single commit to prevent history accumulation
+              git commit --amend -m "docs-live"
+              # Force-push with lease: fails atomically if another workflow pushed
               for attempt in 1 2 3 4 5; do
-                if git push origin docs-live; then
+                if git push --force-with-lease origin docs-live; then
                   break
                 fi
-                echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
-                git pull --rebase origin docs-live
+                echo "Push failed (attempt $attempt), re-fetching and retrying..."
+                git fetch --depth=1 origin docs-live
+                git reset --hard origin/docs-live
+                if [ -d "staging/$PR_NUMBER" ]; then
+                  rm -rf "staging/$PR_NUMBER"
+                  git add -A
+                  git commit --amend -m "docs-live"
+                else
+                  echo "Staging directory already removed by another workflow"
+                  break
+                fi
                 if [ $attempt -eq 5 ]; then
                   echo "Failed to push after 5 attempts"
                   exit 1

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -336,8 +336,8 @@ jobs:
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
 
-          # Fetch docs-live if it exists; otherwise create an orphan branch
-          if git fetch origin docs-live 2>/dev/null; then
+          # Fetch docs-live (depth=1 to avoid accumulating history)
+          if git fetch --depth=1 origin docs-live 2>/dev/null; then
             git checkout -b docs-live origin/docs-live
           else
             echo "docs-live branch does not exist, creating orphan branch"
@@ -345,8 +345,13 @@ jobs:
             git rm -rf . 2>/dev/null || true
             touch .nojekyll
             git add .nojekyll
-            git commit -m "Initialize docs-live branch"
-            git push origin docs-live
+            git commit -m "docs-live"
+            # If another workflow beat us to creating the branch, just use theirs
+            if ! git push origin docs-live 2>/dev/null; then
+              echo "Branch was created by another workflow, fetching it instead"
+              git fetch --depth=1 origin docs-live
+              git checkout -B docs-live origin/docs-live
+            fi
           fi
 
       - name: Download site artifact
@@ -366,23 +371,34 @@ jobs:
               -not -name '..' \
             -exec rm -rf {} \;
           cp -r /tmp/site-temp/. .
-          rm -rf /tmp/site-temp
 
           # Ensure .nojekyll exists so _framework/ directories are served
           touch .nojekyll
 
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add .
+          git add -A
           if ! git diff --cached --quiet; then
-            git commit -m "Deploy main documentation from commit ${{ github.sha }}"
-            # Retry push with rebase in case another workflow pushed in the meantime
+            # Amend the single commit to prevent history accumulation (keeps repo clone size small)
+            git commit --amend -m "docs-live"
+            # Force-push with lease: fails atomically if another workflow pushed in the meantime
             for attempt in 1 2 3 4 5; do
-              if git push origin docs-live; then
+              if git push --force-with-lease origin docs-live; then
                 break
               fi
-              echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
-              git pull --rebase origin docs-live
+              echo "Push failed (attempt $attempt), re-fetching and retrying..."
+              # Hard-reset to latest origin (picks up any staging changes from parallel workflows)
+              # then re-apply our main site content on top, preserving their staging/ dirs.
+              git fetch --depth=1 origin docs-live
+              git reset --hard origin/docs-live
+              find . -maxdepth 1 \
+                  -not -name 'staging' \
+                  -not -name '.git' \
+                  -not -name '.' \
+                  -not -name '..' \
+                -exec rm -rf {} \;
+              cp -r /tmp/site-temp/. .
+              touch .nojekyll
+              git add -A
+              git commit --amend -m "docs-live"
               if [ $attempt -eq 5 ]; then
                 echo "Failed to push after 5 attempts"
                 exit 1
@@ -392,6 +408,8 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+          rm -rf /tmp/site-temp
 
       - name: Deploy staging site content
         if: needs.build.outputs.is_staging == 'true'
@@ -408,24 +426,28 @@ jobs:
           mkdir -p "staging/$PR_NUMBER"
           cp -r /tmp/site-temp/. "staging/$PR_NUMBER/"
 
-          rm -rf /tmp/site-temp
-
           # Ensure .nojekyll exists at root so _framework is served
           touch .nojekyll
 
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add .nojekyll staging/$PR_NUMBER
+          git add .nojekyll "staging/$PR_NUMBER"
           if ! git diff --cached --quiet; then
-            git commit -m "Deploy staging docs for PR #$PR_NUMBER" \
-              -m "https://mono.github.io/SkiaSharp/staging/$PR_NUMBER/"
-            # Retry push with rebase in case another workflow pushed in the meantime
+            # Amend the single commit to prevent history accumulation (keeps repo clone size small)
+            git commit --amend -m "docs-live"
+            # Force-push with lease: fails atomically if another workflow pushed in the meantime
             for attempt in 1 2 3 4 5; do
-              if git push origin docs-live; then
+              if git push --force-with-lease origin docs-live; then
                 break
               fi
-              echo "Push failed (attempt $attempt), pulling with rebase and retrying..."
-              git pull --rebase origin docs-live
+              echo "Push failed (attempt $attempt), re-fetching and retrying..."
+              # Hard-reset to latest origin, then re-apply our staging content
+              git fetch --depth=1 origin docs-live
+              git reset --hard origin/docs-live
+              rm -rf "staging/$PR_NUMBER"
+              mkdir -p "staging/$PR_NUMBER"
+              cp -r /tmp/site-temp/. "staging/$PR_NUMBER/"
+              touch .nojekyll
+              git add .nojekyll "staging/$PR_NUMBER"
+              git commit --amend -m "docs-live"
               if [ $attempt -eq 5 ]; then
                 echo "Failed to push after 5 attempts"
                 exit 1
@@ -435,6 +457,8 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+          rm -rf /tmp/site-temp
 
   # ── Comment on PR with preview URL ──────────────────────────
   comment:


### PR DESCRIPTION
## Problem

A full clone of this repo is **>5 GB** while a shallow clone (`--depth=1`) is only ~250 MB. The bloat comes from the `docs-live` orphan branch, which has accumulated **643 commits** of WASM binaries (~11 MB each) and site artifacts from every PR preview deploy, every main deploy, and every cleanup over time. That's roughly **17 GB of unreachable history** every cloner pays for.

## Solution

Change all docs workflows to use `commit --amend` + `push --force-with-lease` instead of appending new commits. This keeps `docs-live` at exactly **one commit forever**, preventing any history accumulation.

### Files changed

- `build-site.yml` — main + staging deploys
- `build-site-cleanup.yml` — per-PR staging dir removal on PR close
- `build-site-cleanup-stale.yml` — scheduled sweep of stale staging dirs

### Strategy

1. `git fetch --depth=1 origin docs-live` — only need the latest state
2. Make changes (deploy / remove staging dir)
3. `git commit --amend -m "docs-live"` — rewrites the single commit
4. `git push --force-with-lease origin docs-live` — atomic; fails if someone else pushed
5. On lease failure: re-fetch, hard-reset, re-apply changes, retry (up to 5 times)

### Parallel safety

Multiple workflows can push concurrently (main deploy vs PR staging vs sweep). Each retry path was reviewed by both Opus 4.7 and GPT-5.5 to ensure:
- Main deploy retry preserves staging dirs from parallel PRs (`reset --hard` + re-apply main content, leaving `staging/` from origin intact)
- Staging deploy retry recopies its own PR's content from `/tmp/site-temp` on top of latest origin
- Cleanup/sweep retries re-check the target before deleting (idempotent, exits cleanly if already removed)
- Orphan-creation race on first ever deploy is handled (falls back to fetching the winner's branch)

## To activate the fix

After this PR is merged:

1. **Delete the existing `docs-live` branch** on GitHub to drop the 17 GB of history:
   ```bash
   gh api -X DELETE repos/mono/SkiaSharp/git/refs/heads/docs-live
   ```
2. Trigger a docs build (push to main or run the workflow manually) — the workflow will recreate `docs-live` as a fresh single-commit orphan branch.
3. After GitHub GCs the unreachable objects (typically within hours), full clones should drop from >5 GB to ~1–2 GB.

## Verification

The strategy was reviewed by two LLMs (Opus 4.7 and GPT-5.5). Initial reviews caught:
- A staging-resurrection bug in the main deploy retry (fixed)
- An orphan-creation race on first deploy (fixed)
- The sweep workflow failing if `docs-live` didn't exist yet (fixed)
- Fragile mixed reset in staging retry (fixed → hard reset + recopy)

Final reviews from both models: ✅ ship it, no remaining correctness bugs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>