### PR TITLE
Add mono/skia counterpart branching to release-branch skill

### DIFF
--- a/.agents/skills/release-branch/SKILL.md
+++ b/.agents/skills/release-branch/SKILL.md
@@ -27,6 +27,11 @@ Create release branches for SkiaSharp versions.
 
 **Release branches are cut FROM an integration branch (`main` or `release/X.Y.x`), but never modify those branches directly — always go through a branch + PR.**
 
+> **mono/skia counterpart:** every SkiaSharp `release/{version}` branch needs an
+> identically-named `release/{version}` branch in **mono/skia** at the
+> `externals/skia` submodule commit (see [Step 5](#step-5-create-the-monoskia-counterpart-branch)).
+> `release/*` is not protected in mono/skia, so this is a plain ref creation — not a PR.
+
 ---
 
 ## Concept: Integration Branches
@@ -43,7 +48,7 @@ Each one always sits at the *next unreleased version* for its line, with
 - **Every** release (preview, rc, stable, patch) is cut FROM the line's
   integration branch — `release/{version}` is branched off it.
 - **As soon as a stable is cut**, the integration branch is **bumped** to the
-  next version (see Step 5) — immediately, *not* after the release publishes.
+  next version (see Step 6) — immediately, *not* after the release publishes.
   After branching, PRs keep merging into the integration branch, and they must
   land on the *next* version, not the one that was just cut. Fixes for the cut
   release go on its own `release/{version}` branch.
@@ -135,9 +140,41 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py release/{versio
 
 ---
 
-## Step 5: Bump the Integration Branch (Immediately After Cutting a Stable)
+## Step 5: Create the mono/skia Counterpart Branch
 
-**Do this right after Step 4** — as soon as the stable release branch is cut and
+Every SkiaSharp `release/{version}` branch **must** have an identically-named
+`release/{version}` branch in the **mono/skia** fork, pointing at the exact
+`externals/skia` submodule commit that the SkiaSharp branch references. This
+locks/preserves the Skia source for the release so it stays auditable, reproducible,
+and safe from garbage collection.
+
+> This applies to **every** release branch cut — preview, rc, stable, and the
+> `release/X.Y.x` integration forks — not just stables.
+
+1. Read the submodule SHA the release branch points at (no submodule init needed):
+   ```bash
+   SKIA_SHA=$(git rev-parse HEAD:externals/skia)
+   ```
+2. Create the matching branch in mono/skia at that commit:
+   ```bash
+   unset GH_TOKEN && gh api repos/mono/skia/git/refs \
+     -f ref="refs/heads/release/{version}" \
+     -f sha="$SKIA_SHA"
+   ```
+   - The branch name **must** match the SkiaSharp branch name exactly.
+   - `release/*` is not a protected branch in mono/skia, so this ref creation is allowed.
+   - If it already exists (HTTP 422 "Reference already exists"), verify it points at
+     `$SKIA_SHA` and move on — do **not** force-update.
+3. Verify the counterpart matches:
+   ```bash
+   gh api repos/mono/skia/branches/release/{version} --jq '.commit.sha'   # == $SKIA_SHA
+   ```
+
+---
+
+## Step 6: Bump the Integration Branch
+
+**Do this right after cutting & pushing the branch (Steps 3–5)** — as soon as the stable release branch is cut and
 pushed, advance that line's **integration branch** to the next version. Do **not**
 wait for the release to publish.
 

--- a/.agents/skills/release-branch/SKILL.md
+++ b/.agents/skills/release-branch/SKILL.md
@@ -132,11 +132,9 @@ SkiaSharp-Native → SkiaSharp → SkiaSharp-Tests
    (~60-90 min)    (~30-60 min)   (~15-30 min)
 ```
 
-Use the **release-status** skill to track build progress. Quick check:
-
-```bash
-python3 .agents/skills/release-status/scripts/pipeline-status.py release/{version}
-```
+> CI builds Skia from the **pinned submodule commit**, so it runs regardless of the
+> counterpart branch in Step 5 — that branch exists to *preserve* the source, not to
+> feed the build.
 
 ---
 
@@ -157,7 +155,7 @@ and safe from garbage collection.
    ```
 2. Create the matching branch in mono/skia at that commit:
    ```bash
-   unset GH_TOKEN && gh api repos/mono/skia/git/refs \
+   gh api repos/mono/skia/git/refs \
      -f ref="refs/heads/release/{version}" \
      -f sha="$SKIA_SHA"
    ```
@@ -172,7 +170,7 @@ and safe from garbage collection.
 
 ---
 
-## Step 6: Bump the Integration Branch
+## Step 6: Bump the Integration Branch (Stable Only)
 
 **Do this right after cutting & pushing the branch (Steps 3–5)** — as soon as the stable release branch is cut and
 pushed, advance that line's **integration branch** to the next version. Do **not**
@@ -227,6 +225,20 @@ version after release".)
    gh pr create --title "Bump to the next version ({next}) after release" --body ""
    gh pr merge --merge --delete-branch
    ```
+
+---
+
+## Next: Track the Build
+
+Once the branch is cut and pushed (Steps 3–4), its skia counterpart created
+(Step 5), and — for a stable — the integration branch bumped (Step 6), hand off to
+**Step 2 of the release pipeline**, the [release-status](../release-status/SKILL.md)
+skill, to follow the CI chain (`SkiaSharp-Native → SkiaSharp → SkiaSharp-Tests`).
+Quick check:
+
+```bash
+python3 .agents/skills/release-status/scripts/pipeline-status.py release/{version}
+```
 
 ---
 

--- a/.agents/skills/release-branch/scripts/bump-version.ps1
+++ b/.agents/skills/release-branch/scripts/bump-version.ps1
@@ -24,7 +24,7 @@
     Two independent operations, usable together or alone:
       1. Set label only (Step 3 — create release branch):
              -PreviewLabel stable
-      2. Bump to the next PATCH (Step 5 — advance a maintenance line after a
+      2. Bump to the next PATCH (Step 6 — advance a maintenance line after a
          stable ships, e.g. 4.148.0 -> 4.148.1):
              -SkiaSharpVersion 4.148.1 -HarfBuzzSharpVersion 14.2.1 -PreviewLabel preview.0
 
@@ -58,7 +58,7 @@
     pwsh .agents/skills/release-branch/scripts/bump-version.ps1 -PreviewLabel stable
 
 .EXAMPLE
-    # Step 5 — bump the integration branch to the next patch after a release
+    # Step 6 — bump the integration branch to the next patch after a release
     pwsh .agents/skills/release-branch/scripts/bump-version.ps1 `
         -SkiaSharpVersion 4.148.1 -HarfBuzzSharpVersion 14.2.1 -PreviewLabel preview.0
 #>

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -39,7 +39,18 @@ Each skill confirms with `ask_user` before executing destructive operations.
 
 The `{build}` number is auto-assigned by CI.
 
-### Release Type → Base Branch
+### mono/skia Counterpart Branches
+
+Every SkiaSharp `release/{version}` branch has an **identically-named**
+`release/{version}` branch in the [mono/skia](https://github.com/mono/skia) fork,
+created at the exact `externals/skia` submodule commit that the SkiaSharp branch
+references (skia branch HEAD **==** submodule SHA). This locks the Skia source for
+the release so it stays auditable, reproducible, and safe from garbage collection.
+The [release-branch](../../.agents/skills/release-branch/SKILL.md) skill creates it
+right after pushing the SkiaSharp branch (Step 5). `main` is the exception — it
+tracks the `skiasharp` integration branch, not a `release/*` counterpart.
+
+
 
 Releases are cut from the line's **integration branch**: `main` for the newest
 in-development line, or `release/X.Y.x` for an established/maintenance line. Each
@@ -133,8 +144,15 @@ flowchart TB
     ∙ Set PREVIEW_LABEL
     ∙ Commit and push"]
     
-    CREATE --> CI([CI Build Started])
-    CREATE --> IS_STABLE{Stable cut?}
+    CREATE --> SKIA
+    SKIA["Create mono/skia
+    counterpart branch
+    ∙ Read externals/skia SHA
+    ∙ gh api git/refs at that SHA
+    ∙ Same release/{version} name"]
+
+    SKIA --> CI([CI Build Started])
+    SKIA --> IS_STABLE{Stable cut?}
     IS_STABLE -->|No| DONE([Done - wait 2-4 hours])
     IS_STABLE -->|Yes| BUMP
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -39,18 +39,7 @@ Each skill confirms with `ask_user` before executing destructive operations.
 
 The `{build}` number is auto-assigned by CI.
 
-### mono/skia Counterpart Branches
-
-Every SkiaSharp `release/{version}` branch has an **identically-named**
-`release/{version}` branch in the [mono/skia](https://github.com/mono/skia) fork,
-created at the exact `externals/skia` submodule commit that the SkiaSharp branch
-references (skia branch HEAD **==** submodule SHA). This locks the Skia source for
-the release so it stays auditable, reproducible, and safe from garbage collection.
-The [release-branch](../../.agents/skills/release-branch/SKILL.md) skill creates it
-right after pushing the SkiaSharp branch (Step 5). `main` is the exception — it
-tracks the `skiasharp` integration branch, not a `release/*` counterpart.
-
-
+### Release Type → Base Branch
 
 Releases are cut from the line's **integration branch**: `main` for the newest
 in-development line, or `release/X.Y.x` for an established/maintenance line. Each
@@ -67,6 +56,20 @@ preview.0`, and is bumped to the next version **as soon as its stable is cut**
 
 > **Stable is cut from `release/X.Y.x`** — the integration branch that already
 > produced the line's previews/rcs — not from `release/X.Y.Z-preview.{latest}`.
+
+### mono/skia Counterpart Branches
+
+Every SkiaSharp `release/{version}` branch has an **identically-named**
+`release/{version}` branch in the [mono/skia](https://github.com/mono/skia) fork,
+created at the exact `externals/skia` submodule commit the SkiaSharp branch
+references (skia branch HEAD **==** submodule SHA). This locks the Skia source for
+the release so it stays auditable, reproducible, and safe from garbage collection.
+
+- Created by the [release-branch](../../.agents/skills/release-branch/SKILL.md) skill
+  right after the SkiaSharp branch is pushed (its Step 5) — for **every** cut
+  (preview, rc, stable, and `release/X.Y.x` integration forks).
+- `main` is the exception: it tracks the `skiasharp` integration branch, not a
+  `release/*` counterpart.
 
 ### HarfBuzzSharp Versioning
 


### PR DESCRIPTION
## Problem

The `release-branch` skill cut only the SkiaSharp `release/{version}` branch and never created the matching **mono/skia** `release/{version}` branch that locks the `externals/skia` submodule commit for that release. Creating the skia counterpart was an undocumented manual step — and as a result several recent release branches had **no skia counterpart**.

The pairing rule (verified across many pairs): every SkiaSharp `release/*` branch has an identically-named mono/skia `release/*` branch whose HEAD **==** the SkiaSharp branch's `externals/skia` submodule SHA. This keeps the Skia source for each release auditable, reproducible, and safe from garbage collection.

## Changes

**`.agents/skills/release-branch/SKILL.md`**
- Added a real **Step 5: Create the mono/skia Counterpart Branch** — read the submodule SHA (`git rev-parse HEAD:externals/skia`), create the identically-named branch via `gh api repos/mono/skia/git/refs`, then verify.
- Renumbered the integration-branch bump to **Step 6 (Stable Only)** and updated all cross-references.
- Restructured for chronological flow: moved the release-status hand-off out of Step 4 into a closing **"Next: Track the Build"** section, so the steps read cut → push → skia counterpart → bump → track CI.
- Added a note that CI builds from the **pinned submodule commit** (the counterpart branch preserves source, it doesn't feed the build).
- Documented the counterpart requirement in the Branch-Protection section.

**`.agents/skills/release-branch/scripts/bump-version.ps1`**
- Updated the Step 5 → Step 6 doc-comment references.

**`documentation/dev/releasing.md`**
- Added the counterpart node to the Stage 1 diagram (`CREATE → SKIA → CI / Stable?`).
- Added a **mono/skia Counterpart Branches** reference section, placed next to the branch-model sections.

No code/native changes — docs + skill only.

## Backfilled missing counterparts

Created the 4 missing mono/skia branches directly in the fork (out of band, not part of this diff):

| SkiaSharp branch | skia branch created @ | Skia commit |
|---|---|---|
| `release/4.148.x` | `1a155bae…b6a7b722` | `[skia] Merge upstream chrome/m148 (#250)` |
| `release/4.148.0` | `1a155bae…b6a7b722` | same m148 |
| `release/4.148.0-rc.1` | `1a155bae…b6a7b722` | same m148 |
| `release/4.150.0-preview.1` | `94451aa2…85381fa0` | `[skia-sync] Merge upstream chrome/m150 (#253)` |

**Verified:** each new skia branch HEAD == the SkiaSharp submodule SHA, and the repo-wide diff now shows zero SkiaSharp `release/*` branches without a skia counterpart.