### PR TITLE
Bugfix #2967 - Change counter into boolean

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/SKXamlCanvas.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WinUI/SKXamlCanvas.cs
@@ -43,7 +43,7 @@ namespace SkiaSharp.Views.UWP
 		private bool isVisible = true;
 
 		// workaround for https://github.com/mono/SkiaSharp/issues/1118
-		private int loadUnloadCounter = 0;
+		private bool isLoaded;
 
 		public SKXamlCanvas()
 		{
@@ -124,9 +124,10 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			loadUnloadCounter++;
-			if (loadUnloadCounter != 1)
+			if (isLoaded)
 				return;
+
+			isLoaded = true;
 
 #if WINDOWS
 			XamlRoot.Changed += OnXamlRootChanged;
@@ -141,9 +142,10 @@ namespace SkiaSharp.Views.UWP
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
-			loadUnloadCounter--;
-			if (loadUnloadCounter != 0)
+			if (!isLoaded)
 				return;
+
+			isLoaded = false;
 
 #if WINDOWS
 			if (XamlRoot != null)


### PR DESCRIPTION
**Description of Change**

Changed the integer counter for keeping track of Load and Unload events in SKXamlCanvas into a boolean.
This prevents issues when the Unload event comes before Load, and also when multiple Unload events are triggered (both of these situations arise due to WinUI issues).

(No added tests since I couldn't find any previous regarding the SKXamlCanvas)

**Bugs Fixed**

- Fixes #2967 


**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation
