### PR TITLE
docs: drop obsolete GrVkYcbcrConversionInfo page to fix Learn xref collision

### DIFF
--- a/scripts/infra/docs/docs.cake
+++ b/scripts/infra/docs/docs.cake
@@ -482,6 +482,37 @@ Task ("docs-format-docs")
             }
         }
 
+        // Drop the obsolete SkiaSharp.GrVkYcbcrConversionInfo doc page. It is a soft
+        // [Obsolete] forwarder that differs from its replacement,
+        // SkiaSharp.GRVkYcbcrConversionInfo, only by the case of a single letter
+        // ('r' vs 'R'). mdoc documents both (soft-obsolete types are kept), producing two
+        // ECMA-XML files whose names differ only by case. Those cannot coexist on the
+        // case-insensitive filesystem the Learn/OpenPublishing build runs on - one shadows
+        // the other, so crefs to the shadowed type fail with 'Cross reference not found'.
+        // This is the only such case-colliding pair in the API, and the legacy type merely
+        // forwards to the modern one (its only members are the two implicit conversion
+        // operators), so drop its page so only the modern type is published and its xref
+        // always resolves. Mirrors the SkiaSharp.Views.Android.Resource handling above.
+        if (xdoc.Root.Name == "Type") {
+            var ycbcrName = xdoc.Root.Attribute ("FullName")?.Value;
+            if (ycbcrName == "SkiaSharp.GrVkYcbcrConversionInfo") {
+                DeleteFile (file);
+                continue;
+            }
+        }
+        if (xdoc.Root.Name == "Overview") {
+            xdoc.Root.Descendants ("Type")
+                .Where (t => t.Attribute ("Name")?.Value == "GrVkYcbcrConversionInfo")
+                .ToArray ()
+                .Remove ();
+        }
+        if (xdoc.Root.Name == "Framework") {
+            xdoc.Root.Descendants ("Type")
+                .Where (t => t.Attribute ("Name")?.Value == "SkiaSharp.GrVkYcbcrConversionInfo")
+                .ToArray ()
+                .Remove ();
+        }
+
         // count the types without docs
         var typesWithDocs = xdoc.Root
             .Elements ("Docs");


### PR DESCRIPTION
## Symptom

The Learn / OpenPublishing publish build fails with:

```
Cross reference not found: 'SkiaSharp.GRVkYcbcrConversionInfo'
```

## Root cause: two public types that differ only by one letter's case

SkiaSharp exposes two public Vulkan Ycbcr conversion types whose names differ **only** by the case of a single letter:

| Type | Role |
|------|------|
| `GRVkYcbcrConversionInfo` | The modern, real struct (`binding/SkiaSharp/SkiaApi.generated.cs`) |
| `GrVkYcbcrConversionInfo` | A legacy `[Obsolete("Use GRVkYcbcrConversionInfo instead.")]` forwarder (`binding/SkiaSharp/GRDefinitions.cs`) whose **only** members are the two implicit conversion operators to/from the modern type |

mdoc documents soft-`[Obsolete]` types, so it emits a page for **both**, producing two ECMA-XML files whose names differ only by case:

- `SkiaSharp/GRVkYcbcrConversionInfo.xml`
- `SkiaSharp/GrVkYcbcrConversionInfo.xml`

On the **case-insensitive filesystem** the Learn/OpenPublishing build runs on, those two files collide — one silently shadows the other — so every cref to the shadowed type fails to resolve. This is the **only** case-only-colliding public type pair in the entire API.

## Fix

Because the legacy type merely **forwards** to the modern one (ABI-safe; its only members are the implicit conversions), the correct fix is to stop emitting its doc page so only the modern type is published and its xref always resolves.

This mirrors the existing `SkiaSharp.Views.Android.Resource` special-case already present in the same `docs-format-docs` task, removing the obsolete type from all three representations:

- the Type file (`DeleteFile`)
- the `Overview`/index.xml `<Type>` entry
- the `Framework`/FrameworksIndex `<Type>` entry

Matching is **case-sensitive (ordinal)** so the modern `GR…` entry is preserved and only the legacy `Gr…` one is dropped (`"GrVkYcbcrConversionInfo" != "GRVkYcbcrConversionInfo"`).

## Why this is the right place

A companion change in **mono/SkiaSharp-API-docs PR #152** removes the already-committed page manually. This generator-side change is the **durable companion**: it prevents mdoc from regenerating the page on the next *Auto API Docs Writer* run.

## Validation

- Docs-generator-only change; no native build or test-suite impact.
- A full mdoc `update-docs` regeneration is not feasible locally (needs all platform packages and runs on Linux CI), so it was not attempted.
- Verified by inspection that the inserted block compiles cleanly as Cake C# and mirrors the proven Android Resource precedent exactly, and by a throwaway check confirming only the legacy `Gr…` entry is removed while the modern `GR…` entry is preserved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>