### PR TITLE
release-notes: restore in-flight -unreleased naming + per-preview rollup (R1/R2/R3)

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -76,6 +76,28 @@ that version has shipped and the line has moved on to the next patch (e.g. once
 An unreleased page is still listed in its minor group even when no stable page of that exact
 version exists yet (e.g. `3.119.5-unreleased.md` before `3.119.5` ships).
 
+### Page naming & preview rollup (deterministic — script-owned)
+
+The script decides each page's filename and which previews it rolls up. You never compute
+these; this is documented so the behaviour is not lost again (it regressed once when pages were
+migrated and the per-preview sections + in-flight naming were dropped):
+
+- **Terminal → `{version}.md`** when the version shipped (a suffix-less `release/X.Y.Z`
+  branch exists) **or** is `status: superseded` in `versions.json` (keeps its page + banner,
+  e.g. `4.147.0`, `3.119.3`).
+- **In-flight → `{version}-unreleased.md`** otherwise: `main` (upcoming), each servicing
+  `release/X.Y.x`, and any prerelease-only version with no stable branch yet
+  (`4.148.0`, `4.150.0`). The line head (`main`/`.x`) owns the page; the matching
+  `rc`/`preview` branch is deferred so they don't collide.
+- **Preview rollup (rules 9/10):** the data-block's `preview milestones` list is enumerated
+  from **published prerelease git tags** within the page's diff range (deduped to the latest
+  build per milestone, with dates + chained compare links). This is the source of the trailing
+  `## Preview N (date)` sections — render them verbatim from that list. A page rolls up a
+  skipped predecessor minor's previews too (the `4.148` page lists the `4.147` previews,
+  matching its rolled-up PRs). Supersession is separate and stays config-driven in
+  `versions.json`; tags answer "which previews shipped and when", `versions.json` answers
+  "which version supersedes which".
+
 The file starts with an HTML comment block containing both metadata (version, status, branch,
 diff range, PR count) AND the raw PR list. Below the comment is a skeleton heading with a
 placeholder for polished content. The raw data comment must be preserved in the final file.
@@ -199,6 +221,9 @@ Follow these rules:
 9. **Rollup at top** — Aggregate ALL changes across all previews into the main sections.
 
 10. **Previews are minimal** — One sentence + changelog link each, at the bottom.
+    Render one trailing `## <label> (<date>)` section per entry in the data-block's
+    `preview milestones` list (newest first), using that entry's compare link. Do not invent
+    previews or dates — the list is authoritative (sourced from published prerelease tags).
 
 11. **Links section** — Full Changelog, NuGet Package, API Diff.
 

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -47,11 +47,23 @@ from typing import Optional, Tuple
 REPO = "mono/SkiaSharp"
 RELEASES_DIR = Path("documentation/docfx/releases")
 
-SKIA_REPO = "mono/skia"
 SKIA_PR_PATTERNS = [
     re.compile(r"(?:companion|related)\s+(?:skia\s+)?pr[:\s]+https?://github\.com/mono/skia/pull/(\d+)", re.IGNORECASE),
     re.compile(r"https?://github\.com/mono/skia/pull/(\d+)"),
+    re.compile(r"mono/skia#(\d+)"),
 ]
+
+# A skia bump commit in mono/skia names its own PR in its subject, either as a
+# squash "(#N)" suffix or a "Merge pull request #N" merge subject. Used to
+# recover the companion link locally from the submodule when the SkiaSharp PR
+# body didn't spell it out (see resolve_skia_links).
+_SKIA_SELF_PR_PATTERNS = [
+    re.compile(r"^Merge pull request #(\d+)"),
+    re.compile(r"\(#(\d+)\)\s*$"),
+]
+_SKIA_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SKIA_SUBMODULE = Path("externals/skia")
+SKIA_REMOTE_URL = "https://github.com/mono/skia.git"
 
 # Noreply email pattern: {id}+{username}@users.noreply.github.com
 _NOREPLY_RE = re.compile(r"^\d+\+(.+)@users\.noreply\.github\.com$")
@@ -415,163 +427,84 @@ def resolve_pr_authors(prs):
     return prs
 
 
-# ── Effort computation ───────────────────────────────────────────────
+def _ensure_skia_repo():
+    # type: () -> bool
+    """Make ``externals/skia`` usable as a local object store for ``git log``.
 
-
-def _get_pr_effort_from_git(pr_num, target_ref="origin/main", git_dir="."):
-    # type: (int, str, str) -> Tuple[int, set[str], set[str]]
-    """Get commit count, working days, and author names from a PR via git refs.
-
-    Fetches refs/pull/{N}/head, then uses merge-base with the target branch
-    to determine the base commit. Works for both squash-merged and
-    regular-merged PRs.
-
-    Returns (commit_count, set_of_date_strings, set_of_author_names).
+    Works whether the submodule is already checked out (a ``.git`` gitlink file)
+    or absent (we ``git init`` an empty repo there and wire up the origin
+    remote). Only commit metadata is ever fetched into it; the working tree is
+    never populated, so this stays cheap.
     """
-    ref_head = "refs/pull/{}/head".format(pr_num)
-    local_ref = "refs/pr-tmp/{}".format(pr_num)
-
-    try:
-        run(["git", "-C", git_dir, "fetch", "origin",
-             "{}:{}".format(ref_head, local_ref), "--quiet"])
-    except subprocess.CalledProcessError:
-        return 0, set(), set()
-
-    try:
-        head_sha = run(["git", "-C", git_dir, "rev-parse", local_ref])
-        base_sha = run(["git", "-C", git_dir, "merge-base",
-                        local_ref, target_ref])
-    except subprocess.CalledProcessError:
-        run(["git", "-C", git_dir, "update-ref", "-d", local_ref], check=False)
-        return 0, set(), set()
-
-    log_output = run([
-        "git", "-C", git_dir, "log",
-        "--format=%ad\t%an", "--date=short",
-        "{}..{}".format(base_sha, head_sha),
-    ], check=False)
-
-    run(["git", "-C", git_dir, "update-ref", "-d", local_ref], check=False)
-
-    if not log_output:
-        return 0, set(), set()
-
-    count = 0
-    days = set()  # type: set[str]
-    authors = set()  # type: set[str]
-    for line in log_output.splitlines():
-        parts = line.split("\t", 1)
-        if len(parts) != 2:
-            continue
-        date_str, author_name = parts
-        count += 1
-        days.add(date_str)
-        authors.add(author_name)
-
-    return count, days, authors
+    gitdir = SKIA_SUBMODULE / ".git"
+    if not gitdir.exists():
+        SKIA_SUBMODULE.mkdir(parents=True, exist_ok=True)
+        run(["git", "init", "-q", str(SKIA_SUBMODULE)], check=False)
+    if not gitdir.exists():
+        return False
+    remotes = run(["git", "-C", str(SKIA_SUBMODULE), "remote"], check=False).split()
+    if "origin" not in remotes:
+        run(["git", "-C", str(SKIA_SUBMODULE), "remote", "add", "origin",
+             SKIA_REMOTE_URL], check=False)
+    return True
 
 
-def compute_pr_effort(pr):
-    # type: (dict) -> dict
-    """Compute commit count and unique working days from git refs.
+def resolve_skia_links(prs):
+    # type: (list[dict]) -> list[dict]
+    """Fill in companion mono/skia PR numbers for skia-bump PRs, purely locally.
 
-    Uses refs/pull/N/head to get the base..head range for commit counting.
-    If the PR body references a companion mono/skia PR, fetches that PR's
-    commits too (filtered to SkiaSharp contributor authors only).
+    Most SkiaSharp PRs that bump the ``externals/skia`` submodule don't spell out
+    the companion PR in their body (dependency bumps, milestone merges). For
+    those we read the bumped skia commit's own subject from the submodule and
+    parse its ``(#N)`` / ``Merge pull request #N`` self-reference.
+
+    Whether a PR bumped the submodule — and to which skia SHA — is determined
+    locally from the superproject tree (``git rev-parse <commit>:externals/skia``
+    vs its parent), for free. The only network is a single batched, blobless,
+    shallow ``git fetch`` of just the bumped SHAs into the submodule (no working
+    tree, no per-PR fetch); already-present commits are skipped, so ``--all``
+    pays for each skia commit at most once. Anything unresolved keeps
+    ``skiaPr=None``. Mutates and returns ``prs``.
     """
-    pr_num = pr.get("number", 0)
-    commit_count, unique_days, pr_author_names = _get_pr_effort_from_git(pr_num)
-
-    skia_pr_num = None
-    body = pr.get("body") or ""
-    for pattern in SKIA_PR_PATTERNS:
-        m = pattern.search(body)
-        if m:
-            skia_pr_num = m.group(1)
-            break
-
-    skia_commits = 0
-    if skia_pr_num:
-        skia_commits, skia_days = _fetch_skia_pr_effort(
-            skia_pr_num, pr_author_names)
-        unique_days |= skia_days
-
-    return {
-        "commitCount": commit_count + skia_commits,
-        "workingDays": len(unique_days),
-        "skiaPr": int(skia_pr_num) if skia_pr_num else None,
-    }
-
-
-def _fetch_skia_pr_effort(pr_num, author_names):
-    # type: (str, set[str]) -> Tuple[int, set[str]]
-    """Fetch effort from a mono/skia PR using git refs on the submodule.
-
-    Fetches refs/pull/N/head and uses merge-base to find the range,
-    then filters commits to only those by SkiaSharp PR authors
-    (excluding upstream Google committers).
-
-    Returns (commit_count, set_of_date_strings).
-    """
-    skia_dir = Path("externals/skia")
-    if not (skia_dir / ".git").exists():
-        return 0, set()
-
-    ref_head = "refs/pull/{}/head".format(pr_num)
-    local_ref = "refs/pr-tmp/skia-{}".format(pr_num)
-
-    try:
-        run(["git", "-C", str(skia_dir), "fetch", "origin",
-             "{}:{}".format(ref_head, local_ref), "--quiet"])
-    except subprocess.CalledProcessError:
-        return 0, set()
-
-    # Use merge-base with the skiasharp branch (the usual target for mono/skia PRs)
-    base_sha = None
-    for target in ["origin/skiasharp", "origin/main"]:
-        try:
-            base_sha = run(["git", "-C", str(skia_dir), "merge-base",
-                            local_ref, target])
-            break
-        except subprocess.CalledProcessError:
+    pending = []  # type: list[tuple[dict, str]]
+    for pr in prs:
+        if pr.get("skiaPr"):
             continue
-
-    if not base_sha:
-        run(["git", "-C", str(skia_dir), "update-ref", "-d", local_ref],
-            check=False)
-        return 0, set()
-
-    try:
-        head_sha = run(["git", "-C", str(skia_dir), "rev-parse", local_ref])
-    except subprocess.CalledProcessError:
-        run(["git", "-C", str(skia_dir), "update-ref", "-d", local_ref],
-            check=False)
-        return 0, set()
-
-    log_output = run([
-        "git", "-C", str(skia_dir), "log",
-        "--format=%ad\t%an", "--date=short",
-        "{}..{}".format(base_sha, head_sha),
-    ], check=False)
-
-    run(["git", "-C", str(skia_dir), "update-ref", "-d", local_ref],
-        check=False)
-
-    if not log_output:
-        return 0, set()
-
-    count = 0
-    days = set()  # type: set[str]
-    for line in log_output.splitlines():
-        parts = line.split("\t", 1)
-        if len(parts) != 2:
+        commit = pr.get("commit")
+        if not commit:
             continue
-        date_str, author_name = parts
-        if author_name in author_names:
-            count += 1
-            days.add(date_str)
+        revs = run(["git", "rev-parse",
+                    "{}:externals/skia".format(commit),
+                    "{}^:externals/skia".format(commit)], check=False).split()
+        if len(revs) != 2:
+            continue
+        new, old = revs[0], revs[1]
+        if new == old or not _SKIA_SHA_RE.match(new):
+            continue
+        pending.append((pr, new))
 
-    return count, days
+    if not pending or not _ensure_skia_repo():
+        return prs
+
+    missing = sorted({sha for _, sha in pending if subprocess.run(
+        ["git", "-C", str(SKIA_SUBMODULE), "cat-file", "-e", sha],
+        capture_output=True).returncode != 0})
+    if missing:
+        print("  Fetching {} skia commit(s) to resolve companion links...".format(
+            len(missing)), file=sys.stderr)
+        run(["git", "-C", str(SKIA_SUBMODULE), "fetch", "-q", "--depth=1",
+             "--filter=blob:none", "origin"] + missing, check=False)
+
+    for pr, sha in pending:
+        subject = run(["git", "-C", str(SKIA_SUBMODULE), "log", "-1",
+                       "--format=%s", sha], check=False)
+        for pat in _SKIA_SELF_PR_PATTERNS:
+            m = pat.search(subject)
+            if m:
+                pr["skiaPr"] = int(m.group(1))
+                break
+    return prs
+
 
 
 # ── Branch diffing ──────────────────────────────────────────────────
@@ -922,10 +855,8 @@ def get_prs_from_diff(from_ref, to_ref):
     """Extract merged PRs from git log between two refs.
 
     Parses PR numbers, titles, authors, and bodies from commit messages.
-    No GitHub API calls needed — everything comes from git. This is the cheap
-    part: a single ``git log`` plus regex parsing (sub-second even for hundreds
-    of commits). The expensive per-PR effort metrics are computed separately by
-    ``add_pr_effort`` so callers can skip them for unchanged pages.
+    No GitHub API calls needed — everything comes from git: a single ``git log``
+    plus regex parsing, sub-second even for hundreds of commits.
     """
     # Use a format that gives us everything: hash, author email, author name,
     # subject, body. The name is kept as a safe fallback credit for PRs whose
@@ -964,6 +895,16 @@ def get_prs_from_diff(from_ref, to_ref):
         # Title is the subject minus the PR ref
         title = re.sub(r"\s*\(#\d+\)\s*$", "", subject)
 
+        # A companion mono/skia PR link, if the body references one. Parsed
+        # locally from the body — no network — so it stays a cheap hint for the
+        # AI when writing notes about Skia bumps.
+        skia_pr = None
+        for pattern in SKIA_PR_PATTERNS:
+            sm = pattern.search(body)
+            if sm:
+                skia_pr = int(sm.group(1))
+                break
+
         # A GitHub login is only certain from a noreply address; otherwise leave
         # it None and let resolve_pr_authors look up the real handle. We never
         # guess a handle from an email local part — that mis-credits real users.
@@ -979,29 +920,10 @@ def get_prs_from_diff(from_ref, to_ref):
             "url": "https://github.com/{}/pull/{}".format(REPO, num),
             "number": num,
             "body": body,
+            "commit": commit_hash,
+            "skiaPr": skia_pr,
         })
 
-    return prs
-
-
-def add_pr_effort(prs):
-    # type: (list[dict]) -> list[dict]
-    """Annotate each PR in-place with effort metrics (commit count, days).
-
-    This is the SLOW part: it fetches ``refs/pull/{N}/head`` (and any companion
-    mono/skia PR) per PR, so it costs ~1s per PR over the network. Call it ONLY
-    for pages that are actually being (re)written — never for pages that the
-    unchanged check will skip — otherwise an all-unchanged ``--all`` run pays
-    minutes of network cost for output it then discards.
-    """
-    for i, pr in enumerate(prs, 1):
-        try:
-            pr.update(compute_pr_effort(pr))
-        except subprocess.CalledProcessError:
-            pass  # effort stays unset, that's fine
-        if i % 20 == 0:
-            print("  Processed {}/{} PRs...".format(i, len(prs)),
-                  file=sys.stderr)
     return prs
 
 
@@ -1058,11 +980,6 @@ def format_pr_list(prs, metadata):
             url = pr.get("url", "")
             is_community = login != "mattleibow"
             community_str = " [community ✨]" if is_community else ""
-            commits = pr.get("commitCount", 0)
-            days = pr.get("workingDays", 0)
-            effort = " ({} commit{}, {} day{})".format(
-                commits, "s" if commits != 1 else "",
-                days, "s" if days != 1 else "") if commits else ""
             skia_pr = pr.get("skiaPr")
             skia_str = " (skia: mono/skia#{})".format(skia_pr) if skia_pr else ""
 
@@ -1071,8 +988,8 @@ def format_pr_list(prs, metadata):
             # never mention — and notify — the wrong GitHub user.
             by = "by @{}".format(login) if login else "by {}".format(name)
 
-            lines.append("  - {} {} in {}{}{}{}".format(
-                title, by, url, community_str, effort, skia_str))
+            lines.append("  - {} {} in {}{}{}".format(
+                title, by, url, community_str, skia_str))
 
     lines.append("-->")
     lines.append("")
@@ -1435,12 +1352,12 @@ def _write_page(branch, all_branches, verbose=False, force=False):
         print("  Skipping {} (unchanged)".format(output_path))
         return None
 
-    # The page is changing, so it's worth the network work now: resolving the
-    # true GitHub handles (API, cached) and the per-PR effort fetches. Doing this
-    # AFTER the unchanged check is what keeps an all-unchanged --all run cheap:
-    # skipped pages never pay the network cost.
+    # The page is changing, so it's worth the one network step now: resolving
+    # the true GitHub handles (API, cached). Doing this AFTER the unchanged
+    # check keeps an all-unchanged --all run cheap: skipped pages never pay the
+    # network cost.
     resolve_pr_authors(prs)
-    add_pr_effort(prs)
+    resolve_skia_links(prs)
 
     metadata = {
         "branch": branch,

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -600,6 +600,171 @@ def version_from_branch(branch):
     return ver.split("-")[0]
 
 
+# ── Preview-milestone enumeration ───────────────────────────────────
+#
+# WHY THIS EXISTS (regression R3):
+# The original hand-authored pages (PR #3763) and TEMPLATE.md end with a list of
+# per-preview sections, e.g.:
+#
+#     ## Preview 3 (February 5, 2026)
+#     [Full Changelog](.../compare/v3.119.2-preview.2.3...v3.119.2-preview.3.1)
+#
+# SKILL.md rules 9/10 still mandate this ("Rollup at top … Previews are minimal:
+# one sentence + changelog link each, at the bottom"). When pages were migrated
+# to the script (#4174) these sections were lost, because the script never told
+# the AI which previews existed. We restore the feature by enumerating the
+# previews DETERMINISTICALLY here and emitting them into the raw-data block.
+#
+# SOURCE OF TRUTH: published git tags (vX.Y.Z-<stage>.N[.B]). That is literally
+# where previews, their dates, and their compare endpoints are published — and
+# exactly what TEMPLATE's compare links point at. This is NOT a heuristic and is
+# unrelated to supersession (which stays config-driven in versions.json): tags
+# answer "which previews shipped and when", versions.json answers "which version
+# supersedes which".
+
+_FRIENDLY_STAGE = {
+    "alpha": "Alpha", "beta": "Beta",
+    "preview": "Preview", "rc": "Release Candidate",
+}
+
+
+def _core_tuple(core):
+    # type: (str) -> tuple
+    """(major, minor, patch, subpatch) ints from a dotted core like ``4.147.0``."""
+    parts = (core.split(".") + ["0", "0", "0", "0"])[:4]
+    return tuple(int(p) if p.isdigit() else 0 for p in parts)
+
+
+def _parse_tag(tag):
+    # type: (str) -> Optional[dict]
+    """Parse a ``vX.Y.Z[.W][-stage.N[.B]]`` tag into its components.
+
+    Returns a dict with tag, core, core_tuple, label, stage, num and a sort key
+    (reusing ``release_branch_sort_key`` so stage ordering stays identical to
+    branches), or None when the tag is not a recognised ``vMAJOR.MINOR…`` tag.
+    """
+    if not tag.startswith("v"):
+        return None
+    name = tag[1:]
+    core, _, label = name.partition("-")
+    parts = core.split(".")
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        return None
+    stage = num = None
+    if label:
+        m = re.match(r"([A-Za-z]+)", label)
+        stage = m.group(1).lower() if m else None
+        nums = re.findall(r"\d+", label)
+        num = int(nums[0]) if nums else 0
+    return {
+        "tag": tag,
+        "core": core,
+        "core_tuple": _core_tuple(core),
+        "label": label,
+        "stage": stage,
+        "num": num,
+        "key": release_branch_sort_key("release/" + name),
+    }
+
+
+def _tag_date(tag):
+    # type: (str) -> str
+    """ISO date (YYYY-MM-DD) of a tag's commit, or '' when unknown."""
+    return run(["git", "log", "-1", "--format=%ad", "--date=short", tag],
+               check=False).strip()
+
+
+def collect_preview_milestones(page_version, base_version):
+    # type: (str, Optional[str]) -> list[dict]
+    """Preview/rc milestones rolled up into a page, newest first (regression R3).
+
+    Enumerates every published prerelease tag whose CORE version is greater than
+    the page's diff base and not greater than the page version itself
+    (``base_core < tag_core <= page_core``). Bounding by core (not git ancestry)
+    is deliberate: it lets a page roll up the previews of a skipped predecessor
+    minor — e.g. the 4.148 page lists the 4.147 previews because 4.147 never
+    shipped stable and its work rolled into 4.148 (the same reason its PRs are in
+    the diff range). The 4.147 page lists its own previews too; the overlap is
+    intentional and the superseded/successor banners cross-link the pages.
+
+    Each milestone carries a human label ("Preview 3"), the tag's commit date and
+    a compare link — chained to the previous milestone, or to the diff base for
+    the earliest one — matching the trailing ``## Preview N (date)`` sections in
+    TEMPLATE.md. Tags are deduplicated to one entry per (core, stage, number),
+    keeping the latest build, so re-tagged builds (preview.3.1, preview.3.2)
+    collapse to a single milestone.
+
+    Returns [] when there are no in-range prereleases (e.g. a pure stable patch).
+    """
+    raw = run(["git", "tag", "-l", "v*"], check=False)
+    parsed = []
+    for t in raw.splitlines():
+        t = t.strip()
+        if not t:
+            continue
+        p = _parse_tag(t)
+        if p:
+            parsed.append(p)
+    if not parsed:
+        return []
+
+    # Global ascending order — used to find the earliest milestone's predecessor
+    # (the diff-base tag it should compare from).
+    parsed.sort(key=lambda p: p["key"])
+
+    page_core = _core_tuple(page_version)
+    base_core = _core_tuple(base_version) if base_version else (0, 0, 0, 0)
+
+    # In-range prereleases, deduped to the latest build per milestone.
+    milestones = {}  # type: dict[tuple, dict]
+    for p in parsed:
+        if not p["stage"]:
+            continue  # stable tag — not a preview milestone
+        if not (base_core < p["core_tuple"] <= page_core):
+            continue
+        ident = (p["core_tuple"], p["stage"], p["num"])
+        cur = milestones.get(ident)
+        if cur is None or p["key"] > cur["key"]:
+            milestones[ident] = p
+
+    if not milestones:
+        return []
+
+    ordered = sorted(milestones.values(), key=lambda m: m["key"])  # ascending
+
+    # Predecessor (compare-from) for the EARLIEST milestone: the highest global
+    # tag strictly below it. For a page based on a shipped stable this is that
+    # stable tag (v3.119.4); for a page based on an in-flight predecessor it is
+    # that predecessor's latest prerelease tag (v4.148.0-rc.1.N). Later
+    # milestones chain to the prior MILESTONE (not the prior build) so re-tagged
+    # builds never produce a tiny intra-milestone diff link.
+    earliest_key = ordered[0]["key"]
+    global_pred = None
+    for p in parsed:
+        if p["key"] < earliest_key:
+            global_pred = p["tag"]
+        else:
+            break
+
+    result = []
+    for idx, m in enumerate(ordered):
+        prev_tag = ordered[idx - 1]["tag"] if idx > 0 else global_pred
+        compare_url = (
+            "https://github.com/{}/compare/{}...{}".format(REPO, prev_tag, m["tag"])
+            if prev_tag else None)
+        result.append({
+            "version": m["core"],
+            "label": "{} {}".format(
+                _FRIENDLY_STAGE.get(m["stage"], (m["stage"] or "").title()),
+                m["num"]),
+            "tag": m["tag"],
+            "date": _tag_date(m["tag"]),
+            "compare_url": compare_url,
+        })
+    result.reverse()  # newest first, matching TEMPLATE ordering
+    return result
+
+
 def find_previous_stable_base(all_branches, major, minor_num, patch, subpatch=0):
     # type: (list[str], int, int, int, int) -> Optional[str]
     """Find the previous stable release branch to use as the cumulative diff base.
@@ -785,10 +950,26 @@ def determine_diff_range(branch):
         minor_num = int(m_svc.group(2))
         minor = "{}.{}".format(major, minor_num)
 
-        # Read version from the remote branch
+        # Read version from the remote branch (SKIASHARP_VERSION).
         version = get_version_from_remote_branch(branch)
         if not version:
             version = "{}.0".format(minor)
+
+        # Honor an explicit versions.json compare_to first (regression R2). When
+        # the line's .0 has not shipped stable, the .x branch is the in-flight
+        # head and must produce the FULL rollup from the previous stable base —
+        # e.g. 4.148.x (4.148.0 not yet stable) compares 4.148.0 -> 3.119.4, the
+        # same baseline the rc page would use — not the tiny servicing delta
+        # against the latest in-minor preview.
+        config_entry = _versions_config_lookup(version)
+        if config_entry and config_entry.get("compare_to"):
+            resolved = _resolve_compare_to(
+                config_entry["compare_to"], "origin/{}".format(branch),
+                version, all_branches)
+            if resolved:
+                return resolved
+
+        dot0_shipped = _version_has_stable_tag("{}.0".format(minor))
 
         # All versioned branches for this minor (exclude .x)
         candidates = [b for b in all_branches
@@ -796,14 +977,17 @@ def determine_diff_range(branch):
                       and b != branch
                       and not b.endswith(".x")]
 
-        if candidates:
+        # True servicing delta — only once the .0 has shipped stable. Until then
+        # the .x is the in-flight head and must roll up cumulatively (below).
+        if dot0_shipped and candidates:
             candidates.sort(key=release_branch_sort_key)
             latest = candidates[-1]
             return ("origin/{}".format(latest),
                     "origin/{}".format(branch),
                     version)
 
-        # No versioned branches — use previous minor
+        # Cumulative rollup from the previous stable base (in-flight .0, or no
+        # in-minor candidates).
         base = find_previous_stable_base(all_branches, major, minor_num, 0)
         if base:
             return ("origin/{}".format(base),
@@ -991,6 +1175,19 @@ def format_pr_list(prs, metadata):
             lines.append("  - {} {} in {}{}{}".format(
                 title, by, url, community_str, skia_str))
 
+    # Preview milestones (regression R3): the trailing "## Preview N (date)"
+    # sections in TEMPLATE/SKILL are rendered by the AI from this list. Data is
+    # deterministic — published prerelease tags within the page's diff range.
+    milestones = metadata.get("preview_milestones") or []
+    if milestones:
+        lines.append("")
+        lines.append("  preview milestones (newest first — render as trailing "
+                     '"## <label> (<date>)" sections per TEMPLATE.md):')
+        for m in milestones:
+            lines.append("    - {label} · {version} · {date} · {url}".format(
+                label=m["label"], version=m["version"],
+                date=m.get("date") or "", url=m.get("compare_url") or ""))
+
     lines.append("-->")
     lines.append("")
 
@@ -1046,20 +1243,28 @@ def format_pr_list(prs, metadata):
             "below.".format(", ".join(sup_links)))
         lines.append("")
 
-    lines.append(
-        "<!-- AI: Use the raw PR data in the comment above to write polished")
-    lines.append(
-        "     release notes here. Follow documentation/docfx/releases/"
-        "TEMPLATE.md")
+    ai_lines = [
+        "<!-- AI: Use the raw PR data in the comment above to write polished",
+        "     release notes here. Follow documentation/docfx/releases/TEMPLATE.md",
+        "     for structure and tone.",
+    ]
+    if metadata.get("preview_milestones"):
+        ai_lines.append(
+            "     Render each PREVIEW MILESTONE listed above as a minimal trailing")
+        ai_lines.append(
+            '     "## <label> (<date>)" section — one sentence + its compare link,')
+        ai_lines.append(
+            "     newest first, after the rolled-up categories (TEMPLATE rules 9/10).")
     if supersedes:
-        lines.append("     for structure and tone.")
-        lines.append(
-            "     This release SUPERSEDES {} (preview-only, rolled up). Keep "
-            "the \"Supersedes\" note above and mention in the Highlights that "
-            "this release rolls up that skipped preview work cumulatively. -->"
+        ai_lines.append(
+            "     This release SUPERSEDES {} (preview-only, rolled up). Keep the"
             .format(", ".join(supersedes)))
-    else:
-        lines.append("     for structure and tone. -->")
+        ai_lines.append(
+            '     "Supersedes" note above and mention in the Highlights that this')
+        ai_lines.append(
+            "     release rolls up that skipped preview work cumulatively.")
+    ai_lines.append("-->")
+    lines.extend(ai_lines)
     lines.append("")
 
     return "\n".join(lines)
@@ -1277,13 +1482,30 @@ def _compute_page_status(branch, version):
 
 def _page_filename(branch, version):
     # type: (str, str) -> str
-    """Output file for a branch.
+    """Output file for a branch: ``{version}.md`` vs ``{version}-unreleased.md``.
 
-    main and servicing (.x) branches render the in-development page
-    ``{version}-unreleased.md``; a versioned branch renders the released page
-    ``{version}.md``.
+    DETERMINISTIC terminal-vs-in-flight rule (regression R1). A page is the
+    permanent ``{version}.md`` only when the version is TERMINAL:
+      * a suffix-less stable ``release/X.Y.Z`` branch — it shipped; or
+      * ``status: superseded`` in versions.json — a preview-only version that
+        keeps its page with a "superseded by" banner (e.g. 4.147.0, 3.119.3).
+    Otherwise the version is IN-FLIGHT and renders ``{version}-unreleased.md``:
+      * main and servicing (.x) branches — the in-development trackers; and
+      * a prerelease-only versioned branch with no stable branch yet
+        (e.g. release/4.148.0-rc.1, release/4.150.0-preview.1).
+
+    Note for --all: when a prerelease branch maps to an ``-unreleased`` page, its
+    line head (main or the matching ``.x``) owns the same page, so cmd_all drops
+    the prerelease branch from processing to avoid a collision. The branch's
+    previews still surface via collect_preview_milestones on the head's page.
     """
     if branch == "main" or branch.endswith(".x"):
+        return "{}-unreleased.md".format(version)
+    # Versioned branch. A '-' after the core (release/X.Y.Z-rc.1) marks a
+    # prerelease; a suffix-less name (release/X.Y.Z) is the shipped stable.
+    name = _removeprefix(branch, "release/")
+    is_prerelease = "-" in name
+    if is_prerelease and not resolve_superseded_by(version):
         return "{}-unreleased.md".format(version)
     return "{}.md".format(version)
 
@@ -1359,6 +1581,18 @@ def _write_page(branch, all_branches, verbose=False, force=False):
     resolve_pr_authors(prs)
     resolve_skia_links(prs)
 
+    # Enumerate the preview/rc milestones this page rolls up (regression R3), so
+    # the AI can render the trailing "## Preview N (date)" sections that TEMPLATE
+    # and SKILL rules 9/10 require. The lower bound is the diff base, so a page
+    # naturally includes a skipped predecessor minor's previews (the 4.148 page
+    # lists the 4.147 previews — the same work its diff range already rolls up).
+    base_version = None
+    if from_display.startswith("release/"):
+        base_version = version_from_branch(from_display)
+    elif re.match(r"^\d+\.\d+\.\d+", from_display):
+        base_version = from_display
+    preview_milestones = collect_preview_milestones(version, base_version)
+
     metadata = {
         "branch": branch,
         "version": version,
@@ -1370,6 +1604,8 @@ def _write_page(branch, all_branches, verbose=False, force=False):
         metadata["superseded_by"] = superseded_by
     if supersedes:
         metadata["supersedes"] = supersedes
+    if preview_milestones:
+        metadata["preview_milestones"] = preview_milestones
 
     RELEASES_DIR.mkdir(parents=True, exist_ok=True)
     output_path.write_text(format_pr_list(prs, metadata))
@@ -1510,7 +1746,7 @@ def cmd_all(force=False):
     # other and the last one processed wins (e.g. release/3.119.2 and its
     # release/3.119.2-preview.* all render to 3.119.2.md). So:
     #   - main                         -> {upcoming}-unreleased.md
-    #   - each servicing release/X.Y.x -> {X.Y.x}-unreleased.md  (distinct files)
+    #   - each servicing release/X.Y.x -> {X.Y.0}-unreleased.md  (distinct files)
     #   - ONE canonical branch per versioned base version -> {version}.md
     # Superseded versions are still included — they each keep their own page
     # with a "superseded by" label (see docstring).
@@ -1518,7 +1754,32 @@ def cmd_all(force=False):
     canonical_branches = sorted(
         _canonical_branches_by_version(all_branches).values(),
         key=release_branch_sort_key)
-    branches_to_process = ["main"] + servicing_branches + canonical_branches
+
+    # Ownership for in-flight pages (regression R1). A prerelease-only canonical
+    # branch (release/4.148.0-rc.1, release/4.150.0-preview.1) now renders an
+    # ``-unreleased`` page — but that same page is owned by the line head:
+    # ``main`` for the upcoming version, or the matching ``release/X.Y.x``. Drop
+    # the prerelease canonical when a head already produces its file, so the two
+    # don't fight (and cleanup_stale_unreleased doesn't then delete the head's
+    # page). The dropped branch's previews still appear on the head's page via
+    # collect_preview_milestones. Determinism: filenames only, no tags.
+    head_unreleased = set()
+    upcoming = get_upcoming_version()
+    if upcoming:
+        head_unreleased.add(_page_filename("main", upcoming))
+    for b in servicing_branches:
+        v = get_version_from_remote_branch(b) or version_from_branch(b)
+        head_unreleased.add(_page_filename(b, v))
+
+    kept_canonical = []
+    for b in canonical_branches:
+        fn = _page_filename(b, version_from_branch(b))
+        if fn in head_unreleased:
+            print("  (deferring {} — {} owned by its line head)".format(b, fn))
+            continue
+        kept_canonical.append(b)
+
+    branches_to_process = ["main"] + servicing_branches + kept_canonical
 
     files_to_polish = []
     skipped_count = 0

--- a/scripts/infra/docs/docs.cake
+++ b/scripts/infra/docs/docs.cake
@@ -160,9 +160,10 @@ Task ("docs-api-diff-past")
     comparer.SaveAssemblyApiInfo = true;
     comparer.SaveAssemblyMarkdownDiff = true;
 
-    // Include prerelease packages when --nugetDiffPrerelease=true. The 4.x line
-    // ships only as prereleases for now, so the workflow passes true to make sure
-    // those versions get changelogs.
+    // Include prerelease packages so the active development lines (which ship
+    // only as previews/rcs until they go stable, e.g. 4.148/4.150) can be
+    // enumerated. Emission is still collapsed to one changelog per release line
+    // below — prereleases are needed as candidates, not as their own folders.
     var filter = new NuGetVersions.Filter {
         IncludePrerelease = NUGET_DIFF_PRERELEASE
     };
@@ -175,30 +176,60 @@ Task ("docs-api-diff-past")
         Information ($"Comparing the assemblies in '{id}'...");
 
         var allVersions = await NuGetVersions.GetAllAsync (id, filter);
-        for (var idx = 0; idx < allVersions.Length; idx++) {
-            // get the version we are generating a changelog FOR (every version,
-            // including superseded ones, gets its own changelog)
-            var version = allVersions [idx].ToNormalizedString ();
+
+        // The newest stable release on the feed. It is the cut-off for preview
+        // emission: a preview-only line is only worth a changelog while it is
+        // still ahead of the last shipped stable (the active dev line, e.g.
+        // 4.148/4.150). Older preview-only lines that never shipped stay pruned.
+        var latestStable = allVersions
+            .Where (v => !v.IsPrerelease)
+            .OrderByDescending (v => v)
+            .FirstOrDefault ();
+
+        // Collapse the feed into one entry per release LINE, keyed by the numeric
+        // version core with the prerelease label stripped (4.148.0-rc.1.2 ->
+        // 4.148.0; the 4th digit of a real 4-part stable like 1.49.2.1 is kept).
+        // Each line's changelog is a rollup named by that core, diffed against the
+        // line's representative package: the newest stable if it shipped,
+        // otherwise the newest prerelease. This mirrors the release-notes pages,
+        // which are stable-named rollups of all the previews in between.
+        var lines = allVersions
+            .GroupBy (v => v.ToNormalizedString ().Split ('-') [0])
+            .Select (g => {
+                var stable = g.Where (v => !v.IsPrerelease).OrderByDescending (v => v).FirstOrDefault ();
+                return (key: g.Key, rep: stable ?? g.OrderByDescending (v => v).First ());
+            })
+            .OrderBy (l => l.rep)
+            .ToList ();
+
+        // Decide which lines actually get a changelog emitted:
+        //   - a line that shipped stable: always (the historical record);
+        //   - a preview-only line that was abandoned (superseded in versions.json,
+        //     e.g. 4.147): never — it is absorbed into its successor's diff;
+        //   - a preview-only line ahead of the last stable: yes (active dev line);
+        //   - any other preview-only line (old, never shipped): no.
+        var emit = lines
+            .Where (l => !l.rep.IsPrerelease
+                || (!IsVersionSuperseded (versionsConfig, l.rep.ToNormalizedString ())
+                    && (latestStable == null || l.rep.CompareTo (latestStable) > 0)))
+            .ToList ();
+
+        for (var idx = 0; idx < emit.Count; idx++) {
+            // The package we actually diff (e.g. 4.148.0-rc.1.2) and the folder we
+            // write it to (e.g. 4.148.0).
+            var version = emit [idx].rep.ToNormalizedString ();
+            var changelogVersion = emit [idx].key;
 
             // Pick the baseline to diff against:
-            //   1. An explicit compare_to override in versions.json wins.
-            //   2. Otherwise walk back to the most recent NON-superseded version.
-            // Step 2 is what makes a skipped line transparent: when generating
-            // 4.148 we walk past all of 4.147.* (superseded) and land on 3.119.4.
-            // The same walk-back is used for superseded versions themselves, so
-            // e.g. each 4.147 preview diffs cumulatively against 3.119.4.
+            //   1. An explicit compare_to override in versions.json wins
+            //      (e.g. 4.148 -> 3.119.4, deliberately skipping 4.147).
+            //   2. Otherwise diff against the previous EMITTED line, so skipped
+            //      previews and pruned lines are transparent.
             var previous = FindCompareToBaseline (versionsConfig, version, allVersions);
-            if (previous == null) {
-                for (var j = idx - 1; j >= 0; j--) {
-                    var candidate = allVersions [j].ToNormalizedString ();
-                    if (!IsVersionSuperseded (versionsConfig, candidate)) {
-                        previous = candidate;
-                        break;
-                    }
-                }
-            }
+            if (previous == null && idx > 0)
+                previous = emit [idx - 1].rep.ToNormalizedString ();
 
-            Information ($"Comparing version '{previous}' vs '{version}' of '{id}'...");
+            Information ($"Comparing version '{previous}' vs '{version}' of '{id}' (changelog '{changelogVersion}')...");
 
             // pre-cache so we can have better logs
             Debug ($"Caching version '{version}' of '{id}'...");
@@ -210,8 +241,8 @@ Task ("docs-api-diff-past")
 
             // generate the diff and copy to the changelogs
             Debug ($"Running a diff on '{previous}' vs '{version}' of '{id}'...");
-            var diffRoot = $"{baseDir}/{id}/{version}";
-            await RunBreakingAndFullDiff (comparer, id, previous, version, diffRoot);
+            var diffRoot = $"{baseDir}/{id}/{changelogVersion}";
+            await RunBreakingAndFullDiff (comparer, id, previous, version, changelogVersion, diffRoot);
 
             Debug ($"Diff complete of version '{version}' of '{id}'.");
         }
@@ -877,12 +908,14 @@ JArray LoadVersionsConfig ()
 }
 
 // A "superseded" version is one that was previewed but never shipped stable
-// (e.g. 4.147 was abandoned in favour of 4.148). It still gets its OWN changelog
-// generated — it is only excluded from acting as a *baseline* for other
-// versions, so a later release diffs against the last real predecessor instead.
-// Matched on major.minor.patch, so an entry for "4.147.0" covers every
-// 4.147.0-preview.* (all previews of that exact patch), but not a different
-// patch such as 4.147.1.
+// (e.g. 4.147 was abandoned in favour of 4.148). It is excluded from acting as a
+// *baseline* for other versions, so a later release diffs against the last real
+// predecessor instead. A superseded preview-only line is also skipped from
+// emission in docs-api-diff-past (its changes are absorbed into the successor's
+// cumulative diff); a version that actually shipped stable still gets its own
+// changelog regardless. Matched on major.minor.patch, so an entry for "4.147.0"
+// covers every 4.147.0-preview.* (all previews of that exact patch), but not a
+// different patch such as 4.147.1.
 bool IsVersionSuperseded (JArray config, string normalizedVersion)
 {
     var nv = new NuGetVersion (normalizedVersion);
@@ -929,7 +962,10 @@ async Task RunBreakingAndFullDiff (NuGetDiff comparer, string id, string oldVers
 }
 
 // Overload 2 — NEW side is a published feed version (historical regeneration).
-async Task RunBreakingAndFullDiff (NuGetDiff comparer, string id, string oldVersion, string newVersion, string diffRoot)
+// changelogVersion is the folder the changelog is written to (the release-line
+// core, e.g. 4.148.0), which differs from newVersion (the actual package that is
+// diffed, e.g. 4.148.0-rc.1.2) whenever a line is still in preview.
+async Task RunBreakingAndFullDiff (NuGetDiff comparer, string id, string oldVersion, string newVersion, string changelogVersion, string diffRoot)
 {
     comparer.MarkdownDiffFileExtension = ".breaking.md";
     comparer.IgnoreNonBreakingChanges = true;
@@ -939,7 +975,7 @@ async Task RunBreakingAndFullDiff (NuGetDiff comparer, string id, string oldVers
     comparer.IgnoreNonBreakingChanges = false;
     await comparer.SaveCompleteDiffToDirectoryAsync (id, oldVersion, newVersion, diffRoot);
 
-    CopyChangelogs (diffRoot, id, newVersion);
+    CopyChangelogs (diffRoot, id, changelogVersion);
 }
 
 RunTarget(TARGET);


### PR DESCRIPTION
## Why

The versions.json supersession migration (#4171/#4174) correctly made *which version supersedes which* deterministic via `versions.json`, but its move from per-push branch runs to a bulk `--all` pass **silently regressed three documented behaviours**. Pages were migrated in #4174 without the script emitting the data those pages used to contain, so the features were dropped on the next regeneration instead of failing loudly.

Two separate deterministic sources, no magic:
- `versions.json` answers **"which version supersedes which."**
- Published prerelease git tags answer **"which previews shipped and when."**

## The three regressions (each restored from a deterministic source, not heuristics)

| | Regression | Fix | Source |
|---|---|---|---|
| **R1** | In-flight `4.148`/`4.150` written as terminal `{version}.md`; cleanup then deleted the real `{version}-unreleased.md` | terminal-vs-in-flight rule in `_page_filename` + ownership defer in `cmd_all` (line head `main`/`release/X.Y.x` owns the page; matching rc/preview branch deferred) | branch suffix + `versions.json` |
| **R2** | In-flight `.x` rollup was a servicing-delta instead of full cumulative rollup | `determine_diff_range` honors `versions.json` `compare_to` first (4.148.0 → 3.119.4); servicing delta only once `.0` has a stable tag | `versions.json` |
| **R3** | Trailing `## Preview N (date)` sections lost (present in original `3.119.2.md` #3763 + `TEMPLATE.md`; SKILL rules 9/10 mandate them; #4174 deleted them on regen) | `collect_preview_milestones` enumerates them from published prerelease tags in the page's diff range (deduped to latest build per milestone, dated, chained compare links); a page rolls up a skipped predecessor minor's previews too | git tags |

## Self-documentation (so it can't silently regress on the next migration)
- Code comments on every fix referencing R1/R2/R3 + `TEMPLATE`/`SKILL`.
- New `SKILL.md` "Page naming & preview rollup (deterministic — script-owned)" section + rule 10 now points at the `preview milestones` data ("do not invent previews").

## Validation (offline `--all` dry-run, no repo mutation, network stubbed)
- Correct `-unreleased` filenames; **no bare `4.148.0.md`/`4.150.0.md`**.
- `4.148.0-unreleased.md`: diff `3.119.4..release/4.148.x`, rolls up **4.147 p1/p2/p3 + 4.148 rc1**.
- `4.150.0-unreleased.md`: diff `4.148.0-rc.1..main`, lists 4.150 preview1.
- `4.147.0.md` kept (superseded + banner + own previews); `3.119.x` unchanged.
- The `3.119.2.md` compare links reproduce the original page **exactly**.

## Not changed (intentionally kept)
`versions.json` supersession, `--all` idempotency, contributor crediting, skia link resolution, and the previously-dropped effort metric.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>