### PR TITLE
[3.119.x] Fix WinUI Projection DLL not resolved for .NET 9 consumers on Windows

### DIFF
--- a/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
+++ b/binding/SkiaSharp.NativeAssets.WinUI/SkiaSharp.NativeAssets.WinUI.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x64" Folder="lib\$(WindowsTargetFrameworksPrevious)" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\x64\*" RuntimeIdentifier="win-x64" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-x86" Folder="lib\$(WindowsTargetFrameworksPrevious)" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\x86\*" RuntimeIdentifier="win-x86" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksCurrent)" />
+    <NativeAssetPackageFile Include="..\..\output\native\winui\any\*" RuntimeIdentifier="win-arm64" Folder="lib\$(WindowsTargetFrameworksPrevious)" />
     <NativeAssetPackageFile Include="..\..\output\native\winui\arm64\*" RuntimeIdentifier="win-arm64" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Backport of #4084 to release/3.119.x.

Fixes #4082 — `SkiaSharp.Views.WinUI.Native.Projection` assembly not found at runtime on Windows for .NET 9 apps (v3.119.4+).

## Root Cause

When TFMCurrent moved to `net10.0`, the NuGet package placed the Projection DLL only in `runtimes/win-{arch}/lib/net10.0-windows10.0.19041.0/`. NuGet won't serve a `net10.0` asset to a `net9.0` consumer, causing `FileNotFoundException` at runtime.

## Fix

Include the Projection DLL in **all** supported Windows TFM folders (both `WindowsTargetFrameworksCurrent` and `WindowsTargetFrameworksPrevious`), so both .NET 9 and .NET 10 consumers can resolve it.