### PR TITLE
Dev/issue 4110 wasm 4gb swapchain rendering

### DIFF
--- a/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Wasm/WasmScripts/SkiaSharp.Views.Uno.Wasm.js
+++ b/source/SkiaSharp.Views.Uno/SkiaSharp.Views.Uno.WinUI.Wasm/WasmScripts/SkiaSharp.Views.Uno.Wasm.js
@@ -40,7 +40,7 @@
                         ctx.putImageData(imageData, 0, 0);
                     }
                     else {
-                        var buffer = new Uint8ClampedArray(Module.HEAPU8.buffer, byteLength);
+                        var buffer = new Uint8ClampedArray(Module.HEAPU8.buffer, pData, byteLength);
                         var imageData = new ImageData(buffer, width, height);
                         ctx.putImageData(imageData, 0, 0);
                     }
@@ -201,6 +201,8 @@
                     if (!currentGLctx)
                         throw `Failed to get current WebGL context`;
 
+                    SKSwapChainPanel.installLargeHeapUploadFallback(currentGLctx);
+
                     // read values
                     this.canvas = canvas;
                     return {
@@ -239,6 +241,46 @@
                     }
 
                     return ctx;
+                }
+
+                static installLargeHeapUploadFallback(gl) {
+                    if (!gl || gl.__skiaSharpLargeHeapUploadFallback)
+                        return;
+
+                    const maxSignedInt = 0x7fffffff;
+                    const uploadMethods = [
+                        'texImage2D',
+                        'texSubImage2D',
+                        'compressedTexImage2D',
+                        'compressedTexSubImage2D',
+                    ];
+
+                    const copyLargeHeapView = (value) => {
+                        if (!ArrayBuffer.isView(value) || !value.buffer || value.buffer.byteLength <= maxSignedInt || value.byteLength > maxSignedInt)
+                            return value;
+
+                        if (typeof value.slice === 'function')
+                            return value.slice();
+
+                        const buffer = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+                        return new value.constructor(buffer);
+                    };
+
+                    for (const method of uploadMethods) {
+                        const original = gl[method];
+                        if (typeof original !== 'function')
+                            continue;
+
+                        gl[method] = function (...args) {
+                            for (let i = 0; i < args.length; i++) {
+                                args[i] = copyLargeHeapView(args[i]);
+                            }
+
+                            return original.apply(this, args);
+                        };
+                    }
+
+                    gl.__skiaSharpLargeHeapUploadFallback = true;
                 }
             }
 

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SKHtmlCanvas.js
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SKHtmlCanvas.js
@@ -70,6 +70,7 @@ export class SKHtmlCanvas {
             GL.makeContextCurrent(ctx);
             // read values
             const GLctx = SKHtmlCanvas.getGLctx();
+            SKHtmlCanvas.installLargeHeapUploadFallback(GLctx);
             const fbo = GLctx.getParameter(GLctx.FRAMEBUFFER_BINDING);
             this.glInfo = {
                 context: ctx,
@@ -169,6 +170,37 @@ export class SKHtmlCanvas {
             ctx = GL.createContext(htmlCanvas, contextAttributes);
         }
         return ctx;
+    }
+    static installLargeHeapUploadFallback(gl) {
+        if (!gl || gl.__skiaSharpLargeHeapUploadFallback)
+            return;
+        const maxSignedInt = 0x7fffffff;
+        const uploadMethods = [
+            'texImage2D',
+            'texSubImage2D',
+            'compressedTexImage2D',
+            'compressedTexSubImage2D',
+        ];
+        const copyLargeHeapView = (value) => {
+            if (!ArrayBuffer.isView(value) || !value.buffer || value.buffer.byteLength <= maxSignedInt || value.byteLength > maxSignedInt)
+                return value;
+            if (typeof value.slice === 'function')
+                return value.slice();
+            const buffer = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+            return new value.constructor(buffer);
+        };
+        for (const method of uploadMethods) {
+            const original = gl[method];
+            if (typeof original !== 'function')
+                continue;
+            gl[method] = function (...args) {
+                for (let i = 0; i < args.length; i++) {
+                    args[i] = copyLargeHeapView(args[i]);
+                }
+                return original.apply(this, args);
+            };
+        }
+        gl.__skiaSharpLargeHeapUploadFallback = true;
     }
     static getGL() {
         return globalThis.SkiaSharpGL || Module.GL || GL;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SKHtmlCanvas.ts
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SKHtmlCanvas.ts
@@ -119,6 +119,8 @@ export class SKHtmlCanvas {
 
 			// read values
 			const GLctx = SKHtmlCanvas.getGLctx();
+			SKHtmlCanvas.installLargeHeapUploadFallback(GLctx);
+
 			const fbo = GLctx.getParameter(GLctx.FRAMEBUFFER_BINDING);
 			this.glInfo = {
 				context: ctx,
@@ -233,6 +235,46 @@ export class SKHtmlCanvas {
 		}
 
 		return ctx;
+	}
+
+	static installLargeHeapUploadFallback(gl: WebGLRenderingContext | WebGL2RenderingContext) {
+		if (!gl || (gl as any).__skiaSharpLargeHeapUploadFallback)
+			return;
+
+		const maxSignedInt = 0x7fffffff;
+		const uploadMethods = [
+			'texImage2D',
+			'texSubImage2D',
+			'compressedTexImage2D',
+			'compressedTexSubImage2D',
+		];
+
+		const copyLargeHeapView = (value: any) => {
+			if (!ArrayBuffer.isView(value) || !value.buffer || value.buffer.byteLength <= maxSignedInt || value.byteLength > maxSignedInt)
+				return value;
+
+			if (typeof value.slice === 'function')
+				return value.slice();
+
+			const buffer = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+			return new value.constructor(buffer);
+		};
+
+		for (const method of uploadMethods) {
+			const original = (gl as any)[method];
+			if (typeof original !== 'function')
+				continue;
+
+			(gl as any)[method] = function (...args: any[]) {
+				for (let i = 0; i < args.length; i++) {
+					args[i] = copyLargeHeapView(args[i]);
+				}
+
+				return original.apply(this, args);
+			};
+		}
+
+		(gl as any).__skiaSharpLargeHeapUploadFallback = true;
 	}
 
 	static getGL(): any {


### PR DESCRIPTION
**Description of Change**

This fixes WASM rendering issues when apps run with Emscripten `MAXIMUM_MEMORY=4GB`.

The WebGL-backed view path now installs a guarded upload fallback for large WASM heaps. When texture upload APIs receive a typed-array view backed by a heap larger than the 2GB signed boundary, the view is copied before calling WebGL. This avoids browser-side `texSubImage2D: ArrayBufferView not big enough for request` failures caused by large-heap view/offset handling.

This also fixes an Uno `SKXamlCanvas` raster path bug where the non-secure path constructed `Uint8ClampedArray` with `byteLength` as the heap offset instead of `pData`.

Tests were limited by the local environment:
- `node --check` passed for the changed JavaScript assets.
- `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` was blocked by missing mobile workloads.
- `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj -p:TargetFrameworks=net10.0` timed out locally after 10 minutes.

**Bugs Fixed**

- Fixes #4110

**API Changes**

None.

**Behavioral Changes**

WASM WebGL views defensively copy texture upload typed-array data when the backing WASM heap is larger than 2GB. This is intended to preserve rendering correctness for apps using larger Emscripten memory limits.

**Required skia PR**

None.

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [x] Changes adhere to coding standard
- [ ] Updated documentation