### PR TITLE
Document threading test purpose and intentional non-disposal

### DIFF
--- a/tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs
+++ b/tests/SkiaSharp.Tests.Console/SkiaSharp/SKBitmapThreadingTest.cs
@@ -11,15 +11,24 @@ namespace SkiaSharp.Tests
 {
 	public class SKBitmapThreadingTest : SKTest
 	{
+		// This test intentionally hammers the GC and finalizer pipeline: each iteration
+		// creates SkiaSharp objects (SKBitmap/SKImage/SKData) and deliberately does NOT
+		// dispose them, so that they are reclaimed only by the garbage collector and the
+		// finalizer thread. The goal is to verify that SkiaSharp's objects can be finalized
+		// safely from many threads concurrently without crashing or corrupting native state.
+		// Do NOT add `using`/Dispose to ComputeThumbnail - deterministic disposal would
+		// short-circuit finalization and defeat the entire purpose of the test.
 		[SkippableTheory]
 		[InlineData(10, 10)]
 		[InlineData(10, 100)]
 		[InlineData(100, 1000)]
 		public static void ImageScalingMultipleThreadsTest(int numThreads, int numIterationsPerThread)
 		{
-			// The (100, 1000) variant creates 100K undisposed native allocations to stress
-			// GC finalizer throughput. On x86 (2GB address space), the GC can't keep up and
-			// Skia's native allocator fails. See #3608.
+			// The (100, 1000) variant queues up to 100K undisposed native allocations to stress
+			// GC finalizer throughput. On x86 (2GB address space) the finalizer cannot keep up
+			// and Skia's native allocator fails ("Unable to allocate pixels"). This is a genuine
+			// address-space limit, not a leak, so skip the heaviest combination on x86. The
+			// lighter (10, 100) variant still exercises concurrent GC/finalizer behavior. See #3608.
 			if (IntPtr.Size == 4 && numThreads >= 100 && numIterationsPerThread >= 1000)
 				throw new SkipException("Stress test skipped on x86 due to address space limit.");
 
@@ -66,6 +75,8 @@ namespace SkiaSharp.Tests
 			if (!exceptions.IsEmpty)
 				throw new AggregateException(exceptions);
 
+			// Intentionally NOT disposed: these native objects are left for the GC and
+			// finalizer thread to reclaim, which is exactly what this test is exercising.
 			static byte[] ComputeThumbnail(string fileName)
 			{
 				var ms = new MemoryStream();

--- a/tests/Tests/SkiaSharp/SKObjectTest.cs
+++ b/tests/Tests/SkiaSharp/SKObjectTest.cs
@@ -240,15 +240,18 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		// Verifies that many threads can concurrently decode bitmaps through SkiaSharp
+		// without throwing or corrupting native state. The high-iteration variants stress
+		// concurrent allocation and the GC/finalizer pipeline under heavy parallel load.
 		[SkippableTheory]
 		[InlineData(1)]
 		[InlineData(100)]
 		[InlineData(1000)]
 		public async Task EnsureMultithreadingDoesNotThrow(int iterations)
 		{
-			// 1000 concurrent bitmap decodes exceed x86's 2GB address space.
-			// The (100) variant still validates concurrent GC/finalizer behavior.
-			// See #3608.
+			// 1000 concurrent bitmap decodes exceed x86's 2GB address space. This is a genuine
+			// address-space limit, not a leak, so skip it on x86. The (100) variant still
+			// validates concurrent GC/finalizer behavior at lower load. See #3608.
 			if (IntPtr.Size == 4 && iterations >= 1000)
 				throw new SkipException("Stress test skipped on x86 due to address space limit.");
 


### PR DESCRIPTION
## Summary

The x86 .NET Framework OOM fix for the GC/finalizer threading stress tests already landed on `main` in #3674. However, the tests don't explain *why* they are written the way they are, which has led to well-intentioned-but-wrong attempts to "fix" them by adding disposal.

This is a **comment-only** change (no behavioral change) that documents the intent:

- **`SKBitmapThreadingTest.ImageScalingMultipleThreadsTest`** intentionally creates native SkiaSharp objects (SKBitmap/SKImage/SKData) and **does NOT dispose them**, so they are reclaimed only by the GC and finalizer thread. That is the whole point — it verifies SkiaSharp objects can be finalized safely from many threads concurrently. A `Do NOT add using/Dispose` warning is added so future readers don't short-circuit finalization and defeat the test.
- **`SKObjectTest.EnsureMultithreadingDoesNotThrow`** gets a purpose comment describing the concurrent-decode stress and the existing x86 address-space skip.

## Context

The companion fix for `release/3.119.x` (which did not yet have #3674) is #4105. This PR ensures **both** `main` and the release branch carry the same explanatory comments.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>