### PR TITLE
Fix x86 .NET Framework threading test OOM failures (backport #3674)

### DIFF
--- a/tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs
+++ b/tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs
@@ -11,11 +11,27 @@ namespace SkiaSharp.Tests
 {
 	public class SKBitmapThreadingTest : SKTest
 	{
+		// This test intentionally hammers the GC and finalizer pipeline: each iteration
+		// creates SkiaSharp objects (SKBitmap/SKImage/SKData) and deliberately does NOT
+		// dispose them, so that they are reclaimed only by the garbage collector and the
+		// finalizer thread. The goal is to verify that SkiaSharp's objects can be finalized
+		// safely from many threads concurrently without crashing or corrupting native state.
+		// Do NOT add `using`/Dispose to ComputeThumbnail - deterministic disposal would
+		// short-circuit finalization and defeat the entire purpose of the test.
 		[SkippableTheory]
 		[InlineData(10, 10)]
+		[InlineData(10, 100)]
 		[InlineData(100, 1000)]
 		public static void ImageScalingMultipleThreadsTest(int numThreads, int numIterationsPerThread)
 		{
+			// The (100, 1000) variant queues up to 100K undisposed native allocations to stress
+			// GC finalizer throughput. On x86 (2GB address space) the finalizer cannot keep up
+			// and Skia's native allocator fails ("Unable to allocate pixels"). This is a genuine
+			// address-space limit, not a leak, so skip the heaviest combination on x86. The
+			// lighter (10, 100) variant still exercises concurrent GC/finalizer behavior. See #3608.
+			if (IntPtr.Size == 4 && numThreads >= 100 && numIterationsPerThread >= 1000)
+				throw new SkipException("Stress test skipped on x86 due to address space limit.");
+
 			var referenceFile = Path.Combine(PathToImages, "baboon.jpg");
 
 			var tasks = new List<Task>();
@@ -59,6 +75,8 @@ namespace SkiaSharp.Tests
 			if (!exceptions.IsEmpty)
 				throw new AggregateException(exceptions);
 
+			// Intentionally NOT disposed: these native objects are left for the GC and
+			// finalizer thread to reclaim, which is exactly what this test is exercising.
 			static byte[] ComputeThumbnail(string fileName)
 			{
 				var ms = new MemoryStream();

--- a/tests/Tests/SkiaSharp/SKObjectTest.cs
+++ b/tests/Tests/SkiaSharp/SKObjectTest.cs
@@ -240,11 +240,21 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		// Verifies that many threads can concurrently decode bitmaps through SkiaSharp
+		// without throwing or corrupting native state. The high-iteration variants stress
+		// concurrent allocation and the GC/finalizer pipeline under heavy parallel load.
 		[SkippableTheory]
 		[InlineData(1)]
+		[InlineData(100)]
 		[InlineData(1000)]
 		public async Task EnsureMultithreadingDoesNotThrow(int iterations)
 		{
+			// 1000 concurrent bitmap decodes exceed x86's 2GB address space. This is a genuine
+			// address-space limit, not a leak, so skip it on x86. The (100) variant still
+			// validates concurrent GC/finalizer behavior at lower load. See #3608.
+			if (IntPtr.Size == 4 && iterations >= 1000)
+				throw new SkipException("Stress test skipped on x86 due to address space limit.");
+
 			var imagePath = Path.Combine(PathToImages, "baboon.jpg");
 
 			var tasks = new Task[iterations];


### PR DESCRIPTION
## Problem

The internal Tests pipeline on `release/3.119.x` has been chronically red. The failing job is **Windows (.NET Framework)** (x86), where `SKBitmapThreadingTest.ImageScalingMultipleThreadsTest(100, 1000)` and `SKObjectTest.EnsureMultithreadingDoesNotThrow(1000)` throw `Unable to allocate pixels for the bitmap`, with adjacent tests dying as collateral in the same process.

## Root cause (corrected)

These tests **intentionally** create native SkiaSharp objects **without disposing them**, so they are reclaimed only by the GC and finalizer thread. That is the whole point of the tests — they verify SkiaSharp objects can be finalized safely from many threads concurrently. **Disposing would defeat the purpose**, so an earlier "add `using`" approach was wrong and has been reverted.

The real issue is a genuine environment limit: on **x86** (.NET Framework, 2 GB address space) the heaviest variants queue too many undisposed native allocations for the finalizer to keep pace, so Skia's allocator fails. The 64-bit .NET Core jobs have enough address space and pass.

## Fix

This is a backport of #3674 (already on `main`):

- Skip the known-OOM combinations on x86 only (`IntPtr.Size == 4`) — a sanctioned hardware/environment skip, not masking a product bug.
- Add lighter intermediate variants (`10×100` and `100`) so concurrent GC/finalizer behavior is still exercised on x86 at lower load.
- Add comments documenting the test purpose and that **disposal is intentionally omitted** (per request, so future readers don't "fix" it by adding `using`).

Files: `tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs`, `tests/Tests/SkiaSharp/SKObjectTest.cs`.

## Validation

- Compared with `main`'s fix (#3674) and matched its approach exactly.
- Built correct 119.x natives locally and ran both tests (all variants) — **Passed: 6, Failed: 0, Skipped: 0** on 64-bit (the x86 skip can't trigger locally on arm64).
- **CI is now green.** A full pipeline run that built natives fresh in-run (build `3.119.5-preview.0.3+merge`) completed with **all stages succeeded**, including every Tests-stage job. Most importantly, the previously chronically-red **Windows (.NET Framework)** (net48/x86) job now **passes** — confirming the fix on the only environment that can reproduce the address-space exhaustion.

> Note: standard release **PR** pre-merge builds cannot go green on this branch due to a pre-existing CI bootstrap issue unrelated to this change (they download pre-built natives from the last *succeeded* release branch build, of which there are none). Builds that compile natives in-run (branch builds and the manual merge build above) validate the fix correctly. Merging this PR restores a green native-artifact source for the branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>