### PR TITLE
[tizen] Re-enable PDF backend on Tizen (#4155)

### DIFF
--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -42,7 +42,6 @@ Task("libSkiaSharp")
            $"target_os='tizen' " +
            $"target_cpu='{skiaArch}' " +
            $"skia_enable_ganesh=true " +
-           $"skia_enable_pdf=false " +
            $"skia_use_harfbuzz=false " +
            $"skia_use_icu=false " +
            $"skia_use_piex=true " +


### PR DESCRIPTION
Stacked on #4146 (`skia-sync/m150`). Fixes #4155.

## Background
The m150 update disabled the PDF backend on Tizen (`skia_enable_pdf=false` in `native/tizen/build.cake`) as a stopgap. m150's PDF backend uses **C++20** defaulted three-way comparison (`operator<=>`) and defaulted `operator==`, which require `<compare>` and a C++20 stdlib. Tizen Studio's **clang 10 + gcc 9.2 libstdc++** (tizen-8.0 rootstrap) predate C++20 — `<compare>` is missing and clang 10 crashes parsing the defaulted spaceship (ADO build 158198).

## Approach
Rather than an ABI-breaking Tizen platform bump (Tizen ≤9.0 all ship gcc 9.2 libstdc++; only Tizen 10.0 moves to gcc 14.2), the Skia fork backports the PDF backend's C++20 constructs to equivalent **C++17**. With that in place PDF compiles on the existing clang-10 toolchain — no toolchain/container change, no min-OS bump, no native ABI break.

## Changes
- **Bump `externals/skia`** to the fork commit carrying the C++17 backport — depends on **mono/skia #255** ([skiasharp] Backport PDF three-way comparison to C++17 for Tizen).
- **Drop `skia_enable_pdf=false`** from `native/tizen/build.cake`, restoring `SKDocument` PDF support on Tizen. `SK_SUPPORT_PDF` and `-std=c++2a` were already set in the Tizen `project_def.prop`.

The fork backport replaces, in `src/pdf/SkPDFTypes.h` and `src/pdf/SkPDFTag.cpp`:
- defaulted `operator<=>` on `SkPDFIndirectReference` / `SkPDFParentTreeKey` / `ContentIndex` → explicit `==,!=,<,<=,>,>=`;
- defaulted `operator==` on `ContentSpan::Data` / `ContentSpan` → explicit equality;
- drops `<compare>`/`<ranges>` (the `std::views::reverse` was already replaced with a reverse-iterator loop in the parent m150 commit for WASM).

Verified across all 48 `src/pdf` files that these were the only C++20 usages.

## Validation
Tizen native can't be built on macOS; validation is via CI (`native_tizen_x64_windows`, `native_tizen_arm64_windows`) — they must compile PDF and pass.

## Merge order
1. mono/skia #255 → `skia-sync/m150` (fork)
2. #4146 finalizes its submodule pin (will then include the backport)
3. this PR (or fold the one-line stopgap removal into #4146)