### PR TITLE
[skia-sync] Update skia to milestone 150

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "0a248d1b82c80bce5ee5c8ab765233659667e5c2"
+          "commitHash": "047210c1bf111b95acf88e34c4c66cdd834b2262"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1a155bae3ac86db6d3efbd996f00e774b6a7b722"
+          "commitHash": "0a248d1b82c80bce5ee5c8ab765233659667e5c2"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m148",
+          "version": "chrome/m150",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 148,
-      "upstream_merge_commit": "54851b68b7a1d49bc4b4361f12786a7d7ad91fff"
+      "chrome_milestone": 150,
+      "upstream_merge_commit": "c92514572e9faa7f0e32c828be6f6289d8cc5c92"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "047210c1bf111b95acf88e34c4c66cdd834b2262"
+          "commitHash": "94451aa2839ed8ae5185d25d88784c6185381fa0"
         }
       }
     },

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -42,6 +42,7 @@ Task("libSkiaSharp")
            $"target_os='tizen' " +
            $"target_cpu='{skiaArch}' " +
            $"skia_enable_ganesh=true " +
+           $"skia_enable_pdf=false " +
            $"skia_use_harfbuzz=false " +
            $"skia_use_icu=false " +
            $"skia_use_piex=true " +

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -42,7 +42,6 @@ Task("libSkiaSharp")
            $"target_os='tizen' " +
            $"target_cpu='{skiaArch}' " +
            $"skia_enable_ganesh=true " +
-           $"skia_enable_pdf=false " +
            $"skia_use_harfbuzz=false " +
            $"skia_use_icu=false " +
            $"skia_use_piex=true " +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -59,7 +59,11 @@ Task("libSkiaSharp")
             $"skia_enable_skottie=true " +
             $"skia_use_vulkan={SUPPORT_VULKAN} ".ToLower () +
             $"skia_use_direct3d={SUPPORT_DIRECT3D} ".ToLower () +
-            $"win_sdk_version='10.0.22621.0' " +
+            // m150's SkFontMgr_win_dw.cpp uses IDWriteFontSet4, which needs the
+            // Windows 11 SDK (10.0.22621). Skia's gn picks the LOWEST installed
+            // SDK >= min_win_sdk_version, so raise that floor rather than pinning
+            // an exact version (tolerates newer SDKs if 22621 isn't present).
+            $"min_win_sdk_version='10.0.22621.0' " +
             clang +
             win_vcvars_version +
             $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -59,11 +59,6 @@ Task("libSkiaSharp")
             $"skia_enable_skottie=true " +
             $"skia_use_vulkan={SUPPORT_VULKAN} ".ToLower () +
             $"skia_use_direct3d={SUPPORT_DIRECT3D} ".ToLower () +
-            // m150's SkFontMgr_win_dw.cpp uses IDWriteFontSet4, which needs the
-            // Windows 11 SDK (10.0.22621). Skia's gn picks the LOWEST installed
-            // SDK >= min_win_sdk_version, so raise that floor rather than pinning
-            // an exact version (tolerates newer SDKs if 22621 isn't present).
-            $"min_win_sdk_version='10.0.22621.0' " +
             clang +
             win_vcvars_version +
             $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -59,6 +59,7 @@ Task("libSkiaSharp")
             $"skia_enable_skottie=true " +
             $"skia_use_vulkan={SUPPORT_VULKAN} ".ToLower () +
             $"skia_use_direct3d={SUPPORT_DIRECT3D} ".ToLower () +
+            $"win_sdk_version='10.0.22621.0' " +
             clang +
             win_vcvars_version +
             $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.0
-skia                                            release     m148
+skia                                            release     m150
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -62,19 +62,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   148
+libSkiaSharp            milestone   150
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      148.0.0
+libSkiaSharp            soname      150.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61420.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.148.0.0
-SkiaSharp               file        4.148.0.0
+SkiaSharp               assembly    4.150.0.0
+SkiaSharp               file        4.150.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -82,36 +82,36 @@ HarfBuzzSharp           file        14.2.0
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.148.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.148.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.148.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.148.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.148.0
-SkiaSharp.NativeAssets.Android                  nuget       4.148.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.148.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.148.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.148.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.148.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.148.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.148.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.148.0
-SkiaSharp.Views                                 nuget       4.148.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.148.0
-SkiaSharp.Views.Gtk3                            nuget       4.148.0
-SkiaSharp.Views.Gtk4                            nuget       4.148.0
-SkiaSharp.Views.WindowsForms                    nuget       4.148.0
-SkiaSharp.Views.WPF                             nuget       4.148.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.148.0
-SkiaSharp.Views.WinUI                           nuget       4.148.0
-SkiaSharp.Views.Maui.Core                       nuget       4.148.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.148.0
-SkiaSharp.Views.Blazor                          nuget       4.148.0
-SkiaSharp.HarfBuzz                              nuget       4.148.0
-SkiaSharp.Skottie                               nuget       4.148.0
-SkiaSharp.SceneGraph                            nuget       4.148.0
-SkiaSharp.Resources                             nuget       4.148.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.148.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.148.0
+SkiaSharp                                       nuget       4.150.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.150.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.150.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.150.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.150.0
+SkiaSharp.NativeAssets.Android                  nuget       4.150.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.150.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.150.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.150.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.150.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.150.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.150.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.150.0
+SkiaSharp.Views                                 nuget       4.150.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.150.0
+SkiaSharp.Views.Gtk3                            nuget       4.150.0
+SkiaSharp.Views.Gtk4                            nuget       4.150.0
+SkiaSharp.Views.WindowsForms                    nuget       4.150.0
+SkiaSharp.Views.WPF                             nuget       4.150.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.150.0
+SkiaSharp.Views.WinUI                           nuget       4.150.0
+SkiaSharp.Views.Maui.Core                       nuget       4.150.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.150.0
+SkiaSharp.Views.Blazor                          nuget       4.150.0
+SkiaSharp.HarfBuzz                              nuget       4.150.0
+SkiaSharp.Skottie                               nuget       4.150.0
+SkiaSharp.SceneGraph                            nuget       4.150.0
+SkiaSharp.Resources                             nuget       4.150.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.150.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.150.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.0
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.0

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.148.0
+  SKIASHARP_VERSION: 4.150.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated Skia milestone bump from m148 to m150.

**Companion skia PR:** https://github.com/mono/skia/pull/253

# mono/SkiaSharp PR Summary: Skia m148 → m150 Binding Update

## Overview

Updated SkiaSharp parent repository to use the newly merged Skia m150 submodule. This is a version bump with no breaking C API or C# changes.

## Version Changes

| File | Change |
|------|--------|
| `scripts/VERSIONS.txt` | Milestone 148 → 150; NuGet version 4.148.0 → 4.150.0 |
| `cgmanifest.json` | `commitHash` updated to `94451aa283`, `chrome_milestone` = 150, `upstream_merge_commit` = `c92514572e` |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION` = 4.150.0 |
| `externals/skia` | Submodule pointer updated to `94451aa283` (mono/skia PR #253 merge commit on `skiasharp`; m150 merge `0a248d1b82` + portability fixes — see below) |

## SK_C_INCREMENT

`SK_C_INCREMENT` was reset to `0` by the update-versions script on milestone change (was already `0`). No new C API functions were added in this update.

## C API Changes

**None.** The binding generator (`regenerate-bindings.ps1`) confirmed no changes to `SkiaApi.generated.cs` between m148 and m150.

## C# Wrapper Changes

**None.** No new generated functions were detected requiring hand-written C# wrapper code.

## Breaking Change Analysis

| Upstream Change | C# Impact | Action |
|----------------|-----------|--------|
| `SkRegion::setRects` signature | None (not in C API) | — |
| `SkShader::isOpaque()` pure virtual | None (no subclassing in C# layer) | — |
| `SkStrikeRef` new type | None exposed | — |
| Graphite API changes | None (Ganesh only) | — |

## Post-Merge CI / Portability Fixes

After the initial merge, the Azure DevOps native source build (`SkiaSharp (Public)`) surfaced toolchain-specific compile failures on Windows, WASM, and Tizen. These were fixed in the companion skia fork PR #253 (commits on top of the m150 merge) and the submodule was re-pinned forward to `94451aa283` (the PR #253 merge commit on the `skiasharp` branch). Summary of the fork fixes now included:

| Area | Fix | Why |
|------|-----|-----|
| **WASM** (emscripten 3.1.34 / libc++ 15) | `std::views::reverse` → reverse-iterator loop in `SkPDFTag.cpp` | `std::ranges`/`std::views` gated behind incomplete-features in libc++ 15 |
| **Tizen** (clang 10 / gcc 9.2 libstdc++) | PDF backend C++20 three-way comparisons backported to explicit C++17 operators (`SkPDFTypes.h`, `SkPDFTag.cpp`); `optional::emplace` on aggregate → aggregate-init | Tizen toolchain predates C++20 `<compare>`/ranges. Resolves #4155; PDF stays enabled on Tizen (no regression) |
| **Tizen** SkOpts SIMD | `opts("ml3")`/`opts("ml4")` use clang-10 `-march=haswell` / `skylake-avx512` (keeping m150's new `-mprefer-vector-width=512`) | m150 switched to `-march=x86-64-v3`/`v4`, which clang 10 doesn't know (clang ≥ 12) |
| **Windows** | `min_win_sdk_version = "10.0.22621.0"` floor in skia `gn/BUILDCONFIG.gn` | m150's `SkFontMgr_win_dw.cpp` uses `IDWriteFontSet4`, which needs the Win11 SDK (acquired via `QueryInterface` with null-check fallback — runtime-safe on older Windows) |
| **Windows** D3D | `GrD3DBackendSurface.cpp`: `GrBackendFormatData::equal` made unconditional, `GrBackendTextureData::equal` fully guarded under `GPU_TEST_UTILS` | Completes upstream `20c304440c`, which left the D3D backend abstract in non-test builds. Only SkiaSharp compiles the D3D backend, so upstream CI never caught it |
| **All platforms** | Reverted a `SK_SUPPORT_PDF` guard in `src/c/sk_document.cpp` | The C-API shim compiles into skia's `:core` target, which never receives `:pdf`'s `SK_SUPPORT_PDF` public define → guard was always false → PDF factories returned null everywhere (caught by `SKDocumentTest`) |

## Build Results

- **Native library**: Built successfully from source (`externals-linux x64`)
  - `libSkiaSharp.so.150.0.0` ✅
  - `libHarfBuzzSharp.so` ✅
- **C# bindings**: `dotnet build binding/SkiaSharp/SkiaSharp.csproj` ✅ (0 errors, 0 warnings)
- **CI**: Azure DevOps `SkiaSharp (Public)` build 158224 — **all stages green** (Native Windows/macOS/Linux/WASM, Native, Package NuGets, API Diff, Build Managed, Tests, Samples).

## Test Results

```
Passed!  - Failed: 0, Passed: 5507, Skipped: 172, Total: 5679
Duration: 2 m 44 s - SkiaSharp.Tests.dll (net10.0)
```

All 172 skipped tests are expected platform/hardware skips (GPU tests without GPU drivers, platform-specific features). **Zero failures.**

Full test output: `test-output.txt` (workflow artifact)

## Items Needing Human Attention

1. **No C# API additions for `SkStrikeRef`**: Upstream added `SkFont::makeStrikeRef()` returning the new `SkStrikeRef` type. This is not yet exposed in the C API or C# bindings. Could be tracked as a future API addition issue if users request it.

2. **DEPS pinning carries forward**: Fork maintains custom-pinned native library versions (expat 2.8.1, freetype 2.14.3, harfbuzz 14.2.0, etc.) which are security/bug-fix upgrades vs upstream. These remain correct.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).