### PR TITLE
[api-docs] Stop merge from writing unfilled remarks scaffold to XML

### DIFF
--- a/.agents/skills/api-docs/SKILL.md
+++ b/.agents/skills/api-docs/SKILL.md
@@ -360,6 +360,7 @@ pwsh .agents/skills/api-docs/scripts/docs-tool.ps1 merge output/docs-work/
 The merge tool has built-in safety checks:
 - **Signature preservation** — counts `MemberSignature` and `TypeSignature` elements before and after merging each file and aborts with a fatal error if any were lost
 - **Extract guard** — rejects any field not listed in `_extractedKeys` (prevents agents from overwriting existing documentation with "improved" versions). Rejected fields emit a warning.
+- **Placeholder guard** — never writes a field whose content is still unfinished, i.e. a literal `To be added.` stub or an unfilled remarks scaffold (the `[Describe what this type does ...]` blanks). If a large type runs out of time mid-write, its placeholder is left intact so the XML stays clean and the next run can re-detect and re-fill it.
 - **XML validation** — validates the output XML is well-formed after save
 
 Then run formatting to clean up:

--- a/.agents/skills/api-docs/scripts/docs-tool.ps1
+++ b/.agents/skills/api-docs/scripts/docs-tool.ps1
@@ -79,6 +79,34 @@ function Get-ObsoleteAttribute([System.Xml.XmlNode]$node) {
     return $null
 }
 
+# Scaffold injected into each type's <remarks> at extract time so the writer has
+# a structure to complete. Defined once here so Extract (which injects it) and
+# Test-IsUnfilled (which recognises it when left unfinished) cannot drift apart.
+$script:TypeRemarksTemplate = "<format type=`"text/markdown`"><![CDATA[`n## Remarks`n`n[Describe what this type does and when to use it]`n`n[If IDisposable: mention using statement / disposal]`n`n## Examples`n`n``````csharp`n[Show the most common usage pattern, 5-15 lines]`n```````n]]></format>"
+
+# Bracketed instruction fragments that exist only in the *unfilled* scaffold
+# above. Their presence in a field means the writer never replaced them.
+$script:ScaffoldSentinels = @(
+    '[Describe what this type does and when to use it]',
+    '[If IDisposable: mention using statement / disposal]',
+    '[Show the most common usage pattern, 5-15 lines]'
+)
+
+# True when a docs field still holds content nobody has written: either mdoc's
+# "To be added." stub or a leftover scaffold fragment. Extract uses this to
+# (re)collect such fields for the writer; Merge uses it to refuse writing them
+# back. That keeps raw template text like "[Describe what this type does ...]"
+# out of the published XML when a large type runs out of time mid-write, and
+# leaves a "To be added." placeholder the next run can still detect and re-fill.
+function Test-IsUnfilled([string]$content) {
+    if ($null -eq $content) { return $true }
+    if ($content -match '^\s*To be added\.?\s*$') { return $true }
+    foreach ($sentinel in $script:ScaffoldSentinels) {
+        if ($content.Contains($sentinel)) { return $true }
+    }
+    return $false
+}
+
 # ---------------------------------------------------------------------------
 # Extract
 # ---------------------------------------------------------------------------
@@ -116,7 +144,7 @@ function Extract-Docs([string]$inputPath, [string]$outputDir) {
             if ($fields.Count -gt 0) {
                 # Pre-fill remarks template for types — agent completes the blanks
                 if ($fields.ContainsKey("remarks")) {
-                    $fields["remarks"] = "<format type=`"text/markdown`"><![CDATA[`n## Remarks`n`n[Describe what this type does and when to use it]`n`n[If IDisposable: mention using statement / disposal]`n`n## Examples`n`n``````csharp`n[Show the most common usage pattern, 5-15 lines]`n```````n]]></format>"
+                    $fields["remarks"] = $script:TypeRemarksTemplate
                     $fields["remarksRequired"] = $true
                 }
                 $typeSig = ($root.SelectSingleNode("TypeSignature[@Language='C#']"))?.GetAttribute("Value")
@@ -217,19 +245,19 @@ function Extract-DocsBlock([System.Xml.XmlElement]$docs) {
 
         switch ($child.LocalName) {
             "param" {
-                if ($text -match "^\s*To be added\.?\s*$") {
+                if (Test-IsUnfilled $text) {
                     if (-not $fields.ContainsKey("params")) { $fields["params"] = @{} }
                     $fields["params"][$child.GetAttribute("name")] = $text
                 }
             }
             "typeparam" {
-                if ($text -match "^\s*To be added\.?\s*$") {
+                if (Test-IsUnfilled $text) {
                     if (-not $fields.ContainsKey("typeparams")) { $fields["typeparams"] = @{} }
                     $fields["typeparams"][$child.GetAttribute("name")] = $text
                 }
             }
             { $_ -in "summary", "returns", "value", "remarks" } {
-                if ($text -match "^\s*To be added\.?\s*$") {
+                if (Test-IsUnfilled $text) {
                     $fields[$child.LocalName] = $text
                 }
             }
@@ -312,7 +340,7 @@ function Merge-Docs([string]$inputPath) {
             # Update scalar fields
             foreach ($fieldName in @("summary", "returns", "value", "remarks")) {
                 $content = $fields.$fieldName
-                if ($null -ne $content -and $content -notmatch "^\s*To be added\.?\s*$") {
+                if (-not (Test-IsUnfilled $content)) {
                     # Reject fields not in original extract
                     if ($allowedKeys -and -not $allowedKeys.Contains($fieldName)) {
                         Write-Warning "Skipping $($docId ?? 'type').$fieldName — not in original extract (agent-added)"
@@ -337,7 +365,7 @@ function Merge-Docs([string]$inputPath) {
                     $h = @{}; $fields.params.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value }; $h
                 }
                 foreach ($kv in $paramMap.GetEnumerator()) {
-                    if ($null -ne $kv.Value -and $kv.Value -notmatch "^\s*To be added\.?\s*$") {
+                    if (-not (Test-IsUnfilled $kv.Value)) {
                         # Reject params not in original extract
                         if ($allowedKeys -and -not $allowedKeys.Contains("params.$($kv.Key)")) {
                             Write-Warning "Skipping $($docId ?? 'type').params.$($kv.Key) — not in original extract (agent-added)"
@@ -358,7 +386,7 @@ function Merge-Docs([string]$inputPath) {
                     $h = @{}; $fields.typeparams.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value }; $h
                 }
                 foreach ($kv in $tpMap.GetEnumerator()) {
-                    if ($null -ne $kv.Value -and $kv.Value -notmatch "^\s*To be added\.?\s*$") {
+                    if (-not (Test-IsUnfilled $kv.Value)) {
                         # Reject typeparams not in original extract
                         if ($allowedKeys -and -not $allowedKeys.Contains("typeparams.$($kv.Key)")) {
                             Write-Warning "Skipping $($docId ?? 'type').typeparams.$($kv.Key) — not in original extract (agent-added)"


### PR DESCRIPTION
## Problem

The api-docs writer pipeline seeds each type's `<remarks>` with a markdown scaffold at **extract** time so the agent has a structure to complete:

````
## Remarks
[Describe what this type does and when to use it]
[If IDisposable: mention using statement / disposal]
## Examples
```csharp
[Show the most common usage pattern, 5-15 lines]
```
````

The **merge** step wrote back any field that wasn't literally `To be added.`. So when a large type ran out of time mid-write, the **raw scaffold landed in the published XML** instead of the agent's content.

This was observed live in the Auto API Docs Writer run for `SKPathBuilder` (~200 fields). The agent's JSON was fully written, but the merge that landed in the patch used an intermediate state and `SKPathBuilder.xml` got:

```diff
     <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <remarks>...[Describe what this type does and when to use it]...
```

This is **worse than a plain placeholder**: the next run's extractor keys on `To be added.`, so a scaffolded `<remarks>` is never re-detected — the template noise would become **permanent**.

## Fix

Centralise placeholder detection in a single `Test-IsUnfilled` helper shared by extract and merge, treating both `To be added.` and the unfilled scaffold sentinels as unwritten:

- **Merge** refuses to write unfilled scaffold, leaving `To be added.` intact so the XML stays clean and the next run can re-fill it.
- **Extract** now re-collects already-leaked scaffold, so any pollution from earlier runs **self-heals** on the next pass.
- Genuine content (including markdown links like `[SKPath](xref:...)` and array indices like `list[0]`) is unaffected — only the exact scaffold sentinels match.
- The remarks template is defined once as `$script:TypeRemarksTemplate` so extract (which injects it) and the detector cannot drift apart.

## Validation

Round-trip tested against synthetic stubs:

| Scenario | Result |
|---|---|
| Type summary filled, remarks left as scaffold → merge | `<remarks>` stays `To be added.` (scaffold **not** written) ✅ |
| XML already has leaked scaffold (summary real) → extract | remarks re-collected & re-seeded; real summary untouched ✅ |
| Real remarks with `[SKPath](...)` + `list[0]` → merge | written correctly (no false positive) ✅ |
| Fully-filled members → merge | merge unchanged ✅ |

Net change: `+35 / −7` in `docs-tool.ps1`, plus a safety-check bullet in `SKILL.md`. No behavior change for the common (fully-filled) path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>