### PR TITLE
Fix: always emit manifest.json so docs-extracted artifact is never empty

### DIFF
--- a/.agents/skills/api-docs/scripts/docs-tool.ps1
+++ b/.agents/skills/api-docs/scripts/docs-tool.ps1
@@ -230,7 +230,10 @@ function Extract-Docs([string]$inputPath, [string]$outputDir) {
         }
         $totalFields += $fieldCount
     }
-    $manifest | ConvertTo-Json -Depth 3 | Set-Content (Join-Path $outputDir "manifest.json") -Encoding UTF8
+    # Always write a manifest (even when zero placeholders) so the docs-extracted
+    # artifact is always produced and downstream jobs don't fail on a missing artifact.
+    $manifestJson = if ($manifest.Count -eq 0) { '[]' } else { $manifest | ConvertTo-Json -Depth 3 }
+    Set-Content -Path (Join-Path $outputDir "manifest.json") -Value $manifestJson -Encoding UTF8
 
     Write-Host "`nExtracted $totalEntries entries from $totalFiles files to $outputDir/"
     Write-Host "Manifest: $($manifest.Count) files, $totalFields total fields"


### PR DESCRIPTION
## Problem

The `auto-api-docs-writer` workflow (in `mono/SkiaSharp-API-docs`) has a `regenerate-stubs` job that checks out **mono/SkiaSharp** and runs:

```
.agents/skills/api-docs/scripts/docs-tool.ps1 extract docs/SkiaSharpAPI/ -Output output/docs-work/
```

then uploads `output/docs-work/` as the `docs-extracted` artifact. A later `agent` job hard-downloads `docs-extracted`.

On a day when **all** API docs are already complete (zero `To be added.` placeholders), `Extract-Docs` writes no per-file JSON, so `$manifest` is an empty array (`@()`). The old line:

```powershell
$manifest | ConvertTo-Json -Depth 3 | Set-Content (Join-Path $outputDir "manifest.json") -Encoding UTF8
```

pipes `@()` to `ConvertTo-Json`, which emits **nothing**, so `Set-Content` writes no file at all. `output/docs-work/` ends up empty.

`actions/upload-artifact` then silently skips an empty directory (only warns `No files were found`), so the `docs-extracted` artifact is never created. The downstream `agent` job's `actions/download-artifact` for `docs-extracted` then fails hard with `Artifact not found for name: docs-extracted`, breaking the whole run.

This happened on 2026-06-24 (run `28087645912`): the log showed `Extracted 0 entries from 0 files` and `Documentation missing in 0/428 types and 0/5006 members`.

## Fix

Always write `manifest.json`, using `'[]'` when there are zero entries, so the artifact directory is never empty:

```powershell
# Always write a manifest (even when zero placeholders) so the docs-extracted
# artifact is always produced and downstream jobs don't fail on a missing artifact.
$manifestJson = if ($manifest.Count -eq 0) { '[]' } else { $manifest | ConvertTo-Json -Depth 3 }
Set-Content -Path (Join-Path $outputDir "manifest.json") -Value $manifestJson -Encoding UTF8
```

The change is minimal and surgical — non-empty serialization behavior is unchanged.

## Verification

Ran the actual extract path with PowerShell 7.4.6 against two inputs:

- **Zero-placeholder input** (reproduces the failure: `Extracted 0 entries from 0 files`): `output/` now contains `manifest.json` with content `[]`. The directory is no longer empty, so `upload-artifact` will produce `docs-extracted`.
- **Input with placeholders**: `manifest.json` is identical to before (same object structure, 1 file / 4 fields) — non-empty behavior preserved.