### PR TITLE
Fix integration test harness for .NET 10

### DIFF
--- a/tests/SkiaSharp.Tests.Integration/Tests/BlazorTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/BlazorTests.cs
@@ -22,8 +22,10 @@ public class BlazorTests(ITestOutputHelper output) : PlatformTestBase(output)
         var projectName = $"Blazor{canvasView}";
         var projectDir = Path.Combine(TestDir, projectName);
         
-        // Run from TestDir (which has global.json) using relative paths
-        await Run("dotnet", $"new blazorwasm -n {projectName} -o {projectName} --no-https");
+        // Run from TestDir (which has global.json) using relative paths. Pin the template
+        // framework to keep the generated TFM aligned with the .NET 10 SDK band even when a
+        // newer (e.g. net11.0) SDK is installed on the machine.
+        await Run("dotnet", $"new blazorwasm -n {projectName} -o {projectName} -f {BaseFramework} --no-https");
         await Run("dotnet", $"add {projectName} package SkiaSharp.Views.Blazor --version {SkiaVersion}");
         
         await File.WriteAllTextAsync(Path.Combine(projectDir, "Pages", "Home.razor"), $$"""

--- a/tests/SkiaSharp.Tests.Integration/Tests/ConsoleTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/ConsoleTests.cs
@@ -15,8 +15,10 @@ public class ConsoleTests(ITestOutputHelper output) : PlatformTestBase(output)
         var projectName = "SkiaSharpConsoleTest";
         var projectDir = Path.Combine(TestDir, projectName);
         
-        // Run from TestDir (which has global.json) using relative paths
-        await Run("dotnet", $"new console -n {projectName} -o {projectName}");
+        // Run from TestDir (which has global.json) using relative paths. Pin the template
+        // framework to keep the generated TFM aligned with the .NET 10 SDK band even when a
+        // newer (e.g. net11.0) SDK is installed on the machine.
+        await Run("dotnet", $"new console -n {projectName} -o {projectName} -f {BaseFramework}");
         await Run("dotnet", $"add {projectName} package SkiaSharp --version {SkiaVersion}");
         
         var drawCode = TestImage.GetDrawCode();
@@ -53,8 +55,9 @@ public class ConsoleTests(ITestOutputHelper output) : PlatformTestBase(output)
         var projectName = "HarfBuzzConsoleTest";
         var projectDir = Path.Combine(TestDir, projectName);
         
-        // Run from TestDir (which has global.json) using relative paths
-        await Run("dotnet", $"new console -n {projectName} -o {projectName}");
+        // Run from TestDir (which has global.json) using relative paths. Pin the template
+        // framework to keep the generated TFM aligned with the .NET 10 SDK band.
+        await Run("dotnet", $"new console -n {projectName} -o {projectName} -f {BaseFramework}");
         await Run("dotnet", $"add {projectName} package SkiaSharp --version {SkiaVersion}");
         await Run("dotnet", $"add {projectName} package HarfBuzzSharp --version {HarfBuzzVersion}");
         

--- a/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
@@ -147,7 +147,7 @@ public class LinuxConsoleTests(ITestOutputHelper output) : PlatformTestBase(outp
         // Build and run in Docker using dotnet publish (resolves RID-specific native assets)
         var dockerfile = Path.Combine(projectDir, "Dockerfile");
         File.WriteAllText(dockerfile, $"""
-            FROM mcr.microsoft.com/dotnet/sdk:8.0
+            FROM mcr.microsoft.com/dotnet/sdk:10.0
             WORKDIR /src
             COPY {projectName}.csproj nuget.config ./
             RUN dotnet restore

--- a/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
@@ -170,8 +170,12 @@ public abstract class MauiTestBase(ITestOutputHelper output) : PlatformTestBase(
         var projectDir = Path.Combine(TestDir, projectName);
         var relativeProjectDir = projectName;  // Relative to TestDir
         
-        // Create project (run from TestDir to pick up global.json)
-        await Run("dotnet", $"new maui -n {projectName} -o {relativeProjectDir}");
+        // Create project (run from TestDir to pick up global.json). Pin the template to the base
+        // framework derived from TargetFramework (e.g. "net10.0" from "net10.0-maccatalyst") so the
+        // generated TFMs always match the framework the harness builds below — the installed MAUI
+        // template can otherwise default to a newer (e.g. net11.0) framework.
+        var baseFramework = TargetFramework.Split('-')[0];
+        await Run("dotnet", $"new maui -n {projectName} -o {relativeProjectDir} -f {baseFramework}");
 
         // Add SkiaSharp package (run from TestDir)
         await Run("dotnet", $"add {relativeProjectDir} package SkiaSharp.Views.Maui.Controls --version {SkiaVersion}");

--- a/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
@@ -170,12 +170,11 @@ public abstract class MauiTestBase(ITestOutputHelper output) : PlatformTestBase(
         var projectDir = Path.Combine(TestDir, projectName);
         var relativeProjectDir = projectName;  // Relative to TestDir
         
-        // Create project (run from TestDir to pick up global.json). Pin the template to the base
-        // framework derived from TargetFramework (e.g. "net10.0" from "net10.0-maccatalyst") so the
-        // generated TFMs always match the framework the harness builds below — the installed MAUI
-        // template can otherwise default to a newer (e.g. net11.0) framework.
-        var baseFramework = TargetFramework.Split('-')[0];
-        await Run("dotnet", $"new maui -n {projectName} -o {relativeProjectDir} -f {baseFramework}");
+        // Create project (run from TestDir to pick up global.json). Pin the template to the shared
+        // BaseFramework (net10.0) so the generated TFMs always match the framework the harness
+        // builds below — the installed MAUI template can otherwise default to a newer (e.g. net11.0)
+        // framework even when the SDK is pinned, since its default comes from the MAUI workload.
+        await Run("dotnet", $"new maui -n {projectName} -o {relativeProjectDir} -f {BaseFramework}");
 
         // Add SkiaSharp package (run from TestDir)
         await Run("dotnet", $"add {relativeProjectDir} package SkiaSharp.Views.Maui.Controls --version {SkiaVersion}");

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -45,12 +45,18 @@ public abstract class PlatformTestBase : IDisposable
             </configuration>
             """);
         
-        // Write global.json to allow latest SDK (prevents inheriting repo's .NET 8 restriction)
+        // Write global.json to pin the temp projects to the .NET 10 SDK band. The MAUI/console
+        // temp projects are generated outside the repo (in TempPath), so without this they would
+        // resolve to the highest installed SDK — including .NET 11 previews — which makes
+        // `dotnet new maui` emit net11.0-* TFMs that don't match the net10.0-* frameworks the
+        // harness builds (causing NETSDK1005 "doesn't have a target for net10.0-*"). Stay within
+        // 10.0.x and never roll forward to a prerelease major.
         File.WriteAllText(Path.Combine(TestDir, "global.json"), """
             {
               "sdk": {
-                "version": "8.0.0",
-                "rollForward": "latestMajor"
+                "version": "10.0.100",
+                "rollForward": "latestFeature",
+                "allowPrerelease": false
               }
             }
             """);

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -9,6 +9,14 @@ namespace SkiaSharp.Tests.Integration;
 /// </summary>
 public abstract class PlatformTestBase : IDisposable
 {
+    /// <summary>
+    /// Base target framework the generated temp projects build against. Passed to
+    /// <c>dotnet new … -f</c> so the template-generated TFMs stay pinned to the .NET 10 band even
+    /// when a newer SDK (e.g. a net11.0 preview) is installed on the machine. Platform-suffixed
+    /// MAUI TFMs (e.g. net10.0-android) derive from this.
+    /// </summary>
+    protected const string BaseFramework = "net10.0";
+
     protected readonly ITestOutputHelper Output;
     protected readonly string TestDir;
     protected readonly string SkiaVersion;


### PR DESCRIPTION
## Summary

While running the release-testing matrix for **4.148.0**, the integration test harness failed before SkiaSharp was ever exercised because several pieces were still pinned to (or rolling forward past) the wrong SDK/framework. This PR fixes the harness so the generated throwaway projects build against the correct **.NET 10** SDK and TFMs.

## Changes

- **`LinuxConsoleTests.cs`** — bump the Docker base image `mcr.microsoft.com/dotnet/sdk:8.0` → `sdk:10.0` so the container can build the `net10.0` temp project (was failing `NETSDK1045`).
- **`PlatformTestBase.cs`** — pin the temp `global.json` to the `10.0.100` SDK band with `rollForward=latestFeature` and `allowPrerelease=false`. The old `8.0.0`/`latestMajor` rolled forward to installed **.NET 11 preview** SDKs, which made `dotnet new maui` emit `net11.0-*` TFMs that don't match the `net10.0-*` frameworks the harness builds.
- **`MauiTestBase.cs`** — pass `-f net10.0` (derived from each test's `TargetFramework`) to `dotnet new maui` so the generated TFMs match the framework the harness builds, regardless of which MAUI templates are installed locally.

## Validation

Ran the **full integration matrix** against the `4.148.0` release packages (`SkiaSharp 4.148.0-stable.1` / `HarfBuzzSharp 14.2.0-stable.1`) — all green:

| Test | Platform | Status |
|------|----------|--------|
| SmokeTests | .NET | ✅ |
| ConsoleTests | .NET | ✅ |
| LinuxConsoleTests | Docker (sdk:10.0) | ✅ |
| BlazorTests | Chromium | ✅ |
| MauiMacCatalystTests | macOS | ✅ |
| MauiiOSTests | iOS 16.2 + 26.3 | ✅ |
| MauiAndroidTests | API 23 + 36 | ✅ |

> Note: a separate **local-only** env override (`ValidateXcodeVersion=false`) was used during testing because the test machine has Xcode 26.3 while the active .NET Apple workload band recommends 26.2. That is machine-specific and intentionally **not** part of this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>