### PR TITLE
Fix docs.cake moniker collision dropping iOS GL API docs

### DIFF
--- a/scripts/infra/docs/docs.cake
+++ b/scripts/infra/docs/docs.cake
@@ -17,6 +17,19 @@ DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../../.."));
 #load "../shared/download.cake"
 #load "../shared/api-diff-tools.cake"
 
+// Count every type (including nested) in an assembly. Used to keep the richest
+// build when several TFM folders contribute an assembly with the same file name
+// to a single docs moniker (see the staging loop in docs-update-frameworks).
+int CountAssemblyTypes (string path)
+{
+    try {
+        using (var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly (path))
+            return asm.Modules.Sum (m => m.GetTypes ().Count ());
+    } catch (Exception ex) {
+        Warning ("Could not read types from '{0}': {1}", path, ex.Message);
+        return 0;
+    }
+}
 
 Task ("docs-download-output")
     .Does (async () =>
@@ -109,10 +122,27 @@ Task ("docs-update-frameworks")
                         new XAttribute ("Source", moniker)));
             }
 
-            // stage this moniker's assemblies for mdoc to read
+            // stage this moniker's assemblies for mdoc to read. Several TFM folders
+            // feed the same family moniker (e.g. every SkiaSharp.Views.* ->
+            // skiasharp-views), and different TFMs can ship an assembly with the SAME
+            // file name but a different API surface. For example SkiaSharp.Views.iOS.dll
+            // exists for both net*-ios (which includes SKGLView / SKGLLayer /
+            // SKPaintGLSurfaceEventArgs) and net*-maccatalyst (which excludes them via
+            // #if !__MACCATALYST__). A plain copy lets whichever TFM is staged last win,
+            // so the GL-less MacCatalyst build can clobber the richer iOS build and
+            // mdoc's --delete then drops those real types from the committed docs. Keep
+            // the assembly with the most types on a name collision so no platform's API
+            // surface is lost.
             var o = $"{docsTempPathFrameowrks}/{moniker}";
             EnsureDirectoryExists (o);
-            CopyFiles ($"{path}/*.dll", o);
+            foreach (var dll in GetFiles ($"{path}/*.dll")) {
+                FilePath dest = $"{o}/{dll.GetFilename ()}";
+                if (FileExists (dest) && CountAssemblyTypes (dll.FullPath) <= CountAssemblyTypes (dest.FullPath)) {
+                    Verbose ("Keeping richer staged '{0}' for moniker '{1}'; skipping copy from '{2}'.", dll.GetFilename (), moniker, path);
+                    continue;
+                }
+                CopyFile (dll, dest);
+            }
         }
     }
     monikers.Sort ();


### PR DESCRIPTION
## Problem

The `docs-update-frameworks` task in `scripts/infra/docs/docs.cake` stages every TFM folder of a package family into a single moniker directory with a blind `CopyFiles ("{path}/*.dll", o)`.

When two TFMs ship an assembly with the **same file name but a different API surface**, the last copy wins. `SkiaSharp.Views.iOS.dll` exists for both:

- `net*-ios` — includes `SKGLView`, `SKGLLayer`, `SKPaintGLSurfaceEventArgs`
- `net*-maccatalyst` — excludes them via `#if !__MACCATALYST__`

The alpha-last MacCatalyst build clobbered the richer iOS build, so mdoc documented the GL-less assembly and its `--delete` pass **removed the real GL type docs** from the committed output. This is a regression from the moniker-merge work (#4192) and is OS-independent.

## Fix

Stage assemblies per-file instead of with a blind copy. On a file-name collision, keep the build with the **most types** so no platform's API surface is lost. Type counts are read with `Mono.Cecil` (already loaded via `api-diff-tools.cake`).

For `SkiaSharp.Views.iOS.dll`: net-iOS = 16 types vs MacCatalyst = 12 → net-iOS wins → GL docs survive.

## Validation

- `Mono.Cecil` type-count logic confirmed against the real shipped DLLs (16 vs 12).
- `dotnet cake scripts/infra/docs/docs.cake --target=docs-update-frameworks --dryrun` compiles cleanly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>