### PR TITLE
Fix WinUI Projection DLL not resolved for .NET 9 consumers on Windows

### DIFF
--- a/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
+++ b/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksPrevious)" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\x64\*" RuntimeIdentifier="win-x64" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksPrevious)" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\x86\*" RuntimeIdentifier="win-x86" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksPrevious)" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\arm64\*" RuntimeIdentifier="win-arm64" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Fixes #4082 — `SkiaSharp.Views.WinUI.Native.Projection` assembly not found at runtime on Windows for .NET 9 apps (v3.119.4+).

## Root Cause

When the primary TFM moved from `net8.0` to `net10.0` (TFMCurrent), the `NativeAssetPackageFile` entries in `SkiaSharp.NativeAssets.WinUI.csproj` placed the Projection DLL only into:

```
runtimes/win-{arch}/lib/net10.0-windows10.0.19041.0/
```

NuGet's TFM resolution won't serve a `net10.0` asset to a `net9.0` consumer (higher TFM isn't backward-compatible), so .NET 9 apps get a `FileNotFoundException` at runtime.

**In v3.119.2** (TFMCurrent=net8.0): The DLL was in `runtimes/win-{arch}/lib/net8.0-windows10.0.19041.0/` — accessible to both net8 and net9 consumers.

## Fix

Include the Projection DLL in **all** supported Windows TFM folders (`WindowsTargetFrameworksCurrent` and `WindowsTargetFrameworksPrevious`), so the NuGet package serves it to both .NET 9 and .NET 10 consumers.

Resulting package layout:
```
runtimes/win-x64/lib/net10.0-windows10.0.19041.0/SkiaSharp.Views.WinUI.Native.Projection.dll
runtimes/win-x64/lib/net9.0-windows10.0.19041.0/SkiaSharp.Views.WinUI.Native.Projection.dll
runtimes/win-x64/native/SkiaSharp.Views.WinUI.Native.dll
(same pattern for win-x86 and win-arm64)
```

## Testing

- iOS/Android unaffected (they don't use the WinUI Projection)
- Windows .NET 9: Projection DLL now found via net9.0-windows folder
- Windows .NET 10: Projection DLL found via net10.0-windows folder