### PR TITLE
Fix native Windows builds failing to find .NET SDK 10.0.108

### DIFF
--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -192,6 +192,24 @@ jobs:
               retryCountOnTaskFailure: 3
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
 
+      # install the bits needed for .NET
+      - ${{ if and(eq(parameters.installDotNet, 'true'), ne(parameters.skipInstall, 'true')) }}:
+        - task: UseDotNet@2
+          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          inputs:
+            packageType: 'sdk'
+            version: $(DOTNET_VERSION)
+          retryCountOnTaskFailure: 3
+          displayName: Install .NET $(DOTNET_VERSION)
+        - ${{ if eq(parameters.buildAgent.pool.os, 'linux') }}:
+          - pwsh: .\scripts\infra\native\shared\patch-dotnet.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet"
+            displayName: Fix the Microsoft.WinFX.* file
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+        # display dotnet info
+        - pwsh: dotnet --info
+          displayName: Display all the .NET information
+          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+
       # install extra bits for the managed builds
       - ${{ if and(not(startsWith(parameters.name, 'native_')), ne(parameters.skipInstall, 'true')) }}:
         # install ninja
@@ -217,24 +235,8 @@ jobs:
             displayName: Install Android APIs
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-        # install the bits needed for .NET
+        # install workloads
         - ${{ if eq(parameters.installDotNet, 'true') }}:
-          - task: UseDotNet@2
-            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-            inputs:
-              packageType: 'sdk'
-              version: $(DOTNET_VERSION)
-            retryCountOnTaskFailure: 3
-            displayName: Install .NET $(DOTNET_VERSION)
-          - ${{ if eq(parameters.buildAgent.pool.os, 'linux') }}:
-            - pwsh: .\scripts\infra\native\shared\patch-dotnet.ps1 -InstallDir "$env:AGENT_TOOLSDIRECTORY/dotnet"
-              displayName: Fix the Microsoft.WinFX.* file
-              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-          # display dotnet info
-          - pwsh: dotnet --info
-            displayName: Display all the .NET information
-            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-          # install workloads
           - pwsh: .\scripts\infra\managed\install-dotnet-workloads.ps1 -Tizen "$env:DOTNET_WORKLOAD_TIZEN" -Workloads "${{ parameters.dotnetWorkloads }}" -WorkloadSetVersion "$env:DOTNET_WORKLOAD_VERSION"
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             retryCountOnTaskFailure: 3


### PR DESCRIPTION
## Problem

After #4055 bumped the SDK to 10.0.108, native Windows builds fail at the "Restore the .NET tools" step because:

- The `UseDotNet@2` task was only in the **managed** builds section (`not(startsWith(name, 'native_'))`)
- Windows agents only have 10.0.101 pre-installed
- `global.json` requires >= 10.0.108 with `rollForward: latestFeature`
- macOS agents weren't affected because they have 10.0.300, which satisfies the roll-forward policy

## Fix

Move the .NET SDK installation (`UseDotNet@2`, Linux dotnet patch, and `dotnet --info`) to a **common section** that runs for both native and managed builds. Workload installation stays in the managed-only section since native builds don't need workloads.