### PR TITLE
Obsolete remaining legacy paint state-reading APIs (#3732)

### DIFF
--- a/binding/SkiaSharp/SKCanvas.cs
+++ b/binding/SkiaSharp/SKCanvas.cs
@@ -548,6 +548,7 @@ namespace SkiaSharp
 
 		// DrawImage
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawImage (SKImage image, SKPoint p, SKPaint paint = null)
 		{
 			DrawImage (image, p.X, p.Y, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
@@ -558,6 +559,7 @@ namespace SkiaSharp
 			DrawImage (image, p.X, p.Y, sampling, paint);
 		}
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawImage (SKImage image, float x, float y, SKPaint paint = null)
 		{
 			DrawImage (image, x, y, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
@@ -573,6 +575,7 @@ namespace SkiaSharp
 			GC.KeepAlive (this);
 		}
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawImage (SKImage image, SKRect dest, SKPaint paint = null)
 		{
 			DrawImage (image, null, &dest, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
@@ -583,6 +586,7 @@ namespace SkiaSharp
 			DrawImage (image, null, &dest, sampling, paint);
 		}
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawImage (SKImage image, SKRect source, SKRect dest, SKPaint paint = null)
 		{
 			DrawImage (image, &source, &dest, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
@@ -667,25 +671,50 @@ namespace SkiaSharp
 
 		// DrawBitmap
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawBitmap (SKBitmap bitmap, SKPoint p, SKPaint paint = null) =>
 			DrawBitmap (bitmap, p.X, p.Y, paint);
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawBitmap (SKBitmap bitmap, float x, float y, SKPaint paint = null)
 		{
 			using var image = SKImage.FromBitmap (bitmap);
-			DrawImage (image, x, y, paint);
+			DrawImage (image, x, y, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
 		}
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawBitmap (SKBitmap bitmap, SKRect dest, SKPaint paint = null)
 		{
 			using var image = SKImage.FromBitmap (bitmap);
-			DrawImage (image, dest, paint);
+			DrawImage (image, dest, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
 		}
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawBitmap (SKBitmap bitmap, SKRect source, SKRect dest, SKPaint paint = null)
 		{
 			using var image = SKImage.FromBitmap (bitmap);
-			DrawImage (image, source, dest, paint);
+			DrawImage (image, source, dest, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, paint);
+		}
+
+		public void DrawBitmap (SKBitmap bitmap, SKPoint p, SKSamplingOptions sampling, SKPaint paint = null) =>
+			DrawBitmap (bitmap, p.X, p.Y, sampling, paint);
+
+		public void DrawBitmap (SKBitmap bitmap, float x, float y, SKSamplingOptions sampling, SKPaint paint = null)
+		{
+			using var image = SKImage.FromBitmap (bitmap);
+			DrawImage (image, x, y, sampling, paint);
+		}
+
+		public void DrawBitmap (SKBitmap bitmap, SKRect dest, SKSamplingOptions sampling, SKPaint paint = null)
+		{
+			using var image = SKImage.FromBitmap (bitmap);
+			DrawImage (image, dest, sampling, paint);
+		}
+
+		public void DrawBitmap (SKBitmap bitmap, SKRect source, SKRect dest, SKSamplingOptions sampling, SKPaint paint = null)
+		{
+			using var image = SKImage.FromBitmap (bitmap);
+			DrawImage (image, source, dest, sampling, paint);
 		}
 
 		// DrawSurface
@@ -735,11 +764,11 @@ namespace SkiaSharp
 
 		[Obsolete ("Use DrawText(string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public void DrawText (string text, SKPoint p, SKPaint paint) =>
-			DrawText (text, p, paint.TextAlign, paint.GetFont (), paint);
+			DrawText (text, p, paint.TextAlign, paint.GetLegacyFont (), paint);
 
 		[Obsolete ("Use DrawText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public void DrawText (string text, float x, float y, SKPaint paint) =>
-			DrawText (text, x, y, paint.TextAlign, paint.GetFont (), paint);
+			DrawText (text, x, y, paint.TextAlign, paint.GetLegacyFont (), paint);
 
 		[Obsolete ("Use DrawText(string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public void DrawText (string text, SKPoint p, SKFont font, SKPaint paint) =>
@@ -787,20 +816,23 @@ namespace SkiaSharp
 
 		[Obsolete ("Use DrawTextOnPath(string text, SKPath path, SKPoint offset, bool warpGlyphs, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public void DrawTextOnPath (string text, SKPath path, SKPoint offset, bool warpGlyphs, SKPaint paint) =>
-			DrawTextOnPath (text, path, offset, warpGlyphs, paint.GetFont (), paint);
+			DrawTextOnPath (text, path, offset, warpGlyphs, paint.GetLegacyFont (), paint);
 
+		[Obsolete ("Use the overload with SKTextAlign parameter instead.")]
 		public void DrawTextOnPath (string text, SKPath path, SKPoint offset, SKFont font, SKPaint paint) =>
 			DrawTextOnPath (text, path, offset, true, paint.GetLegacyTextAlign (), font, paint);
 
 		public void DrawTextOnPath (string text, SKPath path, SKPoint offset, SKTextAlign textAlign, SKFont font, SKPaint paint) =>
 			DrawTextOnPath (text, path, offset, true, textAlign, font, paint);
 
+		[Obsolete ("Use the overload with SKTextAlign parameter instead.")]
 		public void DrawTextOnPath (string text, SKPath path, float hOffset, float vOffset, SKFont font, SKPaint paint) =>
 			DrawTextOnPath (text, path, new SKPoint (hOffset, vOffset), true, paint.GetLegacyTextAlign (), font, paint);
 
 		public void DrawTextOnPath (string text, SKPath path, float hOffset, float vOffset, SKTextAlign textAlign, SKFont font, SKPaint paint) =>
 			DrawTextOnPath (text, path, new SKPoint (hOffset, vOffset), true, textAlign, font, paint);
 
+		[Obsolete ("Use the overload with SKTextAlign parameter instead.")]
 		public void DrawTextOnPath (string text, SKPath path, SKPoint offset, bool warpGlyphs, SKFont font, SKPaint paint) =>
 			DrawTextOnPath (text, path, offset, warpGlyphs, paint.GetLegacyTextAlign (), font, paint);
 
@@ -1119,18 +1151,21 @@ namespace SkiaSharp
 
 		// DrawAtlas
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKPaint paint = null) =>
 			DrawAtlas (atlas, sprites, transforms, null, SKBlendMode.Dst, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, null, paint);
 
 		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKSamplingOptions sampling, SKPaint paint = null) =>
 			DrawAtlas (atlas, sprites, transforms, null, SKBlendMode.Dst, sampling, null, paint);
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKPaint paint = null) =>
 			DrawAtlas (atlas, sprites, transforms, colors, mode, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, null, paint);
 
 		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKSamplingOptions sampling, SKPaint paint = null) =>
 			DrawAtlas (atlas, sprites, transforms, colors, mode, sampling, null, paint);
 
+		[Obsolete ("Use the overload with SKSamplingOptions instead.")]
 		public void DrawAtlas (SKImage atlas, SKRect[] sprites, SKRotationScaleMatrix[] transforms, SKColor[] colors, SKBlendMode mode, SKRect cullRect, SKPaint paint = null) =>
 			DrawAtlas (atlas, sprites, transforms, colors, mode, paint?.GetLegacyFilterQualitySampling () ?? SKSamplingOptions.Default, &cullRect, paint);
 

--- a/binding/SkiaSharp/SKPaint.cs
+++ b/binding/SkiaSharp/SKPaint.cs
@@ -38,6 +38,7 @@ namespace SkiaSharp
 
 	public unsafe class SKPaint : SKObject, ISKSkipObjectRegistration
 	{
+		[Obsolete]
 		private SKFont font;
 
 		// Shared template that backs SKPaint()'s default font and SKPaint.Reset()'s
@@ -1033,7 +1034,7 @@ namespace SkiaSharp
 		}
 
 		[Obsolete ($"Use {nameof (SKFont)} instead.", error: true)]
-		internal SKFont GetFont () =>
+		private SKFont GetFont () =>
 			font ??= OwnedBy (SKFont.GetObject (SkiaApi.sk_compatpaint_get_font (Handle), false), this);
 
 		// Internal compat-paint bypass helpers used by the non-obsolete public APIs
@@ -1044,15 +1045,19 @@ namespace SkiaSharp
 		// when called from a non-obsolete context. Exposed to SkiaSharp.HarfBuzz
 		// via InternalsVisibleTo. Remove together with SkCompatPaint in Phase 2
 		// of #3732.
+		[Obsolete ("Use SKFont directly instead.")]
 		internal SKTextAlign GetLegacyTextAlign () =>
 			SkiaApi.sk_compatpaint_get_text_align (Handle);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		internal SKTextEncoding GetLegacyTextEncoding () =>
 			SkiaApi.sk_compatpaint_get_text_encoding (Handle);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		internal SKFont GetLegacyFont () =>
-			font ??= OwnedBy (SKFont.GetObject (SkiaApi.sk_compatpaint_get_font (Handle), false), this);
+			GetFont ();
 
+		[Obsolete ("Use SKSamplingOptions directly instead.")]
 		internal SKSamplingOptions GetLegacyFilterQualitySampling ()
 		{
 			var quality = SkiaApi.sk_compatpaint_get_filter_quality (Handle);

--- a/binding/SkiaSharp/SKTypeface.cs
+++ b/binding/SkiaSharp/SKTypeface.cs
@@ -247,28 +247,35 @@ namespace SkiaSharp
 
 		// CountGlyphs
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public int CountGlyphs (string str) =>
 			GetFont ().CountGlyphs (str);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public int CountGlyphs (ReadOnlySpan<char> str) =>
 			GetFont ().CountGlyphs (str);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public int CountGlyphs (byte[] str, SKTextEncoding encoding) =>
 			GetFont ().CountGlyphs (str, encoding);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public int CountGlyphs (ReadOnlySpan<byte> str, SKTextEncoding encoding) =>
 			GetFont ().CountGlyphs (str, encoding);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public int CountGlyphs (IntPtr str, int strLen, SKTextEncoding encoding) =>
 			GetFont ().CountGlyphs (str, strLen * encoding.GetCharacterByteSize (), encoding);
 
 		// GetGlyph
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public ushort GetGlyph (int codepoint) =>
 			GetFont ().GetGlyph (codepoint);
 
 		// GetGlyphs
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public ushort[] GetGlyphs (ReadOnlySpan<int> codepoints) =>
 			GetFont ().GetGlyphs (codepoints);
 
@@ -295,28 +302,35 @@ namespace SkiaSharp
 
 		// ContainsGlyph
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public bool ContainsGlyph (int codepoint) =>
 			GetFont ().ContainsGlyph (codepoint);
 
 		// ContainsGlyphs
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public bool ContainsGlyphs (ReadOnlySpan<int> codepoints) =>
 			GetFont ().ContainsGlyphs (codepoints);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public bool ContainsGlyphs (string text) =>
 			GetFont ().ContainsGlyphs (text);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public bool ContainsGlyphs (ReadOnlySpan<char> text) =>
 			GetFont ().ContainsGlyphs (text);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public bool ContainsGlyphs (ReadOnlySpan<byte> text, SKTextEncoding encoding) =>
 			GetFont ().ContainsGlyphs (text, encoding);
 
+		[Obsolete ("Use SKFont directly instead.")]
 		public bool ContainsGlyphs (IntPtr text, int length, SKTextEncoding encoding) =>
 			GetFont ().ContainsGlyphs (text, length * encoding.GetCharacterByteSize (), encoding);
 
 		// GetFont
 
+		[Obsolete ("Use SKFont directly instead.")]
 		internal SKFont GetFont () =>
 			font ??= OwnedBy (new SKFont (this), this);
 

--- a/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
+++ b/samples/Gallery/Shared/Samples/AnimatedWebpEncoderSample.cs
@@ -306,7 +306,7 @@ public class AnimatedWebpEncoderSample : CanvasSampleBase
 			(width - dw) / 2f, (height - dh) / 2f,
 			(width + dw) / 2f, (height + dh) / 2f);
 
-		canvas.DrawBitmap(_currentBitmap, destRect);
+		canvas.DrawBitmap(_currentBitmap, destRect, SKSamplingOptions.Default);
 
 		// info bar
 		using var infoPaint = new SKPaint { Color = new SKColor(200, 200, 200), IsAntialias = true };

--- a/samples/Gallery/Shared/Samples/BlurImageFilterSample.cs
+++ b/samples/Gallery/Shared/Samples/BlurImageFilterSample.cs
@@ -69,6 +69,6 @@ public class BlurImageFilterSample : CanvasSampleBase
 		using var paint = new SKPaint();
 		paint.ImageFilter = filter;
 
-		canvas.DrawBitmap(cachedBitmap, SKRect.Create(width, height), paint);
+		canvas.DrawBitmap(cachedBitmap, SKRect.Create(width, height), SKSamplingOptions.Default, paint);
 	}
 }

--- a/samples/Gallery/Shared/Samples/GifPlayerSample.cs
+++ b/samples/Gallery/Shared/Samples/GifPlayerSample.cs
@@ -121,7 +121,7 @@ public class GifPlayerSample : CanvasSampleBase
 			var scaledH = info.Height * scale;
 			var destRect = SKRect.Create((width - scaledW) / 2, (height - scaledH) / 2, scaledW, scaledH);
 
-			canvas.DrawBitmap(bitmap, destRect);
+			canvas.DrawBitmap(bitmap, destRect, SKSamplingOptions.Default);
 		}
 
 		// Draw frame info

--- a/samples/Gallery/Shared/Samples/HeroImageSample.cs
+++ b/samples/Gallery/Shared/Samples/HeroImageSample.cs
@@ -290,7 +290,7 @@ public class HeroImageSample : CanvasSampleBase
 			ImageFilter = SKImageFilter.CreateBlur(20, 20),
 			IsAntialias = true,
 		};
-		canvas.DrawImage(bgSnapshot, 0, 0, blurPaint);
+		canvas.DrawImage(bgSnapshot, 0, 0, SKSamplingOptions.Default, blurPaint);
 
 		using var glassPaint = new SKPaint
 		{

--- a/samples/Gallery/Shared/Samples/ImageDecoderSample.cs
+++ b/samples/Gallery/Shared/Samples/ImageDecoderSample.cs
@@ -125,7 +125,7 @@ public class ImageDecoderSample : CanvasSampleBase
 			// Draw checkered background for transparency
 			DrawCheckerboard(canvas, destRect);
 
-			canvas.DrawBitmap(bitmap, destRect);
+			canvas.DrawBitmap(bitmap, destRect, SKSamplingOptions.Default);
 
 			if (_showInfo)
 				DrawMetadata(canvas, width, height, codec, info);

--- a/samples/Gallery/Shared/Samples/PdfComposerSample.cs
+++ b/samples/Gallery/Shared/Samples/PdfComposerSample.cs
@@ -388,7 +388,7 @@ public class PdfComposerSample : DocumentSampleBase
 			{
 				var imgSize = Math.Min(pageWidth - margin * 2, 300);
 				var imgRect = SKRect.Create(margin, y, imgSize, imgSize);
-				canvas.DrawBitmap(baboonBitmap, imgRect);
+				canvas.DrawBitmap(baboonBitmap, imgRect, SKSamplingOptions.Default);
 
 				// Label
 				using var labelFont = new SKFont(SampleMedia.Fonts.Default, 11);
@@ -408,7 +408,7 @@ public class PdfComposerSample : DocumentSampleBase
 					0,     0,     0,     1, 0,
 				});
 				using var grayPaint = new SKPaint { ColorFilter = grayFilter };
-				canvas.DrawBitmap(baboonBitmap, SKRect.Create(rightX, y, smallSize, smallSize), grayPaint);
+				canvas.DrawBitmap(baboonBitmap, SKRect.Create(rightX, y, smallSize, smallSize), SKSamplingOptions.Default, grayPaint);
 				canvas.DrawText("Grayscale filter", rightX, y + smallSize + 16, SKTextAlign.Left, labelFont, labelPaint);
 
 				// Sepia version
@@ -420,7 +420,7 @@ public class PdfComposerSample : DocumentSampleBase
 					0,      0,      0,      1, 0,
 				});
 				using var sepiaPaint = new SKPaint { ColorFilter = sepiaFilter };
-				canvas.DrawBitmap(baboonBitmap, SKRect.Create(rightX, y + smallSize + 30, smallSize, smallSize), sepiaPaint);
+				canvas.DrawBitmap(baboonBitmap, SKRect.Create(rightX, y + smallSize + 30, smallSize, smallSize), SKSamplingOptions.Default, sepiaPaint);
 				canvas.DrawText("Sepia filter", rightX, y + smallSize * 2 + 46, SKTextAlign.Left, labelFont, labelPaint);
 
 				y += imgSize + 40;
@@ -435,7 +435,7 @@ public class PdfComposerSample : DocumentSampleBase
 			if (cwBitmap != null)
 			{
 				var cwSize = 150f;
-				canvas.DrawBitmap(cwBitmap, SKRect.Create(margin, y, cwSize, cwSize));
+				canvas.DrawBitmap(cwBitmap, SKRect.Create(margin, y, cwSize, cwSize), SKSamplingOptions.Default);
 
 				using var cwLabel = new SKFont(SampleMedia.Fonts.Default, 11);
 				using var cwPaint = new SKPaint { IsAntialias = true, Color = SubtitleColor };

--- a/samples/Gallery/Shared/Samples/PhotoLabSample.cs
+++ b/samples/Gallery/Shared/Samples/PhotoLabSample.cs
@@ -185,7 +185,7 @@ public class PhotoLabSample : CanvasSampleBase
 				ColorFilter = colorFilter,
 				ImageFilter = lastFilter,
 			};
-			canvas.DrawBitmap(cachedBitmap, SKRect.Create(width, height), paint);
+			canvas.DrawBitmap(cachedBitmap, SKRect.Create(width, height), SKSamplingOptions.Default, paint);
 		}
 		finally
 		{

--- a/samples/Gallery/Shared/Samples/WideGamutP3Sample.cs
+++ b/samples/Gallery/Shared/Samples/WideGamutP3Sample.cs
@@ -184,7 +184,7 @@ public class WideGamutP3Sample : CanvasSampleBase
 		offCanvas.DrawRect(0, 0, w, h, paint);
 
 		using var image = surface.Snapshot();
-		canvas.DrawImage(image, rect);
+		canvas.DrawImage(image, rect, SKSamplingOptions.Default);
 
 		// Border
 		using var borderPaint = new SKPaint

--- a/samples/Gallery/Shared/Samples/WorldTextSample.cs
+++ b/samples/Gallery/Shared/Samples/WorldTextSample.cs
@@ -128,7 +128,7 @@ public class WorldTextSample : CanvasSampleBase
 				canvas.DrawText("▸ Shaped (HarfBuzz):", x, y, SKTextAlign.Left, labelFont, labelPaint);
 				y += textSize + 10;
 				using var shaper = new SKShaper(typeface);
-				canvas.DrawShapedText(shaper, text, x, y, font, textPaint);
+				canvas.DrawShapedText(shaper, text, x, y, SKTextAlign.Left, font, textPaint);
 				y += textSize + 20;
 
 				// Divider
@@ -154,7 +154,7 @@ public class WorldTextSample : CanvasSampleBase
 				canvas.DrawText("▸ Shaped text:", x, y, SKTextAlign.Left, labelFont, labelPaint);
 				y += textSize + 10;
 				using var shaper = new SKShaper(typeface);
-				canvas.DrawShapedText(shaper, text, x, y, font, textPaint);
+				canvas.DrawShapedText(shaper, text, x, y, SKTextAlign.Left, font, textPaint);
 				y += textSize + 30;
 
 				using var noteFont = new SKFont(GetEmbeddedTypeface(), 13);

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/CanvasExtensions.cs
@@ -4,20 +4,22 @@ namespace SkiaSharp.HarfBuzz
 {
 	public static class CanvasExtensions
 	{
-		[Obsolete("Use DrawShapedText(string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.")]
+		[Obsolete("Use DrawShapedText(string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public static void DrawShapedText(this SKCanvas canvas, string text, SKPoint p, SKPaint paint) =>
 			canvas.DrawShapedText(text, p.X, p.Y, paint.GetLegacyTextAlign(), paint.GetLegacyFont(), paint);
 
+		[Obsolete("Use the overload with SKTextAlign parameter instead.")]
 		public static void DrawShapedText(this SKCanvas canvas, string text, SKPoint p, SKFont font, SKPaint paint) =>
 			canvas.DrawShapedText(text, p.X, p.Y, paint.GetLegacyTextAlign(), font, paint);
 
 		public static void DrawShapedText(this SKCanvas canvas, string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) =>
 			canvas.DrawShapedText(text, p.X, p.Y, textAlign, font, paint);
 
-		[Obsolete("Use DrawShapedText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.")]
+		[Obsolete("Use DrawShapedText(string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public static void DrawShapedText(this SKCanvas canvas, string text, float x, float y, SKPaint paint) =>
 			canvas.DrawShapedText(text, x, y, paint.GetLegacyTextAlign(), paint.GetLegacyFont(), paint);
 
+		[Obsolete("Use the overload with SKTextAlign parameter instead.")]
 		public static void DrawShapedText(this SKCanvas canvas, string text, float x, float y, SKFont font, SKPaint paint) =>
 			canvas.DrawShapedText(text, x, y, paint.GetLegacyTextAlign(), font, paint);
 
@@ -30,20 +32,22 @@ namespace SkiaSharp.HarfBuzz
 			canvas.DrawShapedText(shaper, text, x, y, textAlign, font, paint);
 		}
 
-		[Obsolete("Use DrawShapedText(SKShaper shaper, string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.")]
+		[Obsolete("Use DrawShapedText(SKShaper shaper, string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public static void DrawShapedText(this SKCanvas canvas, SKShaper shaper, string text, SKPoint p, SKPaint paint) =>
 			canvas.DrawShapedText(shaper, text, p.X, p.Y, paint.GetLegacyTextAlign(), paint.GetLegacyFont(), paint);
 
+		[Obsolete("Use the overload with SKTextAlign parameter instead.")]
 		public static void DrawShapedText(this SKCanvas canvas, SKShaper shaper, string text, SKPoint p, SKFont font, SKPaint paint) =>
 			canvas.DrawShapedText(shaper, text, p.X, p.Y, paint.GetLegacyTextAlign(), font, paint);
 
 		public static void DrawShapedText(this SKCanvas canvas, SKShaper shaper, string text, SKPoint p, SKTextAlign textAlign, SKFont font, SKPaint paint) =>
 			canvas.DrawShapedText(shaper, text, p.X, p.Y, textAlign, font, paint);
 
-		[Obsolete("Use DrawShapedText(SKShaper shaper, string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.")]
+		[Obsolete("Use DrawShapedText(SKShaper shaper, string text, float x, float y, SKTextAlign textAlign, SKFont font, SKPaint paint) instead.", error: true)]
 		public static void DrawShapedText(this SKCanvas canvas, SKShaper shaper, string text, float x, float y, SKPaint paint) =>
 			canvas.DrawShapedText(shaper, text, x, y, paint.GetLegacyTextAlign(), paint.GetLegacyFont(), paint);
 
+		[Obsolete("Use the overload with SKTextAlign parameter instead.")]
 		public static void DrawShapedText(this SKCanvas canvas, SKShaper shaper, string text, float x, float y, SKFont font, SKPaint paint) =>
 			canvas.DrawShapedText(shaper, text, x, y, paint.GetLegacyTextAlign(), font, paint);
 

--- a/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/SKShaper.cs
+++ b/source/SkiaSharp.HarfBuzz/SkiaSharp.HarfBuzz/SKShaper.cs
@@ -40,11 +40,11 @@ namespace SkiaSharp.HarfBuzz
 			hbBuffer?.Dispose();
 		}
 
-		[Obsolete("Use Shape(Buffer buffer, SKFont font) instead.")]
+		[Obsolete("Use Shape(Buffer buffer, SKFont font) instead.", error: true)]
 		public Result Shape(Buffer buffer, SKPaint paint) =>
 			Shape(buffer, 0, 0, paint.GetLegacyFont());
 
-		[Obsolete("Use Shape(Buffer buffer, float xOffset, float yOffset, SKFont font) instead.")]
+		[Obsolete("Use Shape(Buffer buffer, float xOffset, float yOffset, SKFont font) instead.", error: true)]
 		public Result Shape(Buffer buffer, float xOffset, float yOffset, SKPaint paint) =>
 			Shape(buffer, xOffset, yOffset, paint.GetLegacyFont());
 
@@ -100,11 +100,11 @@ namespace SkiaSharp.HarfBuzz
 			return new Result(codepoints, clusters, points, width);
 		}
 
-		[Obsolete("Use Shape(string text, SKFont font) instead.")]
+		[Obsolete("Use Shape(string text, SKFont font) instead.", error: true)]
 		public Result Shape(string text, SKPaint paint) =>
 			Shape(text, 0, 0, paint.GetLegacyFont());
 
-		[Obsolete("Use Shape(string text, float xOffset, float yOffset, SKFont font) instead.")]
+		[Obsolete("Use Shape(string text, float xOffset, float yOffset, SKFont font) instead.", error: true)]
 		public Result Shape(string text, float xOffset, float yOffset, SKPaint paint)
 		{
 			if (string.IsNullOrEmpty(text))

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -109,7 +109,7 @@ public abstract class PlatformTestBase : IDisposable
         using var cropped = new SKBitmap(rect.Width, rect.Height);
         using var canvas = new SKCanvas(cropped);
         
-        canvas.DrawBitmap(original, rect, SKRect.Create(rect.Width, rect.Height));
+        canvas.DrawBitmap(original, rect, SKRect.Create(rect.Width, rect.Height), SKSamplingOptions.Default);
         
         using var image = SKImage.FromBitmap(cropped);
         using var data = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -138,7 +138,7 @@ public abstract class PlatformTestBase : IDisposable
             Output.WriteLine($"Resizing actual ({actualImage.Width}x{actualImage.Height}) to match expected ({expectedImage.Width}x{expectedImage.Height})");
             using var resizedBitmap = new SKBitmap(expectedImage.Width, expectedImage.Height);
             using var canvas = new SKCanvas(resizedBitmap);
-            canvas.DrawImage(actualImage, new SKRect(0, 0, expectedImage.Width, expectedImage.Height));
+            canvas.DrawImage(actualImage, new SKRect(0, 0, expectedImage.Width, expectedImage.Height), SKSamplingOptions.Default);
             compareActual = SKImage.FromBitmap(resizedBitmap);
         }
         

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -361,7 +361,7 @@ namespace SkiaSharp.Tests
 			{
 				var canvas = surface.Canvas;
 				canvas.Clear(SKColors.White);
-				canvas.DrawBitmap(bitmap, 0, 0);
+				canvas.DrawBitmap(bitmap, 0, 0, SKSamplingOptions.Default);
 
 				using (var img = surface.Snapshot())
 				using (var bmp = SKBitmap.FromImage(img))

--- a/tests/Tests/SkiaSharp/SKCanvasTest.cs
+++ b/tests/Tests/SkiaSharp/SKCanvasTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Xml.Linq;
 using Xunit;
@@ -185,7 +185,7 @@ namespace SkiaSharp.Tests
 			var sprites = new[] { SKRect.Empty, SKRect.Empty };
 			var transforms = new[] { SKRotationScaleMatrix.Empty };
 
-			Assert.Throws<ArgumentException>("transforms", () => canvas.DrawAtlas(img, sprites, transforms, paint));
+			Assert.Throws<ArgumentException>("transforms", () => canvas.DrawAtlas(img, sprites, transforms, SKSamplingOptions.Default, paint));
 		}
 
 		[SkippableFact]
@@ -358,9 +358,9 @@ namespace SkiaSharp.Tests
 			};
 
 			canvas.Clear(SKColors.White);
-			canvas.DrawAtlas(atlas, tex, xform, paint);
+			canvas.DrawAtlas(atlas, tex, xform, SKSamplingOptions.Default, paint);
 			canvas.Translate(0, 100);
-			canvas.DrawAtlas(atlas, tex, xform, colors, SKBlendMode.SrcIn, paint);
+			canvas.DrawAtlas(atlas, tex, xform, colors, SKBlendMode.SrcIn, SKSamplingOptions.Default, paint);
 
 			Assert.Equal(SKColors.Blue, bitmap.GetPixel(32, 41));
 			Assert.Equal(SKColors.Blue, bitmap.GetPixel(156, 77));

--- a/tests/Tests/SkiaSharp/SKGraphicsTest.cs
+++ b/tests/Tests/SkiaSharp/SKGraphicsTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -74,7 +74,7 @@ namespace SkiaSharp.Tests
 			using var data = SKData.Create(Path.Combine(PathToImages, "baboon.jpg"));
 			using var image = SKImage.FromEncodedData(data);
 
-			canvas.DrawImage(image, 0, 0);
+			canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 			using var dump = new TextWriterDump(true, true);
 
@@ -97,7 +97,7 @@ namespace SkiaSharp.Tests
 			using var data = SKData.Create(Path.Combine(PathToImages, "baboon.jpg"));
 			using var image = SKImage.FromEncodedData(data);
 
-			canvas.DrawImage(image, 0, 0);
+			canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 			using var dump = new TextWriterDump(true, true);
 
@@ -121,7 +121,7 @@ namespace SkiaSharp.Tests
 			using var data = SKData.Create(Path.Combine(PathToImages, "baboon.jpg"));
 			using var image = SKImage.FromEncodedData(data);
 
-			canvas.DrawImage(image, 0, 0);
+			canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 			using var dump = new TextWriterDump(true, true);
 

--- a/tests/Tests/SkiaSharp/SKImageTest.cs
+++ b/tests/Tests/SkiaSharp/SKImageTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -247,7 +247,7 @@ namespace SkiaSharp.Tests
 			{
 				var canvas = surface.Canvas;
 				canvas.Clear(SKColors.White);
-				canvas.DrawImage(image, 0, 0);
+				canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 				using (var snap = surface.Snapshot())
 				using (var bmp = SKBitmap.FromImage(snap))
@@ -271,7 +271,7 @@ namespace SkiaSharp.Tests
 			{
 				var canvas = surface.Canvas;
 				canvas.Clear(SKColors.White);
-				canvas.DrawImage(image, 0, 0);
+				canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 				using (var snap = surface.Snapshot())
 				using (var bmp = SKBitmap.FromImage(snap))
@@ -295,7 +295,7 @@ namespace SkiaSharp.Tests
 			{
 				var canvas = surface.Canvas;
 				canvas.Clear(SKColors.White);
-				canvas.DrawImage(image, 0, 0);
+				canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 				using (var snap = surface.Snapshot())
 				using (var bmp = SKBitmap.FromImage(snap))
@@ -319,7 +319,7 @@ namespace SkiaSharp.Tests
 			{
 				var canvas = surface.Canvas;
 				canvas.Clear(SKColors.White);
-				canvas.DrawImage(image, 0, 0);
+				canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 				using (var snap = surface.Snapshot())
 				using (var bmp = SKBitmap.FromImage(snap))
@@ -696,7 +696,7 @@ namespace SkiaSharp.Tests
 					using (var data = SKData.Create(path))
 					using (var image = SKImage.FromEncodedData(data))
 					{
-						canvas.DrawImage(image, 0, 0);
+						canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 					}
 
 					using (var bmp = new SKBitmap(info))
@@ -732,7 +732,7 @@ namespace SkiaSharp.Tests
 					using (var bitmap = SKBitmap.Decode(path))
 					using (var image = SKImage.FromBitmap(bitmap))
 					{
-						canvas.DrawImage(image, 0, 0);
+						canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 					}
 
 					using (var bmp = new SKBitmap(info))
@@ -767,7 +767,7 @@ namespace SkiaSharp.Tests
 
 					using (var image = SKImage.FromEncodedData(path))
 					{
-						canvas.DrawImage(image, 0, 0);
+						canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 					}
 
 					using (var bmp = new SKBitmap(info))
@@ -796,7 +796,7 @@ namespace SkiaSharp.Tests
 				using (var data = SKData.Create(path))
 				using (var image = SKImage.FromEncodedData(data))
 				{
-					canvas.DrawImage(image, 0, 0);
+					canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 				}
 
 				Assert.Equal(SKColors.Crimson, bmp.GetPixel(3, 3));
@@ -819,7 +819,7 @@ namespace SkiaSharp.Tests
 				using (var bitmap = SKBitmap.Decode(path))
 				using (var image = SKImage.FromBitmap(bitmap))
 				{
-					canvas.DrawImage(image, 0, 0);
+					canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 				}
 
 				Assert.Equal(SKColors.Crimson, bmp.GetPixel(3, 3));
@@ -841,7 +841,7 @@ namespace SkiaSharp.Tests
 
 				using (var image = SKImage.FromEncodedData(path))
 				{
-					canvas.DrawImage(image, 0, 0);
+					canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 				}
 
 				Assert.Equal(SKColors.Crimson, bmp.GetPixel(3, 3));
@@ -885,7 +885,7 @@ namespace SkiaSharp.Tests
 			{
 				using var bmp = new SKBitmap(image.Width, image.Height);
 				using var cnv = new SKCanvas(bmp);
-				cnv.DrawImage(image, 0, 0);
+				cnv.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 				return bmp.Pixels;
 			}
 		}

--- a/tests/Tests/SkiaSharp/SKPictureTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureTest.cs
@@ -120,7 +120,7 @@ namespace SkiaSharp.Tests
 			// create a picture that has an image in it
 			using var picRecorder = new SKPictureRecorder();
 			using var picCanvas = picRecorder.BeginRecording(SKRect.Create(0, 0, 40, 40));
-			picCanvas.DrawBitmap(sourceBitmap, 0, 0);
+			picCanvas.DrawBitmap(sourceBitmap, 0, 0, SKSamplingOptions.Default);
 			using var picture = picRecorder.EndRecording();
 
 			// serialize and then deserialize the picture

--- a/tests/Tests/SkiaSharp/SKShaperTest.cs
+++ b/tests/Tests/SkiaSharp/SKShaperTest.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using HarfBuzzSharp;
@@ -21,7 +21,7 @@ namespace SkiaSharp.HarfBuzz.Tests
 			{
 				canvas.Clear(SKColors.White);
 
-				canvas.DrawShapedText(shaper, "متن", 100, 200, font, paint);
+				canvas.DrawShapedText(shaper, "متن", 100, 200, SKTextAlign.Left, font, paint);
 
 				canvas.Flush();
 

--- a/tests/Tests/SkiaSharp/SKTest.cs
+++ b/tests/Tests/SkiaSharp/SKTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -71,7 +71,7 @@ namespace SkiaSharp.Tests
 			using var canvas = new SKCanvas(bitmap);
 
 			canvas.Clear(SKColors.Transparent);
-			canvas.DrawImage(img, 0, 0);
+			canvas.DrawImage(img, 0, 0, SKSamplingOptions.Default);
 			canvas.Flush();
 
 			using var stream = File.OpenWrite(Path.Combine(PathToImages, filename));
@@ -99,7 +99,7 @@ namespace SkiaSharp.Tests
 			var canvas = surface.Canvas;
 
 			canvas.Clear(SKColors.Transparent);
-			canvas.DrawImage(img, 0, 0);
+			canvas.DrawImage(img, 0, 0, SKSamplingOptions.Default);
 			canvas.Flush();
 
 			using var snap = surface.Snapshot();

--- a/tests/Tests/SkiaSharp/SKTypefaceTest.cs
+++ b/tests/Tests/SkiaSharp/SKTypefaceTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Xunit;
 
@@ -206,6 +206,7 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		[Obsolete ("Tests obsolete SKTypeface.CountGlyphs/GetGlyphs — see SKFontTest for non-obsolete equivalents")]
 		public unsafe void UnicharCountReturnsCorrectCount()
 		{
 			var text = new uint[] { 79 };
@@ -223,6 +224,7 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		[Obsolete ("Tests obsolete SKTypeface.CountGlyphs — see SKFontTest for non-obsolete equivalents")]
 		public void PlainGlyphsReturnsTheCorrectNumberOfCharacters()
 		{
 			const string text = "Hello World!";
@@ -235,6 +237,7 @@ namespace SkiaSharp.Tests
 
 		[Trait(Traits.Category.Key, Traits.Category.Values.MatchCharacter)]
 		[SkippableFact]
+		[Obsolete ("Tests obsolete SKTypeface.CountGlyphs/GetGlyphs — see SKFontTest for non-obsolete equivalents")]
 		public void UnicodeGlyphsReturnsTheCorrectNumberOfCharacters()
 		{
 			SkipOnPlatform(IsBrowser, "WASM has no system fonts with emoji support");
@@ -254,6 +257,7 @@ namespace SkiaSharp.Tests
 		}
 
 		[SkippableFact]
+		[Obsolete ("Tests obsolete SKTypeface.ContainsGlyphs — see SKFontTest for non-obsolete equivalents")]
 		public void ContainsGlyphsWithByteSpanDoesNotStackOverflow ()
 		{
 			using var typeface = SKTypeface.Default;

--- a/tests/Tests/Utils/SKPixelComparer.cs
+++ b/tests/Tests/Utils/SKPixelComparer.cs
@@ -225,7 +225,7 @@ namespace SkiaSharp.Extended
 			var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888));
 
 			using (var canvas = new SKCanvas(bitmap))
-				canvas.DrawImage(image, 0, 0);
+				canvas.DrawImage(image, 0, 0, SKSamplingOptions.Default);
 
 			return bitmap;
 		}


### PR DESCRIPTION
## Summary

Marks remaining legacy paint state-reading APIs as `[Obsolete]` and provides proper non-obsolete replacements, continuing the work from #4068.

**Rule applied:**
- Already obsolete on main → promoted to `[Obsolete("...", error: true)]`
- Newly obsolete (reads legacy paint state internally) → `[Obsolete("...")]` (warning)

## Changes

### SKPaint.cs — Internal plumbing
- `[Obsolete]` on private `font` field
- `GetFont()` made private (only used by already-obsolete members)
- `GetLegacyFont()` delegates to private `GetFont()` instead of duplicating
- All 4 `GetLegacy*()` methods marked `[Obsolete]`

### SKCanvas.cs — New obsolete warnings
- 4 `DrawImage` overloads (read paint.FilterQuality)
- 4 `DrawBitmap` overloads (read paint.FilterQuality)
- 3 `DrawAtlas` overloads (read paint.FilterQuality)
- 3 `DrawTextOnPath` overloads (read paint.TextAlign)

### SKCanvas.cs — New non-obsolete `DrawBitmap` overloads
- 4 `DrawBitmap` overloads accepting `SKSamplingOptions` (migration target)

### SKTypeface.cs — New obsolete warnings
- Internal `GetFont()` marked `[Obsolete]`
- 12 public methods that call it (CountGlyphs, GetGlyph, GetGlyphs, ContainsGlyph, ContainsGlyphs variants)

### HarfBuzz CanvasExtensions.cs
- 4 paint-only `DrawShapedText` overloads promoted to `error: true`
- 4 font+paint `DrawShapedText` overloads (read paint.TextAlign) marked `[Obsolete]`

### HarfBuzz SKShaper.cs
- 4 paint-accepting `Shape` overloads promoted to `error: true`

### Gallery samples
- Migrated `DrawBitmap`/`DrawImage`/`DrawShapedText` calls to non-obsolete overloads

### Tests
- Migrated incidental uses of obsolete APIs to non-obsolete overloads
- Tests specifically exercising obsolete SKTypeface glyph APIs marked `[Obsolete]` (equivalent coverage exists in SKFontTest)

## Design notes

- No `#pragma warning disable` anywhere — C# automatically suppresses obsolete warnings when the caller is itself `[Obsolete]`
- Tests that incidentally used obsolete APIs were migrated, not suppressed
- Tests that specifically test obsolete behavior are marked `[Obsolete]` and have non-obsolete equivalents

Fixes #3732, relates to #4113