### PR TITLE
Update expat to 2.8.1

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -69,7 +69,7 @@
         "type": "other",
         "other": {
           "name": "libexpat",
-          "version": "2.7.5",
+          "version": "2.8.1",
           "downloadUrl": "https://github.com/libexpat/libexpat"
         }
       }


### PR DESCRIPTION
Updates libexpat from 2.7.5 to 2.8.1.

Changes:
- `cgmanifest.json`: version bump
- `externals/skia`: submodule updated

Required skia PR: https://github.com/mono/skia/pull/245