### PR TITLE
Fix #3817: avoid re-entrant singleton cctor NullReferenceException

### DIFF
--- a/binding/SkiaSharp/SKTypeface.cs
+++ b/binding/SkiaSharp/SKTypeface.cs
@@ -22,15 +22,36 @@ namespace SkiaSharp
 
 			empty = new SKTypefaceStatic (SkiaApi.sk_typeface_create_empty ());
 
-			// Use legacyMakeTypeface(null) to get the platform default — this uses
-			// fDefaultStyleSet on Android (which searches "sans-serif", "Roboto",
-			// then falls back to style set 0). matchFamilyStyle(null) doesn't work
-			// on Android/NDK/Custom because onMatchFamily(null) returns null.
-			var matched = SkiaApi.sk_fontmgr_legacy_create_typeface (
-				SKFontManager.Default.Handle, IntPtr.Zero, SKFontStyle.Normal.Handle);
-			defaultTypeface = matched == IntPtr.Zero
-				? empty
-				: new SKTypefaceStatic (matched);
+			// Obtain the default font manager and font style as raw native handles
+			// instead of reading the SKFontManager.Default / SKFontStyle.Normal managed
+			// singletons. Those singletons are SKObject types whose static constructors
+			// participate in the same eager-initialization cascade (see
+			// SKObject.EnsureStaticInstanceAreInitialized). Reading them here can re-enter
+			// a static constructor that is still running on the current thread and observe
+			// a not-yet-assigned (null) singleton, throwing a NullReferenceException.
+			// See issue #3817.
+			var fontManager = IntPtr.Zero;
+			var fontStyle = IntPtr.Zero;
+			try {
+				fontManager = SkiaApi.sk_fontmgr_create_default ();
+				fontStyle = SkiaApi.sk_fontstyle_new (
+					(int)SKFontStyleWeight.Normal, (int)SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+
+				// Use legacyMakeTypeface(null) to get the platform default — this uses
+				// fDefaultStyleSet on Android (which searches "sans-serif", "Roboto",
+				// then falls back to style set 0). matchFamilyStyle(null) doesn't work
+				// on Android/NDK/Custom because onMatchFamily(null) returns null.
+				var matched = SkiaApi.sk_fontmgr_legacy_create_typeface (
+					fontManager, IntPtr.Zero, fontStyle);
+				defaultTypeface = matched == IntPtr.Zero
+					? empty
+					: new SKTypefaceStatic (matched);
+			} finally {
+				if (fontStyle != IntPtr.Zero)
+					SkiaApi.sk_fontstyle_delete (fontStyle);
+				if (fontManager != IntPtr.Zero)
+					SkiaApi.sk_fontmgr_unref (fontManager);
+			}
 		}
 
 		internal static void EnsureStaticInstanceAreInitialized ()

--- a/scripts/infra/tests/tests-netcore.cake
+++ b/scripts/infra/tests/tests-netcore.cake
@@ -28,6 +28,7 @@ Task ("Default")
     var tfm = "net10.0";
     var testAssemblies = new List<string> {
         "SkiaSharp.Tests.Console",
+        "SkiaSharp.Tests.SingletonInit.Console",
         "SkiaSharp.Vulkan.Tests.Console",
         "SkiaSharp.Direct3D.Tests.Console",
     };

--- a/scripts/infra/tests/tests-netfx.cake
+++ b/scripts/infra/tests/tests-netfx.cake
@@ -27,6 +27,7 @@ Task ("Default")
         var tfm = "net48";
         var testAssemblies = new List<string> {
             "SkiaSharp.Tests.Console",
+            "SkiaSharp.Tests.SingletonInit.Console",
             "SkiaSharp.Vulkan.Tests.Console",
             "SkiaSharp.Direct3D.Tests.Console",
         };

--- a/tests/SkiaSharp.Tests.Console.sln
+++ b/tests/SkiaSharp.Tests.Console.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.HarfBuzz", "..\so
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Tests.Console", "SkiaSharp.Tests.Console\SkiaSharp.Tests.Console.csproj", "{8E5284C3-5AAF-4902-B12F-84E9172F20E0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Tests.SingletonInit.Console", "SkiaSharp.Tests.SingletonInit.Console\SkiaSharp.Tests.SingletonInit.Console.csproj", "{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Vulkan.Tests.Console", "SkiaSharp.Vulkan.Tests.Console\SkiaSharp.Vulkan.Tests.Console.csproj", "{9C3F6513-7B66-4DF3-ADBA-1030FEE9C111}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaSharp.Vulkan.SharpVk", "..\source\SkiaSharp.Vulkan\SkiaSharp.Vulkan.SharpVk\SkiaSharp.Vulkan.SharpVk.csproj", "{A53DD2E5-55C4-4F7C-9316-D7FAD9A6F19F}"
@@ -85,6 +87,18 @@ Global
 		{8E5284C3-5AAF-4902-B12F-84E9172F20E0}.Release|x64.Build.0 = Release|x64
 		{8E5284C3-5AAF-4902-B12F-84E9172F20E0}.Release|x86.ActiveCfg = Release|x86
 		{8E5284C3-5AAF-4902-B12F-84E9172F20E0}.Release|x86.Build.0 = Release|x86
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Debug|x64.ActiveCfg = Debug|x64
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Debug|x64.Build.0 = Debug|x64
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Debug|x86.ActiveCfg = Debug|x86
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Debug|x86.Build.0 = Debug|x86
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Release|x64.ActiveCfg = Release|x64
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Release|x64.Build.0 = Release|x64
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Release|x86.ActiveCfg = Release|x86
+		{B7E2F4A1-3C5D-4E6F-9A8B-1C2D3E4F5A6B}.Release|x86.Build.0 = Release|x86
 		{9C3F6513-7B66-4DF3-ADBA-1030FEE9C111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9C3F6513-7B66-4DF3-ADBA-1030FEE9C111}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C3F6513-7B66-4DF3-ADBA-1030FEE9C111}.Debug|x64.ActiveCfg = Debug|x64

--- a/tests/SkiaSharp.Tests.SingletonInit.Console/SKSingletonInitTest.cs
+++ b/tests/SkiaSharp.Tests.SingletonInit.Console/SKSingletonInitTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using SkiaSharp;
+using Xunit;
+
+namespace SkiaSharp.Tests.SingletonInit
+{
+	// Regression guard for https://github.com/mono/SkiaSharp/issues/3817.
+	//
+	// Touching SKFontManager.Default as the very first SkiaSharp type in a fresh
+	// process used to throw a TypeInitializationException: the SKObject static
+	// constructor eagerly initializes a cascade of singletons, and the SKTypeface
+	// initializer in that cascade read the managed SKFontManager.Default and
+	// SKFontStyle.Normal singletons. When SKFontManager was the first type touched,
+	// that re-entered the still-running SKFontManager/SKFontStyle initializer on the
+	// same thread and observed a not-yet-assigned (null) singleton, producing a
+	// NullReferenceException surfaced as a TypeInitializationException.
+	//
+	// This assembly intentionally contains a single test so that this is genuinely
+	// the first SkiaSharp access in the process.
+	public class SKSingletonInitTest
+	{
+		[Fact]
+		public void TouchingFontManagerDefaultFirstDoesNotThrow ()
+		{
+			var fontManager = SKFontManager.Default;
+
+			Assert.NotNull (fontManager);
+			Assert.NotEqual (IntPtr.Zero, fontManager.Handle);
+			Assert.NotEqual (IntPtr.Zero, SKFontStyle.Normal.Handle);
+			Assert.NotEqual (IntPtr.Zero, SKTypeface.Default.Handle);
+		}
+	}
+}

--- a/tests/SkiaSharp.Tests.SingletonInit.Console/SkiaSharp.Tests.SingletonInit.Console.csproj
+++ b/tests/SkiaSharp.Tests.SingletonInit.Console/SkiaSharp.Tests.SingletonInit.Console.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Issue #3817 regression guard. This is a dedicated test assembly that contains a
+    single test which touches SKFontManager.Default as the FIRST SkiaSharp type in
+    the process. Because static constructors run once per process and "dotnet test"
+    launches a separate test host per assembly, this naturally reproduces the
+    "first type touched" scenario that used to crash the SKObject static-constructor
+    eager-initialization cascade. Keeping it in its own assembly is what guarantees
+    the ordering — do not add other tests or types that touch SkiaSharp here.
+  -->
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TFMCurrent)</TargetFrameworks>
+    <TargetFrameworks Condition="$(IsWindows)">$(TargetFrameworks);net48</TargetFrameworks>
+    <RootNamespace>SkiaSharp.Tests.SingletonInit</RootNamespace>
+    <AssemblyName>SkiaSharp.Tests.SingletonInit</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <SkipGenerateAssemblyVersionInfo>true</SkipGenerateAssemblyVersionInfo>
+    <SkipMDocGenerateDocs>true</SkipMDocGenerateDocs>
+    <Platforms>AnyCPU;x64;x86</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="XunitXml.TestLogger" Version="3.0.78" />
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\binding\SkiaSharp\SkiaSharp.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\binding\IncludeNativeAssets.SkiaSharp.targets" />
+
+</Project>


### PR DESCRIPTION
Fixes #3817

## Root cause

`SKTypeface`'s static constructor built its default typeface by reading the **managed** singletons `SKFontManager.Default.Handle` and `SKFontStyle.Normal.Handle`. Those are `SKObject` types whose own static constructors participate in the same eager-initialization cascade driven by `SKObject.EnsureStaticInstanceAreInitialized()`.

When `SKFontManager` or `SKFontStyle` was the **first** SkiaSharp type touched in a process, reading them from `SKTypeface`'s cctor re-entered a static constructor that was still running on the current thread. The CLR allows a thread to re-enter a type initializer it is already running, so the read observed a not-yet-assigned (null) singleton field and threw `NullReferenceException` → surfaced as `TypeInitializationException` (e.g. on `SKFontManager.Default`). This is the chronic `main` CI crash (Windows/Linux .NET Core test jobs).

## Fix

Build the default typeface directly from raw native handles (`sk_fontmgr_create_default` / `sk_fontstyle_new` / `sk_fontmgr_legacy_create_typeface`) inside `SKTypeface`'s cctor, in a `try/finally` that releases them. This severs **both** reads of the vulnerable managed singletons, so the cctor no longer depends on any other singleton being fully constructed.

- Behavior-equivalent: `SKFontStyle.Normal` == `sk_fontstyle_new(Normal=400, Normal=5, Upright)`.
- Native ref-counting unchanged: `sk_fontmgr_create_default` returns +1; `legacy_create_typeface` does not retain the font manager; both temporaries are released in `finally`.
- ABI: additive/internal only — no public surface change.

## Regression test

Static constructors run **once per process**, so an in-process xUnit test in an existing assembly can't reproduce "type X touched first" — something always touches `SKObject` before the test body runs.

Added a small dedicated test assembly, `SkiaSharp.Tests.SingletonInit.Console`, modeled on `SkiaSharp.Vulkan.Tests.Console`. `dotnet test` launches a **separate test-host process per assembly**, so this assembly's single `[Fact]` is the first SkiaSharp code touched in its process. The test accesses `SKFontManager.Default` first and asserts it — plus `SKFontStyle.Normal.Handle` and `SKTypeface.Default.Handle` — are non-zero, reproducing the exact #3817 first-touch ordering with no child processes or copy targets.

The assembly is wired into the cake test runners (`tests-netcore.cake` for net10.0, `tests-netfx.cake` for net48) and `tests/SkiaSharp.Tests.Console.sln`, so it builds and runs on every CI leg including .NET Framework.

## Verification

- Reproduced the NRE deterministically on clean `main`: with the fix reverted, the new test **fails with exit code 1** and the exact chain `SKFontManager..cctor → SKObject..cctor → SKTypeface.EnsureStaticInstanceAreInitialized() → SKTypeface..cctor`. With the fix it **passes, exit code 0**.
- New assembly (net10.0): **Passed 1/1, process exit code 0**.
- The reverted console test project rebuilds clean; full console suite remains green.