### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "94451aa2839ed8ae5185d25d88784c6185381fa0"
+          "commitHash": "caf4799537ffa861286559fa39ff6e99b295f874"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "c92514572e9faa7f0e32c828be6f6289d8cc5c92"
+      "upstream_merge_commit": "9f330f1704305686dafa9eeef11de77caa5314b1"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m150.

**Companion skia PR:** https://github.com/mono/skia/pull/258

# mono/SkiaSharp Sync Summary — chrome/m150 bug fixes

## Type
Same-milestone bug-fix sync (m150 → m150)

## Changes Made

### externals/skia (submodule)
- Updated from `94451aa2839ed8ae5185d25d88784c6185381fa0` → `caf4799537ffa861286559fa39ff6e99b295f874`
- Merged 1 upstream bug-fix commit from `chrome/m150`

### cgmanifest.json
- `commitHash`: updated to new submodule merge commit SHA
- `upstream_merge_commit`: updated to `9f330f1704305686dafa9eeef11de77caa5314b1`

### No changes to:
- `scripts/VERSIONS.txt` (version unchanged: `4.150.0`)
- `scripts/azure-templates-variables.yml` (version unchanged)
- `externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT` remains 0)
- `binding/SkiaSharp/SkiaApi.generated.cs` (bindings unchanged)
- Any C# wrapper files

## Breaking Change Analysis
No breaking changes. The upstream commit is Graphite/Dawn backend only:
- `DawnGraphicsPipeline.cpp`: use-after-free fix for layout pointer stability
- SkiaSharp uses Ganesh, not Graphite — no user-visible behavior change

## Build Results

| Step | Result |
|------|--------|
| Native build (Linux x64) | ✅ Pass |
| C# build (0 errors) | ✅ Pass |
| Smoke tests (32/32) | ✅ Pass |
| Full test suite | ✅ **5544 passed, 0 failed, 172 skipped** |

Skipped tests are expected (GPU/hardware tests without display/GPU drivers).

## Items Needing Human Attention
None. Routine same-milestone bug-fix sync with no API changes, no breaking changes,
and all tests passing.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).