### PR TITLE
Fix SKIASHARP_VERSION yaml missed by the m148 bump

### DIFF
--- a/.agents/skills/update-skia/SKILL.md
+++ b/.agents/skills/update-skia/SKILL.md
@@ -325,7 +325,7 @@ You should still be inside `externals/skia` from Phase 4.
 > If you had a pending increment that must survive, capture it before running.
 
 > 📋 **This phase is handled by a script.** The script updates VERSIONS.txt, cgmanifest.json,
-> azure-pipelines-variables.yml, and verifies SK_C_INCREMENT — then runs the mandatory
+> azure-templates-variables.yml, and verifies SK_C_INCREMENT — then runs the mandatory
 > verification greps. It exits non-zero if any stale references remain.
 
 In the **SkiaSharp parent repo**, run:
@@ -337,7 +337,7 @@ pwsh .agents/skills/update-skia/scripts/update-versions.ps1 -Current {CURRENT} -
 The script handles all of these (so you don't have to do them manually):
 - `scripts/VERSIONS.txt`: milestone, increment→0, soname, assembly, file, ALL ~30 nuget lines
 - `cgmanifest.json`: commitHash, version, chrome_milestone, upstream_merge_commit
-- `scripts/azure-pipelines-variables.yml` (if it exists)
+- `scripts/azure-templates-variables.yml`: `SKIASHARP_VERSION` (must match VERSIONS.txt nuget version)
 - Verifies `SK_C_INCREMENT` is 0 in `externals/skia/include/c/sk_types.h`
 - Runs mandatory `grep` verification — fails if any stale references remain
 

--- a/.agents/skills/update-skia/references/typical-changes.md
+++ b/.agents/skills/update-skia/references/typical-changes.md
@@ -13,7 +13,7 @@
 | mono/SkiaSharp | `externals/skia` | Submodule pointer |
 | mono/SkiaSharp | `scripts/VERSIONS.txt` | All version numbers |
 | mono/SkiaSharp | `cgmanifest.json` | Security tracking |
-| mono/SkiaSharp | `scripts/azure-pipelines-variables.yml` | CI config |
+| mono/SkiaSharp | `scripts/azure-templates-variables.yml` | CI config (`SKIASHARP_VERSION`) |
 | mono/SkiaSharp | `native/*/build.cake` | Per-platform GN flag updates (check for removed declare_args) |
 | mono/SkiaSharp | `binding/SkiaSharp/SkiaApi.generated.cs` | Regenerated |
 | mono/SkiaSharp | `binding/SkiaSharp/Definitions.cs` | Type definitions, new enums |

--- a/.agents/skills/update-skia/scripts/update-versions.ps1
+++ b/.agents/skills/update-skia/scripts/update-versions.ps1
@@ -7,7 +7,7 @@
     Performs ALL version updates required by Phase 6 of the update-skia skill:
     - scripts/VERSIONS.txt (milestone, increment, soname, assembly, file, all nuget lines)
     - cgmanifest.json (commitHash, version, chrome_milestone, upstream_merge_commit)
-    - scripts/azure-pipelines-variables.yml (if it exists)
+    - scripts/azure-templates-variables.yml (SKIASHARP_VERSION)
     - externals/skia/include/c/sk_types.h (verifies SK_C_INCREMENT is 0)
 
     Then runs the mandatory verification greps to catch any stale references.
@@ -105,17 +105,20 @@ foreach ($reg in $cgJson.registrations) {
 $cgJson | ConvertTo-Json -Depth 10 | Set-Content $cgPath
 Write-Host "  Updated cgmanifest.json" -ForegroundColor Green
 
-# --- Step 3: azure-pipelines-variables.yml ---
-$pipelinePath = Join-Path $repoRoot 'scripts/azure-pipelines-variables.yml'
-if (Test-Path $pipelinePath) {
-    Write-Host "`n--- Updating azure-pipelines-variables.yml ---" -ForegroundColor Yellow
-    $pipelineContent = Get-Content $pipelinePath -Raw
-    $pipelineContent = $pipelineContent -replace "$Current", "$Target"
-    Set-Content $pipelinePath $pipelineContent -NoNewline
-    Write-Host "  Updated azure-pipelines-variables.yml" -ForegroundColor Green
-} else {
-    Write-Host "`n--- scripts/azure-pipelines-variables.yml not found (skipping) ---" -ForegroundColor DarkGray
+# --- Step 3: azure-templates-variables.yml (SKIASHARP_VERSION) ---
+# This must match the SkiaSharp nuget version in VERSIONS.txt. It is a separate,
+# compile-time constant used by the BUILD_NUMBER counter, so it cannot be derived
+# dynamically and must be bumped here too.
+$targetNuget = "$currentMajor.$Target.0"
+$pipelinePath = Join-Path $repoRoot 'scripts/azure-templates-variables.yml'
+if (-not (Test-Path $pipelinePath)) {
+    Write-Error "Expected $pipelinePath not found. If the file was renamed, update this script (Step 3) and the verification gate below."
 }
+Write-Host "`n--- Updating azure-templates-variables.yml ---" -ForegroundColor Yellow
+$pipelineContent = Get-Content $pipelinePath -Raw
+$pipelineContent = $pipelineContent -replace "(SKIASHARP_VERSION:\s*)$currentMajor\.$Current\.\d+", "`${1}$targetNuget"
+Set-Content $pipelinePath $pipelineContent -NoNewline
+Write-Host "  Updated SKIASHARP_VERSION -> $targetNuget" -ForegroundColor Green
 
 # --- Step 4: Reset and verify SK_C_INCREMENT ---
 Write-Host "`n--- Checking SK_C_INCREMENT ---" -ForegroundColor Yellow
@@ -148,6 +151,8 @@ if ($Current -eq $Target) {
 
     $staleCgmanifest = Select-String -Path $cgPath -Pattern "m$Current|`"$Current`""
 
+    $stalePipeline = Select-String -Path $pipelinePath -Pattern "SKIASHARP_VERSION:\s*\S*$Current"
+
     $failures = @()
 
     if ($staleVersions) {
@@ -164,6 +169,13 @@ if ($Current -eq $Target) {
         }
     }
 
+    if ($stalePipeline) {
+        $failures += "azure-templates-variables.yml SKIASHARP_VERSION still contains '$Current':"
+        foreach ($match in $stalePipeline) {
+            $failures += "  Line $($match.LineNumber): $($match.Line.Trim())"
+        }
+    }
+
     if ($failures.Count -gt 0) {
         Write-Host "`n❌ GATE FAILED — stale references found:" -ForegroundColor Red
         foreach ($f in $failures) { Write-Host "  $f" -ForegroundColor Red }
@@ -173,5 +185,6 @@ if ($Current -eq $Target) {
         Write-Host "  SK_C_INCREMENT: 0" -ForegroundColor Green
         Write-Host "  VERSIONS.txt: clean" -ForegroundColor Green
         Write-Host "  cgmanifest.json: clean" -ForegroundColor Green
+        Write-Host "  azure-templates-variables.yml: clean" -ForegroundColor Green
     }
 }

--- a/.agents/skills/update-skia/scripts/update-versions.ps1
+++ b/.agents/skills/update-skia/scripts/update-versions.ps1
@@ -151,7 +151,13 @@ if ($Current -eq $Target) {
 
     $staleCgmanifest = Select-String -Path $cgPath -Pattern "m$Current|`"$Current`""
 
-    $stalePipeline = Select-String -Path $pipelinePath -Pattern "SKIASHARP_VERSION:\s*\S*$Current"
+    # Positive assertion: the SKIASHARP_VERSION must end up EXACTLY at the target
+    # nuget version. A stale-only check (looking for $Current) would pass if the
+    # value were stuck on a different milestone (e.g. 4.146.0) or carried a suffix
+    # (e.g. 4.147.0-preview.2 -> 4.148.0-preview.2 no longer contains 147).
+    $pipelineNow = Get-Content $pipelinePath -Raw
+    $pipelineVerMatch = [regex]::Match($pipelineNow, 'SKIASHARP_VERSION:\s*(?<ver>\S+)')
+    $pipelineVer = if ($pipelineVerMatch.Success) { $pipelineVerMatch.Groups['ver'].Value } else { '<missing>' }
 
     $failures = @()
 
@@ -169,11 +175,8 @@ if ($Current -eq $Target) {
         }
     }
 
-    if ($stalePipeline) {
-        $failures += "azure-templates-variables.yml SKIASHARP_VERSION still contains '$Current':"
-        foreach ($match in $stalePipeline) {
-            $failures += "  Line $($match.LineNumber): $($match.Line.Trim())"
-        }
+    if ($pipelineVer -ne $targetNuget) {
+        $failures += "azure-templates-variables.yml SKIASHARP_VERSION is '$pipelineVer', expected '$targetNuget' (must match VERSIONS.txt nuget version)"
     }
 
     if ($failures.Count -gt 0) {
@@ -185,6 +188,6 @@ if ($Current -eq $Target) {
         Write-Host "  SK_C_INCREMENT: 0" -ForegroundColor Green
         Write-Host "  VERSIONS.txt: clean" -ForegroundColor Green
         Write-Host "  cgmanifest.json: clean" -ForegroundColor Green
-        Write-Host "  azure-templates-variables.yml: clean" -ForegroundColor Green
+        Write-Host "  azure-templates-variables.yml: SKIASHARP_VERSION = $targetNuget" -ForegroundColor Green
     }
 }

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.147.0
+  SKIASHARP_VERSION: 4.148.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
## Problem

The m148 milestone bump (#4125) updated all version numbers in `scripts/VERSIONS.txt` to `4.148.0`, but `scripts/azure-templates-variables.yml` was left at `SKIASHARP_VERSION: 4.147.0` — even though that variable's own comment requires it to match the nuget version in `VERSIONS.txt` (it's a compile-time constant feeding the `BUILD_NUMBER` counter and cannot be derived dynamically).

## Root cause

This wasn't a manual oversight — the automation was wired to a filename that no longer exists:

| Date | PR | What happened |
|------|-----|---------------|
| 2025-04-24 | #3247 *Split the pipeline up* | `SKIASHARP_VERSION` was **moved** out of `scripts/azure-pipelines-variables.yml` (deleted) into `scripts/azure-templates-variables.yml`. |
| 2026-03-25 | #3574 *Improve update-skia skill* | The Phase 6 script `update-versions.ps1` was **created referencing the already-deleted** `azure-pipelines-variables.yml`. Its `Test-Path … else { skip }` guard silently no-op'd. |
| 2026-06-11 | #4125 *Update to m148* | The script ran, "file not found → skipped" silently, the gate didn't check the yaml, and `4.147.0` was left behind. |

## Changes

- **Bump** `SKIASHARP_VERSION` to `4.148.0` in `scripts/azure-templates-variables.yml`.
- **Fix the update-skia Phase 6 script** (`update-versions.ps1`):
  - Point at the correct filename `scripts/azure-templates-variables.yml`.
  - Replace only the `SKIASHARP_VERSION` line via a targeted regex (no naive whole-file substitution).
  - **Hard-fail** (`Write-Error`) if the file is missing, instead of silently skipping — so a future rename is caught loudly.
  - Add a **positive verification gate**: assert `SKIASHARP_VERSION` exactly equals the target nuget version, rather than only checking the old milestone number is absent. (Per GPT-5.5 review: the stale-only check would falsely pass if the value were stuck on a different milestone like `4.146.0`, or carried a suffix like `4.147.0-preview.2`.)
- **Update docs** (`SKILL.md`, `references/typical-changes.md`) to the correct filename.

## Verification

- PowerShell parses clean.
- Simulated the gate: `4.146.0` → fails (correct); `4.147.0` → passes at `4.148.0` (correct).