### PR TITLE
Add es-metadata.yml to cache exclude list

### DIFF
--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -21,6 +21,7 @@
     "*.md",
     ".gitattributes",
     ".gitignore",
+    "es-metadata.yml",
     "externals/.gitignore",
     "native/.gitignore",
     "scripts/get-skiasharp-pr.*",


### PR DESCRIPTION
The file `es-metadata.yml` (added in #4075) is unrelated to any build job — it's a repository metadata configuration. It needs to be in the cache-coverage exclude list, otherwise every PR build fails at the "Validate cache config coverage" step with:

```
[FAIL] UNCOVERED FILES:
es-metadata.yml
```

This is a small unblocker — should be merged ASAP so other PRs (e.g. #4062) can pass CI.