### PR TITLE
Compile C API (src/c) in libSkiaSharp instead of upstream :core

### DIFF
--- a/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -34,6 +34,46 @@
 		34CB9AD9205699C400BACCBA /* sk_managedstream.h in Headers */ = {isa = PBXBuildFile; fileRef = 34CB9AD3205699C400BACCBA /* sk_managedstream.h */; };
 		34CB9ADB205699C400BACCBA /* sk_xamarin.h in Headers */ = {isa = PBXBuildFile; fileRef = 34CB9AD5205699C400BACCBA /* sk_xamarin.h */; };
 		34ED40A92A8178A6007F12FA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ED40A82A8178A6007F12FA /* UIKit.framework */; };
+		27331295A41050420606340D /* sk_bitmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A436F129B2D72F23786FD8D5 /* sk_bitmap.cpp */; };
+		42DCDBB12CCC22ABE0EB2392 /* sk_blender.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C1E79198D8EC2E89B6049CA4 /* sk_blender.cpp */; };
+		4B50BC3056D1CA999F929A62 /* sk_canvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 125AF0368147B57D710D957B /* sk_canvas.cpp */; };
+		4C3BB23123B4090ABD7C0173 /* sk_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C84ED81DAD7AFD65B34C8362 /* sk_codec.cpp */; };
+		3CA61084AA27FB82D6DA195E /* sk_colorfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 735EE57A975177517AA1EA25 /* sk_colorfilter.cpp */; };
+		AA1B1C7EB9F941FBA9906B87 /* sk_colorspace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C1E99B4346CCD1927675BDBE /* sk_colorspace.cpp */; };
+		2C3FCE990D2475AD92E63B0E /* sk_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B956D06324239ECA38A3D63F /* sk_data.cpp */; };
+		45317D629A16B580A5355C3C /* sk_document.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8875B28293818C8FB19F48D1 /* sk_document.cpp */; };
+		CCB44964DCDCBF145DCD5436 /* sk_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE5FA207C756556BDF2C1305 /* sk_drawable.cpp */; };
+		9AC0F922078A293C955BD563 /* sk_enums.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8BD447ADC1694593AA85CB27 /* sk_enums.cpp */; };
+		4A59D7316CE0B25C99305C14 /* sk_font.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AFF0EB39B1E7BAA7C21E5263 /* sk_font.cpp */; };
+		87B4E85B15FEAA7A9448BD24 /* sk_general.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9EE4ECBC3B3F161F3F82A7CC /* sk_general.cpp */; };
+		097E2CDA7FB80F1026B88073 /* sk_graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70E32CACD33AA0A83A3C8C58 /* sk_graphics.cpp */; };
+		3BFEE2CE2E5256F8442C191D /* sk_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B4ABA97D95B87D466DFAF09B /* sk_image.cpp */; };
+		FBD217F71B45C458740C771A /* sk_imagefilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CC43BB839125A44F1655511 /* sk_imagefilter.cpp */; };
+		68EE5122EA95274C35ED0035 /* sk_maskfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C450A0A57074733846DB184 /* sk_maskfilter.cpp */; };
+		B39D06A789355E46F4999341 /* sk_matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 014B02757286E7B2D99D13FA /* sk_matrix.cpp */; };
+		EC76571E8306F34DB173A1EA /* sk_paint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C71849F7359A27CD4B48972 /* sk_paint.cpp */; };
+		6A96F15281CF1D5D3D2D3E81 /* sk_path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 090C203243337199C6FA7D99 /* sk_path.cpp */; };
+		B1041C2E0507C634BA138F0B /* sk_pathbuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CFF10F3B1FA0CF3F2897BF3D /* sk_pathbuilder.cpp */; };
+		2E6F434F8ECDFCBC667529CA /* sk_patheffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A6C95EC3634EB81DAC32733F /* sk_patheffect.cpp */; };
+		19BF7BDA3E31316AEEBC3F81 /* sk_picture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B9BB494AC90F41BDB4FE7F2D /* sk_picture.cpp */; };
+		154909BE57AAC648BA152917 /* sk_pixmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2C474BA3A3146F524ACA0B7D /* sk_pixmap.cpp */; };
+		BD031477CE7B9782C9B5F5C7 /* sk_region.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 603D33C31742E1580DE4D174 /* sk_region.cpp */; };
+		42231955C2374EB9B4EE54B1 /* sk_rrect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A6A9C8B6B639234194F1AE1B /* sk_rrect.cpp */; };
+		ECEB46A5F0041D1AC75D8C92 /* sk_runtimeeffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 081C6FD46A34A7EB22243368 /* sk_runtimeeffect.cpp */; };
+		4A8708E249E9FECE0C65D843 /* sk_shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C09C4196F721E82F84788E8 /* sk_shader.cpp */; };
+		9E11123975D05EC6C66BC747 /* sk_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7F3F4A6C588F717A0E3FE201 /* sk_stream.cpp */; };
+		8A53393C2B22CA6E6E1EF6A5 /* sk_string.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CF12DB77FE694A4D480984E /* sk_string.cpp */; };
+		FBECE543D1E37425BE6B7F4C /* sk_structs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A5258AE59917D8BABF74CD2 /* sk_structs.cpp */; };
+		08A274EB829BB7D8433BF197 /* sk_surface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33920571CE1ACEE28DA11A4 /* sk_surface.cpp */; };
+		9CCA186C8AC37BA9F09DF2AD /* sk_svg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8B9B745CA39535F77B132F6 /* sk_svg.cpp */; };
+		68241C7F10E6B995B5B8A7CE /* sk_textblob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 463A8C1D181A4675B7F6E1D2 /* sk_textblob.cpp */; };
+		7B8A42961DE97FED7974C0E6 /* sk_typeface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B14D502D805175E54139082 /* sk_typeface.cpp */; };
+		3491D0C0D3022607F5A5CE81 /* sk_vertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DEA909A61CB287646A3D42EE /* sk_vertices.cpp */; };
+		6F190DDE26F51F942921F296 /* gr_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94B75B383D51830ABFB204C /* gr_context.cpp */; };
+		2746A06FACB645B97CC6203B /* sk_linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DC7C53862594513F0CCD0A1 /* sk_linker.cpp */; };
+		C1DFED553FD4EBF2DF018EBF /* skottie_animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34A43E0D21FA9CE77E6E8149 /* skottie_animation.cpp */; };
+		6AB51532F9E89CB73F87E6FB /* skresources_resource_provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D3AE6963C23F56EB7EC9DBA8 /* skresources_resource_provider.cpp */; };
+		5F3C5AFD82D1F2DEAC8ED44B /* sksg_invalidation_controller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 692148026B87185CB9A66299 /* sksg_invalidation_controller.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +106,46 @@
 		34CB9AD3205699C400BACCBA /* sk_managedstream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sk_managedstream.h; path = ../../../../externals/skia/include/xamarin/sk_managedstream.h; sourceTree = "<group>"; };
 		34CB9AD5205699C400BACCBA /* sk_xamarin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sk_xamarin.h; path = ../../../../externals/skia/include/xamarin/sk_xamarin.h; sourceTree = "<group>"; };
 		34ED40A82A8178A6007F12FA /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		A436F129B2D72F23786FD8D5 /* sk_bitmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_bitmap.cpp; path = ../../../../externals/skia/src/c/sk_bitmap.cpp; sourceTree = "<group>"; };
+		C1E79198D8EC2E89B6049CA4 /* sk_blender.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_blender.cpp; path = ../../../../externals/skia/src/c/sk_blender.cpp; sourceTree = "<group>"; };
+		125AF0368147B57D710D957B /* sk_canvas.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_canvas.cpp; path = ../../../../externals/skia/src/c/sk_canvas.cpp; sourceTree = "<group>"; };
+		C84ED81DAD7AFD65B34C8362 /* sk_codec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_codec.cpp; path = ../../../../externals/skia/src/c/sk_codec.cpp; sourceTree = "<group>"; };
+		735EE57A975177517AA1EA25 /* sk_colorfilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_colorfilter.cpp; path = ../../../../externals/skia/src/c/sk_colorfilter.cpp; sourceTree = "<group>"; };
+		C1E99B4346CCD1927675BDBE /* sk_colorspace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_colorspace.cpp; path = ../../../../externals/skia/src/c/sk_colorspace.cpp; sourceTree = "<group>"; };
+		B956D06324239ECA38A3D63F /* sk_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_data.cpp; path = ../../../../externals/skia/src/c/sk_data.cpp; sourceTree = "<group>"; };
+		8875B28293818C8FB19F48D1 /* sk_document.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_document.cpp; path = ../../../../externals/skia/src/c/sk_document.cpp; sourceTree = "<group>"; };
+		DE5FA207C756556BDF2C1305 /* sk_drawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_drawable.cpp; path = ../../../../externals/skia/src/c/sk_drawable.cpp; sourceTree = "<group>"; };
+		8BD447ADC1694593AA85CB27 /* sk_enums.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_enums.cpp; path = ../../../../externals/skia/src/c/sk_enums.cpp; sourceTree = "<group>"; };
+		AFF0EB39B1E7BAA7C21E5263 /* sk_font.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_font.cpp; path = ../../../../externals/skia/src/c/sk_font.cpp; sourceTree = "<group>"; };
+		9EE4ECBC3B3F161F3F82A7CC /* sk_general.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_general.cpp; path = ../../../../externals/skia/src/c/sk_general.cpp; sourceTree = "<group>"; };
+		70E32CACD33AA0A83A3C8C58 /* sk_graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_graphics.cpp; path = ../../../../externals/skia/src/c/sk_graphics.cpp; sourceTree = "<group>"; };
+		B4ABA97D95B87D466DFAF09B /* sk_image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_image.cpp; path = ../../../../externals/skia/src/c/sk_image.cpp; sourceTree = "<group>"; };
+		4CC43BB839125A44F1655511 /* sk_imagefilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_imagefilter.cpp; path = ../../../../externals/skia/src/c/sk_imagefilter.cpp; sourceTree = "<group>"; };
+		4C450A0A57074733846DB184 /* sk_maskfilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_maskfilter.cpp; path = ../../../../externals/skia/src/c/sk_maskfilter.cpp; sourceTree = "<group>"; };
+		014B02757286E7B2D99D13FA /* sk_matrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_matrix.cpp; path = ../../../../externals/skia/src/c/sk_matrix.cpp; sourceTree = "<group>"; };
+		3C71849F7359A27CD4B48972 /* sk_paint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_paint.cpp; path = ../../../../externals/skia/src/c/sk_paint.cpp; sourceTree = "<group>"; };
+		090C203243337199C6FA7D99 /* sk_path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_path.cpp; path = ../../../../externals/skia/src/c/sk_path.cpp; sourceTree = "<group>"; };
+		CFF10F3B1FA0CF3F2897BF3D /* sk_pathbuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_pathbuilder.cpp; path = ../../../../externals/skia/src/c/sk_pathbuilder.cpp; sourceTree = "<group>"; };
+		A6C95EC3634EB81DAC32733F /* sk_patheffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_patheffect.cpp; path = ../../../../externals/skia/src/c/sk_patheffect.cpp; sourceTree = "<group>"; };
+		B9BB494AC90F41BDB4FE7F2D /* sk_picture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_picture.cpp; path = ../../../../externals/skia/src/c/sk_picture.cpp; sourceTree = "<group>"; };
+		2C474BA3A3146F524ACA0B7D /* sk_pixmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_pixmap.cpp; path = ../../../../externals/skia/src/c/sk_pixmap.cpp; sourceTree = "<group>"; };
+		603D33C31742E1580DE4D174 /* sk_region.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_region.cpp; path = ../../../../externals/skia/src/c/sk_region.cpp; sourceTree = "<group>"; };
+		A6A9C8B6B639234194F1AE1B /* sk_rrect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_rrect.cpp; path = ../../../../externals/skia/src/c/sk_rrect.cpp; sourceTree = "<group>"; };
+		081C6FD46A34A7EB22243368 /* sk_runtimeeffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_runtimeeffect.cpp; path = ../../../../externals/skia/src/c/sk_runtimeeffect.cpp; sourceTree = "<group>"; };
+		1C09C4196F721E82F84788E8 /* sk_shader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_shader.cpp; path = ../../../../externals/skia/src/c/sk_shader.cpp; sourceTree = "<group>"; };
+		7F3F4A6C588F717A0E3FE201 /* sk_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_stream.cpp; path = ../../../../externals/skia/src/c/sk_stream.cpp; sourceTree = "<group>"; };
+		8CF12DB77FE694A4D480984E /* sk_string.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_string.cpp; path = ../../../../externals/skia/src/c/sk_string.cpp; sourceTree = "<group>"; };
+		7A5258AE59917D8BABF74CD2 /* sk_structs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_structs.cpp; path = ../../../../externals/skia/src/c/sk_structs.cpp; sourceTree = "<group>"; };
+		E33920571CE1ACEE28DA11A4 /* sk_surface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_surface.cpp; path = ../../../../externals/skia/src/c/sk_surface.cpp; sourceTree = "<group>"; };
+		E8B9B745CA39535F77B132F6 /* sk_svg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_svg.cpp; path = ../../../../externals/skia/src/c/sk_svg.cpp; sourceTree = "<group>"; };
+		463A8C1D181A4675B7F6E1D2 /* sk_textblob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_textblob.cpp; path = ../../../../externals/skia/src/c/sk_textblob.cpp; sourceTree = "<group>"; };
+		9B14D502D805175E54139082 /* sk_typeface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_typeface.cpp; path = ../../../../externals/skia/src/c/sk_typeface.cpp; sourceTree = "<group>"; };
+		DEA909A61CB287646A3D42EE /* sk_vertices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_vertices.cpp; path = ../../../../externals/skia/src/c/sk_vertices.cpp; sourceTree = "<group>"; };
+		A94B75B383D51830ABFB204C /* gr_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = gr_context.cpp; path = ../../../../externals/skia/src/c/gr_context.cpp; sourceTree = "<group>"; };
+		0DC7C53862594513F0CCD0A1 /* sk_linker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_linker.cpp; path = ../../../../externals/skia/src/c/sk_linker.cpp; sourceTree = "<group>"; };
+		34A43E0D21FA9CE77E6E8149 /* skottie_animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = skottie_animation.cpp; path = ../../../../externals/skia/src/c/skottie_animation.cpp; sourceTree = "<group>"; };
+		D3AE6963C23F56EB7EC9DBA8 /* skresources_resource_provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = skresources_resource_provider.cpp; path = ../../../../externals/skia/src/c/skresources_resource_provider.cpp; sourceTree = "<group>"; };
+		692148026B87185CB9A66299 /* sksg_invalidation_controller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sksg_invalidation_controller.cpp; path = ../../../../externals/skia/src/c/sksg_invalidation_controller.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +207,46 @@
 				34CB9AD2205699C300BACCBA /* SkManagedStream.h */,
 				34B07C3824EF0BE700FE3EC9 /* SkManagedTraceMemoryDump.cpp */,
 				34B07C3724EF0BE700FE3EC9 /* SkManagedTraceMemoryDump.h */,
+				A436F129B2D72F23786FD8D5 /* sk_bitmap.cpp */,
+				C1E79198D8EC2E89B6049CA4 /* sk_blender.cpp */,
+				125AF0368147B57D710D957B /* sk_canvas.cpp */,
+				C84ED81DAD7AFD65B34C8362 /* sk_codec.cpp */,
+				735EE57A975177517AA1EA25 /* sk_colorfilter.cpp */,
+				C1E99B4346CCD1927675BDBE /* sk_colorspace.cpp */,
+				B956D06324239ECA38A3D63F /* sk_data.cpp */,
+				8875B28293818C8FB19F48D1 /* sk_document.cpp */,
+				DE5FA207C756556BDF2C1305 /* sk_drawable.cpp */,
+				8BD447ADC1694593AA85CB27 /* sk_enums.cpp */,
+				AFF0EB39B1E7BAA7C21E5263 /* sk_font.cpp */,
+				9EE4ECBC3B3F161F3F82A7CC /* sk_general.cpp */,
+				70E32CACD33AA0A83A3C8C58 /* sk_graphics.cpp */,
+				B4ABA97D95B87D466DFAF09B /* sk_image.cpp */,
+				4CC43BB839125A44F1655511 /* sk_imagefilter.cpp */,
+				4C450A0A57074733846DB184 /* sk_maskfilter.cpp */,
+				014B02757286E7B2D99D13FA /* sk_matrix.cpp */,
+				3C71849F7359A27CD4B48972 /* sk_paint.cpp */,
+				090C203243337199C6FA7D99 /* sk_path.cpp */,
+				CFF10F3B1FA0CF3F2897BF3D /* sk_pathbuilder.cpp */,
+				A6C95EC3634EB81DAC32733F /* sk_patheffect.cpp */,
+				B9BB494AC90F41BDB4FE7F2D /* sk_picture.cpp */,
+				2C474BA3A3146F524ACA0B7D /* sk_pixmap.cpp */,
+				603D33C31742E1580DE4D174 /* sk_region.cpp */,
+				A6A9C8B6B639234194F1AE1B /* sk_rrect.cpp */,
+				081C6FD46A34A7EB22243368 /* sk_runtimeeffect.cpp */,
+				1C09C4196F721E82F84788E8 /* sk_shader.cpp */,
+				7F3F4A6C588F717A0E3FE201 /* sk_stream.cpp */,
+				8CF12DB77FE694A4D480984E /* sk_string.cpp */,
+				7A5258AE59917D8BABF74CD2 /* sk_structs.cpp */,
+				E33920571CE1ACEE28DA11A4 /* sk_surface.cpp */,
+				E8B9B745CA39535F77B132F6 /* sk_svg.cpp */,
+				463A8C1D181A4675B7F6E1D2 /* sk_textblob.cpp */,
+				9B14D502D805175E54139082 /* sk_typeface.cpp */,
+				DEA909A61CB287646A3D42EE /* sk_vertices.cpp */,
+				A94B75B383D51830ABFB204C /* gr_context.cpp */,
+				0DC7C53862594513F0CCD0A1 /* sk_linker.cpp */,
+				34A43E0D21FA9CE77E6E8149 /* skottie_animation.cpp */,
+				D3AE6963C23F56EB7EC9DBA8 /* skresources_resource_provider.cpp */,
+				692148026B87185CB9A66299 /* sksg_invalidation_controller.cpp */,
 			);
 			name = Source;
 			path = libSkiaSharp;
@@ -244,6 +364,46 @@
 				34CB9ACB205699BC00BACCBA /* sk_managedstream.cpp in Sources */,
 				3419BFE421D405B20067DAFB /* sk_manageddrawable.cpp in Sources */,
 				34CB9ACF205699BC00BACCBA /* SkiaKeeper.c in Sources */,
+				27331295A41050420606340D /* sk_bitmap.cpp in Sources */,
+				42DCDBB12CCC22ABE0EB2392 /* sk_blender.cpp in Sources */,
+				4B50BC3056D1CA999F929A62 /* sk_canvas.cpp in Sources */,
+				4C3BB23123B4090ABD7C0173 /* sk_codec.cpp in Sources */,
+				3CA61084AA27FB82D6DA195E /* sk_colorfilter.cpp in Sources */,
+				AA1B1C7EB9F941FBA9906B87 /* sk_colorspace.cpp in Sources */,
+				2C3FCE990D2475AD92E63B0E /* sk_data.cpp in Sources */,
+				45317D629A16B580A5355C3C /* sk_document.cpp in Sources */,
+				CCB44964DCDCBF145DCD5436 /* sk_drawable.cpp in Sources */,
+				9AC0F922078A293C955BD563 /* sk_enums.cpp in Sources */,
+				4A59D7316CE0B25C99305C14 /* sk_font.cpp in Sources */,
+				87B4E85B15FEAA7A9448BD24 /* sk_general.cpp in Sources */,
+				097E2CDA7FB80F1026B88073 /* sk_graphics.cpp in Sources */,
+				3BFEE2CE2E5256F8442C191D /* sk_image.cpp in Sources */,
+				FBD217F71B45C458740C771A /* sk_imagefilter.cpp in Sources */,
+				68EE5122EA95274C35ED0035 /* sk_maskfilter.cpp in Sources */,
+				B39D06A789355E46F4999341 /* sk_matrix.cpp in Sources */,
+				EC76571E8306F34DB173A1EA /* sk_paint.cpp in Sources */,
+				6A96F15281CF1D5D3D2D3E81 /* sk_path.cpp in Sources */,
+				B1041C2E0507C634BA138F0B /* sk_pathbuilder.cpp in Sources */,
+				2E6F434F8ECDFCBC667529CA /* sk_patheffect.cpp in Sources */,
+				19BF7BDA3E31316AEEBC3F81 /* sk_picture.cpp in Sources */,
+				154909BE57AAC648BA152917 /* sk_pixmap.cpp in Sources */,
+				BD031477CE7B9782C9B5F5C7 /* sk_region.cpp in Sources */,
+				42231955C2374EB9B4EE54B1 /* sk_rrect.cpp in Sources */,
+				ECEB46A5F0041D1AC75D8C92 /* sk_runtimeeffect.cpp in Sources */,
+				4A8708E249E9FECE0C65D843 /* sk_shader.cpp in Sources */,
+				9E11123975D05EC6C66BC747 /* sk_stream.cpp in Sources */,
+				8A53393C2B22CA6E6E1EF6A5 /* sk_string.cpp in Sources */,
+				FBECE543D1E37425BE6B7F4C /* sk_structs.cpp in Sources */,
+				08A274EB829BB7D8433BF197 /* sk_surface.cpp in Sources */,
+				9CCA186C8AC37BA9F09DF2AD /* sk_svg.cpp in Sources */,
+				68241C7F10E6B995B5B8A7CE /* sk_textblob.cpp in Sources */,
+				7B8A42961DE97FED7974C0E6 /* sk_typeface.cpp in Sources */,
+				3491D0C0D3022607F5A5CE81 /* sk_vertices.cpp in Sources */,
+				6F190DDE26F51F942921F296 /* gr_context.cpp in Sources */,
+				2746A06FACB645B97CC6203B /* sk_linker.cpp in Sources */,
+				C1DFED553FD4EBF2DF018EBF /* skottie_animation.cpp in Sources */,
+				6AB51532F9E89CB73F87E6FB /* skresources_resource_provider.cpp in Sources */,
+				5F3C5AFD82D1F2DEAC8ED44B /* sksg_invalidation_controller.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/ios/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -413,6 +413,9 @@
 		21FD2B361C014C000023CFAE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
@@ -492,6 +495,9 @@
 		21FD2B371C014C000023CFAE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
@@ -571,6 +577,9 @@
 		21FD2B391C014C000023CFAE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -602,6 +611,9 @@
 		21FD2B3A1C014C000023CFAE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -399,6 +399,9 @@
 		21C9515C1C03D27A003A1E1D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -466,6 +469,9 @@
 		21C9515D1C03D27A003A1E1D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -534,6 +540,9 @@
 		21C9515F1C03D27A003A1E1D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -558,6 +567,9 @@
 		21C951601C03D27A003A1E1D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/macos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -33,6 +33,46 @@
 		34C7D67923FFE9EB0044EF37 /* sk_compatpaint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34C7D67723FFE9EB0044EF37 /* sk_compatpaint.cpp */; };
 		34C7D67C23FFE9F20044EF37 /* sk_compatpaint.h in Headers */ = {isa = PBXBuildFile; fileRef = 34C7D67A23FFE9F20044EF37 /* sk_compatpaint.h */; };
 		34C7D67D23FFE9F20044EF37 /* SkCompatPaint.h in Headers */ = {isa = PBXBuildFile; fileRef = 34C7D67B23FFE9F20044EF37 /* SkCompatPaint.h */; };
+		C88E220124E9B29C41E716BC /* sk_bitmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3EE8269267C7CA47A6CBEA77 /* sk_bitmap.cpp */; };
+		DD79CD544D4219A20C7B85D0 /* sk_blender.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B768D85BD50755BAC683B89 /* sk_blender.cpp */; };
+		A0152B30CB7E2141C9E4E22B /* sk_canvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4BB9746C0EC103A77F858EC /* sk_canvas.cpp */; };
+		B11A797A13190B66A429902C /* sk_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F87B3AC5131CB56C411F17 /* sk_codec.cpp */; };
+		23024E039FCF406F3DB5816F /* sk_colorfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 481DED3A717CB0C63A360047 /* sk_colorfilter.cpp */; };
+		83BA228DED4DC8276034113C /* sk_colorspace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F20CDF99B4F0F72F26E906 /* sk_colorspace.cpp */; };
+		74F78BEDE333775D41C1F42A /* sk_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5624227C631F6044F4EB296C /* sk_data.cpp */; };
+		08C22D1D1A6B4358FDAC4E51 /* sk_document.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F0915409074C52E8E1D91FE2 /* sk_document.cpp */; };
+		7891A1460204370E533A9025 /* sk_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AA7BCE5EF9E0CF1236D6893 /* sk_drawable.cpp */; };
+		173630E089922072E0BDAA0A /* sk_enums.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3D70559F56A201B67F44AB1 /* sk_enums.cpp */; };
+		9D18E6F17B80089FE207FF5A /* sk_font.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8FB041840D54A69E8EB42 /* sk_font.cpp */; };
+		FC42240A83FDB8AAE30866D4 /* sk_general.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 503FB9D121159662C109E202 /* sk_general.cpp */; };
+		DCE8B2F602E6784C0EE61402 /* sk_graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EED5185D577F71E3B71EA850 /* sk_graphics.cpp */; };
+		1311710C5EB88D9FA4AFCC9C /* sk_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82422FC0C56697D22B289496 /* sk_image.cpp */; };
+		EF76F82C4A846E48D4506FA8 /* sk_imagefilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B274D55155B79289D7675975 /* sk_imagefilter.cpp */; };
+		4B897C217C4F035F35822D89 /* sk_maskfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 077469371825E129C0B860D3 /* sk_maskfilter.cpp */; };
+		E6F7A39C00FBA555C89222C2 /* sk_matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED402F67D383F455086296B5 /* sk_matrix.cpp */; };
+		E86AB63077B9B1EAE4E2F9CF /* sk_paint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC0A435578850B42C0602D11 /* sk_paint.cpp */; };
+		E980BC9C1F7249BFF4C5FC95 /* sk_path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5696266BF28A504ACD3EB570 /* sk_path.cpp */; };
+		150D65B864D18145CBA7EB08 /* sk_pathbuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3566FC627B4388947C907B1 /* sk_pathbuilder.cpp */; };
+		47F182C362C8EEEA5403973B /* sk_patheffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B054A13EE488F3B764B45243 /* sk_patheffect.cpp */; };
+		6435AB911AA635E7ED16F5CA /* sk_picture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A41C88C79D72B963182F713C /* sk_picture.cpp */; };
+		91CBB29EE96CCD4963DD6A49 /* sk_pixmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 299A215000D7D05B438839B4 /* sk_pixmap.cpp */; };
+		DEC7B632B4A0288F167B64BF /* sk_region.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C415044BC0BF465FB34B911 /* sk_region.cpp */; };
+		D246B0207A231369C005C0F1 /* sk_rrect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8DA307E1566D1CF81150610B /* sk_rrect.cpp */; };
+		FC12DED6C9BF4CF9BF80A0B6 /* sk_runtimeeffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A753CC5D0664F215D9F6CB /* sk_runtimeeffect.cpp */; };
+		656CC9CB44572E59CAEDB371 /* sk_shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 896366505B0BAE0918278D0F /* sk_shader.cpp */; };
+		AE3E7FF80F62DEEA6EF9A343 /* sk_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 605A7797C822DC70B647D58A /* sk_stream.cpp */; };
+		6645D0BE12E236656E461E2E /* sk_string.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B24C36098A9CECF8D36413FF /* sk_string.cpp */; };
+		BE2E85F6BB58A746049B8B2B /* sk_structs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A46616BD448D7D7447E6DF68 /* sk_structs.cpp */; };
+		A273DB6BF3FCA5F11F215DB6 /* sk_surface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8620BAEC66AFEF8690D64663 /* sk_surface.cpp */; };
+		616A7F3374EA42AF0E49E0DE /* sk_svg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AAE9EF89E712CCF93F45802 /* sk_svg.cpp */; };
+		2B733B893AEE254DB85F782F /* sk_textblob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8554F3D42A162EE6E80697C0 /* sk_textblob.cpp */; };
+		71B207473DFFD87CB574979E /* sk_typeface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF0D9001E46C88464988078E /* sk_typeface.cpp */; };
+		76FE90E2930E3D6473BBD9DF /* sk_vertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0EFCE341330202A30D134 /* sk_vertices.cpp */; };
+		93FF0CA0D8A83901E4E44010 /* gr_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D063E1088922EAE97625E331 /* gr_context.cpp */; };
+		2571809E304327531D70CDB9 /* sk_linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DEB834356A1A6B7FBB52EFF1 /* sk_linker.cpp */; };
+		1DDE09CB54E19715E0CCF1BA /* skottie_animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E4F771BA02CE18CBC30D25E /* skottie_animation.cpp */; };
+		452DF8B2502DCAAA2A848756 /* skresources_resource_provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3EAABBE16BD1827DFA30AF8B /* skresources_resource_provider.cpp */; };
+		6107D4AC1CC6771EF67C6C5D /* sksg_invalidation_controller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 872581999BD528CB61BB915A /* sksg_invalidation_controller.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -65,6 +105,46 @@
 		34C7D67723FFE9EB0044EF37 /* sk_compatpaint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_compatpaint.cpp; path = ../../../../externals/skia/src/xamarin/sk_compatpaint.cpp; sourceTree = "<group>"; };
 		34C7D67A23FFE9F20044EF37 /* sk_compatpaint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sk_compatpaint.h; path = ../../../../externals/skia/include/xamarin/sk_compatpaint.h; sourceTree = "<group>"; };
 		34C7D67B23FFE9F20044EF37 /* SkCompatPaint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SkCompatPaint.h; path = ../../../../externals/skia/include/xamarin/SkCompatPaint.h; sourceTree = "<group>"; };
+		3EE8269267C7CA47A6CBEA77 /* sk_bitmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_bitmap.cpp; path = ../../../../externals/skia/src/c/sk_bitmap.cpp; sourceTree = "<group>"; };
+		2B768D85BD50755BAC683B89 /* sk_blender.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_blender.cpp; path = ../../../../externals/skia/src/c/sk_blender.cpp; sourceTree = "<group>"; };
+		F4BB9746C0EC103A77F858EC /* sk_canvas.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_canvas.cpp; path = ../../../../externals/skia/src/c/sk_canvas.cpp; sourceTree = "<group>"; };
+		46F87B3AC5131CB56C411F17 /* sk_codec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_codec.cpp; path = ../../../../externals/skia/src/c/sk_codec.cpp; sourceTree = "<group>"; };
+		481DED3A717CB0C63A360047 /* sk_colorfilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_colorfilter.cpp; path = ../../../../externals/skia/src/c/sk_colorfilter.cpp; sourceTree = "<group>"; };
+		97F20CDF99B4F0F72F26E906 /* sk_colorspace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_colorspace.cpp; path = ../../../../externals/skia/src/c/sk_colorspace.cpp; sourceTree = "<group>"; };
+		5624227C631F6044F4EB296C /* sk_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_data.cpp; path = ../../../../externals/skia/src/c/sk_data.cpp; sourceTree = "<group>"; };
+		F0915409074C52E8E1D91FE2 /* sk_document.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_document.cpp; path = ../../../../externals/skia/src/c/sk_document.cpp; sourceTree = "<group>"; };
+		7AA7BCE5EF9E0CF1236D6893 /* sk_drawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_drawable.cpp; path = ../../../../externals/skia/src/c/sk_drawable.cpp; sourceTree = "<group>"; };
+		E3D70559F56A201B67F44AB1 /* sk_enums.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_enums.cpp; path = ../../../../externals/skia/src/c/sk_enums.cpp; sourceTree = "<group>"; };
+		8CD8FB041840D54A69E8EB42 /* sk_font.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_font.cpp; path = ../../../../externals/skia/src/c/sk_font.cpp; sourceTree = "<group>"; };
+		503FB9D121159662C109E202 /* sk_general.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_general.cpp; path = ../../../../externals/skia/src/c/sk_general.cpp; sourceTree = "<group>"; };
+		EED5185D577F71E3B71EA850 /* sk_graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_graphics.cpp; path = ../../../../externals/skia/src/c/sk_graphics.cpp; sourceTree = "<group>"; };
+		82422FC0C56697D22B289496 /* sk_image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_image.cpp; path = ../../../../externals/skia/src/c/sk_image.cpp; sourceTree = "<group>"; };
+		B274D55155B79289D7675975 /* sk_imagefilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_imagefilter.cpp; path = ../../../../externals/skia/src/c/sk_imagefilter.cpp; sourceTree = "<group>"; };
+		077469371825E129C0B860D3 /* sk_maskfilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_maskfilter.cpp; path = ../../../../externals/skia/src/c/sk_maskfilter.cpp; sourceTree = "<group>"; };
+		ED402F67D383F455086296B5 /* sk_matrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_matrix.cpp; path = ../../../../externals/skia/src/c/sk_matrix.cpp; sourceTree = "<group>"; };
+		DC0A435578850B42C0602D11 /* sk_paint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_paint.cpp; path = ../../../../externals/skia/src/c/sk_paint.cpp; sourceTree = "<group>"; };
+		5696266BF28A504ACD3EB570 /* sk_path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_path.cpp; path = ../../../../externals/skia/src/c/sk_path.cpp; sourceTree = "<group>"; };
+		E3566FC627B4388947C907B1 /* sk_pathbuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_pathbuilder.cpp; path = ../../../../externals/skia/src/c/sk_pathbuilder.cpp; sourceTree = "<group>"; };
+		B054A13EE488F3B764B45243 /* sk_patheffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_patheffect.cpp; path = ../../../../externals/skia/src/c/sk_patheffect.cpp; sourceTree = "<group>"; };
+		A41C88C79D72B963182F713C /* sk_picture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_picture.cpp; path = ../../../../externals/skia/src/c/sk_picture.cpp; sourceTree = "<group>"; };
+		299A215000D7D05B438839B4 /* sk_pixmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_pixmap.cpp; path = ../../../../externals/skia/src/c/sk_pixmap.cpp; sourceTree = "<group>"; };
+		0C415044BC0BF465FB34B911 /* sk_region.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_region.cpp; path = ../../../../externals/skia/src/c/sk_region.cpp; sourceTree = "<group>"; };
+		8DA307E1566D1CF81150610B /* sk_rrect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_rrect.cpp; path = ../../../../externals/skia/src/c/sk_rrect.cpp; sourceTree = "<group>"; };
+		C9A753CC5D0664F215D9F6CB /* sk_runtimeeffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_runtimeeffect.cpp; path = ../../../../externals/skia/src/c/sk_runtimeeffect.cpp; sourceTree = "<group>"; };
+		896366505B0BAE0918278D0F /* sk_shader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_shader.cpp; path = ../../../../externals/skia/src/c/sk_shader.cpp; sourceTree = "<group>"; };
+		605A7797C822DC70B647D58A /* sk_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_stream.cpp; path = ../../../../externals/skia/src/c/sk_stream.cpp; sourceTree = "<group>"; };
+		B24C36098A9CECF8D36413FF /* sk_string.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_string.cpp; path = ../../../../externals/skia/src/c/sk_string.cpp; sourceTree = "<group>"; };
+		A46616BD448D7D7447E6DF68 /* sk_structs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_structs.cpp; path = ../../../../externals/skia/src/c/sk_structs.cpp; sourceTree = "<group>"; };
+		8620BAEC66AFEF8690D64663 /* sk_surface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_surface.cpp; path = ../../../../externals/skia/src/c/sk_surface.cpp; sourceTree = "<group>"; };
+		0AAE9EF89E712CCF93F45802 /* sk_svg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_svg.cpp; path = ../../../../externals/skia/src/c/sk_svg.cpp; sourceTree = "<group>"; };
+		8554F3D42A162EE6E80697C0 /* sk_textblob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_textblob.cpp; path = ../../../../externals/skia/src/c/sk_textblob.cpp; sourceTree = "<group>"; };
+		EF0D9001E46C88464988078E /* sk_typeface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_typeface.cpp; path = ../../../../externals/skia/src/c/sk_typeface.cpp; sourceTree = "<group>"; };
+		8CC0EFCE341330202A30D134 /* sk_vertices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_vertices.cpp; path = ../../../../externals/skia/src/c/sk_vertices.cpp; sourceTree = "<group>"; };
+		D063E1088922EAE97625E331 /* gr_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = gr_context.cpp; path = ../../../../externals/skia/src/c/gr_context.cpp; sourceTree = "<group>"; };
+		DEB834356A1A6B7FBB52EFF1 /* sk_linker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_linker.cpp; path = ../../../../externals/skia/src/c/sk_linker.cpp; sourceTree = "<group>"; };
+		9E4F771BA02CE18CBC30D25E /* skottie_animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = skottie_animation.cpp; path = ../../../../externals/skia/src/c/skottie_animation.cpp; sourceTree = "<group>"; };
+		3EAABBE16BD1827DFA30AF8B /* skresources_resource_provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = skresources_resource_provider.cpp; path = ../../../../externals/skia/src/c/skresources_resource_provider.cpp; sourceTree = "<group>"; };
+		872581999BD528CB61BB915A /* sksg_invalidation_controller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sksg_invalidation_controller.cpp; path = ../../../../externals/skia/src/c/sksg_invalidation_controller.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +220,46 @@
 				3459E84B205698D2003EAD17 /* SkManagedStream.h */,
 				34565A1A24EF0CD3002C994A /* SkManagedTraceMemoryDump.cpp */,
 				34565A1D24EF0CD3002C994A /* SkManagedTraceMemoryDump.h */,
+				3EE8269267C7CA47A6CBEA77 /* sk_bitmap.cpp */,
+				2B768D85BD50755BAC683B89 /* sk_blender.cpp */,
+				F4BB9746C0EC103A77F858EC /* sk_canvas.cpp */,
+				46F87B3AC5131CB56C411F17 /* sk_codec.cpp */,
+				481DED3A717CB0C63A360047 /* sk_colorfilter.cpp */,
+				97F20CDF99B4F0F72F26E906 /* sk_colorspace.cpp */,
+				5624227C631F6044F4EB296C /* sk_data.cpp */,
+				F0915409074C52E8E1D91FE2 /* sk_document.cpp */,
+				7AA7BCE5EF9E0CF1236D6893 /* sk_drawable.cpp */,
+				E3D70559F56A201B67F44AB1 /* sk_enums.cpp */,
+				8CD8FB041840D54A69E8EB42 /* sk_font.cpp */,
+				503FB9D121159662C109E202 /* sk_general.cpp */,
+				EED5185D577F71E3B71EA850 /* sk_graphics.cpp */,
+				82422FC0C56697D22B289496 /* sk_image.cpp */,
+				B274D55155B79289D7675975 /* sk_imagefilter.cpp */,
+				077469371825E129C0B860D3 /* sk_maskfilter.cpp */,
+				ED402F67D383F455086296B5 /* sk_matrix.cpp */,
+				DC0A435578850B42C0602D11 /* sk_paint.cpp */,
+				5696266BF28A504ACD3EB570 /* sk_path.cpp */,
+				E3566FC627B4388947C907B1 /* sk_pathbuilder.cpp */,
+				B054A13EE488F3B764B45243 /* sk_patheffect.cpp */,
+				A41C88C79D72B963182F713C /* sk_picture.cpp */,
+				299A215000D7D05B438839B4 /* sk_pixmap.cpp */,
+				0C415044BC0BF465FB34B911 /* sk_region.cpp */,
+				8DA307E1566D1CF81150610B /* sk_rrect.cpp */,
+				C9A753CC5D0664F215D9F6CB /* sk_runtimeeffect.cpp */,
+				896366505B0BAE0918278D0F /* sk_shader.cpp */,
+				605A7797C822DC70B647D58A /* sk_stream.cpp */,
+				B24C36098A9CECF8D36413FF /* sk_string.cpp */,
+				A46616BD448D7D7447E6DF68 /* sk_structs.cpp */,
+				8620BAEC66AFEF8690D64663 /* sk_surface.cpp */,
+				0AAE9EF89E712CCF93F45802 /* sk_svg.cpp */,
+				8554F3D42A162EE6E80697C0 /* sk_textblob.cpp */,
+				EF0D9001E46C88464988078E /* sk_typeface.cpp */,
+				8CC0EFCE341330202A30D134 /* sk_vertices.cpp */,
+				D063E1088922EAE97625E331 /* gr_context.cpp */,
+				DEB834356A1A6B7FBB52EFF1 /* sk_linker.cpp */,
+				9E4F771BA02CE18CBC30D25E /* skottie_animation.cpp */,
+				3EAABBE16BD1827DFA30AF8B /* skresources_resource_provider.cpp */,
+				872581999BD528CB61BB915A /* sksg_invalidation_controller.cpp */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -230,6 +350,46 @@
 				3459E844205698C7003EAD17 /* sk_managedstream.cpp in Sources */,
 				346D1BC521D405D30066C82D /* sk_manageddrawable.cpp in Sources */,
 				3459E848205698C7003EAD17 /* SkiaKeeper.c in Sources */,
+				C88E220124E9B29C41E716BC /* sk_bitmap.cpp in Sources */,
+				DD79CD544D4219A20C7B85D0 /* sk_blender.cpp in Sources */,
+				A0152B30CB7E2141C9E4E22B /* sk_canvas.cpp in Sources */,
+				B11A797A13190B66A429902C /* sk_codec.cpp in Sources */,
+				23024E039FCF406F3DB5816F /* sk_colorfilter.cpp in Sources */,
+				83BA228DED4DC8276034113C /* sk_colorspace.cpp in Sources */,
+				74F78BEDE333775D41C1F42A /* sk_data.cpp in Sources */,
+				08C22D1D1A6B4358FDAC4E51 /* sk_document.cpp in Sources */,
+				7891A1460204370E533A9025 /* sk_drawable.cpp in Sources */,
+				173630E089922072E0BDAA0A /* sk_enums.cpp in Sources */,
+				9D18E6F17B80089FE207FF5A /* sk_font.cpp in Sources */,
+				FC42240A83FDB8AAE30866D4 /* sk_general.cpp in Sources */,
+				DCE8B2F602E6784C0EE61402 /* sk_graphics.cpp in Sources */,
+				1311710C5EB88D9FA4AFCC9C /* sk_image.cpp in Sources */,
+				EF76F82C4A846E48D4506FA8 /* sk_imagefilter.cpp in Sources */,
+				4B897C217C4F035F35822D89 /* sk_maskfilter.cpp in Sources */,
+				E6F7A39C00FBA555C89222C2 /* sk_matrix.cpp in Sources */,
+				E86AB63077B9B1EAE4E2F9CF /* sk_paint.cpp in Sources */,
+				E980BC9C1F7249BFF4C5FC95 /* sk_path.cpp in Sources */,
+				150D65B864D18145CBA7EB08 /* sk_pathbuilder.cpp in Sources */,
+				47F182C362C8EEEA5403973B /* sk_patheffect.cpp in Sources */,
+				6435AB911AA635E7ED16F5CA /* sk_picture.cpp in Sources */,
+				91CBB29EE96CCD4963DD6A49 /* sk_pixmap.cpp in Sources */,
+				DEC7B632B4A0288F167B64BF /* sk_region.cpp in Sources */,
+				D246B0207A231369C005C0F1 /* sk_rrect.cpp in Sources */,
+				FC12DED6C9BF4CF9BF80A0B6 /* sk_runtimeeffect.cpp in Sources */,
+				656CC9CB44572E59CAEDB371 /* sk_shader.cpp in Sources */,
+				AE3E7FF80F62DEEA6EF9A343 /* sk_stream.cpp in Sources */,
+				6645D0BE12E236656E461E2E /* sk_string.cpp in Sources */,
+				BE2E85F6BB58A746049B8B2B /* sk_structs.cpp in Sources */,
+				A273DB6BF3FCA5F11F215DB6 /* sk_surface.cpp in Sources */,
+				616A7F3374EA42AF0E49E0DE /* sk_svg.cpp in Sources */,
+				2B733B893AEE254DB85F782F /* sk_textblob.cpp in Sources */,
+				71B207473DFFD87CB574979E /* sk_typeface.cpp in Sources */,
+				76FE90E2930E3D6473BBD9DF /* sk_vertices.cpp in Sources */,
+				93FF0CA0D8A83901E4E44010 /* gr_context.cpp in Sources */,
+				2571809E304327531D70CDB9 /* sk_linker.cpp in Sources */,
+				1DDE09CB54E19715E0CCF1BA /* skottie_animation.cpp in Sources */,
+				452DF8B2502DCAAA2A848756 /* skresources_resource_provider.cpp in Sources */,
+				6107D4AC1CC6771EF67C6C5D /* sksg_invalidation_controller.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native/tizen/libSkiaSharp/project_def.prop
+++ b/native/tizen/libSkiaSharp/project_def.prop
@@ -59,4 +59,44 @@ USER_SRCS = $(skia_root)/src/xamarin/sk_xamarin.cpp                 \
             $(skia_root)/src/xamarin/sk_manageddrawable.cpp         \
             $(skia_root)/src/xamarin/SkManagedDrawable.cpp          \
             $(skia_root)/src/xamarin/sk_managedtracememorydump.cpp  \
-            $(skia_root)/src/xamarin/SkManagedTraceMemoryDump.cpp
+            $(skia_root)/src/xamarin/SkManagedTraceMemoryDump.cpp   \
+            $(skia_root)/src/c/sk_bitmap.cpp                        \
+            $(skia_root)/src/c/sk_blender.cpp                       \
+            $(skia_root)/src/c/sk_canvas.cpp                        \
+            $(skia_root)/src/c/sk_codec.cpp                         \
+            $(skia_root)/src/c/sk_colorfilter.cpp                   \
+            $(skia_root)/src/c/sk_colorspace.cpp                    \
+            $(skia_root)/src/c/sk_data.cpp                          \
+            $(skia_root)/src/c/sk_document.cpp                      \
+            $(skia_root)/src/c/sk_drawable.cpp                      \
+            $(skia_root)/src/c/sk_enums.cpp                         \
+            $(skia_root)/src/c/sk_font.cpp                          \
+            $(skia_root)/src/c/sk_general.cpp                       \
+            $(skia_root)/src/c/sk_graphics.cpp                      \
+            $(skia_root)/src/c/sk_image.cpp                         \
+            $(skia_root)/src/c/sk_imagefilter.cpp                   \
+            $(skia_root)/src/c/sk_maskfilter.cpp                    \
+            $(skia_root)/src/c/sk_matrix.cpp                        \
+            $(skia_root)/src/c/sk_paint.cpp                         \
+            $(skia_root)/src/c/sk_path.cpp                          \
+            $(skia_root)/src/c/sk_pathbuilder.cpp                   \
+            $(skia_root)/src/c/sk_patheffect.cpp                    \
+            $(skia_root)/src/c/sk_picture.cpp                       \
+            $(skia_root)/src/c/sk_pixmap.cpp                        \
+            $(skia_root)/src/c/sk_region.cpp                        \
+            $(skia_root)/src/c/sk_rrect.cpp                         \
+            $(skia_root)/src/c/sk_runtimeeffect.cpp                 \
+            $(skia_root)/src/c/sk_shader.cpp                        \
+            $(skia_root)/src/c/sk_stream.cpp                        \
+            $(skia_root)/src/c/sk_string.cpp                        \
+            $(skia_root)/src/c/sk_structs.cpp                       \
+            $(skia_root)/src/c/sk_surface.cpp                       \
+            $(skia_root)/src/c/sk_svg.cpp                           \
+            $(skia_root)/src/c/sk_textblob.cpp                      \
+            $(skia_root)/src/c/sk_typeface.cpp                      \
+            $(skia_root)/src/c/sk_vertices.cpp                      \
+            $(skia_root)/src/c/gr_context.cpp                       \
+            $(skia_root)/src/c/sk_linker.cpp                        \
+            $(skia_root)/src/c/skottie_animation.cpp               \
+            $(skia_root)/src/c/skresources_resource_provider.cpp    \
+            $(skia_root)/src/c/sksg_invalidation_controller.cpp

--- a/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -413,6 +413,9 @@
 		21FD2B361C014C000023CFAE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -494,6 +497,9 @@
 		21FD2B371C014C000023CFAE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -575,6 +581,9 @@
 		21FD2B391C014C000023CFAE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -602,6 +611,9 @@
 		21FD2B3A1C014C000023CFAE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_CFLAGS = (
+					"-Werror=deprecated-declarations",
+				);
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
+++ b/native/tvos/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj
@@ -34,6 +34,46 @@
 		34DFD1DB24EF0C2700C61EC6 /* sk_managedtracememorydump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34DFD1D724EF0C2600C61EC6 /* sk_managedtracememorydump.cpp */; };
 		34DFD1DC24EF0C2700C61EC6 /* SkManagedTraceMemoryDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34DFD1D824EF0C2700C61EC6 /* SkManagedTraceMemoryDump.cpp */; };
 		34E9DA112A8183FC00DA8E2F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34E9DA102A8183FC00DA8E2F /* Foundation.framework */; };
+		2AC9764360955F865C3DAE53 /* sk_bitmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB1482D2D511B587CFAB2611 /* sk_bitmap.cpp */; };
+		7D3A81A10F18145D7E9E0228 /* sk_blender.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA321F80F4009AC276DE6F88 /* sk_blender.cpp */; };
+		C7D50268B71DD1951D6384E6 /* sk_canvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D61F9EB9493434E8BCA08F82 /* sk_canvas.cpp */; };
+		70C0A626F76894631EA61BEA /* sk_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CFEE7E46B07EC775B3B101BC /* sk_codec.cpp */; };
+		06157E178E53B3CB9F024B49 /* sk_colorfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD45E553EF1B9E46B4CB7C20 /* sk_colorfilter.cpp */; };
+		6A6A435BFC141D79DBB10C78 /* sk_colorspace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DBD963A191365878D35F486E /* sk_colorspace.cpp */; };
+		0CE76F12B4D012FAFE65BCDB /* sk_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB1D34CD7B4463933457D75B /* sk_data.cpp */; };
+		F0A7CFEC2F77C24F65D2D9F5 /* sk_document.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 714F9A659D9F092DC43289A0 /* sk_document.cpp */; };
+		0028F484CEEE170AFF299B56 /* sk_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6D0D381A0C86615AA407E35C /* sk_drawable.cpp */; };
+		DB3681E0E6962C662A4C6221 /* sk_enums.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1307C52F19F3961CCB47B9B5 /* sk_enums.cpp */; };
+		3C581AB39C0ACA63CBB4DF4C /* sk_font.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D83390317831D16C59855ED1 /* sk_font.cpp */; };
+		D1836E665536CDC3D1E698F3 /* sk_general.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 24C4801B28386B52F4FB31C6 /* sk_general.cpp */; };
+		0A2C8DB0A5A88F87F71A2A7B /* sk_graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E66C55D23CCCD44663474D95 /* sk_graphics.cpp */; };
+		9D8ECCEB69D18D20CA79A086 /* sk_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1BE335434C6832BC0BC25CF /* sk_image.cpp */; };
+		E7FAC080DDA08A0603270D53 /* sk_imagefilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F470878009C625E2892710 /* sk_imagefilter.cpp */; };
+		21E72E178E69099BBA2D795D /* sk_maskfilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 92614301B1315027EE39A244 /* sk_maskfilter.cpp */; };
+		2F27C02AB692A5E77C3A8240 /* sk_matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49E60B8DFB57CE754A903310 /* sk_matrix.cpp */; };
+		49DDD725C10C9A553143886F /* sk_paint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE544B4B59AEB4F7235E6340 /* sk_paint.cpp */; };
+		82211544DD9FF5EB70849808 /* sk_path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E2D9AED55D4E865F57417467 /* sk_path.cpp */; };
+		7BEA6D2E13C00158135A333C /* sk_pathbuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72A190FF9B2D865B464750B8 /* sk_pathbuilder.cpp */; };
+		B2F895FA1B6C0C2C6025AA28 /* sk_patheffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2909FB96CE79123914D56C1B /* sk_patheffect.cpp */; };
+		E9A4C3A1FC3EB39405B231B2 /* sk_picture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC003E220CB3DA813500246E /* sk_picture.cpp */; };
+		C256412E384403DC4F97C7D4 /* sk_pixmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B39925370C2B1CC107BF27BF /* sk_pixmap.cpp */; };
+		E18E5B8B9AFF846CDCC10404 /* sk_region.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FADE03A79FB2D4E6D467DFDC /* sk_region.cpp */; };
+		D094376DAEF8B79EAC46B3F5 /* sk_rrect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3E8018C3A84743E36F04716D /* sk_rrect.cpp */; };
+		B92D632EFB0202F22CA6B073 /* sk_runtimeeffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EAF3E88D9426FDF19C322061 /* sk_runtimeeffect.cpp */; };
+		1D501D28400868A46841ED30 /* sk_shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 830C5C188B12A702846244E8 /* sk_shader.cpp */; };
+		BF708497C3B52A1275112D46 /* sk_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E0705EFBD8CF738CDE2B839E /* sk_stream.cpp */; };
+		8C66A0F876EC281DD3188B2C /* sk_string.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38526F9B935A345FC8343C6F /* sk_string.cpp */; };
+		86F23AFC15CAEB319F0EDA08 /* sk_structs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE2B163F2FF6170819D69EB9 /* sk_structs.cpp */; };
+		BE602B0418CD29D10666CDA5 /* sk_surface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 751A39E30DB76743BC87D1D8 /* sk_surface.cpp */; };
+		3789D0CA4E87924CA5296533 /* sk_svg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CCAC4AE05849181C5D8F2FC3 /* sk_svg.cpp */; };
+		E69D3DD4182BE0755971BF9E /* sk_textblob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2556FB4A5C6A1372F18CD8B3 /* sk_textblob.cpp */; };
+		F34FDDAF0B6234B8B50A0FC8 /* sk_typeface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8A5BEDEE638878A6AF7948D4 /* sk_typeface.cpp */; };
+		51F5EAD0AA511179EB47D010 /* sk_vertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DD56C3D0E432BAED8FACC34 /* sk_vertices.cpp */; };
+		C86E0C5499037A4CEDC1F8ED /* gr_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72189756CBCBEADDED1988E2 /* gr_context.cpp */; };
+		9B1A69F095107678D328A53D /* sk_linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 183D68EA1BC20A7F6B5A01BD /* sk_linker.cpp */; };
+		DC526673A344025A6053826C /* skottie_animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2FA068096FBA110C9DA902BE /* skottie_animation.cpp */; };
+		88D9FA916D9E596CDAA5C941 /* skresources_resource_provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5F7D9A612485AACDA64FD0F7 /* skresources_resource_provider.cpp */; };
+		6468A943CA54DEFF306144F7 /* sksg_invalidation_controller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EDD706547CF00F163494C546 /* sksg_invalidation_controller.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +106,46 @@
 		34DFD1D724EF0C2600C61EC6 /* sk_managedtracememorydump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_managedtracememorydump.cpp; path = ../../../../externals/skia/src/xamarin/sk_managedtracememorydump.cpp; sourceTree = "<group>"; };
 		34DFD1D824EF0C2700C61EC6 /* SkManagedTraceMemoryDump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SkManagedTraceMemoryDump.cpp; path = ../../../../externals/skia/src/xamarin/SkManagedTraceMemoryDump.cpp; sourceTree = "<group>"; };
 		34E9DA102A8183FC00DA8E2F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		EB1482D2D511B587CFAB2611 /* sk_bitmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_bitmap.cpp; path = ../../../../externals/skia/src/c/sk_bitmap.cpp; sourceTree = "<group>"; };
+		CA321F80F4009AC276DE6F88 /* sk_blender.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_blender.cpp; path = ../../../../externals/skia/src/c/sk_blender.cpp; sourceTree = "<group>"; };
+		D61F9EB9493434E8BCA08F82 /* sk_canvas.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_canvas.cpp; path = ../../../../externals/skia/src/c/sk_canvas.cpp; sourceTree = "<group>"; };
+		CFEE7E46B07EC775B3B101BC /* sk_codec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_codec.cpp; path = ../../../../externals/skia/src/c/sk_codec.cpp; sourceTree = "<group>"; };
+		BD45E553EF1B9E46B4CB7C20 /* sk_colorfilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_colorfilter.cpp; path = ../../../../externals/skia/src/c/sk_colorfilter.cpp; sourceTree = "<group>"; };
+		DBD963A191365878D35F486E /* sk_colorspace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_colorspace.cpp; path = ../../../../externals/skia/src/c/sk_colorspace.cpp; sourceTree = "<group>"; };
+		EB1D34CD7B4463933457D75B /* sk_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_data.cpp; path = ../../../../externals/skia/src/c/sk_data.cpp; sourceTree = "<group>"; };
+		714F9A659D9F092DC43289A0 /* sk_document.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_document.cpp; path = ../../../../externals/skia/src/c/sk_document.cpp; sourceTree = "<group>"; };
+		6D0D381A0C86615AA407E35C /* sk_drawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_drawable.cpp; path = ../../../../externals/skia/src/c/sk_drawable.cpp; sourceTree = "<group>"; };
+		1307C52F19F3961CCB47B9B5 /* sk_enums.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_enums.cpp; path = ../../../../externals/skia/src/c/sk_enums.cpp; sourceTree = "<group>"; };
+		D83390317831D16C59855ED1 /* sk_font.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_font.cpp; path = ../../../../externals/skia/src/c/sk_font.cpp; sourceTree = "<group>"; };
+		24C4801B28386B52F4FB31C6 /* sk_general.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_general.cpp; path = ../../../../externals/skia/src/c/sk_general.cpp; sourceTree = "<group>"; };
+		E66C55D23CCCD44663474D95 /* sk_graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_graphics.cpp; path = ../../../../externals/skia/src/c/sk_graphics.cpp; sourceTree = "<group>"; };
+		E1BE335434C6832BC0BC25CF /* sk_image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_image.cpp; path = ../../../../externals/skia/src/c/sk_image.cpp; sourceTree = "<group>"; };
+		83F470878009C625E2892710 /* sk_imagefilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_imagefilter.cpp; path = ../../../../externals/skia/src/c/sk_imagefilter.cpp; sourceTree = "<group>"; };
+		92614301B1315027EE39A244 /* sk_maskfilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_maskfilter.cpp; path = ../../../../externals/skia/src/c/sk_maskfilter.cpp; sourceTree = "<group>"; };
+		49E60B8DFB57CE754A903310 /* sk_matrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_matrix.cpp; path = ../../../../externals/skia/src/c/sk_matrix.cpp; sourceTree = "<group>"; };
+		FE544B4B59AEB4F7235E6340 /* sk_paint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_paint.cpp; path = ../../../../externals/skia/src/c/sk_paint.cpp; sourceTree = "<group>"; };
+		E2D9AED55D4E865F57417467 /* sk_path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_path.cpp; path = ../../../../externals/skia/src/c/sk_path.cpp; sourceTree = "<group>"; };
+		72A190FF9B2D865B464750B8 /* sk_pathbuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_pathbuilder.cpp; path = ../../../../externals/skia/src/c/sk_pathbuilder.cpp; sourceTree = "<group>"; };
+		2909FB96CE79123914D56C1B /* sk_patheffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_patheffect.cpp; path = ../../../../externals/skia/src/c/sk_patheffect.cpp; sourceTree = "<group>"; };
+		DC003E220CB3DA813500246E /* sk_picture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_picture.cpp; path = ../../../../externals/skia/src/c/sk_picture.cpp; sourceTree = "<group>"; };
+		B39925370C2B1CC107BF27BF /* sk_pixmap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_pixmap.cpp; path = ../../../../externals/skia/src/c/sk_pixmap.cpp; sourceTree = "<group>"; };
+		FADE03A79FB2D4E6D467DFDC /* sk_region.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_region.cpp; path = ../../../../externals/skia/src/c/sk_region.cpp; sourceTree = "<group>"; };
+		3E8018C3A84743E36F04716D /* sk_rrect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_rrect.cpp; path = ../../../../externals/skia/src/c/sk_rrect.cpp; sourceTree = "<group>"; };
+		EAF3E88D9426FDF19C322061 /* sk_runtimeeffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_runtimeeffect.cpp; path = ../../../../externals/skia/src/c/sk_runtimeeffect.cpp; sourceTree = "<group>"; };
+		830C5C188B12A702846244E8 /* sk_shader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_shader.cpp; path = ../../../../externals/skia/src/c/sk_shader.cpp; sourceTree = "<group>"; };
+		E0705EFBD8CF738CDE2B839E /* sk_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_stream.cpp; path = ../../../../externals/skia/src/c/sk_stream.cpp; sourceTree = "<group>"; };
+		38526F9B935A345FC8343C6F /* sk_string.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_string.cpp; path = ../../../../externals/skia/src/c/sk_string.cpp; sourceTree = "<group>"; };
+		DE2B163F2FF6170819D69EB9 /* sk_structs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_structs.cpp; path = ../../../../externals/skia/src/c/sk_structs.cpp; sourceTree = "<group>"; };
+		751A39E30DB76743BC87D1D8 /* sk_surface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_surface.cpp; path = ../../../../externals/skia/src/c/sk_surface.cpp; sourceTree = "<group>"; };
+		CCAC4AE05849181C5D8F2FC3 /* sk_svg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_svg.cpp; path = ../../../../externals/skia/src/c/sk_svg.cpp; sourceTree = "<group>"; };
+		2556FB4A5C6A1372F18CD8B3 /* sk_textblob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_textblob.cpp; path = ../../../../externals/skia/src/c/sk_textblob.cpp; sourceTree = "<group>"; };
+		8A5BEDEE638878A6AF7948D4 /* sk_typeface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_typeface.cpp; path = ../../../../externals/skia/src/c/sk_typeface.cpp; sourceTree = "<group>"; };
+		1DD56C3D0E432BAED8FACC34 /* sk_vertices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_vertices.cpp; path = ../../../../externals/skia/src/c/sk_vertices.cpp; sourceTree = "<group>"; };
+		72189756CBCBEADDED1988E2 /* gr_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = gr_context.cpp; path = ../../../../externals/skia/src/c/gr_context.cpp; sourceTree = "<group>"; };
+		183D68EA1BC20A7F6B5A01BD /* sk_linker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sk_linker.cpp; path = ../../../../externals/skia/src/c/sk_linker.cpp; sourceTree = "<group>"; };
+		2FA068096FBA110C9DA902BE /* skottie_animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = skottie_animation.cpp; path = ../../../../externals/skia/src/c/skottie_animation.cpp; sourceTree = "<group>"; };
+		5F7D9A612485AACDA64FD0F7 /* skresources_resource_provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = skresources_resource_provider.cpp; path = ../../../../externals/skia/src/c/skresources_resource_provider.cpp; sourceTree = "<group>"; };
+		EDD706547CF00F163494C546 /* sksg_invalidation_controller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sksg_invalidation_controller.cpp; path = ../../../../externals/skia/src/c/sksg_invalidation_controller.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +207,46 @@
 				34838CF820569A1A009CB8D9 /* SkManagedStream.h */,
 				34DFD1D824EF0C2700C61EC6 /* SkManagedTraceMemoryDump.cpp */,
 				34DFD1D524EF0C2600C61EC6 /* SkManagedTraceMemoryDump.h */,
+				EB1482D2D511B587CFAB2611 /* sk_bitmap.cpp */,
+				CA321F80F4009AC276DE6F88 /* sk_blender.cpp */,
+				D61F9EB9493434E8BCA08F82 /* sk_canvas.cpp */,
+				CFEE7E46B07EC775B3B101BC /* sk_codec.cpp */,
+				BD45E553EF1B9E46B4CB7C20 /* sk_colorfilter.cpp */,
+				DBD963A191365878D35F486E /* sk_colorspace.cpp */,
+				EB1D34CD7B4463933457D75B /* sk_data.cpp */,
+				714F9A659D9F092DC43289A0 /* sk_document.cpp */,
+				6D0D381A0C86615AA407E35C /* sk_drawable.cpp */,
+				1307C52F19F3961CCB47B9B5 /* sk_enums.cpp */,
+				D83390317831D16C59855ED1 /* sk_font.cpp */,
+				24C4801B28386B52F4FB31C6 /* sk_general.cpp */,
+				E66C55D23CCCD44663474D95 /* sk_graphics.cpp */,
+				E1BE335434C6832BC0BC25CF /* sk_image.cpp */,
+				83F470878009C625E2892710 /* sk_imagefilter.cpp */,
+				92614301B1315027EE39A244 /* sk_maskfilter.cpp */,
+				49E60B8DFB57CE754A903310 /* sk_matrix.cpp */,
+				FE544B4B59AEB4F7235E6340 /* sk_paint.cpp */,
+				E2D9AED55D4E865F57417467 /* sk_path.cpp */,
+				72A190FF9B2D865B464750B8 /* sk_pathbuilder.cpp */,
+				2909FB96CE79123914D56C1B /* sk_patheffect.cpp */,
+				DC003E220CB3DA813500246E /* sk_picture.cpp */,
+				B39925370C2B1CC107BF27BF /* sk_pixmap.cpp */,
+				FADE03A79FB2D4E6D467DFDC /* sk_region.cpp */,
+				3E8018C3A84743E36F04716D /* sk_rrect.cpp */,
+				EAF3E88D9426FDF19C322061 /* sk_runtimeeffect.cpp */,
+				830C5C188B12A702846244E8 /* sk_shader.cpp */,
+				E0705EFBD8CF738CDE2B839E /* sk_stream.cpp */,
+				38526F9B935A345FC8343C6F /* sk_string.cpp */,
+				DE2B163F2FF6170819D69EB9 /* sk_structs.cpp */,
+				751A39E30DB76743BC87D1D8 /* sk_surface.cpp */,
+				CCAC4AE05849181C5D8F2FC3 /* sk_svg.cpp */,
+				2556FB4A5C6A1372F18CD8B3 /* sk_textblob.cpp */,
+				8A5BEDEE638878A6AF7948D4 /* sk_typeface.cpp */,
+				1DD56C3D0E432BAED8FACC34 /* sk_vertices.cpp */,
+				72189756CBCBEADDED1988E2 /* gr_context.cpp */,
+				183D68EA1BC20A7F6B5A01BD /* sk_linker.cpp */,
+				2FA068096FBA110C9DA902BE /* skottie_animation.cpp */,
+				5F7D9A612485AACDA64FD0F7 /* skresources_resource_provider.cpp */,
+				EDD706547CF00F163494C546 /* sksg_invalidation_controller.cpp */,
 			);
 			name = Source;
 			path = libSkiaSharp;
@@ -244,6 +364,46 @@
 				34838CF120569A14009CB8D9 /* sk_managedstream.cpp in Sources */,
 				34A5548621D405F000F06E1B /* sk_manageddrawable.cpp in Sources */,
 				34838CF520569A14009CB8D9 /* SkiaKeeper.c in Sources */,
+				2AC9764360955F865C3DAE53 /* sk_bitmap.cpp in Sources */,
+				7D3A81A10F18145D7E9E0228 /* sk_blender.cpp in Sources */,
+				C7D50268B71DD1951D6384E6 /* sk_canvas.cpp in Sources */,
+				70C0A626F76894631EA61BEA /* sk_codec.cpp in Sources */,
+				06157E178E53B3CB9F024B49 /* sk_colorfilter.cpp in Sources */,
+				6A6A435BFC141D79DBB10C78 /* sk_colorspace.cpp in Sources */,
+				0CE76F12B4D012FAFE65BCDB /* sk_data.cpp in Sources */,
+				F0A7CFEC2F77C24F65D2D9F5 /* sk_document.cpp in Sources */,
+				0028F484CEEE170AFF299B56 /* sk_drawable.cpp in Sources */,
+				DB3681E0E6962C662A4C6221 /* sk_enums.cpp in Sources */,
+				3C581AB39C0ACA63CBB4DF4C /* sk_font.cpp in Sources */,
+				D1836E665536CDC3D1E698F3 /* sk_general.cpp in Sources */,
+				0A2C8DB0A5A88F87F71A2A7B /* sk_graphics.cpp in Sources */,
+				9D8ECCEB69D18D20CA79A086 /* sk_image.cpp in Sources */,
+				E7FAC080DDA08A0603270D53 /* sk_imagefilter.cpp in Sources */,
+				21E72E178E69099BBA2D795D /* sk_maskfilter.cpp in Sources */,
+				2F27C02AB692A5E77C3A8240 /* sk_matrix.cpp in Sources */,
+				49DDD725C10C9A553143886F /* sk_paint.cpp in Sources */,
+				82211544DD9FF5EB70849808 /* sk_path.cpp in Sources */,
+				7BEA6D2E13C00158135A333C /* sk_pathbuilder.cpp in Sources */,
+				B2F895FA1B6C0C2C6025AA28 /* sk_patheffect.cpp in Sources */,
+				E9A4C3A1FC3EB39405B231B2 /* sk_picture.cpp in Sources */,
+				C256412E384403DC4F97C7D4 /* sk_pixmap.cpp in Sources */,
+				E18E5B8B9AFF846CDCC10404 /* sk_region.cpp in Sources */,
+				D094376DAEF8B79EAC46B3F5 /* sk_rrect.cpp in Sources */,
+				B92D632EFB0202F22CA6B073 /* sk_runtimeeffect.cpp in Sources */,
+				1D501D28400868A46841ED30 /* sk_shader.cpp in Sources */,
+				BF708497C3B52A1275112D46 /* sk_stream.cpp in Sources */,
+				8C66A0F876EC281DD3188B2C /* sk_string.cpp in Sources */,
+				86F23AFC15CAEB319F0EDA08 /* sk_structs.cpp in Sources */,
+				BE602B0418CD29D10666CDA5 /* sk_surface.cpp in Sources */,
+				3789D0CA4E87924CA5296533 /* sk_svg.cpp in Sources */,
+				E69D3DD4182BE0755971BF9E /* sk_textblob.cpp in Sources */,
+				F34FDDAF0B6234B8B50A0FC8 /* sk_typeface.cpp in Sources */,
+				51F5EAD0AA511179EB47D010 /* sk_vertices.cpp in Sources */,
+				C86E0C5499037A4CEDC1F8ED /* gr_context.cpp in Sources */,
+				9B1A69F095107678D328A53D /* sk_linker.cpp in Sources */,
+				DC526673A344025A6053826C /* skottie_animation.cpp in Sources */,
+				88D9FA916D9E596CDAA5C941 /* skresources_resource_provider.cpp in Sources */,
+				6468A943CA54DEFF306144F7 /* sksg_invalidation_controller.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

Parent-repo side of the change that compiles SkiaSharp's fork-owned C API shim (`externals/skia/src/c/*.cpp`) in the `libSkiaSharp` target on **every** platform, instead of injecting it into upstream Skia's `:core` GN target.

- The GN graph change lives in the submodule: mono/skia#251 (this PR bumps `externals/skia` to it).
- This PR updates the **non-GN** native builds (Apple xcodeprojs, Tizen makefile) to match, and adds deprecation enforcement where GN can't reach.

See mono/skia#251 for the full motivation (the m148 `:fontmgr_fontconfig` / `SK_FONTMGR_FONTCONFIG_AVAILABLE` regression that this architecturally fixes).

## Why the non-GN builds need separate changes

`libSkiaSharp` is produced by **three** independent build systems:

| Build system | Platforms | Compiles `src/c`? |
| --- | --- | --- |
| GN (`externals/skia/BUILD.gn`) | Linux, Windows, WASM, Android | now in `skiasharp_build("SkiaSharp")` (mono/skia#251) |
| Xcode (`*.xcodeproj`) | macOS, iOS, tvOS, **Mac Catalyst** (reuses the ios project) | listed in `project.pbxproj` Sources |
| Tizen makefile (`project_def.prop`) | Tizen | listed in `USER_SRCS` |

The Apple/Tizen builds compile our shim directly and link a prebuilt `libskia.a`, so the GN source-list move doesn't propagate to them automatically — they each carry their own copy of the list.

## Changes

### `externals/skia` submodule
- Bumped to mono/skia#251: `src/c` moved into `libSkiaSharp`; the two dead `:core` workarounds removed; deprecated-`SkPathOps` usages in `sk_path.cpp` fixed; GN warnings/deprecation guardrail added; C API public header list completed.

### Apple xcodeprojs — `native/{macos,ios,tvos}/libSkiaSharp/libSkiaSharp.xcodeproj/project.pbxproj`
- Added the 40 `src/c/*.cpp` sources to each project's Sources build phase (previously they came from `:core` indirectly; now they're explicit, matching the GN move). Covers macOS, iOS, tvOS, and Mac Catalyst (which reuses the ios project via `native/maccatalyst/build.cake`).
- Added `OTHER_CFLAGS = -Werror=deprecated-declarations` to **all four** build configurations in **each** of the three projects. These targets build via `xcodebuild` (not GN), so the GN-side guardrail doesn't apply — without this, deprecated-API usage only warned and the build still succeeded. They compile only our `src/c` + `src/xamarin` shim (upstream Skia is a prebuilt static lib), so the scope is exactly our own sources.

### Tizen — `native/tizen/libSkiaSharp/project_def.prop`
- Added the `src/c/*.cpp` sources to `USER_SRCS`. (Tizen's makefile already builds with `-Wall -Wextra -Werror`, which is what first caught the deprecated `TightBounds` usage.)

## Deprecation enforcement is now consistent everywhere

| Build system | Mechanism |
| --- | --- |
| GN (Linux/Windows/WASM/Android) | `:skiasharp_strict` config → `-Werror=deprecated-declarations` (mono/skia#251) |
| Xcode (macOS/iOS/tvOS/MacCatalyst) | `OTHER_CFLAGS = -Werror=deprecated-declarations` (this PR) |
| Tizen | existing `-Werror` |

## Validation

- **macOS arm64** (native xcodebuild): ARCHIVE SUCCEEDED; real 7.3 MB dylib.
- **Deprecation guardrail proven on macOS**: with the deprecated `TightBounds` call restored, `dotnet cake --target=externals-macos` fails (exit 65) with `error: 'TightBounds' is deprecated [-Werror,-Wdeprecated-declarations]`; with the fix it builds clean.
- **Linux x64** (Docker): clean; fontconfig regression guard passes (non-empty default typeface).
- Tests: SkiaSharp.Tests.Console pass.

## Merge order
Merge mono/skia#251 first, then this PR will point at the merged submodule SHA.