### PR TITLE
[docs] Two-way supersede links in release notes

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -88,6 +88,12 @@ Determine the version's status from the HTML comment block in the file (`status:
   preview that will never ship as stable. Keep the script-generated
   `> **Preview only** · Superseded by [X.Y.Z](...) · Never released as stable …` header and
   add a short note in Highlights that the work rolled up into the superseding version.
+- **Successor** (a `supersedes:` line is present in the comment block): this version rolls
+  up one or more skipped preview-only versions. Keep the script-generated
+  `> **Supersedes [X.Y.Z](...)** · Rolls up preview-only work …` note and mention in
+  Highlights that the skipped preview work is rolled up cumulatively. This is the back-link
+  that makes the supersede relationship **two-way** (the superseded page points forward, the
+  successor points back).
 
 ### Skipped / superseded minors (preview-only versions)
 
@@ -103,7 +109,7 @@ configuration is normally required:
    stable, so e.g. `3.119.4` rolls up the preview-only `3.119.3` (the `3.119.3` page still
    keeps its own notes — duplication across the two pages is expected and fine).
 
-2. **Automatic supersede label.** A version that has only preview tags is flagged as
+2. **Automatic supersede label (two-way).** A version that has only preview tags is flagged as
    *superseded* once a **newer version is known**. A newer version is "known" from a later
    `release/*` branch or `v*` tag, **or from `main` itself**: if `main`'s in-development
    `SKIASHARP_VERSION` is newer and the preview-only version's minor line was never branched
@@ -115,12 +121,20 @@ configuration is normally required:
    page (`{ver}.md`) when it exists, otherwise to its in-development page
    (`{ver}-unreleased.md`). Until a newer version is known, the version is just a normal preview.
 
+   The relationship is rendered **both ways**: the successor page (computed by the inverse
+   `detect_supersedes`) carries a `supersedes:` data-block line and a
+   *"Supersedes [X.Y.Z] · Rolls up preview-only work …"* note, so e.g. `4.148.0` points back
+   to `4.147.0`, `3.119.4` to `3.119.3`, and `3.119.0` to `3.118.0` — automatically, without
+   the AI having to infer it from the diff base.
+
 > Detection is purely tag/branch/`main`-version based, so no configuration file is needed. (If a
 > manual override is ever required it can be reintroduced later; for now the automatic
 > behaviour is the only path.)
 
 When polishing a superseded page, keep the script-generated *"Preview only · Superseded by …"*
 header and add a one-line note in Highlights that the work rolled up into the successor.
+When polishing a **successor** page, keep the script-generated *"Supersedes …"* note and add a
+one-line note in Highlights that the skipped preview work is rolled up cumulatively.
 
 ### Step 4 — Write polished pages
 

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -198,6 +198,30 @@ def resolve_superseded_by(version, all_branches):
     return detect_superseded_by(version, all_branches)
 
 
+def detect_supersedes(version, all_branches):
+    # type: (str, list[str]) -> list[str]
+    """Inverse of detect_superseded_by: the versions this release rolls up.
+
+    Returns every earlier base version whose auto-detected successor is exactly
+    `version` — i.e. the preview-only / skipped versions that were superseded by
+    this one and whose work is rolled up cumulatively. This is the back-link that
+    makes the supersede relationship two-way: the superseded page already points
+    forward ("Superseded by X"), and this lets the successor page point back
+    ("Supersedes Y"). Covers a skipped minor (4.148.0 supersedes 4.147.0) and an
+    abandoned patch preview (3.119.4 supersedes 3.119.3). Returns [] when this
+    version supersedes nothing.
+    """
+    vkey = version_key(version)
+    rolled = []
+    for cand in _all_known_base_versions(all_branches):
+        if cand == version or version_key(cand) >= vkey:
+            continue
+        if resolve_superseded_by(cand, all_branches) == version:
+            rolled.append(cand)
+    rolled.sort(key=version_key)
+    return rolled
+
+
 def _is_valid_stable_base(branch):
     # type: (str) -> bool
     """True if a release branch may serve as a cumulative "previous stable" base.
@@ -722,10 +746,19 @@ def format_pr_list(prs, metadata):
     ]
 
     superseded_by = metadata.get("superseded_by")
+    supersedes = metadata.get("supersedes")
+    meta_extra = []
     if superseded_by:
-        # Insert right after the status line for visibility.
-        lines.insert(8, "  superseded: {} (preview only, never released as stable)".format(
-            superseded_by))
+        meta_extra.append(
+            "  superseded: {} (preview only, never released as stable)".format(
+                superseded_by))
+    if supersedes:
+        meta_extra.append(
+            "  supersedes: {} (preview only, rolled up)".format(
+                ", ".join(supersedes)))
+    # Insert right after the status line for visibility.
+    for i, extra in enumerate(meta_extra):
+        lines.insert(8 + i, extra)
 
     if not prs:
         lines.append("  *No changes found.*")
@@ -784,12 +817,38 @@ def format_pr_list(prs, metadata):
                 version))
     lines.append("")
 
+    # Back-link making the supersede relationship two-way: this release rolls up
+    # one or more preview-only versions that never shipped stable. The superseded
+    # page already links forward ("Superseded by X"); this points back to it.
+    if supersedes:
+        sup_links = []
+        for sup in supersedes:
+            if (RELEASES_DIR / "{}.md".format(sup)).exists():
+                sup_links.append("[{s}]({s}.md)".format(s=sup))
+            elif (RELEASES_DIR / "{}-unreleased.md".format(sup)).exists():
+                sup_links.append("[{s}]({s}-unreleased.md)".format(s=sup))
+            else:
+                sup_links.append(sup)
+        lines.append(
+            "> **Supersedes {}** · Rolls up preview-only work that was never "
+            "released as stable — those changes are included cumulatively "
+            "below.".format(", ".join(sup_links)))
+        lines.append("")
+
     lines.append(
         "<!-- AI: Use the raw PR data in the comment above to write polished")
     lines.append(
         "     release notes here. Follow documentation/docfx/releases/"
         "TEMPLATE.md")
-    lines.append("     for structure and tone. -->")
+    if supersedes:
+        lines.append("     for structure and tone.")
+        lines.append(
+            "     This release SUPERSEDES {} (preview-only, rolled up). Keep "
+            "the \"Supersedes\" note above and mention in the Highlights that "
+            "this release rolls up that skipped preview work cumulatively. -->"
+            .format(", ".join(supersedes)))
+    else:
+        lines.append("     for structure and tone. -->")
     lines.append("")
 
     return "\n".join(lines)
@@ -1029,11 +1088,18 @@ def cmd_branch(branch):
         if superseded_by:
             status = "preview"
 
+    # Inverse relationship (two-way link): the preview-only versions that this
+    # release supersedes / rolls up. Applies to any successor — main, a
+    # servicing .x line, or a stable release branch.
+    supersedes = detect_supersedes(version, all_branches)
+
     print("Branch: {}".format(branch))
     print("Version: {}".format(version))
     print("Status: {}".format(status))
     if superseded_by:
         print("Superseded by: {}".format(superseded_by))
+    if supersedes:
+        print("Supersedes: {}".format(", ".join(supersedes)))
     print("Diff: {}..{}".format(from_display, to_display))
 
     prs = get_prs_from_diff(from_ref, to_ref)
@@ -1059,6 +1125,8 @@ def cmd_branch(branch):
     }
     if superseded_by:
         metadata["superseded_by"] = superseded_by
+    if supersedes:
+        metadata["supersedes"] = supersedes
     content = format_pr_list(prs, metadata)
 
     output_path = RELEASES_DIR / filename

--- a/documentation/docfx/releases/3.119.0.md
+++ b/documentation/docfx/releases/3.119.0.md
@@ -6,6 +6,7 @@
   Generated: 2026-06-11T21:27:08Z by generate-release-notes.py
   version:   3.119.0
   status:    stable
+  supersedes: 3.118.0 (preview only, rolled up)
   branch:    release/3.119.0
   diff:      release/3.116.1..release/3.119.0
   prs:       52
@@ -67,6 +68,8 @@
 # Version 3.119.0
 
 > [NuGet](https://www.nuget.org/packages/SkiaSharp/3.119.0)
+
+> **Supersedes [3.118.0](3.118.0.md)** · Rolls up preview-only work that was never released as stable — those changes are included cumulatively below.
 
 ## Highlights
 

--- a/documentation/docfx/releases/3.119.4.md
+++ b/documentation/docfx/releases/3.119.4.md
@@ -6,6 +6,7 @@
   Generated: 2026-06-11T21:12:31Z by generate-release-notes.py
   version:   3.119.4
   status:    stable
+  supersedes: 3.119.3 (preview only, rolled up)
   branch:    release/3.119.4
   diff:      release/3.119.2..release/3.119.4
   prs:       140
@@ -155,6 +156,8 @@
 # Version 3.119.4
 
 > [NuGet](https://www.nuget.org/packages/SkiaSharp/3.119.4)
+
+> **Supersedes [3.119.3](3.119.3.md)** · Rolls up preview-only work that was never released as stable — those changes are included cumulatively below.
 
 <!-- Generated: 2026-06-11T21:35:00Z by github-copilot -->
 

--- a/documentation/docfx/releases/4.148.0-unreleased.md
+++ b/documentation/docfx/releases/4.148.0-unreleased.md
@@ -6,6 +6,7 @@
   Generated: 2026-06-11T22:06:37Z by generate-release-notes.py
   version:   4.148.0
   status:    unreleased
+  supersedes: 4.147.0 (preview only, rolled up)
   branch:    main
   diff:      release/3.119.4..main
   prs:       158
@@ -175,6 +176,8 @@
 # Version 4.148.0
 
 > **Upcoming release** · In development · Not yet available on NuGet
+
+> **Supersedes [4.147.0](4.147.0.md)** · Rolls up preview-only work that was never released as stable — those changes are included cumulatively below.
 
 ## Highlights
 


### PR DESCRIPTION
## Problem

The supersede relationship in the release-notes generator was **one-directional**. A skipped preview-only version (e.g. `4.147.0`) was labelled *"Superseded by 4.148.0"*, but the successor that rolled up its work (`4.148.0`) carried **no back-link**. Worse, the successor's data block had no supersede signal at all — so when the `update-release-notes` workflow re-ran the script and the AI re-polished from that data block (see #4151), it silently dropped the hand-written *"supersedes 4.147.0"* rollup narrative.

Checking the other pages confirmed it was systemic — only the superseded page ever pointed forward:

| Pair | Superseded → successor | Successor → superseded (before) |
|------|------------------------|----------------------------------|
| 3.118.0 → **3.119.0** | ✅ | ❌ |
| 3.119.3 → **3.119.4** | ✅ | ❌ |
| 4.147.0 → **4.148.0** | ✅ | ⚠️ hand-written only, stripped on regen |

## Fix

- Add `detect_supersedes(version)` — the inverse of `detect_superseded_by` — returning every earlier preview-only version whose auto-detected successor is exactly this version.
- The successor page now emits a `supersedes:` data-block line, a generated `> **Supersedes [X](…)** · Rolls up preview-only work…` banner, and an AI instruction to keep it and mention the rollup in Highlights. Applies to `main`, servicing `.x` lines, and stable branches.
- Detection verified live: `4.148.0→[4.147.0]`, `3.119.4→[3.119.3]`, `3.119.0→[3.118.0]`; the dead-end previews (`4.147.0`, `3.119.3`) correctly supersede nothing.

This makes the relationship symmetric and **durable across regeneration**, so the workflow won't strip it again.

## Backfill

Backfilled the existing polished pages (`3.119.0`, `3.119.4`, `4.148.0-unreleased`) with banners that are byte-identical to what the script now generates, so `main` is consistent immediately and the next workflow run is idempotent.

`SKILL.md` documents the two-way behaviour and the successor-page polishing rule.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>