### PR TITLE
Sync VERSIONS.txt with harfbuzz 14.2.1

### DIFF
--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,5 +1,5 @@
 # native sources
-harfbuzz                                        release     14.2.0
+harfbuzz                                        release     14.2.1
 skia                                            release     m150
 ANGLE                                           release     chromium/6275
 
@@ -72,7 +72,7 @@ libSkiaSharp            increment   0
 # <milestone>.<increment>.0
 libSkiaSharp            soname      150.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
-HarfBuzz                soname      0.61420.0
+HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
@@ -81,7 +81,7 @@ SkiaSharp               file        4.150.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.0
+HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
@@ -116,13 +116,13 @@ SkiaSharp.Resources                             nuget       4.150.0
 SkiaSharp.Vulkan.SharpVk                        nuget       4.150.0
 SkiaSharp.Direct3D.Vortice                      nuget       4.150.0
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.0
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.0
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.0
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.0
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.0
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.0
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.0
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.0
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.0
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.0
+HarfBuzzSharp                                   nuget       14.2.1
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1


### PR DESCRIPTION
## Problem

The harfbuzz 14.2.1 bump (#4167) advanced the `externals/skia` submodule and `cgmanifest.json` to 14.2.1, but left `scripts/VERSIONS.txt` at **14.2.0**. As a result the native soname, the HarfBuzzSharp DLL `FileVersion`, and the published NuGet versions were all out of sync with the bundled binary.

This is not cosmetic: the `soname`/`file` lines feed the native build, so Linux produced `libHarfBuzzSharp.so.0.61420.0` and the DLL reported `FileVersion` 14.2.0 for a 14.2.1 binary.

## Changes

`scripts/VERSIONS.txt` — bring all harfbuzz entries to 14.2.1 (matching DEPS + cgmanifest.json):

| Entry | Before | After |
|-------|--------|-------|
| `harfbuzz release` | `14.2.0` | `14.2.1` |
| `HarfBuzz soname` | `0.61420.0` | `0.61421.0` |
| `HarfBuzzSharp file` | `14.2.0` | `14.2.1` |
| `HarfBuzzSharp` + 9 × `HarfBuzzSharp.NativeAssets.*` nuget | `14.2.0` | `14.2.1` |

soname per the in-file formula `0.<60000 + major*100 + minor*10 + micro>.0` → `60000 + 1400 + 20 + 1 = 61421`.

## Follow-up

The root cause — the `native-dependency-update` skill never listed `scripts/VERSIONS.txt` as a step — is fixed separately in #4215, so this PR stays a clean data-only change.