### PR TITLE
Add ci-status skill for daily CI health dashboard

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -2,8 +2,9 @@
 name: ci-status
 description: >
   Check the CI build health of SkiaSharp across main and recent release branches.
-  Collects the last N builds from the 3-pipeline chain (Native → Managed → Tests)
-  for main and the most recent release/* branches, providing a daily dashboard view.
+  Collects the last N builds from the pipeline chain (Public + Native → Managed → Tests)
+  for main and the most recent release/* branches, providing a daily dashboard view
+  with AI-powered analysis of failures, regressions, and flakes.
 
   Use when user asks to:
   - Check overall CI health
@@ -12,15 +13,18 @@ description: >
   - Check if main is green
   - See recent build failures
   - Monitor branch health
+  - Identify flaky tests or chronic failures
+  - Determine if a release branch is shippable
 
   Triggers: "CI status", "build health", "is main green", "CI dashboard",
   "daily build status", "check builds", "are builds passing", "CI overview",
-  "pipeline health", "branch build status".
+  "pipeline health", "branch build status", "CI report", "why is CI red".
 ---
 
 # CI Status Skill
 
-Provide a dashboard view of SkiaSharp CI health across main and recent release branches.
+Provide a dashboard view of SkiaSharp CI health across main and recent release branches,
+with AI-powered analysis to identify patterns, regressions, and actionable fixes.
 
 Unlike the `release-status` skill (which tracks a single release through the pipeline chain),
 this skill gives a **broad overview** of CI health across multiple branches simultaneously.
@@ -43,10 +47,14 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 
 ---
 
-## Step 1: Run the Status Script
+## Step 1: Collect Data
+
+Run the collector script to gather build status, issues, and commit info:
 
 ```bash
-python3 .agents/skills/ci-status/scripts/ci-status.py
+python3 .agents/skills/ci-status/scripts/ci-status.py \
+  --output output/ai/ci-status-report.md \
+  --json output/ai/ci-status-data.json
 ```
 
 ### Options
@@ -55,79 +63,155 @@ python3 .agents/skills/ci-status/scripts/ci-status.py
 |------|---------|-------------|
 | `--branches N` | 3 | Number of most recent release/* branches to include |
 | `--builds N` | 5 | Number of recent builds to show per pipeline per branch |
-| `--no-issues` | off | Skip fetching errors/warnings (faster) |
-| `--output PATH` | none | Write a formatted markdown report to the given file path |
+| `--no-issues` | off | Skip fetching errors/warnings (faster, less detail) |
+| `--output PATH` | none | Write formatted markdown report |
+| `--json PATH` | none | Write raw structured JSON (for AI analysis) |
 
-Examples:
+### Examples
 
 ```bash
-# Default: main + 3 recent release branches, 5 builds each
-python3 .agents/skills/ci-status/scripts/ci-status.py
+# Full report with all data
+python3 .agents/skills/ci-status/scripts/ci-status.py --output output/ai/ci-status-report.md --json output/ai/ci-status-data.json
 
-# More branches, fewer builds
-python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 3
+# Quick check (no timeline fetch)
+python3 .agents/skills/ci-status/scripts/ci-status.py --no-issues
 
-# Just main with last 10 builds
-python3 .agents/skills/ci-status/scripts/ci-status.py --branches 0 --builds 10
-
-# Generate a markdown report
-python3 .agents/skills/ci-status/scripts/ci-status.py --output output/ai/ci-status.md
-
-# Quick check without issue extraction + markdown
-python3 .agents/skills/ci-status/scripts/ci-status.py --no-issues --output /tmp/report.md
+# Deep analysis window (10 builds, 5 branches)
+python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 10 --output output/ai/ci-status-report.md --json output/ai/ci-status-data.json
 ```
 
 ---
 
-## Step 2: Interpret Results
+## Step 2: AI Analysis
 
-The script outputs:
-1. **Per-branch breakdown** — last N builds for each pipeline on each branch
-2. **Health summary** — one-line status per branch showing latest build from each pipeline
+After the script runs, read the JSON data (`output/ai/ci-status-data.json`) and perform the following analysis. **All claims must reference actual build IDs and URLs from the data.**
 
-### Status Icons
+### 2.1 Executive Summary (Verdict)
 
-| Icon | Meaning |
-|------|---------|
-| ✅ | Succeeded |
-| ⚠️ | Partially succeeded (some platforms had warnings) |
-| ❌ | Failed |
-| 🚫 | Canceled |
-| 🔄 | In progress |
-| ⏳ | Not started / not triggered |
+Classify overall health as one of:
+- 🟢 **Healthy** — all branches green or only warnings
+- 🟡 **Degraded** — some failures but main is green
+- 🔴 **Broken** — main is red or a release branch is blocked
+
+Write 1-2 sentences: what's broken, since when, and the top action.
+
+### 2.2 Root Cause Clustering
+
+Group all errors/warnings across all branches and pipelines by **normalized signature**:
+1. Strip volatile fragments (build IDs, timestamps, GUIDs, file paths with random hashes, agent names)
+2. Cluster on `(task_name, normalized_first_error_line)`
+3. For each cluster, determine:
+   - **Category**: one of `code regression`, `flake`, `infra/network`, `quota/resource`, `chain blockage`, `unknown`
+   - **Footprint**: which branches × pipelines are affected
+   - **First/last seen** within the window
+   - **Sample error** (verbatim from data)
+
+#### Classification Decision Tree
+
+| Signal | Category |
+|--------|----------|
+| Message contains `network`, `timeout`, `EOF`, `connection`, `nuget.org`, `429`, `503` | infra/network |
+| Message contains `No space left`, `OOM`, `killed`, `agent lost`, `pool` | quota/resource |
+| Same build passes/fails with no code change (pass/fail/pass pattern) | flake |
+| Failure appears on multiple unrelated branches simultaneously | infra (not code) |
+| Failure appears at a green→red transition on one branch only | code regression |
+| Downstream pipeline failed but upstream in same chain also failed | chain blockage (don't double-count) |
+| None of the above | unknown |
+
+### 2.3 Pipeline Chain Analysis
+
+The Internal chain is sequential: Native → Managed → Tests.
+- If Native fails, Managed and Tests typically don't run (or fail due to missing artifacts)
+- **Collapse cascaded failures** to the root cause pipeline
+- Report: "N failures on branch X — all root-caused to {pipeline}; downstream was blocked, not independently broken"
+
+### 2.4 Regression Detection
+
+For each branch × pipeline, find green→red transitions (the script pre-computes these in `regression` fields):
+- Report the last green build and the first red build
+- List the associated commits from `changes` — these are the regression suspects
+- Provide link to the first red build for investigation
+
+### 2.5 Flake Detection
+
+Look for alternating pass/fail patterns within a single branch × pipeline:
+- ✅ ❌ ✅ or ❌ ✅ ❌ pattern = likely flake
+- Same error appearing intermittently (present in some builds, absent in others with no code change)
+
+### 2.6 Cross-Branch Correlation
+
+| Pattern | Interpretation |
+|---------|---------------|
+| Same error on ≥2 unrelated branches | Infrastructure issue (toolchain, agent pool, NuGet) |
+| Error on exactly one branch | Code regression specific to that branch |
+| Same error on release/* and main | Shared code issue (or infra) |
+| Error only on release/X.Y.x but not release/X.Y.Z | Servicing-specific backport issue |
+
+### 2.7 Release Risk Assessment
+
+For each `release/*` branch:
+- Is it shippable right now? (yes / no / blocked)
+- Days since last full green chain
+- Blockers (link to root cause clusters)
+- Recommendation: `ship`, `wait`, `cherry-pick fix`, `investigate`
+
+### 2.8 Top Recommendations
+
+Provide **at most 5** prioritized actions, ordered by:
+1. Blocks a release → highest priority
+2. Breaks main → high
+3. Chronic failure → medium
+4. Flake → low
+5. Warning → informational
+
+Each recommendation should include:
+- What to do (imperative sentence)
+- Why (which branch/pipeline is affected)
+- Link to the relevant build
 
 ---
 
-## Step 3: Report to User
+## Step 3: Present to User
 
-Present a concise summary focusing on:
+After analysis, present:
 
-1. **Is main green?** — Are the most recent builds on main all passing?
-2. **Any failing branches?** — Highlight branches with failures
-3. **Trends** — Are recent builds improving or degrading?
+1. **Verdict** (1 sentence + emoji)
+2. **Health matrix** (the table from the markdown report)
+3. **Top 3-5 actions** with build links
+4. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
 
-Example report:
+### Example Output
 
 ```
-SkiaSharp CI Health — 2026-05-28 13:45 UTC
+🟡 CI is degraded — release/3.119.x is blocked by a Guardian TSA upload failure; main is green.
 
-📊 Health Summary:
-  main                    ✅ Native | ✅ Managed | ✅ Tests
-  release/4.147.0-pre.3   ✅ Native | ✅ Managed | ⚠️ Tests
-  release/4.147.0-pre.2   ✅ Native | ✅ Managed | ✅ Tests
-  release/3.119.4          ✅ Native | ✅ Managed | ✅ Tests
+📊 Health:
+  main                         ✅ Public | ✅ Native | ✅ Managed | ✅ Tests
+  release/4.147.0-preview.3    ❌ Public | ⚠️ Native | ✅ Managed | ✅ Tests
+  release/3.119.x              ❌ Public | ⚠️ Native | ⚠️ Managed | ❌ Tests
 
-Status: main is green ✅. release/4.147.0-preview.3 has test warnings.
-```
+Top actions:
+1. [release/3.119.x] Fix Guardian TSA upload — blocks Tests pipeline → build 14177772
+2. [release/4.147.0-preview.3] Public CI failure — investigate CS0016 errors → build 157985
+3. [infra] SkiaSharp-Native partial success on all release branches — Guardian warnings (non-blocking)
 
-If there are failures, include the ADO build link:
-```
-https://devdiv.visualstudio.com/DevDiv/_build/results?buildId={id}
+Full report: output/ai/ci-status-report.md
 ```
 
 ---
 
-## When to Use This vs release-status
+## Step 4: Follow-Up Investigations
+
+If asked to dig deeper:
+- Use the `hlx-azdo_*` tools to fetch specific build timelines, test results, or logs
+- Use `hlx-azdo_build_analysis` for known-issue matching
+- Use `hlx-azdo_test_results` to get specific failing test names
+- Check if failures correlate with specific platforms (look at job names in timeline)
+- For flakes, recommend looking at the last 20 builds to confirm the pattern
+
+---
+
+## When to Use This vs Other Skills
 
 | Question | Use |
 |----------|-----|
@@ -137,6 +221,8 @@ https://devdiv.visualstudio.com/DevDiv/_build/results?buildId={id}
 | "Are packages ready for release X?" | **release-status** |
 | "Any CI failures across the board?" | **ci-status** |
 | "Trace the pipeline chain for branch X" | **release-status** |
+| "Why is CI red?" | **ci-status** (with analysis) |
+| "Is release/X shippable?" | **ci-status** (risk assessment) |
 
 ---
 
@@ -145,6 +231,6 @@ https://devdiv.visualstudio.com/DevDiv/_build/results?buildId={id}
 This skill works well as a daily scheduled workflow:
 
 ```
-Prompt: "Run the ci-status skill and report the health of main and recent release branches"
+Prompt: "Run the ci-status skill and report the health of main and recent release branches. Generate a full report with AI analysis."
 Schedule: Daily at 9:00 AM
 ```

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: ci-status
+description: >
+  Check the CI build health of SkiaSharp across main and recent release branches.
+  Collects the last N builds from the 3-pipeline chain (Native → Managed → Tests)
+  for main and the most recent release/* branches, providing a daily dashboard view.
+
+  Use when user asks to:
+  - Check overall CI health
+  - See build status across branches
+  - Get a daily CI summary
+  - Check if main is green
+  - See recent build failures
+  - Monitor branch health
+
+  Triggers: "CI status", "build health", "is main green", "CI dashboard",
+  "daily build status", "check builds", "are builds passing", "CI overview",
+  "pipeline health", "branch build status".
+---
+
+# CI Status Skill
+
+Provide a dashboard view of SkiaSharp CI health across main and recent release branches.
+
+Unlike the `release-status` skill (which tracks a single release through the pipeline chain),
+this skill gives a **broad overview** of CI health across multiple branches simultaneously.
+
+## Pipelines Tracked
+
+### Public CI (xamarin/public org — triggers on push/PR to main, develop, release/*)
+
+| Pipeline Name | Org/Project | Definition ID | URL |
+|---------------|-------------|---------------|-----|
+| `SkiaSharp (Public)` | xamarin/public | 4 | [link](https://dev.azure.com/xamarin/public/_build?definitionId=4) |
+
+### Internal Release Chain (devdiv/DevDiv org — triggers on release/* branches)
+
+| Order | Pipeline Name | Definition ID | URL |
+|-------|---------------|---------------|-----|
+| 1 | `SkiaSharp-Native` | 26493 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493) |
+| 2 | `SkiaSharp` | 10789 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=10789) |
+| 3 | `SkiaSharp-Tests` | 15756 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=15756) |
+
+---
+
+## Step 1: Run the Status Script
+
+```bash
+python3 .agents/skills/ci-status/scripts/ci-status.py
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--branches N` | 3 | Number of most recent release/* branches to include |
+| `--builds N` | 5 | Number of recent builds to show per pipeline per branch |
+
+Examples:
+
+```bash
+# Default: main + 3 recent release branches, 5 builds each
+python3 .agents/skills/ci-status/scripts/ci-status.py
+
+# More branches, fewer builds
+python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 3
+
+# Just main with last 10 builds
+python3 .agents/skills/ci-status/scripts/ci-status.py --branches 0 --builds 10
+```
+
+---
+
+## Step 2: Interpret Results
+
+The script outputs:
+1. **Per-branch breakdown** — last N builds for each pipeline on each branch
+2. **Health summary** — one-line status per branch showing latest build from each pipeline
+
+### Status Icons
+
+| Icon | Meaning |
+|------|---------|
+| ✅ | Succeeded |
+| ⚠️ | Partially succeeded (some platforms had warnings) |
+| ❌ | Failed |
+| 🚫 | Canceled |
+| 🔄 | In progress |
+| ⏳ | Not started / not triggered |
+
+---
+
+## Step 3: Report to User
+
+Present a concise summary focusing on:
+
+1. **Is main green?** — Are the most recent builds on main all passing?
+2. **Any failing branches?** — Highlight branches with failures
+3. **Trends** — Are recent builds improving or degrading?
+
+Example report:
+
+```
+SkiaSharp CI Health — 2026-05-28 13:45 UTC
+
+📊 Health Summary:
+  main                    ✅ Native | ✅ Managed | ✅ Tests
+  release/4.147.0-pre.3   ✅ Native | ✅ Managed | ⚠️ Tests
+  release/4.147.0-pre.2   ✅ Native | ✅ Managed | ✅ Tests
+  release/3.119.4          ✅ Native | ✅ Managed | ✅ Tests
+
+Status: main is green ✅. release/4.147.0-preview.3 has test warnings.
+```
+
+If there are failures, include the ADO build link:
+```
+https://devdiv.visualstudio.com/DevDiv/_build/results?buildId={id}
+```
+
+---
+
+## When to Use This vs release-status
+
+| Question | Use |
+|----------|-----|
+| "Is main green?" | **ci-status** |
+| "How's the release/3.119.4 build doing?" | **release-status** |
+| "Daily CI check" | **ci-status** |
+| "Are packages ready for release X?" | **release-status** |
+| "Any CI failures across the board?" | **ci-status** |
+| "Trace the pipeline chain for branch X" | **release-status** |
+
+---
+
+## Scheduling as a Daily Workflow
+
+This skill works well as a daily scheduled workflow:
+
+```
+Prompt: "Run the ci-status skill and report the health of main and recent release branches"
+Schedule: Daily at 9:00 AM
+```

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -55,6 +55,8 @@ python3 .agents/skills/ci-status/scripts/ci-status.py
 |------|---------|-------------|
 | `--branches N` | 3 | Number of most recent release/* branches to include |
 | `--builds N` | 5 | Number of recent builds to show per pipeline per branch |
+| `--no-issues` | off | Skip fetching errors/warnings (faster) |
+| `--output PATH` | none | Write a formatted markdown report to the given file path |
 
 Examples:
 
@@ -67,6 +69,12 @@ python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 3
 
 # Just main with last 10 builds
 python3 .agents/skills/ci-status/scripts/ci-status.py --branches 0 --builds 10
+
+# Generate a markdown report
+python3 .agents/skills/ci-status/scripts/ci-status.py --output output/ai/ci-status.md
+
+# Quick check without issue extraction + markdown
+python3 .agents/skills/ci-status/scripts/ci-status.py --no-issues --output /tmp/report.md
 ```
 
 ---

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -118,12 +118,20 @@ Group all errors/warnings across all branches and pipelines by **normalized sign
 | Downstream pipeline failed but upstream in same chain also failed | chain blockage (don't double-count) |
 | None of the above | unknown |
 
-### 2.3 Pipeline Chain Analysis
+### 2.3 Pipeline Chain Analysis (MANDATORY — always perform, even when failures look independent)
 
-The Internal chain is sequential: Native → Managed → Tests.
-- If Native fails, Managed and Tests typically don't run (or fail due to missing artifacts)
-- **Collapse cascaded failures** to the root cause pipeline
-- Report: "N failures on branch X — all root-caused to {pipeline}; downstream was blocked, not independently broken"
+The Internal chain is sequential: **Native → Managed → Tests**. A red pipeline is NOT automatically an independent failure — it is often a downstream casualty of an upstream break.
+
+For **every** branch that has ≥1 red internal pipeline, you MUST:
+1. Find the earliest-in-chain failing pipeline (Native before Managed before Tests).
+2. Decide whether each later red pipeline is an **independent failure** (its own distinct error) or a **cascade** (failed because the upstream artifact never built / a shared error).
+3. **Collapse cascades** into the upstream root cause so a single break is not counted as 2–3 problems.
+
+Emit one explicit sentence per affected branch, even if the answer is "no cascade":
+- Cascade: `"release/X: 3 red internal pipelines — root-caused to {Native}; Managed+Tests were blocked downstream, not independently broken."`
+- Independent: `"release/X: Native and Tests both red but with unrelated errors ({errA} vs {errB}) — two independent failures, not a cascade."`
+
+⚠️ Do not skip this step or list internal pipelines as separate equal-weight failures without first stating the chain verdict. This is the most common analysis miss.
 
 ### 2.4 Regression Detection
 
@@ -177,8 +185,9 @@ After analysis, present:
 
 1. **Verdict** (1 sentence + emoji)
 2. **Health matrix** (the table from the markdown report)
-3. **Top 3-5 actions** with build links
-4. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
+3. **Chain verdict** — for each branch with red internal pipelines, the one-line cascade-vs-independent statement from Step 2.3 (so the reader knows whether N red pipelines = N problems or 1 root cause)
+4. **Top 3-5 actions** with build links (root-caused — never list a cascaded downstream pipeline as its own action)
+5. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
 
 ### Example Output
 

--- a/.agents/skills/ci-status/evals/evals.json
+++ b/.agents/skills/ci-status/evals/evals.json
@@ -1,0 +1,49 @@
+{
+  "skill_name": "ci-status",
+  "evals": [
+    {
+      "id": 0,
+      "name": "daily-health-check",
+      "prompt": "Is main green right now? Give me a quick read on CI health across our branches.",
+      "expected_output": "A concise health summary covering main and recent release branches, showing the status of each pipeline (Public, Native, Managed, Tests), with a clear verdict on whether main is passing.",
+      "files": [],
+      "expectations": [
+        "States a clear verdict on whether main is currently green/passing",
+        "Covers recent release/* branches, not just main",
+        "Reports per-pipeline status naming the pipelines (Public, Native, Managed/SkiaSharp, Tests)",
+        "Includes at least one concrete ADO build ID or build results link as evidence",
+        "Stays concise — a quick read rather than an exhaustive multi-section report"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "full-report-with-analysis",
+      "prompt": "Check the CI build health across all branches. Generate a full report with AI analysis — I want to know if main is green, which release branches are at risk, and what the top actions are to fix any failures.",
+      "expected_output": "A full markdown report with a health matrix, root-cause analysis of failures (classifying them as infra/flake/regression/code), and a prioritized list of top actions with build links.",
+      "files": [],
+      "expectations": [
+        "Includes a health matrix/table covering branches against the four pipelines",
+        "Correctly states that main is green/passing",
+        "Identifies which release branches are failing or at risk",
+        "Classifies failures by category (e.g. infra, flake, regression, or code issue)",
+        "Provides a prioritized list of top actions to fix the failures",
+        "Includes ADO build IDs or links for failing builds as evidence",
+        "Accounts for the pipeline chain — distinguishes root-cause failures from cascaded downstream failures"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "release-readiness",
+      "prompt": "We're thinking about shipping the next release. Are the release branches in good shape, or is something blocking them? What would I need to fix first?",
+      "expected_output": "A risk assessment of the release/* branches: whether each is shippable, what is blocking it (with root cause), and what needs to be fixed, ordered by priority.",
+      "files": [],
+      "expectations": [
+        "Gives a per-release-branch shippability verdict (shippable vs blocked)",
+        "Identifies the specific blocker(s) for each failing release branch with a root cause",
+        "Provides prioritized fixes describing what to fix first",
+        "Covers the actual recent release/* branches in the repo",
+        "Includes ADO build IDs or links as supporting evidence"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Collect CI build status for SkiaSharp main and recent release branches.
+
+Usage:
+    ci-status.py [--branches N] [--builds N]
+
+Options:
+    --branches N    Number of most recent release branches to include (default: 3)
+    --builds N      Number of recent builds per pipeline per branch (default: 5)
+
+Queries Azure DevOps (devdiv/DevDiv) for:
+  Public CI:  SkiaSharp Main Build (25328)
+  Internal:   SkiaSharp-Native (26493) → SkiaSharp (10789) → SkiaSharp-Tests (15756)
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+ORG_DEVDIV = "https://devdiv.visualstudio.com"
+PROJECT_DEVDIV = "DevDiv"
+
+ORG_XAMARIN = "https://dev.azure.com/xamarin"
+PROJECT_XAMARIN = "public"
+
+# Public CI pipeline — runs on every push/PR to main, develop, release/*
+# Lives in the xamarin/public org
+PUBLIC_PIPELINES = [
+    {"name": "SkiaSharp (Public)", "id": 4, "org": ORG_XAMARIN, "project": PROJECT_XAMARIN},
+]
+
+# Internal release pipeline chain — runs on release/* branches
+# Lives in devdiv/DevDiv org
+INTERNAL_PIPELINES = [
+    {"name": "SkiaSharp-Native", "id": 26493, "org": ORG_DEVDIV, "project": PROJECT_DEVDIV},
+    {"name": "SkiaSharp", "id": 10789, "org": ORG_DEVDIV, "project": PROJECT_DEVDIV},
+    {"name": "SkiaSharp-Tests", "id": 15756, "org": ORG_DEVDIV, "project": PROJECT_DEVDIV},
+]
+
+ICONS = {
+    "succeeded": "✅",
+    "partiallySucceeded": "⚠️",
+    "failed": "❌",
+    "canceled": "🚫",
+    "inProgress": "🔄",
+    "notStarted": "⏳",
+}
+
+
+def az(args: list[str]) -> str:
+    """Run az CLI and return stdout."""
+    result = subprocess.run(
+        ["az"] + args, capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def get_runs(pipeline_id: int, branch: str, org: str, project: str, top: int = 5) -> list[dict]:
+    """Get recent runs for a pipeline on a branch."""
+    out = az([
+        "pipelines", "runs", "list",
+        "--pipeline-ids", str(pipeline_id),
+        "--branch", branch,
+        "--org", org, "--project", project,
+        "--query",
+        "[].{id:id, status:status, result:result, buildNumber:buildNumber, "
+        "startTime:startTime, finishTime:finishTime}",
+        "--top", str(top), "-o", "json",
+    ])
+    return json.loads(out) if out else []
+
+
+def get_release_branches(top: int = 3) -> list[str]:
+    """Get the most recent release branches by commit date."""
+    result = subprocess.run(
+        ["git", "branch", "-r", "--sort=-committerdate"],
+        capture_output=True, text=True,
+    )
+    branches = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        # Match origin/release/X.Y.Z* branches (skip release/X.Y.x maintenance branches)
+        if "origin/release/" in line and not line.endswith(".x"):
+            branch = line.replace("origin/", "")
+            branches.append(branch)
+            if len(branches) >= top:
+                break
+    return branches
+
+
+def icon_for(run: dict) -> str:
+    if run["status"] == "completed":
+        return ICONS.get(run.get("result", ""), "❓")
+    return ICONS.get(run["status"], "⏳")
+
+
+def format_time(time_str: str | None) -> str:
+    """Format ISO time string to a short display form."""
+    if not time_str:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError):
+        return time_str[:16] if time_str else "—"
+
+
+def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, group_label: str):
+    """Print status for a group of pipelines on a branch."""
+    print(f"│  ┌ {group_label}")
+
+    for i, pipe in enumerate(pipelines):
+        is_last = i == len(pipelines) - 1
+        prefix = "│  │ └─" if is_last else "│  │ ├─"
+        cont = "│  │    " if not is_last else "│  │    "
+
+        runs = get_runs(pipe["id"], branch, pipe["org"], pipe["project"], top=top_builds)
+
+        if not runs:
+            print(f"{prefix} {pipe['name']}: no builds found")
+        else:
+            print(f"{prefix} {pipe['name']} (last {len(runs)}):")
+            for r in runs:
+                status_icon = icon_for(r)
+                result_text = r.get("result") or r["status"]
+                started = format_time(r.get("startTime"))
+                print(
+                    f"{cont}   {status_icon} {r['buildNumber']:<35} "
+                    f"{result_text:<22} {started}  [id:{r['id']}]"
+                )
+
+    print(f"│  └")
+
+
+def print_branch_status(branch: str, top_builds: int):
+    """Print status table for a single branch across all pipelines."""
+    print(f"\n┌─ Branch: {branch}")
+    print(f"│")
+
+    # Public CI pipeline (runs on all branches)
+    print_pipeline_group(PUBLIC_PIPELINES, branch, top_builds, "Public CI")
+
+    # Internal release chain (most relevant for release/* branches)
+    print_pipeline_group(INTERNAL_PIPELINES, branch, top_builds, "Internal Release Chain")
+
+    print(f"│")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CI status for SkiaSharp main and release branches"
+    )
+    parser.add_argument(
+        "--branches", type=int, default=3,
+        help="Number of recent release branches to check (default: 3)"
+    )
+    parser.add_argument(
+        "--builds", type=int, default=5,
+        help="Number of recent builds per pipeline (default: 5)"
+    )
+    args = parser.parse_args()
+
+    # Collect branches to check
+    branches = ["main"]
+    release_branches = get_release_branches(top=args.branches)
+    branches.extend(release_branches)
+
+    print(f"{'═' * 70}")
+    print(f" SkiaSharp CI Status — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    print(f"{'═' * 70}")
+    print(f" Public CI:  {' | '.join(p['name'] for p in PUBLIC_PIPELINES)}")
+    print(f" Internal:   {' → '.join(p['name'] for p in INTERNAL_PIPELINES)}")
+    print(f" Branches:   main + {len(release_branches)} recent release branches")
+    print(f" Builds:     last {args.builds} per pipeline")
+    print(f"{'═' * 70}")
+
+    for branch in branches:
+        print_branch_status(branch, args.builds)
+
+    print(f"{'═' * 70}")
+
+    # Summary: quick health check
+    print("\n📊 Health Summary:")
+    all_pipelines = PUBLIC_PIPELINES + INTERNAL_PIPELINES
+    for branch in branches:
+        statuses = []
+        for pipe in all_pipelines:
+            runs = get_runs(pipe["id"], branch, pipe["org"], pipe["project"], top=1)
+            if runs:
+                statuses.append((pipe["name"], icon_for(runs[0]), runs[0].get("result") or runs[0]["status"]))
+            else:
+                statuses.append((pipe["name"], "⏳", "no runs"))
+        summary_line = " | ".join(f"{s[1]} {s[0]}" for s in statuses)
+        print(f"  {branch:<40} {summary_line}")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -2,23 +2,28 @@
 """Collect CI build status for SkiaSharp main and recent release branches.
 
 Usage:
-    ci-status.py [--branches N] [--builds N]
+    ci-status.py [--branches N] [--builds N] [--output FILE] [--json FILE]
 
 Options:
     --branches N    Number of most recent release branches to include (default: 3)
     --builds N      Number of recent builds per pipeline per branch (default: 5)
+    --output FILE   Write a formatted markdown report to FILE
+    --json FILE     Write raw structured JSON data to FILE (for AI analysis)
+    --no-issues     Skip fetching errors/warnings (faster)
 
-Queries Azure DevOps (devdiv/DevDiv) for:
-  Public CI:  SkiaSharp Main Build (25328)
+Queries Azure DevOps for:
+  Public CI:  SkiaSharp (Public) — xamarin/public, def 4
   Internal:   SkiaSharp-Native (26493) → SkiaSharp (10789) → SkiaSharp-Tests (15756)
 """
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import urllib.request
 from datetime import datetime, timezone
+from collections import defaultdict
 
 ORG_DEVDIV = "https://devdiv.visualstudio.com"
 PROJECT_DEVDIV = "DevDiv"
@@ -69,10 +74,57 @@ def get_runs(pipeline_id: int, branch: str, org: str, project: str, top: int = 5
         "--org", org, "--project", project,
         "--query",
         "[].{id:id, status:status, result:result, buildNumber:buildNumber, "
-        "startTime:startTime, finishTime:finishTime}",
+        "startTime:startTime, finishTime:finishTime, "
+        "sourceVersion:sourceVersion, reason:reason, "
+        "sourceBranch:sourceBranch}",
         "--top", str(top), "-o", "json",
     ])
     return json.loads(out) if out else []
+
+
+def get_build_changes(build_id: int, org: str, project: str) -> list[dict]:
+    """Fetch associated changes (commits) for a build via REST API."""
+    org_base = org.rstrip("/")
+    url = f"{org_base}/{project}/_apis/build/builds/{build_id}/changes?api-version=7.1&$top=10"
+
+    try:
+        token = _get_token()
+        req = urllib.request.Request(url)
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        return []
+
+    changes = []
+    for c in data.get("value", []):
+        changes.append({
+            "id": c.get("id", "")[:12],
+            "author": c.get("author", {}).get("displayName", "unknown"),
+            "message": (c.get("message", "") or "").split("\n")[0][:100],
+            "timestamp": c.get("timestamp"),
+        })
+    return changes
+
+
+_cached_token = None
+
+
+def _get_token() -> str:
+    """Get ADO access token (cached for the script lifetime)."""
+    global _cached_token
+    if _cached_token is not None:
+        return _cached_token
+    try:
+        _cached_token = subprocess.run(
+            ["az", "account", "get-access-token", "--resource", "499b84ac-1321-427f-aa17-267ca6975798",
+             "--query", "accessToken", "-o", "tsv"],
+            capture_output=True, text=True, timeout=10
+        ).stdout.strip()
+    except Exception:
+        _cached_token = ""
+    return _cached_token
 
 
 def get_build_issues(build_id: int, org: str, project: str) -> list[dict]:
@@ -81,18 +133,11 @@ def get_build_issues(build_id: int, org: str, project: str) -> list[dict]:
     Returns a list of dicts with keys: type, message, task_name.
     Collects all issues from failed or warning records.
     """
-    # URL format: {org}/{project}/_apis/build/builds/{buildId}/timeline?api-version=7.1
     org_base = org.rstrip("/")
     url = f"{org_base}/{project}/_apis/build/builds/{build_id}/timeline?api-version=7.1"
 
     try:
-        # Try using az CLI token for auth
-        token = subprocess.run(
-            ["az", "account", "get-access-token", "--resource", "499b84ac-1321-427f-aa17-267ca6975798",
-             "--query", "accessToken", "-o", "tsv"],
-            capture_output=True, text=True, timeout=10
-        ).stdout.strip()
-
+        token = _get_token()
         req = urllib.request.Request(url)
         if token:
             req.add_header("Authorization", f"Bearer {token}")
@@ -176,12 +221,17 @@ def build_url(build_id: int, org: str, project: str) -> str:
 
 
 def collect_data(branches: list[str], top_builds: int, show_issues: bool) -> dict:
-    """Collect all CI data into a structured dict."""
-    all_pipelines = PUBLIC_PIPELINES + INTERNAL_PIPELINES
+    """Collect all CI data into a structured dict for rendering and AI analysis."""
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
     data = {
         "timestamp": timestamp,
+        "window": {"builds_per_pipeline": top_builds, "branches_count": len(branches)},
+        "pipelines": [
+            {"name": p["name"], "id": p["id"], "org": p["org"], "project": p["project"],
+             "group": "public" if p in PUBLIC_PIPELINES else "internal"}
+            for p in PUBLIC_PIPELINES + INTERNAL_PIPELINES
+        ],
         "branches": [],
     }
 
@@ -193,24 +243,73 @@ def collect_data(branches: list[str], top_builds: int, show_issues: bool) -> dic
 
             for pipe in pipelines:
                 runs = get_runs(pipe["id"], branch, pipe["org"], pipe["project"], top=top_builds)
-                pipe_data = {"name": pipe["name"], "org": pipe["org"], "project": pipe["project"], "runs": []}
+                pipe_data = {
+                    "name": pipe["name"],
+                    "id": pipe["id"],
+                    "org": pipe["org"],
+                    "project": pipe["project"],
+                    "runs": [],
+                    "stats": {"total": 0, "succeeded": 0, "failed": 0, "partial": 0, "other": 0},
+                }
 
                 for idx, r in enumerate(runs):
+                    # Calculate duration
+                    duration_min = None
+                    if r.get("startTime") and r.get("finishTime"):
+                        try:
+                            start = datetime.fromisoformat(r["startTime"].replace("Z", "+00:00"))
+                            finish = datetime.fromisoformat(r["finishTime"].replace("Z", "+00:00"))
+                            duration_min = round((finish - start).total_seconds() / 60, 1)
+                        except (ValueError, TypeError):
+                            pass
+
                     run_data = {
                         "id": r["id"],
                         "buildNumber": r["buildNumber"],
                         "status": r["status"],
                         "result": r.get("result"),
                         "startTime": r.get("startTime"),
+                        "finishTime": r.get("finishTime"),
+                        "durationMinutes": duration_min,
+                        "sourceVersion": r.get("sourceVersion", "")[:12] if r.get("sourceVersion") else None,
+                        "reason": r.get("reason"),
                         "icon": icon_for(r),
                         "url": build_url(r["id"], pipe["org"], pipe["project"]),
                         "issues": None,
+                        "changes": None,
                     }
+
                     # Collect issues for the most recent failed/partial run
                     if show_issues and idx == 0 and r.get("result") in ("failed", "partiallySucceeded"):
                         run_data["issues"] = get_build_issues(r["id"], pipe["org"], pipe["project"])
+                        # Also get associated commits for the failing build
+                        run_data["changes"] = get_build_changes(r["id"], pipe["org"], pipe["project"])
+
+                    # Update stats
+                    pipe_data["stats"]["total"] += 1
+                    result = r.get("result", "")
+                    if result == "succeeded":
+                        pipe_data["stats"]["succeeded"] += 1
+                    elif result == "failed":
+                        pipe_data["stats"]["failed"] += 1
+                    elif result == "partiallySucceeded":
+                        pipe_data["stats"]["partial"] += 1
+                    else:
+                        pipe_data["stats"]["other"] += 1
 
                     pipe_data["runs"].append(run_data)
+
+                # Compute pass rate
+                total = pipe_data["stats"]["total"]
+                if total > 0:
+                    pipe_data["stats"]["pass_rate"] = round(
+                        pipe_data["stats"]["succeeded"] / total * 100, 1
+                    )
+                else:
+                    pipe_data["stats"]["pass_rate"] = None
+
+                # Detect green→red transition
+                pipe_data["regression"] = _detect_regression(pipe_data["runs"])
 
                 group_data["pipelines"].append(pipe_data)
             branch_data["pipeline_groups"].append(group_data)
@@ -218,6 +317,31 @@ def collect_data(branches: list[str], top_builds: int, show_issues: bool) -> dic
         data["branches"].append(branch_data)
 
     return data
+
+
+def _detect_regression(runs: list[dict]) -> dict | None:
+    """Detect a green→red transition in a list of runs (ordered newest first).
+
+    Returns info about the regression point, or None if no transition found.
+    """
+    if len(runs) < 2:
+        return None
+
+    # Find the first transition from green→red (scanning from oldest to newest)
+    reversed_runs = list(reversed(runs))
+    for i in range(len(reversed_runs) - 1):
+        curr = reversed_runs[i]
+        next_run = reversed_runs[i + 1]
+        if curr.get("result") == "succeeded" and next_run.get("result") in ("failed", "partiallySucceeded"):
+            return {
+                "last_green_build_id": curr["id"],
+                "last_green_build_number": curr["buildNumber"],
+                "first_red_build_id": next_run["id"],
+                "first_red_build_number": next_run["buildNumber"],
+                "first_red_url": next_run["url"],
+            }
+
+    return None
 
 
 def render_console(data: dict):
@@ -292,37 +416,74 @@ def render_console(data: dict):
 
 
 def render_markdown(data: dict, output_path: str):
-    """Render collected data as a markdown report."""
+    """Render collected data as a markdown report with AI analysis sections."""
     lines = []
 
     lines.append(f"# SkiaSharp CI Status Report")
     lines.append(f"")
-    lines.append(f"> Generated: **{data['timestamp']}**")
+    lines.append(f"> Generated: **{data['timestamp']}**  ")
+    lines.append(f"> Window: last {data['window']['builds_per_pipeline']} builds × "
+                 f"{data['window']['branches_count']} branches")
     lines.append(f"")
 
     # Health summary table at the top
     lines.append(f"## Health Summary")
     lines.append(f"")
     pipe_names = [p["name"] for p in PUBLIC_PIPELINES + INTERNAL_PIPELINES]
-    header = "| Branch | " + " | ".join(pipe_names) + " |"
-    separator = "|--------|" + "|".join(["-----" for _ in pipe_names]) + "|"
+    header = "| Branch | " + " | ".join(pipe_names) + " | Risk |"
+    separator = "|--------|" + "|".join(["-----" for _ in pipe_names]) + "|------|"
     lines.append(header)
     lines.append(separator)
 
     for branch_data in data["branches"]:
         cells = []
+        any_failed = False
+        all_green = True
         for group in branch_data["pipeline_groups"]:
             for pipe in group["pipelines"]:
                 if pipe["runs"]:
                     run = pipe["runs"][0]
                     result = run["result"] or run["status"]
-                    cells.append(f"{run['icon']} {result}")
+                    rate = pipe["stats"]["pass_rate"]
+                    # Show pass rate in cell only when there are failures in the window
+                    rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 and result != "succeeded" else ""
+                    cells.append(f"{run['icon']} {result}{rate_str}")
+                    if result == "failed":
+                        any_failed = True
+                        all_green = False
+                    elif result != "succeeded":
+                        all_green = False
                 else:
                     cells.append("⏳ no runs")
-        row = f"| `{branch_data['name']}` | " + " | ".join(cells) + " |"
+                    all_green = False
+
+        risk = "🟢 Low" if all_green else ("🔴 High" if any_failed else "🟡 Medium")
+        row = f"| `{branch_data['name']}` | " + " | ".join(cells) + f" | {risk} |"
         lines.append(row)
 
     lines.append(f"")
+
+    # Regressions section
+    regressions = []
+    for branch_data in data["branches"]:
+        for group in branch_data["pipeline_groups"]:
+            for pipe in group["pipelines"]:
+                if pipe.get("regression"):
+                    regressions.append((branch_data["name"], pipe["name"], pipe["regression"]))
+
+    if regressions:
+        lines.append(f"## Regressions Detected")
+        lines.append(f"")
+        lines.append(f"| Branch | Pipeline | Last Green | First Red |")
+        lines.append(f"|--------|----------|-----------|-----------|")
+        for branch_name, pipe_name, reg in regressions:
+            lines.append(
+                f"| `{branch_name}` | {pipe_name} | "
+                f"`{reg['last_green_build_number']}` | "
+                f"[`{reg['first_red_build_number']}`]({reg['first_red_url']}) |"
+            )
+        lines.append(f"")
+
     lines.append(f"---")
     lines.append(f"")
 
@@ -336,7 +497,9 @@ def render_markdown(data: dict, output_path: str):
             lines.append(f"")
 
             for pipe in group["pipelines"]:
-                lines.append(f"#### {pipe['name']}")
+                stats = pipe["stats"]
+                rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats["pass_rate"] is not None else ""
+                lines.append(f"#### {pipe['name']}{rate_str}")
                 lines.append(f"")
 
                 if not pipe["runs"]:
@@ -345,18 +508,20 @@ def render_markdown(data: dict, output_path: str):
                     continue
 
                 # Build history table
-                lines.append(f"| Status | Build | Result | Started | Link |")
-                lines.append(f"|--------|-------|--------|---------|------|")
+                lines.append(f"| Status | Build | Result | Duration | Commit | Started | Link |")
+                lines.append(f"|--------|-------|--------|----------|--------|---------|------|")
                 for run in pipe["runs"]:
                     result_text = run["result"] or run["status"]
                     started = format_time(run["startTime"])
                     link = f"[{run['id']}]({run['url']})"
-                    lines.append(f"| {run['icon']} | `{run['buildNumber']}` | {result_text} | {started} | {link} |")
+                    dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
+                    commit = f"`{run['sourceVersion']}`" if run.get("sourceVersion") else "—"
+                    lines.append(f"| {run['icon']} | `{run['buildNumber']}` | {result_text} | {dur} | {commit} | {started} | {link} |")
                 lines.append(f"")
 
                 # Issues for most recent run
                 latest = pipe["runs"][0]
-                if latest["issues"]:
+                if latest.get("issues"):
                     errors = [i for i in latest["issues"] if i["type"] == "error"]
                     warnings = [i for i in latest["issues"] if i["type"] == "warning"]
 
@@ -386,6 +551,20 @@ def render_markdown(data: dict, output_path: str):
                         lines.append(f"</details>")
                         lines.append(f"")
 
+                # Associated commits for failing build
+                if latest.get("changes"):
+                    lines.append(f"<details>")
+                    lines.append(f"<summary>📝 Associated commits ({len(latest['changes'])})</summary>")
+                    lines.append(f"")
+                    lines.append(f"| Commit | Author | Message |")
+                    lines.append(f"|--------|--------|---------|")
+                    for c in latest["changes"]:
+                        msg = c["message"].replace("|", "\\|")
+                        lines.append(f"| `{c['id']}` | {c['author']} | {msg} |")
+                    lines.append(f"")
+                    lines.append(f"</details>")
+                    lines.append(f"")
+
         lines.append(f"---")
         lines.append(f"")
 
@@ -401,9 +580,18 @@ def render_markdown(data: dict, output_path: str):
     lines.append(f"")
 
     content = "\n".join(lines)
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
     with open(output_path, "w") as f:
         f.write(content)
     print(f"\n📄 Markdown report written to: {output_path}")
+
+
+def render_json(data: dict, output_path: str):
+    """Write raw structured JSON data for AI consumption."""
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"📊 JSON data written to: {output_path}")
 
 
 def main():
@@ -426,6 +614,10 @@ def main():
         "--output", type=str, default=None,
         help="Write a markdown report to the specified file path"
     )
+    parser.add_argument(
+        "--json", type=str, default=None, dest="json_output",
+        help="Write raw structured JSON data to the specified file (for AI analysis)"
+    )
     args = parser.parse_args()
 
     # Collect branches to check
@@ -443,6 +635,10 @@ def main():
     # Optionally write markdown report
     if args.output:
         render_markdown(data, args.output)
+
+    # Optionally write JSON data
+    if args.json_output:
+        render_json(data, args.json_output)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import subprocess
 import sys
+import urllib.request
 from datetime import datetime, timezone
 
 ORG_DEVDIV = "https://devdiv.visualstudio.com"
@@ -74,6 +75,65 @@ def get_runs(pipeline_id: int, branch: str, org: str, project: str, top: int = 5
     return json.loads(out) if out else []
 
 
+def get_build_issues(build_id: int, org: str, project: str, max_issues: int = 10) -> list[dict]:
+    """Fetch timeline issues (errors/warnings) for a build.
+
+    Returns a list of dicts with keys: type, message, task_name.
+    Only returns issues from failed/warning records.
+    """
+    # Use az devops REST to get timeline
+    # URL format: {org}/{project}/_apis/build/builds/{buildId}/timeline?api-version=7.1
+    org_base = org.rstrip("/")
+    url = f"{org_base}/{project}/_apis/build/builds/{build_id}/timeline?api-version=7.1"
+
+    try:
+        # Try using az CLI token for auth
+        token = subprocess.run(
+            ["az", "account", "get-access-token", "--resource", "499b84ac-1321-427f-aa17-267ca6975798",
+             "--query", "accessToken", "-o", "tsv"],
+            capture_output=True, text=True, timeout=10
+        ).stdout.strip()
+
+        req = urllib.request.Request(url)
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        return []
+
+    issues = []
+    records = data.get("records", [])
+    for record in records:
+        # Only look at records that have issues
+        record_issues = record.get("issues", [])
+        if not record_issues:
+            continue
+
+        task_name = record.get("name", "unknown")
+        record_result = record.get("result", "")
+
+        # Only collect from failed or warning records
+        if record_result not in ("failed", "succeededWithIssues"):
+            continue
+
+        for issue in record_issues:
+            issue_type = issue.get("type", "").lower()  # "error" or "warning"
+            message = issue.get("message", "").strip()
+            if not message:
+                continue
+            issues.append({
+                "type": issue_type,
+                "message": message,
+                "task_name": task_name,
+            })
+            if len(issues) >= max_issues:
+                return issues
+
+    return issues
+
+
 def get_release_branches(top: int = 3) -> list[str]:
     """Get the most recent release branches by commit date."""
     result = subprocess.run(
@@ -109,7 +169,7 @@ def format_time(time_str: str | None) -> str:
         return time_str[:16] if time_str else "—"
 
 
-def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, group_label: str):
+def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, group_label: str, show_issues: bool = True):
     """Print status for a group of pipelines on a branch."""
     print(f"│  ┌ {group_label}")
 
@@ -124,7 +184,7 @@ def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, gr
             print(f"{prefix} {pipe['name']}: no builds found")
         else:
             print(f"{prefix} {pipe['name']} (last {len(runs)}):")
-            for r in runs:
+            for idx, r in enumerate(runs):
                 status_icon = icon_for(r)
                 result_text = r.get("result") or r["status"]
                 started = format_time(r.get("startTime"))
@@ -133,19 +193,42 @@ def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, gr
                     f"{result_text:<22} {started}  [id:{r['id']}]"
                 )
 
+                # Show issues for the most recent failed/partial build only
+                if show_issues and idx == 0 and r.get("result") in ("failed", "partiallySucceeded"):
+                    issues = get_build_issues(r["id"], pipe["org"], pipe["project"])
+                    if issues:
+                        errors = [i for i in issues if i["type"] == "error"]
+                        warnings = [i for i in issues if i["type"] == "warning"]
+                        if errors:
+                            print(f"{cont}   ┌── Errors ({len(errors)}):")
+                            for e in errors[:5]:
+                                msg = e["message"][:120]
+                                print(f"{cont}   │ ❌ [{e['task_name']}] {msg}")
+                            if len(errors) > 5:
+                                print(f"{cont}   │ ... and {len(errors) - 5} more errors")
+                            print(f"{cont}   └──")
+                        if warnings:
+                            print(f"{cont}   ┌── Warnings ({len(warnings)}):")
+                            for w in warnings[:5]:
+                                msg = w["message"][:120]
+                                print(f"{cont}   │ ⚠️  [{w['task_name']}] {msg}")
+                            if len(warnings) > 5:
+                                print(f"{cont}   │ ... and {len(warnings) - 5} more warnings")
+                            print(f"{cont}   └──")
+
     print(f"│  └")
 
 
-def print_branch_status(branch: str, top_builds: int):
+def print_branch_status(branch: str, top_builds: int, show_issues: bool = True):
     """Print status table for a single branch across all pipelines."""
     print(f"\n┌─ Branch: {branch}")
     print(f"│")
 
     # Public CI pipeline (runs on all branches)
-    print_pipeline_group(PUBLIC_PIPELINES, branch, top_builds, "Public CI")
+    print_pipeline_group(PUBLIC_PIPELINES, branch, top_builds, "Public CI", show_issues)
 
     # Internal release chain (most relevant for release/* branches)
-    print_pipeline_group(INTERNAL_PIPELINES, branch, top_builds, "Internal Release Chain")
+    print_pipeline_group(INTERNAL_PIPELINES, branch, top_builds, "Internal Release Chain", show_issues)
 
     print(f"│")
 
@@ -161,6 +244,10 @@ def main():
     parser.add_argument(
         "--builds", type=int, default=5,
         help="Number of recent builds per pipeline (default: 5)"
+    )
+    parser.add_argument(
+        "--no-issues", action="store_true",
+        help="Skip fetching errors/warnings from failed builds (faster)"
     )
     args = parser.parse_args()
 
@@ -179,7 +266,7 @@ def main():
     print(f"{'═' * 70}")
 
     for branch in branches:
-        print_branch_status(branch, args.builds)
+        print_branch_status(branch, args.builds, show_issues=not args.no_issues)
 
     print(f"{'═' * 70}")
 

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -75,13 +75,12 @@ def get_runs(pipeline_id: int, branch: str, org: str, project: str, top: int = 5
     return json.loads(out) if out else []
 
 
-def get_build_issues(build_id: int, org: str, project: str, max_issues: int = 10) -> list[dict]:
+def get_build_issues(build_id: int, org: str, project: str) -> list[dict]:
     """Fetch timeline issues (errors/warnings) for a build.
 
     Returns a list of dicts with keys: type, message, task_name.
-    Only returns issues from failed/warning records.
+    Collects all issues from failed or warning records.
     """
-    # Use az devops REST to get timeline
     # URL format: {org}/{project}/_apis/build/builds/{buildId}/timeline?api-version=7.1
     org_base = org.rstrip("/")
     url = f"{org_base}/{project}/_apis/build/builds/{build_id}/timeline?api-version=7.1"
@@ -106,7 +105,6 @@ def get_build_issues(build_id: int, org: str, project: str, max_issues: int = 10
     issues = []
     records = data.get("records", [])
     for record in records:
-        # Only look at records that have issues
         record_issues = record.get("issues", [])
         if not record_issues:
             continue
@@ -128,8 +126,6 @@ def get_build_issues(build_id: int, org: str, project: str, max_issues: int = 10
                 "message": message,
                 "task_name": task_name,
             })
-            if len(issues) >= max_issues:
-                return issues
 
     return issues
 
@@ -193,7 +189,7 @@ def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, gr
                     f"{result_text:<22} {started}  [id:{r['id']}]"
                 )
 
-                # Show issues for the most recent failed/partial build only
+                # Show all issues from the most recent run if it's not clean
                 if show_issues and idx == 0 and r.get("result") in ("failed", "partiallySucceeded"):
                     issues = get_build_issues(r["id"], pipe["org"], pipe["project"])
                     if issues:
@@ -201,19 +197,15 @@ def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, gr
                         warnings = [i for i in issues if i["type"] == "warning"]
                         if errors:
                             print(f"{cont}   ┌── Errors ({len(errors)}):")
-                            for e in errors[:5]:
+                            for e in errors:
                                 msg = e["message"][:120]
                                 print(f"{cont}   │ ❌ [{e['task_name']}] {msg}")
-                            if len(errors) > 5:
-                                print(f"{cont}   │ ... and {len(errors) - 5} more errors")
                             print(f"{cont}   └──")
                         if warnings:
                             print(f"{cont}   ┌── Warnings ({len(warnings)}):")
-                            for w in warnings[:5]:
+                            for w in warnings:
                                 msg = w["message"][:120]
                                 print(f"{cont}   │ ⚠️  [{w['task_name']}] {msg}")
-                            if len(warnings) > 5:
-                                print(f"{cont}   │ ... and {len(warnings) - 5} more warnings")
                             print(f"{cont}   └──")
 
     print(f"│  └")

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -131,7 +131,12 @@ def get_build_issues(build_id: int, org: str, project: str) -> list[dict]:
 
 
 def get_release_branches(top: int = 3) -> list[str]:
-    """Get the most recent release branches by commit date."""
+    """Get the most recent release branches by commit date.
+
+    Includes both versioned release branches (release/X.Y.Z-preview.N)
+    and servicing branches (release/X.Y.x) which are the main equivalent
+    for their respective major.minor.
+    """
     result = subprocess.run(
         ["git", "branch", "-r", "--sort=-committerdate"],
         capture_output=True, text=True,
@@ -139,8 +144,7 @@ def get_release_branches(top: int = 3) -> list[str]:
     branches = []
     for line in result.stdout.splitlines():
         line = line.strip()
-        # Match origin/release/X.Y.Z* branches (skip release/X.Y.x maintenance branches)
-        if "origin/release/" in line and not line.endswith(".x"):
+        if "origin/release/" in line:
             branch = line.replace("origin/", "")
             branches.append(branch)
             if len(branches) >= top:
@@ -165,64 +169,241 @@ def format_time(time_str: str | None) -> str:
         return time_str[:16] if time_str else "—"
 
 
-def print_pipeline_group(pipelines: list[dict], branch: str, top_builds: int, group_label: str, show_issues: bool = True):
-    """Print status for a group of pipelines on a branch."""
-    print(f"│  ┌ {group_label}")
-
-    for i, pipe in enumerate(pipelines):
-        is_last = i == len(pipelines) - 1
-        prefix = "│  │ └─" if is_last else "│  │ ├─"
-        cont = "│  │    " if not is_last else "│  │    "
-
-        runs = get_runs(pipe["id"], branch, pipe["org"], pipe["project"], top=top_builds)
-
-        if not runs:
-            print(f"{prefix} {pipe['name']}: no builds found")
-        else:
-            print(f"{prefix} {pipe['name']} (last {len(runs)}):")
-            for idx, r in enumerate(runs):
-                status_icon = icon_for(r)
-                result_text = r.get("result") or r["status"]
-                started = format_time(r.get("startTime"))
-                print(
-                    f"{cont}   {status_icon} {r['buildNumber']:<35} "
-                    f"{result_text:<22} {started}  [id:{r['id']}]"
-                )
-
-                # Show all issues from the most recent run if it's not clean
-                if show_issues and idx == 0 and r.get("result") in ("failed", "partiallySucceeded"):
-                    issues = get_build_issues(r["id"], pipe["org"], pipe["project"])
-                    if issues:
-                        errors = [i for i in issues if i["type"] == "error"]
-                        warnings = [i for i in issues if i["type"] == "warning"]
-                        if errors:
-                            print(f"{cont}   ┌── Errors ({len(errors)}):")
-                            for e in errors:
-                                msg = e["message"][:120]
-                                print(f"{cont}   │ ❌ [{e['task_name']}] {msg}")
-                            print(f"{cont}   └──")
-                        if warnings:
-                            print(f"{cont}   ┌── Warnings ({len(warnings)}):")
-                            for w in warnings:
-                                msg = w["message"][:120]
-                                print(f"{cont}   │ ⚠️  [{w['task_name']}] {msg}")
-                            print(f"{cont}   └──")
-
-    print(f"│  └")
+def build_url(build_id: int, org: str, project: str) -> str:
+    """Generate ADO build URL."""
+    org_base = org.rstrip("/")
+    return f"{org_base}/{project}/_build/results?buildId={build_id}"
 
 
-def print_branch_status(branch: str, top_builds: int, show_issues: bool = True):
-    """Print status table for a single branch across all pipelines."""
-    print(f"\n┌─ Branch: {branch}")
-    print(f"│")
+def collect_data(branches: list[str], top_builds: int, show_issues: bool) -> dict:
+    """Collect all CI data into a structured dict."""
+    all_pipelines = PUBLIC_PIPELINES + INTERNAL_PIPELINES
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-    # Public CI pipeline (runs on all branches)
-    print_pipeline_group(PUBLIC_PIPELINES, branch, top_builds, "Public CI", show_issues)
+    data = {
+        "timestamp": timestamp,
+        "branches": [],
+    }
 
-    # Internal release chain (most relevant for release/* branches)
-    print_pipeline_group(INTERNAL_PIPELINES, branch, top_builds, "Internal Release Chain", show_issues)
+    for branch in branches:
+        branch_data = {"name": branch, "pipeline_groups": []}
 
-    print(f"│")
+        for group_label, pipelines in [("Public CI", PUBLIC_PIPELINES), ("Internal Release Chain", INTERNAL_PIPELINES)]:
+            group_data = {"label": group_label, "pipelines": []}
+
+            for pipe in pipelines:
+                runs = get_runs(pipe["id"], branch, pipe["org"], pipe["project"], top=top_builds)
+                pipe_data = {"name": pipe["name"], "org": pipe["org"], "project": pipe["project"], "runs": []}
+
+                for idx, r in enumerate(runs):
+                    run_data = {
+                        "id": r["id"],
+                        "buildNumber": r["buildNumber"],
+                        "status": r["status"],
+                        "result": r.get("result"),
+                        "startTime": r.get("startTime"),
+                        "icon": icon_for(r),
+                        "url": build_url(r["id"], pipe["org"], pipe["project"]),
+                        "issues": None,
+                    }
+                    # Collect issues for the most recent failed/partial run
+                    if show_issues and idx == 0 and r.get("result") in ("failed", "partiallySucceeded"):
+                        run_data["issues"] = get_build_issues(r["id"], pipe["org"], pipe["project"])
+
+                    pipe_data["runs"].append(run_data)
+
+                group_data["pipelines"].append(pipe_data)
+            branch_data["pipeline_groups"].append(group_data)
+
+        data["branches"].append(branch_data)
+
+    return data
+
+
+def render_console(data: dict):
+    """Render collected data to console (tree format)."""
+    print(f"{'═' * 70}")
+    print(f" SkiaSharp CI Status — {data['timestamp']}")
+    print(f"{'═' * 70}")
+    print(f" Public CI:  {' | '.join(p['name'] for p in PUBLIC_PIPELINES)}")
+    print(f" Internal:   {' → '.join(p['name'] for p in INTERNAL_PIPELINES)}")
+    print(f" Branches:   {len(data['branches'])} ({', '.join(b['name'] for b in data['branches'])})")
+    print(f"{'═' * 70}")
+
+    for branch_data in data["branches"]:
+        print(f"\n┌─ Branch: {branch_data['name']}")
+        print(f"│")
+
+        for group in branch_data["pipeline_groups"]:
+            print(f"│  ┌ {group['label']}")
+
+            for i, pipe in enumerate(group["pipelines"]):
+                is_last = i == len(group["pipelines"]) - 1
+                prefix = "│  │ └─" if is_last else "│  │ ├─"
+                cont = "│  │    " if not is_last else "│  │    "
+
+                if not pipe["runs"]:
+                    print(f"{prefix} {pipe['name']}: no builds found")
+                else:
+                    print(f"{prefix} {pipe['name']} (last {len(pipe['runs'])}):")
+                    for run in pipe["runs"]:
+                        result_text = run["result"] or run["status"]
+                        started = format_time(run["startTime"])
+                        print(
+                            f"{cont}   {run['icon']} {run['buildNumber']:<35} "
+                            f"{result_text:<22} {started}  [id:{run['id']}]"
+                        )
+
+                        if run["issues"]:
+                            errors = [i for i in run["issues"] if i["type"] == "error"]
+                            warnings = [i for i in run["issues"] if i["type"] == "warning"]
+                            if errors:
+                                print(f"{cont}   ┌── Errors ({len(errors)}):")
+                                for e in errors:
+                                    msg = e["message"][:120]
+                                    print(f"{cont}   │ ❌ [{e['task_name']}] {msg}")
+                                print(f"{cont}   └──")
+                            if warnings:
+                                print(f"{cont}   ┌── Warnings ({len(warnings)}):")
+                                for w in warnings:
+                                    msg = w["message"][:120]
+                                    print(f"{cont}   │ ⚠️  [{w['task_name']}] {msg}")
+                                print(f"{cont}   └──")
+
+            print(f"│  └")
+
+        print(f"│")
+
+    print(f"{'═' * 70}")
+
+    # Health summary
+    print("\n📊 Health Summary:")
+    all_pipelines_names = [p["name"] for p in PUBLIC_PIPELINES + INTERNAL_PIPELINES]
+    for branch_data in data["branches"]:
+        statuses = []
+        for group in branch_data["pipeline_groups"]:
+            for pipe in group["pipelines"]:
+                if pipe["runs"]:
+                    statuses.append(f"{pipe['runs'][0]['icon']} {pipe['name']}")
+                else:
+                    statuses.append(f"⏳ {pipe['name']}")
+        print(f"  {branch_data['name']:<40} {' | '.join(statuses)}")
+    print()
+
+
+def render_markdown(data: dict, output_path: str):
+    """Render collected data as a markdown report."""
+    lines = []
+
+    lines.append(f"# SkiaSharp CI Status Report")
+    lines.append(f"")
+    lines.append(f"> Generated: **{data['timestamp']}**")
+    lines.append(f"")
+
+    # Health summary table at the top
+    lines.append(f"## Health Summary")
+    lines.append(f"")
+    pipe_names = [p["name"] for p in PUBLIC_PIPELINES + INTERNAL_PIPELINES]
+    header = "| Branch | " + " | ".join(pipe_names) + " |"
+    separator = "|--------|" + "|".join(["-----" for _ in pipe_names]) + "|"
+    lines.append(header)
+    lines.append(separator)
+
+    for branch_data in data["branches"]:
+        cells = []
+        for group in branch_data["pipeline_groups"]:
+            for pipe in group["pipelines"]:
+                if pipe["runs"]:
+                    run = pipe["runs"][0]
+                    result = run["result"] or run["status"]
+                    cells.append(f"{run['icon']} {result}")
+                else:
+                    cells.append("⏳ no runs")
+        row = f"| `{branch_data['name']}` | " + " | ".join(cells) + " |"
+        lines.append(row)
+
+    lines.append(f"")
+    lines.append(f"---")
+    lines.append(f"")
+
+    # Detailed per-branch sections
+    for branch_data in data["branches"]:
+        lines.append(f"## `{branch_data['name']}`")
+        lines.append(f"")
+
+        for group in branch_data["pipeline_groups"]:
+            lines.append(f"### {group['label']}")
+            lines.append(f"")
+
+            for pipe in group["pipelines"]:
+                lines.append(f"#### {pipe['name']}")
+                lines.append(f"")
+
+                if not pipe["runs"]:
+                    lines.append(f"_No builds found._")
+                    lines.append(f"")
+                    continue
+
+                # Build history table
+                lines.append(f"| Status | Build | Result | Started | Link |")
+                lines.append(f"|--------|-------|--------|---------|------|")
+                for run in pipe["runs"]:
+                    result_text = run["result"] or run["status"]
+                    started = format_time(run["startTime"])
+                    link = f"[{run['id']}]({run['url']})"
+                    lines.append(f"| {run['icon']} | `{run['buildNumber']}` | {result_text} | {started} | {link} |")
+                lines.append(f"")
+
+                # Issues for most recent run
+                latest = pipe["runs"][0]
+                if latest["issues"]:
+                    errors = [i for i in latest["issues"] if i["type"] == "error"]
+                    warnings = [i for i in latest["issues"] if i["type"] == "warning"]
+
+                    if errors:
+                        lines.append(f"<details>")
+                        lines.append(f"<summary>❌ Errors ({len(errors)})</summary>")
+                        lines.append(f"")
+                        lines.append(f"| Task | Message |")
+                        lines.append(f"|------|---------|")
+                        for e in errors:
+                            msg = e["message"].replace("|", "\\|").replace("\n", " ")
+                            lines.append(f"| {e['task_name']} | {msg} |")
+                        lines.append(f"")
+                        lines.append(f"</details>")
+                        lines.append(f"")
+
+                    if warnings:
+                        lines.append(f"<details>")
+                        lines.append(f"<summary>⚠️ Warnings ({len(warnings)})</summary>")
+                        lines.append(f"")
+                        lines.append(f"| Task | Message |")
+                        lines.append(f"|------|---------|")
+                        for w in warnings:
+                            msg = w["message"].replace("|", "\\|").replace("\n", " ")
+                            lines.append(f"| {w['task_name']} | {msg} |")
+                        lines.append(f"")
+                        lines.append(f"</details>")
+                        lines.append(f"")
+
+        lines.append(f"---")
+        lines.append(f"")
+
+    # Footer
+    lines.append(f"## Pipeline Links")
+    lines.append(f"")
+    lines.append(f"| Pipeline | Org | Definition |")
+    lines.append(f"|----------|-----|------------|")
+    for pipe in PUBLIC_PIPELINES + INTERNAL_PIPELINES:
+        org_short = "xamarin/public" if pipe["org"] == ORG_XAMARIN else "devdiv/DevDiv"
+        url = f"{pipe['org'].rstrip('/')}/{pipe['project']}/_build?definitionId={pipe['id']}"
+        lines.append(f"| {pipe['name']} | {org_short} | [{pipe['id']}]({url}) |")
+    lines.append(f"")
+
+    content = "\n".join(lines)
+    with open(output_path, "w") as f:
+        f.write(content)
+    print(f"\n📄 Markdown report written to: {output_path}")
 
 
 def main():
@@ -241,6 +422,10 @@ def main():
         "--no-issues", action="store_true",
         help="Skip fetching errors/warnings from failed builds (faster)"
     )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Write a markdown report to the specified file path"
+    )
     args = parser.parse_args()
 
     # Collect branches to check
@@ -248,35 +433,16 @@ def main():
     release_branches = get_release_branches(top=args.branches)
     branches.extend(release_branches)
 
-    print(f"{'═' * 70}")
-    print(f" SkiaSharp CI Status — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
-    print(f"{'═' * 70}")
-    print(f" Public CI:  {' | '.join(p['name'] for p in PUBLIC_PIPELINES)}")
-    print(f" Internal:   {' → '.join(p['name'] for p in INTERNAL_PIPELINES)}")
-    print(f" Branches:   main + {len(release_branches)} recent release branches")
-    print(f" Builds:     last {args.builds} per pipeline")
-    print(f"{'═' * 70}")
+    # Collect all data
+    show_issues = not args.no_issues
+    data = collect_data(branches, args.builds, show_issues)
 
-    for branch in branches:
-        print_branch_status(branch, args.builds, show_issues=not args.no_issues)
+    # Always render console output
+    render_console(data)
 
-    print(f"{'═' * 70}")
-
-    # Summary: quick health check
-    print("\n📊 Health Summary:")
-    all_pipelines = PUBLIC_PIPELINES + INTERNAL_PIPELINES
-    for branch in branches:
-        statuses = []
-        for pipe in all_pipelines:
-            runs = get_runs(pipe["id"], branch, pipe["org"], pipe["project"], top=1)
-            if runs:
-                statuses.append((pipe["name"], icon_for(runs[0]), runs[0].get("result") or runs[0]["status"]))
-            else:
-                statuses.append((pipe["name"], "⏳", "no runs"))
-        summary_line = " | ".join(f"{s[1]} {s[0]}" for s in statuses)
-        print(f"  {branch:<40} {summary_line}")
-
-    print()
+    # Optionally write markdown report
+    if args.output:
+        render_markdown(data, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a new `ci-status` skill that gives a **broad, at-a-glance view** of SkiaSharp CI health across `main` and the recent `release/*` branches, then layers AI analysis on top to turn raw red/green into actionable diagnosis. Unlike `release-status` (which tracks a single release through its pipeline chain), this is a daily dashboard across all branches at once.

## Pipelines tracked

- **Public CI:** `SkiaSharp (Public)` on `xamarin/public` (definition 4) — push/PR to `main`, `release/*`
- **Internal release chain:** `SkiaSharp-Native` (26493) → `SkiaSharp` (10789) → `SkiaSharp-Tests` (15756) on `devdiv/DevDiv`

## What it does

`scripts/ci-status.py` queries each pipeline once and renders three views from a single data-collection pass:

- **Console summary** — quick terminal use
- **Markdown report** (`--output`) — health matrix, per-branch commit info (SHA/author/message), build durations, pass-rate stats, and a green→red regression table
- **Structured JSON** (`--json`) — consumed by the AI analysis step

It auto-discovers the N most recent `release/*` branches (including `.x` servicing branches), extracts errors/warnings from failed builds, caches the ADO token across requests, and pre-computes green→red regression transitions.

`SKILL.md` drives the AI layer: root-cause clustering by normalized error signature, a classification decision tree (infra / flake / regression / quota / chain blockage), **mandatory pipeline-chain cascade analysis**, flake detection, cross-branch correlation, release-risk assessment, and a capped top-5 prioritized action list — every claim tied to a real build ID and URL.

## Usage

```bash
# Full report with AI-ready data
python3 .agents/skills/ci-status/scripts/ci-status.py \
  --output output/ai/ci-status-report.md \
  --json output/ai/ci-status-data.json

# Quick check (no timeline fetch)
python3 .agents/skills/ci-status/scripts/ci-status.py --no-issues

# Wider window
python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 10
```

Works well as a daily scheduled workflow.

## Evaluation

Benchmarked with skill-creator's evaluator across three scenarios (daily health check, full report with analysis, release readiness). The eval surfaced one recurring miss — the analysis sometimes listed internal pipelines as independent failures instead of collapsing cascaded downstream failures to their upstream root cause — which is why Step 2.3 (chain cascade) is now mandatory and the chain verdict is surfaced in the presentation. Eval test cases are committed under `evals/` so the skill stays benchmarkable.

**Triggers:** "CI status", "build health", "is main green", "CI dashboard", "daily build status", "why is CI red", "is release/X shippable"