### PR TITLE
Purge unused Alpine packages from the musl cross sysroot to reduce CG findings

### DIFF
--- a/scripts/infra/native/linux/docker/alpine/Dockerfile
+++ b/scripts/infra/native/linux/docker/alpine/Dockerfile
@@ -59,6 +59,80 @@ RUN case "${BUILD_ARCH}" in \
     && GCC_VER=$(ls ${ROOTFS_DIR}/usr/lib/gcc/${TOOLCHAIN_ARCH}/ 2>/dev/null | sort -V | tail -1) \
     && echo "export GCC_LIB_DIR=${ROOTFS_DIR}/usr/lib/gcc/${TOOLCHAIN_ARCH}/${GCC_VER}" >> /etc/skia-env
 
+# apk.static (musl, static) — used to operate on the Alpine cross sysroot from
+# the Azure Linux host (which has no apk of its own). Shared by the purge step
+# below and the fontconfig install step further down.
+ARG APK_STATIC_VERSION=2.12.14
+ARG APK_STATIC_SHA256=cd282c693059c39b68ce0575fbdc4e0c162af85ed633a7834f9cfd01b8b1d58b
+
+# Purge unused Alpine packages from the cross sysroot to shrink the Component
+# Governance surface. The base image's sysroot ships a full Alpine build
+# toolchain plus a pile of dev/runtime packages we never use (python3, lldb,
+# llvm*-libs, libxml2, icu, krb5, lttng-ust, glib, gettext, ncurses, busybox,
+# curl, openssl-dev …): we cross-compile with the host's clang/lld + libc++ and
+# only need musl + headers, the GCC CRT/libgcc/libstdc++ archives, and the libs
+# Skia links against (fontconfig and its freetype/png/expat/bz2/zlib/brotli deps
+# are installed in the next step).
+#
+# apk garbage-collects a package's dependencies once they become orphaned, so we
+# first pin everything that must survive into the apk "world", then delete the
+# unwanted top-level world members and let apk drop the rest. Removal is done
+# with `apk del` (never `rm`) so lib/apk/db/installed — which CG reads — stays in
+# sync. The delete set is derived from the sysroot's own world file, so it is
+# fully arch-agnostic: arch-specific members (llvm19-libs on riscv64, llvm22-libs
+# on loongarch64, …) are handled automatically. `--no-scripts` keeps apk from
+# trying to execute target-architecture trigger scripts on the x86_64 host.
+RUN . /etc/skia-env \
+    && APK_DIR="$(mktemp -d)" \
+    && curl -fSL --retry 5 --retry-delay 10 --retry-all-errors \
+        -o "$APK_DIR/apk.static" \
+        "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v${APK_STATIC_VERSION}/x86_64/apk.static" \
+    && echo "${APK_STATIC_SHA256}  $APK_DIR/apk.static" | sha256sum -c - \
+    && chmod +x "$APK_DIR/apk.static" \
+    && APK="$APK_DIR/apk.static --root ${SYSROOT_ROOT} --no-network" \
+    # World members that the clang/lld cross toolchain still needs — keep these.
+    && KEEP_WORLD="compiler-rt linux-headers zlib-dev" \
+    # Toolchain + Skia link-time libraries to pin so apk does not collect them
+    # when their parent world members (e.g. build-base) are deleted. gcc supplies
+    # the CRT objects + libgcc.a used by -static-libgcc and pulls in binutils,
+    # which is therefore unavoidable; libstdc++-dev supplies the libstdc++.a that
+    # libc++ delegates its ABI to (see native/linux-clang-cross/build.cake).
+    # alpine-keys is kept so the apk signing keys (and /etc/apk/keys) survive for
+    # the fontconfig-dev install in the next step.
+    && PIN="gcc libstdc++ libstdc++-dev libgcc binutils musl musl-dev libc-dev \
+            libc-utils musl-utils scanelf fortify-headers libucontext alpine-keys \
+            zlib brotli brotli-dev brotli-libs libexpat libbz2" \
+    # Pin only the packages actually present (libc-dev/libc-utils are absent on
+    # some arches), otherwise apk add would try to fetch them over the network.
+    && PIN_PRESENT="" \
+    && for p in ${PIN}; do \
+         if ${APK} info -e "$p" >/dev/null 2>&1; then PIN_PRESENT="${PIN_PRESENT} $p"; fi; \
+       done \
+    && ${APK} add --no-scripts ${PIN_PRESENT} \
+    # Delete every world member that is neither required nor pinned; apk then
+    # autoremoves the dependencies that are no longer referenced.
+    && DEL="$(grep -vxF -f <(printf '%s\n' ${KEEP_WORLD} ${PIN_PRESENT}) \
+                "${SYSROOT_ROOT}/etc/apk/world" | tr '\n' ' ')" \
+    && echo "Purging unused sysroot world members:${DEL:+ }${DEL}" \
+    && if [ -n "${DEL}" ]; then \
+         ${APK} del --no-scripts --purge --force-broken-world ${DEL}; \
+       fi \
+    # Fail the build immediately if the purge took out a toolchain artifact the
+    # clang/lld cross link depends on, instead of discovering it later in Skia.
+    && for f in \
+         "${GCC_LIB_DIR}/crtbeginS.o" \
+         "${GCC_LIB_DIR}/libgcc.a" \
+         "${SYSROOT_ROOT}/usr/lib/libstdc++.a" \
+         "${SYSROOT_ROOT}/usr/lib/crt1.o" \
+         "${SYSROOT_ROOT}/usr/lib/libc.a" \
+         "${SYSROOT_ROOT}/usr/include/bits/alltypes.h" \
+         "${SYSROOT_ROOT}/usr/include/linux/limits.h" \
+       ; do \
+         test -e "$f" || { echo "FATAL: required toolchain artifact missing after purge: $f" >&2; exit 1; }; \
+       done \
+    && rm -rf "$APK_DIR" \
+    && rm -rf "${SYSROOT_ROOT}/var/cache/apk/"* "${SYSROOT_ROOT}/tmp/"*
+
 # Install the .NET SDK (needed for Cake build scripts).
 ARG DOTNET_SDK_VERSION=10.0.108
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
@@ -72,8 +146,6 @@ ENV CC=clang CXX=clang++
 # Install fontconfig-dev into the sysroot from Alpine repos.
 # The sysroot is Alpine 3.17 but we pull fontconfig from 3.21 (newer keys needed).
 # SSL_CERT_FILE is needed because apk.static (musl) can't find Azure Linux's CA bundle.
-ARG APK_STATIC_VERSION=2.12.14
-ARG APK_STATIC_SHA256=cd282c693059c39b68ce0575fbdc4e0c162af85ed633a7834f9cfd01b8b1d58b
 ARG ALPINE_VERSION=3.21
 RUN . /etc/skia-env \
     && APK_DIR="$(mktemp -d)" \
@@ -82,6 +154,7 @@ RUN . /etc/skia-env \
         "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v${APK_STATIC_VERSION}/x86_64/apk.static" \
     && echo "${APK_STATIC_SHA256}  $APK_DIR/apk.static" | sha256sum -c - \
     && chmod +x "$APK_DIR/apk.static" \
+    && mkdir -p ${SYSROOT_ROOT}/etc/apk/keys \
     && curl -fsSL -o ${SYSROOT_ROOT}/etc/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub \
         "https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub" \
     && curl -fsSL -o ${SYSROOT_ROOT}/etc/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub \


### PR DESCRIPTION
## Summary

The musl cross image (`scripts/infra/native/linux/docker/alpine/Dockerfile`) ships a full Alpine build toolchain plus a large set of dev/runtime packages in its `/crossrootfs/<arch>` sysroot that the SkiaSharp cross build never uses. We cross-compile with the **host's** clang 20 + lld and libc++, so the sysroot only needs musl + headers, the GCC CRT/`libgcc.a`/`libstdc++.a` archives, and the libraries Skia links against (fontconfig + its freetype/png/expat/bz2/zlib/brotli deps). Everything else drives dozens of Component Governance findings against old Alpine 3.17 package versions.

This adds a single purge `RUN` step (after `/etc/skia-env`, before the SDK/fontconfig installs). Scope is the alpine musl image only — no other Dockerfiles, no base-image tag, no CG baselines, no pipeline YAML, no host-OS (`.azl3`) packages.

## How it works

apk garbage-collects a package once it becomes an orphaned dependency, and `--force-broken-world` does **not** force-remove a package another installed package still depends on. So instead of naming individual packages to delete (fragile across arches), the step:

1. Downloads `apk.static` (x86_64, sha256-verified) — the Azure Linux host has no apk of its own.
2. **Pins** the required toolchain + link packages into the apk `world` via `apk add --no-scripts` (so they survive once their parent `build-base` world member is removed).
3. Computes `DEL = (world members) − KEEP_WORLD − pinned` from the **sysroot's own** `etc/apk/world`, then runs `apk del --no-scripts --purge --force-broken-world $DEL` and lets apk autoremove the orphans.
4. Verifies required toolchain artifacts still exist (fails the layer immediately otherwise), then cleans `var/cache/apk/*` and `tmp/*`.

Removal goes through `apk del` (never `rm`) so `lib/apk/db/installed` — which CG reads — stays consistent. `--no-scripts` avoids executing target-arch trigger scripts on the x86_64 host. Deriving `DEL` from the world file makes it **arch-agnostic**: arch-specific members (`llvm19-libs` on riscv64, `llvm22-libs` on loongarch64) are dropped automatically.

## Final purge result (per arch)

Derived automatically; no per-arch special-casing in the Dockerfile. World members deleted (→ orphans autoremoved): `alpine-base build-base curl-dev gettext-dev icu-dev krb5-dev libedit libunwind-dev lldb-dev llvm{15,19,22}-libs lttng-ust-dev openssl-dev python3`.

Packages dropped from the sysroot include: `clang15-libs, llvm15-libs, lldb, lldb-dev, python3, py3-lttng, lttng-ust, lttng-ust-dev, libxml2, icu/icu-dev/icu-libs/icu-data-en, krb5-conf/krb5-dev/krb5-libs, libcurl, curl-dev, openssl-dev, libssl3, libcrypto3, glib, gettext*, ncurses-libs, ncurses-terminfo-base, libunwind/libunwind-dev, gawk, make, patch, file, libmagic, sqlite-libs, e2fsprogs*, util-linux-dev, nghttp2*, libldap, libsasl, ca-certificates*, openrc, alpine-conf, …`.

The candidate purge list in the issue mentioned `perl*`, `systemd-rpm-macros`, `python3-pyc`, `ncurses` (the meta), and `lttng-ust-devel` — none of these are present in this base image's sysroot, so they're naturally absent from the result.

## Allow-list additions (beyond the "never purge" set)

Kept because the clang/lld cross **link** needs them (see `native/linux-clang-cross/build.cake` `GetGnArgs`):

- **gcc** — supplies the CRT objects (`crtbeginS.o`) and `libgcc.a` used by `-static-libgcc` (via `GCC_LIB_DIR`).
- **binutils** — unavoidable: `gcc` depends on it. (Assembly itself uses clang's integrated assembler, but the package can't be removed while gcc stays. This one remains a CG entry; removing it would require removing gcc, which breaks the link.)
- **libstdc++-dev** — supplies the `libstdc++.a` that libc++ delegates its ABI to (`-Wl,--whole-archive,-lstdc++`).
- **gcc dependency closure** kept by apk: `gmp, isl25/isl26, mpfr4, mpc1, libatomic, libgomp` (+ `jansson, zstd-libs` for gcc 14/15 on riscv64/loongarch64, `libgcc-static` on loongarch64).
- **musl-utils, scanelf, fortify-headers, libucontext, libc-dev, libc-utils** — musl toolchain support (libc-dev/libc-utils are absent on riscv64/loongarch64; the pin list filters to what's present).
- **alpine-keys** — kept so the apk signing keys (and `/etc/apk/keys`) survive; the later `fontconfig-dev` install verifies the Alpine 3.21 `APKINDEX` signature against them. (Public-key data only — no CG concern.) A defensive `mkdir -p .../etc/apk/keys` was also added to the fontconfig step.

## `apk info -v` before vs. after (arm64)

| | packages |
|---|---|
| **Before** (base image sysroot) | **121** |
| **After** (final image) | **41** |

→ **80 packages removed.** (`busybox`, `libexpat`, `libbz2` are then re-pulled/upgraded by `fontconfig-dev` to newer Alpine 3.21 builds — e.g. `busybox 1.37.0-r14`, not the old 3.17 one.)

Other arches land at the same 41 (arm, x64), 41 (riscv64), and 42 (loongarch64, +`libgcc-static`); riscv64/loongarch64 swap `isl25`→`isl26` and add `jansson`/`zstd-libs` from their newer gcc.

## Verification

- ✅ **All 5 arch images build** (`arm, arm64, x64, riscv64, loongarch64`) via `docker build --build-arg BUILD_ARCH=$arch`. The post-purge toolchain sanity check passes for each.
- ✅ **`apk info -v`** on each image shows only musl/toolchain + Skia link libs — no `binutils`-adjacent CG offenders like `python3`, `llvm*-libs`, `lldb`, `libxml2`, `icu*`, `krb5*`, `lttng-ust*`, `glib`, `ncurses*`, `libcurl`, `openssl-dev`.
- ✅ **Real cross-build smoke test** for arm64: `dotnet cake --target=externals-linux-clang-cross --configuration=Release --buildarch=arm64 --variant=alpine --verifyIncluded=fontconfig` builds **and links** `libSkiaSharp.so` + `libHarfBuzzSharp.so`, and the `verifyIncluded=fontconfig` check passes.
- ✅ **`readelf -d`** on the produced binaries — `NEEDED` entries are exactly `libstdc++.so.6`, `libfontconfig.so.1`, `libc.musl-aarch64.so.1` (HarfBuzz: the latter two). All map to kept packages / standard Alpine arm64 runtime libs. freetype/png/expat/zlib/harfbuzz/brotli/bz2 are statically linked into libSkiaSharp (`skia_use_system_*=false`), so they correctly do not appear.

## Out of scope

Host-OS (Azure Linux `.azl3`) package findings, base-image tag/digest changes, CG baseline files, and pipeline YAML — all untouched.