### PR TITLE
Fix release-branch skill integration-branch model and add bump-version helper

### DIFF
--- a/.agents/skills/release-branch/SKILL.md
+++ b/.agents/skills/release-branch/SKILL.md
@@ -42,9 +42,11 @@ Each one always sits at the *next unreleased version* for its line, with
 
 - **Every** release (preview, rc, stable, patch) is cut FROM the line's
   integration branch — `release/{version}` is branched off it.
-- After a release ships, the integration branch is **bumped** to the next
-  version (see Step 5). This applies to maintenance-line stables too, not just
-  previews from `main`.
+- **As soon as a stable is cut**, the integration branch is **bumped** to the
+  next version (see Step 5) — immediately, *not* after the release publishes.
+  After branching, PRs keep merging into the integration branch, and they must
+  land on the *next* version, not the one that was just cut. Fixes for the cut
+  release go on its own `release/{version}` branch.
 - A new minor's `release/X.Y.x` is forked from `main` when stabilization begins;
   `main` is then bumped to the next minor. From that point on, all `X.Y.*`
   releases come from `release/X.Y.x`, not `main`.
@@ -133,15 +135,23 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py release/{versio
 
 ---
 
-## Step 5: Bump the Integration Branch After Release
+## Step 5: Bump the Integration Branch (Immediately After Cutting a Stable)
 
-When a version is released (stable ships), advance that line's **integration
-branch** to the next version so future builds don't collide with the released
-version. Crucially this is **not** "preview-from-main only" — **maintenance-line
-stables bump too**: e.g. after `3.119.4` shipped, `release/3.119.x` was bumped to
-`3.119.5` ("Bump to the next version after release"). Previews/RCs of an
-in-progress version do **not** bump it (they all share the same `X.Y.Z`); the
-bump happens once that `X.Y.Z` is released.
+**Do this right after Step 4** — as soon as the stable release branch is cut and
+pushed, advance that line's **integration branch** to the next version. Do **not**
+wait for the release to publish.
+
+Why immediately: once `release/{version}` is branched off, PRs keep merging into
+the integration branch (`release/X.Y.x`, and `main` for its line). Those changes
+must land on the **next** version, not the one that was just cut. Any fixes for
+the cut release go onto its own `release/{version}` branch instead. If the
+integration branch isn't bumped at cut time, post-branch merges collide with the
+released version.
+
+Previews/RCs do **not** trigger this — they're iterations toward the same
+`X.Y.Z`. Cutting the **stable** does, because that finalizes `X.Y.Z`. (e.g. when
+`3.119.4` was cut, `release/3.119.x` was bumped to `3.119.5` — "Bump to the next
+version after release".)
 
 **How each line advances:**
 

--- a/.agents/skills/release-branch/SKILL.md
+++ b/.agents/skills/release-branch/SKILL.md
@@ -135,30 +135,31 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py release/{versio
 
 ## Step 5: Bump the Integration Branch After Release
 
-When a version is released (stable ships) or a line otherwise moves on, bump that
-line's **integration branch** to the next version so future builds don't collide
-with the released version. Crucially this is **not** "preview-from-main only" —
-**maintenance-line stables bump too**: e.g. after `3.119.4` shipped,
-`release/3.119.x` was bumped to `3.119.5` ("Bump to the next version after
-release"). Previews/RCs of an in-progress version do **not** bump it (they all
-share the same `X.Y.Z`); the bump happens once that `X.Y.Z` is released.
+When a version is released (stable ships), advance that line's **integration
+branch** to the next version so future builds don't collide with the released
+version. Crucially this is **not** "preview-from-main only" — **maintenance-line
+stables bump too**: e.g. after `3.119.4` shipped, `release/3.119.x` was bumped to
+`3.119.5` ("Bump to the next version after release"). Previews/RCs of an
+in-progress version do **not** bump it (they all share the same `X.Y.Z`); the
+bump happens once that `X.Y.Z` is released.
 
-**Which integration branch / next version:**
+**How each line advances:**
 
-| Released line | Integration branch to bump | Next version |
-|---------------|----------------------------|--------------|
-| Newest line (cut from `main`) | `main` | next **minor** (`X.Y.0` → `X.(Y+next).0`) |
-| Maintenance line (cut from `release/X.Y.x`) | `release/X.Y.x` | next **patch** (`X.Y.Z` → `X.Y.(Z+1)`) |
+| Released line | Integration branch | How it advances |
+|---------------|--------------------|-----------------|
+| Maintenance line | `release/X.Y.x` | Next **patch** (`X.Y.Z` → `X.Y.(Z+1)`) — use the helper below. `assembly` stays pinned at `X.Y.0.0`; only `file` / `nuget` / `SKIASHARP_VERSION` move. |
+| Newest line | `main` | Next **minor** (`X.Y` → next milestone). This is a **Skia milestone update** (e.g. `[skia-sync] Update Skia to milestone mNNN`) that also rewrites the milestone/soname/increment lines, `assembly`, `cgmanifest.json` and native sources — a **separate process, not this helper.** |
 
-> This step only advances the **version numbers**. Native/milestone source changes
-> (Skia upgrades, soname, increments) are a separate activity and out of scope here.
+> The helper below covers the **maintenance-line patch bump only**. It refuses a
+> `major.minor` change (that's a milestone update — out of scope).
 
-1. Create branch `bump-version-{next}` from the integration branch
+1. Create branch `bump-version-{next}` from the maintenance branch
    (e.g. `git checkout -b bump-version-{next} origin/release/X.Y.x`)
 
-2. Apply the bump with the helper script. It edits + verifies `SKIASHARP_VERSION`
-   in `azure-templates-variables.yml` and all SkiaSharp / HarfBuzzSharp
-   `file`+`nuget` lines in `VERSIONS.txt` (assembly versions are left untouched):
+2. Apply the patch bump with the helper script. It edits + verifies
+   `SKIASHARP_VERSION` in `azure-templates-variables.yml` and all SkiaSharp /
+   HarfBuzzSharp `file`+`nuget` lines in `VERSIONS.txt` (SkiaSharp `assembly`
+   stays `X.Y.0.0`, HarfBuzzSharp `assembly` stays `1.0.0.0`):
    ```bash
    pwsh .agents/skills/release-branch/scripts/bump-version.ps1 \
      -SkiaSharpVersion {next} \

--- a/.agents/skills/release-branch/SKILL.md
+++ b/.agents/skills/release-branch/SKILL.md
@@ -25,7 +25,29 @@ Create release branches for SkiaSharp versions.
 | SkiaSharp (parent) | `main` | Create `release/X.Y.Z` branch, never commit to main |
 | externals/skia (submodule) | `main`, `skiasharp` | Must use feature branch if submodule changes needed |
 
-**Release branches are created FROM main, but never modify main directly.**
+**Release branches are cut FROM an integration branch (`main` or `release/X.Y.x`), but never modify those branches directly — always go through a branch + PR.**
+
+---
+
+## Concept: Integration Branches
+
+There is **not one "main"** — there is an **integration branch per release line**.
+Each one always sits at the *next unreleased version* for its line, with
+`PREVIEW_LABEL: preview.0`:
+
+| Integration branch | Line it serves | Example state |
+|--------------------|----------------|---------------|
+| `main` | Newest in-development line (not yet forked) | `4.150.0` / `preview.0` |
+| `release/X.Y.x` | An established / maintenance line | `release/3.119.x` @ `3.119.5`; `release/4.148.x` @ `4.148.0` |
+
+- **Every** release (preview, rc, stable, patch) is cut FROM the line's
+  integration branch — `release/{version}` is branched off it.
+- After a release ships, the integration branch is **bumped** to the next
+  version (see Step 5). This applies to maintenance-line stables too, not just
+  previews from `main`.
+- A new minor's `release/X.Y.x` is forked from `main` when stabilization begins;
+  `main` is then bumped to the next minor. From that point on, all `X.Y.*`
+  releases come from `release/X.Y.x`, not `main`.
 
 ---
 
@@ -33,7 +55,7 @@ Create release branches for SkiaSharp versions.
 
 ### Auto-detect (user says "release now")
 
-1. Fetch main and read `SKIASHARP_VERSION` from `scripts/azure-templates-variables.yml`
+1. Fetch the integration branch (`main` for the newest line, or `release/X.Y.x` for a maintenance line) and read `SKIASHARP_VERSION` from `scripts/azure-templates-variables.yml`
 2. List existing branches: `git branch -r | grep "release/{version}-preview"`
 3. Next preview = highest + 1 (or 1 if none)
 4. **⚠️ Semver check:** Also verify no bare `release/{version}` branch exists — if it does, the stable release is already cut and you should NOT create another preview. Ask the user to confirm.
@@ -51,14 +73,22 @@ Use the provided version directly.
 branches to find the latest, remember that `release/3.119.2` > `release/3.119.2-preview.3`.
 Do NOT use alphabetical sorting — it gives wrong results for semver.
 
-| Version Format | Type | Base | PREVIEW_LABEL |
-|----------------|------|------|---------------|
-| `X.Y.Z-preview.N` | Preview | `main` | `preview.N` |
-| `X.Y.Z` | Stable | `release/X.Y.Z-preview.{latest}` | `stable` |
+| Version Format | Type | Base (integration branch) | PREVIEW_LABEL |
+|----------------|------|---------------------------|---------------|
+| `X.Y.Z-preview.N` / `X.Y.Z-rc.N` | Preview / RC | `release/X.Y.x` (or `main` if the line isn't forked yet) | `preview.N` / `rc.N` |
+| `X.Y.Z` | Stable | `release/X.Y.x` | `stable` |
 | `X.Y.Z.F-preview.N` | Hotfix Preview | tag `vX.Y.Z` | `preview.N` |
 | `X.Y.Z.F` | Hotfix Stable | `release/X.Y.Z.F-preview.{latest}` | `stable` |
 
-For stable releases, find latest preview: `git branch -r | grep "release/X.Y.Z-preview" | sort -V | tail -1`
+> **Base = the line's integration branch**, NOT a previous preview/rc branch.
+> A stable `X.Y.Z` is cut from `release/X.Y.x` (which already produced its
+> previews/rcs), not from `release/X.Y.Z-preview.{latest}`.
+>
+> Find the integration branch:
+> ```bash
+> git branch -r | grep -E "release/X\.Y\.x$"   # established line (substitute real X.Y)
+> # newest line not yet forked → use main
+> ```
 
 **NuGet version format by release type:**
 - **Preview:** `{base}-{PREVIEW_LABEL}.{build}` (e.g., `3.119.2-preview.2.3`) — build number is part of the prerelease tag
@@ -68,11 +98,17 @@ For stable releases, find latest preview: `git branch -r | grep "release/X.Y.Z-p
 
 ## Step 3: Create Branch and Update PREVIEW_LABEL
 
-1. Checkout the base (main, preview branch, or tag)
+1. Checkout the base — the line's **integration branch** (`release/X.Y.x`, or
+   `main` / a tag for the special cases above)
 2. Create branch `release/{version}`
-3. Edit `scripts/azure-templates-variables.yml`: set `PREVIEW_LABEL`
+3. Set `PREVIEW_LABEL` with the helper script (edits + verifies
+   `scripts/azure-templates-variables.yml`):
+   ```bash
+   pwsh .agents/skills/release-branch/scripts/bump-version.ps1 -PreviewLabel {label}
+   # {label} = stable | preview.N | rc.N   (add -DryRun to preview)
+   ```
 4. Commit: `git commit -m "Bump the version to {version}"`
-5. Show diff summary to user and **confirm with `ask_user`** before pushing
+5. Show diff summary to user and **confirm with the user** before pushing
 
 ---
 
@@ -97,25 +133,46 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py release/{versio
 
 ---
 
-## Step 5: Bump Version on Main (Preview from main only)
+## Step 5: Bump the Integration Branch After Release
 
-**Skip for stable and hotfix releases.**
+When a version is released (stable ships) or a line otherwise moves on, bump that
+line's **integration branch** to the next version so future builds don't collide
+with the released version. Crucially this is **not** "preview-from-main only" —
+**maintenance-line stables bump too**: e.g. after `3.119.4` shipped,
+`release/3.119.x` was bumped to `3.119.5` ("Bump to the next version after
+release"). Previews/RCs of an in-progress version do **not** bump it (they all
+share the same `X.Y.Z`); the bump happens once that `X.Y.Z` is released.
 
-1. Create branch `bump-version-{next}` from main
+**Which integration branch / next version:**
 
-2. Edit `scripts/azure-templates-variables.yml`:
-   - Update `SKIASHARP_VERSION` to next version
-   - Reset `PREVIEW_LABEL` to `preview.0`
+| Released line | Integration branch to bump | Next version |
+|---------------|----------------------------|--------------|
+| Newest line (cut from `main`) | `main` | next **minor** (`X.Y.0` → `X.(Y+next).0`) |
+| Maintenance line (cut from `release/X.Y.x`) | `release/X.Y.x` | next **patch** (`X.Y.Z` → `X.Y.(Z+1)`) |
 
-3. Edit `scripts/VERSIONS.txt`:
-   - `SkiaSharp file` → `{next}.0`
-   - All `SkiaSharp ... nuget` lines → `{next}`
-   - `HarfBuzzSharp file` → increment 4th digit (e.g., `8.3.1.4` → `8.3.1.5`)
-   - All `HarfBuzzSharp ... nuget` lines → same as file version
+> This step only advances the **version numbers**. Native/milestone source changes
+> (Skia upgrades, soname, increments) are a separate activity and out of scope here.
 
-4. Commit: `git commit -m "Bump to the next version ({next}) after release"`
+1. Create branch `bump-version-{next}` from the integration branch
+   (e.g. `git checkout -b bump-version-{next} origin/release/X.Y.x`)
 
-5. Show diff to user, then:
+2. Apply the bump with the helper script. It edits + verifies `SKIASHARP_VERSION`
+   in `azure-templates-variables.yml` and all SkiaSharp / HarfBuzzSharp
+   `file`+`nuget` lines in `VERSIONS.txt` (assembly versions are left untouched):
+   ```bash
+   pwsh .agents/skills/release-branch/scripts/bump-version.ps1 \
+     -SkiaSharpVersion {next} \
+     -HarfBuzzSharpVersion {hb-next} \
+     -PreviewLabel preview.0
+   # add -DryRun first to preview
+   ```
+   - `{hb-next}`: the next HarfBuzzSharp version — normally increment the last
+     digit (`8.3.1.4` → `8.3.1.5`); on a native HarfBuzz upgrade, reset to the
+     3-digit native version (e.g. `14.2.0`).
+
+3. Commit: `git commit -m "Bump to the next version ({next}) after release"`
+
+4. Show diff to user, then:
    ```bash
    git push -u origin bump-version-{next}
    gh pr create --title "Bump to the next version ({next}) after release" --body ""
@@ -126,4 +183,5 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py release/{versio
 
 ## Resources
 
+- [scripts/bump-version.ps1](scripts/bump-version.ps1) — Sets `PREVIEW_LABEL` and/or bumps SkiaSharp + HarfBuzzSharp versions in `VERSIONS.txt` and `azure-templates-variables.yml`, with a verification gate (`-DryRun` to preview)
 - [releasing.md](../../../documentation/dev/releasing.md) — Version patterns, HarfBuzz versioning, workflow diagrams

--- a/.agents/skills/release-branch/SKILL.md
+++ b/.agents/skills/release-branch/SKILL.md
@@ -177,9 +177,10 @@ version after release".)
      -PreviewLabel preview.0
    # add -DryRun first to preview
    ```
-   - `{hb-next}`: the next HarfBuzzSharp version — normally increment the last
-     digit (`8.3.1.4` → `8.3.1.5`); on a native HarfBuzz upgrade, reset to the
-     3-digit native version (e.g. `14.2.0`).
+   - `{hb-next}`: the next HarfBuzzSharp version — normally increment/append the
+     **4th** digit in lockstep with the SkiaSharp patch (`14.2.0` → `14.2.0.1`,
+     `8.3.1.4` → `8.3.1.5`); only on an actual native HarfBuzz upgrade do you
+     reset to the 3-digit native version (e.g. `14.3.0`).
 
 3. Commit: `git commit -m "Bump to the next version ({next}) after release"`
 

--- a/.agents/skills/release-branch/scripts/bump-version.ps1
+++ b/.agents/skills/release-branch/scripts/bump-version.ps1
@@ -24,8 +24,14 @@
     Two independent operations, usable together or alone:
       1. Set label only (Step 3 — create release branch):
              -PreviewLabel stable
-      2. Bump versions (Step 5 — bump integration branch after a release):
+      2. Bump to the next PATCH (Step 5 — advance a maintenance line after a
+         stable ships, e.g. 4.148.0 -> 4.148.1):
              -SkiaSharpVersion 4.148.1 -HarfBuzzSharpVersion 14.2.1 -PreviewLabel preview.0
+
+    Scope: label changes and PATCH bumps only. A change to the major.minor is a
+    Skia milestone update (it also rewrites the milestone/soname/increment lines,
+    cgmanifest.json and native sources) and is intentionally out of scope — the
+    script refuses it.
 
     A bump requires BOTH -SkiaSharpVersion and -HarfBuzzSharpVersion. The caller
     decides the exact HarfBuzzSharp version (4-digit X.Y.Z.N normally; reset to
@@ -93,6 +99,20 @@ $pipelinePath = Join-Path $repoRoot 'scripts/azure-templates-variables.yml'
 foreach ($p in @($versionsPath, $pipelinePath)) {
     if (-not (Test-Path $p)) {
         Write-Error "Expected file not found: $p. If it was renamed, update this script."
+    }
+}
+
+# --- Guard: refuse major.minor changes (those are Skia milestone updates) ----
+if ($doBump) {
+    $curAssembly = Get-Content $versionsPath |
+        Where-Object { $_ -match '^SkiaSharp\s+assembly\s+(?<maj>\d+)\.(?<min>\d+)\.' } |
+        Select-Object -First 1
+    if ($curAssembly -match '^SkiaSharp\s+assembly\s+(?<maj>\d+)\.(?<min>\d+)\.') {
+        $curMajorMinor = "$($Matches['maj']).$($Matches['min'])"
+        $newMajorMinor = ($SkiaSharpVersion -split '\.')[0..1] -join '.'
+        if ($curMajorMinor -ne $newMajorMinor) {
+            Write-Error "SkiaSharp major.minor would change ($curMajorMinor -> $newMajorMinor). That is a Skia milestone update (it also rewrites the milestone/soname/increment lines, assembly, cgmanifest.json and native sources) and is out of scope for this helper, which only does label changes and patch bumps."
+        }
     }
 }
 

--- a/.agents/skills/release-branch/scripts/bump-version.ps1
+++ b/.agents/skills/release-branch/scripts/bump-version.ps1
@@ -1,0 +1,213 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Apply SkiaSharp release version edits: set the prerelease label and/or bump
+    the package versions on an integration branch.
+
+.DESCRIPTION
+    Applies only the version edits a SkiaSharp release needs. It does NOT touch
+    milestone/soname/increment values, cgmanifest.json, or sk_types.h — only the
+    two files a release version change needs:
+
+    - scripts/azure-templates-variables.yml
+        * SKIASHARP_VERSION   (when -SkiaSharpVersion is given)
+        * PREVIEW_LABEL       (when -PreviewLabel is given)
+    - scripts/VERSIONS.txt    (only when bumping versions)
+        * SkiaSharp    file   -> {SkiaSharpVersion}.0
+        * SkiaSharp*   nuget  -> {SkiaSharpVersion}
+        * HarfBuzzSharp file  -> {HarfBuzzSharpVersion}
+        * HarfBuzzSharp* nuget-> {HarfBuzzSharpVersion}
+
+    Assembly versions are NEVER changed (they are intentionally pinned to
+    major.minor.0.0 / 1.0.0.0 and must stay stable across patch releases).
+
+    Two independent operations, usable together or alone:
+      1. Set label only (Step 3 — create release branch):
+             -PreviewLabel stable
+      2. Bump versions (Step 5 — bump integration branch after a release):
+             -SkiaSharpVersion 4.148.1 -HarfBuzzSharpVersion 14.2.1 -PreviewLabel preview.0
+
+    A bump requires BOTH -SkiaSharpVersion and -HarfBuzzSharpVersion. The caller
+    decides the exact HarfBuzzSharp version (4-digit X.Y.Z.N normally; reset to
+    3-digit on a native HarfBuzz upgrade), so this script never guesses it.
+
+.PARAMETER SkiaSharpVersion
+    Target SkiaSharp nuget version, e.g. 4.148.1. Requires -HarfBuzzSharpVersion.
+
+.PARAMETER HarfBuzzSharpVersion
+    Target HarfBuzzSharp nuget version, e.g. 14.2.1 or 8.3.1.7. Requires
+    -SkiaSharpVersion.
+
+.PARAMETER PreviewLabel
+    Value for PREVIEW_LABEL: 'stable', 'preview.N', 'rc.N', or 'preview.0'.
+
+.PARAMETER DryRun
+    Show the planned changes and run the verification gate against the would-be
+    result, but do not write any files.
+
+.EXAMPLE
+    # Step 3 — cut a stable release branch
+    pwsh .agents/skills/release-branch/scripts/bump-version.ps1 -PreviewLabel stable
+
+.EXAMPLE
+    # Step 5 — bump the integration branch to the next patch after a release
+    pwsh .agents/skills/release-branch/scripts/bump-version.ps1 `
+        -SkiaSharpVersion 4.148.1 -HarfBuzzSharpVersion 14.2.1 -PreviewLabel preview.0
+#>
+
+param(
+    [string]$SkiaSharpVersion,
+    [string]$HarfBuzzSharpVersion,
+    [string]$PreviewLabel,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = git rev-parse --show-toplevel
+
+$doBump  = $PSBoundParameters.ContainsKey('SkiaSharpVersion') -or $PSBoundParameters.ContainsKey('HarfBuzzSharpVersion')
+$doLabel = $PSBoundParameters.ContainsKey('PreviewLabel')
+
+if (-not $doBump -and -not $doLabel) {
+    Write-Error "Nothing to do. Provide -PreviewLabel and/or (-SkiaSharpVersion AND -HarfBuzzSharpVersion)."
+}
+if ($doBump -and (-not $SkiaSharpVersion -or -not $HarfBuzzSharpVersion)) {
+    Write-Error "A version bump requires BOTH -SkiaSharpVersion and -HarfBuzzSharpVersion."
+}
+
+# --- Validate formats -------------------------------------------------------
+if ($doBump) {
+    if ($SkiaSharpVersion -notmatch '^\d+\.\d+\.\d+$') {
+        Write-Error "SkiaSharpVersion '$SkiaSharpVersion' must be X.Y.Z (e.g. 4.148.1)."
+    }
+    if ($HarfBuzzSharpVersion -notmatch '^\d+(\.\d+){2,3}$') {
+        Write-Error "HarfBuzzSharpVersion '$HarfBuzzSharpVersion' must be 3- or 4-part (e.g. 14.2.1 or 8.3.1.7)."
+    }
+}
+if ($doLabel -and $PreviewLabel -notmatch '^(stable|preview\.\d+|rc\.\d+)$') {
+    Write-Error "PreviewLabel '$PreviewLabel' must be 'stable', 'preview.N', or 'rc.N'."
+}
+
+$versionsPath = Join-Path $repoRoot 'scripts/VERSIONS.txt'
+$pipelinePath = Join-Path $repoRoot 'scripts/azure-templates-variables.yml'
+foreach ($p in @($versionsPath, $pipelinePath)) {
+    if (-not (Test-Path $p)) {
+        Write-Error "Expected file not found: $p. If it was renamed, update this script."
+    }
+}
+
+$mode = if ($DryRun) { ' (dry run)' } else { '' }
+Write-Host "`n=== Release version update$mode ===" -ForegroundColor Cyan
+
+# ---------------------------------------------------------------------------
+# scripts/VERSIONS.txt
+# ---------------------------------------------------------------------------
+$assemblyBefore = $null
+if ($doBump) {
+    Write-Host "`n--- scripts/VERSIONS.txt ---" -ForegroundColor Yellow
+    $lines = Get-Content $versionsPath
+    $assemblyBefore = ($lines | Where-Object { $_ -match '^SkiaSharp\s+assembly\s' })
+
+    $skiaFileVer = "$SkiaSharpVersion.0"
+    $newLines = foreach ($line in $lines) {
+        if     ($line -match '^(SkiaSharp\s+file\s+)\S+\s*$')         { ($Matches[1] + $skiaFileVer) }
+        elseif ($line -match '^(SkiaSharp\S*\s+nuget\s+)\S+\s*$')     { ($Matches[1] + $SkiaSharpVersion) }
+        elseif ($line -match '^(HarfBuzzSharp\s+file\s+)\S+\s*$')     { ($Matches[1] + $HarfBuzzSharpVersion) }
+        elseif ($line -match '^(HarfBuzzSharp\S*\s+nuget\s+)\S+\s*$') { ($Matches[1] + $HarfBuzzSharpVersion) }
+        else { $line }
+    }
+
+    if ($DryRun) {
+        $diff = Compare-Object $lines $newLines | Where-Object SideIndicator -eq '=>'
+        $diff | ForEach-Object { Write-Host "  + $($_.InputObject)" -ForegroundColor DarkGray }
+    } else {
+        Set-Content $versionsPath $newLines
+    }
+    Write-Host "  SkiaSharp     -> $SkiaSharpVersion (file $skiaFileVer)" -ForegroundColor Green
+    Write-Host "  HarfBuzzSharp -> $HarfBuzzSharpVersion" -ForegroundColor Green
+}
+
+# ---------------------------------------------------------------------------
+# scripts/azure-templates-variables.yml
+# ---------------------------------------------------------------------------
+Write-Host "`n--- scripts/azure-templates-variables.yml ---" -ForegroundColor Yellow
+$pipeline = Get-Content $pipelinePath -Raw
+if ($doBump) {
+    $pipeline = [regex]::Replace($pipeline, '(?m)^(\s*SKIASHARP_VERSION:\s*)\S+\s*$', "`${1}$SkiaSharpVersion")
+    Write-Host "  SKIASHARP_VERSION -> $SkiaSharpVersion" -ForegroundColor Green
+}
+if ($doLabel) {
+    $pipeline = [regex]::Replace($pipeline, "(?m)^(\s*PREVIEW_LABEL:\s*).*$", "`${1}'$PreviewLabel'")
+    Write-Host "  PREVIEW_LABEL -> '$PreviewLabel'" -ForegroundColor Green
+}
+if (-not $DryRun) {
+    Set-Content $pipelinePath $pipeline -NoNewline
+}
+
+# ---------------------------------------------------------------------------
+# Verification gate
+# ---------------------------------------------------------------------------
+Write-Host "`n=== Verification ===" -ForegroundColor Cyan
+$failures = @()
+
+# Re-read effective content (in-memory for dry run, from disk otherwise).
+if ($DryRun) {
+    $versionsNow = if ($doBump) { $newLines } else { Get-Content $versionsPath }
+    $pipelineNow = $pipeline
+} else {
+    $versionsNow = Get-Content $versionsPath
+    $pipelineNow = Get-Content $pipelinePath -Raw
+}
+
+if ($doBump) {
+    $skiaFileVer = "$SkiaSharpVersion.0"
+
+    $fileLine = $versionsNow | Where-Object { $_ -match '^SkiaSharp\s+file\s+(\S+)' } | Select-Object -First 1
+    if ($fileLine -notmatch "^SkiaSharp\s+file\s+$([regex]::Escape($skiaFileVer))\s*$") {
+        $failures += "SkiaSharp file version is not '$skiaFileVer': $fileLine"
+    }
+
+    $hbFileLine = $versionsNow | Where-Object { $_ -match '^HarfBuzzSharp\s+file\s+(\S+)' } | Select-Object -First 1
+    if ($hbFileLine -notmatch "^HarfBuzzSharp\s+file\s+$([regex]::Escape($HarfBuzzSharpVersion))\s*$") {
+        $failures += "HarfBuzzSharp file version is not '$HarfBuzzSharpVersion': $hbFileLine"
+    }
+
+    $badSkia = $versionsNow | Where-Object { $_ -match '^SkiaSharp\S*\s+nuget\s+(\S+)' -and $Matches[1] -ne $SkiaSharpVersion }
+    foreach ($b in $badSkia) { $failures += "Stale SkiaSharp nuget line: $($b.Trim())" }
+
+    $badHb = $versionsNow | Where-Object { $_ -match '^HarfBuzzSharp\S*\s+nuget\s+(\S+)' -and $Matches[1] -ne $HarfBuzzSharpVersion }
+    foreach ($b in $badHb) { $failures += "Stale HarfBuzzSharp nuget line: $($b.Trim())" }
+
+    # Assembly versions must be untouched.
+    $assemblyAfter = ($versionsNow | Where-Object { $_ -match '^SkiaSharp\s+assembly\s' })
+    if ($assemblyBefore -and ($assemblyAfter -ne $assemblyBefore)) {
+        $failures += "SkiaSharp assembly line changed (must stay pinned): '$assemblyAfter'"
+    }
+
+    $pipeVer = [regex]::Match($pipelineNow, '(?m)^\s*SKIASHARP_VERSION:\s*(?<v>\S+)\s*$').Groups['v'].Value
+    if ($pipeVer -ne $SkiaSharpVersion) {
+        $failures += "azure-templates-variables.yml SKIASHARP_VERSION is '$pipeVer', expected '$SkiaSharpVersion'."
+    }
+}
+
+if ($doLabel) {
+    $labelNow = [regex]::Match($pipelineNow, "(?m)^\s*PREVIEW_LABEL:\s*'?(?<l>[^'\r\n]*?)'?\s*$").Groups['l'].Value
+    if ($labelNow -ne $PreviewLabel) {
+        $failures += "azure-templates-variables.yml PREVIEW_LABEL is '$labelNow', expected '$PreviewLabel'."
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`n❌ GATE FAILED:" -ForegroundColor Red
+    foreach ($f in $failures) { Write-Host "  $f" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host "`n✅ GATE PASSED" -ForegroundColor Green
+if ($doBump)  {
+    Write-Host "  SkiaSharp nuget/file = $SkiaSharpVersion / $SkiaSharpVersion.0" -ForegroundColor Green
+    Write-Host "  HarfBuzzSharp nuget/file = $HarfBuzzSharpVersion" -ForegroundColor Green
+    Write-Host "  SKIASHARP_VERSION = $SkiaSharpVersion (assembly versions unchanged)" -ForegroundColor Green
+}
+if ($doLabel) { Write-Host "  PREVIEW_LABEL = '$PreviewLabel'" -ForegroundColor Green }
+if ($DryRun)  { Write-Host "`n(dry run — no files written)" -ForegroundColor Yellow }

--- a/.agents/skills/release-branch/scripts/bump-version.ps1
+++ b/.agents/skills/release-branch/scripts/bump-version.ps1
@@ -34,8 +34,10 @@
     script refuses it.
 
     A bump requires BOTH -SkiaSharpVersion and -HarfBuzzSharpVersion. The caller
-    decides the exact HarfBuzzSharp version (4-digit X.Y.Z.N normally; reset to
-    3-digit on a native HarfBuzz upgrade), so this script never guesses it.
+    decides the exact HarfBuzzSharp version, so this script never guesses it. The
+    next version normally increments/appends the 4th digit in lockstep with the
+    SkiaSharp patch (X.Y.Z -> X.Y.Z.1, X.Y.Z.N -> X.Y.Z.(N+1)); only on an actual
+    native HarfBuzz upgrade does it reset to the 3-digit native version.
 
 .PARAMETER SkiaSharpVersion
     Target SkiaSharp nuget version, e.g. 4.148.1. Requires -HarfBuzzSharpVersion.
@@ -107,12 +109,26 @@ if ($doBump) {
     $curAssembly = Get-Content $versionsPath |
         Where-Object { $_ -match '^SkiaSharp\s+assembly\s+(?<maj>\d+)\.(?<min>\d+)\.' } |
         Select-Object -First 1
-    if ($curAssembly -match '^SkiaSharp\s+assembly\s+(?<maj>\d+)\.(?<min>\d+)\.') {
-        $curMajorMinor = "$($Matches['maj']).$($Matches['min'])"
-        $newMajorMinor = ($SkiaSharpVersion -split '\.')[0..1] -join '.'
-        if ($curMajorMinor -ne $newMajorMinor) {
-            Write-Error "SkiaSharp major.minor would change ($curMajorMinor -> $newMajorMinor). That is a Skia milestone update (it also rewrites the milestone/soname/increment lines, assembly, cgmanifest.json and native sources) and is out of scope for this helper, which only does label changes and patch bumps."
-        }
+    if (-not ($curAssembly -match '^SkiaSharp\s+assembly\s+(?<maj>\d+)\.(?<min>\d+)\.')) {
+        Write-Error "Could not find/parse the 'SkiaSharp assembly' line in $versionsPath. Refusing to proceed: this line is the guard that prevents an out-of-scope milestone change."
+    }
+    $curMajorMinor = "$($Matches['maj']).$($Matches['min'])"
+    $newMajorMinor = ($SkiaSharpVersion -split '\.')[0..1] -join '.'
+    if ($curMajorMinor -ne $newMajorMinor) {
+        Write-Error "SkiaSharp major.minor would change ($curMajorMinor -> $newMajorMinor). That is a Skia milestone update (it also rewrites the milestone/soname/increment lines, assembly, cgmanifest.json and native sources) and is out of scope for this helper, which only does label changes and patch bumps."
+    }
+
+    # Guard: require a strictly-increasing patch (no equal/lower re-runs)
+    $curNuget = Get-Content $versionsPath |
+        Where-Object { $_ -match '^SkiaSharp\s+.*\bnuget\s+(?<v>\d+\.\d+\.\d+)\s*$' } |
+        Select-Object -First 1
+    if (-not ($curNuget -match '\bnuget\s+(?<v>\d+\.\d+\.\d+)\s*$')) {
+        Write-Error "Could not find/parse the 'SkiaSharp ... nuget' line in $versionsPath. Refusing to proceed: this is the guard that prevents an equal/lower patch."
+    }
+    $curPatch = [int](($Matches['v'] -split '\.')[2])
+    $newPatch = [int](($SkiaSharpVersion -split '\.')[2])
+    if ($newPatch -le $curPatch) {
+        Write-Error "SkiaSharp patch must increase. Current nuget is $($Matches['v']); requested $SkiaSharpVersion is not greater. (Re-running the same bump, or a typo'd lower patch, would publish a duplicate/downgraded package version.)"
     }
 }
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -32,6 +32,7 @@ Each skill confirms with `ask_user` before executing destructive operations.
 | Release Type | Version Format | Branch | NuGet Pattern | Tag |
 |--------------|----------------|--------|---------------|-----|
 | Preview | `X.Y.Z-preview.N` | `release/X.Y.Z-preview.N` | `X.Y.Z-preview.N.{build}` | `vX.Y.Z-preview.N.{build}` |
+| RC | `X.Y.Z-rc.N` | `release/X.Y.Z-rc.N` | `X.Y.Z-rc.N.{build}` | `vX.Y.Z-rc.N.{build}` |
 | Stable | `X.Y.Z` | `release/X.Y.Z` | `X.Y.Z-stable.{build}` | `vX.Y.Z` |
 | Hotfix Preview | `X.Y.Z.F-preview.N` | `release/X.Y.Z.F-preview.N` | `X.Y.Z.F-preview.N.{build}` | `vX.Y.Z.F-preview.N.{build}` |
 | Hotfix Stable | `X.Y.Z.F` | `release/X.Y.Z.F` | `X.Y.Z.F-stable.{build}` | `vX.Y.Z.F` |
@@ -40,12 +41,20 @@ The `{build}` number is auto-assigned by CI.
 
 ### Release Type → Base Branch
 
-| Type | Base | PREVIEW_LABEL |
-|------|------|---------------|
-| Preview | `main` | `preview.N` |
-| Stable | `release/X.Y.Z-preview.{latest}` | `stable` |
+Releases are cut from the line's **integration branch**: `main` for the newest
+in-development line, or `release/X.Y.x` for an established/maintenance line. Each
+integration branch sits at the next unreleased version with `PREVIEW_LABEL:
+preview.0`, and is bumped to the next version once its current version is released.
+
+| Type | Base (integration branch) | PREVIEW_LABEL |
+|------|---------------------------|---------------|
+| Preview / RC | `release/X.Y.x` (or `main` if the line isn't forked yet) | `preview.N` / `rc.N` |
+| Stable | `release/X.Y.x` | `stable` |
 | Hotfix Preview | tag `vX.Y.Z` | `preview.N` |
 | Hotfix Stable | `release/X.Y.Z.F-preview.{latest}` | `stable` |
+
+> **Stable is cut from `release/X.Y.x`** — the integration branch that already
+> produced the line's previews/rcs — not from `release/X.Y.Z-preview.{latest}`.
 
 ### HarfBuzzSharp Versioning
 
@@ -102,17 +111,19 @@ flowchart TB
     
     PARSE["Parse Version String"] --> TYPE{Release type?}
     
-    TYPE -->|Preview| BASE_MAIN["Base: main"]
-    TYPE -->|Stable| BASE_PREVIEW["Base: preview branch"]
+    TYPE -->|Preview / RC| BASE_INTEG["Base: integration branch
+    (release/X.Y.x, or main)"]
+    TYPE -->|Stable| BASE_STABLE["Base: integration branch
+    (release/X.Y.x)"]
     TYPE -->|Hotfix Preview| BASE_TAG["Base: tag"]
     TYPE -->|Hotfix Stable| BASE_HOTFIX["Base: hotfix preview"]
     
-    BASE_PREVIEW --> EXISTS{Base exists?}
+    BASE_INTEG --> EXISTS{Base exists?}
+    BASE_STABLE --> EXISTS
     BASE_TAG --> EXISTS
     BASE_HOTFIX --> EXISTS
     EXISTS -->|No| ERROR([Error])
     
-    BASE_MAIN --> CREATE
     EXISTS -->|Yes| CREATE
     
     CREATE["Create Branch
@@ -123,11 +134,11 @@ flowchart TB
     
     CREATE --> CI([CI Build Started])
     
-    CI --> IS_PREVIEW{Preview from main?}
-    IS_PREVIEW -->|No| DONE([Done - wait 2-4 hours])
-    IS_PREVIEW -->|Yes| BUMP
+    CI --> IS_RELEASED{Version now released?}
+    IS_RELEASED -->|No| DONE([Done - wait 2-4 hours])
+    IS_RELEASED -->|Yes| BUMP
     
-    BUMP["Bump Main Version
+    BUMP["Bump Integration Branch
     ∙ Edit SKIASHARP_VERSION
     ∙ Edit VERSIONS.txt
     ∙ Increment HarfBuzzSharp

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -44,7 +44,8 @@ The `{build}` number is auto-assigned by CI.
 Releases are cut from the line's **integration branch**: `main` for the newest
 in-development line, or `release/X.Y.x` for an established/maintenance line. Each
 integration branch sits at the next unreleased version with `PREVIEW_LABEL:
-preview.0`, and is bumped to the next version once its current version is released.
+preview.0`, and is bumped to the next version **as soon as its stable is cut**
+(immediately at branch time, not when the release publishes).
 
 | Type | Base (integration branch) | PREVIEW_LABEL |
 |------|---------------------------|---------------|
@@ -133,17 +134,18 @@ flowchart TB
     ∙ Commit and push"]
     
     CREATE --> CI([CI Build Started])
-    
-    CI --> IS_RELEASED{Version now released?}
-    IS_RELEASED -->|No| DONE([Done - wait 2-4 hours])
-    IS_RELEASED -->|Yes| BUMP
-    
-    BUMP["Bump Integration Branch
+    CREATE --> IS_STABLE{Stable cut?}
+    IS_STABLE -->|No| DONE([Done - wait 2-4 hours])
+    IS_STABLE -->|Yes| BUMP
+
+    BUMP["Bump Integration Branch (now,
+    in parallel with CI)
     ∙ Edit SKIASHARP_VERSION
     ∙ Edit VERSIONS.txt
     ∙ Increment HarfBuzzSharp
     ∙ Create and merge PR"]
     
+    CI --> DONE
     BUMP --> DONE
 
     classDef error fill:#ffebee,stroke:#c62828


### PR DESCRIPTION
## Summary

The `release-branch` skill carried an incorrect mental model: it treated `main` as the only "integration branch" and described stable releases as being cut from a preview branch. In reality **each release line has its own integration branch**:

- `main` serves the newest in-development line (currently `4.150.0`)
- `release/X.Y.x` serves each established/maintenance line (e.g. `release/3.119.x` @ `3.119.5`, `release/4.148.x` @ `4.148.0`)

Every release type (preview, rc, stable, patch) is cut **from that line's integration branch**, and the branch is bumped to the next version **immediately when a stable branch is cut** — not after the release publishes.

## Changes

- **`SKILL.md`**
  - Add an "Integration Branches" concept section.
  - Fix the Step 2 base-branch table — a stable `X.Y.Z` is cut from `release/X.Y.x` (which already produced its previews/rcs), **not** from `release/X.Y.Z-preview.{latest}`.
  - Rewrite Step 5 ("Immediately After Cutting a Stable"): the integration branch is bumped at branch-cut time, in parallel with CI, because PRs keep merging into it right after branching and must target the next version (fixes for the cut release go on its own `release/{version}` branch). The helper covers the **maintenance-line patch bump only**; the main line's move to the next minor is a **Skia milestone update** (separate process).
- **`scripts/bump-version.ps1`** (new) — sets `PREVIEW_LABEL` and/or bumps SkiaSharp + HarfBuzzSharp `file`/`nuget` versions in `VERSIONS.txt` and `azure-templates-variables.yml`, with a verification gate. Never touches `assembly` versions, and **fails closed** if it can't parse the guard lines. It refuses a `major.minor` change (that's a milestone update) and refuses an equal/lower patch (would publish a duplicate/downgraded package).
- **`documentation/dev/releasing.md`** — sync the version-pattern + base-branch tables (added the missing RC row) and the Stage 1 flow diagram to the integration-branch model (the bump now runs in parallel with CI, gated on "stable cut?").

## Why the minor bump is out of scope

Git history is decisive: `release/3.119.x` sits at `file 3.119.5.0` / `nuget 3.119.5` but `assembly 3.119.0.0` — `assembly` is pinned at `X.Y.0.0` across patches. The bump that moved `main` from `4.148` to `4.150` (`4e08384cd2`, `[skia-sync] Update Skia to milestone m150`) also rewrote the milestone/soname/increment lines, the assembly version, `cgmanifest.json` **and native sources**. So a minor bump is a milestone update, not a version-number edit — and the helper refuses it.

## HarfBuzzSharp versioning

The next HarfBuzzSharp version increments/appends the **4th** digit in lockstep with the SkiaSharp patch (`14.2.0` → `14.2.0.1`, `8.3.1.4` → `8.3.1.5`); it resets to the 3-digit native version only on an actual native HarfBuzz upgrade. The caller always supplies it — the script never guesses.

## Validation

Ran the helper against the real version files and inspected the exact diff for each case:

| Scenario | Result |
|---|---|
| `-PreviewLabel stable` / `preview.N` / `rc.N` | single-line `PREVIEW_LABEL` change |
| Patch bump (`4.150.0 → 4.150.1`) | `file`+`nuget` lines + `SKIASHARP_VERSION`; `assembly`/`milestone`/`soname` untouched; no EOF drift |
| Patch bump, HarfBuzz unchanged | only SkiaSharp lines change |
| Minor bump (`4.150.0 → 4.151.0`) | refused, non-zero exit, no file changes |
| Equal/lower patch (`4.150.0 → 4.150.0`) | refused, non-zero exit, no file changes |

A code-review pass independently ran the script (dry-run + real-run/revert) and confirmed the real output of #4212 (the 4.148.1 bump produced by this helper) changes only the intended lines.

These are doc/skill/script changes only — no C# or native code touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>