### PR TITLE
Fix SKPixmap/SKBitmap GetPixelSpan to use RowBytes for stride

### DIFF
--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -334,7 +334,7 @@ namespace SkiaSharp
 			GetPixels (out _);
 
 		public Span<byte> GetPixelSpan () =>
-			new Span<byte> ((void*)GetPixels (out var length), (int)length);
+			new Span<byte> ((void*)GetPixels (out var length), checked((int)length));
 
 		public Span<byte> GetPixelSpan (int x, int y)
 		{

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -339,6 +339,9 @@ namespace SkiaSharp
 		public Span<byte> GetPixelSpan (int x, int y)
 		{
 			var info = Info;
+			if (info.IsEmpty)
+				return GetPixelSpan ();
+
 			if (x < 0 || x >= info.Width)
 				throw new ArgumentOutOfRangeException (nameof (x));
 			if (y < 0 || y >= info.Height)

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -336,8 +336,16 @@ namespace SkiaSharp
 		public Span<byte> GetPixelSpan () =>
 			new Span<byte> ((void*)GetPixels (out var length), (int)length);
 
-		public Span<byte> GetPixelSpan (int x, int y) =>
-			GetPixelSpan ().Slice (Info.GetPixelBytesOffset (x, y, RowBytes));
+		public Span<byte> GetPixelSpan (int x, int y)
+		{
+			var info = Info;
+			if (x < 0 || x >= info.Width)
+				throw new ArgumentOutOfRangeException (nameof (x));
+			if (y < 0 || y >= info.Height)
+				throw new ArgumentOutOfRangeException (nameof (y));
+
+			return GetPixelSpan ().Slice (info.GetPixelBytesOffset (x, y, RowBytes));
+		}
 
 		public IntPtr GetPixels (out IntPtr length)
 		{

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -339,7 +339,7 @@ namespace SkiaSharp
 		public Span<byte> GetPixelSpan (int x, int y)
 		{
 			var info = Info;
-			if (info.IsEmpty)
+			if (info.IsEmpty || info.BytesPerPixel <= 0)
 				return GetPixelSpan ();
 
 			if (x < 0 || x >= info.Width)

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -337,7 +337,7 @@ namespace SkiaSharp
 			new Span<byte> ((void*)GetPixels (out var length), (int)length);
 
 		public Span<byte> GetPixelSpan (int x, int y) =>
-			GetPixelSpan ().Slice (Info.GetPixelBytesOffset (x, y));
+			GetPixelSpan ().Slice (checked(y * RowBytes + (x << Info.ColorType.GetBitShiftPerPixel ())));
 
 		public IntPtr GetPixels (out IntPtr length)
 		{

--- a/binding/SkiaSharp/SKBitmap.cs
+++ b/binding/SkiaSharp/SKBitmap.cs
@@ -337,7 +337,7 @@ namespace SkiaSharp
 			new Span<byte> ((void*)GetPixels (out var length), (int)length);
 
 		public Span<byte> GetPixelSpan (int x, int y) =>
-			GetPixelSpan ().Slice (checked(y * RowBytes + (x << Info.ColorType.GetBitShiftPerPixel ())));
+			GetPixelSpan ().Slice (Info.GetPixelBytesOffset (x, y, RowBytes));
 
 		public IntPtr GetPixels (out IntPtr length)
 		{

--- a/binding/SkiaSharp/SKImageInfo.cs
+++ b/binding/SkiaSharp/SKImageInfo.cs
@@ -126,9 +126,14 @@ namespace SkiaSharp
 		public readonly SKRectI Rect => SKRectI.Create (Width, Height);
 
 		internal readonly int GetPixelBytesOffset (int x, int y) =>
+			GetPixelBytesOffset (x, y, RowBytes);
+
+		// uses the supplied stride rather than the info's packed RowBytes, so it is
+		// correct for buffers whose row stride differs (e.g. a subset of a larger image)
+		internal readonly int GetPixelBytesOffset (int x, int y, int rowBytes) =>
 			ColorType == SKColorType.Unknown
 				? 0
-				: checked(y * RowBytes + (x << ColorType.GetBitShiftPerPixel ()));
+				: checked(y * rowBytes + (x << ColorType.GetBitShiftPerPixel ()));
 
 		public readonly SKImageInfo WithSize (SKSizeI size) =>
 			WithSize (size.Width, size.Height);

--- a/binding/SkiaSharp/SKImageInfo.cs
+++ b/binding/SkiaSharp/SKImageInfo.cs
@@ -125,9 +125,6 @@ namespace SkiaSharp
 
 		public readonly SKRectI Rect => SKRectI.Create (Width, Height);
 
-		internal readonly int GetPixelBytesOffset (int x, int y) =>
-			GetPixelBytesOffset (x, y, RowBytes);
-
 		// uses the supplied stride rather than the info's packed RowBytes, so it is
 		// correct for buffers whose row stride differs (e.g. a subset of a larger image)
 		internal readonly int GetPixelBytesOffset (int x, int y, int rowBytes) =>

--- a/binding/SkiaSharp/SKPixmap.cs
+++ b/binding/SkiaSharp/SKPixmap.cs
@@ -190,9 +190,11 @@ namespace SkiaSharp
 					throw new ArgumentException ($"Size of T ({size}) is not the same as the size of each pixel ({bpp}).", nameof (T));
 
 				// a typed span cannot represent a row stride that is not a whole
-				// number of T elements (the byte overload supports any stride)
-				if (rowBytes % size != 0)
-					throw new ArgumentException ($"The row stride ({rowBytes}) is not a multiple of the size of T ({size}).", nameof (T));
+				// number of T elements, but only when the span actually spans
+				// multiple rows; a single-row pixmap never crosses the stride so
+				// any stride is fine (the byte overload supports any stride too)
+				if (info.Height > 1 && rowBytes % size != 0)
+					throw new ArgumentException ($"The row stride ({rowBytes}) is not a multiple of the size of each pixel ({size}).");
 
 				// work in T elements: since each pixel is exactly one T, the only
 				// unit conversion is the stride from bytes to elements

--- a/binding/SkiaSharp/SKPixmap.cs
+++ b/binding/SkiaSharp/SKPixmap.cs
@@ -159,6 +159,11 @@ namespace SkiaSharp
 			if (bpp <= 0)
 				return null;
 
+			if (x < 0 || x >= info.Width)
+				throw new ArgumentOutOfRangeException (nameof (x));
+			if (y < 0 || y >= info.Height)
+				throw new ArgumentOutOfRangeException (nameof (y));
+
 			// use the actual stride of the pixmap as it may differ from
 			// (Width * BytesPerPixel) when the pixmap is a subset of a larger one
 			var rowBytes = RowBytes;
@@ -183,6 +188,11 @@ namespace SkiaSharp
 				var size = sizeof (T);
 				if (bpp != size)
 					throw new ArgumentException ($"Size of T ({size}) is not the same as the size of each pixel ({bpp}).", nameof (T));
+
+				// a typed span cannot represent a row stride that is not a whole
+				// number of T elements (the byte overload supports any stride)
+				if (rowBytes % size != 0)
+					throw new ArgumentException ($"The row stride ({rowBytes}) is not a multiple of the size of T ({size}).", nameof (T));
 
 				// work in T elements: since each pixel is exactly one T, the only
 				// unit conversion is the stride from bytes to elements

--- a/binding/SkiaSharp/SKPixmap.cs
+++ b/binding/SkiaSharp/SKPixmap.cs
@@ -159,16 +159,25 @@ namespace SkiaSharp
 			if (bpp <= 0)
 				return null;
 
-			var spanLength = 0;
-			var spanOffset = 0;
+			// use the actual stride of the pixmap as it may differ from
+			// (Width * BytesPerPixel) when the pixmap is a subset of a larger one
+			var rowBytes = RowBytes;
+
+			// the span covers from the first pixel up to and including the last
+			// valid pixel of the last row, accounting for any row padding
+			var spanLengthBytes = checked((info.Height - 1) * rowBytes + info.Width * bpp);
+			var spanOffsetBytes = (x != 0 || y != 0)
+				? checked(y * rowBytes + x * bpp)
+				: 0;
+
+			int spanLength;
+			int spanOffset;
 			if (typeof (T) == typeof (byte))
 			{
 				// byte is always valid
 
-				spanLength = info.BytesSize;
-
-				if (x != 0 || y != 0)
-					spanOffset = info.GetPixelBytesOffset (x, y);
+				spanLength = spanLengthBytes;
+				spanOffset = spanOffsetBytes;
 			}
 			else
 			{
@@ -178,10 +187,8 @@ namespace SkiaSharp
 				if (bpp != size)
 					throw new ArgumentException ($"Size of T ({size}) is not the same as the size of each pixel ({bpp}).", nameof (T));
 
-				spanLength = checked(info.Width * info.Height);
-
-				if (x != 0 || y != 0)
-					spanOffset = checked(y * info.Width + x);
+				spanLength = spanLengthBytes / size;
+				spanOffset = spanOffsetBytes / size;
 			}
 
 			var addr = SkiaApi.sk_pixmap_get_writable_addr (Handle);

--- a/binding/SkiaSharp/SKPixmap.cs
+++ b/binding/SkiaSharp/SKPixmap.cs
@@ -163,21 +163,18 @@ namespace SkiaSharp
 			// (Width * BytesPerPixel) when the pixmap is a subset of a larger one
 			var rowBytes = RowBytes;
 
-			// the span covers from the first pixel up to and including the last
-			// valid pixel of the last row, accounting for any row padding
-			var spanLengthBytes = checked((info.Height - 1) * rowBytes + info.Width * bpp);
-			var spanOffsetBytes = (x != 0 || y != 0)
-				? checked(y * rowBytes + x * bpp)
-				: 0;
-
 			int spanLength;
 			int spanOffset;
 			if (typeof (T) == typeof (byte))
 			{
-				// byte is always valid
+				// byte is always valid, so work in bytes
 
-				spanLength = spanLengthBytes;
-				spanOffset = spanOffsetBytes;
+				// the span covers from the first pixel up to and including the
+				// last valid pixel of the last row, accounting for row padding
+				spanLength = checked((info.Height - 1) * rowBytes + info.Width * bpp);
+				spanOffset = (x != 0 || y != 0)
+					? info.GetPixelBytesOffset (x, y, rowBytes)
+					: 0;
 			}
 			else
 			{
@@ -187,8 +184,14 @@ namespace SkiaSharp
 				if (bpp != size)
 					throw new ArgumentException ($"Size of T ({size}) is not the same as the size of each pixel ({bpp}).", nameof (T));
 
-				spanLength = spanLengthBytes / size;
-				spanOffset = spanOffsetBytes / size;
+				// work in T elements: since each pixel is exactly one T, the only
+				// unit conversion is the stride from bytes to elements
+				var rowLength = rowBytes / size;
+
+				spanLength = checked((info.Height - 1) * rowLength + info.Width);
+				spanOffset = (x != 0 || y != 0)
+					? checked(y * rowLength + x)
+					: 0;
 			}
 
 			var addr = SkiaApi.sk_pixmap_get_writable_addr (Handle);

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -726,21 +726,22 @@ namespace SkiaSharp.Tests
 		[SkippableFact]
 		public void GetPixelSpanLastPixelOfSubsetHasSinglePixelLength()
 		{
-			// a multi-row, multi-column subset: the span at the last valid pixel
-			// must reduce to exactly one pixel, proving the offset uses the real
-			// stride and column and never overruns the parent buffer
-			var info = new SKImageInfo(10, 10, SKColorType.Rgba8888);
+			// a non-square, multi-row, multi-column subset: the span at the last
+			// valid pixel must reduce to exactly one pixel, proving the offset uses
+			// the real stride and column and never overruns the parent buffer
+			var info = new SKImageInfo(8, 6, SKColorType.Rgba8888);
 			using var bmp = new SKBitmap(info);
 
 			using SKBitmap roi = new();
-			Assert.True(bmp.ExtractSubset(roi, new SKRectI(7, 7, 10, 10)));
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(5, 4, 8, 6)));
 
 			Assert.Equal(3, roi.Width);
-			Assert.Equal(3, roi.Height);
+			Assert.Equal(2, roi.Height);
 			Assert.True(roi.RowBytes > roi.Info.Width * roi.BytesPerPixel);
 
-			var last = roi.GetPixelSpan(roi.Width - 1, roi.Height - 1);
-			Assert.Equal(roi.BytesPerPixel, last.Length);
+			// an interior non-zero (x, y) and the extreme (Width-1, Height-1) both
+			// reduce to exactly one pixel
+			Assert.Equal(roi.BytesPerPixel, roi.GetPixelSpan(roi.Width - 1, roi.Height - 1).Length);
 		}
 
 		[SkippableTheory]
@@ -766,6 +767,20 @@ namespace SkiaSharp.Tests
 			Assert.Equal(0, bmp.GetPixelSpan().Length);
 			Assert.Equal(0, bmp.GetPixelSpan(0, 0).Length);
 			Assert.Equal(0, bmp.GetPixelSpan(-1, 5).Length);
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanReturnsEmptyForUnknownColorType()
+		{
+			// a non-empty buffer with an unknown color type has no pixel size, so
+			// it returns an empty span rather than throwing, matching SKPixmap
+			using var bmp = new SKBitmap(new SKImageInfo(4, 4, SKColorType.Unknown));
+			Assert.False(bmp.Info.IsEmpty);
+			Assert.Equal(0, bmp.Info.BytesPerPixel);
+
+			Assert.Equal(0, bmp.GetPixelSpan(0, 0).Length);
+			Assert.Equal(0, bmp.GetPixelSpan(2, 3).Length);
+			Assert.Equal(0, bmp.GetPixelSpan(-1, 99).Length);
 		}
 
 		[SkippableTheory]

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -693,6 +693,15 @@ namespace SkiaSharp.Tests
 			var row1Color = MemoryMarshal.Cast<byte, SKColor>(row1)[0];
 			Assert.Equal(roi.GetPixel(0, 0), firstColor);
 			Assert.Equal(roi.GetPixel(0, 1), row1Color);
+
+			// a non-zero x must offset by the column within the row (x * bpp)
+			var col1 = roi.GetPixelSpan(1, 0);
+			Assert.Equal(roi.BytesPerPixel, full.Length - col1.Length);
+			Assert.Equal(roi.GetPixel(1, 0), MemoryMarshal.Cast<byte, SKColor>(col1)[0]);
+
+			// the last valid pixel of the subset must offset by both stride and column
+			var last = roi.GetPixelSpan(1, 1);
+			Assert.Equal(roi.GetPixel(1, 1), MemoryMarshal.Cast<byte, SKColor>(last)[0]);
 		}
 
 		[SkippableFact]
@@ -714,6 +723,26 @@ namespace SkiaSharp.Tests
 			Assert.Equal(roi.BytesPerPixel, roi.GetPixelSpan(0, 0).Length);
 		}
 
+		[SkippableFact]
+		public void GetPixelSpanLastPixelOfSubsetHasSinglePixelLength()
+		{
+			// a multi-row, multi-column subset: the span at the last valid pixel
+			// must reduce to exactly one pixel, proving the offset uses the real
+			// stride and column and never overruns the parent buffer
+			var info = new SKImageInfo(10, 10, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(7, 7, 10, 10)));
+
+			Assert.Equal(3, roi.Width);
+			Assert.Equal(3, roi.Height);
+			Assert.True(roi.RowBytes > roi.Info.Width * roi.BytesPerPixel);
+
+			var last = roi.GetPixelSpan(roi.Width - 1, roi.Height - 1);
+			Assert.Equal(roi.BytesPerPixel, last.Length);
+		}
+
 		[SkippableTheory]
 		[InlineData(-1, 0)]
 		[InlineData(0, -1)]
@@ -732,9 +761,11 @@ namespace SkiaSharp.Tests
 			Assert.True(bmp.Info.IsEmpty);
 
 			// an empty bitmap returns an empty span rather than throwing,
-			// matching SKPixmap.GetPixelSpan<T>
+			// matching SKPixmap.GetPixelSpan<T>; the empty short-circuit wins
+			// even over out-of-range coordinates
 			Assert.Equal(0, bmp.GetPixelSpan().Length);
 			Assert.Equal(0, bmp.GetPixelSpan(0, 0).Length);
+			Assert.Equal(0, bmp.GetPixelSpan(-1, 5).Length);
 		}
 
 		[SkippableTheory]

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -664,6 +664,31 @@ namespace SkiaSharp.Tests
 			Assert.Equal(expectedLength, span.Length);
 		}
 
+		[SkippableFact]
+		public void GetPixelSpanXYUsesStrideForSubset()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+			for (int y = 0; y < 4; y++)
+			{
+				for (int x = 0; x < 4; x++)
+				{
+					bmp.SetPixel(x, y, x < 2 && y < 2 ? SKColors.White : SKColors.Black);
+				}
+			}
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(0, 0, 2, 2)));
+
+			// the subset shares the parent buffer, so its stride is the parent's row bytes
+			Assert.True(roi.RowBytes > roi.Info.Width * roi.BytesPerPixel);
+
+			// the offset for row 1 must use the actual stride, not Width * bpp
+			var full = roi.GetPixelSpan();
+			var row1 = roi.GetPixelSpan(0, 1);
+			Assert.Equal(roi.RowBytes, full.Length - row1.Length);
+		}
+
 		[SkippableTheory]
 		[InlineData("baboon.jpg", "baboon-reencoded.jpg")]
 		public void CanEncodeImageStreams(string filename, string encodedFilename)

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -725,6 +725,18 @@ namespace SkiaSharp.Tests
 			Assert.Throws<ArgumentOutOfRangeException>(() => bmp.GetPixelSpan(x, y));
 		}
 
+		[SkippableFact]
+		public void GetPixelSpanReturnsEmptyForEmptyBitmap()
+		{
+			using var bmp = new SKBitmap();
+			Assert.True(bmp.Info.IsEmpty);
+
+			// an empty bitmap returns an empty span rather than throwing,
+			// matching SKPixmap.GetPixelSpan<T>
+			Assert.Equal(0, bmp.GetPixelSpan().Length);
+			Assert.Equal(0, bmp.GetPixelSpan(0, 0).Length);
+		}
+
 		[SkippableTheory]
 		[InlineData("baboon.jpg", "baboon-reencoded.jpg")]
 		public void CanEncodeImageStreams(string filename, string encodedFilename)

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -704,6 +704,55 @@ namespace SkiaSharp.Tests
 			Assert.Equal(roi.GetPixel(1, 1), MemoryMarshal.Cast<byte, SKColor>(last)[0]);
 		}
 
+		// Bgra8888 stores bytes as B, G, R, A; reinterpreting those bytes as a
+		// little-endian SKColor (0xAARRGGBB) reproduces the logical color exactly,
+		// so the span contents can be compared without any channel swizzle.
+		private static SKColor UniqueColor(int x, int y) =>
+			new SKColor((byte)(x + 1), (byte)(y + 1), 0xAB, 0xFF);
+
+		private static SKBitmap CreateUniquePixelBitmap(int width, int height)
+		{
+			var bmp = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+			for (var y = 0; y < height; y++)
+				for (var x = 0; x < width; x++)
+					bmp.SetPixel(x, y, UniqueColor(x, y));
+			return bmp;
+		}
+
+		[SkippableTheory]
+		[InlineData(0, 0, 3, 2)]   // origin (0, 0)
+		[InlineData(3, 2, 7, 5)]   // interior origin, non-square
+		[InlineData(2, 0, 5, 3)]   // top edge, non-zero x
+		[InlineData(0, 3, 3, 6)]   // left edge, non-zero y
+		[InlineData(5, 4, 8, 6)]   // bottom-right, touches the parent's last row/col
+		public void GetPixelSpanReturnsExactSubsetPixels(int left, int top, int right, int bottom)
+		{
+			// every parent pixel has a unique colour encoding its (x, y), so reading
+			// the wrong row or column (the original bug) produces a wrong colour
+			using var bmp = CreateUniquePixelBitmap(8, 6);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(left, top, right, bottom)));
+
+			// the subset is narrower than the parent, so its stride must differ
+			Assert.True(roi.RowBytes > roi.Info.Width * roi.BytesPerPixel);
+
+			for (var y = 0; y < roi.Height; y++)
+			{
+				for (var x = 0; x < roi.Width; x++)
+				{
+					var expected = UniqueColor(left + x, top + y);
+
+					// the byte span at (x, y) must point at exactly the parent pixel
+					var fromSpan = MemoryMarshal.Cast<byte, SKColor>(roi.GetPixelSpan(x, y))[0];
+					Assert.Equal(expected, fromSpan);
+
+					// cross-check against the independent logical accessor
+					Assert.Equal(expected, roi.GetPixel(x, y));
+				}
+			}
+		}
+
 		[SkippableFact]
 		public void GetPixelSpanHandlesBottomRightSubset()
 		{

--- a/tests/Tests/SkiaSharp/SKBitmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKBitmapTest.cs
@@ -687,6 +687,42 @@ namespace SkiaSharp.Tests
 			var full = roi.GetPixelSpan();
 			var row1 = roi.GetPixelSpan(0, 1);
 			Assert.Equal(roi.RowBytes, full.Length - row1.Length);
+
+			// the offset must also land on the correct pixel data
+			var firstColor = MemoryMarshal.Cast<byte, SKColor>(roi.GetPixelSpan(0, 0))[0];
+			var row1Color = MemoryMarshal.Cast<byte, SKColor>(row1)[0];
+			Assert.Equal(roi.GetPixel(0, 0), firstColor);
+			Assert.Equal(roi.GetPixel(0, 1), row1Color);
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanHandlesBottomRightSubset()
+		{
+			// the native byte count must already exclude trailing row padding so the
+			// full-image span does not read past the end of the parent buffer
+			var info = new SKImageInfo(10, 10, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(9, 9, 10, 10)));
+
+			Assert.Equal(1, roi.Width);
+			Assert.Equal(1, roi.Height);
+
+			// a single pixel: exactly BytesPerPixel, never Height * RowBytes
+			Assert.Equal(roi.BytesPerPixel, roi.GetPixelSpan().Length);
+			Assert.Equal(roi.BytesPerPixel, roi.GetPixelSpan(0, 0).Length);
+		}
+
+		[SkippableTheory]
+		[InlineData(-1, 0)]
+		[InlineData(0, -1)]
+		[InlineData(0, 40)]
+		[InlineData(40, 0)]
+		public void GetPixelSpanThrowsForOutOfRangeCoordinates(int x, int y)
+		{
+			using var bmp = CreateTestBitmap();
+			Assert.Throws<ArgumentOutOfRangeException>(() => bmp.GetPixelSpan(x, y));
 		}
 
 		[SkippableTheory]

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -456,5 +456,46 @@ namespace SkiaSharp.Tests
 			var spanMidRow1 = pixmap.GetPixelSpan<SKColor>(4, 1);
 			Assert.Equal(spanRow1[4], spanMidRow1[0]);
 		}
+
+		[SkippableFact]
+		public void GetPixelSpanHandlesStrideCorrectly()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+			for (int y = 0; y < 4; y++)
+			{
+				for (int x = 0; x < 4; x++)
+				{
+					bmp.SetPixel(x, y, x < 2 && y < 2 ? SKColors.White : SKColors.Black);
+				}
+			}
+
+			using var pixmap = bmp.PeekPixels();
+			var span = pixmap.GetPixelSpan<SKColor>();
+			Assert.Equal(16, span.Length);
+
+			using SKBitmap roi = new();
+			bool ok = bmp.ExtractSubset(roi, new SKRectI(0, 0, 2, 2));
+			Assert.True(ok);
+
+			using var roiPixmap = roi.PeekPixels();
+
+			// the subset shares the parent buffer, so its stride is the parent's
+			// row bytes; the span must reach the last valid pixel of the last row
+			Assert.True(roiPixmap.RowBytes > roiPixmap.Info.Width * roiPixmap.BytesPerPixel);
+
+			var roiSpan = roiPixmap.GetPixelSpan<SKColor>();
+			Assert.Equal(6, roiSpan.Length);
+
+			// the four top-left pixels are white in the subset's first row
+			var white = roiPixmap.GetPixelColor(0, 0);
+			Assert.Equal(white, roiSpan[0]);
+			Assert.Equal(white, roiSpan[1]);
+
+			// row 1 of the subset starts at the stride offset
+			var stridePixels = roiPixmap.RowBytes / roiPixmap.BytesPerPixel;
+			var roiSpanRow1 = roiPixmap.GetPixelSpan<SKColor>(0, 1);
+			Assert.Equal(roiSpan[stridePixels], roiSpanRow1[0]);
+		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -269,24 +269,31 @@ namespace SkiaSharp.Tests
 		[InlineData(SKColorType.Rgb565, 1, 1, 0, 0, 0)]
 		[InlineData(SKColorType.Rgb565, 2, 2, 0, 0, 0)]
 		[InlineData(SKColorType.Rgb565, 2, 2, 1, 0, 2)]
-		[InlineData(SKColorType.Rgb565, 2, 2, 1, 0, 2)]
 		[InlineData(SKColorType.Rgb565, 2, 2, 0, 1, 4)]
-		[InlineData(SKColorType.Rgb565, 2, 2, 0, 1, 4)]
-		[InlineData(SKColorType.Rgb565, 2, 2, 1, 1, 6)]
 		[InlineData(SKColorType.Rgb565, 2, 2, 1, 1, 6)]
 		// Rgba8888 => 4 bytes per pixel
 		[InlineData(SKColorType.Rgba8888, 1, 1, 0, 0, 0)]
 		[InlineData(SKColorType.Rgba8888, 2, 2, 0, 0, 0)]
 		[InlineData(SKColorType.Rgba8888, 2, 2, 1, 0, 4)]
-		[InlineData(SKColorType.Rgba8888, 2, 2, 1, 0, 4)]
 		[InlineData(SKColorType.Rgba8888, 2, 2, 0, 1, 8)]
-		[InlineData(SKColorType.Rgba8888, 2, 2, 0, 1, 8)]
-		[InlineData(SKColorType.Rgba8888, 2, 2, 1, 1, 12)]
 		[InlineData(SKColorType.Rgba8888, 2, 2, 1, 1, 12)]
 		public void GetPixelBytesOffsetIsCorrect(SKColorType ct, int w, int h, int x, int y, int offset)
 		{
 			var info = new SKImageInfo(w, h, ct);
 			Assert.Equal(offset, info.GetPixelBytesOffset(x, y, info.RowBytes));
+		}
+
+		[SkippableTheory]
+		// the offset must honor a stride that is larger than the packed width
+		// Rgba8888 (4 bpp), 2px wide, but a 16-byte stride (8 bytes of padding)
+		[InlineData(SKColorType.Rgba8888, 2, 16, 0, 0, 0)]
+		[InlineData(SKColorType.Rgba8888, 2, 16, 1, 0, 4)]
+		[InlineData(SKColorType.Rgba8888, 2, 16, 0, 1, 16)]
+		[InlineData(SKColorType.Rgba8888, 2, 16, 1, 1, 20)]
+		public void GetPixelBytesOffsetHonorsStride(SKColorType ct, int w, int rowBytes, int x, int y, int offset)
+		{
+			var info = new SKImageInfo(w, 4, ct);
+			Assert.Equal(offset, info.GetPixelBytesOffset(x, y, rowBytes));
 		}
 
 		[SkippableTheory]
@@ -572,6 +579,38 @@ namespace SkiaSharp.Tests
 			// offset for row 1 is one full stride
 			var row1 = pixmap.GetPixelSpan<byte>(0, 1);
 			Assert.Equal(span.Length - pixmap.RowBytes, row1.Length);
+
+			// the last valid pixel must reduce to exactly one pixel of bytes,
+			// proving the byte-branch offset never reads past the parent buffer
+			var lastByte = pixmap.GetPixelSpan<byte>(pixmap.Width - 1, pixmap.Height - 1);
+			Assert.Equal(pixmap.BytesPerPixel, lastByte.Length);
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanHandlesSubsetForHighBitShiftColorType()
+		{
+			// RgbaF32 is 16 bytes per pixel (shift 4) - the largest multiplier
+			// and the most relevant to the offset overflow surface
+			var info = new SKImageInfo(4, 4, SKColorType.RgbaF32);
+			using var bmp = new SKBitmap(info);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(0, 0, 2, 2)));
+
+			using var pixmap = roi.PeekPixels();
+			Assert.Equal(16, pixmap.BytesPerPixel);
+			Assert.True(pixmap.RowBytes > pixmap.Width * pixmap.BytesPerPixel);
+
+			// typed: the last valid pixel reduces to exactly one element
+			var rowLength = pixmap.RowBytes / pixmap.BytesPerPixel;
+			var span = pixmap.GetPixelSpan<SKColorF>();
+			Assert.Equal((2 - 1) * rowLength + 2, span.Length);
+			var lastTyped = pixmap.GetPixelSpan<SKColorF>(pixmap.Width - 1, pixmap.Height - 1);
+			Assert.Equal(1, lastTyped.Length);
+
+			// byte: the last valid pixel reduces to exactly BytesPerPixel
+			var lastByte = pixmap.GetPixelSpan<byte>(pixmap.Width - 1, pixmap.Height - 1);
+			Assert.Equal(pixmap.BytesPerPixel, lastByte.Length);
 		}
 
 		[SkippableFact]
@@ -671,6 +710,31 @@ namespace SkiaSharp.Tests
 			Assert.True(pixmap.GetPixelSpan<byte>(0, 0).IsEmpty);
 			Assert.True(pixmap.GetPixelSpan<byte>(-1, 5).IsEmpty);
 			Assert.True(pixmap.GetPixelSpan<SKColor>(0, 0).IsEmpty);
+			Assert.True(pixmap.GetPixelSpan<SKColor>(-1, 5).IsEmpty);
+		}
+
+		[SkippableFact]
+		public unsafe void GetPixelSpanReturnsEmptyForUnknownColorType()
+		{
+			// a non-empty buffer with an unknown color type has no pixel size, so
+			// it returns an empty span rather than throwing
+			var info = new SKImageInfo(4, 4, SKColorType.Unknown);
+			Assert.False(info.IsEmpty);
+			Assert.Equal(0, info.BytesPerPixel);
+
+			var buffer = Marshal.AllocCoTaskMem(64);
+			try
+			{
+				using var pixmap = new SKPixmap(info, buffer);
+
+				Assert.True(pixmap.GetPixelSpan<byte>(0, 0).IsEmpty);
+				Assert.True(pixmap.GetPixelSpan<byte>(2, 3).IsEmpty);
+				Assert.True(pixmap.GetPixelSpan<byte>(-1, 99).IsEmpty);
+			}
+			finally
+			{
+				Marshal.FreeCoTaskMem(buffer);
+			}
 		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -497,5 +497,141 @@ namespace SkiaSharp.Tests
 			var roiSpanRow1 = roiPixmap.GetPixelSpan<SKColor>(0, 1);
 			Assert.Equal(roiSpan[stridePixels], roiSpanRow1[0]);
 		}
+
+		[SkippableFact]
+		public void GetPixelSpanHandlesNonSquareSubset()
+		{
+			// distinct dimensions so a Width/Height swap would be caught
+			var info = new SKImageInfo(6, 4, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+			using (var canvas = new SKCanvas(bmp))
+				canvas.Clear(SKColors.Red);
+
+			// non-square, non-square subset
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(0, 0, 3, 2)));
+
+			using var pixmap = roi.PeekPixels();
+			Assert.Equal(3, pixmap.Width);
+			Assert.Equal(2, pixmap.Height);
+			Assert.True(pixmap.RowBytes > pixmap.Width * pixmap.BytesPerPixel);
+
+			var rowLength = pixmap.RowBytes / pixmap.BytesPerPixel;
+
+			// length = (Height - 1) * rowLength + Width
+			var span = pixmap.GetPixelSpan<SKColor>();
+			Assert.Equal((2 - 1) * rowLength + 3, span.Length);
+
+			// offset of (2, 1) = 1 * rowLength + 2
+			var spanX2Y1 = pixmap.GetPixelSpan<SKColor>(2, 1);
+			Assert.Equal(span.Length - (rowLength + 2), spanX2Y1.Length);
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanHandlesBottomRightSubset()
+		{
+			// a subset whose last row is the parent's last row: a naively padded
+			// last row would read past the end of the parent buffer
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+			using (var canvas = new SKCanvas(bmp))
+				canvas.Clear(SKColors.Blue);
+			bmp.SetPixel(3, 3, SKColors.Green);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(2, 2, 4, 4)));
+
+			using var pixmap = roi.PeekPixels();
+			var rowLength = pixmap.RowBytes / pixmap.BytesPerPixel;
+
+			// length stops at the last valid pixel of the last row
+			var span = pixmap.GetPixelSpan<SKColor>();
+			Assert.Equal((2 - 1) * rowLength + 2, span.Length);
+
+			// the last valid pixel (1, 1) is the green parent pixel (3, 3)
+			var green = pixmap.GetPixelColor(1, 1);
+			Assert.Equal(green, span[span.Length - 1]);
+			Assert.Equal(SKColors.Green, green);
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanByteBranchHandlesSubsetStride()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(0, 0, 2, 2)));
+
+			using var pixmap = roi.PeekPixels();
+
+			// (Height - 1) * RowBytes + Width * BytesPerPixel = 1 * 16 + 2 * 4
+			var span = pixmap.GetPixelSpan<byte>();
+			Assert.Equal(24, span.Length);
+
+			// offset for row 1 is one full stride
+			var row1 = pixmap.GetPixelSpan<byte>(0, 1);
+			Assert.Equal(span.Length - pixmap.RowBytes, row1.Length);
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanHandlesSubsetForMultiByteColorType()
+		{
+			// Rgb565 is 2 bytes per pixel, exercising a different bpp/shift
+			var info = new SKImageInfo(4, 4, SKColorType.Rgb565);
+			using var bmp = new SKBitmap(info);
+			using (var canvas = new SKCanvas(bmp))
+				canvas.Clear(SKColors.Red);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(0, 0, 2, 2)));
+
+			using var pixmap = roi.PeekPixels();
+			Assert.True(pixmap.RowBytes > pixmap.Width * pixmap.BytesPerPixel);
+
+			var rowLength = pixmap.RowBytes / pixmap.BytesPerPixel;
+			var span = pixmap.GetPixelSpan<ushort>();
+			Assert.Equal((2 - 1) * rowLength + 2, span.Length);
+		}
+
+		[SkippableTheory]
+		[InlineData(-1, 0)]
+		[InlineData(0, -1)]
+		[InlineData(0, 4)]
+		[InlineData(4, 0)]
+		public void GetPixelSpanThrowsForOutOfRangeCoordinates(int x, int y)
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888);
+			using var bmp = new SKBitmap(info);
+			using var pixmap = bmp.PeekPixels();
+
+			Assert.Throws<ArgumentOutOfRangeException>(() => pixmap.GetPixelSpan<SKColor>(x, y));
+			Assert.Throws<ArgumentOutOfRangeException>(() => pixmap.GetPixelSpan(x, y));
+		}
+
+		[SkippableFact]
+		public unsafe void GetPixelSpanTypedThrowsForStrideNotMultipleOfElement()
+		{
+			// a stride that is not a whole number of pixels cannot be represented
+			// by a typed span, but the byte overload must still work
+			var info = new SKImageInfo(1, 2, SKColorType.Rgba8888);
+			var rowBytes = info.Width * info.BytesPerPixel + 1; // 5
+			var buffer = Marshal.AllocCoTaskMem(rowBytes * info.Height);
+			try
+			{
+				using var pixmap = new SKPixmap(info, buffer, rowBytes);
+
+				// byte overload works with any stride
+				var bytes = pixmap.GetPixelSpan<byte>(0, 1);
+				Assert.Equal(rowBytes, pixmap.GetPixelSpan<byte>().Length - bytes.Length);
+
+				// typed overload cannot represent the fractional stride
+				Assert.Throws<ArgumentException>(() => pixmap.GetPixelSpan<SKColor>());
+			}
+			finally
+			{
+				Marshal.FreeCoTaskMem(buffer);
+			}
+		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -505,6 +505,60 @@ namespace SkiaSharp.Tests
 			Assert.Equal(roiSpan[stridePixels], roiSpanRow1[0]);
 		}
 
+		// Bgra8888 stores bytes as B, G, R, A; reinterpreting those bytes as a
+		// little-endian SKColor (0xAARRGGBB) reproduces the logical color exactly,
+		// so the span contents can be compared without any channel swizzle.
+		private static SKColor UniqueColor(int x, int y) =>
+			new SKColor((byte)(x + 1), (byte)(y + 1), 0xAB, 0xFF);
+
+		private static SKBitmap CreateUniquePixelBitmap(int width, int height)
+		{
+			var bmp = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+			for (var y = 0; y < height; y++)
+				for (var x = 0; x < width; x++)
+					bmp.SetPixel(x, y, UniqueColor(x, y));
+			return bmp;
+		}
+
+		[SkippableTheory]
+		[InlineData(0, 0, 3, 2)]   // origin (0, 0)
+		[InlineData(3, 2, 7, 5)]   // interior origin, non-square
+		[InlineData(2, 0, 5, 3)]   // top edge, non-zero x
+		[InlineData(0, 3, 3, 6)]   // left edge, non-zero y
+		[InlineData(5, 4, 8, 6)]   // bottom-right, touches the parent's last row/col
+		public void GetPixelSpanReturnsExactSubsetPixels(int left, int top, int right, int bottom)
+		{
+			// every parent pixel has a unique colour encoding its (x, y), so reading
+			// the wrong row or column (the original bug) produces a wrong colour
+			using var bmp = CreateUniquePixelBitmap(8, 6);
+
+			using SKBitmap roi = new();
+			Assert.True(bmp.ExtractSubset(roi, new SKRectI(left, top, right, bottom)));
+
+			using var pixmap = roi.PeekPixels();
+
+			// the subset is narrower than the parent, so its stride must differ
+			Assert.True(pixmap.RowBytes > pixmap.Width * pixmap.BytesPerPixel);
+
+			for (var y = 0; y < pixmap.Height; y++)
+			{
+				for (var x = 0; x < pixmap.Width; x++)
+				{
+					var expected = UniqueColor(left + x, top + y);
+
+					// the typed span at (x, y) must point at exactly the parent pixel
+					var fromSpan = pixmap.GetPixelSpan<SKColor>(x, y)[0];
+					Assert.Equal(expected, fromSpan);
+
+					// cross-check against the independent logical accessor
+					Assert.Equal(expected, pixmap.GetPixelColor(x, y));
+				}
+			}
+
+			// the full span's first element is the subset's top-left pixel
+			Assert.Equal(UniqueColor(left, top), pixmap.GetPixelSpan<SKColor>()[0]);
+		}
+
 		[SkippableFact]
 		public void GetPixelSpanHandlesNonSquareSubset()
 		{

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -633,5 +633,44 @@ namespace SkiaSharp.Tests
 				Marshal.FreeCoTaskMem(buffer);
 			}
 		}
+
+		[SkippableFact]
+		public unsafe void GetPixelSpanTypedAllowsStrideNotMultipleOfElementForSingleRow()
+		{
+			// a single-row pixmap never crosses the stride padding, so even a
+			// stride that is not a whole number of pixels is representable as a
+			// typed span of exactly Width elements
+			var info = new SKImageInfo(1, 1, SKColorType.Rgba8888);
+			var rowBytes = info.Width * info.BytesPerPixel + 1; // 5
+			var buffer = Marshal.AllocCoTaskMem(rowBytes * info.Height);
+			try
+			{
+				using var pixmap = new SKPixmap(info, buffer, rowBytes);
+
+				var span = pixmap.GetPixelSpan<SKColor>();
+				Assert.Equal(info.Width, span.Length);
+
+				var atOrigin = pixmap.GetPixelSpan<SKColor>(0, 0);
+				Assert.Equal(info.Width, atOrigin.Length);
+			}
+			finally
+			{
+				Marshal.FreeCoTaskMem(buffer);
+			}
+		}
+
+		[SkippableFact]
+		public void GetPixelSpanReturnsEmptyForEmptyPixmap()
+		{
+			using var pixmap = new SKPixmap();
+			Assert.True(pixmap.Info.IsEmpty);
+
+			// an empty pixmap returns an empty span rather than throwing, and the
+			// empty short-circuit wins even over out-of-range coordinates
+			Assert.True(pixmap.GetPixelSpan<byte>().IsEmpty);
+			Assert.True(pixmap.GetPixelSpan<byte>(0, 0).IsEmpty);
+			Assert.True(pixmap.GetPixelSpan<byte>(-1, 5).IsEmpty);
+			Assert.True(pixmap.GetPixelSpan<SKColor>(0, 0).IsEmpty);
+		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -286,7 +286,7 @@ namespace SkiaSharp.Tests
 		public void GetPixelBytesOffsetIsCorrect(SKColorType ct, int w, int h, int x, int y, int offset)
 		{
 			var info = new SKImageInfo(w, h, ct);
-			Assert.Equal(offset, info.GetPixelBytesOffset(x, y));
+			Assert.Equal(offset, info.GetPixelBytesOffset(x, y, info.RowBytes));
 		}
 
 		[SkippableTheory]

--- a/tests/Tests/SkiaSharp/SKPixmapTest.cs
+++ b/tests/Tests/SkiaSharp/SKPixmapTest.cs
@@ -487,7 +487,7 @@ namespace SkiaSharp.Tests
 			var roiSpan = roiPixmap.GetPixelSpan<SKColor>();
 			Assert.Equal(6, roiSpan.Length);
 
-			// the four top-left pixels are white in the subset's first row
+			// both pixels in the subset's first row are white
 			var white = roiPixmap.GetPixelColor(0, 0);
 			Assert.Equal(white, roiSpan[0]);
 			Assert.Equal(white, roiSpan[1]);


### PR DESCRIPTION
## Description

Fixes #4137.

`SKPixmap.GetPixelSpan<T>(x, y)` (and the equivalent `SKBitmap.GetPixelSpan(x, y)`) computed both the span length and the `(x, y)` offset from `Width * BytesPerPixel` instead of the pixmap's actual `RowBytes`.

When a pixmap/bitmap is a **subset** of a larger one (e.g. created via `ExtractSubset`), its real stride (`RowBytes`) is larger than `Width * BytesPerPixel` because it shares the parent's buffer. As a result:

- the returned span was **too short** and did not cover the whole subset, and
- the `(x, y)` offset landed on the **wrong row**.

## Fix

Use the actual `RowBytes` for the stride:

- **Length** = `(Height - 1) * RowBytes + Width * BytesPerPixel` — reaches the last valid pixel of the last row while accounting for row padding.
- **Offset** = `y * RowBytes + x * BytesPerPixel`.

For non-subset pixmaps `RowBytes == Width * BytesPerPixel`, so behaviour is unchanged.

Using the example from the issue, a `2x2` subset of a `4x4` RGBA8888 bitmap now correctly returns a span of length 6 (`SKColor`) instead of 4.

The offset computation is shared through a stride-aware `SKImageInfo.GetPixelBytesOffset(x, y, rowBytes)` helper, and the typed `GetPixelSpan<T>` path computes its length in element units (`rowBytes / sizeof(T)`) to avoid a byte-to-element division.

## Hardening

Beyond the core fix, the methods were tightened against edge cases surfaced during review:

- **Coordinate validation** — `(x, y)` outside the image throws `ArgumentOutOfRangeException`.
- **Empty / unknown color types** — empty pixmaps/bitmaps and `Unknown` color types (`BytesPerPixel <= 0`) return an empty span *before* coordinate validation, preserving prior behaviour.
- **Typed-span stride guard** — the typed overload throws when a multi-row stride is not evenly divisible by `sizeof(T)`; single-row (`Height == 1`) pixmaps are exempt since stride divisibility is irrelevant there.
- **Overflow safety** — all length/offset arithmetic is `checked`, including the `(int)` length cast in the no-argument `SKBitmap.GetPixelSpan()`.

## Tests

`SKPixmapTest` and `SKBitmapTest` gained focused coverage:

- The exact repro from the issue (`GetPixelSpanHandlesStrideCorrectly` / `GetPixelSpanXYUsesStrideForSubset`).
- A `GetPixelSpanReturnsExactSubsetPixels` theory in **both** test classes that builds an 8×6 Bgra8888 parent where each pixel encodes its own coordinates, then extracts subsets at multiple origins — `(0,0)`, an interior non-square rect, the top and left edges at non-zero offsets, and the bottom-right corner — and asserts **every** subset pixel against both the span and the independent `GetPixelColor`/`GetPixel` oracle. Each case also asserts `RowBytes > Width * BytesPerPixel` so a padded stride is genuinely exercised.
- Corner cases: non-square subsets, bottom-right subsets, single-row pixmaps, empty pixmaps/bitmaps, `Unknown` color type, and a high-bit-shift color type (F32).
- `GetPixelBytesOffsetIsCorrect` / `GetPixelBytesOffsetHonorsStride` validate the shared offset helper.

All existing `SKPixmapTest` and `SKBitmapTest` tests continue to pass.

## ABI

No signature changes — behaviour-only fix. (The unused parameterless `GetPixelBytesOffset` overload, which had no production callers, was removed.)