### PR TITLE
Add Chromium release heads-up to the security-audit skill

### DIFF
--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -33,6 +33,7 @@ combined into a single unified report.
 ## Key References
 
 - **[references/chrome-releases.md](references/chrome-releases.md)** — Chrome Releases blog: RSS query, two-pass extraction (regex + AI review), cross-referencing with NVD
+- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium milestone release schedule: branch/stable dates per milestone, release heads-up for pending Skia bumps
 - **[references/skia-cve-resolution.md](references/skia-cve-resolution.md)** — Skia core CVE pipeline (NVD → Bug ID → Commit → Branch → Cherry-pick → Reachability). **The Skia process is fine-grained — read this before auditing Skia.**
 - **[references/third-party-deps.md](references/third-party-deps.md)** — Third-party CVE process (libpng, freetype, harfbuzz, etc.): version verification, fix-commit ancestry, known false positives
 - **[references/cg-alerts.md](references/cg-alerts.md)** — Component Governance alerts: ADO pipeline queries, Docker container CVEs, fix locations
@@ -49,15 +50,16 @@ combined into a single unified report.
 
 1. Search GitHub issues/PRs (all deps including Skia)
 2. Query Chrome Releases blog (`query-chrome-releases.py`) — see [Chrome Releases](references/chrome-releases.md)
-3. Verify dependency versions from submodule/DEPS/headers (NOT cgmanifest.json)
-4. Audit Skia core CVEs — see [Skia CVE Resolution](references/skia-cve-resolution.md)
-5. Audit third-party dependency CVEs — see [Third-Party Deps](references/third-party-deps.md)
-6. Query Component Governance alerts — see [CG Alerts](references/cg-alerts.md)
-7. Check false positives
-8. Assemble structured JSON report
-9. Validate report (`validate-security-audit.py`)
-10. Render HTML (`render-security-audit.py`)
-11. Present markdown summary to user
+3. Query Chromium milestone schedule (`query-milestone-schedule.py`) — see [Milestone Schedule](references/milestone-schedule.md)
+4. Verify dependency versions from submodule/DEPS/headers (NOT cgmanifest.json)
+5. Audit Skia core CVEs — see [Skia CVE Resolution](references/skia-cve-resolution.md)
+6. Audit third-party dependency CVEs — see [Third-Party Deps](references/third-party-deps.md)
+7. Query Component Governance alerts — see [CG Alerts](references/cg-alerts.md)
+8. Check false positives
+9. Assemble structured JSON report
+10. Validate report (`validate-security-audit.py`)
+11. Render HTML (`render-security-audit.py`)
+12. Present markdown summary to user
 
 ---
 
@@ -113,6 +115,41 @@ After the NVD query in Step 3, compare results:
 | ❌ Not found | ✅ Found | Vendor bulletin CVE (Android/Huawei) — not in Chrome stable |
 
 Set the `source` field on each CVE object: `"both"`, `"chrome_releases"`, or `"nvd"`.
+
+---
+
+### Step 1.6: Query Chromium Milestone Schedule (Release Heads-Up)
+
+> 🗓️ This step is scheduling context, **not** a security check on its own. It tells us *when*
+> the next Skia milestone goes stable so pending bumps are ready before CVEs reach users.
+
+Skia milestones track Chrome milestones, so the Chromium release calendar tells us the deadline
+for each pending Skia bump. **See [references/milestone-schedule.md](references/milestone-schedule.md)**
+for the data source and alert levels.
+
+#### Run the script
+
+```bash
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
+  --verbose --output output/ai/milestone-schedule-cache.json
+```
+
+This reads the current Skia milestone from `scripts/VERSIONS.txt`, fetches a window of milestones
+around it from chromiumdash, and prints prioritized heads-up alerts:
+
+| Level | Meaning |
+|-------|---------|
+| 🔴 `critical` | A milestone we have **not** bumped to is **already stable** — we are behind. |
+| 🟠 `urgent` | A pending milestone goes stable within the window (default 14 days). |
+| 🟡 `watch` | A pending milestone branches within the window — start the bump. |
+| 🔵 `info` | The current milestone's stable window is ending. |
+
+#### Use the result
+
+- Escalate Skia bump recommendations in `nextSteps` when an `urgent`/`critical` milestone also
+  carries HIGH/CRITICAL CVEs from the Chrome Releases / NVD passes.
+- Cite the target milestone's **stable date** when recommending a bump so the deadline is clear.
+- Treat a `critical` heads-up as a finding even if no GitHub issue has been filed yet.
 
 ---
 
@@ -378,6 +415,7 @@ conversation pointing to the generated files:
 Then highlight the **top actionable items** from the report:
 - Any `needs_attention` or `undiscovered` findings
 - Chrome Releases CVEs above our current milestone (especially Skia/ANGLE)
+- 🔴/🟠 milestone-schedule heads-up (Step 1.6) — pending Skia bumps that are stable or going stable soon
 - Critical/High CG alerts
 
 #### Report quality rules

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -33,7 +33,7 @@ combined into a single unified report.
 ## Key References
 
 - **[references/chrome-releases.md](references/chrome-releases.md)** — Chrome Releases blog: RSS query, two-pass extraction (regex + AI review), cross-referencing with NVD
-- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium milestone schedule + channel tracking: branch/stable dates per milestone, and the live milestone + Skia commit per channel (Extended/Stable/Beta/Dev/Canary) for concurrent channel support
+- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium release heads-up: `main` vs Beta milestone coverage, channel milestones + Skia commits, and the optional `release/<major>.<M>.x` backport check
 - **[references/skia-cve-resolution.md](references/skia-cve-resolution.md)** — Skia core CVE pipeline (NVD → Bug ID → Commit → Branch → Cherry-pick → Reachability). **The Skia process is fine-grained — read this before auditing Skia.**
 - **[references/third-party-deps.md](references/third-party-deps.md)** — Third-party CVE process (libpng, freetype, harfbuzz, etc.): version verification, fix-commit ancestry, known false positives
 - **[references/cg-alerts.md](references/cg-alerts.md)** — Component Governance alerts: ADO pipeline queries, Docker container CVEs, fix locations
@@ -50,7 +50,7 @@ combined into a single unified report.
 
 1. Search GitHub issues/PRs (all deps including Skia)
 2. Query Chrome Releases blog (`query-chrome-releases.py`) — see [Chrome Releases](references/chrome-releases.md)
-3. Query Chromium milestone schedule (`query-milestone-schedule.py`) — see [Milestone Schedule](references/milestone-schedule.md)
+3. Query Chromium release schedule (`query-milestone-schedule.py`) — main vs Beta heads-up, see [Milestone Schedule](references/milestone-schedule.md)
 4. Verify dependency versions from submodule/DEPS/headers (NOT cgmanifest.json)
 5. Audit Skia core CVEs — see [Skia CVE Resolution](references/skia-cve-resolution.md)
 6. Audit third-party dependency CVEs — see [Third-Party Deps](references/third-party-deps.md)
@@ -118,17 +118,18 @@ Set the `source` field on each CVE object: `"both"`, `"chrome_releases"`, or `"n
 
 ---
 
-### Step 1.6: Query Chromium Milestone Schedule & Channels (Release Heads-Up)
+### Step 1.6: Query Chromium Release Schedule (main vs Beta Heads-Up)
 
-> 🗓️ This step is scheduling + channel context, **not** a security check on its own. It tells us
-> *when* the next Skia milestone goes stable, and *which Skia commit* each channel ships, so
-> pending bumps are ready before CVEs reach users.
+> 🗓️ Scheduling + channel context, **not** a security check on its own. It tells us whether `main`
+> is keeping up with the Chrome Beta milestone and how much lead time remains before the next
+> milestone reaches stable.
 
-Skia milestones track Chrome milestones. SkiaSharp maintains support for **Extended stable,
-Stable, and Beta concurrently**, so we must know the milestone + Skia commit behind each tracked
-channel. **See [references/milestone-schedule.md](references/milestone-schedule.md)** for the data
-sources (`fetch_milestone_schedule` for dates, `fetch_releases` for per-channel milestone + Skia
-commit) and alert levels.
+`main` is the SkiaSharp front line and tracks the Chrome **Beta** milestone; as milestones
+graduate Beta → Stable → Extended stable, a `release/<major>.<M>.x` line is cut from a main that
+was already on M. So "where we are" = main's milestone, and the signal that matters is
+**`main_milestone >= beta_channel_milestone`**. **See
+[references/milestone-schedule.md](references/milestone-schedule.md)** for the model, endpoints,
+flags, and the optional within-milestone backport check.
 
 #### Run the script
 
@@ -137,26 +138,25 @@ python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
   --verbose --output output/ai/milestone-schedule-cache.json
 ```
 
-This reads the current Skia milestone from `scripts/VERSIONS.txt`, fetches each channel's live
-release (Extended/Stable/Beta/Dev/Canary, with the exact `hashes.skia` commit) plus the milestone
-schedule around them, and prints prioritized heads-up alerts:
+This reads main's milestone + major from `scripts/VERSIONS.txt`, fetches the live channels and the
+upcoming schedule, and prints prioritized heads-up alerts:
 
 | Level | Meaning |
 |-------|---------|
-| 🔴 `critical` | A milestone we have **not** bumped to is **already stable** — we are behind. |
-| 🟠 `urgent` | A pending milestone goes stable within the window (default 14 days), or a tracked channel (Extended/Stable/Beta) has advanced past the pinned milestone. |
-| 🟡 `watch` | A pending milestone branches within the window — start the bump. |
-| 🔵 `info` | A tracked channel matches/should pin a milestone, or the current milestone's stable window is ending. |
+| 🔴 `critical` | `main < Beta` **and** the Beta milestone is already stable — the bump is overdue. |
+| 🟠 `urgent` | `main < Beta` — the front line is behind; bump main to the Beta milestone. |
+| 🟡 `watch` | A milestone past main branches within the window — start preparing. |
+| 🟢 `ok` | `main >= Beta` — front line current. |
 
 #### Use the result
 
-- **Verify tracked channels** — confirm each SkiaSharp branch (Extended/Stable/Beta) points at the
-  Skia commit (`hashes.skia`) its channel currently ships.
-- Escalate Skia bump recommendations in `nextSteps` when an `urgent`/`critical` milestone also
-  carries HIGH/CRITICAL CVEs from the Chrome Releases / NVD passes.
-- Cite the target milestone's **stable date** when recommending a bump so the deadline is clear.
-- Treat a `critical` heads-up (or an `urgent` tracked-channel gap) as a finding even if no GitHub
-  issue has been filed yet.
+- **Where we are vs what's coming** — `meta.status` + the `upcoming` table answer it directly.
+- Escalate Skia bump recommendations in `nextSteps` when `status == "behind"` (or a `watch`
+  milestone) also carries HIGH/CRITICAL CVEs from the Chrome Releases / NVD passes; cite the
+  target milestone's **stable date** as the deadline.
+- **Deep check (optional):** run with `--check-backports` to resolve each shipped
+  `release/<major>.<M>.x` line and surface its pinned Skia for the within-milestone backport
+  audit (axis 2). Treat a `critical` heads-up as a finding even with no GitHub issue filed.
 
 ---
 
@@ -422,7 +422,7 @@ conversation pointing to the generated files:
 Then highlight the **top actionable items** from the report:
 - Any `needs_attention` or `undiscovered` findings
 - Chrome Releases CVEs above our current milestone (especially Skia/ANGLE)
-- 🔴/🟠 milestone-schedule heads-up (Step 1.6) — pending Skia bumps that are stable or going stable soon
+- 🔴/🟠 release heads-up (Step 1.6) — `main` behind the Beta milestone, or a milestone branching/going stable soon
 - Critical/High CG alerts
 
 #### Report quality rules

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -33,7 +33,7 @@ combined into a single unified report.
 ## Key References
 
 - **[references/chrome-releases.md](references/chrome-releases.md)** — Chrome Releases blog: RSS query, two-pass extraction (regex + AI review), cross-referencing with NVD
-- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium release heads-up: `main` vs Beta milestone coverage, channel milestones + Skia commits, and the optional `release/<major>.<M>.x` backport check
+- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium release heads-up: `main` vs Beta milestone coverage, channel milestones + Skia commits
 - **[references/skia-cve-resolution.md](references/skia-cve-resolution.md)** — Skia core CVE pipeline (NVD → Bug ID → Commit → Branch → Cherry-pick → Reachability). **The Skia process is fine-grained — read this before auditing Skia.**
 - **[references/third-party-deps.md](references/third-party-deps.md)** — Third-party CVE process (libpng, freetype, harfbuzz, etc.): version verification, fix-commit ancestry, known false positives
 - **[references/cg-alerts.md](references/cg-alerts.md)** — Component Governance alerts: ADO pipeline queries, Docker container CVEs, fix locations
@@ -129,7 +129,7 @@ graduate Beta → Stable → Extended stable, a `release/<major>.<M>.x` line is 
 was already on M. So "where we are" = main's milestone, and the signal that matters is
 **`main_milestone >= beta_channel_milestone`**. **See
 [references/milestone-schedule.md](references/milestone-schedule.md)** for the model, endpoints,
-flags, and the optional within-milestone backport check.
+and flags.
 
 #### Run the script
 
@@ -153,10 +153,11 @@ upcoming schedule, and prints prioritized heads-up alerts:
 - **Where we are vs what's coming** — `meta.status` + the `upcoming` table answer it directly.
 - Escalate Skia bump recommendations in `nextSteps` when `status == "behind"` (or a `watch`
   milestone) also carries HIGH/CRITICAL CVEs from the Chrome Releases / NVD passes; cite the
-  target milestone's **stable date** as the deadline.
-- **Deep check (optional):** run with `--check-backports` to resolve each shipped
-  `release/<major>.<M>.x` line and surface its pinned Skia for the within-milestone backport
-  audit (axis 2). Treat a `critical` heads-up as a finding even with no GitHub issue filed.
+  target milestone's **stable date** as the deadline. Treat a `critical` heads-up as a finding
+  even with no GitHub issue filed.
+- For whether a shipped `release/*.x` line is missing a *within-milestone* Skia backport, use the
+  [Skia CVE resolution](references/skia-cve-resolution.md) process (merge-base ancestry) — the
+  schedule tool only covers milestone alignment.
 
 ---
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -143,8 +143,9 @@ upcoming schedule, and prints prioritized heads-up alerts:
 
 | Level | Meaning |
 |-------|---------|
-| 🔴 `critical` | `main < Beta` **and** the Beta milestone is already stable — the bump is overdue. |
+| 🔴 `critical` | `main < Beta` **and** a newer milestone already ships on a stable-class channel — the bump is overdue and reaching non-preview users. |
 | 🟠 `urgent` | `main < Beta` — the front line is behind; bump main to the Beta milestone. |
+| ❓ `unknown` | The Beta milestone couldn't be read (Chromium Dash down) — signal not evaluated. **Don't treat as OK; re-run.** |
 | 🟡 `watch` | A milestone past main branches within the window — start preparing. |
 | 🟢 `ok` | `main >= Beta` — front line current. |
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -33,7 +33,7 @@ combined into a single unified report.
 ## Key References
 
 - **[references/chrome-releases.md](references/chrome-releases.md)** — Chrome Releases blog: RSS query, two-pass extraction (regex + AI review), cross-referencing with NVD
-- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium milestone release schedule: branch/stable dates per milestone, release heads-up for pending Skia bumps
+- **[references/milestone-schedule.md](references/milestone-schedule.md)** — Chromium milestone schedule + channel tracking: branch/stable dates per milestone, and the live milestone + Skia commit per channel (Extended/Stable/Beta/Dev/Canary) for concurrent channel support
 - **[references/skia-cve-resolution.md](references/skia-cve-resolution.md)** — Skia core CVE pipeline (NVD → Bug ID → Commit → Branch → Cherry-pick → Reachability). **The Skia process is fine-grained — read this before auditing Skia.**
 - **[references/third-party-deps.md](references/third-party-deps.md)** — Third-party CVE process (libpng, freetype, harfbuzz, etc.): version verification, fix-commit ancestry, known false positives
 - **[references/cg-alerts.md](references/cg-alerts.md)** — Component Governance alerts: ADO pipeline queries, Docker container CVEs, fix locations
@@ -118,14 +118,17 @@ Set the `source` field on each CVE object: `"both"`, `"chrome_releases"`, or `"n
 
 ---
 
-### Step 1.6: Query Chromium Milestone Schedule (Release Heads-Up)
+### Step 1.6: Query Chromium Milestone Schedule & Channels (Release Heads-Up)
 
-> 🗓️ This step is scheduling context, **not** a security check on its own. It tells us *when*
-> the next Skia milestone goes stable so pending bumps are ready before CVEs reach users.
+> 🗓️ This step is scheduling + channel context, **not** a security check on its own. It tells us
+> *when* the next Skia milestone goes stable, and *which Skia commit* each channel ships, so
+> pending bumps are ready before CVEs reach users.
 
-Skia milestones track Chrome milestones, so the Chromium release calendar tells us the deadline
-for each pending Skia bump. **See [references/milestone-schedule.md](references/milestone-schedule.md)**
-for the data source and alert levels.
+Skia milestones track Chrome milestones. SkiaSharp maintains support for **Extended stable,
+Stable, and Beta concurrently**, so we must know the milestone + Skia commit behind each tracked
+channel. **See [references/milestone-schedule.md](references/milestone-schedule.md)** for the data
+sources (`fetch_milestone_schedule` for dates, `fetch_releases` for per-channel milestone + Skia
+commit) and alert levels.
 
 #### Run the script
 
@@ -134,22 +137,26 @@ python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
   --verbose --output output/ai/milestone-schedule-cache.json
 ```
 
-This reads the current Skia milestone from `scripts/VERSIONS.txt`, fetches a window of milestones
-around it from chromiumdash, and prints prioritized heads-up alerts:
+This reads the current Skia milestone from `scripts/VERSIONS.txt`, fetches each channel's live
+release (Extended/Stable/Beta/Dev/Canary, with the exact `hashes.skia` commit) plus the milestone
+schedule around them, and prints prioritized heads-up alerts:
 
 | Level | Meaning |
 |-------|---------|
 | 🔴 `critical` | A milestone we have **not** bumped to is **already stable** — we are behind. |
-| 🟠 `urgent` | A pending milestone goes stable within the window (default 14 days). |
+| 🟠 `urgent` | A pending milestone goes stable within the window (default 14 days), or a tracked channel (Extended/Stable/Beta) has advanced past the pinned milestone. |
 | 🟡 `watch` | A pending milestone branches within the window — start the bump. |
-| 🔵 `info` | The current milestone's stable window is ending. |
+| 🔵 `info` | A tracked channel matches/should pin a milestone, or the current milestone's stable window is ending. |
 
 #### Use the result
 
+- **Verify tracked channels** — confirm each SkiaSharp branch (Extended/Stable/Beta) points at the
+  Skia commit (`hashes.skia`) its channel currently ships.
 - Escalate Skia bump recommendations in `nextSteps` when an `urgent`/`critical` milestone also
   carries HIGH/CRITICAL CVEs from the Chrome Releases / NVD passes.
 - Cite the target milestone's **stable date** when recommending a bump so the deadline is clear.
-- Treat a `critical` heads-up as a finding even if no GitHub issue has been filed yet.
+- Treat a `critical` heads-up (or an `urgent` tracked-channel gap) as a finding even if no GitHub
+  issue has been filed yet.
 
 ---
 

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -135,7 +135,7 @@ and flags.
 
 ```bash
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
-  --verbose --output output/ai/milestone-schedule-cache.json
+  --output output/ai/milestone-schedule-cache.json
 ```
 
 This reads main's milestone + major from `scripts/VERSIONS.txt`, fetches the live channels and the

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -75,7 +75,7 @@ Search PRs in both `mono/SkiaSharp` and `mono/skia` for dependency updates alrea
 
 ---
 
-### Step 1.5: Query Chrome Releases Blog
+### Step 2: Query Chrome Releases Blog
 
 > 🔍 The Chrome Releases blog often discloses Skia CVEs **before NVD** processes them.
 > This step provides early detection and cross-validation.
@@ -104,9 +104,9 @@ This takes ~10-30 seconds (fetches RSS feed pages). Cache is reused if < 24 hour
    - Wild exploitation notices (highest priority!)
    - Related component CVEs (GPU, Compositing) that may involve Skia code
 
-#### Cross-reference with NVD (Step 3)
+#### Cross-reference with NVD (Step 5)
 
-After the NVD query in Step 3, compare results:
+After the NVD query in Step 5, compare results:
 
 | Chrome Releases | NVD | Interpretation |
 |-----------------|-----|----------------|
@@ -118,7 +118,7 @@ Set the `source` field on each CVE object: `"both"`, `"chrome_releases"`, or `"n
 
 ---
 
-### Step 1.6: Query Chromium Release Schedule (main vs Beta Heads-Up)
+### Step 3: Query Chromium Release Schedule (main vs Beta Heads-Up)
 
 > 🗓️ Scheduling + channel context, **not** a security check on its own. It tells us whether `main`
 > is keeping up with the Chrome Beta milestone and how much lead time remains before the next
@@ -160,13 +160,13 @@ upcoming schedule, and prints prioritized heads-up alerts:
 
 ---
 
-### Step 3: Verify Dependency Versions
+### Step 4: Verify Dependency Versions
 
 > ⚠️ **CRITICAL: Never trust `cgmanifest.json` blindly.** Always verify versions against the
 > actual submodule, DEPS file, and source headers. cgmanifest.json is manually maintained
 > and can drift. Report any mismatches as findings.
 
-#### 2.1 Verify Skia milestone and upstream commit
+#### 4.1 Verify Skia milestone and upstream commit
 
 > 🛑 **MANDATORY:** Fetching the upstream `google/skia` branch is **required**, not optional.
 > Adding a git remote and fetching is read-only — it does not modify any tracked files.
@@ -206,14 +206,14 @@ Compare against cgmanifest.json and report mismatches:
 | Fork commit | `git submodule status` | git entry `commitHash` |
 | Upstream commit | `git fetch upstream chrome/mNNN` tip | `upstream_merge_commit` |
 
-#### 2.2 Verify third-party dependency versions
+#### 4.2 Verify third-party dependency versions
 
 See **[references/third-party-deps.md](references/third-party-deps.md)** for the full table of
 header files and the googlesource mirror URL pattern. In short: read pinned commit hashes
 from `externals/skia/DEPS`, then fetch each dependency's version header at that commit and
 parse the version string.
 
-#### 2.3 Verify ANGLE and its submodules
+#### 4.3 Verify ANGLE and its submodules
 
 ANGLE is a **separate** native component (Windows-only, for WinUI). It is NOT part of the
 Skia submodule.
@@ -228,7 +228,7 @@ ANGLE has its own submodules (`third_party/zlib`, `jsoncpp`, `vulkan-deps`,
 [references/third-party-deps.md](references/third-party-deps.md#angle-and-its-submodules)
 for details. Flag any missing from cgmanifest.json as a coverage gap.
 
-#### 2.4 Build the dependency overview
+#### 4.4 Build the dependency overview
 
 The `versionVerification` array in the JSON report must include **ALL** dependencies from
 ALL sources:
@@ -246,7 +246,7 @@ Report mismatches as findings.
 
 ---
 
-### Step 4: Audit Skia Core CVEs
+### Step 5: Audit Skia Core CVEs
 
 > 🛑 Skia is the product, not just a dependency. Every Skia CVE must be resolved to a
 > specific fix commit, branch, cherry-pick test, and reachability assessment. Classification
@@ -266,7 +266,7 @@ process**, including:
 
 ---
 
-### Step 5: Audit Third-Party Dependency CVEs
+### Step 6: Audit Third-Party Dependency CVEs
 
 For libpng, freetype, harfbuzz, libexpat, brotli, zlib, libjpeg-turbo, libwebp, ANGLE
 submodules, etc.
@@ -281,7 +281,7 @@ submodules, etc.
 
 ---
 
-### Step 6: Query Component Governance Alerts
+### Step 7: Query Component Governance Alerts
 
 CG scans Docker container images and build-time deps from both ADO pipelines. CG alerts are
 invisible to GitHub Issues and NVD searches alone.
@@ -302,7 +302,7 @@ invisible to GitHub Issues and NVD searches alone.
 
 ---
 
-### Step 7: Check False Positives
+### Step 8: Check False Positives
 
 Before flagging anything, verify the CVE actually affects SkiaSharp.
 
@@ -321,7 +321,7 @@ Before flagging anything, verify the CVE actually affects SkiaSharp.
 
 ---
 
-### Step 8: Assemble Structured JSON Report
+### Step 9: Assemble Structured JSON Report
 
 > 🛑 **MANDATORY:** The audit MUST produce a JSON file conforming to
 > [references/report-schema.md](references/report-schema.md). This is the machine-readable
@@ -338,7 +338,7 @@ Build the JSON object with these top-level keys:
 7. **`nextSteps`** — Prioritized action items with severity, command, and reason
 
 > 🛑 **COMPLETENESS REQUIREMENT:** The `findings` array MUST include **every CVE returned
-> by the NVD query** (Step 3 of skia-cve-resolution.md). CVEs that are verified as already
+> by the NVD query** (Step 1 of skia-cve-resolution.md). CVEs that are verified as already
 > fixed in our tree are classified as `"already_fixed"` or `"false_positive"` — they are
 > NOT dropped from the report. An audit that finds 15 CVEs in NVD but only reports 7 in the
 > JSON is INCOMPLETE and will fail review. The total CVE count in `summary.totalCves` must
@@ -354,7 +354,7 @@ Save as `output/ai/security-audit-{date}.json`.
 
 ---
 
-### Step 9: Validate Report
+### Step 10: Validate Report
 
 > 🛑 **MANDATORY:** Always validate before rendering. Fix any errors reported.
 
@@ -368,7 +368,7 @@ Warnings are informational — errors must be fixed before proceeding.
 
 ---
 
-### Step 10: Render HTML + Markdown Reports
+### Step 11: Render HTML + Markdown Reports
 
 > 🛑 **MANDATORY:** Always generate both reports.
 
@@ -403,9 +403,9 @@ Present the output path to the user:
 
 ---
 
-### Step 11: Present Summary to User
+### Step 12: Present Summary to User
 
-The Markdown report was already generated in Step 10. Present a brief summary in the
+The Markdown report was already generated in Step 11. Present a brief summary in the
 conversation pointing to the generated files:
 
 ```
@@ -422,12 +422,12 @@ conversation pointing to the generated files:
 Then highlight the **top actionable items** from the report:
 - Any `needs_attention` or `undiscovered` findings
 - Chrome Releases CVEs above our current milestone (especially Skia/ANGLE)
-- 🔴/🟠 release heads-up (Step 1.6) — `main` behind the Beta milestone, or a milestone branching/going stable soon
+- 🔴/🟠 release heads-up (Step 3) — `main` behind the Beta milestone, or a milestone branching/going stable soon
 - Critical/High CG alerts
 
 #### Report quality rules
 
-These rules apply to the JSON assembly (Step 8) and are enforced by the renderers:
+These rules apply to the JSON assembly (Step 9) and are enforced by the renderers:
 
 1. **Skia bump recommendations must target the highest-severity CVE**, not the lowest. If
    there are HIGH CVEs at m146 and a MEDIUM at m133, recommend m146 as the target.

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -1,37 +1,45 @@
-# Chromium Milestone Schedule (Release Heads-Up)
+# Chromium Milestone Schedule & Channel Tracking (Release Heads-Up)
 
-The [Chromium Dash schedule](https://chromiumdash.appspot.com/schedule) publishes the release
-calendar for every Chrome/Chromium milestone — when each milestone branches from trunk and when
-it reaches the stable channel.
+The [Chromium Dash](https://chromiumdash.appspot.com/) project exposes two JSON endpoints we use
+together:
 
-Because **Skia milestones track Chrome milestones** (our submodule pins `chrome/mNNN`), this
-calendar tells us *when* the next Skia milestone we need to bump to goes stable. That makes it an
-early-warning signal: if a milestone we still owe a bump for is about to go stable — or already
-has — security fixes are reaching users before SkiaSharp ships them.
+1. **Milestone schedule** — when each milestone branches from trunk and reaches stable.
+2. **Channel releases** — which milestone *and exact Skia commit* is live in each channel
+   (Extended stable, Stable, Beta, Dev, Canary).
 
-> ℹ️ This is **not** a security check on its own. It is scheduling context. Pair it with the
-> Chrome Releases blog (CVE disclosure) and the Skia CVE resolution process to decide urgency.
+Because **Skia milestones track Chrome milestones** (our submodule pins `chrome/mNNN`), these tell
+us *when* the next Skia milestone we need goes stable, and *which Skia commit* each channel sits
+on right now. That makes them an early-warning + tracking signal: SkiaSharp maintains support for
+**Extended stable, Stable, and Beta concurrently**, so we need to know the milestone and Skia
+commit behind each of those channels at any time.
+
+> ℹ️ This is **not** a security check on its own. It is scheduling + channel context. Pair it with
+> the Chrome Releases blog (CVE disclosure) and the Skia CVE resolution process to decide urgency.
 
 ## Why This Matters for SkiaSharp
 
-1. **Bump timing:** A bump that lands *after* the milestone goes stable means a window where
-   known CVEs fixed upstream are unpatched in SkiaSharp. The schedule tells us the deadline.
-2. **Planning:** Branch points and stable dates are fixed weeks ahead. We can start a bump as
-   soon as a milestone branches instead of reacting to a CVE.
-3. **Release coordination:** If a SkiaSharp release is planned for a given week, this surfaces
-   which Skia milestone should be in it.
+1. **Concurrent channel support:** We ship/maintain branches for Extended stable, Stable, and Beta
+   at the same time. Each channel pins a *different* milestone and a *different* Skia commit. We
+   must track all three so each branch carries the right Skia.
+2. **Bump timing:** A bump that lands *after* a channel advances means a window where known CVEs
+   fixed upstream are unpatched in that SkiaSharp branch. The schedule gives the deadline.
+3. **Exact commit verification:** The channel endpoint returns `hashes.skia` — the precise upstream
+   Skia commit in that channel — so we can verify a SkiaSharp branch points at the right merge base.
+4. **Planning:** Branch points and stable dates are fixed weeks ahead; we can start a bump as soon
+   as a milestone branches instead of reacting to a CVE.
 
 ## Data Access
+
+### 1. Milestone schedule (dates)
 
 - **Endpoint:** `https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<value>`
 - **`mstone` accepts:** a milestone number (e.g. `150`), or the keywords `current`, `next`,
   `previous`. Invalid values return a pydantic validation error.
-- **Returns:** `{"mstones": [ { ... } ]}` — **one milestone per request**. There is no documented
-  bulk/range parameter (`num_milestones` and `mstone=all` do not return ranges), so the script
+- **Returns:** `{"mstones": [ { ... } ]}` — **one milestone per request**. There is no working
+  bulk/range parameter (`num_milestones` and `mstone=all` do **not** return ranges), so the script
   iterates one number at a time.
-- **No authentication; no documented rate limit** (be polite: ~0.3s between calls).
 
-### Milestone object fields (dates are ISO-8601, midnight UTC)
+#### Milestone object fields (dates are ISO-8601, midnight UTC)
 
 | Field | Meaning |
 |-------|---------|
@@ -42,49 +50,95 @@ has — security fixes are reaching users before SkiaSharp ships them.
 | `feature_freeze`, `earliest_beta`, `final_beta` | Earlier cycle dates (context) |
 | `owners`, `ldaps` | Google release TPMs (not relevant to us) |
 
+### 2. Channel releases (milestone + Skia commit per channel)
+
+- **Endpoint:** `https://chromiumdash.appspot.com/fetch_releases?channel=<Channel>&platform=<Platform>&num=1`
+- **Channels:** `Extended` (extended stable), `Stable`, `Beta`, `Dev`, `Canary`.
+- **Platform:** use `Windows` — it carries **all** channels (Extended stable and Canary are absent
+  on Linux). `Mac` also has Extended stable.
+- **Returns:** a JSON array of releases (newest first). The first element is the current release.
+
+#### Release object fields (the ones we use)
+
+| Field | Meaning |
+|-------|---------|
+| `channel` | `Extended` / `Stable` / `Beta` / `Dev` / `Canary` |
+| `milestone` | Milestone number live in that channel |
+| `version` | Full Chrome version string (e.g. `150.0.7871.24`) |
+| `hashes.skia` | **Exact upstream Skia commit** in that channel — verify the SkiaSharp branch against this |
+| `hashes.chromium` | Chromium commit (context) |
+| `time` | Release timestamp (epoch **milliseconds**) |
+
+Typical mapping (channels advance one milestone at a time): Extended < Stable < Beta < Dev ≈ Canary.
+
 ## Script Usage
 
 ```bash
-# Heads-up relative to the milestone pinned in scripts/VERSIONS.txt
+# Heads-up + channel tracking relative to the milestone pinned in scripts/VERSIONS.txt
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
   --output output/ai/milestone-schedule-cache.json
 
-# Look further ahead / behind, widen the urgency window to 3 weeks
+# Track a different set of channels, widen the urgency window
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
-  --behind 1 --ahead 6 --window 21 --verbose \
+  --track Extended,Stable,Beta --window 21 --verbose \
   --output output/ai/milestone-schedule-cache.json
+
+# Schedule only (skip the channel lookup)
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --no-channels
 
 # Override the "current" milestone (skip reading VERSIONS.txt)
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --current 150
 ```
 
 The script determines the **current** Skia milestone from `scripts/VERSIONS.txt`
-(`libSkiaSharp  milestone  NNN`, falling back to `skia  release  mNNN`), fetches a window of
-milestones around it, computes day-deltas against today, and emits prioritized heads-up alerts.
+(`libSkiaSharp  milestone  NNN`, falling back to `skia  release  mNNN`), fetches each channel's live
+release **and** a window of milestones around the current/channel milestones, computes day-deltas
+against today, and emits prioritized heads-up alerts.
+
+### Key flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--platform` | `Windows` | Platform for channel releases (Windows has all channels) |
+| `--channels` | `Extended,Stable,Beta,Dev,Canary` | Which channels to fetch |
+| `--track` | `Extended,Stable,Beta` | Channels SkiaSharp supports concurrently (drives alerts) |
+| `--window` | `14` | Days-ahead threshold for urgent/watch alerts |
+| `--behind` / `--ahead` | `1` / `4` | Schedule window around the current milestone |
+| `--no-channels` | off | Schedule-only mode |
 
 ## Output Structure
 
 ```jsonc
 {
   "meta": {
-    "generated_at": "2026-06-16T...",
+    "generated_at": "2026-06-17T...",
     "current_milestone": 150,
     "current_milestone_source": "scripts/VERSIONS.txt",
-    "window_days": 14
+    "window_days": 14,
+    "platform": "Windows",
+    "tracked_channels": ["Extended", "Stable", "Beta"]
   },
+  "channels": [
+    { "channel": "Extended", "milestone": 148, "version": "148.0.7778.271",
+      "skia_hash": "3a90f6662a2c...", "date": "2026-06-...", "tracked": true },
+    { "channel": "Beta", "milestone": 150, "version": "150.0.7871.24",
+      "skia_hash": "9f330f170430...", "date": "2026-06-...", "tracked": true }
+  ],
   "milestones": [
     {
       "milestone": 151,
       "status": "pending",          // "bumped" (<= current) or "pending" (> current)
       "is_current": false,
+      "channels": ["Dev", "Canary"],
+      "skia_hash": "fc2311fe7338...",
       "dates": {
-        "branch_point": { "date": "2026-06-29", "days_from_now": 13 },
-        "stable_date":  { "date": "2026-07-28", "days_from_now": 42 }
+        "branch_point": { "date": "2026-06-29", "days_from_now": 12 },
+        "stable_date":  { "date": "2026-07-28", "days_from_now": 41 }
       }
     }
   ],
   "headsup": [
-    { "level": "watch", "milestone": 151, "message": "..." }
+    { "level": "urgent", "milestone": 150, "channel": "Beta", "message": "..." }
   ]
 }
 ```
@@ -94,21 +148,24 @@ milestones around it, computes day-deltas against today, and emits prioritized h
 | Level | Icon | Trigger |
 |-------|------|---------|
 | `critical` | 🔴 | A **pending** milestone (we haven't bumped to it) is **already stable**. CVEs fixed upstream are live for users with no SkiaSharp bump. |
-| `urgent` | 🟠 | A pending milestone goes stable **within the window** (default 14 days). The bump should be ready. |
+| `urgent` | 🟠 | A pending milestone goes stable **within the window** (default 14 days), **or** a tracked channel (Extended/Stable/Beta) has advanced past the pinned milestone and its branch needs a bump. |
 | `watch` | 🟡 | A pending milestone **branches within the window**. Good time to start the bump. |
-| `info` | 🔵 | The current milestone's stable window is ending; the next milestone takes over soon. |
+| `info` | 🔵 | A tracked channel matches/should pin a milestone, or the current milestone's stable window is ending. |
 
 ## How the Audit Uses This
 
 Run this in **Step 1.6** of the audit (right after the Chrome Releases blog query). Use it to:
 
+- **Track concurrent channels** — confirm each SkiaSharp branch (Extended/Stable/Beta) points at
+  the Skia commit (`hashes.skia`) its channel currently ships.
 - **Prioritize Skia bump recommendations** — if a milestone with HIGH/CRITICAL CVEs (from the
   Chrome Releases / NVD passes) is also `critical`/`urgent` on the schedule, escalate it in
   `nextSteps`.
 - **Add timing to the report** — when recommending a Skia bump, cite the target milestone's
   stable date so the reader knows the deadline.
-- **Catch silent gaps** — a `critical` heads-up means we are already behind a stable milestone
-  even if no GitHub issue has been filed yet.
+- **Catch silent gaps** — a `critical` heads-up means we are already behind a stable milestone,
+  and an `urgent` channel alert means a tracked channel branch is behind, even if no GitHub issue
+  has been filed yet.
 
 The script output is advisory context; it does not need to be embedded in the structured report
 schema, but its `critical`/`urgent` findings should inform the prose summary and `nextSteps`.

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -167,7 +167,7 @@ upcoming schedule, and emits the main-vs-Beta heads-up.
 
 ## How the Audit Uses This
 
-Run in **Step 1.6** (right after the Chrome Releases blog query):
+Run in **Step 3** (right after the Chrome Releases blog query):
 
 - **Where we are vs what's coming** — `meta.status` + the `upcoming` table answer it directly.
 - **Escalate bumps** — if `status == "behind"` (or a `watch` milestone) also carries HIGH/CRITICAL

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -99,21 +99,18 @@ python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --json
 ```
 
 The script reads `main`'s milestone + major from `scripts/VERSIONS.txt`
-(`libSkiaSharp milestone NNN` and `SkiaSharp nuget <major>.NNN.x`), fetches the channels and the
-upcoming schedule, and emits the main-vs-Beta heads-up.
+(`libSkiaSharp milestone NNN` and `SkiaSharp nuget <major>.NNN.x`), fetches the channels
+(`platform=Windows`, which carries all five) and the upcoming schedule, and emits the
+main-vs-Beta heads-up. Progress is logged to stderr, so stdout/`--output` stay clean.
 
 ### Flags
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `--current N` | from VERSIONS.txt | Override main's milestone |
-| `--platform` | `Windows` | Channel platform (Windows has all channels) |
 | `--ahead N` | `4` | How many milestones past main to include in the schedule |
 | `--window N` | `14` | Days-ahead threshold for schedule `watch` alerts |
-| `--no-channels` | off | Schedule-only (disables the main-vs-Beta signal) |
 | `--json` | off | Print JSON to stdout instead of a table |
-| `--output PATH` | — | Write the structured JSON |
-| `--repo-root` / `--verbose` | auto / off | Path override, progress detail |
+| `--output PATH` | — | Write the structured JSON (how the audit consumes it) |
 
 ## Output Structure
 

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -1,0 +1,114 @@
+# Chromium Milestone Schedule (Release Heads-Up)
+
+The [Chromium Dash schedule](https://chromiumdash.appspot.com/schedule) publishes the release
+calendar for every Chrome/Chromium milestone — when each milestone branches from trunk and when
+it reaches the stable channel.
+
+Because **Skia milestones track Chrome milestones** (our submodule pins `chrome/mNNN`), this
+calendar tells us *when* the next Skia milestone we need to bump to goes stable. That makes it an
+early-warning signal: if a milestone we still owe a bump for is about to go stable — or already
+has — security fixes are reaching users before SkiaSharp ships them.
+
+> ℹ️ This is **not** a security check on its own. It is scheduling context. Pair it with the
+> Chrome Releases blog (CVE disclosure) and the Skia CVE resolution process to decide urgency.
+
+## Why This Matters for SkiaSharp
+
+1. **Bump timing:** A bump that lands *after* the milestone goes stable means a window where
+   known CVEs fixed upstream are unpatched in SkiaSharp. The schedule tells us the deadline.
+2. **Planning:** Branch points and stable dates are fixed weeks ahead. We can start a bump as
+   soon as a milestone branches instead of reacting to a CVE.
+3. **Release coordination:** If a SkiaSharp release is planned for a given week, this surfaces
+   which Skia milestone should be in it.
+
+## Data Access
+
+- **Endpoint:** `https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<value>`
+- **`mstone` accepts:** a milestone number (e.g. `150`), or the keywords `current`, `next`,
+  `previous`. Invalid values return a pydantic validation error.
+- **Returns:** `{"mstones": [ { ... } ]}` — **one milestone per request**. There is no documented
+  bulk/range parameter (`num_milestones` and `mstone=all` do not return ranges), so the script
+  iterates one number at a time.
+- **No authentication; no documented rate limit** (be polite: ~0.3s between calls).
+
+### Milestone object fields (dates are ISO-8601, midnight UTC)
+
+| Field | Meaning |
+|-------|---------|
+| `mstone` | Milestone number (e.g. `150`) |
+| `branch_point` | When the release branch is cut from trunk — earliest a stable Skia `chrome/mNNN` branch exists |
+| `stable_date` | When the milestone reaches the **stable** channel (the deadline that matters most) |
+| `late_stable_date` | End of the stable window / first refresh boundary |
+| `feature_freeze`, `earliest_beta`, `final_beta` | Earlier cycle dates (context) |
+| `owners`, `ldaps` | Google release TPMs (not relevant to us) |
+
+## Script Usage
+
+```bash
+# Heads-up relative to the milestone pinned in scripts/VERSIONS.txt
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
+  --output output/ai/milestone-schedule-cache.json
+
+# Look further ahead / behind, widen the urgency window to 3 weeks
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
+  --behind 1 --ahead 6 --window 21 --verbose \
+  --output output/ai/milestone-schedule-cache.json
+
+# Override the "current" milestone (skip reading VERSIONS.txt)
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --current 150
+```
+
+The script determines the **current** Skia milestone from `scripts/VERSIONS.txt`
+(`libSkiaSharp  milestone  NNN`, falling back to `skia  release  mNNN`), fetches a window of
+milestones around it, computes day-deltas against today, and emits prioritized heads-up alerts.
+
+## Output Structure
+
+```jsonc
+{
+  "meta": {
+    "generated_at": "2026-06-16T...",
+    "current_milestone": 150,
+    "current_milestone_source": "scripts/VERSIONS.txt",
+    "window_days": 14
+  },
+  "milestones": [
+    {
+      "milestone": 151,
+      "status": "pending",          // "bumped" (<= current) or "pending" (> current)
+      "is_current": false,
+      "dates": {
+        "branch_point": { "date": "2026-06-29", "days_from_now": 13 },
+        "stable_date":  { "date": "2026-07-28", "days_from_now": 42 }
+      }
+    }
+  ],
+  "headsup": [
+    { "level": "watch", "milestone": 151, "message": "..." }
+  ]
+}
+```
+
+### Heads-up alert levels
+
+| Level | Icon | Trigger |
+|-------|------|---------|
+| `critical` | 🔴 | A **pending** milestone (we haven't bumped to it) is **already stable**. CVEs fixed upstream are live for users with no SkiaSharp bump. |
+| `urgent` | 🟠 | A pending milestone goes stable **within the window** (default 14 days). The bump should be ready. |
+| `watch` | 🟡 | A pending milestone **branches within the window**. Good time to start the bump. |
+| `info` | 🔵 | The current milestone's stable window is ending; the next milestone takes over soon. |
+
+## How the Audit Uses This
+
+Run this in **Step 1.6** of the audit (right after the Chrome Releases blog query). Use it to:
+
+- **Prioritize Skia bump recommendations** — if a milestone with HIGH/CRITICAL CVEs (from the
+  Chrome Releases / NVD passes) is also `critical`/`urgent` on the schedule, escalate it in
+  `nextSteps`.
+- **Add timing to the report** — when recommending a Skia bump, cite the target milestone's
+  stable date so the reader knows the deadline.
+- **Catch silent gaps** — a `critical` heads-up means we are already behind a stable milestone
+  even if no GitHub issue has been filed yet.
+
+The script output is advisory context; it does not need to be embedded in the structured report
+schema, but its `critical`/`urgent` findings should inform the prose summary and `nextSteps`.

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -1,144 +1,152 @@
-# Chromium Milestone Schedule & Channel Tracking (Release Heads-Up)
+# Chromium Release Heads-Up (main vs Beta)
 
-The [Chromium Dash](https://chromiumdash.appspot.com/) project exposes two JSON endpoints we use
-together:
+[Chromium Dash](https://chromiumdash.appspot.com/) exposes two JSON endpoints we combine to
+answer one question: **are we keeping up with what's coming, and how much time do we have?**
 
-1. **Milestone schedule** — when each milestone branches from trunk and reaches stable.
-2. **Channel releases** — which milestone *and exact Skia commit* is live in each channel
+1. **Channel releases** — which milestone *and exact Skia commit* is live in each channel
    (Extended stable, Stable, Beta, Dev, Canary).
+2. **Milestone schedule** — when each milestone branches from trunk and reaches stable.
 
-Because **Skia milestones track Chrome milestones** (our submodule pins `chrome/mNNN`), these tell
-us *when* the next Skia milestone we need goes stable, and *which Skia commit* each channel sits
-on right now. That makes them an early-warning + tracking signal: SkiaSharp maintains support for
-**Extended stable, Stable, and Beta concurrently**, so we need to know the milestone and Skia
-commit behind each of those channels at any time.
+## The Model (why this is simple)
 
-> ℹ️ This is **not** a security check on its own. It is scheduling + channel context. Pair it with
-> the Chrome Releases blog (CVE disclosure) and the Skia CVE resolution process to decide urgency.
+- SkiaSharp's `main` is the **front line** and tracks the Chrome **Beta** milestone.
+- As a milestone graduates **Beta → Stable → Extended stable**, a `release/<major>.<M>.x` branch
+  is cut from a `main` that was *already* on milestone M. So on the **milestone axis**, the
+  stable / extended-stable release lines are inherently covered — their branch *name* states the
+  milestone (`release/4.148.x` = m148), and they inherited that Skia from main.
+- Therefore **"where we are" = main's milestone**, and the single signal that matters is:
 
-## Why This Matters for SkiaSharp
+  > **is `main_milestone >= beta_channel_milestone` ?**
 
-1. **Concurrent channel support:** We ship/maintain branches for Extended stable, Stable, and Beta
-   at the same time. Each channel pins a *different* milestone and a *different* Skia commit. We
-   must track all three so each branch carries the right Skia.
-2. **Bump timing:** A bump that lands *after* a channel advances means a window where known CVEs
-   fixed upstream are unpatched in that SkiaSharp branch. The schedule gives the deadline.
-3. **Exact commit verification:** The channel endpoint returns `hashes.skia` — the precise upstream
-   Skia commit in that channel — so we can verify a SkiaSharp branch points at the right merge base.
-4. **Planning:** Branch points and stable dates are fixed weeks ahead; we can start a bump as soon
-   as a milestone branches instead of reacting to a CVE.
+  If `main` falls behind Beta, the Skia bump to the new milestone is overdue. The schedule then
+  tells us how much lead time remains before that gap reaches the **stable** channel.
+
+This is why the default output is main-centric and does **not** walk previous release branches.
+
+> ℹ️ This is scheduling context, **not** a security check on its own. Pair it with the Chrome
+> Releases blog (CVE disclosure) and the Skia CVE resolution process to decide urgency.
+
+### Branch ↔ milestone mapping (verified)
+
+| Branch | Pinned milestone | NuGet |
+|--------|------------------|-------|
+| `main` | 150 (current Beta) | 4.150.x |
+| `release/4.148.x` | 148 (Extended) | 4.148.0 |
+| `release/3.119.x` | 119 | 3.119.5 |
+| `release/2.88.x` | 88 | 2.88.x |
+
+`<major>` is the SkiaSharp epoch (currently `4`); the **minor is the milestone**. Milestones are
+globally unique across majors, so `release/*.<M>.x` is unambiguous. A `release/<major>.<M>.x`
+branch is only cut partway through the cycle — until then, `main` is the head for that milestone.
+
+## Two Axes (only one needs tracking by default)
+
+| Axis | Question | What it needs |
+|------|----------|---------------|
+| **1. Milestone coverage** (default) | Are we keeping up with the front line? | `main` milestone + Beta channel milestone. Nothing else. |
+| **2. Within-milestone backports** (`--check-backports`) | Does a shipped `release/*.x` line carry the latest Skia *for its milestone* (e.g. a cherry-picked CVE fix in `149.0.7827.x`)? | Resolve `release/<major>.<M>.x`, read its Skia submodule SHA, compare against the channel's current `hashes.skia` via the Skia CVE process. |
+
+Axis 1 is the heads-up. Axis 2 is a deeper, opt-in audit check.
 
 ## Data Access
 
-### 1. Milestone schedule (dates)
+### Channel releases (milestone + Skia commit per channel)
 
-- **Endpoint:** `https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<value>`
-- **`mstone` accepts:** a milestone number (e.g. `150`), or the keywords `current`, `next`,
-  `previous`. Invalid values return a pydantic validation error.
-- **Returns:** `{"mstones": [ { ... } ]}` — **one milestone per request**. There is no working
-  bulk/range parameter (`num_milestones` and `mstone=all` do **not** return ranges), so the script
-  iterates one number at a time.
+```
+https://chromiumdash.appspot.com/fetch_releases?channel=<Channel>&platform=<Platform>&num=1
+```
 
-#### Milestone object fields (dates are ISO-8601, midnight UTC)
-
-| Field | Meaning |
-|-------|---------|
-| `mstone` | Milestone number (e.g. `150`) |
-| `branch_point` | When the release branch is cut from trunk — earliest a stable Skia `chrome/mNNN` branch exists |
-| `stable_date` | When the milestone reaches the **stable** channel (the deadline that matters most) |
-| `late_stable_date` | End of the stable window / first refresh boundary |
-| `feature_freeze`, `earliest_beta`, `final_beta` | Earlier cycle dates (context) |
-| `owners`, `ldaps` | Google release TPMs (not relevant to us) |
-
-### 2. Channel releases (milestone + Skia commit per channel)
-
-- **Endpoint:** `https://chromiumdash.appspot.com/fetch_releases?channel=<Channel>&platform=<Platform>&num=1`
-- **Channels:** `Extended` (extended stable), `Stable`, `Beta`, `Dev`, `Canary`.
-- **Platform:** use `Windows` — it carries **all** channels (Extended stable and Canary are absent
-  on Linux). `Mac` also has Extended stable.
-- **Returns:** a JSON array of releases (newest first). The first element is the current release.
-
-#### Release object fields (the ones we use)
+- **Channels:** `Extended`, `Stable`, `Beta`, `Dev`, `Canary`.
+- **Platform:** use `Windows` — it carries **all** channels (Extended stable & Canary are absent on
+  Linux). `Mac` also has Extended stable.
+- **Returns:** a JSON array (newest first); element `[0]` is the current release.
 
 | Field | Meaning |
 |-------|---------|
 | `channel` | `Extended` / `Stable` / `Beta` / `Dev` / `Canary` |
-| `milestone` | Milestone number live in that channel |
-| `version` | Full Chrome version string (e.g. `150.0.7871.24`) |
-| `hashes.skia` | **Exact upstream Skia commit** in that channel — verify the SkiaSharp branch against this |
-| `hashes.chromium` | Chromium commit (context) |
+| `milestone` | Milestone live in that channel |
+| `version` | Full Chrome version (e.g. `150.0.7871.24`) |
+| `hashes.skia` | **Exact upstream Skia commit** in that channel |
 | `time` | Release timestamp (epoch **milliseconds**) |
 
-Typical mapping (channels advance one milestone at a time): Extended < Stable < Beta < Dev ≈ Canary.
+### Milestone schedule (dates)
+
+```
+https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
+```
+
+- Returns `{"mstones": [ { ... } ]}` — **one milestone per request** (no working range param).
+- Fields: `mstone`, `branch_point`, `stable_date`, `late_stable_date`, `feature_freeze`,
+  `earliest_beta`, `final_beta` (ISO-8601, midnight UTC).
+
+No authentication, no documented rate limit (be polite: ~0.3s between calls).
 
 ## Script Usage
 
 ```bash
-# Heads-up + channel tracking relative to the milestone pinned in scripts/VERSIONS.txt
+# Lean heads-up to stdout (main vs Beta + upcoming schedule)
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py
+
+# + structured JSON for the audit report
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
   --output output/ai/milestone-schedule-cache.json
 
-# Track a different set of channels, widen the urgency window
-python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
-  --track Extended,Stable,Beta --window 21 --verbose \
-  --output output/ai/milestone-schedule-cache.json
+# Axis 2: also resolve release/<major>.<M>.x lines and their Skia SHA
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --check-backports
 
-# Schedule only (skip the channel lookup)
-python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --no-channels
-
-# Override the "current" milestone (skip reading VERSIONS.txt)
-python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --current 150
+# Print JSON instead of a table
+python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --json
 ```
 
-The script determines the **current** Skia milestone from `scripts/VERSIONS.txt`
-(`libSkiaSharp  milestone  NNN`, falling back to `skia  release  mNNN`), fetches each channel's live
-release **and** a window of milestones around the current/channel milestones, computes day-deltas
-against today, and emits prioritized heads-up alerts.
+The script reads `main`'s milestone + major from `scripts/VERSIONS.txt`
+(`libSkiaSharp milestone NNN` and `SkiaSharp nuget <major>.NNN.x`), fetches the channels and the
+upcoming schedule, and emits the main-vs-Beta heads-up.
 
-### Key flags
+### Flags
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `--platform` | `Windows` | Platform for channel releases (Windows has all channels) |
-| `--channels` | `Extended,Stable,Beta,Dev,Canary` | Which channels to fetch |
-| `--track` | `Extended,Stable,Beta` | Channels SkiaSharp supports concurrently (drives alerts) |
-| `--window` | `14` | Days-ahead threshold for urgent/watch alerts |
-| `--behind` / `--ahead` | `1` / `4` | Schedule window around the current milestone |
-| `--no-channels` | off | Schedule-only mode |
+| `--current N` | from VERSIONS.txt | Override main's milestone |
+| `--platform` | `Windows` | Channel platform (Windows has all channels) |
+| `--ahead N` | `4` | How many milestones past main to include in the schedule |
+| `--window N` | `14` | Days-ahead threshold for schedule `watch` alerts |
+| `--no-channels` | off | Schedule-only (disables the main-vs-Beta signal) |
+| `--check-backports` | off | Resolve each tracked channel's `release/<major>.<M>.x` line + Skia SHA |
+| `--track` | `Extended,Stable` | Channels to resolve in `--check-backports` (Beta == main) |
+| `--json` | off | Print JSON to stdout instead of a table |
+| `--output PATH` | — | Write the structured JSON |
+| `--repo-root` / `--verbose` | auto / off | Path override, progress detail |
 
 ## Output Structure
 
 ```jsonc
 {
   "meta": {
-    "generated_at": "2026-06-17T...",
-    "current_milestone": 150,
-    "current_milestone_source": "scripts/VERSIONS.txt",
-    "window_days": 14,
+    "main_milestone": 150,
+    "main_milestone_source": "scripts/VERSIONS.txt",
+    "major": 4,
+    "beta_milestone": 150,
+    "status": "current",          // "current" if main >= Beta, else "behind"
     "platform": "Windows",
-    "tracked_channels": ["Extended", "Stable", "Beta"]
+    "window_days": 14
   },
   "channels": [
-    { "channel": "Extended", "milestone": 148, "version": "148.0.7778.271",
-      "skia_hash": "3a90f6662a2c...", "date": "2026-06-...", "tracked": true },
     { "channel": "Beta", "milestone": 150, "version": "150.0.7871.24",
-      "skia_hash": "9f330f170430...", "date": "2026-06-...", "tracked": true }
+      "skia_hash": "9f330f170430...", "date": "2026-06-..." }
   ],
-  "milestones": [
-    {
-      "milestone": 151,
-      "status": "pending",          // "bumped" (<= current) or "pending" (> current)
-      "is_current": false,
-      "channels": ["Dev", "Canary"],
-      "skia_hash": "fc2311fe7338...",
-      "dates": {
-        "branch_point": { "date": "2026-06-29", "days_from_now": 12 },
-        "stable_date":  { "date": "2026-07-28", "days_from_now": 41 }
-      }
-    }
+  "upcoming": [
+    { "milestone": 151, "is_main": false, "channels": ["Dev", "Canary"],
+      "dates": { "branch_point": { "date": "2026-06-29", "days_from_now": 12 },
+                 "stable_date":  { "date": "2026-07-28", "days_from_now": 41 } } }
   ],
   "headsup": [
-    { "level": "urgent", "milestone": 150, "channel": "Beta", "message": "..." }
+    { "level": "ok", "milestone": 150, "message": "main (m150) is at or ahead of Beta..." }
+  ],
+  // only with --check-backports:
+  "backports": [
+    { "channel": "Extended", "channel_milestone": 148, "channel_skia": "3a90f6662a2c...",
+      "branch": "origin/release/4.148.x", "branch_exists": true,
+      "branch_milestone": 148, "branch_skia_fork": "1a155bae3ac8..." }
   ]
 }
 ```
@@ -147,25 +155,26 @@ against today, and emits prioritized heads-up alerts.
 
 | Level | Icon | Trigger |
 |-------|------|---------|
-| `critical` | 🔴 | A **pending** milestone (we haven't bumped to it) is **already stable**. CVEs fixed upstream are live for users with no SkiaSharp bump. |
-| `urgent` | 🟠 | A pending milestone goes stable **within the window** (default 14 days), **or** a tracked channel (Extended/Stable/Beta) has advanced past the pinned milestone and its branch needs a bump. |
-| `watch` | 🟡 | A pending milestone **branches within the window**. Good time to start the bump. |
-| `info` | 🔵 | A tracked channel matches/should pin a milestone, or the current milestone's stable window is ending. |
+| `critical` | 🔴 | `main < Beta` **and** the Beta milestone is already stable — the bump is overdue and shipping to stable users. |
+| `urgent` | 🟠 | `main < Beta` — the front line is behind; bump main to the Beta milestone. |
+| `watch` | 🟡 | A milestone past main **branches within the window** — start preparing. |
+| `ok` | 🟢 | `main >= Beta` — front line current. |
+| `info` | 🔵 | Other context. |
+
+> ⚠️ `backports` reports the **mono/skia fork** submodule SHA, which is not directly comparable to
+> the channel's upstream `hashes.skia`. Use it to confirm a release line exists and to feed the
+> Skia CVE resolution process (merge-base check) — not as a literal SHA-equality test.
 
 ## How the Audit Uses This
 
-Run this in **Step 1.6** of the audit (right after the Chrome Releases blog query). Use it to:
+Run in **Step 1.6** (right after the Chrome Releases blog query):
 
-- **Track concurrent channels** — confirm each SkiaSharp branch (Extended/Stable/Beta) points at
-  the Skia commit (`hashes.skia`) its channel currently ships.
-- **Prioritize Skia bump recommendations** — if a milestone with HIGH/CRITICAL CVEs (from the
-  Chrome Releases / NVD passes) is also `critical`/`urgent` on the schedule, escalate it in
-  `nextSteps`.
-- **Add timing to the report** — when recommending a Skia bump, cite the target milestone's
-  stable date so the reader knows the deadline.
-- **Catch silent gaps** — a `critical` heads-up means we are already behind a stable milestone,
-  and an `urgent` channel alert means a tracked channel branch is behind, even if no GitHub issue
-  has been filed yet.
+- **Where we are vs what's coming** — `meta.status` + the `upcoming` table answer it directly.
+- **Escalate bumps** — if `status == "behind"` (or a `watch` milestone) also carries HIGH/CRITICAL
+  Skia CVEs from the Chrome Releases / NVD pass, raise it in `nextSteps` with the stable date as
+  the deadline.
+- **Deep check (optional)** — run `--check-backports` when auditing whether a shipped
+  `release/*.x` line is missing a within-milestone Skia security backport.
 
-The script output is advisory context; it does not need to be embedded in the structured report
-schema, but its `critical`/`urgent` findings should inform the prose summary and `nextSteps`.
+The output is advisory context; it need not be embedded in the structured report schema, but its
+`critical`/`urgent` findings should inform the prose summary and `nextSteps`.

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -39,14 +39,17 @@ This is why the default output is main-centric and does **not** walk previous re
 globally unique across majors, so `release/*.<M>.x` is unambiguous. A `release/<major>.<M>.x`
 branch is only cut partway through the cycle — until then, `main` is the head for that milestone.
 
-## Two Axes (only one needs tracking by default)
+## What This Tool Tracks (and What It Doesn't)
 
-| Axis | Question | What it needs |
-|------|----------|---------------|
-| **1. Milestone coverage** (default) | Are we keeping up with the front line? | `main` milestone + Beta channel milestone. Nothing else. |
-| **2. Within-milestone backports** (`--check-backports`) | Does a shipped `release/*.x` line carry the latest Skia *for its milestone* (e.g. a cherry-picked CVE fix in `149.0.7827.x`)? | Resolve `release/<major>.<M>.x`, read its Skia submodule SHA, compare against the channel's current `hashes.skia` via the Skia CVE process. |
+This tool answers **milestone coverage**: is `main` keeping up with the front line? It needs
+only `main`'s milestone and the Beta channel milestone — nothing else.
 
-Axis 1 is the heads-up. Axis 2 is a deeper, opt-in audit check.
+It does **not** try to verify whether a shipped `release/*.x` line carries the latest Skia
+*within* its milestone (e.g. a cherry-picked CVE fix in `150.0.7871.x`). That within-milestone
+backport question belongs to the [Skia CVE resolution](skia-cve-resolution.md) process, which
+does proper merge-base ancestry against the upstream fix commit. A naive SHA comparison can't
+answer it anyway: our submodule pins the **mono/skia fork**, not upstream google/skia, so the
+branch SHA and the channel's `hashes.skia` are not directly comparable.
 
 ## Data Access
 
@@ -91,9 +94,6 @@ python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py \
   --output output/ai/milestone-schedule-cache.json
 
-# Axis 2: also resolve release/<major>.<M>.x lines and their Skia SHA
-python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --check-backports
-
 # Print JSON instead of a table
 python3 .agents/skills/security-audit/scripts/query-milestone-schedule.py --json
 ```
@@ -111,8 +111,6 @@ upcoming schedule, and emits the main-vs-Beta heads-up.
 | `--ahead N` | `4` | How many milestones past main to include in the schedule |
 | `--window N` | `14` | Days-ahead threshold for schedule `watch` alerts |
 | `--no-channels` | off | Schedule-only (disables the main-vs-Beta signal) |
-| `--check-backports` | off | Resolve each tracked channel's `release/<major>.<M>.x` line + Skia SHA |
-| `--track` | `Extended,Stable` | Channels to resolve in `--check-backports` (Beta == main) |
 | `--json` | off | Print JSON to stdout instead of a table |
 | `--output PATH` | — | Write the structured JSON |
 | `--repo-root` / `--verbose` | auto / off | Path override, progress detail |
@@ -141,12 +139,6 @@ upcoming schedule, and emits the main-vs-Beta heads-up.
   ],
   "headsup": [
     { "level": "ok", "milestone": 150, "message": "main (m150) is at or ahead of Beta..." }
-  ],
-  // only with --check-backports:
-  "backports": [
-    { "channel": "Extended", "channel_milestone": 148, "channel_skia": "3a90f6662a2c...",
-      "branch": "origin/release/4.148.x", "branch_exists": true,
-      "branch_milestone": 148, "branch_skia_fork": "1a155bae3ac8..." }
   ]
 }
 ```
@@ -161,10 +153,6 @@ upcoming schedule, and emits the main-vs-Beta heads-up.
 | `ok` | 🟢 | `main >= Beta` — front line current. |
 | `info` | 🔵 | Other context. |
 
-> ⚠️ `backports` reports the **mono/skia fork** submodule SHA, which is not directly comparable to
-> the channel's upstream `hashes.skia`. Use it to confirm a release line exists and to feed the
-> Skia CVE resolution process (merge-base check) — not as a literal SHA-equality test.
-
 ## How the Audit Uses This
 
 Run in **Step 3** (right after the Chrome Releases blog query):
@@ -173,8 +161,9 @@ Run in **Step 3** (right after the Chrome Releases blog query):
 - **Escalate bumps** — if `status == "behind"` (or a `watch` milestone) also carries HIGH/CRITICAL
   Skia CVEs from the Chrome Releases / NVD pass, raise it in `nextSteps` with the stable date as
   the deadline.
-- **Deep check (optional)** — run `--check-backports` when auditing whether a shipped
-  `release/*.x` line is missing a within-milestone Skia security backport.
+- **Within-milestone backports** — for whether a shipped `release/*.x` line is missing a
+  cherry-picked Skia security fix, use the [Skia CVE resolution](skia-cve-resolution.md) process
+  (merge-base ancestry), not this tool.
 
 The output is advisory context; it need not be embedded in the structured report schema, but its
 `critical`/`urgent` findings should inform the prose summary and `nextSteps`.

--- a/.agents/skills/security-audit/references/milestone-schedule.md
+++ b/.agents/skills/security-audit/references/milestone-schedule.md
@@ -121,7 +121,7 @@ main-vs-Beta heads-up. Progress is logged to stderr, so stdout/`--output` stay c
     "main_milestone_source": "scripts/VERSIONS.txt",
     "major": 4,
     "beta_milestone": 150,
-    "status": "current",          // "current" if main >= Beta, else "behind"
+    "status": "current",          // "current" (main >= Beta), "behind" (main < Beta), or "unknown" (Beta lookup failed)
     "platform": "Windows",
     "window_days": 14
   },
@@ -144,11 +144,15 @@ main-vs-Beta heads-up. Progress is logged to stderr, so stdout/`--output` stay c
 
 | Level | Icon | Trigger |
 |-------|------|---------|
-| `critical` | 🔴 | `main < Beta` **and** the Beta milestone is already stable — the bump is overdue and shipping to stable users. |
+| `critical` | 🔴 | `main < Beta` **and** a milestone newer than main already ships on a stable-class channel (Stable/Extended) — the bump is overdue and reaching non-preview users. |
 | `urgent` | 🟠 | `main < Beta` — the front line is behind; bump main to the Beta milestone. |
+| `unknown` | ❓ | The Beta channel milestone could not be read (Chromium Dash unavailable) — the signal could not be evaluated. **Do not treat as OK.** |
 | `watch` | 🟡 | A milestone past main **branches within the window** — start preparing. |
 | `ok` | 🟢 | `main >= Beta` — front line current. |
 | `info` | 🔵 | Other context. |
+
+> The `critical` trigger uses the **live** Stable/Extended channel milestones from `fetch_releases`
+> (authoritative), falling back to the scheduled stable date only when channel data is missing.
 
 ## How the Audit Uses This
 

--- a/.agents/skills/security-audit/references/report-schema.md
+++ b/.agents/skills/security-audit/references/report-schema.md
@@ -209,7 +209,7 @@ Array of action objects:
 
 ## `chromeReleases` — Chrome Releases Blog Data (Optional)
 
-When the Chrome Releases blog was queried (Step 1.5), include this section for traceability.
+When the Chrome Releases blog was queried (Step 2), include this section for traceability.
 This section is optional — omit it only if the blog query was skipped or failed.
 
 ```json

--- a/.agents/skills/security-audit/references/skia-cve-resolution.md
+++ b/.agents/skills/security-audit/references/skia-cve-resolution.md
@@ -55,7 +55,7 @@ curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=Skia&res
 
 ### Cross-reference with Chrome Releases blog
 
-After the NVD query, compare results against the Chrome Releases data (from Step 1.5 of the
+After the NVD query, compare results against the Chrome Releases data (from Step 2 of the
 main workflow, cached in `output/ai/chrome-releases-cache.json`):
 
 - **CVEs in both NVD and Chrome Releases:** Normal. Use NVD for CVSS score, Chrome Releases

--- a/.agents/skills/security-audit/scripts/query-milestone-schedule.py
+++ b/.agents/skills/security-audit/scripts/query-milestone-schedule.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Query the Chromium milestone release schedule and produce a release heads-up for
+SkiaSharp's Skia bumps.
+
+This is NOT a security check by itself. It is an early-warning tool: Skia milestones
+track Chrome milestones, so the Chromium schedule tells us *when* a given milestone
+branches and goes stable. If a milestone we still need to bump to is about to go
+stable (or has already), we should make sure the Skia bump is ready so security
+fixes land in time.
+
+Data source:
+  https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
+  - Returns one milestone per request as {"mstones": [ {...} ]}.
+  - `mstone` accepts a milestone number, or the keywords 'current', 'next', 'previous'.
+  - No authentication, no documented rate limit (be polite: small delay between calls).
+
+Each milestone object includes (dates are ISO-8601, midnight UTC):
+  - mstone           : milestone number (e.g. 150)
+  - branch_point     : when the release branch is cut from trunk
+  - stable_date      : when the milestone reaches the stable channel
+  - late_stable_date : end of the stable window / next refresh boundary
+  - feature_freeze, earliest_beta, final_beta, etc.
+
+Prerequisites:
+  - Python 3.8+ (uses urllib, no external dependencies)
+
+Usage:
+  # Heads-up relative to the milestone currently pinned in scripts/VERSIONS.txt
+  python3 query-milestone-schedule.py --output output/ai/milestone-schedule-cache.json
+
+  # Look further ahead / behind
+  python3 query-milestone-schedule.py --behind 1 --ahead 6 \
+    --output output/ai/milestone-schedule-cache.json
+
+  # Override the "current" milestone instead of reading VERSIONS.txt
+  python3 query-milestone-schedule.py --current 150
+
+  # Flag anything going stable within N days as urgent (default 14)
+  python3 query-milestone-schedule.py --window 21 --verbose
+
+Output:
+  JSON written to --output (if given) and a human-readable summary to stdout.
+  The JSON has:
+    - meta: { generated_at, current_milestone, current_milestone_source, window_days }
+    - milestones[]: one entry per fetched milestone with parsed dates + day deltas
+    - headsup[]: prioritized alerts (e.g. milestone going stable within the window
+                 that we have not bumped to yet)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+
+SCHEDULE_URL = "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone={mstone}"
+
+# Dates we care about for a release heads-up, in chronological order.
+KEY_DATES = ["branch_point", "stable_date", "late_stable_date"]
+
+
+def log(msg, verbose=True):
+    if verbose:
+        print(msg, file=sys.stderr)
+
+
+def find_repo_root(start):
+    """Walk up from `start` looking for the SkiaSharp repo root (has scripts/VERSIONS.txt)."""
+    cur = os.path.abspath(start)
+    while True:
+        if os.path.isfile(os.path.join(cur, "scripts", "VERSIONS.txt")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+
+
+def read_current_milestone(repo_root):
+    """Parse the pinned Skia milestone from scripts/VERSIONS.txt.
+
+    Looks for a line like: `libSkiaSharp            milestone   150`
+    Falls back to `skia ... release m150`.
+    """
+    if not repo_root:
+        return None
+    versions = os.path.join(repo_root, "scripts", "VERSIONS.txt")
+    if not os.path.isfile(versions):
+        return None
+    milestone = None
+    skia_release = None
+    with open(versions, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.lstrip().startswith("#"):
+                continue
+            m = re.match(r"\s*libSkiaSharp\s+milestone\s+(\d+)", line)
+            if m:
+                milestone = int(m.group(1))
+            m = re.match(r"\s*skia\s+\S+\s+m(\d+)", line)
+            if m:
+                skia_release = int(m.group(1))
+    return milestone if milestone is not None else skia_release
+
+
+def fetch_milestone(mstone, retries=3, delay=0.4):
+    url = SCHEDULE_URL.format(mstone=mstone)
+    last_err = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "skiasharp-security-audit/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+            stones = data.get("mstones") or []
+            if not stones:
+                return None
+            return stones[0]
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as e:
+            last_err = e
+            time.sleep(delay * (attempt + 1))
+    log(f"  ! failed to fetch mstone={mstone}: {last_err}")
+    return None
+
+
+def parse_date(value):
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return None
+
+
+def days_until(dt, now):
+    if dt is None:
+        return None
+    return (dt.date() - now.date()).days
+
+
+def build_milestone_entry(raw, now):
+    entry = {"milestone": raw.get("mstone"), "dates": {}}
+    for key in KEY_DATES + ["feature_freeze", "earliest_beta", "final_beta"]:
+        dt = parse_date(raw.get(key))
+        if dt is None:
+            continue
+        entry["dates"][key] = {
+            "date": dt.date().isoformat(),
+            "days_from_now": days_until(dt, now),
+        }
+    return entry
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Chromium milestone release heads-up for Skia bumps.")
+    ap.add_argument("--current", type=int, default=None,
+                    help="Override the current Skia milestone (default: read scripts/VERSIONS.txt).")
+    ap.add_argument("--behind", type=int, default=1,
+                    help="How many milestones before current to include (default: 1).")
+    ap.add_argument("--ahead", type=int, default=4,
+                    help="How many milestones after current to include (default: 4).")
+    ap.add_argument("--window", type=int, default=14,
+                    help="Flag milestones reaching stable within this many days as urgent (default: 14).")
+    ap.add_argument("--output", default=None, help="Write the JSON result to this path.")
+    ap.add_argument("--repo-root", default=None, help="Repo root (default: auto-detect from cwd).")
+    ap.add_argument("--verbose", action="store_true", help="Print extra progress detail.")
+    args = ap.parse_args()
+
+    now = datetime.now(timezone.utc)
+
+    repo_root = args.repo_root or find_repo_root(os.getcwd()) or find_repo_root(
+        os.path.dirname(os.path.abspath(__file__)))
+
+    current = args.current
+    source = "--current argument"
+    if current is None:
+        current = read_current_milestone(repo_root)
+        source = "scripts/VERSIONS.txt"
+    if current is None:
+        # Last resort: ask the API what the current Chrome milestone is.
+        raw = fetch_milestone("current")
+        if raw:
+            current = raw.get("mstone")
+            source = "chromiumdash 'current'"
+    if current is None:
+        print("ERROR: could not determine the current Skia milestone. Pass --current N.",
+              file=sys.stderr)
+        return 2
+
+    lo = current - max(0, args.behind)
+    hi = current + max(0, args.ahead)
+    log(f"Current Skia milestone: {current} (from {source})", args.verbose)
+    log(f"Fetching milestones {lo}..{hi} from chromiumdash...", args.verbose)
+
+    milestones = []
+    for m in range(lo, hi + 1):
+        raw = fetch_milestone(m)
+        time.sleep(0.3)
+        if not raw:
+            continue
+        entry = build_milestone_entry(raw, now)
+        entry["is_current"] = (m == current)
+        entry["status"] = "bumped" if m <= current else "pending"
+        milestones.append(entry)
+        if args.verbose:
+            sd = entry["dates"].get("stable_date", {})
+            log(f"  m{m}: stable {sd.get('date', '?')} ({sd.get('days_from_now', '?')}d)")
+
+    headsup = build_headsup(milestones, current, args.window, now)
+
+    result = {
+        "meta": {
+            "generated_at": now.isoformat(),
+            "current_milestone": current,
+            "current_milestone_source": source,
+            "window_days": args.window,
+            "data_source": "https://chromiumdash.appspot.com/fetch_milestone_schedule",
+        },
+        "milestones": milestones,
+        "headsup": headsup,
+    }
+
+    if args.output:
+        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2)
+        log(f"Wrote {args.output}", True)
+
+    print_summary(result)
+    return 0
+
+
+def build_headsup(milestones, current, window, now):
+    """Produce prioritized alerts about pending bumps relative to the schedule."""
+    alerts = []
+    for entry in milestones:
+        m = entry["milestone"]
+        stable = entry["dates"].get("stable_date")
+        branch = entry["dates"].get("branch_point")
+
+        if entry["status"] == "pending":
+            # We have NOT bumped to this milestone yet.
+            if stable is not None:
+                d = stable["days_from_now"]
+                if d is not None and d < 0:
+                    alerts.append({
+                        "level": "critical",
+                        "milestone": m,
+                        "message": (f"m{m} reached stable {abs(d)} day(s) ago but SkiaSharp is "
+                                    f"still on m{current}. Security fixes in m{m} are shipping "
+                                    f"to users without a SkiaSharp bump."),
+                    })
+                elif d is not None and d <= window:
+                    alerts.append({
+                        "level": "urgent",
+                        "milestone": m,
+                        "message": (f"m{m} goes stable in {d} day(s) ({stable['date']}). "
+                                    f"Make sure the Skia bump from m{current} is ready."),
+                    })
+                elif branch is not None and branch["days_from_now"] is not None \
+                        and branch["days_from_now"] <= window:
+                    bd = branch["days_from_now"]
+                    when = "branched" if bd < 0 else f"branches in {bd} day(s)"
+                    alerts.append({
+                        "level": "watch",
+                        "milestone": m,
+                        "message": (f"m{m} {when} ({branch['date']}); stable {stable['date']}. "
+                                    f"Start preparing the bump."),
+                    })
+        else:
+            # Already on/ahead of this milestone; note its support window winding down.
+            late = entry["dates"].get("late_stable_date")
+            if entry["is_current"] and late is not None and late["days_from_now"] is not None \
+                    and 0 <= late["days_from_now"] <= window:
+                alerts.append({
+                    "level": "info",
+                    "milestone": m,
+                    "message": (f"Current milestone m{m} stable window ends ~{late['date']} "
+                                f"({late['days_from_now']}d). Next milestone takes over soon."),
+                })
+
+    order = {"critical": 0, "urgent": 1, "watch": 2, "info": 3}
+    alerts.sort(key=lambda a: (order.get(a["level"], 9), a["milestone"]))
+    return alerts
+
+
+LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "watch": "🟡", "info": "🔵"}
+
+
+def print_summary(result):
+    meta = result["meta"]
+    print()
+    print(f"Chromium release schedule — heads-up for Skia bumps")
+    print(f"  Current SkiaSharp milestone: m{meta['current_milestone']} "
+          f"(from {meta['current_milestone_source']})")
+    print(f"  Urgency window: {meta['window_days']} days\n")
+
+    print("  Milestone   Branch point   Stable date    Status    In")
+    print("  " + "-" * 58)
+    for entry in result["milestones"]:
+        m = entry["milestone"]
+        b = entry["dates"].get("branch_point", {})
+        s = entry["dates"].get("stable_date", {})
+        d = s.get("days_from_now")
+        din = f"{d:+d}d" if isinstance(d, int) else "  ?"
+        marker = "*" if entry.get("is_current") else " "
+        print(f"  {marker}m{m:<8}  {b.get('date','?'):<13}  {s.get('date','?'):<13}  "
+              f"{entry['status']:<8}  {din:>5}")
+
+    print()
+    headsup = result["headsup"]
+    if not headsup:
+        print("  ✅ No release heads-up: no pending milestones inside the urgency window.")
+    else:
+        print("  Heads-up:")
+        for a in headsup:
+            icon = LEVEL_ICON.get(a["level"], "•")
+            print(f"   {icon} [{a['level'].upper()}] {a['message']}")
+    print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/security-audit/scripts/query-milestone-schedule.py
+++ b/.agents/skills/security-audit/scripts/query-milestone-schedule.py
@@ -20,25 +20,18 @@ Data sources (no auth, no documented rate limit):
 
 Default output is main-centric and lean. The full 5-channel list is included as context.
 
-Optional --check-backports (the deeper, axis-2 check): resolve each tracked channel's
-`release/<major>.<M>.x` branch and report its pinned milestone + Skia submodule commit, so
-the audit can spot a shipped release line that is missing a within-milestone Skia backport.
-
 Usage:
   python3 query-milestone-schedule.py                       # lean heads-up to stdout
   python3 query-milestone-schedule.py --output out.json     # + structured JSON
-  python3 query-milestone-schedule.py --check-backports     # also resolve release/* lines
   python3 query-milestone-schedule.py --json                # print JSON instead of a table
 
-Prerequisites: Python 3.8+ (stdlib only). --check-backports needs a git checkout with the
-release branches fetched (origin/release/*).
+Prerequisites: Python 3.8+ (stdlib only).
 """
 
 import argparse
 import json
 import os
 import re
-import subprocess
 import sys
 import time
 import urllib.error
@@ -53,8 +46,6 @@ RELEASES_URL = ("https://chromiumdash.appspot.com/fetch_releases"
 ALL_CHANNELS = ["Extended", "Stable", "Beta", "Dev", "Canary"]
 FRONT_CHANNEL = "Beta"            # the channel `main` is expected to keep up with
 DEFAULT_PLATFORM = "Windows"
-# Channels backed by a cut release/<major>.<M>.x line (Beta == main, so not listed).
-DEFAULT_BACKPORT_CHANNELS = ["Extended", "Stable"]
 
 KEY_DATES = ["branch_point", "stable_date", "late_stable_date"]
 LEVEL_ORDER = {"critical": 0, "urgent": 1, "watch": 2, "ok": 3, "info": 4}
@@ -146,41 +137,6 @@ def read_main_versions(repo_root):
         return parse_versions(f.read())
 
 
-# --- git helpers (only used by --check-backports) ---
-
-def run_git(repo_root, args):
-    try:
-        out = subprocess.run(["git", "-C", repo_root] + args,
-                             capture_output=True, text=True, timeout=30)
-        return out.stdout if out.returncode == 0 else None
-    except (subprocess.SubprocessError, FileNotFoundError):
-        return None
-
-
-def resolve_release_branch(repo_root, major, milestone):
-    """Find the release/<major>.<milestone>.x ref (remote preferred)."""
-    for ref in (f"origin/release/{major}.{milestone}.x", f"release/{major}.{milestone}.x"):
-        if run_git(repo_root, ["rev-parse", "--verify", "-q", ref]) is not None:
-            return ref
-    return None
-
-
-def branch_skia_sha(repo_root, ref):
-    out = run_git(repo_root, ["ls-tree", ref, "externals/skia"])
-    if not out:
-        return None
-    m = re.search(r"commit\s+([0-9a-f]{40})", out)
-    return m.group(1) if m else None
-
-
-def branch_milestone(repo_root, ref):
-    out = run_git(repo_root, ["show", f"{ref}:scripts/VERSIONS.txt"])
-    if not out:
-        return None
-    ms, _ = parse_versions(out)
-    return ms
-
-
 # --- date math ---
 
 def parse_date(value):
@@ -245,28 +201,6 @@ def build_headsup(main_ms, beta_ms, upcoming, window, beta_stable_days):
     return alerts
 
 
-def check_backports(repo_root, major, channels, track, now):
-    """Axis-2: resolve each tracked channel's release/<major>.<M>.x line."""
-    rows = []
-    by_channel = {c["channel"]: c for c in channels}
-    for name in track:
-        ch = by_channel.get(name)
-        if not ch or not isinstance(ch.get("milestone"), int):
-            continue
-        m = ch["milestone"]
-        ref = resolve_release_branch(repo_root, major, m)
-        rows.append({
-            "channel": name,
-            "channel_milestone": m,
-            "channel_skia": ch.get("skia_hash"),
-            "branch": ref,
-            "branch_exists": ref is not None,
-            "branch_milestone": branch_milestone(repo_root, ref) if ref else None,
-            "branch_skia_fork": branch_skia_sha(repo_root, ref) if ref else None,
-        })
-    return rows
-
-
 def main():
     ap = argparse.ArgumentParser(description="Chromium release heads-up for SkiaSharp Skia bumps (main vs Beta).")
     ap.add_argument("--current", type=int, default=None,
@@ -279,10 +213,6 @@ def main():
                     help="Days-ahead threshold for schedule 'watch' alerts (default: 14).")
     ap.add_argument("--no-channels", action="store_true",
                     help="Skip channel lookup (schedule-only; disables the main-vs-Beta signal).")
-    ap.add_argument("--check-backports", action="store_true",
-                    help="Resolve each tracked channel's release/<major>.<M>.x line and its Skia SHA.")
-    ap.add_argument("--track", default=",".join(DEFAULT_BACKPORT_CHANNELS),
-                    help="Channels to resolve in --check-backports (default: Extended,Stable).")
     ap.add_argument("--json", action="store_true", help="Print the JSON result to stdout instead of a table.")
     ap.add_argument("--output", default=None, help="Write the JSON result to this path.")
     ap.add_argument("--repo-root", default=None, help="Repo root (default: auto-detect).")
@@ -338,12 +268,6 @@ def main():
     status = "behind" if (beta_ms is not None and main_ms < beta_ms) else "current"
     headsup = build_headsup(main_ms, beta_ms, upcoming, args.window, beta_stable_days)
 
-    backports = []
-    if args.check_backports:
-        track = [c.strip() for c in args.track.split(",") if c.strip()]
-        log(f"Resolving release branches for: {', '.join(track)}", args.verbose)
-        backports = check_backports(repo_root, major, channels, track, now)
-
     result = {
         "meta": {
             "generated_at": now.isoformat(),
@@ -363,8 +287,6 @@ def main():
         "upcoming": upcoming,
         "headsup": headsup,
     }
-    if args.check_backports:
-        result["backports"] = backports
 
     if args.output:
         os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
@@ -411,20 +333,6 @@ def print_summary(result):
         print(f"  {marker}m{e['milestone']:<7}  {b.get('date','?'):<13}  {s.get('date','?'):<13}  "
               f"{din:>8}   {','.join(e.get('channels') or [])}")
     print()
-
-    bp = result.get("backports")
-    if bp:
-        print("  Backport check (release/<major>.<M>.x lines)")
-        print("  " + "-" * 58)
-        for r in bp:
-            if r["branch_exists"]:
-                ok = "✓" if r["branch_milestone"] == r["channel_milestone"] else "⚠ milestone mismatch"
-                print(f"  {r['channel']:<9} m{r['channel_milestone']}: {r['branch']} "
-                      f"(pins m{r['branch_milestone']}, skia {(r['branch_skia_fork'] or '?')[:12]}) {ok}")
-            else:
-                print(f"  {r['channel']:<9} m{r['channel_milestone']}: no release/<major>.{r['channel_milestone']}.x branch found")
-        print("  note: branch Skia is the mono/skia fork SHA; compare upstream coverage via the Skia CVE process.")
-        print()
 
     print("  Heads-up:")
     for a in result["headsup"]:

--- a/.agents/skills/security-audit/scripts/query-milestone-schedule.py
+++ b/.agents/skills/security-audit/scripts/query-milestone-schedule.py
@@ -1,88 +1,64 @@
 #!/usr/bin/env python3
 """
-Query the Chromium milestone release schedule and produce a release heads-up for
-SkiaSharp's Skia bumps.
+Chromium release heads-up for SkiaSharp's Skia bumps.
 
-This is NOT a security check by itself. It is an early-warning tool: Skia milestones
-track Chrome milestones, so the Chromium schedule tells us *when* a given milestone
-branches and goes stable. If a milestone we still need to bump to is about to go
-stable (or has already), we should make sure the Skia bump is ready so security
-fixes land in time.
+Model (see references/milestone-schedule.md for the full rationale):
+  - `main` is the SkiaSharp front line and tracks the Chrome **Beta** milestone.
+  - As milestones graduate Beta -> Stable -> Extended stable, a `release/<major>.<M>.x`
+    branch is cut from a `main` that was already on milestone M, so on the *milestone*
+    axis those release lines are inherently covered.
+  - Therefore "where we are" = main's milestone, and the one signal that matters is:
+        is  main_milestone >= beta_channel_milestone ?
+    If main falls behind Beta, the bump to the new milestone is overdue. The schedule
+    tells us how much lead time remains before that gap reaches the stable channel.
 
-Two data sources are combined:
+Data sources (no auth, no documented rate limit):
+  1. https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
+       -> branch_point / stable_date / ... for one milestone per request.
+  2. https://chromiumdash.appspot.com/fetch_releases?channel=<C>&platform=<P>&num=1
+       -> the live milestone + exact Skia commit (hashes.skia) per channel.
 
-1. Milestone *schedule* (dates per milestone):
-   https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
-   - Returns one milestone per request as {"mstones": [ {...} ]}.
-   - `mstone` accepts a milestone number, or the keywords 'current', 'next', 'previous'.
+Default output is main-centric and lean. The full 5-channel list is included as context.
 
-2. Channel *releases* (which milestone + Skia commit is live in each channel):
-   https://chromiumdash.appspot.com/fetch_releases?channel=<Channel>&platform=<Platform>&num=1
-   - Channels: Extended (extended stable), Stable, Beta, Dev, Canary.
-   - Each release carries hashes.skia (the exact upstream Skia commit), milestone, version, time.
-   - This is what lets us track Extended/Stable/Beta concurrently: each channel pins a different
-     milestone and a different Skia commit, and SkiaSharp will maintain a branch per channel.
-
-Each milestone schedule object includes (dates are ISO-8601, midnight UTC):
-  - mstone           : milestone number (e.g. 150)
-  - branch_point     : when the release branch is cut from trunk
-  - stable_date      : when the milestone reaches the stable channel
-  - late_stable_date : end of the stable window / next refresh boundary
-  - feature_freeze, earliest_beta, final_beta, etc.
-
-No authentication, no documented rate limit (be polite: small delay between calls).
-
-Prerequisites:
-  - Python 3.8+ (uses urllib, no external dependencies)
+Optional --check-backports (the deeper, axis-2 check): resolve each tracked channel's
+`release/<major>.<M>.x` branch and report its pinned milestone + Skia submodule commit, so
+the audit can spot a shipped release line that is missing a within-milestone Skia backport.
 
 Usage:
-  # Heads-up relative to the milestone currently pinned in scripts/VERSIONS.txt
-  python3 query-milestone-schedule.py --output output/ai/milestone-schedule-cache.json
+  python3 query-milestone-schedule.py                       # lean heads-up to stdout
+  python3 query-milestone-schedule.py --output out.json     # + structured JSON
+  python3 query-milestone-schedule.py --check-backports     # also resolve release/* lines
+  python3 query-milestone-schedule.py --json                # print JSON instead of a table
 
-  # Look further ahead / behind
-  python3 query-milestone-schedule.py --behind 1 --ahead 6 \
-    --output output/ai/milestone-schedule-cache.json
-
-  # Override the "current" milestone instead of reading VERSIONS.txt
-  python3 query-milestone-schedule.py --current 150
-
-  # Flag anything going stable within N days as urgent (default 14)
-  python3 query-milestone-schedule.py --window 21 --verbose
-
-Output:
-  JSON written to --output (if given) and a human-readable summary to stdout.
-  The JSON has:
-    - meta: { generated_at, current_milestone, current_milestone_source, window_days,
-              platform, tracked_channels }
-    - channels[]: per-channel live release (channel, milestone, version, skia_hash, date, tracked)
-    - milestones[]: one entry per fetched milestone with parsed dates, day deltas, and the
-                    channel(s) currently sitting on that milestone
-    - headsup[]: prioritized alerts (schedule + tracked-channel coverage)
+Prerequisites: Python 3.8+ (stdlib only). --check-backports needs a git checkout with the
+release branches fetched (origin/release/*).
 """
 
 import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import time
-import urllib.request
 import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 SCHEDULE_URL = "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone={mstone}"
 RELEASES_URL = ("https://chromiumdash.appspot.com/fetch_releases"
                 "?channel={channel}&platform={platform}&num=1")
 
-# Chromium release channels, oldest milestone to newest.
+# Channels oldest -> newest milestone. Windows carries all of them.
 ALL_CHANNELS = ["Extended", "Stable", "Beta", "Dev", "Canary"]
-# Channels SkiaSharp maintains support for concurrently.
-DEFAULT_TRACKED_CHANNELS = ["Extended", "Stable", "Beta"]
-# Extended stable + Canary only exist on Windows/Mac; Windows has every channel.
+FRONT_CHANNEL = "Beta"            # the channel `main` is expected to keep up with
 DEFAULT_PLATFORM = "Windows"
+# Channels backed by a cut release/<major>.<M>.x line (Beta == main, so not listed).
+DEFAULT_BACKPORT_CHANNELS = ["Extended", "Stable"]
 
-# Dates we care about for a release heads-up, in chronological order.
 KEY_DATES = ["branch_point", "stable_date", "late_stable_date"]
+LEVEL_ORDER = {"critical": 0, "urgent": 1, "watch": 2, "ok": 3, "info": 4}
+LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "watch": "🟡", "ok": "🟢", "info": "🔵"}
 
 
 def log(msg, verbose=True):
@@ -90,8 +66,51 @@ def log(msg, verbose=True):
         print(msg, file=sys.stderr)
 
 
+# --- HTTP ---
+
+def http_json(url, retries=3, delay=0.4):
+    last = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "skiasharp-security-audit/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as e:
+            last = e
+            time.sleep(delay * (attempt + 1))
+    log(f"  ! request failed: {url} ({last})")
+    return None
+
+
+def fetch_schedule(mstone):
+    data = http_json(SCHEDULE_URL.format(mstone=mstone))
+    stones = (data or {}).get("mstones") or []
+    return stones[0] if stones else None
+
+
+def fetch_channel(channel, platform):
+    data = http_json(RELEASES_URL.format(channel=channel, platform=platform))
+    if not isinstance(data, list) or not data:
+        return None
+    rel = data[0]
+    hashes = rel.get("hashes") or {}
+    ts = rel.get("time")
+    date = None
+    if isinstance(ts, (int, float)):
+        date = datetime.fromtimestamp(ts / 1000.0, tz=timezone.utc).date().isoformat()
+    return {
+        "channel": channel,
+        "platform": platform,
+        "milestone": rel.get("milestone"),
+        "version": rel.get("version"),
+        "skia_hash": hashes.get("skia"),
+        "date": date,
+    }
+
+
+# --- Local repo / VERSIONS.txt ---
+
 def find_repo_root(start):
-    """Walk up from `start` looking for the SkiaSharp repo root (has scripts/VERSIONS.txt)."""
     cur = os.path.abspath(start)
     while True:
         if os.path.isfile(os.path.join(cur, "scripts", "VERSIONS.txt")):
@@ -102,230 +121,250 @@ def find_repo_root(start):
         cur = parent
 
 
-def read_current_milestone(repo_root):
-    """Parse the pinned Skia milestone from scripts/VERSIONS.txt.
+def parse_versions(text):
+    """Return (milestone, major) from a VERSIONS.txt body."""
+    milestone = major = None
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        m = re.match(r"\s*libSkiaSharp\s+milestone\s+(\d+)", line)
+        if m:
+            milestone = int(m.group(1))
+        m = re.match(r"\s*SkiaSharp\s+nuget\s+(\d+)\.\d+", line)
+        if m:
+            major = int(m.group(1))
+    return milestone, major
 
-    Looks for a line like: `libSkiaSharp            milestone   150`
-    Falls back to `skia ... release m150`.
-    """
+
+def read_main_versions(repo_root):
     if not repo_root:
-        return None
-    versions = os.path.join(repo_root, "scripts", "VERSIONS.txt")
-    if not os.path.isfile(versions):
-        return None
-    milestone = None
-    skia_release = None
-    with open(versions, "r", encoding="utf-8") as f:
-        for line in f:
-            if line.lstrip().startswith("#"):
-                continue
-            m = re.match(r"\s*libSkiaSharp\s+milestone\s+(\d+)", line)
-            if m:
-                milestone = int(m.group(1))
-            m = re.match(r"\s*skia\s+\S+\s+m(\d+)", line)
-            if m:
-                skia_release = int(m.group(1))
-    return milestone if milestone is not None else skia_release
+        return None, None
+    path = os.path.join(repo_root, "scripts", "VERSIONS.txt")
+    if not os.path.isfile(path):
+        return None, None
+    with open(path, "r", encoding="utf-8") as f:
+        return parse_versions(f.read())
 
 
-def fetch_milestone(mstone, retries=3, delay=0.4):
-    url = SCHEDULE_URL.format(mstone=mstone)
-    last_err = None
-    for attempt in range(retries):
-        try:
-            req = urllib.request.Request(url, headers={"User-Agent": "skiasharp-security-audit/1.0"})
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                data = json.loads(resp.read().decode("utf-8"))
-            stones = data.get("mstones") or []
-            if not stones:
-                return None
-            return stones[0]
-        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as e:
-            last_err = e
-            time.sleep(delay * (attempt + 1))
-    log(f"  ! failed to fetch mstone={mstone}: {last_err}")
+# --- git helpers (only used by --check-backports) ---
+
+def run_git(repo_root, args):
+    try:
+        out = subprocess.run(["git", "-C", repo_root] + args,
+                             capture_output=True, text=True, timeout=30)
+        return out.stdout if out.returncode == 0 else None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
+def resolve_release_branch(repo_root, major, milestone):
+    """Find the release/<major>.<milestone>.x ref (remote preferred)."""
+    for ref in (f"origin/release/{major}.{milestone}.x", f"release/{major}.{milestone}.x"):
+        if run_git(repo_root, ["rev-parse", "--verify", "-q", ref]) is not None:
+            return ref
     return None
 
 
-def fetch_channel_release(channel, platform, retries=3, delay=0.4):
-    """Fetch the current release for a channel/platform from fetch_releases.
+def branch_skia_sha(repo_root, ref):
+    out = run_git(repo_root, ["ls-tree", ref, "externals/skia"])
+    if not out:
+        return None
+    m = re.search(r"commit\s+([0-9a-f]{40})", out)
+    return m.group(1) if m else None
 
-    Returns a dict with channel, milestone, version, skia_hash, date (ISO), and the
-    full hashes map, or None if the channel/platform has no release.
-    """
-    url = RELEASES_URL.format(channel=channel, platform=platform)
-    last_err = None
-    for attempt in range(retries):
-        try:
-            req = urllib.request.Request(url, headers={"User-Agent": "skiasharp-security-audit/1.0"})
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                data = json.loads(resp.read().decode("utf-8"))
-            if not isinstance(data, list) or not data:
-                return None
-            rel = data[0]
-            hashes = rel.get("hashes") or {}
-            ts = rel.get("time")
-            date = None
-            if isinstance(ts, (int, float)):
-                # `time` is epoch milliseconds.
-                date = datetime.fromtimestamp(ts / 1000.0, tz=timezone.utc).date().isoformat()
-            return {
-                "channel": channel,
-                "platform": platform,
-                "milestone": rel.get("milestone"),
-                "version": rel.get("version"),
-                "skia_hash": hashes.get("skia"),
-                "chromium_hash": hashes.get("chromium"),
-                "date": date,
-            }
-        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as e:
-            last_err = e
-            time.sleep(delay * (attempt + 1))
-    log(f"  ! failed to fetch channel={channel} platform={platform}: {last_err}")
-    return None
 
+def branch_milestone(repo_root, ref):
+    out = run_git(repo_root, ["show", f"{ref}:scripts/VERSIONS.txt"])
+    if not out:
+        return None
+    ms, _ = parse_versions(out)
+    return ms
+
+
+# --- date math ---
 
 def parse_date(value):
     if not value:
         return None
     try:
         dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
     except ValueError:
         return None
 
 
 def days_until(dt, now):
-    if dt is None:
-        return None
-    return (dt.date() - now.date()).days
+    return None if dt is None else (dt.date() - now.date()).days
 
 
-def build_milestone_entry(raw, now):
-    entry = {"milestone": raw.get("mstone"), "dates": {}}
+def milestone_dates(raw, now):
+    dates = {}
     for key in KEY_DATES + ["feature_freeze", "earliest_beta", "final_beta"]:
         dt = parse_date(raw.get(key))
-        if dt is None:
+        if dt is not None:
+            dates[key] = {"date": dt.date().isoformat(), "days_from_now": days_until(dt, now)}
+    return dates
+
+
+# --- core ---
+
+def build_headsup(main_ms, beta_ms, upcoming, window, beta_stable_days):
+    alerts = []
+
+    # Primary signal: is the front line keeping up with Beta?
+    if beta_ms is None:
+        pass
+    elif main_ms < beta_ms:
+        behind = beta_ms - main_ms
+        if beta_stable_days is not None and beta_stable_days < 0:
+            alerts.append({"level": "critical", "milestone": beta_ms,
+                           "message": (f"main is on m{main_ms} but Beta has moved to m{beta_ms} "
+                                       f"({behind} ahead) and m{beta_ms} is ALREADY stable. The "
+                                       f"Skia bump on main is overdue.")})
+        else:
+            in_days = f" (stable in {beta_stable_days}d)" if beta_stable_days is not None else ""
+            alerts.append({"level": "urgent", "milestone": beta_ms,
+                           "message": (f"main is on m{main_ms} but Beta is on m{beta_ms} "
+                                       f"({behind} ahead){in_days}. Bump main to m{beta_ms}.")})
+    else:
+        alerts.append({"level": "ok", "milestone": main_ms,
+                       "message": f"main (m{main_ms}) is at or ahead of Beta (m{beta_ms}). Front line current."})
+
+    # Schedule watch for milestones beyond main that haven't branched/stabilised yet.
+    for entry in upcoming:
+        if entry["milestone"] <= main_ms:
             continue
-        entry["dates"][key] = {
-            "date": dt.date().isoformat(),
-            "days_from_now": days_until(dt, now),
-        }
-    return entry
+        branch = entry["dates"].get("branch_point")
+        stable = entry["dates"].get("stable_date")
+        if branch and branch["days_from_now"] is not None and 0 <= branch["days_from_now"] <= window:
+            alerts.append({"level": "watch", "milestone": entry["milestone"],
+                           "message": (f"m{entry['milestone']} branches in {branch['days_from_now']}d "
+                                       f"({branch['date']}); stable {stable['date'] if stable else '?'}.")})
+
+    alerts.sort(key=lambda a: (LEVEL_ORDER.get(a["level"], 9), a["milestone"]))
+    return alerts
+
+
+def check_backports(repo_root, major, channels, track, now):
+    """Axis-2: resolve each tracked channel's release/<major>.<M>.x line."""
+    rows = []
+    by_channel = {c["channel"]: c for c in channels}
+    for name in track:
+        ch = by_channel.get(name)
+        if not ch or not isinstance(ch.get("milestone"), int):
+            continue
+        m = ch["milestone"]
+        ref = resolve_release_branch(repo_root, major, m)
+        rows.append({
+            "channel": name,
+            "channel_milestone": m,
+            "channel_skia": ch.get("skia_hash"),
+            "branch": ref,
+            "branch_exists": ref is not None,
+            "branch_milestone": branch_milestone(repo_root, ref) if ref else None,
+            "branch_skia_fork": branch_skia_sha(repo_root, ref) if ref else None,
+        })
+    return rows
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Chromium milestone release heads-up for Skia bumps.")
+    ap = argparse.ArgumentParser(description="Chromium release heads-up for SkiaSharp Skia bumps (main vs Beta).")
     ap.add_argument("--current", type=int, default=None,
-                    help="Override the current Skia milestone (default: read scripts/VERSIONS.txt).")
-    ap.add_argument("--behind", type=int, default=1,
-                    help="How many milestones before current to include (default: 1).")
-    ap.add_argument("--ahead", type=int, default=4,
-                    help="How many milestones after current to include (default: 4).")
-    ap.add_argument("--window", type=int, default=14,
-                    help="Flag milestones reaching stable within this many days as urgent (default: 14).")
+                    help="Override main's milestone (default: read scripts/VERSIONS.txt).")
     ap.add_argument("--platform", default=DEFAULT_PLATFORM,
-                    help="Platform for channel releases (default: Windows — has all channels).")
-    ap.add_argument("--channels", default=",".join(ALL_CHANNELS),
-                    help="Comma-separated channels to fetch (default: Extended,Stable,Beta,Dev,Canary).")
-    ap.add_argument("--track", default=",".join(DEFAULT_TRACKED_CHANNELS),
-                    help="Channels SkiaSharp supports concurrently (default: Extended,Stable,Beta).")
+                    help="Channel platform (default: Windows — has all channels).")
+    ap.add_argument("--ahead", type=int, default=4,
+                    help="How many milestones past main to include in the schedule (default: 4).")
+    ap.add_argument("--window", type=int, default=14,
+                    help="Days-ahead threshold for schedule 'watch' alerts (default: 14).")
     ap.add_argument("--no-channels", action="store_true",
-                    help="Skip the channel-release lookup (schedule-only mode).")
+                    help="Skip channel lookup (schedule-only; disables the main-vs-Beta signal).")
+    ap.add_argument("--check-backports", action="store_true",
+                    help="Resolve each tracked channel's release/<major>.<M>.x line and its Skia SHA.")
+    ap.add_argument("--track", default=",".join(DEFAULT_BACKPORT_CHANNELS),
+                    help="Channels to resolve in --check-backports (default: Extended,Stable).")
+    ap.add_argument("--json", action="store_true", help="Print the JSON result to stdout instead of a table.")
     ap.add_argument("--output", default=None, help="Write the JSON result to this path.")
-    ap.add_argument("--repo-root", default=None, help="Repo root (default: auto-detect from cwd).")
-    ap.add_argument("--verbose", action="store_true", help="Print extra progress detail.")
+    ap.add_argument("--repo-root", default=None, help="Repo root (default: auto-detect).")
+    ap.add_argument("--verbose", action="store_true", help="Extra progress detail on stderr.")
     args = ap.parse_args()
 
-    channel_names = [c.strip() for c in args.channels.split(",") if c.strip()]
-    tracked = [c.strip() for c in args.track.split(",") if c.strip()]
-
     now = datetime.now(timezone.utc)
+    repo_root = args.repo_root or find_repo_root(os.getcwd()) or \
+        find_repo_root(os.path.dirname(os.path.abspath(__file__)))
 
-    repo_root = args.repo_root or find_repo_root(os.getcwd()) or find_repo_root(
-        os.path.dirname(os.path.abspath(__file__)))
-
-    current = args.current
-    source = "--current argument"
-    if current is None:
-        current = read_current_milestone(repo_root)
-        source = "scripts/VERSIONS.txt"
-    if current is None:
-        # Last resort: ask the API what the current Chrome milestone is.
-        raw = fetch_milestone("current")
-        if raw:
-            current = raw.get("mstone")
-            source = "chromiumdash 'current'"
-    if current is None:
-        print("ERROR: could not determine the current Skia milestone. Pass --current N.",
-              file=sys.stderr)
+    main_ms, major = read_main_versions(repo_root)
+    source = "scripts/VERSIONS.txt"
+    if args.current is not None:
+        main_ms, source = args.current, "--current argument"
+    if main_ms is None:
+        print("ERROR: could not determine main's milestone. Pass --current N.", file=sys.stderr)
         return 2
 
-    log(f"Current Skia milestone: {current} (from {source})", args.verbose)
-
-    # Fetch live channel releases first (Extended/Stable/Beta/Dev/Canary).
-    channels = []
+    # Channels (for the main-vs-Beta signal + context).
+    channels, beta_ms = [], None
     if not args.no_channels:
-        log(f"Fetching channel releases ({args.platform}): {', '.join(channel_names)}", args.verbose)
-        for ch in channel_names:
-            rel = fetch_channel_release(ch, args.platform)
+        log(f"Fetching channels ({args.platform})...", args.verbose)
+        for name in ALL_CHANNELS:
+            rel = fetch_channel(name, args.platform)
             time.sleep(0.3)
-            if not rel:
-                continue
-            rel["tracked"] = ch in tracked
-            channels.append(rel)
-            if args.verbose:
-                log(f"  {ch}: m{rel.get('milestone')} {rel.get('version')} "
-                    f"skia={(rel.get('skia_hash') or '?')[:12]}")
+            if rel:
+                channels.append(rel)
+                if name == FRONT_CHANNEL:
+                    beta_ms = rel.get("milestone")
+                log(f"  {name}: m{rel.get('milestone')} {rel.get('version')} "
+                    f"skia={(rel.get('skia_hash') or '?')[:12]}", args.verbose)
 
-    # Schedule range: current ± behind/ahead, widened to cover every channel milestone.
-    channel_mstones = [c["milestone"] for c in channels if isinstance(c.get("milestone"), int)]
-    lo = min([current - max(0, args.behind)] + channel_mstones)
-    hi = max([current + max(0, args.ahead)] + channel_mstones)
-    log(f"Fetching milestone schedule {lo}..{hi} from chromiumdash...", args.verbose)
-
-    milestones = []
-    for m in range(lo, hi + 1):
-        raw = fetch_milestone(m)
+    # Upcoming schedule: main .. max(main+ahead, beta).
+    hi = max(main_ms + max(0, args.ahead), beta_ms or main_ms)
+    log(f"Fetching schedule m{main_ms}..m{hi}...", args.verbose)
+    upcoming = []
+    for m in range(main_ms, hi + 1):
+        raw = fetch_schedule(m)
         time.sleep(0.3)
         if not raw:
             continue
-        entry = build_milestone_entry(raw, now)
-        entry["is_current"] = (m == current)
-        entry["status"] = "bumped" if m <= current else "pending"
-        # Attach the channel(s) currently sitting on this milestone.
-        entry["channels"] = [c["channel"] for c in channels if c.get("milestone") == m]
-        skia = next((c["skia_hash"] for c in channels if c.get("milestone") == m and c.get("skia_hash")), None)
-        if skia:
-            entry["skia_hash"] = skia
-        milestones.append(entry)
-        if args.verbose:
-            sd = entry["dates"].get("stable_date", {})
-            log(f"  m{m}: stable {sd.get('date', '?')} ({sd.get('days_from_now', '?')}d)")
+        entry = {"milestone": m, "dates": milestone_dates(raw, now),
+                 "is_main": m == main_ms,
+                 "channels": [c["channel"] for c in channels if c.get("milestone") == m]}
+        upcoming.append(entry)
 
-    headsup = build_headsup(milestones, current, args.window, now)
-    headsup += build_channel_headsup(channels, tracked, current)
-    headsup.sort(key=lambda a: (LEVEL_ORDER.get(a["level"], 9), a.get("milestone") or 0))
+    beta_stable_days = None
+    for e in upcoming:
+        if e["milestone"] == beta_ms:
+            sd = e["dates"].get("stable_date")
+            beta_stable_days = sd["days_from_now"] if sd else None
+
+    status = "behind" if (beta_ms is not None and main_ms < beta_ms) else "current"
+    headsup = build_headsup(main_ms, beta_ms, upcoming, args.window, beta_stable_days)
+
+    backports = []
+    if args.check_backports:
+        track = [c.strip() for c in args.track.split(",") if c.strip()]
+        log(f"Resolving release branches for: {', '.join(track)}", args.verbose)
+        backports = check_backports(repo_root, major, channels, track, now)
 
     result = {
         "meta": {
             "generated_at": now.isoformat(),
-            "current_milestone": current,
-            "current_milestone_source": source,
-            "window_days": args.window,
+            "main_milestone": main_ms,
+            "main_milestone_source": source,
+            "major": major,
+            "beta_milestone": beta_ms,
+            "status": status,
             "platform": args.platform,
-            "tracked_channels": tracked,
+            "window_days": args.window,
             "data_sources": [
                 "https://chromiumdash.appspot.com/fetch_milestone_schedule",
                 "https://chromiumdash.appspot.com/fetch_releases",
             ],
         },
         "channels": channels,
-        "milestones": milestones,
+        "upcoming": upcoming,
         "headsup": headsup,
     }
+    if args.check_backports:
+        result["backports"] = backports
 
     if args.output:
         os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
@@ -333,156 +372,63 @@ def main():
             json.dump(result, f, indent=2)
         log(f"Wrote {args.output}", True)
 
-    print_summary(result)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print_summary(result)
     return 0
-
-
-def build_headsup(milestones, current, window, now):
-    """Produce prioritized alerts about pending bumps relative to the schedule."""
-    alerts = []
-    for entry in milestones:
-        m = entry["milestone"]
-        stable = entry["dates"].get("stable_date")
-        branch = entry["dates"].get("branch_point")
-
-        if entry["status"] == "pending":
-            # We have NOT bumped to this milestone yet.
-            if stable is not None:
-                d = stable["days_from_now"]
-                if d is not None and d < 0:
-                    alerts.append({
-                        "level": "critical",
-                        "milestone": m,
-                        "message": (f"m{m} reached stable {abs(d)} day(s) ago but SkiaSharp is "
-                                    f"still on m{current}. Security fixes in m{m} are shipping "
-                                    f"to users without a SkiaSharp bump."),
-                    })
-                elif d is not None and d <= window:
-                    alerts.append({
-                        "level": "urgent",
-                        "milestone": m,
-                        "message": (f"m{m} goes stable in {d} day(s) ({stable['date']}). "
-                                    f"Make sure the Skia bump from m{current} is ready."),
-                    })
-                elif branch is not None and branch["days_from_now"] is not None \
-                        and branch["days_from_now"] <= window:
-                    bd = branch["days_from_now"]
-                    when = "branched" if bd < 0 else f"branches in {bd} day(s)"
-                    alerts.append({
-                        "level": "watch",
-                        "milestone": m,
-                        "message": (f"m{m} {when} ({branch['date']}); stable {stable['date']}. "
-                                    f"Start preparing the bump."),
-                    })
-        else:
-            # Already on/ahead of this milestone; note its support window winding down.
-            late = entry["dates"].get("late_stable_date")
-            if entry["is_current"] and late is not None and late["days_from_now"] is not None \
-                    and 0 <= late["days_from_now"] <= window:
-                alerts.append({
-                    "level": "info",
-                    "milestone": m,
-                    "message": (f"Current milestone m{m} stable window ends ~{late['date']} "
-                                f"({late['days_from_now']}d). Next milestone takes over soon."),
-                })
-
-    order = {"critical": 0, "urgent": 1, "watch": 2, "info": 3}
-    alerts.sort(key=lambda a: (order.get(a["level"], 9), a["milestone"]))
-    return alerts
-
-
-def build_channel_headsup(channels, tracked, current):
-    """Alerts about the channels SkiaSharp tracks concurrently (Extended/Stable/Beta).
-
-    Each tracked channel pins a milestone + Skia commit. If a tracked channel has advanced
-    past the milestone SkiaSharp is pinned to, that channel's branch needs a bump.
-    """
-    alerts = []
-    for ch in channels:
-        if not ch.get("tracked"):
-            continue
-        m = ch.get("milestone")
-        if not isinstance(m, int):
-            continue
-        name = ch["channel"]
-        skia = (ch.get("skia_hash") or "?")[:12]
-        ver = ch.get("version") or "?"
-        if m > current:
-            alerts.append({
-                "level": "urgent",
-                "milestone": m,
-                "channel": name,
-                "message": (f"Tracked channel {name} is on m{m} ({ver}, skia {skia}) but SkiaSharp "
-                            f"is pinned to m{current}. The {name} branch needs a Skia bump to m{m}."),
-            })
-        elif m == current:
-            alerts.append({
-                "level": "info",
-                "milestone": m,
-                "channel": name,
-                "message": (f"Tracked channel {name} is on m{m} ({ver}, skia {skia}) — matches the "
-                            f"pinned milestone."),
-            })
-        else:
-            alerts.append({
-                "level": "info",
-                "milestone": m,
-                "channel": name,
-                "message": (f"Tracked channel {name} is on m{m} ({ver}, skia {skia}); SkiaSharp's "
-                            f"{name} branch should pin m{m}."),
-            })
-    return alerts
-
-
-LEVEL_ORDER = {"critical": 0, "urgent": 1, "watch": 2, "info": 3}
-LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "watch": "🟡", "info": "🔵"}
 
 
 def print_summary(result):
     meta = result["meta"]
+    icon = "🟢" if meta["status"] == "current" else "🟠"
     print()
-    print(f"Chromium release schedule — heads-up for Skia bumps")
-    print(f"  Current SkiaSharp milestone: m{meta['current_milestone']} "
-          f"(from {meta['current_milestone_source']})")
-    print(f"  Urgency window: {meta['window_days']} days")
-    if meta.get("tracked_channels"):
-        print(f"  Tracked channels ({meta.get('platform','?')}): "
-              f"{', '.join(meta['tracked_channels'])}")
+    print("Chromium release heads-up (main vs Beta)")
+    print(f"  Where we are: main = m{meta['main_milestone']} "
+          f"(major {meta.get('major','?')}, from {meta['main_milestone_source']})")
+    print(f"  Beta channel: m{meta.get('beta_milestone','?')}   {icon} {meta['status'].upper()}")
+    print(f"  Urgency window: {meta['window_days']}d ({meta.get('platform','?')})")
     print()
 
     channels = result.get("channels") or []
     if channels:
-        print("  Channel     Milestone   Version             Skia commit   Track")
-        print("  " + "-" * 64)
+        print("  Channel     Milestone   Version             Skia commit")
+        print("  " + "-" * 58)
         for c in channels:
-            track = "✓" if c.get("tracked") else " "
-            skia = (c.get("skia_hash") or "?")[:12]
-            print(f"  {c.get('channel',''):<10}  m{str(c.get('milestone','?')):<8}  "
-                  f"{c.get('version','?'):<18}  {skia:<12}  {track}")
+            front = " <- main tracks this" if c["channel"] == FRONT_CHANNEL else ""
+            print(f"  {c['channel']:<10}  m{str(c.get('milestone','?')):<8}  "
+                  f"{c.get('version','?'):<18}  {(c.get('skia_hash') or '?')[:12]}{front}")
         print()
 
-    print("  Milestone   Branch point   Stable date    Status    In      Channels")
-    print("  " + "-" * 72)
-    for entry in result["milestones"]:
-        m = entry["milestone"]
-        b = entry["dates"].get("branch_point", {})
-        s = entry["dates"].get("stable_date", {})
+    print("  Upcoming    Branch point   Stable date    Stable in   Channels")
+    print("  " + "-" * 66)
+    for e in result["upcoming"]:
+        b = e["dates"].get("branch_point", {})
+        s = e["dates"].get("stable_date", {})
         d = s.get("days_from_now")
-        din = f"{d:+d}d" if isinstance(d, int) else "  ?"
-        marker = "*" if entry.get("is_current") else " "
-        chans = ",".join(entry.get("channels") or [])
-        print(f"  {marker}m{m:<8}  {b.get('date','?'):<13}  {s.get('date','?'):<13}  "
-              f"{entry['status']:<8}  {din:>5}   {chans}")
-
+        din = f"{d:+d}d" if isinstance(d, int) else "?"
+        marker = "*" if e.get("is_main") else " "
+        print(f"  {marker}m{e['milestone']:<7}  {b.get('date','?'):<13}  {s.get('date','?'):<13}  "
+              f"{din:>8}   {','.join(e.get('channels') or [])}")
     print()
-    headsup = result["headsup"]
-    if not headsup:
-        print("  ✅ No release heads-up: no pending milestones inside the urgency window.")
-    else:
-        print("  Heads-up:")
-        for a in headsup:
-            icon = LEVEL_ICON.get(a["level"], "•")
-            print(f"   {icon} [{a['level'].upper()}] {a['message']}")
+
+    bp = result.get("backports")
+    if bp:
+        print("  Backport check (release/<major>.<M>.x lines)")
+        print("  " + "-" * 58)
+        for r in bp:
+            if r["branch_exists"]:
+                ok = "✓" if r["branch_milestone"] == r["channel_milestone"] else "⚠ milestone mismatch"
+                print(f"  {r['channel']:<9} m{r['channel_milestone']}: {r['branch']} "
+                      f"(pins m{r['branch_milestone']}, skia {(r['branch_skia_fork'] or '?')[:12]}) {ok}")
+            else:
+                print(f"  {r['channel']:<9} m{r['channel_milestone']}: no release/<major>.{r['channel_milestone']}.x branch found")
+        print("  note: branch Skia is the mono/skia fork SHA; compare upstream coverage via the Skia CVE process.")
+        print()
+
+    print("  Heads-up:")
+    for a in result["headsup"]:
+        print(f"   {LEVEL_ICON.get(a['level'], '•')} [{a['level'].upper()}] {a['message']}")
     print()
 
 

--- a/.agents/skills/security-audit/scripts/query-milestone-schedule.py
+++ b/.agents/skills/security-audit/scripts/query-milestone-schedule.py
@@ -45,11 +45,12 @@ RELEASES_URL = ("https://chromiumdash.appspot.com/fetch_releases"
 # Channels oldest -> newest milestone. Windows carries all of them.
 ALL_CHANNELS = ["Extended", "Stable", "Beta", "Dev", "Canary"]
 FRONT_CHANNEL = "Beta"            # the channel `main` is expected to keep up with
+STABLE_LIKE = {"Extended", "Stable"}  # channels that ship to non-preview users
 PLATFORM = "Windows"             # the only platform that carries all five channels
 
 KEY_DATES = ["branch_point", "stable_date", "late_stable_date"]
-LEVEL_ORDER = {"critical": 0, "urgent": 1, "watch": 2, "ok": 3, "info": 4}
-LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "watch": "🟡", "ok": "🟢", "info": "🔵"}
+LEVEL_ORDER = {"critical": 0, "urgent": 1, "unknown": 1, "watch": 2, "ok": 3, "info": 4}
+LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "unknown": "❓", "watch": "🟡", "ok": "🟢", "info": "🔵"}
 
 
 def log(msg):
@@ -74,13 +75,17 @@ def http_json(url, retries=3, delay=0.4):
 
 def fetch_schedule(mstone):
     data = http_json(SCHEDULE_URL.format(mstone=mstone))
-    stones = (data or {}).get("mstones") or []
-    return stones[0] if stones else None
+    if not isinstance(data, dict):
+        return None
+    stones = data.get("mstones")
+    if isinstance(stones, list) and stones and isinstance(stones[0], dict):
+        return stones[0]
+    return None
 
 
 def fetch_channel(channel, platform):
     data = http_json(RELEASES_URL.format(channel=channel, platform=platform))
-    if not isinstance(data, list) or not data:
+    if not isinstance(data, list) or not data or not isinstance(data[0], dict):
         return None
     rel = data[0]
     hashes = rel.get("hashes") or {}
@@ -139,7 +144,7 @@ def read_main_versions(repo_root):
 # --- date math ---
 
 def parse_date(value):
-    if not value:
+    if not isinstance(value, str) or not value:
         return None
     try:
         dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -163,19 +168,27 @@ def milestone_dates(raw, now):
 
 # --- core ---
 
-def build_headsup(main_ms, beta_ms, upcoming, window, beta_stable_days):
+def build_headsup(main_ms, beta_ms, stable_like_ms, upcoming, window, beta_stable_days):
     alerts = []
 
     # Primary signal: is the front line keeping up with Beta?
     if beta_ms is None:
-        pass
+        alerts.append({"level": "unknown", "milestone": main_ms,
+                       "message": ("Could not read the Beta channel milestone (Chromium Dash "
+                                   "unavailable or returned no data). The main-vs-Beta signal "
+                                   "could not be evaluated — re-run before relying on this.")})
     elif main_ms < beta_ms:
         behind = beta_ms - main_ms
-        if beta_stable_days is not None and beta_stable_days < 0:
+        # Critical when a milestone newer than main is ALREADY on a stable-class channel
+        # (live channel data is authoritative; the schedule date is a fallback hint).
+        live_stable = stable_like_ms is not None and stable_like_ms > main_ms
+        if live_stable or (beta_stable_days is not None and beta_stable_days < 0):
+            where = (f"m{stable_like_ms} already ships on a stable channel" if live_stable
+                     else f"m{beta_ms} is already stable")
             alerts.append({"level": "critical", "milestone": beta_ms,
-                           "message": (f"main is on m{main_ms} but Beta has moved to m{beta_ms} "
-                                       f"({behind} ahead) and m{beta_ms} is ALREADY stable. The "
-                                       f"Skia bump on main is overdue.")})
+                           "message": (f"main is on m{main_ms} but Beta is on m{beta_ms} "
+                                       f"({behind} ahead) and {where}. The Skia bump on main "
+                                       f"is overdue.")})
         else:
             in_days = f" (stable in {beta_stable_days}d)" if beta_stable_days is not None else ""
             alerts.append({"level": "urgent", "milestone": beta_ms,
@@ -252,8 +265,19 @@ def main():
             sd = e["dates"].get("stable_date")
             beta_stable_days = sd["days_from_now"] if sd else None
 
-    status = "behind" if (beta_ms is not None and main_ms < beta_ms) else "current"
-    headsup = build_headsup(main_ms, beta_ms, upcoming, args.window, beta_stable_days)
+    # Highest milestone already live on a non-preview (Stable/Extended) channel.
+    stable_like_ms = max(
+        (c["milestone"] for c in channels
+         if c.get("channel") in STABLE_LIKE and isinstance(c.get("milestone"), int)),
+        default=None)
+
+    if beta_ms is None:
+        status = "unknown"
+    elif main_ms < beta_ms:
+        status = "behind"
+    else:
+        status = "current"
+    headsup = build_headsup(main_ms, beta_ms, stable_like_ms, upcoming, args.window, beta_stable_days)
 
     result = {
         "meta": {
@@ -290,12 +314,12 @@ def main():
 
 def print_summary(result):
     meta = result["meta"]
-    icon = "🟢" if meta["status"] == "current" else "🟠"
+    icon = {"current": "🟢", "behind": "🟠", "unknown": "❓"}.get(meta["status"], "🟠")
     print()
     print("Chromium release heads-up (main vs Beta)")
     print(f"  Where we are: main = m{meta['main_milestone']} "
           f"(major {meta.get('major','?')}, from {meta['main_milestone_source']})")
-    print(f"  Beta channel: m{meta.get('beta_milestone','?')}   {icon} {meta['status'].upper()}")
+    print(f"  Beta channel: m{meta.get('beta_milestone') or '?'}   {icon} {meta['status'].upper()}")
     print(f"  Urgency window: {meta['window_days']}d ({meta.get('platform','?')})")
     print()
 

--- a/.agents/skills/security-audit/scripts/query-milestone-schedule.py
+++ b/.agents/skills/security-audit/scripts/query-milestone-schedule.py
@@ -15,7 +15,7 @@ Model (see references/milestone-schedule.md for the full rationale):
 Data sources (no auth, no documented rate limit):
   1. https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
        -> branch_point / stable_date / ... for one milestone per request.
-  2. https://chromiumdash.appspot.com/fetch_releases?channel=<C>&platform=<P>&num=1
+  2. https://chromiumdash.appspot.com/fetch_releases?channel=<C>&platform=Windows&num=1
        -> the live milestone + exact Skia commit (hashes.skia) per channel.
 
 Default output is main-centric and lean. The full 5-channel list is included as context.
@@ -45,16 +45,15 @@ RELEASES_URL = ("https://chromiumdash.appspot.com/fetch_releases"
 # Channels oldest -> newest milestone. Windows carries all of them.
 ALL_CHANNELS = ["Extended", "Stable", "Beta", "Dev", "Canary"]
 FRONT_CHANNEL = "Beta"            # the channel `main` is expected to keep up with
-DEFAULT_PLATFORM = "Windows"
+PLATFORM = "Windows"             # the only platform that carries all five channels
 
 KEY_DATES = ["branch_point", "stable_date", "late_stable_date"]
 LEVEL_ORDER = {"critical": 0, "urgent": 1, "watch": 2, "ok": 3, "info": 4}
 LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "watch": "🟡", "ok": "🟢", "info": "🔵"}
 
 
-def log(msg, verbose=True):
-    if verbose:
-        print(msg, file=sys.stderr)
+def log(msg):
+    print(msg, file=sys.stderr)
 
 
 # --- HTTP ---
@@ -203,51 +202,39 @@ def build_headsup(main_ms, beta_ms, upcoming, window, beta_stable_days):
 
 def main():
     ap = argparse.ArgumentParser(description="Chromium release heads-up for SkiaSharp Skia bumps (main vs Beta).")
-    ap.add_argument("--current", type=int, default=None,
-                    help="Override main's milestone (default: read scripts/VERSIONS.txt).")
-    ap.add_argument("--platform", default=DEFAULT_PLATFORM,
-                    help="Channel platform (default: Windows — has all channels).")
     ap.add_argument("--ahead", type=int, default=4,
                     help="How many milestones past main to include in the schedule (default: 4).")
     ap.add_argument("--window", type=int, default=14,
                     help="Days-ahead threshold for schedule 'watch' alerts (default: 14).")
-    ap.add_argument("--no-channels", action="store_true",
-                    help="Skip channel lookup (schedule-only; disables the main-vs-Beta signal).")
     ap.add_argument("--json", action="store_true", help="Print the JSON result to stdout instead of a table.")
     ap.add_argument("--output", default=None, help="Write the JSON result to this path.")
-    ap.add_argument("--repo-root", default=None, help="Repo root (default: auto-detect).")
-    ap.add_argument("--verbose", action="store_true", help="Extra progress detail on stderr.")
     args = ap.parse_args()
 
     now = datetime.now(timezone.utc)
-    repo_root = args.repo_root or find_repo_root(os.getcwd()) or \
+    repo_root = find_repo_root(os.getcwd()) or \
         find_repo_root(os.path.dirname(os.path.abspath(__file__)))
 
     main_ms, major = read_main_versions(repo_root)
-    source = "scripts/VERSIONS.txt"
-    if args.current is not None:
-        main_ms, source = args.current, "--current argument"
     if main_ms is None:
-        print("ERROR: could not determine main's milestone. Pass --current N.", file=sys.stderr)
+        print("ERROR: could not determine main's milestone from scripts/VERSIONS.txt.", file=sys.stderr)
         return 2
 
     # Channels (for the main-vs-Beta signal + context).
     channels, beta_ms = [], None
-    if not args.no_channels:
-        log(f"Fetching channels ({args.platform})...", args.verbose)
-        for name in ALL_CHANNELS:
-            rel = fetch_channel(name, args.platform)
-            time.sleep(0.3)
-            if rel:
-                channels.append(rel)
-                if name == FRONT_CHANNEL:
-                    beta_ms = rel.get("milestone")
-                log(f"  {name}: m{rel.get('milestone')} {rel.get('version')} "
-                    f"skia={(rel.get('skia_hash') or '?')[:12]}", args.verbose)
+    log(f"Fetching channels ({PLATFORM})...")
+    for name in ALL_CHANNELS:
+        rel = fetch_channel(name, PLATFORM)
+        time.sleep(0.3)
+        if rel:
+            channels.append(rel)
+            if name == FRONT_CHANNEL:
+                beta_ms = rel.get("milestone")
+            log(f"  {name}: m{rel.get('milestone')} {rel.get('version')} "
+                f"skia={(rel.get('skia_hash') or '?')[:12]}")
 
     # Upcoming schedule: main .. max(main+ahead, beta).
     hi = max(main_ms + max(0, args.ahead), beta_ms or main_ms)
-    log(f"Fetching schedule m{main_ms}..m{hi}...", args.verbose)
+    log(f"Fetching schedule m{main_ms}..m{hi}...")
     upcoming = []
     for m in range(main_ms, hi + 1):
         raw = fetch_schedule(m)
@@ -272,11 +259,11 @@ def main():
         "meta": {
             "generated_at": now.isoformat(),
             "main_milestone": main_ms,
-            "main_milestone_source": source,
+            "main_milestone_source": "scripts/VERSIONS.txt",
             "major": major,
             "beta_milestone": beta_ms,
             "status": status,
-            "platform": args.platform,
+            "platform": PLATFORM,
             "window_days": args.window,
             "data_sources": [
                 "https://chromiumdash.appspot.com/fetch_milestone_schedule",
@@ -292,7 +279,7 @@ def main():
         os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
         with open(args.output, "w", encoding="utf-8") as f:
             json.dump(result, f, indent=2)
-        log(f"Wrote {args.output}", True)
+        log(f"Wrote {args.output}")
 
     if args.json:
         print(json.dumps(result, indent=2))

--- a/.agents/skills/security-audit/scripts/query-milestone-schedule.py
+++ b/.agents/skills/security-audit/scripts/query-milestone-schedule.py
@@ -9,18 +9,28 @@ branches and goes stable. If a milestone we still need to bump to is about to go
 stable (or has already), we should make sure the Skia bump is ready so security
 fixes land in time.
 
-Data source:
-  https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
-  - Returns one milestone per request as {"mstones": [ {...} ]}.
-  - `mstone` accepts a milestone number, or the keywords 'current', 'next', 'previous'.
-  - No authentication, no documented rate limit (be polite: small delay between calls).
+Two data sources are combined:
 
-Each milestone object includes (dates are ISO-8601, midnight UTC):
+1. Milestone *schedule* (dates per milestone):
+   https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<N|current|next|previous>
+   - Returns one milestone per request as {"mstones": [ {...} ]}.
+   - `mstone` accepts a milestone number, or the keywords 'current', 'next', 'previous'.
+
+2. Channel *releases* (which milestone + Skia commit is live in each channel):
+   https://chromiumdash.appspot.com/fetch_releases?channel=<Channel>&platform=<Platform>&num=1
+   - Channels: Extended (extended stable), Stable, Beta, Dev, Canary.
+   - Each release carries hashes.skia (the exact upstream Skia commit), milestone, version, time.
+   - This is what lets us track Extended/Stable/Beta concurrently: each channel pins a different
+     milestone and a different Skia commit, and SkiaSharp will maintain a branch per channel.
+
+Each milestone schedule object includes (dates are ISO-8601, midnight UTC):
   - mstone           : milestone number (e.g. 150)
   - branch_point     : when the release branch is cut from trunk
   - stable_date      : when the milestone reaches the stable channel
   - late_stable_date : end of the stable window / next refresh boundary
   - feature_freeze, earliest_beta, final_beta, etc.
+
+No authentication, no documented rate limit (be polite: small delay between calls).
 
 Prerequisites:
   - Python 3.8+ (uses urllib, no external dependencies)
@@ -42,10 +52,12 @@ Usage:
 Output:
   JSON written to --output (if given) and a human-readable summary to stdout.
   The JSON has:
-    - meta: { generated_at, current_milestone, current_milestone_source, window_days }
-    - milestones[]: one entry per fetched milestone with parsed dates + day deltas
-    - headsup[]: prioritized alerts (e.g. milestone going stable within the window
-                 that we have not bumped to yet)
+    - meta: { generated_at, current_milestone, current_milestone_source, window_days,
+              platform, tracked_channels }
+    - channels[]: per-channel live release (channel, milestone, version, skia_hash, date, tracked)
+    - milestones[]: one entry per fetched milestone with parsed dates, day deltas, and the
+                    channel(s) currently sitting on that milestone
+    - headsup[]: prioritized alerts (schedule + tracked-channel coverage)
 """
 
 import argparse
@@ -59,6 +71,15 @@ import urllib.error
 from datetime import datetime, timezone
 
 SCHEDULE_URL = "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone={mstone}"
+RELEASES_URL = ("https://chromiumdash.appspot.com/fetch_releases"
+                "?channel={channel}&platform={platform}&num=1")
+
+# Chromium release channels, oldest milestone to newest.
+ALL_CHANNELS = ["Extended", "Stable", "Beta", "Dev", "Canary"]
+# Channels SkiaSharp maintains support for concurrently.
+DEFAULT_TRACKED_CHANNELS = ["Extended", "Stable", "Beta"]
+# Extended stable + Canary only exist on Windows/Mac; Windows has every channel.
+DEFAULT_PLATFORM = "Windows"
 
 # Dates we care about for a release heads-up, in chronological order.
 KEY_DATES = ["branch_point", "stable_date", "late_stable_date"]
@@ -126,6 +147,44 @@ def fetch_milestone(mstone, retries=3, delay=0.4):
     return None
 
 
+def fetch_channel_release(channel, platform, retries=3, delay=0.4):
+    """Fetch the current release for a channel/platform from fetch_releases.
+
+    Returns a dict with channel, milestone, version, skia_hash, date (ISO), and the
+    full hashes map, or None if the channel/platform has no release.
+    """
+    url = RELEASES_URL.format(channel=channel, platform=platform)
+    last_err = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "skiasharp-security-audit/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+            if not isinstance(data, list) or not data:
+                return None
+            rel = data[0]
+            hashes = rel.get("hashes") or {}
+            ts = rel.get("time")
+            date = None
+            if isinstance(ts, (int, float)):
+                # `time` is epoch milliseconds.
+                date = datetime.fromtimestamp(ts / 1000.0, tz=timezone.utc).date().isoformat()
+            return {
+                "channel": channel,
+                "platform": platform,
+                "milestone": rel.get("milestone"),
+                "version": rel.get("version"),
+                "skia_hash": hashes.get("skia"),
+                "chromium_hash": hashes.get("chromium"),
+                "date": date,
+            }
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as e:
+            last_err = e
+            time.sleep(delay * (attempt + 1))
+    log(f"  ! failed to fetch channel={channel} platform={platform}: {last_err}")
+    return None
+
+
 def parse_date(value):
     if not value:
         return None
@@ -167,10 +226,21 @@ def main():
                     help="How many milestones after current to include (default: 4).")
     ap.add_argument("--window", type=int, default=14,
                     help="Flag milestones reaching stable within this many days as urgent (default: 14).")
+    ap.add_argument("--platform", default=DEFAULT_PLATFORM,
+                    help="Platform for channel releases (default: Windows — has all channels).")
+    ap.add_argument("--channels", default=",".join(ALL_CHANNELS),
+                    help="Comma-separated channels to fetch (default: Extended,Stable,Beta,Dev,Canary).")
+    ap.add_argument("--track", default=",".join(DEFAULT_TRACKED_CHANNELS),
+                    help="Channels SkiaSharp supports concurrently (default: Extended,Stable,Beta).")
+    ap.add_argument("--no-channels", action="store_true",
+                    help="Skip the channel-release lookup (schedule-only mode).")
     ap.add_argument("--output", default=None, help="Write the JSON result to this path.")
     ap.add_argument("--repo-root", default=None, help="Repo root (default: auto-detect from cwd).")
     ap.add_argument("--verbose", action="store_true", help="Print extra progress detail.")
     args = ap.parse_args()
+
+    channel_names = [c.strip() for c in args.channels.split(",") if c.strip()]
+    tracked = [c.strip() for c in args.track.split(",") if c.strip()]
 
     now = datetime.now(timezone.utc)
 
@@ -193,10 +263,28 @@ def main():
               file=sys.stderr)
         return 2
 
-    lo = current - max(0, args.behind)
-    hi = current + max(0, args.ahead)
     log(f"Current Skia milestone: {current} (from {source})", args.verbose)
-    log(f"Fetching milestones {lo}..{hi} from chromiumdash...", args.verbose)
+
+    # Fetch live channel releases first (Extended/Stable/Beta/Dev/Canary).
+    channels = []
+    if not args.no_channels:
+        log(f"Fetching channel releases ({args.platform}): {', '.join(channel_names)}", args.verbose)
+        for ch in channel_names:
+            rel = fetch_channel_release(ch, args.platform)
+            time.sleep(0.3)
+            if not rel:
+                continue
+            rel["tracked"] = ch in tracked
+            channels.append(rel)
+            if args.verbose:
+                log(f"  {ch}: m{rel.get('milestone')} {rel.get('version')} "
+                    f"skia={(rel.get('skia_hash') or '?')[:12]}")
+
+    # Schedule range: current ± behind/ahead, widened to cover every channel milestone.
+    channel_mstones = [c["milestone"] for c in channels if isinstance(c.get("milestone"), int)]
+    lo = min([current - max(0, args.behind)] + channel_mstones)
+    hi = max([current + max(0, args.ahead)] + channel_mstones)
+    log(f"Fetching milestone schedule {lo}..{hi} from chromiumdash...", args.verbose)
 
     milestones = []
     for m in range(lo, hi + 1):
@@ -207,12 +295,19 @@ def main():
         entry = build_milestone_entry(raw, now)
         entry["is_current"] = (m == current)
         entry["status"] = "bumped" if m <= current else "pending"
+        # Attach the channel(s) currently sitting on this milestone.
+        entry["channels"] = [c["channel"] for c in channels if c.get("milestone") == m]
+        skia = next((c["skia_hash"] for c in channels if c.get("milestone") == m and c.get("skia_hash")), None)
+        if skia:
+            entry["skia_hash"] = skia
         milestones.append(entry)
         if args.verbose:
             sd = entry["dates"].get("stable_date", {})
             log(f"  m{m}: stable {sd.get('date', '?')} ({sd.get('days_from_now', '?')}d)")
 
     headsup = build_headsup(milestones, current, args.window, now)
+    headsup += build_channel_headsup(channels, tracked, current)
+    headsup.sort(key=lambda a: (LEVEL_ORDER.get(a["level"], 9), a.get("milestone") or 0))
 
     result = {
         "meta": {
@@ -220,8 +315,14 @@ def main():
             "current_milestone": current,
             "current_milestone_source": source,
             "window_days": args.window,
-            "data_source": "https://chromiumdash.appspot.com/fetch_milestone_schedule",
+            "platform": args.platform,
+            "tracked_channels": tracked,
+            "data_sources": [
+                "https://chromiumdash.appspot.com/fetch_milestone_schedule",
+                "https://chromiumdash.appspot.com/fetch_releases",
+            ],
         },
+        "channels": channels,
         "milestones": milestones,
         "headsup": headsup,
     }
@@ -290,6 +391,50 @@ def build_headsup(milestones, current, window, now):
     return alerts
 
 
+def build_channel_headsup(channels, tracked, current):
+    """Alerts about the channels SkiaSharp tracks concurrently (Extended/Stable/Beta).
+
+    Each tracked channel pins a milestone + Skia commit. If a tracked channel has advanced
+    past the milestone SkiaSharp is pinned to, that channel's branch needs a bump.
+    """
+    alerts = []
+    for ch in channels:
+        if not ch.get("tracked"):
+            continue
+        m = ch.get("milestone")
+        if not isinstance(m, int):
+            continue
+        name = ch["channel"]
+        skia = (ch.get("skia_hash") or "?")[:12]
+        ver = ch.get("version") or "?"
+        if m > current:
+            alerts.append({
+                "level": "urgent",
+                "milestone": m,
+                "channel": name,
+                "message": (f"Tracked channel {name} is on m{m} ({ver}, skia {skia}) but SkiaSharp "
+                            f"is pinned to m{current}. The {name} branch needs a Skia bump to m{m}."),
+            })
+        elif m == current:
+            alerts.append({
+                "level": "info",
+                "milestone": m,
+                "channel": name,
+                "message": (f"Tracked channel {name} is on m{m} ({ver}, skia {skia}) — matches the "
+                            f"pinned milestone."),
+            })
+        else:
+            alerts.append({
+                "level": "info",
+                "milestone": m,
+                "channel": name,
+                "message": (f"Tracked channel {name} is on m{m} ({ver}, skia {skia}); SkiaSharp's "
+                            f"{name} branch should pin m{m}."),
+            })
+    return alerts
+
+
+LEVEL_ORDER = {"critical": 0, "urgent": 1, "watch": 2, "info": 3}
 LEVEL_ICON = {"critical": "🔴", "urgent": "🟠", "watch": "🟡", "info": "🔵"}
 
 
@@ -299,10 +444,25 @@ def print_summary(result):
     print(f"Chromium release schedule — heads-up for Skia bumps")
     print(f"  Current SkiaSharp milestone: m{meta['current_milestone']} "
           f"(from {meta['current_milestone_source']})")
-    print(f"  Urgency window: {meta['window_days']} days\n")
+    print(f"  Urgency window: {meta['window_days']} days")
+    if meta.get("tracked_channels"):
+        print(f"  Tracked channels ({meta.get('platform','?')}): "
+              f"{', '.join(meta['tracked_channels'])}")
+    print()
 
-    print("  Milestone   Branch point   Stable date    Status    In")
-    print("  " + "-" * 58)
+    channels = result.get("channels") or []
+    if channels:
+        print("  Channel     Milestone   Version             Skia commit   Track")
+        print("  " + "-" * 64)
+        for c in channels:
+            track = "✓" if c.get("tracked") else " "
+            skia = (c.get("skia_hash") or "?")[:12]
+            print(f"  {c.get('channel',''):<10}  m{str(c.get('milestone','?')):<8}  "
+                  f"{c.get('version','?'):<18}  {skia:<12}  {track}")
+        print()
+
+    print("  Milestone   Branch point   Stable date    Status    In      Channels")
+    print("  " + "-" * 72)
     for entry in result["milestones"]:
         m = entry["milestone"]
         b = entry["dates"].get("branch_point", {})
@@ -310,8 +470,9 @@ def print_summary(result):
         d = s.get("days_from_now")
         din = f"{d:+d}d" if isinstance(d, int) else "  ?"
         marker = "*" if entry.get("is_current") else " "
+        chans = ",".join(entry.get("channels") or [])
         print(f"  {marker}m{m:<8}  {b.get('date','?'):<13}  {s.get('date','?'):<13}  "
-              f"{entry['status']:<8}  {din:>5}")
+              f"{entry['status']:<8}  {din:>5}   {chans}")
 
     print()
     headsup = result["headsup"]


### PR DESCRIPTION
## What & why

Adds a lightweight "release heads-up" capability to the `security-audit` skill so the team gets advance warning when a Skia bump is needed before a Chrome security fix reaches users. It answers one question: **is SkiaSharp's `main` keeping up with the Chrome Beta milestone, and how much lead time remains before the next milestone reaches stable?**

This is scheduling context, not a security check on its own — it pairs with the existing Chrome Releases blog and Skia CVE resolution steps to set urgency.

## The model

SkiaSharp's `main` is the front line and tracks the Chrome **Beta** milestone. As milestones graduate Beta → Stable → Extended stable, a `release/<major>.<M>.x` branch is cut from a `main` already on that milestone — so on the milestone axis those lines are inherently covered. The single signal that matters is:

> **`main_milestone >= beta_channel_milestone`**

So "where we are" is just main's milestone (read from `scripts/VERSIONS.txt`), and the tool flags when `main` falls behind Beta.

## What's included

- **`scripts/query-milestone-schedule.py`** (new, stdlib-only, Python 3.8+) — reads main's milestone/major from `VERSIONS.txt`, queries two Chromium Dash JSON endpoints (`fetch_releases` per channel + `fetch_milestone_schedule` per milestone), and prints a main-vs-Beta heads-up with prioritized alerts (🔴 critical / 🟠 urgent / ❓ unknown / 🟡 watch / 🟢 ok). Table by default, `--json` to stdout, `--output` to write the cache file. Four flags only: `--ahead`, `--window`, `--json`, `--output`.
- **`references/milestone-schedule.md`** (new) — documents the model, endpoints, flags, JSON shape, and alert levels.
- **`SKILL.md`** — inserts the schedule query as workflow Step 3 and renumbers the detailed steps to a consistent 1–12 (the inserted steps had left fractional/duplicate/missing numbers, with subsections mislabeled).
- **`references/skia-cve-resolution.md`**, **`references/report-schema.md`** — fix stale cross-references to the renumbered steps.

## Design notes

The script went through deliberate simplification: an earlier per-channel tracker and a `--check-backports` feature were **removed** because the within-milestone backport question can't be answered by a naive SHA compare (our submodule pins the mono/skia **fork**, not upstream google/skia) — that analysis already lives in the Skia CVE resolution process. The flag set was trimmed from 9 to the 4 that earn their place.

## Review

Reviewed by **GPT-5.5** and **Claude Opus 4.7**. Both independently flagged that a failed Beta lookup silently reported `current` with no alert — hidden loss of the only signal that matters. Fixes applied:
- Missing Beta → `status="unknown"` + a loud ❓ alert (never false-green).
- `critical` now keys off the **live** Stable/Extended channel milestone rather than only the scheduled stable date.
- Defensive parsing: `parse_date` ignores non-string values; `fetch_schedule`/`fetch_channel` validate JSON shape before indexing.

Exercised by running the script against the live Chromium Dash endpoints, including a controlled `main`-behind-Beta input (VERSIONS.txt pinned to an older milestone) to confirm the 🔴 critical path fires. There are no automated tests for this tooling.

## Notes

All changes are confined to `.agents/skills/security-audit/` — no product code, bindings, or native changes. Nothing to build or bootstrap.