### PR TITLE
[skia-sync] Merge upstream chrome/m147 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "bf112f783f3389c414bf1bf9003dc6d8fbd3e7fe"
+          "commitHash": "4c9e5002d7bfb25b897708198181ae628f4e24a3"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m147.



# mono/SkiaSharp PR Summary

## Sync Type
Same-milestone sync: **m147 → m147** (bug-fix / metadata correction)

## What Changed

### cgmanifest.json
Updated `commitHash` for the `mono/skia` component governance entry:
- **Before:** `bf112f783f3389c414bf1bf9003dc6d8fbd3e7fe` (initial scaffold commit)
- **After:** `4c9e5002d7bfb25b897708198181ae628f4e24a3` (current HEAD of `skiasharp` branch, includes expat 2.8.1 update)

The stale hash was introduced in #4079 (Update expat to 2.8.1), which advanced the submodule but only updated the expat CG entry, not the main `mono/skia` reference entry.

### Breaking Change Analysis
| Change | Risk | Action |
|--------|------|--------|
| No upstream C++ changes | N/A | No action needed |
| No C API changes | N/A | No action needed |

### Version/Binding Updates
- No version number changes (same milestone m147)
- No binding regeneration required (C API unchanged)
- No C# wrapper changes required

## Build Results
- **Platform:** Linux x64
- **Native build:** ✅ Clean (libSkiaSharp.so + libHarfBuzzSharp.so produced)
- **C# build:** ✅ 0 errors, 0 warnings on public API

## Test Results
```
Passed!  - Failed: 0, Passed: 5450, Skipped: 171, Total: 5621
```
Skipped tests: GPU hardware not available (expected in CI environment).

## Items Needing Human Attention
- None. This is a metadata-only correction.

## Submodule Reference
Parent repo `externals/skia` submodule: `4c9e5002d7bfb25b897708198181ae628f4e24a3`  
(unchanged from `origin/main` — no new submodule commit in this PR)

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).