### PR TITLE
Add --pull to Docker builds to ensure fresh base images

### DIFF
--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -359,7 +359,7 @@ jobs:
                 dockerfile: ${{ parameters.docker }}/Dockerfile
                 context: ${{ parameters.docker }}
                 image: skiasharp:skiasharp
-                buildArguments: --platform linux/amd64 --tag skiasharp ${{ parameters.dockerArgs }}
+                buildArguments: --pull --platform linux/amd64 --tag skiasharp ${{ parameters.dockerArgs }}
                 enableNetwork: true
           - ${{ if ne(parameters.use1ESPipelineTemplates, 'true') }}:
             - task: Docker@2
@@ -374,7 +374,7 @@ jobs:
                 command: build
                 buildContext: ${{ parameters.docker }}
                 dockerfile: ${{ parameters.docker }}/Dockerfile
-                arguments: --platform linux/amd64 --tag skiasharp ${{ parameters.dockerArgs }}
+                arguments: --pull --platform linux/amd64 --tag skiasharp ${{ parameters.dockerArgs }}
           - bash: |
               echo dotnet tool restore > cmd.sh
               echo dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }} >> cmd.sh


### PR DESCRIPTION
## Problem

Docker builds on CI agents reuse whatever base image layer is cached locally. Without `--pull`, the cached copy can lag behind MCR by days or weeks, so updates shipped in the .NET prereqs images never reach our builds until an agent happens to lose its cache.

## Fix

Add `--pull` to both the `1ES.BuildContainerImage@1` and `Docker@2` build commands so the agent always checks MCR for updated base images before building.

**Trade-off:** Adds a few seconds per build (registry metadata check), but ensures our containers always start from the latest upstream base layer.