### PR TITLE
Add blame-hang-timeout to .NET test runs so hangs fail fast

### DIFF
--- a/scripts/infra/tests/test-shared.cake
+++ b/scripts/infra/tests/test-shared.cake
@@ -89,7 +89,9 @@ void RunDotNetTest(
         Verbosity = DotNetVerbosity.Normal,
         ArgumentCustomization = args => {
             args = args
-                .Append("/p:Platform=\"AnyCPU\"");
+                .Append("/p:Platform=\"AnyCPU\"")
+                .Append("--blame-hang-timeout").Append("15m")
+                .Append("--blame-hang-dump-type").Append("none");
             if (COVERAGE)
                 args = args
                     .Append("/p:CollectCoverage=true")


### PR DESCRIPTION
## Summary

Adds a process-level hang-timeout safety net so a stuck .NET Core test fails fast (~15 min) instead of burning to the 180-min job cap.

This came out of the investigation into intermittent `macOS (.NET Core)` test-job hangs — see #4139 for the full root cause.

## Background

The `macOS (.NET Core)` test job intermittently hangs for 30 min – 3 h (vs a healthy ~8 min) and sometimes hits the 180-min job timeout. Root cause: a GC-finalizer-bound stress test (`SKBitmapThreadingTest.ImageScalingMultipleThreadsTest`) can take 13–15 min or crash the test host on a contended Microsoft-hosted macOS VM. When the host crashes, AzDO retries the entire `tests-netcore` step up to 3× (`retryCountOnTaskFailure: 3`), bounded only by `timeoutInMinutes: 180`. There is currently **no** per-test or process-level hang timeout.

## Change

In the shared `RunDotNetTest` helper (`scripts/infra/tests/test-shared.cake`), append the VSTest blame-hang collector flags to the `ArgumentCustomization`. This single place covers all .NET Core desktop test projects run by the `tests-netcore` target:

```csharp
.Append("--blame-hang-timeout").Append("15m")
.Append("--blame-hang-dump-type").Append("none");
```

- **15m** is safely above the worst observed *passing* run (~793s ≈ 13 min) so it won't false-fire, while bounding a true hang well under the 180-min cap.
- `--blame-hang-timeout` auto-enables blame-hang mode (no separate `--blame` needed).
- `none` dump type avoids large dump artifacts (can revisit to `mini`/`full` later if a stack trace is wanted).

The device/WASM runner path (`RunDeviceRunnersTest`) is intentionally left **unchanged**: those tests run in-process inside a MAUI/Blazor host (DeviceRunners) and do not use the VSTest blame collector, so these flags don't apply there.

## Verification

C#-only/infra change — bootstrapped with `externals-download` (no native rebuild). Ran a filtered subset of the netcore tests locally; the runner accepted the `--blame-hang-timeout`/`--blame-hang-dump-type` flags and executed tests normally (no argument-parsing rejection).

Refs #4139