### PR TITLE
[infra] Move release-notes Prepare into its own job (verbose, disk-managed, artifact handoff)

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -139,17 +139,14 @@ diff range, PR count) AND the raw PR list. Below the comment is a skeleton headi
 placeholder for polished content. The raw data comment must be preserved in the final file.
 
 **IMPORTANT:** The list of files to polish is **always** at `output/files-to-polish.txt`
-(one repo-relative path per line). For a **manual** run the Prepare script writes it there
-(and echoes it to the log); for an **automated** run it has already been placed there for
-you. The echoed summary looks like:
+(one repo-relative path per line, nothing else). For a **manual** run the Prepare script
+writes it there (and echoes the same paths to the log); for an **automated** run it has
+already been placed there for you. The file is a plain list, e.g.:
 
 ```
-========================================
-Files to polish:
-  - documentation/docfx/releases/4.147.0.md
-  - documentation/docfx/releases/3.119.5-unreleased.md
-  - documentation/docfx/releases/4.148.0-unreleased.md
-========================================
+documentation/docfx/releases/4.147.0.md
+documentation/docfx/releases/3.119.5-unreleased.md
+documentation/docfx/releases/4.148.0-unreleased.md
 ```
 
 You MUST polish **every file** in the "Files to polish" list — not just the first one.

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -20,9 +20,10 @@ description: >
 
     NOTE: The full set is normally regenerated automatically by the `update-release-notes`
   agentic workflow when code lands on main, release branches, or tags are pushed. That
-  workflow runs the Prepare script in a pre-agent host step and then invokes this skill
-  for the Polish phase only. The same skill is used manually for regeneration or
-  corrections, in which case you run the Prepare script yourself and then polish.
+  workflow runs the Prepare script in a dedicated `prepare` job (its own disk-managed
+  runner), restores its output into the agent's checkout, and then invokes this skill for
+  the Polish phase only. The same skill is used manually for regeneration or corrections,
+  in which case you run the Prepare script yourself and then polish.
 ---
 
 # Release Notes & API Changelogs Skill
@@ -39,7 +40,8 @@ The skill is just **two phases**:
 
 1. **Prepare** — run one script, `scripts/generate.sh`, which regenerates everything
    deterministic (the API-diff tree, each page's raw-data block, the page→API-diff
-   links) and prints the "Files to polish" list. No AI.
+   links) and reports the "Files to polish" list. No AI. (Manual runs print that list;
+   the workflow's `prepare` job has the script write it to a file — see below.)
 2. **Polish** — you (the AI) rewrite only the *prose* of the pages the script flagged as
    changed.
 
@@ -48,18 +50,19 @@ polish.** `generate.sh` is the single entry point for the Prepare phase — you 
 to know what it runs internally.
 
 > **Running unattended from the `update-release-notes` workflow?** The **Prepare** phase
-> has **already been run for you in pre-agent host steps** — the API-diff tree and the
-> raw-data pages are already on disk. **Skip Prepare entirely** and go straight to
-> [Polish the prose](#polish-the-prose), polishing exactly the files in the
-> workflow-provided "Files to polish" list.
+> has **already been run for you in a dedicated `prepare` job** and its output restored
+> into your checkout — the API-diff tree and the raw-data pages are already on disk.
+> **Skip Prepare entirely** and go straight to [Polish the prose](#polish-the-prose),
+> polishing exactly the files listed in `/tmp/gh-aw/files-to-polish.txt` (one
+> repo-relative path per line; an empty file means nothing changed — make no edits).
 
 ## Process
 
 ### Prepare — run the script first
 
-> **In the automated workflow this already ran** in a pre-agent host step — **skip this
-> whole phase** and jump to [Polish the prose](#polish-the-prose). Run it yourself only
-> for **manual** regeneration.
+> **In the automated workflow this already ran** in a dedicated `prepare` job and its
+> output was restored into your checkout — **skip this whole phase** and jump to
+> [Polish the prose](#polish-the-prose). Run it yourself only for **manual** regeneration.
 
 **Decide scope, then run it.** Ask the user which version(s) to generate (or infer from
 context) and pick the matching invocation from the table below. From anywhere in the repo,
@@ -86,8 +89,7 @@ the printed **"Files to polish"** list: those are the pages whose raw data chang
 that you polish next. You never create, rename, or delete pages — the script owns that.
 
 **Requirements.** The script needs the .NET SDK and `python3`, plus network access to
-nuget.org and the GitHub API. In the workflow these are provisioned in the pre-agent host
-steps. For **manual** runs, if a required tool or the network is missing the script stops
+nuget.org and the GitHub API. In the workflow these are provisioned in the `prepare` job. For **manual** runs, if a required tool or the network is missing the script stops
 with a clear error — **ask the user to install it / restore connectivity**; never work
 around it or hand-write API-diff links to compensate.
 
@@ -125,7 +127,9 @@ The file starts with an HTML comment block containing both metadata (version, st
 diff range, PR count) AND the raw PR list. Below the comment is a skeleton heading with a
 placeholder for polished content. The raw data comment must be preserved in the final file.
 
-**IMPORTANT:** The script prints a summary at the end listing ALL files to polish:
+**IMPORTANT:** The Prepare phase reports ALL files to polish. Manual runs print this
+summary at the end; the workflow's `prepare` job writes the same list (one path per line)
+to `/tmp/gh-aw/files-to-polish.txt` for you to read:
 
 ```
 ========================================

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -19,11 +19,11 @@ description: >
   "refresh release notes".
 
     NOTE: The full set is normally regenerated automatically by the `update-release-notes`
-  agentic workflow when code lands on main, release branches, or tags are pushed. That
-  workflow runs the Prepare script in a dedicated `prepare` job (its own disk-managed
-  runner), restores its output into the agent's checkout, and then invokes this skill for
-  the Polish phase only. The same skill is used manually for regeneration or corrections,
-  in which case you run the Prepare script yourself and then polish.
+  agentic workflow when code lands on main, release branches, or tags are pushed. In that
+  automated run the Prepare script has already been run for you, so you skip it and only do
+  the Polish phase. Run manually for regeneration or corrections, in which case you run the
+  Prepare script yourself first and then polish. Either way, the pages to polish are listed
+  in `output/files-to-polish.txt`.
 ---
 
 # Release Notes & API Changelogs Skill
@@ -35,6 +35,15 @@ on push to `main`, `release/*` branches, and tags) and manually when regeneratin
 correcting, or bulk-processing the release pages.
 
 ## How it works: prepare, then polish
+
+The skill runs **one of two ways**, and both end at the same place — a list of pages to
+polish in `output/files-to-polish.txt`:
+
+- **Manually** (regeneration or corrections): you run the Prepare script yourself; it
+  writes `output/files-to-polish.txt`, then you read it and polish those pages.
+- **Automatically** (the `update-release-notes` workflow): Prepare has **already run** for
+  you, so you **skip it**; `output/files-to-polish.txt` is already on disk — read it and
+  polish those pages.
 
 The skill is just **two phases**:
 
@@ -50,19 +59,19 @@ polish.** `generate.sh` is the single entry point for the Prepare phase — you 
 to know what it runs internally.
 
 > **Running unattended from the `update-release-notes` workflow?** The **Prepare** phase
-> has **already been run for you in a dedicated `prepare` job** and its output restored
-> into your checkout — the API-diff tree and the raw-data pages are already on disk.
-> **Skip Prepare entirely** and go straight to [Polish the prose](#polish-the-prose),
-> polishing exactly the files listed in `/tmp/gh-aw/files-to-polish.txt` (one
-> repo-relative path per line; an empty file means nothing changed — make no edits).
+> has **already been run for you** — the API-diff tree and the raw-data pages are already
+> on disk. **Skip Prepare entirely** and go straight to
+> [Polish the prose](#polish-the-prose), polishing exactly the files listed in
+> `output/files-to-polish.txt` (one repo-relative path per line; an empty file means
+> nothing changed — make no edits).
 
 ## Process
 
 ### Prepare — run the script first
 
-> **In the automated workflow this already ran** in a dedicated `prepare` job and its
-> output was restored into your checkout — **skip this whole phase** and jump to
-> [Polish the prose](#polish-the-prose). Run it yourself only for **manual** regeneration.
+> **In the automated workflow this already ran for you** — **skip this whole phase** and
+> jump to [Polish the prose](#polish-the-prose). Run it yourself only for **manual**
+> regeneration.
 
 **Decide scope, then run it.** Ask the user which version(s) to generate (or infer from
 context) and pick the matching invocation from the table below. From anywhere in the repo,
@@ -91,9 +100,9 @@ are the pages whose raw data changed and that you polish next. You never create,
 or delete pages — the script owns that.
 
 **Requirements.** The script needs the .NET SDK and `python3`, plus network access to
-nuget.org and the GitHub API. In the workflow these are provisioned in the `prepare` job. For **manual** runs, if a required tool or the network is missing the script stops
-with a clear error — **ask the user to install it / restore connectivity**; never work
-around it or hand-write API-diff links to compensate.
+nuget.org and the GitHub API. For **manual** runs, if a required tool or the network is
+missing the script stops with a clear error — **ask the user to install it / restore
+connectivity**; never work around it or hand-write API-diff links to compensate.
 
 ### Polish the prose
 
@@ -129,10 +138,10 @@ The file starts with an HTML comment block containing both metadata (version, st
 diff range, PR count) AND the raw PR list. Below the comment is a skeleton heading with a
 placeholder for polished content. The raw data comment must be preserved in the final file.
 
-**IMPORTANT:** The Prepare script always writes the full list of files to polish to
-`output/files-to-polish.txt` (one repo-relative path per line) and echoes it to the log.
-In the `update-release-notes` workflow that file is restored for you at
-`/tmp/gh-aw/files-to-polish.txt`. The echoed summary looks like:
+**IMPORTANT:** The list of files to polish is **always** at `output/files-to-polish.txt`
+(one repo-relative path per line). For a **manual** run the Prepare script writes it there
+(and echoes it to the log); for an **automated** run it has already been placed there for
+you. The echoed summary looks like:
 
 ```
 ========================================

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -40,8 +40,8 @@ The skill is just **two phases**:
 
 1. **Prepare** — run one script, `scripts/generate.sh`, which regenerates everything
    deterministic (the API-diff tree, each page's raw-data block, the page→API-diff
-   links) and reports the "Files to polish" list. No AI. (Manual runs print that list;
-   the workflow's `prepare` job has the script write it to a file — see below.)
+   links) and writes the "Files to polish" list to a file
+   (`output/files-to-polish.txt`). No AI.
 2. **Polish** — you (the AI) rewrite only the *prose* of the pages the script flagged as
    changed.
 
@@ -72,8 +72,9 @@ with no arguments, it does a full regeneration of everything:
 .agents/skills/release-notes/scripts/generate.sh
 ```
 
-By default it regenerates **both** artifacts for every branch and prints the
-**"Files to polish"** list. The flags narrow what it touches:
+By default it regenerates **both** artifacts for every branch and writes the
+**"Files to polish"** list to `output/files-to-polish.txt` (also echoed to the log).
+The flags narrow what it touches:
 
 | Invocation | What it regenerates |
 | --- | --- |
@@ -85,8 +86,9 @@ By default it regenerates **both** artifacts for every branch and prints the
 How it produces those files (which engine runs, the on-disk layout, diff ranges,
 supersession, which pages are skipped because nothing changed) is **implementation detail
 owned by the script** — you don't need it to run the skill. The only output you act on is
-the printed **"Files to polish"** list: those are the pages whose raw data changed and
-that you polish next. You never create, rename, or delete pages — the script owns that.
+the **"Files to polish"** list the script writes to `output/files-to-polish.txt`: those
+are the pages whose raw data changed and that you polish next. You never create, rename,
+or delete pages — the script owns that.
 
 **Requirements.** The script needs the .NET SDK and `python3`, plus network access to
 nuget.org and the GitHub API. In the workflow these are provisioned in the `prepare` job. For **manual** runs, if a required tool or the network is missing the script stops
@@ -127,9 +129,10 @@ The file starts with an HTML comment block containing both metadata (version, st
 diff range, PR count) AND the raw PR list. Below the comment is a skeleton heading with a
 placeholder for polished content. The raw data comment must be preserved in the final file.
 
-**IMPORTANT:** The Prepare phase reports ALL files to polish. Manual runs print this
-summary at the end; the workflow's `prepare` job writes the same list (one path per line)
-to `/tmp/gh-aw/files-to-polish.txt` for you to read:
+**IMPORTANT:** The Prepare script always writes the full list of files to polish to
+`output/files-to-polish.txt` (one repo-relative path per line) and echoes it to the log.
+In the `update-release-notes` workflow that file is restored for you at
+`/tmp/gh-aw/files-to-polish.txt`. The echoed summary looks like:
 
 ```
 ========================================

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -407,6 +407,8 @@ def write_polish_list(files, path=None):
             fh.write("{}\n".format(f))
     log("Wrote files-to-polish list ({} file{}) -> {}".format(
         len(files), "" if len(files) == 1 else "s", path))
+    for f in files:
+        log(f)
 
 
 def run(args, check=True):
@@ -2431,11 +2433,6 @@ def cmd_branch(branch, force=False, polish_list_path=None):
     cmd_update_toc()
 
     log("")
-    print("========================================")
-    print("Files to polish:")
-    for f in files_to_polish:
-        print("  - {}".format(f))
-    print("========================================")
     write_polish_list(files_to_polish, polish_list_path)
 
 def _regen_unreleased(trigger_branch, all_branches, force=False):
@@ -2601,16 +2598,8 @@ def cmd_all(force=False, polish_list_path=None):
 
     # Print summary for the AI agent
     log("")
-    print("========================================")
     log("Processed: {}, Skipped/unchanged: {}".format(
         processed_count, skipped_count))
-    print("Files to polish:")
-    if files_to_polish:
-        for f in files_to_polish:
-            print("  - {}".format(f))
-    else:
-        print("  (none — all files up to date)")
-    print("========================================")
     write_polish_list(files_to_polish, polish_list_path)
 
 def main():

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -31,10 +31,10 @@ plus a human-readable summary block to STDOUT, so a CI job log shows the work (a
 any disk/timeout failure) as it happens (spec §2.2/§2.3).
 
 The machine-readable result the Polish phase consumes — the list of pages whose raw
-data changed — is written to the file named by ``--polish-list`` (one repo-relative
-path per line; an empty file means nothing changed). It is NOT scraped from stdout,
-so verbose progress can flow freely. Keep using ``log()`` for progress; the only
-output tied to a stable format is the ``--polish-list`` file.
+data changed — is ALWAYS written to a file: ``output/files-to-polish.txt`` by
+default, or the path given to ``--polish-list``. One repo-relative path per line; an
+empty file means nothing changed. The list never rides on stdout, so verbose
+progress can flow freely (spec §2.3).
 
 Page model (two files per in-flight version — released + unreleased coexist)
 ---------------------------------------------------------------------------
@@ -104,6 +104,11 @@ from typing import Optional, Tuple
 
 REPO = "mono/SkiaSharp"
 RELEASES_DIR = Path("documentation/docfx/releases")
+
+# The Prepare phase ALWAYS writes the machine-readable "Files to polish" list to a
+# file (overridable with --polish-list). output/ is gitignored, so the list stays
+# out of the working-tree patch the Prepare job hands to the Polish agent.
+DEFAULT_POLISH_LIST = Path("output/files-to-polish.txt")
 
 SKIA_PR_PATTERNS = [
     re.compile(r"(?:companion|related)\s+(?:skia\s+)?pr[:\s]+https?://github\.com/mono/skia/pull/(\d+)", re.IGNORECASE),
@@ -378,27 +383,30 @@ def log(*args, **kwargs):
     This generator is verbose: ``log()`` progress appears in the CI job log
     alongside the stdout summary so a long download or a disk/timeout failure is
     visible as it happens (spec §2.2). The machine-readable "Files to polish"
-    list does NOT ride on a stream — it is written to the ``--polish-list`` file
-    (spec §2.3) — so callers never have to parse progress out of stdout.
+    list does NOT ride on a stream — it is always written to a file (spec §2.3) —
+    so callers never have to parse progress out of stdout.
     """
     kwargs["file"] = sys.stderr
     print(*args, **kwargs)
 
 
-def write_polish_list(files, path):
-    # type: (list, str) -> None
-    """Write the machine-readable "Files to polish" list to *path* (spec §2.3).
+def write_polish_list(files, path=None):
+    # type: (list, ...) -> None
+    """Write the machine-readable "Files to polish" list to a file (spec §2.3).
 
-    One repo-relative page path per line; an **empty file** means nothing changed
-    this run. The Prepare phase passes ``--polish-list`` so the list survives the
-    job boundary as a workflow artifact instead of riding on stdout (which now
-    streams verbose progress). A no-op when *path* is falsy.
+    Always writes a file — ``output/files-to-polish.txt`` by default, or *path* if
+    given. One repo-relative page path per line; an **empty file** means nothing
+    changed this run. This is the Prepare phase's only machine-readable output, so
+    the Polish agent reads a file instead of scraping stdout. The parent directory
+    is created if needed.
     """
-    if not path:
-        return
-    with open(path, "w", encoding="utf-8") as fh:
+    path = Path(path) if path else DEFAULT_POLISH_LIST
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
         for f in files:
             fh.write("{}\n".format(f))
+    log("Wrote files-to-polish list ({} file{}) -> {}".format(
+        len(files), "" if len(files) == 1 else "s", path))
 
 
 def run(args, check=True):
@@ -2635,11 +2643,11 @@ def main():
         help="Rewrite pages even when the raw data is unchanged "
              "(use with --all or --branch to re-resolve author handles)")
     parser.add_argument(
-        "--polish-list", metavar="FILE",
-        help="Write the machine-readable 'Files to polish' list to FILE (one "
-             "repo-relative path per line; empty file = nothing changed). The "
-             "Prepare phase uses this so the list crosses the job boundary as an "
-             "artifact instead of riding on stdout (spec §2.3).")
+        "--polish-list", metavar="FILE", default=None,
+        help="Write the 'Files to polish' list to FILE (one repo-relative path "
+             "per line; empty file = nothing changed). Defaults to "
+             "output/files-to-polish.txt. The Prepare job uploads this file as an "
+             "artifact for the Polish agent (spec §2.3).")
 
     args = parser.parse_args()
 

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -25,13 +25,16 @@ Polish phase STOPS and reports; a maintainer fixes the script here.
 
 Output streams (the Prepare-phase contract)
 --------------------------------------------
-STDOUT carries ONLY the machine-readable result the Polish phase consumes: the
-delimited "Files to polish" block (see cmd_all / the `log` helper). Every piece of
-human progress and diagnostics — "Processing…", "Found N PRs", "Skipping
-(unchanged)", warnings, errors — goes to STDERR via ``log()``. So a caller can
-``generate-release-notes.py --all 2>/dev/null`` (or capture stdout in a workflow
-step) and get nothing but the list. Do NOT add bare ``print()`` for progress; use
-``log()``. The only ``print()`` to stdout is the final list block itself.
+This generator runs VERBOSE: progress and diagnostics — "Processing…", "Found N
+PRs", "Skipping (unchanged)", warnings, errors — stream to STDERR via ``log()``,
+plus a human-readable summary block to STDOUT, so a CI job log shows the work (and
+any disk/timeout failure) as it happens (spec §2.2/§2.3).
+
+The machine-readable result the Polish phase consumes — the list of pages whose raw
+data changed — is written to the file named by ``--polish-list`` (one repo-relative
+path per line; an empty file means nothing changed). It is NOT scraped from stdout,
+so verbose progress can flow freely. Keep using ``log()`` for progress; the only
+output tied to a stable format is the ``--polish-list`` file.
 
 Page model (two files per in-flight version — released + unreleased coexist)
 ---------------------------------------------------------------------------
@@ -372,16 +375,30 @@ def log(*args, **kwargs):
     # type: (...) -> None
     """Human-facing progress and diagnostics — always written to STDERR.
 
-    STDOUT is reserved for the single machine-readable artifact the Prepare
-    phase produces: the delimited "Files to polish" block the AI Polish phase
-    consumes (SKILL.md §Prepare). Keeping every "Processing…", "Found N PRs",
-    "Skipping (unchanged)", warning and error on stderr means a caller can do
-    ``generate-release-notes.py --all 2>/dev/null`` (or capture stdout in a
-    workflow step) and get nothing but the list — no progress noise to parse
-    around.
+    This generator is verbose: ``log()`` progress appears in the CI job log
+    alongside the stdout summary so a long download or a disk/timeout failure is
+    visible as it happens (spec §2.2). The machine-readable "Files to polish"
+    list does NOT ride on a stream — it is written to the ``--polish-list`` file
+    (spec §2.3) — so callers never have to parse progress out of stdout.
     """
     kwargs["file"] = sys.stderr
     print(*args, **kwargs)
+
+
+def write_polish_list(files, path):
+    # type: (list, str) -> None
+    """Write the machine-readable "Files to polish" list to *path* (spec §2.3).
+
+    One repo-relative page path per line; an **empty file** means nothing changed
+    this run. The Prepare phase passes ``--polish-list`` so the list survives the
+    job boundary as a workflow artifact instead of riding on stdout (which now
+    streams verbose progress). A no-op when *path* is falsy.
+    """
+    if not path:
+        return
+    with open(path, "w", encoding="utf-8") as fh:
+        for f in files:
+            fh.write("{}\n".format(f))
 
 
 def run(args, check=True):
@@ -2355,8 +2372,8 @@ def _write_harfbuzz_page(hb, all_branches, force=False):
     return str(output_path), owned
 
 
-def cmd_branch(branch, force=False):
-    # type: (str, bool) -> None
+def cmd_branch(branch, force=False, polish_list_path=None):
+    # type: (str, bool, str) -> None
     """Diff a branch against its predecessor and write raw data to the version file."""
     branch = _removeprefix(branch, "origin/")
 
@@ -2411,7 +2428,7 @@ def cmd_branch(branch, force=False):
     for f in files_to_polish:
         print("  - {}".format(f))
     print("========================================")
-
+    write_polish_list(files_to_polish, polish_list_path)
 
 def _regen_unreleased(trigger_branch, all_branches, force=False):
     # type: (str, list[str], bool) -> list[str]
@@ -2495,8 +2512,8 @@ def _process_harfbuzz_family(all_branches, force=False):
     return files_to_polish, processed, skipped
 
 
-def cmd_all(force=False):
-    # type: (bool) -> None
+def cmd_all(force=False, polish_list_path=None):
+    # type: (bool, str) -> None
     """Process all branches (main + all release/*). Skip unchanged files.
 
     This is the idempotent "regenerate everything" mode used by the automated
@@ -2586,7 +2603,7 @@ def cmd_all(force=False):
     else:
         print("  (none — all files up to date)")
     print("========================================")
-
+    write_polish_list(files_to_polish, polish_list_path)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -2617,6 +2634,12 @@ def main():
         "--force", action="store_true",
         help="Rewrite pages even when the raw data is unchanged "
              "(use with --all or --branch to re-resolve author handles)")
+    parser.add_argument(
+        "--polish-list", metavar="FILE",
+        help="Write the machine-readable 'Files to polish' list to FILE (one "
+             "repo-relative path per line; empty file = nothing changed). The "
+             "Prepare phase uses this so the list crosses the job boundary as an "
+             "artifact instead of riding on stdout (spec §2.3).")
 
     args = parser.parse_args()
 
@@ -2631,9 +2654,10 @@ def main():
     if args.update_toc:
         cmd_update_toc()
     elif args.all:
-        cmd_all(force=args.force)
+        cmd_all(force=args.force, polish_list_path=args.polish_list)
     elif args.branch:
-        cmd_branch(args.branch, force=args.force)
+        cmd_branch(args.branch, force=args.force,
+                   polish_list_path=args.polish_list)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -25,16 +25,16 @@ Polish phase STOPS and reports; a maintainer fixes the script here.
 
 Output streams (the Prepare-phase contract)
 --------------------------------------------
-This generator runs VERBOSE: progress and diagnostics — "Processing…", "Found N
-PRs", "Skipping (unchanged)", warnings, errors — stream to STDERR via ``log()``,
-plus a human-readable summary block to STDOUT, so a CI job log shows the work (and
-any disk/timeout failure) as it happens (spec §2.2/§2.3).
+This generator runs VERBOSE: all progress and diagnostics — "Processing…", "Found N
+PRs", "Skipping (unchanged)", warnings, errors, and the final list of pages to
+polish — stream to STDERR via ``log()``, so a CI job log shows the work (and any
+disk/timeout failure) as it happens (spec §2.2/§2.3). Nothing is printed to STDOUT.
 
 The machine-readable result the Polish phase consumes — the list of pages whose raw
 data changed — is ALWAYS written to a file: ``output/files-to-polish.txt`` by
-default, or the path given to ``--polish-list``. One repo-relative path per line; an
-empty file means nothing changed. The list never rides on stdout, so verbose
-progress can flow freely (spec §2.3).
+default, or the path given to ``--polish-list``. It is a plain list, one
+repo-relative path per line; an empty file means nothing changed. Because the list
+lives in a file (not a stream), verbose progress can flow freely (spec §2.3).
 
 Page model (two files per in-flight version — released + unreleased coexist)
 ---------------------------------------------------------------------------
@@ -380,11 +380,11 @@ def log(*args, **kwargs):
     # type: (...) -> None
     """Human-facing progress and diagnostics — always written to STDERR.
 
-    This generator is verbose: ``log()`` progress appears in the CI job log
-    alongside the stdout summary so a long download or a disk/timeout failure is
-    visible as it happens (spec §2.2). The machine-readable "Files to polish"
-    list does NOT ride on a stream — it is always written to a file (spec §2.3) —
-    so callers never have to parse progress out of stdout.
+    This generator is verbose: ``log()`` is the ONLY output stream (nothing goes to
+    STDOUT), so a long download or a disk/timeout failure is visible in the CI job
+    log as it happens (spec §2.2). The machine-readable "Files to polish" list does
+    NOT ride on a stream — it is always written to a file (spec §2.3) — so callers
+    never have to parse it out of progress text.
     """
     kwargs["file"] = sys.stderr
     print(*args, **kwargs)

--- a/.agents/skills/release-notes/scripts/generate-release-notes.py
+++ b/.agents/skills/release-notes/scripts/generate-release-notes.py
@@ -2646,8 +2646,7 @@ def main():
         "--polish-list", metavar="FILE", default=None,
         help="Write the 'Files to polish' list to FILE (one repo-relative path "
              "per line; empty file = nothing changed). Defaults to "
-             "output/files-to-polish.txt. The Prepare job uploads this file as an "
-             "artifact for the Polish agent (spec §2.3).")
+             "output/files-to-polish.txt.")
 
     args = parser.parse_args()
 

--- a/.agents/skills/release-notes/scripts/generate.sh
+++ b/.agents/skills/release-notes/scripts/generate.sh
@@ -8,9 +8,10 @@
 # stream their full progress straight to stdout/stderr (i.e. the CI job log), so
 # a long NuGet download or a disk/timeout failure is visible AS IT HAPPENS — it
 # is never hidden in a temp log. The machine-readable "Files to polish" list does
-# NOT ride on stdout; pass --polish-list <path> and the Python generator writes
-# the list there (one repo-relative path per line; empty file = nothing changed).
-# The Prepare job uploads that file as an artifact for the Polish agent to read.
+# NOT ride on stdout: the Python generator ALWAYS writes it to a file
+# (output/files-to-polish.txt by default; pass --polish-list <path> to choose the
+# location). One repo-relative path per line; an empty file = nothing changed. The
+# Prepare job uploads that file as an artifact for the Polish agent to read.
 #
 # This is the single entry point for the Prepare phase. The release-notes skill
 # and the update-release-notes workflow both call THIS, so neither has to know the
@@ -26,7 +27,8 @@
 #   --api-only           Run only the Cake API-changelog generator.
 #   --notes-only         Run only the Python release-notes generator.
 #   --polish-list <path> Forwarded to the Python generator: write the "Files to
-#                        polish" list to <path> instead of relying on stdout.
+#                        polish" list to <path> instead of the default
+#                        output/files-to-polish.txt.
 #   <extra args>         Forwarded verbatim to generate-release-notes.py, replacing
 #                        the default `--all` (e.g. `--branch main`, a version, etc.).
 #

--- a/.agents/skills/release-notes/scripts/generate.sh
+++ b/.agents/skills/release-notes/scripts/generate.sh
@@ -1,32 +1,39 @@
 #!/usr/bin/env bash
 #
 # generate.sh — the Prepare phase: run the two deterministic
-# release-notes/changelog generators in the required order, then print the
-# "Files to polish" list.
+# release-notes/changelog generators in the required order (Cake -> Python),
+# VERBOSE, and write the "Files to polish" list to a file.
 #
-# Output contract: STDOUT carries ONLY that list (forwarded verbatim from
-# generate-release-notes.py). All verbose Cake + Python progress is redirected to
-# a temp log whose path is announced on STDERR; on failure the log tail is shown
-# on STDERR. So `generate.sh | …` (or capturing its stdout) yields just the list.
+# Output contract (spec §2.2/§2.3): this script is VERBOSE. Cake and Python
+# stream their full progress straight to stdout/stderr (i.e. the CI job log), so
+# a long NuGet download or a disk/timeout failure is visible AS IT HAPPENS — it
+# is never hidden in a temp log. The machine-readable "Files to polish" list does
+# NOT ride on stdout; pass --polish-list <path> and the Python generator writes
+# the list there (one repo-relative path per line; empty file = nothing changed).
+# The Prepare job uploads that file as an artifact for the Polish agent to read.
 #
-# This is the single entry point for the Prepare phase (Cake -> Python; spec
-# §2.2). The release-notes skill and the update-release-notes workflow both call
-# THIS, so neither has to know the individual commands. The AI Polish phase (spec
-# §2.2) is deliberately NOT run here — that is the human/agent's job once this
-# script finishes.
+# This is the single entry point for the Prepare phase. The release-notes skill
+# and the update-release-notes workflow both call THIS, so neither has to know the
+# individual commands. The AI Polish phase (spec §2.2) is deliberately NOT run
+# here — that is the agent's job once this script finishes.
 #
 # Usage:
-#   generate.sh [--notes-only | --api-only] [extra args for the Python script...]
+#   generate.sh [--api-only | --notes-only] [--polish-list <path>] \
+#               [extra args for the Python script...]
 #
-#   (no args)            Full regeneration of everything: API changelogs (Cake)
+#   (no scope args)      Full regeneration of everything: API changelogs (Cake)
 #                        then release-notes raw data for every branch (Python --all).
 #   --api-only           Run only the Cake API-changelog generator.
 #   --notes-only         Run only the Python release-notes generator.
+#   --polish-list <path> Forwarded to the Python generator: write the "Files to
+#                        polish" list to <path> instead of relying on stdout.
 #   <extra args>         Forwarded verbatim to generate-release-notes.py, replacing
 #                        the default `--all` (e.g. `--branch main`, a version, etc.).
 #
 # Exit status is non-zero (with a clear message) if a required tool is missing —
 # the skill must then stop and ask the user to install it, never work around it.
+# Any generator failure aborts immediately (set -e); the verbose log already shows
+# why, so there is no separate failure dump.
 
 set -euo pipefail
 
@@ -35,14 +42,17 @@ REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
 run_api=1
 run_notes=1
+polish_list=""
 notes_args=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --api-only)   run_notes=0; shift ;;
-    --notes-only) run_api=0;   shift ;;
-    --)           shift; notes_args+=("$@"); break ;;
-    *)            notes_args+=("$1"); shift ;;
+    --api-only)        run_notes=0; shift ;;
+    --notes-only)      run_api=0;   shift ;;
+    --polish-list)     polish_list="${2:?--polish-list needs a path}"; shift 2 ;;
+    --polish-list=*)   polish_list="${1#*=}"; shift ;;
+    --)                shift; notes_args+=("$@"); break ;;
+    *)                 notes_args+=("$1"); shift ;;
   esac
 done
 
@@ -53,24 +63,15 @@ fi
 
 cd "$REPO_ROOT"
 
-# Keep STDOUT clean: the only thing this script emits to stdout is the
-# machine-readable "Files to polish" list (generate-release-notes.py's stdout),
-# so the Polish phase / workflow can consume it without wading through progress.
-# All verbose Cake + Python progress is redirected to a log; its path is announced
-# on stderr, and on failure its tail is surfaced there too.
-PREPARE_LOG="$(mktemp "${TMPDIR:-/tmp}/release-notes-prepare.XXXXXX")"
-echo "==> Prepare: verbose progress -> $PREPARE_LOG" >&2
-
 if [ "$run_api" = 1 ]; then
   if ! command -v dotnet >/dev/null 2>&1; then
     echo "ERROR: the .NET SDK ('dotnet') is required for the API-changelog generator but was not found." >&2
     echo "       Install the SDK pinned in global.json and retry, or pass --notes-only to skip it." >&2
     exit 1
   fi
-  echo "==> Prepare [1/2]: API changelogs (Cake: docs-api-diff-past)" >&2
-  { dotnet tool restore && \
-    dotnet cake --target=docs-api-diff-past --nugetDiffPrerelease=true ; } >>"$PREPARE_LOG" 2>&1 \
-    || { echo "ERROR: API-changelog generation failed — last 50 log lines:" >&2; tail -50 "$PREPARE_LOG" >&2; exit 1; }
+  echo "==> Prepare [1/2]: API changelogs (Cake: docs-api-diff-past) — verbose"
+  dotnet tool restore
+  dotnet cake --target=docs-api-diff-past --nugetDiffPrerelease=true
 fi
 
 if [ "$run_notes" = 1 ]; then
@@ -79,10 +80,11 @@ if [ "$run_notes" = 1 ]; then
     echo "       Install Python 3 and retry, or pass --api-only to skip it." >&2
     exit 1
   fi
-  echo "==> Prepare [2/2]: release-notes raw data (generate-release-notes.py ${notes_args[*]})" >&2
-  # The Python generator writes the clean "Files to polish" list to stdout and all
-  # progress to stderr; send progress to the log and let the list flow through to
-  # THIS script's stdout unchanged.
-  python3 "$SCRIPT_DIR/generate-release-notes.py" "${notes_args[@]}" 2>>"$PREPARE_LOG" \
-    || { echo "ERROR: release-notes generation failed — last 50 log lines:" >&2; tail -50 "$PREPARE_LOG" >&2; exit 1; }
+  py_args=("${notes_args[@]}")
+  if [ -n "$polish_list" ]; then
+    py_args+=(--polish-list "$polish_list")
+    echo "==> Files-to-polish list -> $polish_list"
+  fi
+  echo "==> Prepare [2/2]: release-notes raw data (generate-release-notes.py ${py_args[*]}) — verbose"
+  python3 "$SCRIPT_DIR/generate-release-notes.py" "${py_args[@]}"
 fi

--- a/.github/workflows/update-release-notes.lock.yml
+++ b/.github/workflows/update-release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c89c0236ff2fbd85b30388fc58291d0c58edfc079e2920305f6ea3572a374eb7","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8c0b2cfbeabbcb4af3e41184084ae9fdb2ac9aa861510498686f026e334f6fe","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -200,23 +200,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_54f750cc481323c4_EOF'
+          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
           <system>
-          GH_AW_PROMPT_54f750cc481323c4_EOF
+          GH_AW_PROMPT_81983a805e906fd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_54f750cc481323c4_EOF'
+          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_54f750cc481323c4_EOF
+          GH_AW_PROMPT_81983a805e906fd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_54f750cc481323c4_EOF'
+          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_54f750cc481323c4_EOF
+          GH_AW_PROMPT_81983a805e906fd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_54f750cc481323c4_EOF'
+          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -248,12 +248,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_54f750cc481323c4_EOF
+          GH_AW_PROMPT_81983a805e906fd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_54f750cc481323c4_EOF'
+          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
           </system>
           {{#runtime-import .github/workflows/update-release-notes.md}}
-          GH_AW_PROMPT_54f750cc481323c4_EOF
+          GH_AW_PROMPT_81983a805e906fd8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -328,7 +328,9 @@ jobs:
           retention-days: 1
 
   agent:
-    needs: activation
+    needs:
+      - activation
+      - prepare
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -437,16 +439,18 @@ jobs:
           GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
         run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
       - name: Start from a clean main tree
-        run: "set -euo pipefail\n# Release notes/changelogs always target main. A push to release/* is a\n# content *source*, not the PR base, so rebase onto origin/main first to\n# avoid leaking release-branch-only files into the main-targeted PR.\nmkdir -p /tmp/gh-aw\ngit fetch origin main --quiet\ngit checkout -B main origin/main\n"
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # 67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/gh-aw
+          git fetch origin main --quiet
+          git checkout -B main origin/main
+      - name: Download Prepare output
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          global-json-file: global.json
-      - env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-        name: Generate changelogs + release-notes raw data
-        run: "set -euo pipefail\n# Single entry point: runs Cake (API changelogs) then Python (raw data) in\n# order and prints the \"Files to polish\" list. Tee it so the agent can read\n# exactly which pages to polish. No args = full regeneration (Python --all).\nbash .agents/skills/release-notes/scripts/generate.sh \\\n  | tee /tmp/gh-aw/files-to-polish.txt\n"
+          name: release-notes-prepare
+          path: /tmp/gh-aw/prepare-in
+      - name: Restore Prepare output
+        run: "set -euo pipefail\n# The files-to-polish list the agent reads (spec §2.3).\ncp /tmp/gh-aw/prepare-in/files-to-polish.txt /tmp/gh-aw/files-to-polish.txt\n# Replay Prepare's working-tree changes; an empty patch = nothing changed.\nif [ -s /tmp/gh-aw/prepare-in/prepare.patch ]; then\n  git apply --3way --whitespace=nowarn /tmp/gh-aw/prepare-in/prepare.patch\n  echo \"Applied Prepare patch.\"\nelse\n  echo \"Prepare produced no changes; nothing to apply.\"\nfi\n"
 
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
@@ -455,9 +459,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_629c9a97a01fb9a0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2ad00e3914e244fc_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"draft":false,"labels":["documentation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true,"title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_629c9a97a01fb9a0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2ad00e3914e244fc_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -665,7 +669,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f8b18c94046dcd7d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_966800b43ca00d83_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -706,7 +710,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f8b18c94046dcd7d_EOF
+          GH_AW_MCP_CONFIG_966800b43ca00d83_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -758,7 +762,7 @@ jobs:
         # --allow-tool shell(wc)
         # --allow-tool shell(yq)
         # --allow-tool write
-        timeout-minutes: 90
+        timeout-minutes: 60
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -957,6 +961,7 @@ jobs:
       - activation
       - agent
       - detection
+      - prepare
       - safe_outputs
     if: >
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
@@ -1088,7 +1093,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "90"
+          GH_AW_TIMEOUT_MINUTES: "60"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1327,6 +1332,81 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_bots.cjs');
             await main();
+
+  prepare:
+    name: Prepare (changelogs + release-notes raw data)
+    needs: activation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    timeout-minutes: 120
+    steps:
+      - name: Configure GH_HOST for enterprise compatibility
+        id: ghes-host-config
+        shell: bash
+        run: |
+          # Derive GH_HOST from GITHUB_SERVER_URL so the gh CLI targets the correct
+          # GitHub instance (GHES/GHEC). On github.com this is a harmless no-op.
+          GH_HOST="${GITHUB_SERVER_URL#https://}"
+          GH_HOST="${GH_HOST#http://}"
+          echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Free up disk space
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"; df -h /
+          # Drop large preinstalled toolchains we never use here so the NuGet
+          # diff (every package of both families) has room. setup-dotnet below
+          # reinstalls the pinned SDK after we clear the preinstalled one.
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup \
+                      /usr/share/swift /usr/share/dotnet/sdk 2>/dev/null || true
+          sudo docker image prune --all --force 2>/dev/null || true
+          echo "Disk after cleanup:"; df -h /
+      - name: Start from a clean main tree
+        run: |
+          set -euo pipefail
+          # Release notes/changelogs always target main; a push to release/* is a
+          # content *source*, not the PR base, so generate from origin/main.
+          git fetch origin main --quiet
+          git checkout -B main origin/main
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # 67a3573c9a986a3f9c594539f4ab511d57bb3ce9
+        with:
+          global-json-file: global.json
+      - name: Generate (verbose)
+        run: |
+          set -euo pipefail
+          # Single entry point: Cake (API changelogs) then Python (raw data), both
+          # VERBOSE, writing the "Files to polish" list to a file. No args = --all.
+          bash .agents/skills/release-notes/scripts/generate.sh \
+            --polish-list "$RUNNER_TEMP/files-to-polish.txt"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Package Prepare output
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/prepare-out"
+          # Capture EVERY working-tree change (the releases tree, the co-release
+          # map sidecar, the author cache, and any deletions/pruning) as one patch
+          # so the agent can replay it onto a clean main checkout.
+          git add -A
+          git diff --cached --binary > "$RUNNER_TEMP/prepare-out/prepare.patch"
+          git reset -q
+          cp "$RUNNER_TEMP/files-to-polish.txt" "$RUNNER_TEMP/prepare-out/files-to-polish.txt"
+          echo "Patch size: $(wc -c < "$RUNNER_TEMP/prepare-out/prepare.patch") bytes"
+          echo "Files to polish:"; cat "$RUNNER_TEMP/prepare-out/files-to-polish.txt" || true
+      - name: Upload Prepare output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: error
+          name: release-notes-prepare
+          path: ${{ runner.temp }}/prepare-out
+          retention-days: 1
 
   safe_outputs:
     needs:

--- a/.github/workflows/update-release-notes.lock.yml
+++ b/.github/workflows/update-release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8c0b2cfbeabbcb4af3e41184084ae9fdb2ac9aa861510498686f026e334f6fe","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3eaf876b9b5bd7b32e15d5ff6c40caf4cc139291f823605d0631e9d03dee1576","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -200,23 +200,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
+          cat << 'GH_AW_PROMPT_517e56355342f3e5_EOF'
           <system>
-          GH_AW_PROMPT_81983a805e906fd8_EOF
+          GH_AW_PROMPT_517e56355342f3e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
+          cat << 'GH_AW_PROMPT_517e56355342f3e5_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_81983a805e906fd8_EOF
+          GH_AW_PROMPT_517e56355342f3e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
+          cat << 'GH_AW_PROMPT_517e56355342f3e5_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_81983a805e906fd8_EOF
+          GH_AW_PROMPT_517e56355342f3e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
+          cat << 'GH_AW_PROMPT_517e56355342f3e5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -248,12 +248,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_81983a805e906fd8_EOF
+          GH_AW_PROMPT_517e56355342f3e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_81983a805e906fd8_EOF'
+          cat << 'GH_AW_PROMPT_517e56355342f3e5_EOF'
           </system>
           {{#runtime-import .github/workflows/update-release-notes.md}}
-          GH_AW_PROMPT_81983a805e906fd8_EOF
+          GH_AW_PROMPT_517e56355342f3e5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -450,7 +450,7 @@ jobs:
           name: release-notes-prepare
           path: /tmp/gh-aw/prepare-in
       - name: Restore Prepare output
-        run: "set -euo pipefail\n# The files-to-polish list the agent reads (spec §2.3).\ncp /tmp/gh-aw/prepare-in/files-to-polish.txt /tmp/gh-aw/files-to-polish.txt\n# Replay Prepare's working-tree changes; an empty patch = nothing changed.\nif [ -s /tmp/gh-aw/prepare-in/prepare.patch ]; then\n  git apply --3way --whitespace=nowarn /tmp/gh-aw/prepare-in/prepare.patch\n  echo \"Applied Prepare patch.\"\nelse\n  echo \"Prepare produced no changes; nothing to apply.\"\nfi\n"
+        run: "set -euo pipefail\n# The skill always reads output/files-to-polish.txt — put it back at that same\n# path so the agent's Polish phase is identical to a manual run.\nmkdir -p output\ncp /tmp/gh-aw/prepare-in/files-to-polish.txt output/files-to-polish.txt\n# Replay Prepare's working-tree changes; an empty patch = nothing changed.\nif [ -s /tmp/gh-aw/prepare-in/prepare.patch ]; then\n  git apply --3way --whitespace=nowarn /tmp/gh-aw/prepare-in/prepare.patch\n  echo \"Applied Prepare patch.\"\nelse\n  echo \"Prepare produced no changes; nothing to apply.\"\nfi\n"
 
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
@@ -459,9 +459,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2ad00e3914e244fc_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d60e76d83ed18e47_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"draft":false,"labels":["documentation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true,"title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2ad00e3914e244fc_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d60e76d83ed18e47_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -669,7 +669,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_966800b43ca00d83_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8b89dca6360f0c05_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -710,7 +710,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_966800b43ca00d83_EOF
+          GH_AW_MCP_CONFIG_8b89dca6360f0c05_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1381,9 +1381,9 @@ jobs:
         run: |
           set -euo pipefail
           # Single entry point: Cake (API changelogs) then Python (raw data), both
-          # VERBOSE, writing the "Files to polish" list to a file. No args = --all.
-          bash .agents/skills/release-notes/scripts/generate.sh \
-            --polish-list "$RUNNER_TEMP/files-to-polish.txt"
+          # VERBOSE. No args = --all; the "Files to polish" list lands at its
+          # default location, output/files-to-polish.txt.
+          bash .agents/skills/release-notes/scripts/generate.sh
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -1397,7 +1397,7 @@ jobs:
           git add -A
           git diff --cached --binary > "$RUNNER_TEMP/prepare-out/prepare.patch"
           git reset -q
-          cp "$RUNNER_TEMP/files-to-polish.txt" "$RUNNER_TEMP/prepare-out/files-to-polish.txt"
+          cp output/files-to-polish.txt "$RUNNER_TEMP/prepare-out/files-to-polish.txt"
           echo "Patch size: $(wc -c < "$RUNNER_TEMP/prepare-out/prepare.patch") bytes"
           echo "Files to polish:"; cat "$RUNNER_TEMP/prepare-out/files-to-polish.txt" || true
       - name: Upload Prepare output

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -14,48 +14,122 @@ on:
 concurrency:
   group: update-release-notes
   cancel-in-progress: true
-# Cake regenerates the full historical API-diff tree from the NuGet feed and
-# Python regenerates every branch's raw data, so this is much longer than a
-# pure-AI run.
-timeout-minutes: 90
+# The agent only POLISHES prose now — the heavy, deterministic Prepare phase runs
+# in its own `prepare` job (below), so the agent's own budget is modest.
+timeout-minutes: 60
 permissions:
   contents: read
-# Python --all fetches the release/* refs it needs; full history is required so
-# it can walk each branch's commits.
+# The agent replays the Prepare patch onto a clean main checkout and polishes; it
+# needs main's history for create-pull-request's branch operations.
 checkout:
   - fetch-depth: 0
-# The deterministic Prepare phase (the generate.sh script) runs on the HOST before
-# the agent so the AI never waits on — or pays for — the long script runs.
-# Everything these steps write lands in the working tree and is captured into the
-# same PR as the agent's prose (Polish) edits.
+# ---------------------------------------------------------------------------
+# PREPARE — a dedicated, disk-managed, VERBOSE job on its own runner.
+#
+# The deterministic generators (Cake API-diff over EVERY published NuGet of BOTH
+# families incl. prereleases + Python raw data over every branch) are far too
+# disk- and time-heavy to share the agent runner: that combination exhausted the
+# hosted runner's disk on the first post-merge run (issue #4191). So Prepare gets
+# its OWN job with its OWN timeout and a free-disk-space step, runs verbose (all
+# progress visible in the job log), and hands its result to the agent as an
+# artifact — a git patch of every working-tree change plus the files-to-polish
+# list. See documentation/dev/release-notes-and-changelogs.md §2.2/§2.3.
+# ---------------------------------------------------------------------------
+jobs:
+  prepare:
+    name: Prepare (changelogs + release-notes raw data)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Free up disk space
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"; df -h /
+          # Drop large preinstalled toolchains we never use here so the NuGet
+          # diff (every package of both families) has room. setup-dotnet below
+          # reinstalls the pinned SDK after we clear the preinstalled one.
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup \
+                      /usr/share/swift /usr/share/dotnet/sdk 2>/dev/null || true
+          sudo docker image prune --all --force 2>/dev/null || true
+          echo "Disk after cleanup:"; df -h /
+      - name: Start from a clean main tree
+        run: |
+          set -euo pipefail
+          # Release notes/changelogs always target main; a push to release/* is a
+          # content *source*, not the PR base, so generate from origin/main.
+          git fetch origin main --quiet
+          git checkout -B main origin/main
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+      - name: Generate (verbose)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Single entry point: Cake (API changelogs) then Python (raw data), both
+          # VERBOSE, writing the "Files to polish" list to a file. No args = --all.
+          bash .agents/skills/release-notes/scripts/generate.sh \
+            --polish-list "$RUNNER_TEMP/files-to-polish.txt"
+      - name: Package Prepare output
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/prepare-out"
+          # Capture EVERY working-tree change (the releases tree, the co-release
+          # map sidecar, the author cache, and any deletions/pruning) as one patch
+          # so the agent can replay it onto a clean main checkout.
+          git add -A
+          git diff --cached --binary > "$RUNNER_TEMP/prepare-out/prepare.patch"
+          git reset -q
+          cp "$RUNNER_TEMP/files-to-polish.txt" "$RUNNER_TEMP/prepare-out/files-to-polish.txt"
+          echo "Patch size: $(wc -c < "$RUNNER_TEMP/prepare-out/prepare.patch") bytes"
+          echo "Files to polish:"; cat "$RUNNER_TEMP/prepare-out/files-to-polish.txt" || true
+      - name: Upload Prepare output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.4.3
+        with:
+          name: release-notes-prepare
+          path: ${{ runner.temp }}/prepare-out
+          retention-days: 1
+          if-no-files-found: error
+# ---------------------------------------------------------------------------
+# POLISH — the agent restores Prepare's output, then edits prose only.
+# These steps run in the agent job after its checkout and before the engine.
+# ---------------------------------------------------------------------------
 pre-agent-steps:
   - name: Start from a clean main tree
     run: |
       set -euo pipefail
-      # Release notes/changelogs always target main. A push to release/* is a
-      # content *source*, not the PR base, so rebase onto origin/main first to
-      # avoid leaking release-branch-only files into the main-targeted PR.
       mkdir -p /tmp/gh-aw
       git fetch origin main --quiet
       git checkout -B main origin/main
-  - name: Setup .NET
-    uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+  - name: Download Prepare output
+    uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4.1.8
     with:
-      global-json-file: global.json
-  - name: Generate changelogs + release-notes raw data
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GITHUB_TOKEN: ${{ github.token }}
+      name: release-notes-prepare
+      path: /tmp/gh-aw/prepare-in
+  - name: Restore Prepare output
     run: |
       set -euo pipefail
-      # Single entry point: runs Cake (API changelogs) then Python (raw data) in
-      # order and prints the "Files to polish" list. Tee it so the agent can read
-      # exactly which pages to polish. No args = full regeneration (Python --all).
-      bash .agents/skills/release-notes/scripts/generate.sh \
-        | tee /tmp/gh-aw/files-to-polish.txt
+      # The files-to-polish list the agent reads (spec §2.3).
+      cp /tmp/gh-aw/prepare-in/files-to-polish.txt /tmp/gh-aw/files-to-polish.txt
+      # Replay Prepare's working-tree changes; an empty patch = nothing changed.
+      if [ -s /tmp/gh-aw/prepare-in/prepare.patch ]; then
+        git apply --3way --whitespace=nowarn /tmp/gh-aw/prepare-in/prepare.patch
+        echo "Applied Prepare patch."
+      else
+        echo "Prepare produced no changes; nothing to apply."
+      fi
 tools:
-  # The agent only reads the generated files and rewrites prose — it must NOT run
-  # the scripts (they already ran above). No python3 here on purpose.
+  # The agent only reads the restored files and rewrites prose — it must NOT run
+  # the scripts (they already ran in the prepare job). No python3 here on purpose.
   bash: ["cat", "grep", "sort", "head", "tail", "sed", "awk", "git"]
   edit:
 # The agent has no network: it only polishes prose from already-generated files.
@@ -73,23 +147,26 @@ safe-outputs:
 # Update Release Notes & API Changelogs
 
 This is the single pipeline that keeps the website release notes **and** the API
-changelogs current — there is no separate api-diff workflow. It runs the
-deterministic generators on the host, then uses the AI to polish prose, and opens
-**one** pull request with everything.
+changelogs current — there is no separate api-diff workflow. The deterministic
+generators run in a dedicated **`prepare`** job, the agent then polishes prose,
+and **one** pull request ships everything.
 
 ## What already ran: the Prepare phase (do NOT re-run)
 
-Before you (the agent) started, a host step already ran the skill's **Prepare**
-phase — the single script `.agents/skills/release-notes/scripts/generate.sh`, which
-in turn:
+Before you (the agent) started, a **separate `prepare` job** ran the skill's
+**Prepare** phase on its own disk-managed runner — the single script
+`.agents/skills/release-notes/scripts/generate.sh`, which in turn:
 
 1. ran **Cake** (`docs-api-diff-past`) to regenerate the complete API-diff tree and
    `co-release-map.json` sidecar under `documentation/docfx/releases/`, then
 2. ran **Python** (`generate-release-notes.py --all`) to regenerate every version
-   page's raw-data block, write the deterministic page→API-diff links, and print the
-   **"Files to polish"** list (teed to `/tmp/gh-aw/files-to-polish.txt`).
+   page's raw-data block, write the deterministic page→API-diff links, and write
+   the **"Files to polish"** list.
 
-These changes are already on disk. **Do not run `generate.sh`, `dotnet cake`, the
+The `prepare` job uploaded its complete working-tree change as a patch plus that
+list as an artifact, and a host step **already restored both** into this checkout:
+the regenerated files are on disk, and the list is at
+`/tmp/gh-aw/files-to-polish.txt`. **Do not run `generate.sh`, `dotnet cake`, the
 Python script, or `git commit`/`git push`.** Your job is the Polish phase only.
 
 ## Your job: the Polish phase
@@ -100,9 +177,10 @@ in its **unattended** mode: the Prepare phase already ran, so skip it and go str
 to **Polish**.
 
 1. Read `/tmp/gh-aw/files-to-polish.txt`. It lists exactly the pages under
-   `documentation/docfx/releases/` whose raw data changed this run.
-2. If it says **"(none — all files up to date)"** or is empty, make **no edits**
-   and exit — leave any existing PR untouched. No PR will be created.
+   `documentation/docfx/releases/` whose raw data changed this run (one
+   repo-relative path per line).
+2. If it is **empty**, make **no edits** and exit — leave any existing PR
+   untouched. No PR will be created.
 3. Otherwise, for **each** listed file, follow the skill: rewrite only the human
    prose, keeping every script-owned region verbatim — the raw-data HTML comment
    block, the `> **API changes**` link line, and the `## Links` entries. Never
@@ -112,7 +190,7 @@ to **Polish**.
 ## How the PR is made
 
 The `create-pull-request` safe-output captures **all** working-tree changes —
-the Cake tree, the Python raw data, and your prose edits — into one PR targeting
-`main` on the single `bot/release-notes` branch. You do not git commit or push.
-If nothing changed (scripts produced no diff and you made no edits), no PR is
-opened or updated.
+the restored Prepare output (Cake tree + Python raw data) and your prose edits —
+into one PR targeting `main` on the single `bot/release-notes` branch. You do not
+git commit or push. If nothing changed (Prepare produced an empty patch and you
+made no edits), no PR is opened or updated.

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -76,9 +76,9 @@ jobs:
         run: |
           set -euo pipefail
           # Single entry point: Cake (API changelogs) then Python (raw data), both
-          # VERBOSE, writing the "Files to polish" list to a file. No args = --all.
-          bash .agents/skills/release-notes/scripts/generate.sh \
-            --polish-list "$RUNNER_TEMP/files-to-polish.txt"
+          # VERBOSE. No args = --all; the "Files to polish" list lands at its
+          # default location, output/files-to-polish.txt.
+          bash .agents/skills/release-notes/scripts/generate.sh
       - name: Package Prepare output
         run: |
           set -euo pipefail
@@ -89,7 +89,7 @@ jobs:
           git add -A
           git diff --cached --binary > "$RUNNER_TEMP/prepare-out/prepare.patch"
           git reset -q
-          cp "$RUNNER_TEMP/files-to-polish.txt" "$RUNNER_TEMP/prepare-out/files-to-polish.txt"
+          cp output/files-to-polish.txt "$RUNNER_TEMP/prepare-out/files-to-polish.txt"
           echo "Patch size: $(wc -c < "$RUNNER_TEMP/prepare-out/prepare.patch") bytes"
           echo "Files to polish:"; cat "$RUNNER_TEMP/prepare-out/files-to-polish.txt" || true
       - name: Upload Prepare output
@@ -118,8 +118,10 @@ pre-agent-steps:
   - name: Restore Prepare output
     run: |
       set -euo pipefail
-      # The files-to-polish list the agent reads (spec §2.3).
-      cp /tmp/gh-aw/prepare-in/files-to-polish.txt /tmp/gh-aw/files-to-polish.txt
+      # The skill always reads output/files-to-polish.txt — put it back at that same
+      # path so the agent's Polish phase is identical to a manual run.
+      mkdir -p output
+      cp /tmp/gh-aw/prepare-in/files-to-polish.txt output/files-to-polish.txt
       # Replay Prepare's working-tree changes; an empty patch = nothing changed.
       if [ -s /tmp/gh-aw/prepare-in/prepare.patch ]; then
         git apply --3way --whitespace=nowarn /tmp/gh-aw/prepare-in/prepare.patch
@@ -166,7 +168,7 @@ Before you (the agent) started, a **separate `prepare` job** ran the skill's
 The `prepare` job uploaded its complete working-tree change as a patch plus that
 list as an artifact, and a host step **already restored both** into this checkout:
 the regenerated files are on disk, and the list is at
-`/tmp/gh-aw/files-to-polish.txt`. **Do not run `generate.sh`, `dotnet cake`, the
+`output/files-to-polish.txt`. **Do not run `generate.sh`, `dotnet cake`, the
 Python script, or `git commit`/`git push`.** Your job is the Polish phase only.
 
 ## Your job: the Polish phase
@@ -176,7 +178,7 @@ Use the **release-notes skill**
 in its **unattended** mode: the Prepare phase already ran, so skip it and go straight
 to **Polish**.
 
-1. Read `/tmp/gh-aw/files-to-polish.txt`. It lists exactly the pages under
+1. Read `output/files-to-polish.txt`. It lists exactly the pages under
    `documentation/docfx/releases/` whose raw data changed this run (one
    repo-relative path per line).
 2. If it is **empty**, make **no edits** and exit — leave any existing PR

--- a/documentation/dev/release-notes-and-changelogs.md
+++ b/documentation/dev/release-notes-and-changelogs.md
@@ -289,13 +289,16 @@ The two jobs hand off through a **workflow artifact**, never a shared runner. Th
 `prepare` job uploads (a) all of its working-tree changes (the regenerated `releases/`
 tree — pages, API-diff folders, and the co-release-map sidecar) and (b) the
 `files-to-polish.txt` list. The agent job declares `needs: prepare`, downloads the
-artifact, and restores those changes into a clean checkout *before* the agent starts.
-The agent then runs the **Polish** phase (§2.2) with **no network and no
-`python3`/`cake` access** — it reads `files-to-polish.txt` first and edits only the
-prose of the listed pages. The `create-pull-request` safe-output captures the *combined*
-working-tree diff (restored Prepare output + agent prose edits) into the single PR, so
-both artifacts always ship together. If `files-to-polish.txt` is empty **and** the
-restored tree has no diff, no PR is opened (§4.6 idempotency).
+artifact, and restores those changes into a clean checkout *before* the agent starts:
+the working-tree changes are re-applied and the list is placed back at
+`output/files-to-polish.txt` — the **same path a manual Prepare run writes** — so the
+Polish phase reads it from one place regardless of how it was triggered. The agent then
+runs the **Polish** phase (§2.2) with **no network and no `python3`/`cake` access** — it
+reads `output/files-to-polish.txt` first and edits only the prose of the listed pages.
+The `create-pull-request` safe-output captures the *combined* working-tree diff (restored
+Prepare output + agent prose edits) into the single PR, so both artifacts always ship
+together. If `files-to-polish.txt` is empty **and** the restored tree has no diff, no PR
+is opened (§4.6 idempotency).
 
 ---
 

--- a/documentation/dev/release-notes-and-changelogs.md
+++ b/documentation/dev/release-notes-and-changelogs.md
@@ -253,8 +253,9 @@ individually, so the run order lives in one place:
 
 Both generators run **verbose**: Cake and Python stream their progress to the job log so
 a long download or a disk/timeout failure is visible as it happens. The machine-readable
-"Files to polish" list is therefore *not* on stdout — Python writes it to a dedicated
-`files-to-polish.txt` file that the Polish phase reads (§2.3).
+"Files to polish" list is therefore *not* on stdout — Python **always** writes it to a
+file (`output/files-to-polish.txt` by default, overridable via `--polish-list`) that the
+Polish phase reads (§2.3).
 
 **Polish.** The AI (the skill) rewrites only the *prose* of the listed human pages
 (§4.4). It never creates, renames, or deletes files, never writes structural content or

--- a/documentation/dev/release-notes-and-changelogs.md
+++ b/documentation/dev/release-notes-and-changelogs.md
@@ -214,7 +214,8 @@ self-contained and the targets reflect the docs they produce:
 .agents/skills/release-notes/
   SKILL.md                       the AI's polish-only instructions (§4.4)
   scripts/
-    generate.sh                  wrapper: runs the two generators in order (§2.2)
+    generate.sh                  wrapper: runs the two generators in order, verbose,
+                                 and writes the Files-to-polish list to a file (§2.2)
     generate-release-notes.py    release-notes engine (§4)
     api-diff.cake                API-changelog engine (§5)
 ```
@@ -247,8 +248,13 @@ individually, so the run order lives in one place:
 - **Python (`generate-release-notes.py`)** regenerates the human pages' **raw-data
   blocks** (the structured in-page region the AI polishes from, §4.3) under `releases/`
   (§3.2) from git history, reads the co-release map sidecar (§3.6) to write the
-  deterministic page→API-diff links (including the HarfBuzz link), and prints the
-  "Files to polish" list.
+  deterministic page→API-diff links (including the HarfBuzz link), and writes the
+  "Files to polish" list **to a file** (§2.3).
+
+Both generators run **verbose**: Cake and Python stream their progress to the job log so
+a long download or a disk/timeout failure is visible as it happens. The machine-readable
+"Files to polish" list is therefore *not* on stdout — Python writes it to a dedicated
+`files-to-polish.txt` file that the Polish phase reads (§2.3).
 
 **Polish.** The AI (the skill) rewrites only the *prose* of the listed human pages
 (§4.4). It never creates, renames, or deletes files, never writes structural content or
@@ -269,16 +275,26 @@ tree. If nothing changed, no PR is opened. There is no separate "api-diff" vs
 (Pushing to `release/*` is a *git source* for content, not an emission trigger;
 emission is governed solely by §1.4.)
 
-**Deterministic steps run on the host; the AI only polishes.** The **Prepare** phase
-(the `generate.sh` script — Cake then Python, §2.2) runs as **pre-agent host
-steps**: ordinary GitHub-Actions steps with the .NET SDK and full network, executing
-*before* the AI agent starts. This keeps the long generation off the agent's clock
-and out of its (network-restricted) sandbox. The Python generator tees its "Files to
-polish" list to a file the agent reads. The agent then runs the **Polish** phase (§2.2)
-with **no network and no `python3`/`cake` access** — it can only edit prose. The
-`create-pull-request` safe-output captures the *combined* working-tree diff (host
-script output + agent prose edits) into the single PR, so both artifacts always ship
-together.
+**Prepare runs as a standalone job; the agent only polishes.** The **Prepare** phase
+(the `generate.sh` script — Cake then Python, §2.2) runs in its **own dedicated job**
+(`prepare`), separate from the agent job. It uses an ordinary GitHub-Actions runner with
+the .NET SDK and full network, and — because the historical API diff downloads *every*
+published package of *both* families — it owns a **free-disk-space step** and its **own
+`timeout-minutes`** so the heavy generation can't exhaust the agent runner's disk or
+clock. Giving Prepare its own machine is the whole point of the split: a download, disk,
+or timeout failure fails *Prepare* loudly and in isolation, not the agent mid-polish.
+
+The two jobs hand off through a **workflow artifact**, never a shared runner. The
+`prepare` job uploads (a) all of its working-tree changes (the regenerated `releases/`
+tree — pages, API-diff folders, and the co-release-map sidecar) and (b) the
+`files-to-polish.txt` list. The agent job declares `needs: prepare`, downloads the
+artifact, and restores those changes into a clean checkout *before* the agent starts.
+The agent then runs the **Polish** phase (§2.2) with **no network and no
+`python3`/`cake` access** — it reads `files-to-polish.txt` first and edits only the
+prose of the listed pages. The `create-pull-request` safe-output captures the *combined*
+working-tree diff (restored Prepare output + agent prose edits) into the single PR, so
+both artifacts always ship together. If `files-to-polish.txt` is empty **and** the
+restored tree has no diff, no PR is opened (§4.6 idempotency).
 
 ---
 
@@ -614,8 +630,10 @@ mapping, and — for a HarfBuzz page — its canonical SkiaSharp back-link targe
 even when the PR set is identical; likewise, a page that newly gains (or loses) an
 API-diff folder is rewritten to inject (or drop) the API-changes link — which is what
 backfills the link across historical pages on first run. Then regenerate `TOC.yml` +
-`index.md`. The "Files to polish" summary lists only genuinely-changed pages, so the AI
-never re-polishes an up-to-date page.
+`index.md`. The "Files to polish" list — written to the `files-to-polish.txt` file the
+Polish phase reads (§2.3) — names only genuinely-changed pages, so the AI never
+re-polishes an up-to-date page. When it is empty and the tree is unchanged, the workflow
+opens no PR (§2.3).
 
 ---
 
@@ -657,7 +675,8 @@ artifacts — never the committed `releases/` tree.
 ### 5.4 How it runs
 
 `dotnet cake … --target=…` for `api-diff.cake`, as the Cake generator of the §2.2
-**Prepare** phase inside the unified workflow (§2.3). There is no AI polish on the diffs
+**Prepare** phase, which runs in the workflow's dedicated `prepare` job (§2.3). There is
+no AI polish on the diffs
 themselves — the generated diff *is* the artifact; the human pages merely link to it
 (§1.5/§4.4).
 
@@ -706,3 +725,7 @@ page links straight to its API diffs.
    engine edits the other's files.
 7. **Prove no regression.** Both generators are idempotent: run before/after on a
    clean tree and diff the generated outputs; intended changes only.
+8. **Prepare is isolated and verbose.** The Prepare phase runs in its own job with its
+   own disk/timeout budget and streams progress to the log; it hands off to the Polish
+   agent **only** through the uploaded artifact (working-tree changes + the
+   `files-to-polish.txt` list), never a shared runner or stdout capture (§2.3).


### PR DESCRIPTION
## The problem

The first post-merge auto-run of the unified release-notes + API-changelog workflow ([run 27767832525](https://github.com/mono/SkiaSharp/actions/runs/27767832525), push to `main`) **failed with `No space left on device`** ~11.5 minutes into the Prepare step, opened no regeneration PR, and auto-filed failure issue #4191.

Root cause: the deterministic Prepare phase (`generate.sh` → Cake `docs-api-diff-past` + Python `--all`) ran as **pre-agent host steps inside the agent job**, sharing that runner's disk and clock. The historical API diff downloads *every* published package of *both* families (prereleases included). After the HarfBuzz peer family roughly doubled the download set, `Mono.ApiTools.NuGetDiff`'s package cache exhausted the ~14 GB hosted-runner disk and took the whole job down. The failure was also **invisible** until the job died, because `generate.sh` hid all Cake/Python progress to keep stdout clean for the "Files to polish" list.

## The fix

Redesign the Prepare phase so the heavy, network-bound generation can't starve or hide from the agent:

- **Standalone `prepare` job** with its own `timeout-minutes: 120` and a **free-disk-space** step (drops unused preinstalled toolchains before the NuGet diff), isolated from the agent runner — a download/disk/timeout failure now fails *Prepare* loudly and alone. The gh-aw compiler auto-adds `needs: prepare` to the agent and `needs: activation` to `prepare`, so skip-bots gating still guards the expensive work.
- **Verbose** generators: Cake and Python stream progress to the job log, so a slow download or a disk failure is visible as it happens.
- **Polish list to a file, always:** the machine-readable "Files to polish" list always goes to a file — `output/files-to-polish.txt` by default, or the `--polish-list` path — and **never** to stdout, in every mode (manual or CI). There is one contract, no stdout fallback; verbose progress streams to the log instead.
- **Artifact handoff:** `prepare` captures every working-tree change (the releases tree, the co-release-map sidecar, the author cache, any pruning) as a binary git patch, uploads it alongside the polish list, and the agent job downloads/restores both into a clean `origin/main` checkout (`git apply --3way`), reads the list, and polishes prose only — `python3` is removed from its tool allow-list. `create-pull-request` still captures the combined diff, and the empty-list + clean-tree case still opens no PR.

## Where to look

- **`documentation/dev/release-notes-and-changelogs.md`** — the behavior spec and source of truth (committed first). §2.1/§2.2/§2.3 describe the standalone job, verbose output, the always-a-file polish list, and artifact handoff; §4.6/§5.4 the file and job; §7.2 invariant 8 (Prepare is isolated and verbose) so this can't silently regress.
- **`.github/workflows/update-release-notes.md`** — the `jobs.prepare` block, the `pre-agent-steps` download/restore, and the recompiled `.lock.yml` (generated by `gh aw compile`; do not hand-edit). Worth confirming the job graph and the patch-replay-onto-clean-main approach.
- **`.agents/skills/release-notes/scripts/`** — `generate.sh` (verbose + `--polish-list`) and `generate-release-notes.py` (`write_polish_list()` always writes `output/files-to-polish.txt` by default). `SKILL.md` documents the separate job and the restored `/tmp/gh-aw/files-to-polish.txt`.

**Idempotency is preserved:** empty `files-to-polish.txt` *and* no working-tree diff ⇒ no PR. Once this lands and runs successfully, the first run also self-heals `main`'s 5 deleted SkiaSharp/HarfBuzz pages.

## Validation

A `workflow_dispatch` smoke test on this branch ([run 27773439793](https://github.com/mono/SkiaSharp/actions/runs/27773439793)) confirmed the job graph fires: `pre_activation ✓ → activation ✓ → prepare`, with the new **Free up disk space** and **clean-main** steps passing. Note this only validates the job *structure* — both jobs reset their tree to `origin/main` before running `generate.sh`, so the pipeline always executes **main's** scripts; the new scripts in this PR can only be exercised once it's merged (the post-merge push run, which auto-files an issue on failure).