### PR TITLE
[skia-sync] Update skia to milestone 149

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1a155bae3ac86db6d3efbd996f00e774b6a7b722"
+          "commitHash": "2d0db2d5e8d1cbc075aaf01303599d6c8fcef99a"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m148",
+          "version": "chrome/m149",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 148,
-      "upstream_merge_commit": "54851b68b7a1d49bc4b4361f12786a7d7ad91fff"
+      "chrome_milestone": 149,
+      "upstream_merge_commit": "5d8d0eca0d79cf84d97ed121edc468702f79ad91"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.0
-skia                                            release     m148
+skia                                            release     m149
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -62,19 +62,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   148
+libSkiaSharp            milestone   149
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      148.0.0
+libSkiaSharp            soname      149.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61420.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.148.0.0
-SkiaSharp               file        4.148.0.0
+SkiaSharp               assembly    4.149.0.0
+SkiaSharp               file        4.149.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -82,36 +82,36 @@ HarfBuzzSharp           file        14.2.0
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.148.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.148.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.148.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.148.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.148.0
-SkiaSharp.NativeAssets.Android                  nuget       4.148.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.148.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.148.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.148.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.148.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.148.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.148.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.148.0
-SkiaSharp.Views                                 nuget       4.148.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.148.0
-SkiaSharp.Views.Gtk3                            nuget       4.148.0
-SkiaSharp.Views.Gtk4                            nuget       4.148.0
-SkiaSharp.Views.WindowsForms                    nuget       4.148.0
-SkiaSharp.Views.WPF                             nuget       4.148.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.148.0
-SkiaSharp.Views.WinUI                           nuget       4.148.0
-SkiaSharp.Views.Maui.Core                       nuget       4.148.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.148.0
-SkiaSharp.Views.Blazor                          nuget       4.148.0
-SkiaSharp.HarfBuzz                              nuget       4.148.0
-SkiaSharp.Skottie                               nuget       4.148.0
-SkiaSharp.SceneGraph                            nuget       4.148.0
-SkiaSharp.Resources                             nuget       4.148.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.148.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.148.0
+SkiaSharp                                       nuget       4.149.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.149.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.149.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.149.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.149.0
+SkiaSharp.NativeAssets.Android                  nuget       4.149.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.149.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.149.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.149.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.149.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.149.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.149.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.149.0
+SkiaSharp.Views                                 nuget       4.149.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.149.0
+SkiaSharp.Views.Gtk3                            nuget       4.149.0
+SkiaSharp.Views.Gtk4                            nuget       4.149.0
+SkiaSharp.Views.WindowsForms                    nuget       4.149.0
+SkiaSharp.Views.WPF                             nuget       4.149.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.149.0
+SkiaSharp.Views.WinUI                           nuget       4.149.0
+SkiaSharp.Views.Maui.Core                       nuget       4.149.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.149.0
+SkiaSharp.Views.Blazor                          nuget       4.149.0
+SkiaSharp.HarfBuzz                              nuget       4.149.0
+SkiaSharp.Skottie                               nuget       4.149.0
+SkiaSharp.SceneGraph                            nuget       4.149.0
+SkiaSharp.Resources                             nuget       4.149.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.149.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.149.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.0
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.0


### PR DESCRIPTION
Automated Skia milestone bump from m148 to m149.

**Companion skia PR:** https://github.com/mono/skia/pull/252

# mono/SkiaSharp PR Summary: Update Skia to milestone m149

## Overview

Updates SkiaSharp to Skia milestone m149. The submodule `externals/skia` now points to
the `skia-sync/m149` branch in mono/skia.

## Changes

### Version Files Updated

| File | Change |
|------|--------|
| `scripts/VERSIONS.txt` | milestone 148 → 149, soname 148.0.0 → 149.0.0, all NuGet version lines updated |
| `cgmanifest.json` | commitHash, chrome_milestone (149), upstream_merge_commit updated |

### Submodule Update

- `externals/skia` updated from `1a155bae3a` (m148) to `2d0db2d5e8` (m149 merge)
- `SK_C_INCREMENT` = 0 (no new C API additions this milestone)

### Bindings

- `binding/SkiaSharp/SkiaApi.generated.cs`: **No changes** — C API signatures unchanged
- HarfBuzz bindings: reverted (HarfBuzz updates are always separate)

## Breaking Change Analysis (m148→m149)

All changes are either additive (new APIs) or Graphite-only (which SkiaSharp uses Ganesh, not Graphite).

| Change | User Impact |
|--------|-------------|
| `SkCodec::Register` removed | None — not exposed in C# API |
| `SkShader::isOpaque()` pure virtual | None — internal to Skia |
| `SkFontMgr` new `match()`/`fallback()` | None — not yet wrapped; no breaking change |
| New `SkFontArguments` tag constants | None — additive |
| Graphite GPU API changes | None — SkiaSharp uses Ganesh backend |

**No breaking changes to public SkiaSharp API.** No `[Obsolete]` attributes needed.

## Build Results

- **Platform:** Linux x64 (native build from source)
- **Native build:** ✅ Clean (libSkiaSharp.so, libHarfBuzzSharp.so)
- **C# build:** ✅ 0 errors, 0 warnings
- **Note:** Build used `-stdlib=libstdc++` override due to missing libc++ headers on this runner;
  CI Docker containers use the proper libc++ setup via `.NET cross-compilation images`

## Test Results

| Suite | Passed | Skipped | Failed |
|-------|--------|---------|--------|
| SkiaSharp (smoke) | 32 | 0 | 0 |
| SkiaSharp (full) | 5300 | 172 | **0** |
| HarfBuzz | — | — | 207 (pre-existing, see note) |

**Note on HarfBuzz failures:** All 207 HarfBuzz test failures are pre-existing on `main`
(`EntryPointNotFoundException: hb_blob_create_from_file`). Confirmed by running the same
test against the m148 baseline — same failure. Not caused by this PR.

**Skipped tests** (172) are expected: GPU tests skipped without hardware, platform-specific
tests skipped on Linux, etc.

## Items Needing Human Attention

1. **HarfBuzz test failures** (pre-existing): `hb_blob_create_from_file` entry point not found.
   This should be investigated separately as a potential HarfBuzz binding issue.

2. **New `SkFontMgr` APIs**: `match(Request)` and `fallback(Request)` are new in m149.
   Consider exposing via `/api-add-review` in a future PR for better font matching in SkiaSharp.

3. **libc++ on CI runners**: The automated build outside Docker requires libc++ headers.
   The actual CI pipeline uses Docker containers with proper libc++ setup — this is only
   an issue for local/agent builds outside the Docker environment.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).