### PR TITLE
Update harfbuzz to 14.2.1

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -59,7 +59,7 @@
         "type": "other",
         "other": {
           "name": "harfbuzz",
-          "version": "14.2.0",
+          "version": "14.2.1",
           "downloadUrl": "https://github.com/harfbuzz/harfbuzz"
         }
       }


### PR DESCRIPTION
Updates harfbuzz from 14.2.0 to 14.2.1.

- `externals/skia` submodule → `dev/update-harfbuzz` (DEPS bumped to tag 14.2.1, commit `56feae40`)
- `cgmanifest.json` → `14.2.1`

Built and tested locally (macOS arm64): native build succeeded, full test suite passed (5703 passed, 0 failed, 13 skipped).

Required skia PR: https://github.com/mono/skia/pull/257