### PR TITLE
feat(ci-status): add GitHub Actions tracking and restructure as collect → AI → render pipeline

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: ci-status
 description: >
-  Check the CI build health of SkiaSharp across main and recent release branches.
-  Collects the last N builds from the pipeline chain (Public + Native → Managed → Tests)
-  for main and the most recent release/* branches, providing a daily dashboard view
+  Check the CI build health and automation status of SkiaSharp across main and
+  recent release branches. Collects the last N builds from the AzDO pipeline chain
+  (Public + Native → Managed → Tests) and all GitHub Actions workflows from
+  mono/SkiaSharp and mono/SkiaSharp-API-docs, providing a daily dashboard view
   with AI-powered analysis of failures, regressions, and flakes.
 
   Use when user asks to:
@@ -15,10 +16,13 @@ description: >
   - Monitor branch health
   - Identify flaky tests or chronic failures
   - Determine if a release branch is shippable
+  - Check GitHub Actions workflow health
+  - See what automation is failing
 
   Triggers: "CI status", "build health", "is main green", "CI dashboard",
   "daily build status", "check builds", "are builds passing", "CI overview",
-  "pipeline health", "branch build status", "CI report", "why is CI red".
+  "pipeline health", "branch build status", "CI report", "why is CI red",
+  "what automation is failing", "GitHub Actions status".
 ---
 
 # CI Status Skill
@@ -47,16 +51,24 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 
 ### GitHub Actions (mono/SkiaSharp and mono/SkiaSharp-API-docs)
 
-| Workflow | Repository | Triggers | Why Track |
-|----------|------------|----------|-----------|
+| Workflow | Repository | Trigger | Why Track |
+|----------|------------|---------|-----------|
 | Docs - Deploy | mono/SkiaSharp | Push/PR to main | Docs site broken if failing |
 | Docs - Go Live! | mono/SkiaSharp | Workflow dispatch | Docs don't publish if failing |
-| Publish Samples | mono/SkiaSharp | Push/PR touching `samples/` | Sample projects broken if failing |
-| API Diff | mono/SkiaSharp | Weekly schedule, push to main | API regression detection |
-| Auto Docs Submodule Sync | mono/SkiaSharp | Push to main | API docs get out of sync if broken |
-| Update Release Notes | mono/SkiaSharp | Push to main/release, tags | Release notes stop auto-updating |
-| Skia Upstream Sync | mono/SkiaSharp | Scheduled | Upstream tracking breaks if failing |
-| Nightly Fix Finder | mono/SkiaSharp | Nightly schedule | Nightly automation health |
+| Docs - PR Staging - Cleanup | mono/SkiaSharp | PR close events | Stale staging deploys accumulate |
+| Docs - PR Staging - Sweep Stale | mono/SkiaSharp | Daily (06:00 UTC) | Stale staging deploys accumulate |
+| Publish Samples | mono/SkiaSharp | Push/PR to `samples/` | Sample projects broken if failing |
+| API Diff | mono/SkiaSharp | Weekly (Sun 00:00 UTC) | API regression detection |
+| Auto Docs Submodule Sync | mono/SkiaSharp | Daily (10:00 UTC) | API docs get out of sync |
+| Update Release Notes | mono/SkiaSharp | Push to main/release/tags | Release notes stop auto-updating |
+| Skia Upstream Sync | mono/SkiaSharp | Daily (07:00 UTC) | Upstream tracking breaks |
+| Nightly Fix Finder | mono/SkiaSharp | Nightly | Nightly automation health |
+| Auto-Triage SkiaSharp Issue | mono/SkiaSharp | Daily (04:05 UTC) + issue events | Triage automation stops |
+| Persist Agentic Workflow Data | mono/SkiaSharp | Push to main | AI workflow data lost |
+| Backport | mono/SkiaSharp | PR label/comment | Cherry-picks to release branches fail |
+| Automatic Rebase | mono/SkiaSharp | PR comment | PR rebase automation broken |
+| Add PR Artifacts Comment | mono/SkiaSharp | Workflow run events | Build links not posted to PRs |
+| Manage NuGet Feed | mono/SkiaSharp | Disabled (manual) | Feed management broken |
 | Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch | XML docs stop being written |
 | Automerge Docs | mono/SkiaSharp-API-docs | PR events | Doc PRs won't auto-merge |
 | Go Live | mono/SkiaSharp-API-docs | Workflow dispatch | Docs don't publish to live |
@@ -196,14 +208,20 @@ Each recommendation should include:
 ### 2.9 GitHub Actions Health
 
 For each tracked GitHub Actions workflow:
-- Current status on main (pass/fail/no recent runs)
-- Any failures or patterns across branches
+- Current status (pass/fail/skipped/no recent runs)
+- Any failures or patterns (recurring failures, recent regressions)
 - Whether failures are related to AzDO failures (same commit?) or independent
-- For SkiaSharp-API-docs workflows: note if docs generation or publishing is broken
+- Categorize by severity:
+  - **High**: Docs - Deploy, Publish Samples, Update Release Notes, Skia Upstream Sync,
+    Auto API Docs Writer (broken = user-facing impact or release process blocked)
+  - **Medium**: Auto Docs Submodule Sync, Nightly Fix Finder, Auto-Triage,
+    Backport, Go Live (broken = automation degraded, manual workaround exists)
+  - **Low**: PR Staging Cleanup, Sweep Stale, Rebase, PR Artifacts Comment,
+    Persist Agentic Workflow Data (broken = cosmetic/housekeeping)
 
-GitHub Actions failures are typically lower severity than AzDO pipeline failures
-(which block releases), but broken docs deployment or sample validation should still
-be flagged as actionable.
+GitHub Actions failures don't block releases directly (AzDO owns that), but they
+indicate broken automation that accumulates tech debt if ignored. Flag all failures
+as actionable — the goal is "what automation is failing" not just "can we release".
 
 ---
 

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -45,6 +45,16 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 | 2 | `SkiaSharp` | 10789 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=10789) |
 | 3 | `SkiaSharp-Tests` | 15756 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=15756) |
 
+### GitHub Actions (mono/SkiaSharp and mono/SkiaSharp-API-docs)
+
+| Workflow | Repository | Triggers |
+|----------|------------|----------|
+| Docs - Deploy | mono/SkiaSharp | Push/PR to main |
+| Publish Samples | mono/SkiaSharp | Push/PR touching `samples/` |
+| API Diff | mono/SkiaSharp | Weekly schedule, push to main |
+| Automerge Docs | mono/SkiaSharp-API-docs | PR events |
+| Go Live | mono/SkiaSharp-API-docs | Workflow dispatch |
+
 ---
 
 ## Step 1: Collect Data
@@ -89,7 +99,7 @@ After the script runs, read the JSON data (`output/ai/ci-status-data.json`) and 
 ### 2.1 Executive Summary (Verdict)
 
 Classify overall health as one of:
-- 🟢 **Healthy** — all branches green or only warnings
+- 🟢 **Healthy** — all branches green or only warnings (both AzDO and GitHub Actions)
 - 🟡 **Degraded** — some failures but main is green
 - 🔴 **Broken** — main is red or a release branch is blocked
 
@@ -177,6 +187,18 @@ Each recommendation should include:
 - Why (which branch/pipeline is affected)
 - Link to the relevant build
 
+### 2.9 GitHub Actions Health
+
+For each tracked GitHub Actions workflow:
+- Current status on main (pass/fail/no recent runs)
+- Any failures or patterns across branches
+- Whether failures are related to AzDO failures (same commit?) or independent
+- For SkiaSharp-API-docs workflows: note if docs generation or publishing is broken
+
+GitHub Actions failures are typically lower severity than AzDO pipeline failures
+(which block releases), but broken docs deployment or sample validation should still
+be flagged as actionable.
+
 ---
 
 ## Step 3: Present to User
@@ -185,9 +207,10 @@ After analysis, present:
 
 1. **Verdict** (1 sentence + emoji)
 2. **Health matrix** (the table from the markdown report)
-3. **Chain verdict** — for each branch with red internal pipelines, the one-line cascade-vs-independent statement from Step 2.3 (so the reader knows whether N red pipelines = N problems or 1 root cause)
-4. **Top 3-5 actions** with build links (root-caused — never list a cascaded downstream pipeline as its own action)
-5. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
+3. **GitHub Actions health** (one-line summary per workflow)
+4. **Chain verdict** — for each branch with red internal pipelines, the one-line cascade-vs-independent statement from Step 2.3 (so the reader knows whether N red pipelines = N problems or 1 root cause)
+5. **Top 3-5 actions** with build links (root-caused — never list a cascaded downstream pipeline as its own action)
+6. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
 
 ### Example Output
 
@@ -198,6 +221,13 @@ After analysis, present:
   main                         ✅ Public | ✅ Native | ✅ Managed | ✅ Tests
   release/4.147.0-preview.3    ❌ Public | ⚠️ Native | ✅ Managed | ✅ Tests
   release/3.119.x              ❌ Public | ⚠️ Native | ⚠️ Managed | ❌ Tests
+
+🐙 GitHub Actions:
+  Docs - Deploy                ✅ main
+  Publish Samples              ✅ main
+  API Diff                     ✅ main
+  Automerge Docs               ✅ main (SkiaSharp-API-docs)
+  Go Live                      ✅ main (SkiaSharp-API-docs)
 
 Top actions:
 1. [release/3.119.x] Fix Guardian TSA upload — blocks Tests pipeline → build 14177772

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -47,14 +47,19 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 
 ### GitHub Actions (mono/SkiaSharp and mono/SkiaSharp-API-docs)
 
-| Workflow | Repository | Triggers |
-|----------|------------|----------|
-| Docs - Deploy | mono/SkiaSharp | Push/PR to main |
-| Publish Samples | mono/SkiaSharp | Push/PR touching `samples/` |
-| API Diff | mono/SkiaSharp | Weekly schedule, push to main |
-| Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch, writes XML docs |
-| Automerge Docs | mono/SkiaSharp-API-docs | PR events |
-| Go Live | mono/SkiaSharp-API-docs | Workflow dispatch |
+| Workflow | Repository | Triggers | Why Track |
+|----------|------------|----------|-----------|
+| Docs - Deploy | mono/SkiaSharp | Push/PR to main | Docs site broken if failing |
+| Docs - Go Live! | mono/SkiaSharp | Workflow dispatch | Docs don't publish if failing |
+| Publish Samples | mono/SkiaSharp | Push/PR touching `samples/` | Sample projects broken if failing |
+| API Diff | mono/SkiaSharp | Weekly schedule, push to main | API regression detection |
+| Auto Docs Submodule Sync | mono/SkiaSharp | Push to main | API docs get out of sync if broken |
+| Update Release Notes | mono/SkiaSharp | Push to main/release, tags | Release notes stop auto-updating |
+| Skia Upstream Sync | mono/SkiaSharp | Scheduled | Upstream tracking breaks if failing |
+| Nightly Fix Finder | mono/SkiaSharp | Nightly schedule | Nightly automation health |
+| Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch | XML docs stop being written |
+| Automerge Docs | mono/SkiaSharp-API-docs | PR events | Doc PRs won't auto-merge |
+| Go Live | mono/SkiaSharp-API-docs | Workflow dispatch | Docs don't publish to live |
 
 ---
 

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -35,6 +35,13 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 
 ## Pipelines Tracked
 
+### Prerequisites
+
+The collector script requires:
+- **`az` CLI** — authenticated with access to `xamarin/public` and `devdiv/DevDiv` orgs
+- **`gh` CLI** — authenticated with read access to `mono/SkiaSharp` and `mono/SkiaSharp-API-docs`
+- **Git remotes** — fetched recently so `git branch -r` returns up-to-date release branches
+
 ### Public CI (xamarin/public org — triggers on push/PR to main, develop, release/*)
 
 | Pipeline Name | Org/Project | Definition ID | URL |
@@ -68,7 +75,6 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 | Backport | mono/SkiaSharp | PR label/comment | Cherry-picks to release branches fail |
 | Automatic Rebase | mono/SkiaSharp | PR comment | PR rebase automation broken |
 | Add PR Artifacts Comment | mono/SkiaSharp | Workflow run events | Build links not posted to PRs |
-| Manage NuGet Feed | mono/SkiaSharp | Disabled (manual) | Feed management broken |
 | Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch | XML docs stop being written |
 | Automerge Docs | mono/SkiaSharp-API-docs | PR events | Doc PRs won't auto-merge |
 | Go Live | mono/SkiaSharp-API-docs | Workflow dispatch | Docs don't publish to live |
@@ -133,6 +139,8 @@ Group all errors/warnings across all branches and pipelines by **normalized sign
    - **Footprint**: which branches × pipelines are affected
    - **First/last seen** within the window
    - **Sample error** (verbatim from data)
+
+> ⚠️ **Important:** Finalize root-cause clusters only AFTER performing the Pipeline Chain Analysis (§2.3). Downstream cascade failures must be collapsed into the upstream root cause, not counted as independent clusters.
 
 #### Classification Decision Tree
 
@@ -243,22 +251,27 @@ After analysis, present:
 ```
 🟡 CI is degraded — release/3.119.x is blocked by a Guardian TSA upload failure; main is green.
 
-📊 Health:
+📊 AzDO Health:
   main                         ✅ Public | ✅ Native | ✅ Managed | ✅ Tests
   release/4.147.0-preview.3    ❌ Public | ⚠️ Native | ✅ Managed | ✅ Tests
   release/3.119.x              ❌ Public | ⚠️ Native | ⚠️ Managed | ❌ Tests
 
+🔗 Chain verdict:
+  release/3.119.x: Tests red independently (Guardian TSA upload); Native/Managed are warnings only — no cascade.
+  release/4.147.0-preview.3: Public CI red (CS0016 errors); internal chain unaffected — independent failure.
+
 🐙 GitHub Actions:
-  Docs - Deploy                ✅ main
-  Publish Samples              ✅ main
-  API Diff                     ✅ main
-  Automerge Docs               ✅ main (SkiaSharp-API-docs)
-  Go Live                      ✅ main (SkiaSharp-API-docs)
+  Docs - Deploy                ✅ success (2026-05-29 15:19)
+  Publish Samples              ✅ success (2026-05-28 10:00)
+  Skia Upstream Sync           ✅ success (2026-05-29 07:00)
+  Auto API Docs Writer         ❌ failure (2026-05-29 04:00)
+  Backport                     ✅ success (2026-05-28 22:15)
 
 Top actions:
 1. [release/3.119.x] Fix Guardian TSA upload — blocks Tests pipeline → build 14177772
 2. [release/4.147.0-preview.3] Public CI failure — investigate CS0016 errors → build 157985
-3. [infra] SkiaSharp-Native partial success on all release branches — Guardian warnings (non-blocking)
+3. [GitHub Actions] Auto API Docs Writer failing — XML docs not being generated → run 26651087356
+4. [infra] SkiaSharp-Native partial success on all release branches — Guardian warnings (non-blocking)
 
 Full report: output/ai/ci-status-report.md
 ```

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -191,21 +191,7 @@ For each `release/*` branch:
 - Blockers (link to root cause clusters)
 - Recommendation: `ship`, `wait`, `cherry-pick fix`, `investigate`
 
-### 2.8 Top Recommendations
-
-Provide **at most 5** prioritized actions, ordered by:
-1. Blocks a release → highest priority
-2. Breaks main → high
-3. Chronic failure → medium
-4. Flake → low
-5. Warning → informational
-
-Each recommendation should include:
-- What to do (imperative sentence)
-- Why (which branch/pipeline is affected)
-- Link to the relevant build
-
-### 2.9 GitHub Actions Health
+### 2.8 GitHub Actions Health
 
 For each tracked GitHub Actions workflow:
 - Current status (pass/fail/skipped/no recent runs)
@@ -223,6 +209,22 @@ GitHub Actions failures don't block releases directly (AzDO owns that), but they
 indicate broken automation that accumulates tech debt if ignored. Flag all failures
 as actionable — the goal is "what automation is failing" not just "can we release".
 
+### 2.9 Top Recommendations
+
+Provide **at most 5** prioritized actions, ordered by:
+1. Blocks a release → highest priority
+2. Breaks main → high
+3. High-severity GitHub Actions failure → high
+4. Chronic failure → medium
+5. Medium-severity GitHub Actions failure → medium
+6. Flake → low
+7. Warning / low-severity GitHub Actions → informational
+
+Each recommendation should include:
+- What to do (imperative sentence)
+- Why (which branch/pipeline/workflow is affected)
+- Link to the relevant build or run
+
 ---
 
 ## Step 3: Present to User
@@ -230,9 +232,9 @@ as actionable — the goal is "what automation is failing" not just "can we rele
 After analysis, present:
 
 1. **Verdict** (1 sentence + emoji)
-2. **Health matrix** (the table from the markdown report)
-3. **GitHub Actions health** (one-line summary per workflow)
-4. **Chain verdict** — for each branch with red internal pipelines, the one-line cascade-vs-independent statement from Step 2.3 (so the reader knows whether N red pipelines = N problems or 1 root cause)
+2. **AzDO health matrix** (the table from the markdown report)
+3. **Chain verdict** — for each branch with red internal pipelines, the one-line cascade-vs-independent statement from §2.3 (so the reader knows whether N red pipelines = N problems or 1 root cause)
+4. **GitHub Actions health** (one-line summary per workflow, grouped by severity)
 5. **Top 3-5 actions** with build links (root-caused — never list a cascaded downstream pipeline as its own action)
 6. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
 
@@ -283,9 +285,11 @@ If asked to dig deeper:
 | "Daily CI check" | **ci-status** |
 | "Are packages ready for release X?" | **release-status** |
 | "Any CI failures across the board?" | **ci-status** |
+| "What automation is failing?" | **ci-status** |
 | "Trace the pipeline chain for branch X" | **release-status** |
 | "Why is CI red?" | **ci-status** (with analysis) |
 | "Is release/X shippable?" | **ci-status** (risk assessment) |
+| "GitHub Actions status?" | **ci-status** |
 
 ---
 

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -52,6 +52,7 @@ this skill gives a **broad overview** of CI health across multiple branches simu
 | Docs - Deploy | mono/SkiaSharp | Push/PR to main |
 | Publish Samples | mono/SkiaSharp | Push/PR touching `samples/` |
 | API Diff | mono/SkiaSharp | Weekly schedule, push to main |
+| Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch, writes XML docs |
 | Automerge Docs | mono/SkiaSharp-API-docs | PR events |
 | Go Live | mono/SkiaSharp-API-docs | Workflow dispatch |
 

--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -81,15 +81,18 @@ The collector script requires:
 
 ---
 
-## Step 1: Collect Data
+## Step 1: Collect Raw Data
 
 Run the collector script to gather build status, issues, and commit info:
 
 ```bash
 python3 .agents/skills/ci-status/scripts/ci-status.py \
-  --output output/ai/ci-status-report.md \
   --json output/ai/ci-status-data.json
 ```
+
+This produces `ci-status-data.json` containing raw pipeline runs, GitHub Actions statuses,
+regression markers, issues/errors, and associated commits. The script also prints a console
+summary for quick visual inspection.
 
 ### Options
 
@@ -98,21 +101,30 @@ python3 .agents/skills/ci-status/scripts/ci-status.py \
 | `--branches N` | 3 | Number of most recent release/* branches to include |
 | `--builds N` | 5 | Number of recent builds to show per pipeline per branch |
 | `--no-issues` | off | Skip fetching errors/warnings (faster, less detail) |
-| `--output PATH` | none | Write formatted markdown report |
 | `--json PATH` | none | Write raw structured JSON (for AI analysis) |
 
 ### Examples
 
 ```bash
-# Full report with all data
-python3 .agents/skills/ci-status/scripts/ci-status.py --output output/ai/ci-status-report.md --json output/ai/ci-status-data.json
+# Standard collection
+python3 .agents/skills/ci-status/scripts/ci-status.py --json output/ai/ci-status-data.json
 
 # Quick check (no timeline fetch)
 python3 .agents/skills/ci-status/scripts/ci-status.py --no-issues
 
 # Deep analysis window (10 builds, 5 branches)
-python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 10 --output output/ai/ci-status-report.md --json output/ai/ci-status-data.json
+python3 .agents/skills/ci-status/scripts/ci-status.py --branches 5 --builds 10 --json output/ai/ci-status-data.json
 ```
+
+### File Boundary
+
+| File | Produced By | Consumed By |
+|------|-------------|-------------|
+| `output/ai/ci-status-data.json` | Collector script (Step 1) | AI analysis only (Step 2) |
+| `output/ai/ci-status-YYYY-MM-DD.json` | AI (Step 3) | Validator + Renderers (Steps 4–5) |
+
+> ⚠️ **Never pass `ci-status-data.json` to validate or render scripts.** Those scripts expect the
+> augmented report JSON that the AI assembles in Step 3.
 
 ---
 
@@ -135,7 +147,7 @@ Group all errors/warnings across all branches and pipelines by **normalized sign
 1. Strip volatile fragments (build IDs, timestamps, GUIDs, file paths with random hashes, agent names)
 2. Cluster on `(task_name, normalized_first_error_line)`
 3. For each cluster, determine:
-   - **Category**: one of `code regression`, `flake`, `infra/network`, `quota/resource`, `chain blockage`, `unknown`
+   - **Category**: one of `code_regression`, `flake`, `infra_network`, `quota_resource`, `chain_blockage`, `unknown`
    - **Footprint**: which branches × pipelines are affected
    - **First/last seen** within the window
    - **Sample error** (verbatim from data)
@@ -146,12 +158,12 @@ Group all errors/warnings across all branches and pipelines by **normalized sign
 
 | Signal | Category |
 |--------|----------|
-| Message contains `network`, `timeout`, `EOF`, `connection`, `nuget.org`, `429`, `503` | infra/network |
-| Message contains `No space left`, `OOM`, `killed`, `agent lost`, `pool` | quota/resource |
+| Message contains `network`, `timeout`, `EOF`, `connection`, `nuget.org`, `429`, `503` | infra_network |
+| Message contains `No space left`, `OOM`, `killed`, `agent lost`, `pool` | quota_resource |
 | Same build passes/fails with no code change (pass/fail/pass pattern) | flake |
-| Failure appears on multiple unrelated branches simultaneously | infra (not code) |
-| Failure appears at a green→red transition on one branch only | code regression |
-| Downstream pipeline failed but upstream in same chain also failed | chain blockage (don't double-count) |
+| Failure appears on multiple unrelated branches simultaneously | infra_network |
+| Failure appears at a green→red transition on one branch only | code_regression |
+| Downstream pipeline failed but upstream in same chain also failed | chain_blockage |
 | None of the above | unknown |
 
 ### 2.3 Pipeline Chain Analysis (MANDATORY — always perform, even when failures look independent)
@@ -197,7 +209,7 @@ For each `release/*` branch:
 - Is it shippable right now? (yes / no / blocked)
 - Days since last full green chain
 - Blockers (link to root cause clusters)
-- Recommendation: `ship`, `wait`, `cherry-pick fix`, `investigate`
+- Recommendation: `ship`, `wait`, `cherry-pick`, `investigate`
 
 ### 2.8 GitHub Actions Health
 
@@ -235,16 +247,83 @@ Each recommendation should include:
 
 ---
 
-## Step 3: Present to User
+## Step 3: Assemble Report JSON
 
-After analysis, present:
+After completing the analysis, assemble a **single JSON file** that combines the raw data
+with your analysis. This JSON is the source of truth for rendering.
+
+Write the JSON to: `output/ai/ci-status-YYYY-MM-DD.json`
+
+The schema is documented in `references/report-schema.md`. Top-level keys:
+
+```json
+{
+  "meta": { "date", "timestamp", "schemaVersion": "1.0", "window", "branches" },
+  "verdict": { "status", "emoji", "summary" },
+  "azdoHealth": { "branches": [...], "regressions": [...] },
+  "chainAnalysis": [ { "branch", "verdict", "summary", "rootPipeline", "cascadedPipelines" } ],
+  "rootCauses": [ { "id", "title", "category", "severity", "footprint", "sampleError", ... } ],
+  "githubActions": { "workflows": [...], "summary": { "total", "healthy", "failing", ... } },
+  "flakes": [ { "branch", "pipeline", "pattern", "confidence", "description" } ],
+  "releaseRisk": [ { "branch", "shippable", "daysSinceGreen", "blockers", "recommendation" } ],
+  "recommendations": [ { "priority", "severity", "action", "reason", "target", "buildUrl" } ]
+}
+```
+
+**Rules for assembling the JSON:**
+1. The `azdoHealth` section contains the raw pipeline data from `ci-status-data.json`, restructured to match the schema
+2. The `githubActions` section combines raw workflow data with your severity/status classifications
+3. All other sections (`verdict`, `chainAnalysis`, `rootCauses`, `flakes`, `releaseRisk`, `recommendations`) are your AI analysis
+4. Every `buildUrl` and `buildEvidence` must reference real builds from the collected data
+5. Maximum 5 recommendations, sorted by priority
+
+---
+
+## Step 4: Validate Report
+
+Run the validator to check the assembled JSON:
+
+```bash
+python3 .agents/skills/ci-status/scripts/validate-ci-status.py output/ai/ci-status-YYYY-MM-DD.json
+```
+
+If validation fails, fix the JSON and re-validate. Common issues:
+- Missing required keys
+- Invalid enum values (e.g., verdict.status must be healthy/degraded/broken)
+- rootCauseId references that don't exist
+- recommendations not sorted by priority
+
+---
+
+## Step 5: Render Reports
+
+Generate HTML and Markdown reports from the validated JSON:
+
+```bash
+# HTML dashboard (self-contained, opens in browser)
+python3 .agents/skills/ci-status/scripts/render-ci-status.py output/ai/ci-status-YYYY-MM-DD.json
+
+# Markdown report (for AI consumption and downstream agents)
+python3 .agents/skills/ci-status/scripts/render-ci-status-md.py output/ai/ci-status-YYYY-MM-DD.json
+```
+
+This produces:
+- `output/ai/ci-status-YYYY-MM-DD.html` — Bootstrap 5 dashboard viewable in any browser
+- `output/ai/ci-status-YYYY-MM-DD.md` — Comprehensive markdown for AI agents
+
+---
+
+## Step 6: Present to User
+
+After rendering, present a brief summary in chat and point to the files:
 
 1. **Verdict** (1 sentence + emoji)
-2. **AzDO health matrix** (the table from the markdown report)
-3. **Chain verdict** — for each branch with red internal pipelines, the one-line cascade-vs-independent statement from §2.3 (so the reader knows whether N red pipelines = N problems or 1 root cause)
-4. **GitHub Actions health** (one-line summary per workflow, grouped by severity)
-5. **Top 3-5 actions** with build links (root-caused — never list a cascaded downstream pipeline as its own action)
-6. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build? Check if this is a known issue?"
+2. **AzDO health matrix** (compact table)
+3. **Chain verdict** — one-line cascade-vs-independent statement per affected branch
+4. **GitHub Actions health** — one-line summary per workflow, grouped by severity
+5. **Top 3-5 actions** with build links
+6. **File locations** — point to the JSON, HTML, and MD files
+7. **Offer follow-ups**: "Want me to investigate the regression on release/X? Open the failing build?"
 
 ### Example Output
 
@@ -257,28 +336,28 @@ After analysis, present:
   release/3.119.x              ❌ Public | ⚠️ Native | ⚠️ Managed | ❌ Tests
 
 🔗 Chain verdict:
-  release/3.119.x: Tests red independently (Guardian TSA upload); Native/Managed are warnings only — no cascade.
-  release/4.147.0-preview.3: Public CI red (CS0016 errors); internal chain unaffected — independent failure.
+  release/3.119.x: Tests red independently (Guardian TSA); Native/Managed warnings only — no cascade.
+  release/4.147.0-preview.3: Public CI red (CS0016 errors); internal chain unaffected.
 
 🐙 GitHub Actions:
-  Docs - Deploy                ✅ success (2026-05-29 15:19)
-  Publish Samples              ✅ success (2026-05-28 10:00)
-  Skia Upstream Sync           ✅ success (2026-05-29 07:00)
-  Auto API Docs Writer         ❌ failure (2026-05-29 04:00)
-  Backport                     ✅ success (2026-05-28 22:15)
+  🟠 High:    Docs - Deploy ✅ | Publish Samples ✅ | Auto API Docs Writer ❌
+  🟡 Medium:  Backport ✅ | Go Live ✅ | Auto-Triage ✅
+  ⚪ Low:     All passing
 
 Top actions:
-1. [release/3.119.x] Fix Guardian TSA upload — blocks Tests pipeline → build 14177772
-2. [release/4.147.0-preview.3] Public CI failure — investigate CS0016 errors → build 157985
-3. [GitHub Actions] Auto API Docs Writer failing — XML docs not being generated → run 26651087356
-4. [infra] SkiaSharp-Native partial success on all release branches — Guardian warnings (non-blocking)
+1. [release/3.119.x] Fix Guardian TSA upload — blocks Tests → build 14177772
+2. [release/4.147.0-preview.3] Investigate CS0016 errors → build 157985
+3. [GitHub Actions] Auto API Docs Writer failing → run 26651087356
 
-Full report: output/ai/ci-status-report.md
+📁 Reports:
+  JSON: output/ai/ci-status-2026-05-29.json
+  HTML: output/ai/ci-status-2026-05-29.html
+  MD:   output/ai/ci-status-2026-05-29.md
 ```
 
 ---
 
-## Step 4: Follow-Up Investigations
+## Step 7: Follow-Up Investigations
 
 If asked to dig deeper:
 - Use the `hlx-azdo_*` tools to fetch specific build timelines, test results, or logs

--- a/.agents/skills/ci-status/references/report-schema.md
+++ b/.agents/skills/ci-status/references/report-schema.md
@@ -1,0 +1,294 @@
+# CI Status Report Schema
+
+JSON schema for the CI status report. The AI generates this JSON by combining raw collector data
+with analysis, then render scripts produce HTML and Markdown reports.
+
+## Top-Level Structure
+
+```json
+{
+  "meta": { ... },
+  "verdict": { ... },
+  "azdoHealth": { ... },
+  "chainAnalysis": [ ... ],
+  "rootCauses": [ ... ],
+  "githubActions": { ... },
+  "flakes": [ ... ],
+  "releaseRisk": [ ... ],
+  "recommendations": [ ... ]
+}
+```
+
+## `meta` — Report Metadata
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `date` | string | Yes | ISO date of the report (YYYY-MM-DD) |
+| `timestamp` | string | Yes | Full ISO timestamp |
+| `schemaVersion` | string | Yes | Always `"1.0"` |
+| `window` | object | Yes | Collection window parameters |
+| `window.buildsPerPipeline` | integer | Yes | Number of builds per pipeline checked |
+| `window.branchesCount` | integer | Yes | Number of branches checked |
+| `branches` | array[string] | Yes | Branch names that were checked |
+
+## `verdict` — Executive Summary
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | string | Yes | One of: `"healthy"`, `"degraded"`, `"broken"` |
+| `emoji` | string | Yes | `"🟢"`, `"🟡"`, or `"🔴"` |
+| `summary` | string | Yes | 1-2 sentence summary of overall health |
+
+Classification rules:
+- 🟢 **healthy** — all branches green or only warnings
+- 🟡 **degraded** — some failures but main is green
+- 🔴 **broken** — main is red or a release branch is blocked
+
+## `azdoHealth` — Azure DevOps Pipeline Health
+
+```json
+{
+  "branches": [
+    {
+      "name": "main",
+      "risk": "low",
+      "pipelines": [
+        {
+          "name": "SkiaSharp (Public)",
+          "definitionId": 4,
+          "org": "xamarin/public",
+          "latestResult": "succeeded",
+          "latestIcon": "✅",
+          "passRate": 100.0,
+          "runs": [
+            {
+              "id": 157985,
+              "buildNumber": "6.0.0-preview.3.24305.1",
+              "result": "succeeded",
+              "status": "completed",
+              "icon": "✅",
+              "startTime": "2026-05-28T10:00:00Z",
+              "finishTime": "2026-05-28T11:30:00Z",
+              "durationMinutes": 90,
+              "sourceVersion": "abc1234",
+              "url": "https://dev.azure.com/..."
+            }
+          ],
+          "issues": [ ... ],
+          "changes": [ ... ],
+          "regression": null
+        }
+      ]
+    }
+  ],
+  "regressions": [
+    {
+      "branch": "main",
+      "pipeline": "SkiaSharp (Public)",
+      "lastGreenId": 157980,
+      "lastGreenBuildNumber": "6.0.0-preview.3.24300.1",
+      "firstRedId": 157985,
+      "firstRedBuildNumber": "6.0.0-preview.3.24305.1",
+      "firstRedUrl": "https://...",
+      "suspects": [ { "id": "abc1234", "author": "dev@example.com", "message": "..." } ]
+    }
+  ]
+}
+```
+
+### `azdoHealth.branches[].risk`
+
+| Value | Meaning |
+|-------|---------|
+| `"low"` | All pipelines green |
+| `"medium"` | Some warnings/partial success, no failures |
+| `"high"` | At least one pipeline failed |
+
+## `chainAnalysis` — Pipeline Chain Verdicts
+
+Array of chain analysis verdicts. One entry per branch with ≥1 red internal pipeline.
+
+```json
+{
+  "branch": "release/3.119.x",
+  "verdict": "cascade",
+  "summary": "Tests red independently (Guardian TSA); Native/Managed warnings only — no cascade.",
+  "rootPipeline": "SkiaSharp-Tests",
+  "cascadedPipelines": []
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `branch` | string | Yes | Branch name |
+| `verdict` | string | Yes | One of: `"cascade"`, `"independent"`, `"mixed"` |
+| `summary` | string | Yes | One-sentence explanation |
+| `rootPipeline` | string | Yes | Earliest-in-chain failing pipeline |
+| `cascadedPipelines` | array[string] | Yes | Pipelines that failed due to cascade (not independent) |
+
+## `rootCauses` — Clustered Error Analysis
+
+```json
+{
+  "id": "A",
+  "title": "SKRuntimeEffectTest hang on Windows .NET Framework",
+  "category": "code_regression",
+  "severity": "high",
+  "footprint": {
+    "branches": ["release/3.119.x"],
+    "pipelines": ["SkiaSharp (Public)", "SkiaSharp-Tests"]
+  },
+  "firstSeen": "2026-05-25T10:00:00Z",
+  "lastSeen": "2026-05-29T10:00:00Z",
+  "sampleError": "Process exited with code -1 (hang timeout)...",
+  "buildEvidence": [
+    { "id": 157820, "url": "https://..." }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Short ID (A, B, C...) for cross-referencing |
+| `title` | string | Yes | Human-readable error title |
+| `category` | string | Yes | One of: `"code_regression"`, `"flake"`, `"infra_network"`, `"quota_resource"`, `"chain_blockage"`, `"unknown"` |
+| `severity` | string | Yes | One of: `"critical"`, `"high"`, `"medium"`, `"low"` |
+| `footprint.branches` | array[string] | Yes | Affected branches |
+| `footprint.pipelines` | array[string] | Yes | Affected pipelines/workflows |
+| `firstSeen` | string | Yes | ISO timestamp of earliest occurrence in window |
+| `lastSeen` | string | Yes | ISO timestamp of latest occurrence in window |
+| `sampleError` | string | Yes | Verbatim error text (truncated at 500 chars) |
+| `buildEvidence` | array[object] | Yes | Build/run IDs + URLs as evidence |
+
+## `githubActions` — GitHub Actions Health
+
+```json
+{
+  "workflows": [
+    {
+      "name": "Docs - Deploy",
+      "repo": "mono/SkiaSharp",
+      "trigger": "push",
+      "scope": "branch",
+      "severity": "high",
+      "status": "healthy",
+      "branches": [
+        {
+          "name": "main",
+          "latestResult": "success",
+          "latestIcon": "✅",
+          "passRate": 100.0,
+          "runs": [ ... ]
+        }
+      ],
+      "failedJobs": []
+    }
+  ],
+  "summary": {
+    "total": 18,
+    "healthy": 15,
+    "failing": 2,
+    "stale": 1,
+    "highSeverityFailing": 0,
+    "mediumSeverityFailing": 1,
+    "lowSeverityFailing": 1
+  }
+}
+```
+
+### `githubActions.workflows[].status`
+
+| Value | Meaning |
+|-------|---------|
+| `"healthy"` | Latest run(s) all passed |
+| `"failing"` | Latest run failed |
+| `"degraded"` | Mixed results (some branches pass, some fail) |
+| `"stale"` | No runs in last 7 days |
+| `"skipped"` | Workflow disabled or no trigger events |
+
+### `githubActions.workflows[].severity`
+
+| Value | Impact |
+|-------|--------|
+| `"high"` | User-facing impact or release process blocked |
+| `"medium"` | Automation degraded, manual workaround exists |
+| `"low"` | Cosmetic/housekeeping |
+
+### `githubActions.workflows[].failedJobs`
+
+```json
+[
+  {
+    "name": "build-and-deploy",
+    "failedSteps": ["Run build", "Deploy to Azure"],
+    "runId": 26651087356,
+    "runUrl": "https://github.com/mono/SkiaSharp/actions/runs/..."
+  }
+]
+```
+
+## `flakes` — Flake Detection
+
+```json
+{
+  "branch": "main",
+  "pipeline": "SkiaSharp (Public)",
+  "pattern": "✅❌✅❌✅",
+  "confidence": "high",
+  "description": "Alternating pass/fail on NUnit runner timeout"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `branch` | string | Yes | Branch where flake observed |
+| `pipeline` | string | Yes | Pipeline or workflow name |
+| `pattern` | string | Yes | Visual pattern of recent results |
+| `confidence` | string | Yes | `"high"`, `"medium"`, `"low"` |
+| `description` | string | Yes | What appears to be flaking |
+
+## `releaseRisk` — Release Risk Assessment
+
+```json
+{
+  "branch": "release/3.119.x",
+  "shippable": false,
+  "daysSinceGreen": 7,
+  "blockers": ["A"],
+  "recommendation": "investigate"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `branch` | string | Yes | Release branch name |
+| `shippable` | boolean | Yes | Can this be released right now? |
+| `daysSinceGreen` | integer | No | Days since full green chain (null if never green in window) |
+| `blockers` | array[string] | Yes | Root cause IDs blocking this release |
+| `recommendation` | string | Yes | One of: `"ship"`, `"wait"`, `"cherry-pick"`, `"investigate"` |
+
+## `recommendations` — Top Actions
+
+```json
+{
+  "priority": 1,
+  "severity": "high",
+  "action": "Fix SKRuntimeEffectTest hang on Windows .NET Framework",
+  "reason": "Blocks Public CI and Tests on release/3.119.x (5/5 failures)",
+  "target": "release/3.119.x",
+  "rootCauseId": "A",
+  "buildUrl": "https://..."
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `priority` | integer | Yes | 1-5, lower is more urgent |
+| `severity` | string | Yes | `"critical"`, `"high"`, `"medium"`, `"low"` |
+| `action` | string | Yes | Imperative sentence: what to do |
+| `reason` | string | Yes | Why this matters |
+| `target` | string | Yes | Branch, workflow, or infrastructure affected |
+| `rootCauseId` | string | No | Cross-reference to root cause cluster |
+| `buildUrl` | string | Yes | Link to relevant build/run |
+
+Maximum 5 recommendations, ordered by priority.

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -54,6 +54,16 @@ ICONS = {
     "notStarted": "⏳",
 }
 
+# GitHub Actions workflows to track
+# Each entry: repo, workflow file name, display name, relevant branches
+GITHUB_WORKFLOWS = [
+    {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy"},
+    {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples"},
+    {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live"},
+]
+
 
 def az(args: list[str]) -> str:
     """Run az CLI and return stdout."""
@@ -175,6 +185,150 @@ def get_build_issues(build_id: int, org: str, project: str) -> list[dict]:
     return issues
 
 
+def gh(args: list[str]) -> str:
+    """Run gh CLI and return stdout."""
+    result = subprocess.run(
+        ["gh"] + args, capture_output=True, text=True, timeout=30
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def get_github_workflow_runs(repo: str, workflow: str, branch: str | None, top: int = 5) -> list[dict]:
+    """Get recent workflow runs from GitHub Actions via gh CLI.
+
+    If branch is None, fetches runs across all branches.
+    """
+    cmd = [
+        "run", "list",
+        "--repo", repo,
+        "--workflow", workflow,
+        "--limit", str(top),
+        "--json", "databaseId,headBranch,status,conclusion,displayTitle,createdAt,updatedAt,url,event,headSha,workflowName",
+    ]
+    if branch:
+        cmd.extend(["--branch", branch])
+
+    out = gh(cmd)
+    if not out:
+        return []
+    try:
+        return json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+
+def gh_icon_for(run: dict) -> str:
+    """Map GitHub Actions status/conclusion to an icon."""
+    status = run.get("status", "")
+    conclusion = run.get("conclusion", "")
+
+    if status == "in_progress":
+        return "🔄"
+    if status == "queued" or status == "waiting" or status == "pending":
+        return "⏳"
+
+    # Completed runs — check conclusion
+    if conclusion == "success":
+        return "✅"
+    elif conclusion == "failure":
+        return "❌"
+    elif conclusion == "cancelled":
+        return "🚫"
+    elif conclusion == "skipped":
+        return "⏭️"
+    elif conclusion == "startup_failure":
+        return "❌"
+    else:
+        return "❓"
+
+
+def gh_result_for(run: dict) -> str:
+    """Map GitHub Actions status/conclusion to a normalized result string."""
+    status = run.get("status", "")
+    conclusion = run.get("conclusion", "")
+
+    if status in ("in_progress", "queued", "waiting", "pending"):
+        return status
+
+    return conclusion or status
+
+
+def collect_github_data(branches: list[str], top_builds: int) -> list[dict]:
+    """Collect GitHub Actions workflow run data for all tracked workflows.
+
+    Returns a list of workflow data dicts, each containing runs per branch.
+    """
+    workflows_data = []
+
+    for wf in GITHUB_WORKFLOWS:
+        wf_data = {
+            "repo": wf["repo"],
+            "workflow": wf["workflow"],
+            "name": wf["name"],
+            "branches": [],
+        }
+
+        for branch in branches:
+            runs = get_github_workflow_runs(wf["repo"], wf["workflow"], branch, top=top_builds)
+            branch_runs = []
+
+            for r in runs:
+                # Calculate duration if possible
+                duration_min = None
+                if r.get("createdAt") and r.get("updatedAt"):
+                    try:
+                        created = datetime.fromisoformat(r["createdAt"].replace("Z", "+00:00"))
+                        updated = datetime.fromisoformat(r["updatedAt"].replace("Z", "+00:00"))
+                        duration_min = round((updated - created).total_seconds() / 60, 1)
+                    except (ValueError, TypeError):
+                        pass
+
+                run_data = {
+                    "id": r.get("databaseId"),
+                    "displayTitle": r.get("displayTitle", ""),
+                    "status": r.get("status", ""),
+                    "conclusion": r.get("conclusion", ""),
+                    "result": gh_result_for(r),
+                    "createdAt": r.get("createdAt"),
+                    "updatedAt": r.get("updatedAt"),
+                    "durationMinutes": duration_min,
+                    "headSha": (r.get("headSha") or "")[:12],
+                    "headBranch": r.get("headBranch", ""),
+                    "event": r.get("event", ""),
+                    "url": r.get("url", ""),
+                    "icon": gh_icon_for(r),
+                }
+                branch_runs.append(run_data)
+
+            # Compute stats
+            stats = {"total": 0, "succeeded": 0, "failed": 0, "other": 0}
+            for run in branch_runs:
+                stats["total"] += 1
+                if run["conclusion"] == "success":
+                    stats["succeeded"] += 1
+                elif run["conclusion"] == "failure":
+                    stats["failed"] += 1
+                else:
+                    stats["other"] += 1
+
+            if stats["total"] > 0:
+                stats["pass_rate"] = round(stats["succeeded"] / stats["total"] * 100, 1)
+            else:
+                stats["pass_rate"] = None
+
+            wf_data["branches"].append({
+                "name": branch,
+                "runs": branch_runs,
+                "stats": stats,
+            })
+
+        workflows_data.append(wf_data)
+
+    return workflows_data
+
+
 def get_release_branches(top: int = 3) -> list[str]:
     """Get the most recent release branches by commit date.
 
@@ -232,6 +386,7 @@ def collect_data(branches: list[str], top_builds: int, show_issues: bool) -> dic
              "group": "public" if p in PUBLIC_PIPELINES else "internal"}
             for p in PUBLIC_PIPELINES + INTERNAL_PIPELINES
         ],
+        "github_workflows": GITHUB_WORKFLOWS,
         "branches": [],
     }
 
@@ -315,6 +470,9 @@ def collect_data(branches: list[str], top_builds: int, show_issues: bool) -> dic
             branch_data["pipeline_groups"].append(group_data)
 
         data["branches"].append(branch_data)
+
+    # Collect GitHub Actions data
+    data["github_actions"] = collect_github_data(branches, top_builds)
 
     return data
 
@@ -413,6 +571,49 @@ def render_console(data: dict):
                     statuses.append(f"⏳ {pipe['name']}")
         print(f"  {branch_data['name']:<40} {' | '.join(statuses)}")
     print()
+
+    # GitHub Actions summary
+    if data.get("github_actions"):
+        print(f"{'═' * 70}")
+        print(f" GitHub Actions Status")
+        print(f"{'═' * 70}")
+
+        for wf_data in data["github_actions"]:
+            print(f"\n┌─ {wf_data['name']} ({wf_data['repo']})")
+            print(f"│  Workflow: {wf_data['workflow']}")
+            print(f"│")
+
+            for branch_info in wf_data["branches"]:
+                if not branch_info["runs"]:
+                    print(f"│  {branch_info['name']}: no runs found")
+                    continue
+
+                print(f"│  ┌ {branch_info['name']} (last {len(branch_info['runs'])})")
+                for run in branch_info["runs"]:
+                    started = format_time(run["createdAt"])
+                    title = run["displayTitle"][:50] if run["displayTitle"] else ""
+                    print(
+                        f"│  │   {run['icon']} {run['result']:<12} "
+                        f"{started}  {title}  [id:{run['id']}]"
+                    )
+                print(f"│  └")
+
+            print(f"└")
+        print()
+        print(f"{'═' * 70}")
+
+        # GitHub Actions health line
+        print("\n🐙 GitHub Actions Health:")
+        for wf_data in data["github_actions"]:
+            branch_statuses = []
+            for branch_info in wf_data["branches"]:
+                if branch_info["runs"]:
+                    latest = branch_info["runs"][0]
+                    branch_statuses.append(f"{latest['icon']} {branch_info['name']}")
+                else:
+                    branch_statuses.append(f"⏳ {branch_info['name']}")
+            print(f"  {wf_data['name']:<35} {' | '.join(branch_statuses)}")
+        print()
 
 
 def render_markdown(data: dict, output_path: str):
@@ -568,6 +769,54 @@ def render_markdown(data: dict, output_path: str):
         lines.append(f"---")
         lines.append(f"")
 
+    # GitHub Actions section
+    if data.get("github_actions"):
+        lines.append(f"## GitHub Actions")
+        lines.append(f"")
+
+        # Summary table
+        lines.append(f"| Workflow | Repository | " + " | ".join(b["name"] for b in data["github_actions"][0]["branches"]) + " |")
+        lines.append(f"|----------|------------|" + "|".join(["------" for _ in data["github_actions"][0]["branches"]]) + "|")
+        for wf_data in data["github_actions"]:
+            cells = []
+            for branch_info in wf_data["branches"]:
+                if branch_info["runs"]:
+                    latest = branch_info["runs"][0]
+                    rate = branch_info["stats"]["pass_rate"]
+                    rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 else ""
+                    cells.append(f"{latest['icon']} {latest['result']}{rate_str}")
+                else:
+                    cells.append("— no runs")
+            lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | " + " | ".join(cells) + " |")
+        lines.append(f"")
+
+        # Detailed per-workflow sections
+        for wf_data in data["github_actions"]:
+            lines.append(f"### {wf_data['name']} (`{wf_data['repo']}`)")
+            lines.append(f"")
+
+            for branch_info in wf_data["branches"]:
+                if not branch_info["runs"]:
+                    continue
+
+                stats = branch_info["stats"]
+                rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats["pass_rate"] is not None else ""
+                lines.append(f"#### `{branch_info['name']}`{rate_str}")
+                lines.append(f"")
+                lines.append(f"| Status | Title | Result | Duration | Commit | Started | Link |")
+                lines.append(f"|--------|-------|--------|----------|--------|---------|------|")
+                for run in branch_info["runs"]:
+                    started = format_time(run["createdAt"])
+                    title = run["displayTitle"][:60] if run["displayTitle"] else "—"
+                    dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
+                    commit = f"`{run['headSha']}`" if run.get("headSha") else "—"
+                    link = f"[{run['id']}]({run['url']})" if run.get("url") else str(run.get("id", "—"))
+                    lines.append(f"| {run['icon']} | {title} | {run['result']} | {dur} | {commit} | {started} | {link} |")
+                lines.append(f"")
+
+        lines.append(f"---")
+        lines.append(f"")
+
     # Footer
     lines.append(f"## Pipeline Links")
     lines.append(f"")
@@ -578,6 +827,15 @@ def render_markdown(data: dict, output_path: str):
         url = f"{pipe['org'].rstrip('/')}/{pipe['project']}/_build?definitionId={pipe['id']}"
         lines.append(f"| {pipe['name']} | {org_short} | [{pipe['id']}]({url}) |")
     lines.append(f"")
+
+    # GitHub workflow links
+    if GITHUB_WORKFLOWS:
+        lines.append(f"| Workflow | Repository | File |")
+        lines.append(f"|----------|------------|------|")
+        for wf in GITHUB_WORKFLOWS:
+            url = f"https://github.com/{wf['repo']}/actions/workflows/{wf['workflow']}"
+            lines.append(f"| {wf['name']} | `{wf['repo']}` | [{wf['workflow']}]({url}) |")
+        lines.append(f"")
 
     content = "\n".join(lines)
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -58,8 +58,13 @@ ICONS = {
 # Each entry: repo, workflow file name, display name, relevant branches
 GITHUB_WORKFLOWS = [
     {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Docs - Go Live!"},
     {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples"},
     {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Auto Docs Submodule Sync"},
+    {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Update Release Notes"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Skia Upstream Sync"},
+    {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live"},

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -55,32 +55,31 @@ ICONS = {
 }
 
 # GitHub Actions workflows to track
-# Each entry: repo, workflow file name, display name, relevant branches
+# Each entry: repo, workflow file name, display name
+# scope: "branch" = filter by branch, "global" = fetch latest runs regardless of branch
 GITHUB_WORKFLOWS = [
-    # mono/SkiaSharp — Build & Docs
-    {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Docs - Go Live!"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Docs - PR Staging - Cleanup"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Docs - PR Staging - Sweep Stale"},
-    {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples"},
-    {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff"},
-    # mono/SkiaSharp — Automation & Sync
-    {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Auto Docs Submodule Sync"},
-    {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Update Release Notes"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Skia Upstream Sync"},
-    {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Auto-Triage SkiaSharp Issue"},
-    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Persist Agentic Workflow Data"},
-    # mono/SkiaSharp — PR Utilities
-    {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "Backport"},
-    {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "Automatic Rebase"},
-    {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "Add PR Artifacts Comment"},
-    # mono/SkiaSharp — Dependency Management
-    {"repo": "mono/SkiaSharp", "workflow": "manage-nuget-feed.yml", "name": "Manage NuGet Feed"},
-    # mono/SkiaSharp-API-docs
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer"},
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs"},
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live"},
+    # mono/SkiaSharp — Build & Docs (branch-scoped: run on push/PR to specific branches)
+    {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy", "scope": "branch"},
+    {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples", "scope": "branch"},
+    # mono/SkiaSharp — Automation & Sync (global: scheduled/dispatch, not branch-specific)
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Docs - Go Live!", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Docs - PR Staging - Cleanup", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Docs - PR Staging - Sweep Stale", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Auto Docs Submodule Sync", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Update Release Notes", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Skia Upstream Sync", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Auto-Triage SkiaSharp Issue", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Persist Agentic Workflow Data", "scope": "global"},
+    # mono/SkiaSharp — PR Utilities (global: triggered by PR events, not branch-specific)
+    {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "Backport", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "Automatic Rebase", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "Add PR Artifacts Comment", "scope": "global"},
+    # mono/SkiaSharp-API-docs (global: scheduled/dispatch/PR events)
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer", "scope": "global"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs", "scope": "global"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live", "scope": "global"},
 ]
 
 
@@ -277,75 +276,95 @@ def gh_result_for(run: dict) -> str:
 def collect_github_data(branches: list[str], top_builds: int) -> list[dict]:
     """Collect GitHub Actions workflow run data for all tracked workflows.
 
-    Returns a list of workflow data dicts, each containing runs per branch.
+    Workflows with scope "branch" are queried per-branch.
+    Workflows with scope "global" are queried once without branch filter.
+    Returns a list of workflow data dicts.
     """
     workflows_data = []
 
     for wf in GITHUB_WORKFLOWS:
+        scope = wf.get("scope", "global")
         wf_data = {
             "repo": wf["repo"],
             "workflow": wf["workflow"],
             "name": wf["name"],
-            "branches": [],
+            "scope": scope,
+            "branches": [],  # Used for branch-scoped workflows
+            "runs": [],      # Used for global-scoped workflows
+            "stats": None,   # Used for global-scoped workflows
+            "error": None,   # Capture collection failures
         }
 
-        for branch in branches:
-            runs = get_github_workflow_runs(wf["repo"], wf["workflow"], branch, top=top_builds)
-            branch_runs = []
-
-            for r in runs:
-                # Calculate duration if possible
-                duration_min = None
-                if r.get("createdAt") and r.get("updatedAt"):
-                    try:
-                        created = datetime.fromisoformat(r["createdAt"].replace("Z", "+00:00"))
-                        updated = datetime.fromisoformat(r["updatedAt"].replace("Z", "+00:00"))
-                        duration_min = round((updated - created).total_seconds() / 60, 1)
-                    except (ValueError, TypeError):
-                        pass
-
-                run_data = {
-                    "id": r.get("databaseId"),
-                    "displayTitle": r.get("displayTitle", ""),
-                    "status": r.get("status", ""),
-                    "conclusion": r.get("conclusion", ""),
-                    "result": gh_result_for(r),
-                    "createdAt": r.get("createdAt"),
-                    "updatedAt": r.get("updatedAt"),
-                    "durationMinutes": duration_min,
-                    "headSha": (r.get("headSha") or "")[:12],
-                    "headBranch": r.get("headBranch", ""),
-                    "event": r.get("event", ""),
-                    "url": r.get("url", ""),
-                    "icon": gh_icon_for(r),
-                }
-                branch_runs.append(run_data)
-
-            # Compute stats
-            stats = {"total": 0, "succeeded": 0, "failed": 0, "other": 0}
-            for run in branch_runs:
-                stats["total"] += 1
-                if run["conclusion"] == "success":
-                    stats["succeeded"] += 1
-                elif run["conclusion"] == "failure":
-                    stats["failed"] += 1
-                else:
-                    stats["other"] += 1
-
-            if stats["total"] > 0:
-                stats["pass_rate"] = round(stats["succeeded"] / stats["total"] * 100, 1)
-            else:
-                stats["pass_rate"] = None
-
-            wf_data["branches"].append({
-                "name": branch,
-                "runs": branch_runs,
-                "stats": stats,
-            })
+        if scope == "branch":
+            # Query per-branch (push/PR workflows)
+            for branch in branches:
+                runs_raw = get_github_workflow_runs(wf["repo"], wf["workflow"], branch, top=top_builds)
+                branch_runs = _parse_gh_runs(runs_raw)
+                stats = _compute_gh_stats(branch_runs)
+                wf_data["branches"].append({
+                    "name": branch,
+                    "runs": branch_runs,
+                    "stats": stats,
+                })
+        else:
+            # Query globally (scheduled/dispatch/event-driven workflows)
+            runs_raw = get_github_workflow_runs(wf["repo"], wf["workflow"], branch=None, top=top_builds)
+            wf_data["runs"] = _parse_gh_runs(runs_raw)
+            wf_data["stats"] = _compute_gh_stats(wf_data["runs"])
 
         workflows_data.append(wf_data)
 
     return workflows_data
+
+
+def _parse_gh_runs(runs_raw: list[dict]) -> list[dict]:
+    """Parse raw GitHub Actions run data into normalized format."""
+    parsed = []
+    for r in runs_raw:
+        duration_min = None
+        if r.get("createdAt") and r.get("updatedAt"):
+            try:
+                created = datetime.fromisoformat(r["createdAt"].replace("Z", "+00:00"))
+                updated = datetime.fromisoformat(r["updatedAt"].replace("Z", "+00:00"))
+                duration_min = round((updated - created).total_seconds() / 60, 1)
+            except (ValueError, TypeError):
+                pass
+
+        parsed.append({
+            "id": r.get("databaseId"),
+            "displayTitle": r.get("displayTitle", ""),
+            "status": r.get("status", ""),
+            "conclusion": r.get("conclusion", ""),
+            "result": gh_result_for(r),
+            "createdAt": r.get("createdAt"),
+            "updatedAt": r.get("updatedAt"),
+            "durationMinutes": duration_min,
+            "headSha": (r.get("headSha") or "")[:12],
+            "headBranch": r.get("headBranch", ""),
+            "event": r.get("event", ""),
+            "url": r.get("url", ""),
+            "icon": gh_icon_for(r),
+        })
+    return parsed
+
+
+def _compute_gh_stats(runs: list[dict]) -> dict:
+    """Compute pass/fail stats for a list of GitHub Actions runs."""
+    stats = {"total": 0, "succeeded": 0, "failed": 0, "other": 0}
+    for run in runs:
+        stats["total"] += 1
+        if run["conclusion"] == "success":
+            stats["succeeded"] += 1
+        elif run["conclusion"] == "failure":
+            stats["failed"] += 1
+        else:
+            stats["other"] += 1
+
+    if stats["total"] > 0:
+        stats["pass_rate"] = round(stats["succeeded"] / stats["total"] * 100, 1)
+    else:
+        stats["pass_rate"] = None
+    return stats
 
 
 def get_release_branches(top: int = 3) -> list[str]:
@@ -599,23 +618,39 @@ def render_console(data: dict):
 
         for wf_data in data["github_actions"]:
             print(f"\n┌─ {wf_data['name']} ({wf_data['repo']})")
-            print(f"│  Workflow: {wf_data['workflow']}")
+            print(f"│  Workflow: {wf_data['workflow']}  [scope: {wf_data.get('scope', 'global')}]")
             print(f"│")
 
-            for branch_info in wf_data["branches"]:
-                if not branch_info["runs"]:
-                    print(f"│  {branch_info['name']}: no runs found")
-                    continue
+            if wf_data.get("scope") == "branch":
+                # Branch-scoped: show per-branch runs
+                for branch_info in wf_data["branches"]:
+                    if not branch_info["runs"]:
+                        print(f"│  {branch_info['name']}: no runs found")
+                        continue
 
-                print(f"│  ┌ {branch_info['name']} (last {len(branch_info['runs'])})")
-                for run in branch_info["runs"]:
-                    started = format_time(run["createdAt"])
-                    title = run["displayTitle"][:50] if run["displayTitle"] else ""
-                    print(
-                        f"│  │   {run['icon']} {run['result']:<12} "
-                        f"{started}  {title}  [id:{run['id']}]"
-                    )
-                print(f"│  └")
+                    print(f"│  ┌ {branch_info['name']} (last {len(branch_info['runs'])})")
+                    for run in branch_info["runs"]:
+                        started = format_time(run["createdAt"])
+                        title = run["displayTitle"][:50] if run["displayTitle"] else ""
+                        print(
+                            f"│  │   {run['icon']} {run['result']:<12} "
+                            f"{started}  {title}  [id:{run['id']}]"
+                        )
+                    print(f"│  └")
+            else:
+                # Global-scoped: show latest runs
+                runs = wf_data.get("runs", [])
+                if not runs:
+                    print(f"│  (no recent runs)")
+                else:
+                    for run in runs:
+                        started = format_time(run["createdAt"])
+                        title = run["displayTitle"][:50] if run["displayTitle"] else ""
+                        branch_tag = f"[{run['headBranch']}]" if run.get("headBranch") else ""
+                        print(
+                            f"│  {run['icon']} {run['result']:<12} "
+                            f"{started}  {title}  {branch_tag}  [id:{run['id']}]"
+                        )
 
             print(f"└")
         print()
@@ -624,14 +659,22 @@ def render_console(data: dict):
         # GitHub Actions health line
         print("\n🐙 GitHub Actions Health:")
         for wf_data in data["github_actions"]:
-            branch_statuses = []
-            for branch_info in wf_data["branches"]:
-                if branch_info["runs"]:
-                    latest = branch_info["runs"][0]
-                    branch_statuses.append(f"{latest['icon']} {branch_info['name']}")
+            if wf_data.get("scope") == "branch":
+                branch_statuses = []
+                for branch_info in wf_data["branches"]:
+                    if branch_info["runs"]:
+                        latest = branch_info["runs"][0]
+                        branch_statuses.append(f"{latest['icon']} {branch_info['name']}")
+                    else:
+                        branch_statuses.append(f"⏳ {branch_info['name']}")
+                print(f"  {wf_data['name']:<35} {' | '.join(branch_statuses)}")
+            else:
+                runs = wf_data.get("runs", [])
+                if runs:
+                    latest = runs[0]
+                    print(f"  {wf_data['name']:<35} {latest['icon']} {latest['result']} ({format_time(latest['createdAt'])})")
                 else:
-                    branch_statuses.append(f"⏳ {branch_info['name']}")
-            print(f"  {wf_data['name']:<35} {' | '.join(branch_statuses)}")
+                    print(f"  {wf_data['name']:<35} ⏳ no recent runs")
         print()
 
 
@@ -793,44 +836,96 @@ def render_markdown(data: dict, output_path: str):
         lines.append(f"## GitHub Actions")
         lines.append(f"")
 
-        # Summary table
-        lines.append(f"| Workflow | Repository | " + " | ".join(b["name"] for b in data["github_actions"][0]["branches"]) + " |")
-        lines.append(f"|----------|------------|" + "|".join(["------" for _ in data["github_actions"][0]["branches"]]) + "|")
-        for wf_data in data["github_actions"]:
-            cells = []
-            for branch_info in wf_data["branches"]:
-                if branch_info["runs"]:
-                    latest = branch_info["runs"][0]
-                    rate = branch_info["stats"]["pass_rate"]
-                    rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 else ""
-                    cells.append(f"{latest['icon']} {latest['result']}{rate_str}")
+        # Split into branch-scoped and global-scoped
+        branch_scoped = [w for w in data["github_actions"] if w.get("scope") == "branch"]
+        global_scoped = [w for w in data["github_actions"] if w.get("scope") != "branch"]
+
+        # Branch-scoped summary table
+        if branch_scoped:
+            # Get branch names from first branch-scoped workflow
+            branch_names = [b["name"] for b in branch_scoped[0]["branches"]]
+            lines.append(f"### Branch-Scoped Workflows")
+            lines.append(f"")
+            lines.append(f"| Workflow | Repository | " + " | ".join(branch_names) + " |")
+            lines.append(f"|----------|------------|" + "|".join(["------" for _ in branch_names]) + "|")
+            for wf_data in branch_scoped:
+                cells = []
+                for branch_info in wf_data["branches"]:
+                    if branch_info["runs"]:
+                        latest = branch_info["runs"][0]
+                        rate = branch_info["stats"]["pass_rate"]
+                        rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 else ""
+                        cells.append(f"{latest['icon']} {latest['result']}{rate_str}")
+                    else:
+                        cells.append("— no runs")
+                lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | " + " | ".join(cells) + " |")
+            lines.append(f"")
+
+        # Global-scoped summary table
+        if global_scoped:
+            lines.append(f"### Global Workflows (scheduled/dispatch/event-driven)")
+            lines.append(f"")
+            lines.append(f"| Workflow | Repository | Latest | Result | Last Run | Link |")
+            lines.append(f"|----------|------------|--------|--------|----------|------|")
+            for wf_data in global_scoped:
+                runs = wf_data.get("runs", [])
+                if runs:
+                    latest = runs[0]
+                    started = format_time(latest["createdAt"])
+                    link = f"[{latest['id']}]({latest['url']})" if latest.get("url") else "—"
+                    lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | {latest['icon']} | {latest['result']} | {started} | {link} |")
                 else:
-                    cells.append("— no runs")
-            lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | " + " | ".join(cells) + " |")
-        lines.append(f"")
+                    lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | ⏳ | no runs | — | — |")
+            lines.append(f"")
 
         # Detailed per-workflow sections
         for wf_data in data["github_actions"]:
+            if wf_data.get("scope") == "branch":
+                has_runs = any(b["runs"] for b in wf_data["branches"])
+            else:
+                has_runs = bool(wf_data.get("runs"))
+
+            if not has_runs:
+                continue
+
             lines.append(f"### {wf_data['name']} (`{wf_data['repo']}`)")
             lines.append(f"")
 
-            for branch_info in wf_data["branches"]:
-                if not branch_info["runs"]:
-                    continue
+            if wf_data.get("scope") == "branch":
+                for branch_info in wf_data["branches"]:
+                    if not branch_info["runs"]:
+                        continue
 
-                stats = branch_info["stats"]
-                rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats["pass_rate"] is not None else ""
-                lines.append(f"#### `{branch_info['name']}`{rate_str}")
+                    stats = branch_info["stats"]
+                    rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats["pass_rate"] is not None else ""
+                    lines.append(f"#### `{branch_info['name']}`{rate_str}")
+                    lines.append(f"")
+                    lines.append(f"| Status | Title | Result | Duration | Commit | Started | Link |")
+                    lines.append(f"|--------|-------|--------|----------|--------|---------|------|")
+                    for run in branch_info["runs"]:
+                        started = format_time(run["createdAt"])
+                        title = run["displayTitle"][:60] if run["displayTitle"] else "—"
+                        dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
+                        commit = f"`{run['headSha']}`" if run.get("headSha") else "—"
+                        link = f"[{run['id']}]({run['url']})" if run.get("url") else str(run.get("id", "—"))
+                        lines.append(f"| {run['icon']} | {title} | {run['result']} | {dur} | {commit} | {started} | {link} |")
+                    lines.append(f"")
+            else:
+                runs = wf_data.get("runs", [])
+                stats = wf_data.get("stats", {})
+                rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats and stats.get("pass_rate") is not None else ""
+                lines.append(f"_Scope: global (latest runs across all branches){rate_str}_")
                 lines.append(f"")
-                lines.append(f"| Status | Title | Result | Duration | Commit | Started | Link |")
-                lines.append(f"|--------|-------|--------|----------|--------|---------|------|")
-                for run in branch_info["runs"]:
+                lines.append(f"| Status | Title | Result | Branch | Duration | Commit | Started | Link |")
+                lines.append(f"|--------|-------|--------|--------|----------|--------|---------|------|")
+                for run in runs:
                     started = format_time(run["createdAt"])
                     title = run["displayTitle"][:60] if run["displayTitle"] else "—"
                     dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
                     commit = f"`{run['headSha']}`" if run.get("headSha") else "—"
+                    branch = run.get("headBranch", "—")
                     link = f"[{run['id']}]({run['url']})" if run.get("url") else str(run.get("id", "—"))
-                    lines.append(f"| {run['icon']} | {title} | {run['result']} | {dur} | {commit} | {started} | {link} |")
+                    lines.append(f"| {run['icon']} | {title} | {run['result']} | {branch} | {dur} | {commit} | {started} | {link} |")
                 lines.append(f"")
 
         lines.append(f"---")

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -60,6 +60,7 @@ GITHUB_WORKFLOWS = [
     {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy"},
     {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples"},
     {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live"},
 ]

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -57,14 +57,27 @@ ICONS = {
 # GitHub Actions workflows to track
 # Each entry: repo, workflow file name, display name, relevant branches
 GITHUB_WORKFLOWS = [
+    # mono/SkiaSharp — Build & Docs
     {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy"},
     {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Docs - Go Live!"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Docs - PR Staging - Cleanup"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Docs - PR Staging - Sweep Stale"},
     {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples"},
     {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff"},
+    # mono/SkiaSharp — Automation & Sync
     {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Auto Docs Submodule Sync"},
     {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Update Release Notes"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Skia Upstream Sync"},
     {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Auto-Triage SkiaSharp Issue"},
+    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Persist Agentic Workflow Data"},
+    # mono/SkiaSharp — PR Utilities
+    {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "Backport"},
+    {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "Automatic Rebase"},
+    {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "Add PR Artifacts Comment"},
+    # mono/SkiaSharp — Dependency Management
+    {"repo": "mono/SkiaSharp", "workflow": "manage-nuget-feed.yml", "name": "Manage NuGet Feed"},
+    # mono/SkiaSharp-API-docs
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live"},

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -57,29 +57,33 @@ ICONS = {
 # GitHub Actions workflows to track
 # Each entry: repo, workflow file name, display name
 # scope: "branch" = filter by branch, "global" = fetch latest runs regardless of branch
+# trigger: "push" = push/PR, "schedule" = cron, "dispatch" = manual, "event" = PR/issue events
+# branches: (optional) override which branches to query for branch-scoped workflows.
+#           If omitted, uses the full set (main + release/*).
 GITHUB_WORKFLOWS = [
-    # mono/SkiaSharp — Build & Docs (branch-scoped: run on push/PR to specific branches)
-    {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy", "scope": "branch"},
-    {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples", "scope": "branch"},
+    # mono/SkiaSharp — Build & Docs (push-triggered, main + release/*)
+    {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Docs - Deploy", "scope": "branch", "trigger": "push"},
+    {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Publish Samples", "scope": "branch", "trigger": "push"},
+    # mono/SkiaSharp — Release-path push workflow (main + release/*)
+    {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Update Release Notes", "scope": "branch", "trigger": "push"},
     # mono/SkiaSharp — Automation & Sync (global: scheduled/dispatch, not branch-specific)
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Docs - Go Live!", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Docs - PR Staging - Cleanup", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Docs - PR Staging - Sweep Stale", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Auto Docs Submodule Sync", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Update Release Notes", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Skia Upstream Sync", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Auto-Triage SkiaSharp Issue", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Persist Agentic Workflow Data", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Docs - Go Live!", "scope": "global", "trigger": "dispatch"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Docs - PR Staging - Cleanup", "scope": "global", "trigger": "event"},
+    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Docs - PR Staging - Sweep Stale", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "api-diff.yml", "name": "API Diff", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Auto Docs Submodule Sync", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Skia Upstream Sync", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Auto-Triage SkiaSharp Issue", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Persist Agentic Workflow Data", "scope": "global", "trigger": "push"},
     # mono/SkiaSharp — PR Utilities (global: triggered by PR events, not branch-specific)
-    {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "Backport", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "Automatic Rebase", "scope": "global"},
-    {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "Add PR Artifacts Comment", "scope": "global"},
+    {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "Backport", "scope": "global", "trigger": "event"},
+    {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "Automatic Rebase", "scope": "global", "trigger": "event"},
+    {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "Add PR Artifacts Comment", "scope": "global", "trigger": "event"},
     # mono/SkiaSharp-API-docs (global: scheduled/dispatch/PR events)
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer", "scope": "global"},
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs", "scope": "global"},
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live", "scope": "global"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs", "scope": "global", "trigger": "event"},
+    {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live", "scope": "global", "trigger": "dispatch"},
 ]
 
 
@@ -284,11 +288,13 @@ def collect_github_data(branches: list[str], top_builds: int) -> list[dict]:
 
     for wf in GITHUB_WORKFLOWS:
         scope = wf.get("scope", "global")
+        trigger = wf.get("trigger", "unknown")
         wf_data = {
             "repo": wf["repo"],
             "workflow": wf["workflow"],
             "name": wf["name"],
             "scope": scope,
+            "trigger": trigger,
             "branches": [],  # Used for branch-scoped workflows
             "runs": [],      # Used for global-scoped workflows
             "stats": None,   # Used for global-scoped workflows
@@ -297,7 +303,9 @@ def collect_github_data(branches: list[str], top_builds: int) -> list[dict]:
 
         if scope == "branch":
             # Query per-branch (push/PR workflows)
-            for branch in branches:
+            # Use workflow-specific branch override if defined, else full branch list
+            wf_branches = wf.get("branches", branches)
+            for branch in wf_branches:
                 runs_raw = get_github_workflow_runs(wf["repo"], wf["workflow"], branch, top=top_builds)
                 branch_runs = _parse_gh_runs(runs_raw)
                 stats = _compute_gh_stats(branch_runs)
@@ -311,6 +319,9 @@ def collect_github_data(branches: list[str], top_builds: int) -> list[dict]:
             runs_raw = get_github_workflow_runs(wf["repo"], wf["workflow"], branch=None, top=top_builds)
             wf_data["runs"] = _parse_gh_runs(runs_raw)
             wf_data["stats"] = _compute_gh_stats(wf_data["runs"])
+
+        # Fetch failed job details for the latest failed run
+        _enrich_failed_runs(wf_data)
 
         workflows_data.append(wf_data)
 
@@ -365,6 +376,64 @@ def _compute_gh_stats(runs: list[dict]) -> dict:
     else:
         stats["pass_rate"] = None
     return stats
+
+
+def get_failed_job_details(repo: str, run_id: int) -> list[dict]:
+    """Fetch failed job and step details for a GitHub Actions run.
+
+    Returns a list of failed jobs with their failed steps.
+    Only called for runs with conclusion == "failure".
+    """
+    out = gh([
+        "run", "view", str(run_id),
+        "--repo", repo,
+        "--json", "jobs",
+    ])
+    if not out:
+        return []
+    try:
+        data = json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    failed_jobs = []
+    for job in data.get("jobs", []):
+        if job.get("conclusion") != "failure":
+            continue
+        failed_steps = []
+        for step in job.get("steps", []):
+            if step.get("conclusion") == "failure":
+                failed_steps.append({
+                    "name": step.get("name", "unknown"),
+                    "conclusion": step.get("conclusion", ""),
+                })
+        failed_jobs.append({
+            "name": job.get("name", "unknown"),
+            "conclusion": job.get("conclusion", ""),
+            "failed_steps": failed_steps,
+        })
+    return failed_jobs
+
+
+def _enrich_failed_runs(wf_data: dict):
+    """For a workflow's collected data, fetch job details for the latest failed run.
+
+    For branch-scoped workflows: fetch for the latest failed run per branch.
+    For global-scoped workflows: fetch for the latest failed run overall.
+    """
+    repo = wf_data["repo"]
+
+    if wf_data.get("scope") == "branch":
+        for branch_info in wf_data.get("branches", []):
+            for run in branch_info.get("runs", []):
+                if run.get("conclusion") == "failure":
+                    run["failed_jobs"] = get_failed_job_details(repo, run["id"])
+                    break  # Only latest failed run per branch
+    else:
+        for run in wf_data.get("runs", []):
+            if run.get("conclusion") == "failure":
+                run["failed_jobs"] = get_failed_job_details(repo, run["id"])
+                break  # Only latest failed run
 
 
 def get_release_branches(top: int = 3) -> list[str]:
@@ -659,6 +728,7 @@ def render_console(data: dict):
         # GitHub Actions health line
         print("\n🐙 GitHub Actions Health:")
         for wf_data in data["github_actions"]:
+            trigger_tag = f"[{wf_data.get('trigger', '?')}]"
             if wf_data.get("scope") == "branch":
                 branch_statuses = []
                 for branch_info in wf_data["branches"]:
@@ -667,295 +737,25 @@ def render_console(data: dict):
                         branch_statuses.append(f"{latest['icon']} {branch_info['name']}")
                     else:
                         branch_statuses.append(f"⏳ {branch_info['name']}")
-                print(f"  {wf_data['name']:<35} {' | '.join(branch_statuses)}")
+                print(f"  {trigger_tag:<10} {wf_data['name']:<30} {' | '.join(branch_statuses)}")
             else:
                 runs = wf_data.get("runs", [])
                 if runs:
                     latest = runs[0]
-                    print(f"  {wf_data['name']:<35} {latest['icon']} {latest['result']} ({format_time(latest['createdAt'])})")
+                    print(f"  {trigger_tag:<10} {wf_data['name']:<30} {latest['icon']} {latest['result']} ({format_time(latest['createdAt'])})")
+                    # Show failed job details if available
+                    if latest.get("failed_jobs"):
+                        for job in latest["failed_jobs"]:
+                            steps_str = ", ".join(s["name"] for s in job.get("failed_steps", []))
+                            if steps_str:
+                                print(f"             {'':30} ↳ {job['name']}: {steps_str}")
+                            else:
+                                print(f"             {'':30} ↳ {job['name']}")
                 else:
-                    print(f"  {wf_data['name']:<35} ⏳ no recent runs")
+                    print(f"  {trigger_tag:<10} {wf_data['name']:<30} ⏳ no recent runs")
         print()
 
 
-def render_markdown(data: dict, output_path: str):
-    """Render collected data as a markdown report with AI analysis sections."""
-    lines = []
-
-    lines.append(f"# SkiaSharp CI Status Report")
-    lines.append(f"")
-    lines.append(f"> Generated: **{data['timestamp']}**  ")
-    lines.append(f"> Window: last {data['window']['builds_per_pipeline']} builds × "
-                 f"{data['window']['branches_count']} branches")
-    lines.append(f"")
-
-    # Health summary table at the top
-    lines.append(f"## Health Summary")
-    lines.append(f"")
-    pipe_names = [p["name"] for p in PUBLIC_PIPELINES + INTERNAL_PIPELINES]
-    header = "| Branch | " + " | ".join(pipe_names) + " | Risk |"
-    separator = "|--------|" + "|".join(["-----" for _ in pipe_names]) + "|------|"
-    lines.append(header)
-    lines.append(separator)
-
-    for branch_data in data["branches"]:
-        cells = []
-        any_failed = False
-        all_green = True
-        for group in branch_data["pipeline_groups"]:
-            for pipe in group["pipelines"]:
-                if pipe["runs"]:
-                    run = pipe["runs"][0]
-                    result = run["result"] or run["status"]
-                    rate = pipe["stats"]["pass_rate"]
-                    # Show pass rate in cell only when there are failures in the window
-                    rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 and result != "succeeded" else ""
-                    cells.append(f"{run['icon']} {result}{rate_str}")
-                    if result == "failed":
-                        any_failed = True
-                        all_green = False
-                    elif result != "succeeded":
-                        all_green = False
-                else:
-                    cells.append("⏳ no runs")
-                    all_green = False
-
-        risk = "🟢 Low" if all_green else ("🔴 High" if any_failed else "🟡 Medium")
-        row = f"| `{branch_data['name']}` | " + " | ".join(cells) + f" | {risk} |"
-        lines.append(row)
-
-    lines.append(f"")
-
-    # Regressions section
-    regressions = []
-    for branch_data in data["branches"]:
-        for group in branch_data["pipeline_groups"]:
-            for pipe in group["pipelines"]:
-                if pipe.get("regression"):
-                    regressions.append((branch_data["name"], pipe["name"], pipe["regression"]))
-
-    if regressions:
-        lines.append(f"## Regressions Detected")
-        lines.append(f"")
-        lines.append(f"| Branch | Pipeline | Last Green | First Red |")
-        lines.append(f"|--------|----------|-----------|-----------|")
-        for branch_name, pipe_name, reg in regressions:
-            lines.append(
-                f"| `{branch_name}` | {pipe_name} | "
-                f"`{reg['last_green_build_number']}` | "
-                f"[`{reg['first_red_build_number']}`]({reg['first_red_url']}) |"
-            )
-        lines.append(f"")
-
-    lines.append(f"---")
-    lines.append(f"")
-
-    # Detailed per-branch sections
-    for branch_data in data["branches"]:
-        lines.append(f"## `{branch_data['name']}`")
-        lines.append(f"")
-
-        for group in branch_data["pipeline_groups"]:
-            lines.append(f"### {group['label']}")
-            lines.append(f"")
-
-            for pipe in group["pipelines"]:
-                stats = pipe["stats"]
-                rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats["pass_rate"] is not None else ""
-                lines.append(f"#### {pipe['name']}{rate_str}")
-                lines.append(f"")
-
-                if not pipe["runs"]:
-                    lines.append(f"_No builds found._")
-                    lines.append(f"")
-                    continue
-
-                # Build history table
-                lines.append(f"| Status | Build | Result | Duration | Commit | Started | Link |")
-                lines.append(f"|--------|-------|--------|----------|--------|---------|------|")
-                for run in pipe["runs"]:
-                    result_text = run["result"] or run["status"]
-                    started = format_time(run["startTime"])
-                    link = f"[{run['id']}]({run['url']})"
-                    dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
-                    commit = f"`{run['sourceVersion']}`" if run.get("sourceVersion") else "—"
-                    lines.append(f"| {run['icon']} | `{run['buildNumber']}` | {result_text} | {dur} | {commit} | {started} | {link} |")
-                lines.append(f"")
-
-                # Issues for most recent run
-                latest = pipe["runs"][0]
-                if latest.get("issues"):
-                    errors = [i for i in latest["issues"] if i["type"] == "error"]
-                    warnings = [i for i in latest["issues"] if i["type"] == "warning"]
-
-                    if errors:
-                        lines.append(f"<details>")
-                        lines.append(f"<summary>❌ Errors ({len(errors)})</summary>")
-                        lines.append(f"")
-                        lines.append(f"| Task | Message |")
-                        lines.append(f"|------|---------|")
-                        for e in errors:
-                            msg = e["message"].replace("|", "\\|").replace("\n", " ")
-                            lines.append(f"| {e['task_name']} | {msg} |")
-                        lines.append(f"")
-                        lines.append(f"</details>")
-                        lines.append(f"")
-
-                    if warnings:
-                        lines.append(f"<details>")
-                        lines.append(f"<summary>⚠️ Warnings ({len(warnings)})</summary>")
-                        lines.append(f"")
-                        lines.append(f"| Task | Message |")
-                        lines.append(f"|------|---------|")
-                        for w in warnings:
-                            msg = w["message"].replace("|", "\\|").replace("\n", " ")
-                            lines.append(f"| {w['task_name']} | {msg} |")
-                        lines.append(f"")
-                        lines.append(f"</details>")
-                        lines.append(f"")
-
-                # Associated commits for failing build
-                if latest.get("changes"):
-                    lines.append(f"<details>")
-                    lines.append(f"<summary>📝 Associated commits ({len(latest['changes'])})</summary>")
-                    lines.append(f"")
-                    lines.append(f"| Commit | Author | Message |")
-                    lines.append(f"|--------|--------|---------|")
-                    for c in latest["changes"]:
-                        msg = c["message"].replace("|", "\\|")
-                        lines.append(f"| `{c['id']}` | {c['author']} | {msg} |")
-                    lines.append(f"")
-                    lines.append(f"</details>")
-                    lines.append(f"")
-
-        lines.append(f"---")
-        lines.append(f"")
-
-    # GitHub Actions section
-    if data.get("github_actions"):
-        lines.append(f"## GitHub Actions")
-        lines.append(f"")
-
-        # Split into branch-scoped and global-scoped
-        branch_scoped = [w for w in data["github_actions"] if w.get("scope") == "branch"]
-        global_scoped = [w for w in data["github_actions"] if w.get("scope") != "branch"]
-
-        # Branch-scoped summary table
-        if branch_scoped:
-            # Get branch names from first branch-scoped workflow
-            branch_names = [b["name"] for b in branch_scoped[0]["branches"]]
-            lines.append(f"### Branch-Scoped Workflows")
-            lines.append(f"")
-            lines.append(f"| Workflow | Repository | " + " | ".join(branch_names) + " |")
-            lines.append(f"|----------|------------|" + "|".join(["------" for _ in branch_names]) + "|")
-            for wf_data in branch_scoped:
-                cells = []
-                for branch_info in wf_data["branches"]:
-                    if branch_info["runs"]:
-                        latest = branch_info["runs"][0]
-                        rate = branch_info["stats"]["pass_rate"]
-                        rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 else ""
-                        cells.append(f"{latest['icon']} {latest['result']}{rate_str}")
-                    else:
-                        cells.append("— no runs")
-                lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | " + " | ".join(cells) + " |")
-            lines.append(f"")
-
-        # Global-scoped summary table
-        if global_scoped:
-            lines.append(f"### Global Workflows (scheduled/dispatch/event-driven)")
-            lines.append(f"")
-            lines.append(f"| Workflow | Repository | Latest | Result | Last Run | Link |")
-            lines.append(f"|----------|------------|--------|--------|----------|------|")
-            for wf_data in global_scoped:
-                runs = wf_data.get("runs", [])
-                if runs:
-                    latest = runs[0]
-                    started = format_time(latest["createdAt"])
-                    link = f"[{latest['id']}]({latest['url']})" if latest.get("url") else "—"
-                    lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | {latest['icon']} | {latest['result']} | {started} | {link} |")
-                else:
-                    lines.append(f"| {wf_data['name']} | `{wf_data['repo']}` | ⏳ | no runs | — | — |")
-            lines.append(f"")
-
-        # Detailed per-workflow sections
-        for wf_data in data["github_actions"]:
-            if wf_data.get("scope") == "branch":
-                has_runs = any(b["runs"] for b in wf_data["branches"])
-            else:
-                has_runs = bool(wf_data.get("runs"))
-
-            if not has_runs:
-                continue
-
-            lines.append(f"### {wf_data['name']} (`{wf_data['repo']}`)")
-            lines.append(f"")
-
-            if wf_data.get("scope") == "branch":
-                for branch_info in wf_data["branches"]:
-                    if not branch_info["runs"]:
-                        continue
-
-                    stats = branch_info["stats"]
-                    rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats["pass_rate"] is not None else ""
-                    lines.append(f"#### `{branch_info['name']}`{rate_str}")
-                    lines.append(f"")
-                    lines.append(f"| Status | Title | Result | Duration | Commit | Started | Link |")
-                    lines.append(f"|--------|-------|--------|----------|--------|---------|------|")
-                    for run in branch_info["runs"]:
-                        started = format_time(run["createdAt"])
-                        title = run["displayTitle"][:60] if run["displayTitle"] else "—"
-                        dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
-                        commit = f"`{run['headSha']}`" if run.get("headSha") else "—"
-                        link = f"[{run['id']}]({run['url']})" if run.get("url") else str(run.get("id", "—"))
-                        lines.append(f"| {run['icon']} | {title} | {run['result']} | {dur} | {commit} | {started} | {link} |")
-                    lines.append(f"")
-            else:
-                runs = wf_data.get("runs", [])
-                stats = wf_data.get("stats", {})
-                rate_str = f" — pass rate: {stats['pass_rate']:.0f}%" if stats and stats.get("pass_rate") is not None else ""
-                lines.append(f"_Scope: global (latest runs across all branches){rate_str}_")
-                lines.append(f"")
-                lines.append(f"| Status | Title | Result | Branch | Duration | Commit | Started | Link |")
-                lines.append(f"|--------|-------|--------|--------|----------|--------|---------|------|")
-                for run in runs:
-                    started = format_time(run["createdAt"])
-                    title = run["displayTitle"][:60] if run["displayTitle"] else "—"
-                    dur = f"{run['durationMinutes']}m" if run.get("durationMinutes") else "—"
-                    commit = f"`{run['headSha']}`" if run.get("headSha") else "—"
-                    branch = run.get("headBranch", "—")
-                    link = f"[{run['id']}]({run['url']})" if run.get("url") else str(run.get("id", "—"))
-                    lines.append(f"| {run['icon']} | {title} | {run['result']} | {branch} | {dur} | {commit} | {started} | {link} |")
-                lines.append(f"")
-
-        lines.append(f"---")
-        lines.append(f"")
-
-    # Footer
-    lines.append(f"## Pipeline Links")
-    lines.append(f"")
-    lines.append(f"| Pipeline | Org | Definition |")
-    lines.append(f"|----------|-----|------------|")
-    for pipe in PUBLIC_PIPELINES + INTERNAL_PIPELINES:
-        org_short = "xamarin/public" if pipe["org"] == ORG_XAMARIN else "devdiv/DevDiv"
-        url = f"{pipe['org'].rstrip('/')}/{pipe['project']}/_build?definitionId={pipe['id']}"
-        lines.append(f"| {pipe['name']} | {org_short} | [{pipe['id']}]({url}) |")
-    lines.append(f"")
-
-    # GitHub workflow links
-    if GITHUB_WORKFLOWS:
-        lines.append(f"| Workflow | Repository | File |")
-        lines.append(f"|----------|------------|------|")
-        for wf in GITHUB_WORKFLOWS:
-            url = f"https://github.com/{wf['repo']}/actions/workflows/{wf['workflow']}"
-            lines.append(f"| {wf['name']} | `{wf['repo']}` | [{wf['workflow']}]({url}) |")
-        lines.append(f"")
-
-    content = "\n".join(lines)
-    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-    with open(output_path, "w") as f:
-        f.write(content)
-    print(f"\n📄 Markdown report written to: {output_path}")
 
 
 def render_json(data: dict, output_path: str):
@@ -983,10 +783,6 @@ def main():
         help="Skip fetching errors/warnings from failed builds (faster)"
     )
     parser.add_argument(
-        "--output", type=str, default=None,
-        help="Write a markdown report to the specified file path"
-    )
-    parser.add_argument(
         "--json", type=str, default=None, dest="json_output",
         help="Write raw structured JSON data to the specified file (for AI analysis)"
     )
@@ -1003,10 +799,6 @@ def main():
 
     # Always render console output
     render_console(data)
-
-    # Optionally write markdown report
-    if args.output:
-        render_markdown(data, args.output)
 
     # Optionally write JSON data
     if args.json_output:

--- a/.agents/skills/ci-status/scripts/render-ci-status-md.py
+++ b/.agents/skills/ci-status/scripts/render-ci-status-md.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Render a CI status report JSON as a Markdown file.
+
+Usage:
+    python3 render-ci-status-md.py <path-to-json> [output.md]
+
+Produces a comprehensive markdown report suitable for AI consumption,
+including all analysis sections, pipeline health, and recommendations.
+"""
+import json
+import sys
+from pathlib import Path
+
+
+def sev_emoji(sev):
+    s = (sev or "").lower()
+    if s == "critical":
+        return "🔴"
+    elif s == "high":
+        return "🟠"
+    elif s == "medium":
+        return "🟡"
+    return "⚪"
+
+
+def status_emoji(status):
+    m = {
+        "healthy": "✅",
+        "failing": "❌",
+        "degraded": "⚠️",
+        "stale": "⏳",
+        "skipped": "⏭️",
+    }
+    return m.get(status, "❓")
+
+
+def sanitize_cell(text):
+    if not text:
+        return ""
+    text = text.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    text = text.replace("|", "\\|")
+    return text
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 render-ci-status-md.py <path-to-json> [output.md]")
+        sys.exit(1)
+
+    json_path = Path(sys.argv[1])
+    if not json_path.exists():
+        print(f"❌ JSON file not found: {json_path}")
+        sys.exit(1)
+
+    if len(sys.argv) >= 3:
+        output_path = Path(sys.argv[2])
+    else:
+        output_path = json_path.with_suffix(".md")
+
+    with open(json_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Verify this is an augmented report JSON, not raw collector output
+    required_keys = ("meta", "verdict", "azdoHealth", "githubActions", "recommendations")
+    missing = [k for k in required_keys if k not in data]
+    if missing:
+        print(f"❌ Missing required keys: {missing}")
+        print(f"   This looks like raw collector output. Run Step 3 (AI assembles report JSON) first.")
+        print(f"   Expected: augmented ci-status-YYYY-MM-DD.json, not ci-status-data.json")
+        sys.exit(1)
+
+    lines = render(data)
+    content = "\n".join(lines)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    print(f"✅ {output_path.name} ({len(content)} chars, {len(lines)} lines)")
+    print(f"   Output: {output_path}")
+
+
+def render(data):
+    lines = []
+    meta = data.get("meta", {})
+    verdict = data.get("verdict", {})
+    azdo = data.get("azdoHealth", {})
+    chain = data.get("chainAnalysis", [])
+    root_causes = data.get("rootCauses", [])
+    gha = data.get("githubActions", {})
+    flakes = data.get("flakes", [])
+    release_risk = data.get("releaseRisk", [])
+    recs = data.get("recommendations", [])
+
+    # Header
+    lines.append("# SkiaSharp CI Status Report")
+    lines.append("")
+    lines.append(f"> Generated: **{meta.get('timestamp', '?')}**  ")
+    lines.append(f"> Window: {meta.get('window', {}).get('buildsPerPipeline', '?')} builds × "
+                 f"{meta.get('window', {}).get('branchesCount', '?')} branches  ")
+    lines.append(f"> Branches: {', '.join(f'`{b}`' for b in meta.get('branches', []))}")
+    lines.append("")
+
+    # Verdict
+    lines.append("## Executive Summary")
+    lines.append("")
+    lines.append(f"{verdict.get('emoji', '?')} **{verdict.get('status', '?').upper()}** — {verdict.get('summary', 'No summary available.')}")
+    lines.append("")
+
+    # AzDO Health Matrix
+    lines.append("## Azure DevOps Health")
+    lines.append("")
+    azdo_branches = azdo.get("branches", [])
+    if azdo_branches:
+        # Collect all pipeline names
+        all_pipe_names = []
+        for b in azdo_branches:
+            for p in b.get("pipelines", []):
+                if p["name"] not in all_pipe_names:
+                    all_pipe_names.append(p["name"])
+
+        header = "| Branch | " + " | ".join(all_pipe_names) + " | Risk |"
+        sep = "|--------|" + "|".join(["------" for _ in all_pipe_names]) + "|------|"
+        lines.append(header)
+        lines.append(sep)
+
+        for branch in azdo_branches:
+            pipe_map = {p["name"]: p for p in branch.get("pipelines", [])}
+            cells = []
+            for pname in all_pipe_names:
+                p = pipe_map.get(pname)
+                if p:
+                    icon = p.get("latestIcon", "❓")
+                    result = p.get("latestResult", "?")
+                    rate = p.get("passRate")
+                    rate_str = f" ({rate:.0f}%)" if rate is not None and rate < 100 else ""
+                    cells.append(f"{icon} {result}{rate_str}")
+                else:
+                    cells.append("— no data")
+
+            risk_map = {"low": "🟢 Low", "medium": "🟡 Medium", "high": "🔴 High"}
+            risk = risk_map.get(branch.get("risk"), branch.get("risk", "?"))
+            lines.append(f"| `{branch['name']}` | " + " | ".join(cells) + f" | {risk} |")
+        lines.append("")
+
+    # Regressions
+    regressions = azdo.get("regressions", [])
+    if regressions:
+        lines.append("### Regressions Detected")
+        lines.append("")
+        lines.append("| Branch | Pipeline | Last Green | First Red | Suspects |")
+        lines.append("|--------|----------|-----------|-----------|----------|")
+        for reg in regressions:
+            suspects = reg.get("suspects", [])
+            suspect_str = ", ".join(f"`{s.get('id', '?')[:7]}`" for s in suspects[:3])
+            if len(suspects) > 3:
+                suspect_str += f" +{len(suspects)-3} more"
+            url = reg.get("firstRedUrl", "")
+            first_red = f"[`{reg.get('firstRedBuildNumber', '?')}`]({url})" if url else f"`{reg.get('firstRedBuildNumber', '?')}`"
+            lines.append(f"| `{reg.get('branch', '?')}` | {reg.get('pipeline', '?')} | "
+                        f"`{reg.get('lastGreenBuildNumber', '?')}` | {first_red} | {suspect_str} |")
+        lines.append("")
+
+    # Chain Analysis
+    if chain:
+        lines.append("## Pipeline Chain Analysis")
+        lines.append("")
+        lines.append("The internal chain is sequential: **Native → Managed → Tests**. "
+                     "Failures may cascade downstream.")
+        lines.append("")
+        for entry in chain:
+            verdict_icon = {"cascade": "🔗", "independent": "🔀", "mixed": "🔀🔗"}.get(entry.get("verdict"), "❓")
+            lines.append(f"- {verdict_icon} **`{entry.get('branch', '?')}`** [{entry.get('verdict', '?')}]: "
+                        f"{entry.get('summary', 'No summary')}")
+            if entry.get("cascadedPipelines"):
+                lines.append(f"  - Cascaded: {', '.join(entry['cascadedPipelines'])}")
+        lines.append("")
+
+    # Root Causes
+    if root_causes:
+        lines.append("## Root Causes")
+        lines.append("")
+        for rc in root_causes:
+            sev = rc.get("severity", "?")
+            cat = rc.get("category", "?").replace("_", " ")
+            lines.append(f"### [{rc.get('id', '?')}] {sev_emoji(sev)} {rc.get('title', 'Untitled')}")
+            lines.append("")
+            lines.append(f"- **Category:** {cat}")
+            lines.append(f"- **Severity:** {sev}")
+            footprint = rc.get("footprint", {})
+            lines.append(f"- **Branches:** {', '.join(f'`{b}`' for b in footprint.get('branches', []))}")
+            lines.append(f"- **Pipelines:** {', '.join(footprint.get('pipelines', []))}")
+            lines.append(f"- **First seen:** {rc.get('firstSeen', '?')}")
+            lines.append(f"- **Last seen:** {rc.get('lastSeen', '?')}")
+            lines.append("")
+            sample = rc.get("sampleError", "")
+            if sample:
+                lines.append(f"```")
+                lines.append(sanitize_cell(sample[:500]))
+                lines.append(f"```")
+                lines.append("")
+            evidence = rc.get("buildEvidence", [])
+            if evidence:
+                lines.append("Evidence: " + ", ".join(
+                    f"[{e.get('id', '?')}]({e.get('url', '')})" for e in evidence[:5]
+                ))
+                lines.append("")
+
+    # GitHub Actions
+    lines.append("## GitHub Actions")
+    lines.append("")
+    gha_summary = gha.get("summary", {})
+    lines.append(f"**Total:** {gha_summary.get('total', '?')} workflows | "
+                 f"✅ {gha_summary.get('healthy', '?')} healthy | "
+                 f"❌ {gha_summary.get('failing', '?')} failing | "
+                 f"⏳ {gha_summary.get('stale', 0)} stale")
+    lines.append("")
+
+    workflows = gha.get("workflows", [])
+    if workflows:
+        # Group by severity
+        for severity in ("high", "medium", "low"):
+            group = [w for w in workflows if w.get("severity") == severity]
+            if not group:
+                continue
+            sev_label = {"high": "🟠 High Severity", "medium": "🟡 Medium Severity", "low": "⚪ Low Severity"}
+            lines.append(f"### {sev_label.get(severity, severity)}")
+            lines.append("")
+            lines.append("| Workflow | Repo | Status | Details |")
+            lines.append("|----------|------|--------|---------|")
+            for wf in group:
+                status = wf.get("status", "?")
+                icon = status_emoji(status)
+                detail = ""
+                if wf.get("scope") == "branch":
+                    branch_bits = []
+                    for b in wf.get("branches", []):
+                        b_icon = {"success": "✅", "failure": "❌"}.get(b.get("latestResult"), "❓")
+                        branch_bits.append(f"{b_icon} {b['name']}")
+                    detail = " ".join(branch_bits)
+                else:
+                    # Show latest run info
+                    failed_jobs = wf.get("failedJobs", [])
+                    if failed_jobs:
+                        detail = "; ".join(f"{j['name']}" for j in failed_jobs[:2])
+                    elif wf.get("branches"):
+                        # branch-scoped data in flat form
+                        b = wf["branches"][0] if wf["branches"] else {}
+                        detail = b.get("latestResult", "")
+                lines.append(f"| {wf['name']} | `{wf.get('repo', '?')}` | {icon} {status} | {sanitize_cell(detail)} |")
+            lines.append("")
+
+    # Failed job details
+    failed_wfs = [w for w in workflows if w.get("failedJobs")]
+    if failed_wfs:
+        lines.append("### Failed Job Details")
+        lines.append("")
+        for wf in failed_wfs:
+            lines.append(f"**{wf['name']}** (`{wf.get('repo', '?')}`) [{wf.get('trigger', '?')}]")
+            lines.append("")
+            for job in wf.get("failedJobs", []):
+                steps = ", ".join(f"`{s}`" for s in job.get("failedSteps", []))
+                run_url = job.get("runUrl", "")
+                run_link = f" — [run {job.get('runId', '?')}]({run_url})" if run_url else ""
+                lines.append(f"- **{job['name']}**: {steps}{run_link}")
+            lines.append("")
+
+    # Flakes
+    if flakes:
+        lines.append("## Flake Detection")
+        lines.append("")
+        lines.append("| Branch | Pipeline | Pattern | Confidence | Description |")
+        lines.append("|--------|----------|---------|------------|-------------|")
+        for f in flakes:
+            lines.append(f"| `{f.get('branch', '?')}` | {f.get('pipeline', '?')} | "
+                        f"{f.get('pattern', '?')} | {f.get('confidence', '?')} | "
+                        f"{sanitize_cell(f.get('description', ''))} |")
+        lines.append("")
+
+    # Release Risk
+    if release_risk:
+        lines.append("## Release Risk Assessment")
+        lines.append("")
+        lines.append("| Branch | Shippable | Days Since Green | Blockers | Recommendation |")
+        lines.append("|--------|-----------|-----------------|----------|----------------|")
+        for rr in release_risk:
+            ship = "✅ Yes" if rr.get("shippable") else "❌ No"
+            days = rr.get("daysSinceGreen", "—")
+            blockers = ", ".join(rr.get("blockers", [])) or "—"
+            rec = rr.get("recommendation", "?")
+            lines.append(f"| `{rr.get('branch', '?')}` | {ship} | {days} | {blockers} | {rec} |")
+        lines.append("")
+
+    # Recommendations
+    if recs:
+        lines.append("## Top Recommendations")
+        lines.append("")
+        for rec in recs:
+            sev = rec.get("severity", "?")
+            priority = rec.get("priority", "?")
+            url = rec.get("buildUrl", "")
+            link = f" → [{url.split('/')[-1] if '/' in url else 'link'}]({url})" if url else ""
+            lines.append(f"{priority}. {sev_emoji(sev)} **{rec.get('action', '?')}**")
+            lines.append(f"   - {rec.get('reason', '?')}")
+            lines.append(f"   - Target: `{rec.get('target', '?')}`{link}")
+            lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append("")
+    lines.append(f"*Report generated {meta.get('timestamp', '?')} • Schema v{meta.get('schemaVersion', '?')}*")
+    lines.append("")
+
+    return lines
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ci-status/scripts/render-ci-status.py
+++ b/.agents/skills/ci-status/scripts/render-ci-status.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Render a CI status report JSON as a self-contained HTML file.
+
+Usage:
+    python3 render-ci-status.py <path-to-json> [output.html]
+
+If output path is omitted, writes to the same directory as the JSON
+with a .html extension.
+
+Exit codes: 0=success, 1=error.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 render-ci-status.py <path-to-json> [output.html]")
+        sys.exit(1)
+
+    json_path = Path(sys.argv[1])
+    if not json_path.exists():
+        print(f"❌ JSON file not found: {json_path}")
+        sys.exit(1)
+
+    # Determine output path
+    if len(sys.argv) >= 3:
+        output_path = Path(sys.argv[2])
+    else:
+        output_path = json_path.with_suffix(".html")
+
+    # Load JSON data
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"❌ Invalid JSON: {e}")
+        sys.exit(1)
+
+    # Validate required fields
+    for key in ("meta", "verdict", "azdoHealth", "githubActions", "recommendations"):
+        if key not in data:
+            print(f"❌ Missing required key: {key}")
+            sys.exit(1)
+
+    # Load HTML template
+    template_path = Path(__file__).parent / "viewer.html"
+    if not template_path.exists():
+        print(f"❌ Template not found: {template_path}")
+        sys.exit(1)
+
+    with open(template_path, encoding="utf-8") as f:
+        template = f.read()
+
+    # Serialize JSON for injection
+    json_str = json.dumps(data, ensure_ascii=False)
+    json_str = json_str.replace("</script>", "<\\/script>")
+    json_str = json_str.replace("</Script>", "<\\/Script>")
+    json_str = json_str.replace("</SCRIPT>", "<\\/SCRIPT>")
+
+    data_script = f"<script>const DATA = {json_str};</script>"
+
+    marker = "<!--INJECT_DATA_HERE-->"
+    if marker not in template:
+        print(f"❌ Injection marker '{marker}' not found in template")
+        sys.exit(1)
+
+    html = template.replace(marker, data_script)
+
+    # Update title
+    meta = data.get("meta", {})
+    date = meta.get("date", "?")
+    verdict = data.get("verdict", {})
+    status = verdict.get("status", "unknown")
+    html = html.replace(
+        "<title>CI Status Report</title>",
+        f"<title>CI Status — {status} ({date})</title>"
+    )
+
+    # Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    size_kb = os.path.getsize(output_path) / 1024
+    emoji = verdict.get("emoji", "?")
+    summary_text = verdict.get("summary", "")[:80]
+    print(f"✅ {output_path.name} ({size_kb:.0f} KB)")
+    print(f"   {emoji} {status} • {date}")
+    print(f"   {summary_text}")
+    print(f"   Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ci-status/scripts/validate-ci-status.py
+++ b/.agents/skills/ci-status/scripts/validate-ci-status.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Validate a CI status report JSON against the schema.
+
+Usage: python3 validate-ci-status.py <report.json>
+Exits: 0=valid, 1=fixable errors (retry), 2=fatal.
+"""
+import json
+import sys
+from pathlib import Path
+
+if len(sys.argv) != 2:
+    print("Usage: python3 validate-ci-status.py <report.json>")
+    sys.exit(2)
+
+path = Path(sys.argv[1])
+if not path.exists():
+    print(f"❌ File not found: {path}")
+    sys.exit(2)
+
+try:
+    with open(path) as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    print(f"❌ Invalid JSON: {e}")
+    sys.exit(2)
+
+errors = []
+warnings = []
+
+# --- Required top-level keys ---
+REQUIRED_KEYS = ["meta", "verdict", "azdoHealth", "chainAnalysis", "rootCauses",
+                 "githubActions", "flakes", "releaseRisk", "recommendations"]
+
+for key in REQUIRED_KEYS:
+    if key not in data:
+        errors.append(f"Missing required top-level key: '{key}'")
+
+if errors:
+    # Fatal — can't validate further without structure
+    print(f"❌ {len(errors)} error(s):")
+    for e in errors:
+        print(f"   ❌ {e}")
+    sys.exit(1)
+
+# --- meta validation ---
+meta = data["meta"]
+if not meta.get("date"):
+    errors.append("meta.date is required")
+if not meta.get("timestamp"):
+    errors.append("meta.timestamp is required")
+if meta.get("schemaVersion") != "1.0":
+    errors.append(f"meta.schemaVersion must be '1.0' (got {meta.get('schemaVersion')!r})")
+if not meta.get("window"):
+    errors.append("meta.window is required")
+elif not isinstance(meta["window"].get("buildsPerPipeline"), int):
+    errors.append("meta.window.buildsPerPipeline must be an integer")
+if not meta.get("branches") or not isinstance(meta["branches"], list):
+    errors.append("meta.branches must be a non-empty array of branch names")
+
+# --- verdict validation ---
+verdict = data["verdict"]
+valid_statuses = ("healthy", "degraded", "broken")
+if verdict.get("status") not in valid_statuses:
+    errors.append(f"verdict.status must be one of {valid_statuses} (got {verdict.get('status')!r})")
+if not verdict.get("summary"):
+    errors.append("verdict.summary is required (1-2 sentence health summary)")
+if verdict.get("emoji") not in ("🟢", "🟡", "🔴"):
+    warnings.append(f"verdict.emoji should be 🟢/🟡/🔴 (got {verdict.get('emoji')!r})")
+
+# --- azdoHealth validation ---
+azdo = data["azdoHealth"]
+if "branches" not in azdo or not isinstance(azdo["branches"], list):
+    errors.append("azdoHealth.branches must be an array")
+else:
+    for i, branch in enumerate(azdo["branches"]):
+        if not branch.get("name"):
+            errors.append(f"azdoHealth.branches[{i}].name is required")
+        if branch.get("risk") not in ("low", "medium", "high"):
+            errors.append(f"azdoHealth.branches[{i}].risk must be low/medium/high (got {branch.get('risk')!r})")
+        if "pipelines" not in branch or not isinstance(branch["pipelines"], list):
+            errors.append(f"azdoHealth.branches[{i}].pipelines must be an array")
+
+if "regressions" not in azdo:
+    warnings.append("azdoHealth.regressions missing — should be an array (empty if none)")
+
+# --- chainAnalysis validation ---
+chain = data["chainAnalysis"]
+if not isinstance(chain, list):
+    errors.append("chainAnalysis must be an array")
+else:
+    for i, entry in enumerate(chain):
+        if not entry.get("branch"):
+            errors.append(f"chainAnalysis[{i}].branch is required")
+        if entry.get("verdict") not in ("cascade", "independent", "mixed"):
+            errors.append(f"chainAnalysis[{i}].verdict must be cascade/independent/mixed")
+        if not entry.get("summary"):
+            errors.append(f"chainAnalysis[{i}].summary is required")
+
+# --- rootCauses validation ---
+root_causes = data["rootCauses"]
+if not isinstance(root_causes, list):
+    errors.append("rootCauses must be an array")
+else:
+    valid_categories = ("code_regression", "flake", "infra_network", "quota_resource", "chain_blockage", "unknown")
+    valid_severities = ("critical", "high", "medium", "low")
+    ids_seen = set()
+    for i, rc in enumerate(root_causes):
+        if not rc.get("id"):
+            errors.append(f"rootCauses[{i}].id is required")
+        elif rc["id"] in ids_seen:
+            errors.append(f"rootCauses[{i}].id '{rc['id']}' is duplicate")
+        else:
+            ids_seen.add(rc["id"])
+        if not rc.get("title"):
+            errors.append(f"rootCauses[{i}].title is required")
+        if rc.get("category") not in valid_categories:
+            errors.append(f"rootCauses[{i}].category must be one of {valid_categories}")
+        if rc.get("severity") not in valid_severities:
+            errors.append(f"rootCauses[{i}].severity must be one of {valid_severities}")
+        if not rc.get("sampleError"):
+            warnings.append(f"rootCauses[{i}].sampleError should include verbatim error text")
+
+# --- githubActions validation ---
+gha = data["githubActions"]
+if "workflows" not in gha or not isinstance(gha["workflows"], list):
+    errors.append("githubActions.workflows must be an array")
+else:
+    valid_gha_statuses = ("healthy", "failing", "degraded", "stale", "skipped")
+    valid_severities_gha = ("high", "medium", "low")
+    for i, wf in enumerate(gha["workflows"]):
+        if not wf.get("name"):
+            errors.append(f"githubActions.workflows[{i}].name is required")
+        if wf.get("status") not in valid_gha_statuses:
+            errors.append(f"githubActions.workflows[{i}].status must be one of {valid_gha_statuses}")
+        if wf.get("severity") not in valid_severities_gha:
+            errors.append(f"githubActions.workflows[{i}].severity must be one of {valid_severities_gha}")
+
+if "summary" not in gha:
+    errors.append("githubActions.summary is required")
+else:
+    summary = gha["summary"]
+    for field in ("total", "healthy", "failing"):
+        if not isinstance(summary.get(field), int):
+            errors.append(f"githubActions.summary.{field} must be an integer")
+
+# --- flakes validation ---
+flakes = data["flakes"]
+if not isinstance(flakes, list):
+    errors.append("flakes must be an array")
+
+# --- releaseRisk validation ---
+release_risk = data["releaseRisk"]
+if not isinstance(release_risk, list):
+    errors.append("releaseRisk must be an array")
+else:
+    valid_recs = ("ship", "wait", "cherry-pick", "investigate")
+    for i, rr in enumerate(release_risk):
+        if not rr.get("branch"):
+            errors.append(f"releaseRisk[{i}].branch is required")
+        if not isinstance(rr.get("shippable"), bool):
+            errors.append(f"releaseRisk[{i}].shippable must be a boolean")
+        if rr.get("recommendation") not in valid_recs:
+            errors.append(f"releaseRisk[{i}].recommendation must be one of {valid_recs}")
+
+# --- recommendations validation ---
+recs = data["recommendations"]
+if not isinstance(recs, list):
+    errors.append("recommendations must be an array")
+elif len(recs) > 5:
+    warnings.append(f"recommendations has {len(recs)} items — should be at most 5")
+else:
+    for i, rec in enumerate(recs):
+        if not isinstance(rec.get("priority"), int):
+            errors.append(f"recommendations[{i}].priority must be an integer")
+        if not rec.get("action"):
+            errors.append(f"recommendations[{i}].action is required")
+        if not rec.get("reason"):
+            errors.append(f"recommendations[{i}].reason is required")
+    # Check sorted by priority
+    priorities = [r.get("priority", 999) for r in recs]
+    if priorities != sorted(priorities):
+        warnings.append("recommendations not sorted by priority")
+
+# --- Cross-reference checks ---
+# releaseRisk.blockers should reference existing rootCauses.id
+root_cause_ids = {rc.get("id") for rc in root_causes}
+for rr in release_risk:
+    for blocker in rr.get("blockers", []):
+        if blocker not in root_cause_ids:
+            errors.append(f"releaseRisk '{rr.get('branch')}' references rootCause '{blocker}' which doesn't exist")
+
+# recommendations.rootCauseId should reference existing rootCauses.id
+for rec in recs:
+    rcid = rec.get("rootCauseId")
+    if rcid and rcid not in root_cause_ids:
+        errors.append(f"recommendation '{rec.get('action', '?')[:40]}' references rootCause '{rcid}' which doesn't exist")
+
+# --- Output ---
+if warnings:
+    print(f"⚠️  {len(warnings)} warning(s):")
+    for w in warnings:
+        print(f"   ⚠️  {w}")
+
+if errors:
+    print(f"\n❌ {len(errors)} error(s):")
+    for e in errors:
+        print(f"   ❌ {e}")
+    sys.exit(1)
+else:
+    branch_count = len(azdo.get("branches", []))
+    wf_count = len(gha.get("workflows", []))
+    rc_count = len(root_causes)
+    print(f"✅ Valid CI status report")
+    print(f"   {meta.get('date', '?')} • {verdict.get('emoji', '?')} {verdict.get('status', '?')}")
+    print(f"   {branch_count} branches • {wf_count} workflows • {rc_count} root causes • {len(recs)} recommendations")
+    if warnings:
+        print(f"   ({len(warnings)} warnings — review above)")
+    sys.exit(0)

--- a/.agents/skills/ci-status/scripts/viewer.html
+++ b/.agents/skills/ci-status/scripts/viewer.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CI Status Report</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <style>
+    :root { --bg: #f6f8fa; --border: #d0d7de; --muted: #57606a; --surface: #fff; }
+    body { background: var(--bg); color: #1f2328; }
+    .page-shell { max-width: 1200px; }
+    .sticky-header { position: sticky; top: 0; z-index: 1030; backdrop-filter: blur(10px);
+      background: rgba(255,255,255,0.94); border-bottom: 1px solid var(--border); }
+    .card { border: 1px solid var(--border); box-shadow: 0 1px 2px rgba(16,24,40,0.04); }
+    .verdict-healthy { background: #dcfce7; border-color: #86efac; }
+    .verdict-degraded { background: #fef3c7; border-color: #fcd34d; }
+    .verdict-broken { background: #fee2e2; border-color: #fca5a5; }
+    .risk-low { color: #166534; }
+    .risk-medium { color: #92400e; }
+    .risk-high { color: #991b1b; font-weight: 700; }
+    .sev-critical { color: #7f1d1d; font-weight: 700; }
+    .sev-high { color: #991b1b; font-weight: 600; }
+    .sev-medium { color: #92400e; }
+    .sev-low { color: #6b7280; }
+    .status-pill { font-size: 0.75rem; font-weight: 600; padding: 2px 8px; border-radius: 12px; display: inline-block; }
+    .pill-healthy { background: #dcfce7; color: #166534; }
+    .pill-failing { background: #fee2e2; color: #991b1b; }
+    .pill-degraded { background: #fef3c7; color: #92400e; }
+    .pill-stale { background: #f3f4f6; color: #6b7280; }
+    .pill-skipped { background: #f3f4f6; color: #6b7280; }
+    .category-badge { font-size: 0.7rem; padding: 1px 6px; border-radius: 4px; }
+    .cat-code_regression { background: #fee2e2; color: #991b1b; }
+    .cat-flake { background: #fef3c7; color: #92400e; }
+    .cat-infra_network { background: #dbeafe; color: #1e40af; }
+    .cat-quota_resource { background: #ede9fe; color: #5b21b6; }
+    .cat-chain_blockage { background: #f3f4f6; color: #6b7280; }
+    .cat-unknown { background: #f3f4f6; color: #6b7280; }
+    .chain-cascade { border-left: 3px solid #f59e0b; padding-left: 10px; }
+    .chain-independent { border-left: 3px solid #3b82f6; padding-left: 10px; }
+    .rec-card { border-left: 4px solid; padding: 8px 12px; margin-bottom: 8px; background: var(--surface); }
+    .rec-critical { border-color: #dc2626; }
+    .rec-high { border-color: #f59e0b; }
+    .rec-medium { border-color: #6b7280; }
+    .rec-low { border-color: #d1d5db; }
+    .meta-table td, .meta-table th { font-size: 0.85rem; padding: 4px 8px; }
+    code { font-size: 0.8rem; }
+    .section-header { cursor: pointer; }
+    .section-header:hover { color: #0969da; }
+  </style>
+</head>
+<body>
+<!--INJECT_DATA_HERE-->
+<div class="page-shell mx-auto px-3 py-4">
+
+  <!-- Sticky header -->
+  <div class="sticky-header py-2 px-3 mb-3 rounded-bottom">
+    <div class="d-flex align-items-center justify-content-between">
+      <h5 class="mb-0"><i class="bi bi-activity"></i> SkiaSharp CI Status</h5>
+      <small class="text-muted" id="header-date"></small>
+    </div>
+  </div>
+
+  <!-- Verdict card -->
+  <div class="card mb-3" id="verdict-card">
+    <div class="card-body">
+      <h4 id="verdict-title"></h4>
+      <p class="mb-0" id="verdict-summary"></p>
+    </div>
+  </div>
+
+  <!-- AzDO Health Matrix -->
+  <div class="card mb-3">
+    <div class="card-header section-header" onclick="toggle('azdo-body')">
+      <h6 class="mb-0"><i class="bi bi-grid-3x3"></i> Azure DevOps Health Matrix</h6>
+    </div>
+    <div class="card-body" id="azdo-body">
+      <div class="table-responsive">
+        <table class="table table-sm table-bordered" id="azdo-table"></table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Chain Analysis -->
+  <div class="card mb-3" id="chain-card" style="display:none">
+    <div class="card-header section-header" onclick="toggle('chain-body')">
+      <h6 class="mb-0"><i class="bi bi-link-45deg"></i> Pipeline Chain Analysis</h6>
+    </div>
+    <div class="card-body" id="chain-body"></div>
+  </div>
+
+  <!-- Root Causes -->
+  <div class="card mb-3" id="rootcauses-card" style="display:none">
+    <div class="card-header section-header" onclick="toggle('rootcauses-body')">
+      <h6 class="mb-0"><i class="bi bi-bug"></i> Root Causes</h6>
+    </div>
+    <div class="card-body" id="rootcauses-body"></div>
+  </div>
+
+  <!-- GitHub Actions -->
+  <div class="card mb-3">
+    <div class="card-header section-header" onclick="toggle('gha-body')">
+      <h6 class="mb-0"><i class="bi bi-github"></i> GitHub Actions</h6>
+    </div>
+    <div class="card-body" id="gha-body">
+      <div id="gha-summary" class="mb-2"></div>
+      <div class="table-responsive">
+        <table class="table table-sm" id="gha-table"></table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Flakes -->
+  <div class="card mb-3" id="flakes-card" style="display:none">
+    <div class="card-header section-header" onclick="toggle('flakes-body')">
+      <h6 class="mb-0"><i class="bi bi-shuffle"></i> Flake Detection</h6>
+    </div>
+    <div class="card-body" id="flakes-body"></div>
+  </div>
+
+  <!-- Release Risk -->
+  <div class="card mb-3" id="release-card" style="display:none">
+    <div class="card-header section-header" onclick="toggle('release-body')">
+      <h6 class="mb-0"><i class="bi bi-shield-exclamation"></i> Release Risk Assessment</h6>
+    </div>
+    <div class="card-body" id="release-body"></div>
+  </div>
+
+  <!-- Recommendations -->
+  <div class="card mb-3">
+    <div class="card-header">
+      <h6 class="mb-0"><i class="bi bi-lightbulb"></i> Top Recommendations</h6>
+    </div>
+    <div class="card-body" id="recs-body"></div>
+  </div>
+
+  <!-- Meta -->
+  <div class="card mb-3">
+    <div class="card-header section-header" onclick="toggle('meta-body')">
+      <h6 class="mb-0"><i class="bi bi-info-circle"></i> Report Metadata</h6>
+    </div>
+    <div class="card-body" id="meta-body">
+      <table class="table table-sm meta-table" id="meta-table"></table>
+    </div>
+  </div>
+
+</div>
+
+<script>
+function toggle(id) {
+  const el = document.getElementById(id);
+  el.style.display = el.style.display === 'none' ? '' : 'none';
+}
+
+function esc(s) { return (s||'').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+function render() {
+  if (typeof DATA === 'undefined') return;
+  const {meta, verdict, azdoHealth, chainAnalysis, rootCauses, githubActions, flakes, releaseRisk, recommendations} = DATA;
+
+  // Header
+  document.getElementById('header-date').textContent = meta.date || '';
+
+  // Verdict
+  const vc = document.getElementById('verdict-card');
+  vc.classList.add(`verdict-${verdict.status}`);
+  document.getElementById('verdict-title').innerHTML = `${verdict.emoji || ''} ${(verdict.status||'').toUpperCase()}`;
+  document.getElementById('verdict-summary').textContent = verdict.summary || '';
+
+  // AzDO Health Matrix
+  const azTable = document.getElementById('azdo-table');
+  if (azdoHealth.branches && azdoHealth.branches.length > 0) {
+    const pipeNames = [];
+    azdoHealth.branches.forEach(b => b.pipelines.forEach(p => {
+      if (!pipeNames.includes(p.name)) pipeNames.push(p.name);
+    }));
+    let html = '<thead><tr><th>Branch</th>' + pipeNames.map(n => `<th>${esc(n)}</th>`).join('') + '<th>Risk</th></tr></thead><tbody>';
+    azdoHealth.branches.forEach(b => {
+      const pipeMap = {};
+      b.pipelines.forEach(p => pipeMap[p.name] = p);
+      html += '<tr>';
+      html += `<td><code>${esc(b.name)}</code></td>`;
+      pipeNames.forEach(pn => {
+        const p = pipeMap[pn];
+        if (p) {
+          const rate = p.passRate != null && p.passRate < 100 ? ` (${Math.round(p.passRate)}%)` : '';
+          html += `<td>${p.latestIcon || '❓'} ${esc(p.latestResult||'')}${rate}</td>`;
+        } else {
+          html += '<td>—</td>';
+        }
+      });
+      html += `<td class="risk-${b.risk}">${b.risk}</td>`;
+      html += '</tr>';
+    });
+    html += '</tbody>';
+    azTable.innerHTML = html;
+  }
+
+  // Chain Analysis
+  if (chainAnalysis && chainAnalysis.length > 0) {
+    document.getElementById('chain-card').style.display = '';
+    const body = document.getElementById('chain-body');
+    body.innerHTML = chainAnalysis.map(c => {
+      const cls = c.verdict === 'cascade' ? 'chain-cascade' : 'chain-independent';
+      return `<div class="${cls} mb-2"><strong><code>${esc(c.branch)}</code></strong> [${esc(c.verdict)}]<br><small>${esc(c.summary)}</small></div>`;
+    }).join('');
+  }
+
+  // Root Causes
+  if (rootCauses && rootCauses.length > 0) {
+    document.getElementById('rootcauses-card').style.display = '';
+    const body = document.getElementById('rootcauses-body');
+    body.innerHTML = rootCauses.map(rc => {
+      const catCls = `cat-${rc.category}`;
+      return `<div class="mb-3 border-bottom pb-2">
+        <strong>[${esc(rc.id)}]</strong> <span class="sev-${rc.severity}">${esc(rc.severity).toUpperCase()}</span>
+        <span class="category-badge ${catCls}">${esc(rc.category)}</span><br>
+        <strong>${esc(rc.title)}</strong><br>
+        <small class="text-muted">Branches: ${(rc.footprint?.branches||[]).map(b=>`<code>${esc(b)}</code>`).join(', ')}
+        | Pipelines: ${(rc.footprint?.pipelines||[]).join(', ')}</small><br>
+        ${rc.sampleError ? `<pre class="bg-light p-2 mt-1 mb-0" style="font-size:0.75rem;max-height:100px;overflow:auto">${esc(rc.sampleError.substring(0,500))}</pre>` : ''}
+      </div>`;
+    }).join('');
+  }
+
+  // GitHub Actions
+  const ghaSummary = githubActions.summary || {};
+  document.getElementById('gha-summary').innerHTML =
+    `<strong>${ghaSummary.total||0}</strong> workflows: ` +
+    `✅ ${ghaSummary.healthy||0} healthy | ❌ ${ghaSummary.failing||0} failing | ⏳ ${ghaSummary.stale||0} stale`;
+
+  const ghaTable = document.getElementById('gha-table');
+  const wfs = githubActions.workflows || [];
+  if (wfs.length > 0) {
+    let html = '<thead><tr><th>Workflow</th><th>Repo</th><th>Trigger</th><th>Severity</th><th>Status</th></tr></thead><tbody>';
+    wfs.forEach(wf => {
+      const pillCls = `pill-${wf.status}`;
+      html += `<tr>
+        <td>${esc(wf.name)}</td>
+        <td><code>${esc(wf.repo)}</code></td>
+        <td><small>${esc(wf.trigger)}</small></td>
+        <td class="sev-${wf.severity}">${esc(wf.severity)}</td>
+        <td><span class="status-pill ${pillCls}">${esc(wf.status)}</span></td>
+      </tr>`;
+    });
+    html += '</tbody>';
+    ghaTable.innerHTML = html;
+  }
+
+  // Flakes
+  if (flakes && flakes.length > 0) {
+    document.getElementById('flakes-card').style.display = '';
+    const body = document.getElementById('flakes-body');
+    let html = '<table class="table table-sm"><thead><tr><th>Branch</th><th>Pipeline</th><th>Pattern</th><th>Confidence</th><th>Description</th></tr></thead><tbody>';
+    flakes.forEach(f => {
+      html += `<tr><td><code>${esc(f.branch)}</code></td><td>${esc(f.pipeline)}</td><td>${esc(f.pattern)}</td><td>${esc(f.confidence)}</td><td>${esc(f.description)}</td></tr>`;
+    });
+    html += '</tbody></table>';
+    body.innerHTML = html;
+  }
+
+  // Release Risk
+  if (releaseRisk && releaseRisk.length > 0) {
+    document.getElementById('release-card').style.display = '';
+    const body = document.getElementById('release-body');
+    let html = '<table class="table table-sm"><thead><tr><th>Branch</th><th>Shippable</th><th>Days Since Green</th><th>Blockers</th><th>Recommendation</th></tr></thead><tbody>';
+    releaseRisk.forEach(rr => {
+      const ship = rr.shippable ? '✅ Yes' : '❌ No';
+      html += `<tr><td><code>${esc(rr.branch)}</code></td><td>${ship}</td><td>${rr.daysSinceGreen ?? '—'}</td><td>${(rr.blockers||[]).join(', ')||'—'}</td><td>${esc(rr.recommendation)}</td></tr>`;
+    });
+    html += '</tbody></table>';
+    body.innerHTML = html;
+  }
+
+  // Recommendations
+  const recsBody = document.getElementById('recs-body');
+  if (recommendations && recommendations.length > 0) {
+    recsBody.innerHTML = recommendations.map(r => {
+      const url = r.buildUrl ? `<a href="${esc(r.buildUrl)}" target="_blank" class="text-decoration-none"><i class="bi bi-box-arrow-up-right"></i></a>` : '';
+      return `<div class="rec-card rec-${r.severity}">
+        <strong>#${r.priority}</strong> ${esc(r.action)} ${url}<br>
+        <small class="text-muted">${esc(r.reason)}</small><br>
+        <small>Target: <code>${esc(r.target)}</code></small>
+      </div>`;
+    }).join('');
+  } else {
+    recsBody.innerHTML = '<p class="text-muted">No recommendations — all systems healthy.</p>';
+  }
+
+  // Meta
+  const metaTable = document.getElementById('meta-table');
+  metaTable.innerHTML = `
+    <tr><th>Date</th><td>${esc(meta.date)}</td></tr>
+    <tr><th>Timestamp</th><td>${esc(meta.timestamp)}</td></tr>
+    <tr><th>Schema</th><td>v${esc(meta.schemaVersion)}</td></tr>
+    <tr><th>Window</th><td>${meta.window?.buildsPerPipeline} builds × ${meta.window?.branchesCount} branches</td></tr>
+    <tr><th>Branches</th><td>${(meta.branches||[]).map(b=>`<code>${esc(b)}</code>`).join(', ')}</td></tr>
+  `;
+}
+
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Restructures the `ci-status` skill to follow the same architecture as `security-audit`: a collector script produces raw JSON, the AI assembles an augmented report with analysis, then validate/render scripts produce HTML + Markdown outputs.

Also adds GitHub Actions workflow tracking for both `mono/SkiaSharp` and `mono/SkiaSharp-API-docs` repositories.

## Changes

### New pipeline architecture
```
Collector → AI Analysis → Assemble JSON → Validate → Render HTML+MD → Present
```

### New files
- `scripts/validate-ci-status.py` — Schema validation (exit 0/1/2)
- `scripts/render-ci-status.py` — JSON → HTML via viewer.html template injection
- `scripts/render-ci-status-md.py` — JSON → comprehensive Markdown report
- `scripts/viewer.html` — Bootstrap 5 self-contained dashboard template
- `references/report-schema.md` — Augmented JSON schema documentation

### Modified files
- `scripts/ci-status.py` — Stripped markdown renderer, now outputs console + raw JSON only. Added GitHub Actions collection with scope-aware fetching (branch vs global).
- `SKILL.md` — Complete rewrite with 7-step flow, file boundary table, AI assembly instructions

### GitHub Actions tracking
- 18 workflows tracked across mono/SkiaSharp and mono/SkiaSharp-API-docs
- Scope-aware collection: branch-scoped (main + release/*) vs global (last run only)
- Failed job details fetched for the latest failed run per workflow
- Trigger type classification (push, cron, dispatch, event)

## Testing
- All scripts pass syntax check
- Validator + renderers tested with sample JSON
- Full end-to-end test: background agent given "please do a ci status report" successfully produced all 3 output files (263KB JSON, 195KB HTML, 11KB MD) with AI analysis embedded