### PR TITLE
Support release-branch targeting in Skia upstream sync (+ Opus 4.7, libc++ build fix)

### DIFF
--- a/.agents/skills/update-skia/SKILL.md
+++ b/.agents/skills/update-skia/SKILL.md
@@ -131,7 +131,37 @@ E. Ship (Phase 11)
    > **Note:** When this phase is pre-computed by the automated workflow, you still need to
    > add the `upstream` remote and fetch `chrome/m{TARGET}` — Phase 5 depends on it.
 
-> 🛑 **GATE**: Confirm current milestone, target milestone, and that upstream branch exists.
+5. **Determine the base branch (`main` vs a release line).** Most updates target `main`
+   (newest, in-development line) with `skiasharp` as the mono/skia base. But when the target
+   milestone is **older** than `main`'s milestone AND a matching release branch exists, the
+   update targets that release line instead:
+
+   ```bash
+   # SkiaSharp uses release/<major>.<milestone>.x (e.g. release/4.148.x for m148)
+   git ls-remote --heads origin "refs/heads/release/*.{TARGET}.x"
+   # mono/skia mirrors the SAME branch name
+   git -C externals/skia ls-remote --heads origin "refs/heads/release/*.{TARGET}.x"
+   ```
+
+   | Variable | `main` target | release-line target |
+   |----------|---------------|---------------------|
+   | `{BASE_BRANCH}` (SkiaSharp) | `main` | `release/<major>.{TARGET}.x` |
+   | `{SKIA_BASE_BRANCH}` (mono/skia) | `skiasharp` | `release/<major>.{TARGET}.x` |
+   | `{HEAD_BRANCH}` (both repos) | `skia-sync/m{TARGET}` | `skia-sync/release-<major>.{TARGET}.x` |
+
+   A release-line update is always a **bug-fix-only sync** (`CURRENT == TARGET`): do NOT bump
+   the milestone/soname/nuget version in Phase 6 — only `cgmanifest.json`'s commit hash changes.
+
+   > 🛑 **The release branch must already exist in BOTH repos.** Branch *creation* is owned by
+   > the release process (`release-branch` skill), not this skill. If the SkiaSharp
+   > `release/<major>.{TARGET}.x` branch exists but the mono/skia one does NOT, **STOP and fail** —
+   > do not create it here. Ask a human to cut the mono/skia release branch first.
+
+   Use these `{BASE_BRANCH}` / `{SKIA_BASE_BRANCH}` / `{HEAD_BRANCH}` values everywhere below in
+   place of the hardcoded `main` / `skiasharp` / `skia-sync/m{TARGET}` defaults.
+
+> 🛑 **GATE**: Confirm current milestone, target milestone, the base branch (main vs release line,
+> with the mono/skia base branch confirmed to exist), and that the upstream branch exists.
 
 ### Phase 2: Breaking Change Analysis
 
@@ -197,27 +227,30 @@ milestone numbers and paste your breaking change analysis table. The default exp
 
 > ⚠️ **This phase creates BOTH branches before making ANY changes.** You may be on a
 > workflow branch, a feature branch, or a detached HEAD — none of which is the right base.
-> You MUST branch from `origin/main` (parent) and `origin/skiasharp` (submodule).
+> You MUST branch from `origin/{BASE_BRANCH}` (parent) and `origin/{SKIA_BASE_BRANCH}`
+> (submodule). For a `main` update those are `origin/main` and `origin/skiasharp`; for a
+> release-line update they are `origin/release/<major>.{TARGET}.x` in both repos
+> (see Phase 1 step 5).
 
 **Parent repo (SkiaSharp):**
 
-1. **Fetch the latest `main`:**
+1. **Fetch the latest base branch:**
    ```bash
-   git fetch origin main
+   git fetch origin {BASE_BRANCH}
    ```
 
-2. **Create the feature branch from `origin/main`:**
+2. **Create the feature branch from `origin/{BASE_BRANCH}`:**
    ```bash
-   git checkout -b skia-sync/m{TARGET} origin/main
+   git checkout -b {HEAD_BRANCH} origin/{BASE_BRANCH}
    ```
    If the branch already exists on the remote, check it out instead:
    ```bash
-   git fetch origin skia-sync/m{TARGET} && git checkout skia-sync/m{TARGET}
+   git fetch origin {HEAD_BRANCH} && git checkout {HEAD_BRANCH}
    ```
 
-3. **Verify you are on the correct branch and it is based on `origin/main`:**
+3. **Verify you are on the correct branch and it is based on `origin/{BASE_BRANCH}`:**
    ```bash
-   git log --oneline -1 origin/main
+   git log --oneline -1 origin/{BASE_BRANCH}
    git log --oneline -1 HEAD
    ```
    These should show the same commit (or HEAD should be ahead by only your own commits).
@@ -229,34 +262,35 @@ milestone numbers and paste your breaking change analysis table. The default exp
    cd externals/skia
    ```
 
-5. **Align to the SHA that `origin/main` expects** (the submodule tracks the `skiasharp`
-   branch in mono/skia, NOT `main`):
+5. **Align to the SHA that `origin/{BASE_BRANCH}` expects** (the submodule tracks
+   `{SKIA_BASE_BRANCH}` in mono/skia — `skiasharp` for a `main` update, or the matching
+   `release/<major>.{TARGET}.x` for a release-line update — NOT `main`):
    ```bash
-   MAIN_SUB_SHA=$(git -C ../.. ls-tree origin/main -- externals/skia | awk '{print $3}')
-   git fetch origin skiasharp
-   git checkout "$MAIN_SUB_SHA"
+   BASE_SUB_SHA=$(git -C ../.. ls-tree origin/{BASE_BRANCH} -- externals/skia | awk '{print $3}')
+   git fetch origin {SKIA_BASE_BRANCH}
+   git checkout "$BASE_SUB_SHA"
    ```
-   Verify this SHA is on `origin/skiasharp`:
+   Verify this SHA is on `origin/{SKIA_BASE_BRANCH}`:
    ```bash
-   git branch -r --contains "$MAIN_SUB_SHA" | grep 'origin/skiasharp'
+   git branch -r --contains "$BASE_SUB_SHA" | grep 'origin/{SKIA_BASE_BRANCH}'
    ```
 
 6. **Create the submodule feature branch:**
    ```bash
-   git checkout -b skia-sync/m{TARGET}
+   git checkout -b {HEAD_BRANCH}
    ```
 
 > ⚠️ **Do NOT skip the SHA alignment step (step 5).** If the submodule is at a different
-> SHA than `origin/main` expects, the merge will produce phantom diffs — functions that
-> already exist on `main` will appear as new or removed.
+> SHA than `origin/{BASE_BRANCH}` expects, the merge will produce phantom diffs — functions that
+> already exist on the base branch will appear as new or removed.
 
 > 🛑 **GATE**: Both branches created. Verify:
 > ```bash
 > # In parent repo:
-> git rev-parse --abbrev-ref HEAD          # → skia-sync/m{TARGET}
-> git merge-base HEAD origin/main          # → should match origin/main tip
+> git rev-parse --abbrev-ref HEAD          # → {HEAD_BRANCH}
+> git merge-base HEAD origin/{BASE_BRANCH}  # → should match origin/{BASE_BRANCH} tip
 > # In submodule:
-> git -C externals/skia rev-parse --abbrev-ref HEAD  # → skia-sync/m{TARGET}
+> git -C externals/skia rev-parse --abbrev-ref HEAD  # → {HEAD_BRANCH}
 > ```
 
 ### Phase 5: Upstream Merge (mono/skia)
@@ -520,22 +554,28 @@ before the update can be considered complete. Do not create PRs with only smoke 
 > **Same-milestone bug-fix syncs:** When `CURRENT == TARGET`, only `cgmanifest.json`'s
 > `commitHash`/`upstream_merge_commit` change. Use PR titles like
 > `[skia-sync] Merge upstream chrome/m{TARGET} bug fixes` instead of milestone-bump titles.
+> A release-line update is always such a sync.
+
+> **Release-line targets:** Use the `{BASE_BRANCH}` / `{SKIA_BASE_BRANCH}` / `{HEAD_BRANCH}`
+> values resolved in Phase 1 step 5. For a `main` update they are `main` / `skiasharp` /
+> `skia-sync/m{TARGET}`; for a release-line update they are `release/<major>.{TARGET}.x` (both
+> repos) / `skia-sync/release-<major>.{TARGET}.x`.
 
 #### PR 1: mono/skia (submodule)
 
 | Field | Value |
 |-------|-------|
-| Branch | `skia-sync/m{TARGET}` |
-| Target | `skiasharp` |
+| Branch | `{HEAD_BRANCH}` |
+| Target | `{SKIA_BASE_BRANCH}` |
 | Title | `[skia-sync] Merge upstream chrome/m{TARGET}` |
 
 #### PR 2: mono/SkiaSharp (parent)
 
 | Field | Value |
 |-------|-------|
-| Branch | `skia-sync/m{TARGET}` |
-| Target | `main` |
-| Title | `[skia-sync] Update skia to milestone {TARGET}` |
+| Branch | `{HEAD_BRANCH}` |
+| Target | `{BASE_BRANCH}` |
+| Title | `[skia-sync] Update skia to milestone {TARGET}` (or `Merge upstream chrome/m{TARGET} bug fixes` when `CURRENT == TARGET`) |
 
 **Submodule must point to the mono/skia PR branch.**
 
@@ -548,9 +588,9 @@ Both PRs must reference each other.
 
 Before proceeding to merge, verify ALL of these:
 
-- [ ] Branch names follow `skia-sync/m{TARGET}` convention in BOTH repos
-- [ ] mono/skia PR targets `skiasharp` branch
-- [ ] mono/SkiaSharp PR targets `main` branch
+- [ ] Branch names follow `{HEAD_BRANCH}` convention in BOTH repos
+- [ ] mono/skia PR targets `{SKIA_BASE_BRANCH}` branch
+- [ ] mono/SkiaSharp PR targets `{BASE_BRANCH}` branch
 - [ ] **SkiaSharp's `externals/skia` submodule points to the mono/skia PR branch** (`git submodule status`)
 - [ ] `cgmanifest.json` updated with new commit hash, version, and chrome_milestone
 - [ ] `scripts/VERSIONS.txt` updated (ALL version lines, not just milestone)
@@ -562,7 +602,7 @@ Before proceeding to merge, verify ALL of these:
 
 #### Merge Sequence (CRITICAL)
 
-1. Merge mono/skia PR first → creates new squashed SHA on `skiasharp`
+1. Merge mono/skia PR first → creates new squashed SHA on `{SKIA_BASE_BRANCH}`
 2. Fetch new SHA in SkiaSharp's submodule
 3. Update submodule pointer, push to SkiaSharp PR branch
 4. **Only then** merge SkiaSharp PR
@@ -572,12 +612,12 @@ Before proceeding to merge, verify ALL of these:
 Before proceeding past each step, verify:
 
 - [ ] mono/skia PR merged
-- [ ] Fetched `skiasharp` branch to get new squashed SHA
+- [ ] Fetched `{SKIA_BASE_BRANCH}` branch to get new squashed SHA
 - [ ] Updated SkiaSharp submodule to new SHA (`cd externals/skia && git fetch origin && git checkout {new-sha}`)
 - [ ] Pushed submodule update to SkiaSharp PR branch
 - [ ] CI passes on updated SkiaSharp PR
 - [ ] SkiaSharp PR merged
-- [ ] **Submodule points to a commit on `skiasharp` branch** (not an orphaned branch commit)
+- [ ] **Submodule points to a commit on `{SKIA_BASE_BRANCH}` branch** (not an orphaned branch commit)
 
 > ❌ **NEVER** merge both PRs without updating the submodule in between.
 > ❌ **NEVER** assume the submodule reference is correct after squash-merging mono/skia.

--- a/.github/scripts/skia-sync-align-submodule.sh
+++ b/.github/scripts/skia-sync-align-submodule.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# skia-sync-align-submodule.sh — Point externals/skia at the SHA the base branch
+# records, before the agent runs.
+#
+# The agent job checks out the workflow branch (usually main), so the submodule may
+# sit at a different SHA than the base branch (`main` or a release line) expects. The
+# submodule tracks `$skia_base_branch` in mono/skia (skiasharp for a main sync,
+# release/<major>.<milestone>.x for a release sync), so the base-branch submodule SHA
+# should be a commit on that branch.
+#
+# Requires (export these by sourcing skia-sync-detect.sh's output first):
+#   base_branch        parent base branch (main or release/<major>.<ms>.x)
+#   skia_base_branch   mono/skia base branch (skiasharp or release/<major>.<ms>.x)
+
+set -euo pipefail
+
+BASE_BRANCH="${base_branch:?base_branch not set — source skia-sync-detect.sh first}"
+SKIA_BASE_BRANCH="${skia_base_branch:?skia_base_branch not set — source skia-sync-detect.sh first}"
+
+echo "Aligning submodule to origin/${BASE_BRANCH} (mono/skia ${SKIA_BASE_BRANCH})"
+git fetch origin "$BASE_BRANCH" 2>&1 || true
+BASE_SUB_SHA=$(git ls-tree "origin/${BASE_BRANCH}" -- externals/skia | awk '{print $3}')
+echo "origin/${BASE_BRANCH} submodule SHA: $BASE_SUB_SHA"
+git -C externals/skia fetch origin "$SKIA_BASE_BRANCH" 2>&1
+git -C externals/skia checkout "$BASE_SUB_SHA" 2>&1
+echo "Verifying SHA is on ${SKIA_BASE_BRANCH} branch:"
+git -C externals/skia branch -r --contains "$BASE_SUB_SHA" | grep -q "origin/${SKIA_BASE_BRANCH}" \
+  && echo "  ✅ SHA is on origin/${SKIA_BASE_BRANCH}" \
+  || echo "  ⚠️ SHA is NOT on origin/${SKIA_BASE_BRANCH} — submodule pointer may be stale"

--- a/.github/scripts/skia-sync-detect.sh
+++ b/.github/scripts/skia-sync-detect.sh
@@ -37,12 +37,15 @@ MODE=""
 MILESTONE=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --gate)      GATE=true ;;
-    --mode)      MODE="${2:-}"; shift ;;
-    --milestone) MILESTONE="${2:-}"; shift ;;
+    --gate) GATE=true; shift ;;
+    --mode)
+      [ $# -ge 2 ] || { echo "::error::skia-sync-detect.sh: --mode requires a value"; exit 2; }
+      MODE="$2"; shift 2 ;;
+    --milestone)
+      [ $# -ge 2 ] || { echo "::error::skia-sync-detect.sh: --milestone requires a value"; exit 2; }
+      MILESTONE="$2"; shift 2 ;;
     *) echo "::error::skia-sync-detect.sh: unknown argument '$1'"; exit 2 ;;
   esac
-  shift
 done
 MODE="${MODE:-next}"
 
@@ -93,7 +96,8 @@ if [ "$TARGET" -lt "$MAIN_MS" ] 2>/dev/null; then
   # The glob can match more than one major (e.g. release/4.148.x and a stray
   # release/14.148.x). Refuse to guess — fail so a human disambiguates.
   if [ "$(printf '%s' "$RELEASE_BRANCH" | grep -c . || true)" -gt 1 ]; then
-    echo "::error::Multiple release branches match milestone ${TARGET}: $(echo $RELEASE_BRANCH) — cannot disambiguate."
+    matches=$(echo "$RELEASE_BRANCH" | paste -sd' ' -)
+    echo "::error::Multiple release branches match milestone ${TARGET}: ${matches} — cannot disambiguate."
     exit 1
   fi
 fi

--- a/.github/scripts/skia-sync-detect.sh
+++ b/.github/scripts/skia-sync-detect.sh
@@ -14,22 +14,37 @@
 #   - All human-readable logs and ::error::/::notice:: workflow commands go to stdout
 #     (so GitHub renders annotations and the machine output stays clean for sourcing).
 #
+# Args:
+#   --mode <current|next|latest>   Which milestone line to track. The workflow resolves
+#                                  this from the dispatch input or the triggering cron
+#                                  (the cron→mode mapping lives in the workflow, next to
+#                                  where the crons are declared). Defaults to `next`.
+#   --milestone <number>           Exact milestone override; when set, mode becomes
+#                                  `explicit` and the target is this number.
+#   --gate                         Also run the gating checks (does upstream exist? is it
+#                                  already merged?) and emit `skip=true` / exit
+#                                  accordingly. Only pre_activation needs this.
+#
 # Inputs (env):
-#   INPUT_MODE        github.event.inputs.mode      (current|next|latest, optional)
-#   INPUT_MILESTONE   github.event.inputs.milestone (exact number, optional override)
-#   SCHEDULE          github.event.schedule         (cron string, optional)
 #   GITHUB_REPOSITORY owner/repo of this SkiaSharp checkout (default GitHub env)
 #   GITHUB_REF        ref whose scripts/VERSIONS.txt gives main's milestone
 #   GH_TOKEN          token for `gh api`
-#
-# Flags:
-#   --gate   Also run the gating checks (does upstream exist? is it already merged?)
-#            and emit `skip=true` / exit accordingly. Only pre_activation needs this.
 
 set -euo pipefail
 
 GATE=false
-[ "${1:-}" = "--gate" ] && GATE=true
+MODE=""
+MILESTONE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --gate)      GATE=true ;;
+    --mode)      MODE="${2:-}"; shift ;;
+    --milestone) MILESTONE="${2:-}"; shift ;;
+    *) echo "::error::skia-sync-detect.sh: unknown argument '$1'"; exit 2 ;;
+  esac
+  shift
+done
+MODE="${MODE:-next}"
 
 OUT="${SKIA_SYNC_OUT:-${GITHUB_OUTPUT:?SKIA_SYNC_OUT or GITHUB_OUTPUT must be set}}"
 emit() { printf '%s=%s\n' "$1" "$2" >>"$OUT"; }
@@ -41,24 +56,16 @@ milestone_of() {
 }
 
 # -- Mode -------------------------------------------------------------
-if [ -n "${INPUT_MODE:-}" ]; then
-  MODE="$INPUT_MODE"
-elif [ "${SCHEDULE:-}" = "0 7 * * *" ]; then
-  MODE=current
-elif [ "${SCHEDULE:-}" = "0 17 * * *" ]; then
-  MODE=latest
-else
-  MODE=next
-fi
-
+# Resolved by the caller (workflow): the cron→mode mapping lives in the workflow,
+# next to where the crons are declared. Here it is simply a value in {current,next,latest}.
 MAIN_MS=$(milestone_of "$GITHUB_REF")
 NEXT=$((MAIN_MS + 1))
 LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
   | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1)
 
 # -- Target -----------------------------------------------------------
-if [ -n "${INPUT_MILESTONE:-}" ]; then
-  TARGET="$INPUT_MILESTONE"; MODE="explicit"
+if [ -n "$MILESTONE" ]; then
+  TARGET="$MILESTONE"; MODE="explicit"
 elif [ "$MODE" = latest ]; then
   TARGET="$LATEST"
 elif [ "$MODE" = current ]; then

--- a/.github/scripts/skia-sync-detect.sh
+++ b/.github/scripts/skia-sync-detect.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# skia-sync-detect.sh — Resolve which Skia milestone and branch line the upstream
+# sync targets. This is the SINGLE source of truth for branch resolution, shared by:
+#
+#   - the pre_activation "Detect milestone" step  → run with --gate; writes the job
+#     outputs consumed by the prompt and the activation gate.
+#   - the agent job "Align submodule" step        → run without --gate and sourced,
+#     because that job cannot read pre_activation's outputs and must recompute them.
+#
+# Contract:
+#   - `key=value` lines (lowercase, matching the workflow's declared outputs) are
+#     appended to the file named by $SKIA_SYNC_OUT, defaulting to $GITHUB_OUTPUT.
+#   - All human-readable logs and ::error::/::notice:: workflow commands go to stdout
+#     (so GitHub renders annotations and the machine output stays clean for sourcing).
+#
+# Inputs (env):
+#   INPUT_MODE        github.event.inputs.mode      (current|next|latest, optional)
+#   INPUT_MILESTONE   github.event.inputs.milestone (exact number, optional override)
+#   SCHEDULE          github.event.schedule         (cron string, optional)
+#   GITHUB_REPOSITORY owner/repo of this SkiaSharp checkout (default GitHub env)
+#   GITHUB_REF        ref whose scripts/VERSIONS.txt gives main's milestone
+#   GH_TOKEN          token for `gh api`
+#
+# Flags:
+#   --gate   Also run the gating checks (does upstream exist? is it already merged?)
+#            and emit `skip=true` / exit accordingly. Only pre_activation needs this.
+
+set -euo pipefail
+
+GATE=false
+[ "${1:-}" = "--gate" ] && GATE=true
+
+OUT="${SKIA_SYNC_OUT:-${GITHUB_OUTPUT:?SKIA_SYNC_OUT or GITHUB_OUTPUT must be set}}"
+emit() { printf '%s=%s\n' "$1" "$2" >>"$OUT"; }
+
+# Milestone number from scripts/VERSIONS.txt at the given ref (remote read, no checkout).
+milestone_of() {
+  gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/VERSIONS.txt?ref=$1" \
+    --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}'
+}
+
+# -- Mode -------------------------------------------------------------
+if [ -n "${INPUT_MODE:-}" ]; then
+  MODE="$INPUT_MODE"
+elif [ "${SCHEDULE:-}" = "0 7 * * *" ]; then
+  MODE=current
+elif [ "${SCHEDULE:-}" = "0 17 * * *" ]; then
+  MODE=latest
+else
+  MODE=next
+fi
+
+MAIN_MS=$(milestone_of "$GITHUB_REF")
+NEXT=$((MAIN_MS + 1))
+LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
+  | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1)
+
+# -- Target -----------------------------------------------------------
+if [ -n "${INPUT_MILESTONE:-}" ]; then
+  TARGET="$INPUT_MILESTONE"; MODE="explicit"
+elif [ "$MODE" = latest ]; then
+  TARGET="$LATEST"
+elif [ "$MODE" = current ]; then
+  TARGET="$MAIN_MS"
+else
+  TARGET="$NEXT"
+fi
+
+# -- Target line: `main` (newest) vs a release/<major>.<TARGET>.x maintenance line.
+# A maintenance line lives under the SAME branch name in both mono/SkiaSharp and
+# mono/skia. We only look for one when TARGET is strictly OLDER than main's milestone;
+# the newest line is always served by `main`. The release branch itself is owned by
+# the release process (release-branch skill), NOT this sync.
+IS_RELEASE=false
+BASE_BRANCH=main
+SKIA_BASE_BRANCH=skiasharp
+HEAD_BRANCH="skia-sync/m${TARGET}"
+RELEASE_BRANCH=""
+# `2>/dev/null` swallows the "integer expression expected" noise for a non-numeric
+# TARGET, which then falls through to the main line.
+if [ "$TARGET" -lt "$MAIN_MS" ] 2>/dev/null; then
+  RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" \
+      "refs/heads/release/*.${TARGET}.x" \
+    | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | sort -u)
+  # The glob can match more than one major (e.g. release/4.148.x and a stray
+  # release/14.148.x). Refuse to guess — fail so a human disambiguates.
+  if [ "$(printf '%s' "$RELEASE_BRANCH" | grep -c . || true)" -gt 1 ]; then
+    echo "::error::Multiple release branches match milestone ${TARGET}: $(echo $RELEASE_BRANCH) — cannot disambiguate."
+    exit 1
+  fi
+fi
+if [ -n "$RELEASE_BRANCH" ]; then
+  IS_RELEASE=true
+  BASE_BRANCH="$RELEASE_BRANCH"
+  SKIA_BASE_BRANCH="$RELEASE_BRANCH"
+  HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
+  # The matching mono/skia release branch MUST already exist.
+  if [ -z "$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')" ]; then
+    echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
+    exit 1
+  fi
+fi
+
+# `current` = milestone of the BASE branch we sync INTO:
+#   - main line → main's milestone
+#   - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
+if [ "$IS_RELEASE" = true ]; then
+  CURRENT=$(milestone_of "$BASE_BRANCH")
+else
+  CURRENT="$MAIN_MS"
+fi
+
+emit mode "$MODE"
+emit next "$NEXT"
+emit latest "$LATEST"
+emit target "$TARGET"
+emit is_release "$IS_RELEASE"
+emit base_branch "$BASE_BRANCH"
+emit skia_base_branch "$SKIA_BASE_BRANCH"
+emit head_branch "$HEAD_BRANCH"
+emit current "$CURRENT"
+
+echo "Resolved: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH}, release=${IS_RELEASE})"
+
+# Branch derivation is all the agent job needs; gating is pre_activation-only.
+$GATE || exit 0
+
+# -- Gate: only spin up the (expensive) agent when there is new upstream work ----
+UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
+if [ -z "$UPSTREAM_SHA" ]; then
+  echo "::notice::upstream/chrome/m${TARGET} does not exist yet"
+  [ "$MODE" = explicit ] && exit 1
+  emit skip true
+  exit 0
+fi
+
+# Compare upstream HEAD against the existing sync branch if present; otherwise, for a
+# release line, against the release base branch. A main milestone bump has no sync
+# branch yet and always has work, so it proceeds.
+SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
+COMPARE_REF=""
+if [ -n "$SYNC_SHA" ]; then
+  COMPARE_REF="$HEAD_BRANCH"
+elif [ "$IS_RELEASE" = true ]; then
+  COMPARE_REF="$SKIA_BASE_BRANCH"
+fi
+if [ -n "$COMPARE_REF" ]; then
+  BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" --jq '.behind_by' 2>/dev/null || echo unknown)
+  if [ "$BEHIND" = 0 ]; then
+    echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
+    emit skip true
+    exit 0
+  fi
+  echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
+fi

--- a/.github/scripts/skia-sync-push-prs.sh
+++ b/.github/scripts/skia-sync-push-prs.sh
@@ -6,7 +6,8 @@
 #   GH_TOKEN — PAT with write access to mono/skia and mono/SkiaSharp
 #
 # Expected files (written by the agent):
-#   /tmp/gh-aw/agent/skia-sync-env.sh — TARGET and CURRENT vars
+#   /tmp/gh-aw/agent/skia-sync-env.sh — TARGET, CURRENT, and (optionally) IS_RELEASE,
+#       BASE_BRANCH, SKIA_BASE_BRANCH, HEAD_BRANCH vars
 #   /tmp/gh-aw/agent/skia-sync-skia-summary.md — mono/skia PR body
 #   /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md — mono/SkiaSharp PR body
 #
@@ -24,7 +25,15 @@ if [ -z "${TARGET:-}" ]; then
     exit 0
 fi
 
-BRANCH="skia-sync/m${TARGET}"
+# Branch targets. For a main sync these default to the historical values; for a
+# release-line sync the agent provides explicit HEAD_BRANCH / BASE_BRANCH /
+# SKIA_BASE_BRANCH that point at the matching release/<major>.<milestone>.x line.
+BRANCH="${HEAD_BRANCH:-skia-sync/m${TARGET}}"
+SS_BASE="${BASE_BRANCH:-main}"
+SKIA_BASE="${SKIA_BASE_BRANCH:-skiasharp}"
+IS_RELEASE="${IS_RELEASE:-false}"
+echo "Sync branch: $BRANCH | SkiaSharp base: $SS_BASE | mono/skia base: $SKIA_BASE | release: $IS_RELEASE"
+
 SKIA_SUMMARY=""
 SS_SUMMARY=""
 [ -f /tmp/gh-aw/agent/skia-sync-skia-summary.md ] && SKIA_SUMMARY=$(cat /tmp/gh-aw/agent/skia-sync-skia-summary.md)
@@ -37,6 +46,9 @@ if [ "$CURRENT" = "$TARGET" ]; then
 else
     SS_TITLE="[skia-sync] Update skia to milestone ${TARGET}"
     SS_BODY_INTRO="Automated Skia milestone bump from m${CURRENT} to m${TARGET}."
+fi
+if [ "$IS_RELEASE" = "true" ]; then
+    SS_BODY_INTRO="${SS_BODY_INTRO} Targeting release branch \`${SS_BASE}\` (mono/skia \`${SKIA_BASE}\`)."
 fi
 
 WORKFLOW_LINK="[skia-upstream-sync](https://github.com/${GITHUB_REPOSITORY:-mono/SkiaSharp}/actions/workflows/auto-skia-sync.lock.yml)"
@@ -58,7 +70,7 @@ push_skia() {
     if [ -z "$pr" ]; then
         echo "Creating mono/skia PR..."
         gh pr create --repo mono/skia \
-            --head "$BRANCH" --base skiasharp \
+            --head "$BRANCH" --base "$SKIA_BASE" \
             --title "[skia-sync] Merge upstream chrome/m${TARGET}" \
             --draft \
             --body "Automated upstream merge of \`chrome/m${TARGET}\`.
@@ -98,7 +110,7 @@ push_skiasharp() {
     if [ -z "$ss_pr" ]; then
         echo "Creating mono/SkiaSharp PR..."
         gh pr create --repo mono/SkiaSharp \
-            --head "$BRANCH" --base main \
+            --head "$BRANCH" --base "$SS_BASE" \
             --title "$SS_TITLE" \
             --draft \
             --body "${SS_BODY_INTRO}

--- a/.github/scripts/skia-sync-push-prs.sh
+++ b/.github/scripts/skia-sync-push-prs.sh
@@ -18,6 +18,8 @@ if [ ! -f /tmp/gh-aw/agent/skia-sync-env.sh ]; then
     echo "No skia-sync-env.sh — agent determined no work needed"
     exit 0
 fi
+# Written by the agent at runtime; not resolvable at lint time.
+# shellcheck source=/dev/null
 source /tmp/gh-aw/agent/skia-sync-env.sh
 
 if [ -z "${TARGET:-}" ]; then

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"23520ea9dfe94887804849d1637be2d607317b1b23d8364b0262cee491d4d6b9","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f837ac9c789c59020f6a17a866aa3a43e2086a6421e464b3bf1f406c03a15937","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -231,23 +231,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
+          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
           <system>
-          GH_AW_PROMPT_318360b86911c4d8_EOF
+          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
+          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_318360b86911c4d8_EOF
+          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
+          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_318360b86911c4d8_EOF
+          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
+          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -279,12 +279,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_318360b86911c4d8_EOF
+          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
+          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_318360b86911c4d8_EOF
+          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -536,7 +536,7 @@ jobs:
         name: Install native build dependencies
         run: |-
           sudo apt-get update -qq
-          sudo apt-get install -y clang fontconfig libfontconfig1-dev ninja-build fonts-dejavu-core ttf-ancient-fonts
+          sudo apt-get install -y clang libc++-dev libc++abi-dev fontconfig libfontconfig1-dev ninja-build fonts-dejavu-core ttf-ancient-fonts
           fc-cache -f
           dotnet workload install android --skip-sign-check
 
@@ -547,9 +547,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a35deaa2484fa3b2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_23016918b95809af_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a35deaa2484fa3b2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_23016918b95809af_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -747,7 +747,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_2c5d7a4ccfdfe64e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_81e9d30c8bfb6908_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -795,7 +795,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2c5d7a4ccfdfe64e_EOF
+          GH_AW_MCP_CONFIG_81e9d30c8bfb6908_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c6bbf9789260e93f5f0c4327813b2def5a3da617e56dff527364a7e3f268a448","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3a223b93d31db74929a5ffb8f1555585301d36f6cbb17c6e31e62f578b585aca","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -36,6 +36,7 @@
 #   - SKIASHARP_AUTOBUMP_TOKEN
 #
 # Custom actions used:
+#   - actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -58,6 +59,10 @@ name: "Skia Upstream Sync"
   - cron: "0 12 * * *"
   - cron: "0 17 * * *"
   # steps: # Steps injected into pre-activation job
+  # - name: Check out detection scripts
+    # uses: actions/checkout@v4
+    # with:
+      # sparse-checkout: .github/scripts
   # - env:
       # GH_TOKEN: ${{ github.token }}
       # INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
@@ -65,121 +70,7 @@ name: "Skia Upstream Sync"
       # SCHEDULE: ${{ github.event.schedule }}
     # id: detect
     # name: Detect milestone
-    # run: |
-      # if [ -n "$INPUT_MODE" ]; then
-        # MODE="$INPUT_MODE"
-      # elif [ "$SCHEDULE" = "0 7 * * *" ]; then
-        # MODE=current
-      # elif [ "$SCHEDULE" = "0 17 * * *" ]; then
-        # MODE=latest
-      # else
-        # MODE=next
-      # fi
-      # echo "mode=$MODE" >> "$GITHUB_OUTPUT"
-      # 
-      # # main's milestone — the basis for `current`/`next` mode math.
-      # MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
-        # --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-      # 
-      # NEXT=$((MAIN_MS + 1))
-      # echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-      # 
-      # LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
-        # | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' \
-        # | sort -n | tail -1)
-      # echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
-      # 
-      # # Explicit milestone input overrides mode
-      # if [ -n "$INPUT_MILESTONE" ]; then
-        # TARGET="$INPUT_MILESTONE"
-        # MODE="explicit"
-      # elif [ "$MODE" = "latest" ]; then
-        # TARGET="$LATEST"
-      # elif [ "$MODE" = "current" ]; then
-        # TARGET="$MAIN_MS"
-      # else
-        # TARGET="$NEXT"
-      # fi
-      # echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-      # 
-      # # -- Resolve the target line: `main` (newest, in-development) or a release line.
-      # # A maintenance line lives as `release/<major>.<TARGET>.x` in BOTH mono/SkiaSharp
-      # # and mono/skia. We only look for one when TARGET is older than main's milestone —
-      # # the newest line is always served by `main`. The release branch itself is created
-      # # by the release process (release-branch skill), NOT this sync; if the mono/skia
-      # # side is missing we fail so branch ownership stays with the release process.
-      # IS_RELEASE=false
-      # BASE_BRANCH=main
-      # SKIA_BASE_BRANCH=skiasharp
-      # HEAD_BRANCH="skia-sync/m${TARGET}"
-      # RELEASE_BRANCH=""
-      # if [ "$TARGET" != "$MAIN_MS" ]; then
-        # RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
-          # | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
-      # fi
-      # if [ -n "$RELEASE_BRANCH" ]; then
-        # IS_RELEASE=true
-        # BASE_BRANCH="$RELEASE_BRANCH"
-        # SKIA_BASE_BRANCH="$RELEASE_BRANCH"
-        # HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
-      # 
-        # # The matching mono/skia release branch MUST already exist.
-        # SKIA_BASE_SHA=$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')
-        # if [ -z "$SKIA_BASE_SHA" ]; then
-          # echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
-          # exit 1
-        # fi
-      # fi
-      # echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-      # echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
-      # echo "skia_base_branch=$SKIA_BASE_BRANCH" >> "$GITHUB_OUTPUT"
-      # echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
-      # 
-      # # `current` is the milestone of the BASE branch we're syncing INTO:
-      # #  - main line → main's milestone
-      # #  - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
-      # if [ "$IS_RELEASE" = true ]; then
-        # CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=${BASE_BRANCH}" \
-          # --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-      # else
-        # CURRENT="$MAIN_MS"
-      # fi
-      # echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-      # 
-      # UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
-      # if [ -z "$UPSTREAM_SHA" ]; then
-        # echo "::notice::upstream/chrome/m${TARGET} does not exist yet"
-        # if [ "$MODE" = "explicit" ]; then
-          # exit 1
-        # fi
-        # echo "skip=true" >> "$GITHUB_OUTPUT"
-        # exit 0
-      # fi
-      # 
-      # # Check whether there is anything new to merge from upstream. Compare upstream
-      # # HEAD against the existing sync branch if present; otherwise, for release lines,
-      # # against the release base branch. This avoids spinning up the expensive agent
-      # # job when there's nothing new. (For a main milestone bump the sync branch won't
-      # # exist yet and there is always new work, so we proceed.)
-      # SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
-      # COMPARE_REF=""
-      # if [ -n "$SYNC_SHA" ]; then
-        # COMPARE_REF="$HEAD_BRANCH"
-      # elif [ "$IS_RELEASE" = true ]; then
-        # COMPARE_REF="$SKIA_BASE_BRANCH"
-      # fi
-      # if [ -n "$COMPARE_REF" ]; then
-        # BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" \
-          # --jq '.behind_by' 2>/dev/null || echo "unknown")
-        # if [ "$BEHIND" = "0" ]; then
-          # echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
-          # echo "skip=true" >> "$GITHUB_OUTPUT"
-          # exit 0
-        # fi
-        # echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
-      # fi
-      # 
-      # echo "Will process: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH})"
+    # run: bash .github/scripts/skia-sync-detect.sh --gate
   workflow_dispatch:
     inputs:
       aw_context:
@@ -340,23 +231,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
+          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
           <system>
-          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
+          GH_AW_PROMPT_edc8624e8bd34a95_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
+          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
+          GH_AW_PROMPT_edc8624e8bd34a95_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
+          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
+          GH_AW_PROMPT_edc8624e8bd34a95_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
+          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -388,12 +279,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
+          GH_AW_PROMPT_edc8624e8bd34a95_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
+          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
+          GH_AW_PROMPT_edc8624e8bd34a95_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -563,51 +454,14 @@ jobs:
           NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - name: Align submodule to the base branch
         run: |
-          # Re-derive the sync base branch here (same rules as the pre-activation
-          # `Detect milestone` step, which stays the source of truth). We can't read
-          # its outputs: this step runs in the agent job, which only `needs:`
-          # activation, and the cheap pre-activation job has no checkout to share a
-          # script from. github.event inputs ARE available in any job, so we redo the
-          # small base-branch resolution from them.
-          if [ -n "$INPUT_MODE" ]; then MODE="$INPUT_MODE";
-          elif [ "$SCHEDULE" = "0 7 * * *" ]; then MODE=current;
-          elif [ "$SCHEDULE" = "0 17 * * *" ]; then MODE=latest;
-          else MODE=next; fi
-          MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
-            --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-          if [ -n "$INPUT_MILESTONE" ]; then TARGET="$INPUT_MILESTONE";
-          elif [ "$MODE" = "latest" ]; then
-            TARGET=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
-              | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1);
-          elif [ "$MODE" = "current" ]; then TARGET="$MAIN_MS";
-          else TARGET="$((MAIN_MS + 1))"; fi
-
-          BASE_BRANCH=main
-          SKIA_BASE_BRANCH=skiasharp
-          if [ "$TARGET" != "$MAIN_MS" ]; then
-            RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
-              | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
-            if [ -n "$RELEASE_BRANCH" ]; then
-              BASE_BRANCH="$RELEASE_BRANCH"
-              SKIA_BASE_BRANCH="$RELEASE_BRANCH"
-            fi
-          fi
-
-          # The checkout uses the workflow branch (main), so the submodule may be at a
-          # different SHA than the base branch expects. Fix it before the agent runs.
-          # The submodule tracks `${SKIA_BASE_BRANCH}` in mono/skia (skiasharp for a
-          # main sync, release/<major>.<milestone>.x for a release sync), so the
-          # base-branch submodule SHA should be a commit on that branch.
-          echo "Aligning submodule to origin/${BASE_BRANCH} (mono/skia ${SKIA_BASE_BRANCH})"
-          git fetch origin "$BASE_BRANCH" 2>&1 || true
-          BASE_SUB_SHA=$(git ls-tree "origin/${BASE_BRANCH}" -- externals/skia | awk '{print $3}')
-          echo "origin/${BASE_BRANCH} submodule SHA: $BASE_SUB_SHA"
-          git -C externals/skia fetch origin "$SKIA_BASE_BRANCH" 2>&1
-          git -C externals/skia checkout "$BASE_SUB_SHA" 2>&1
-          echo "Verifying SHA is on ${SKIA_BASE_BRANCH} branch:"
-          git -C externals/skia branch -r --contains "$BASE_SUB_SHA" | grep -q "origin/${SKIA_BASE_BRANCH}" \
-            && echo "  ✅ SHA is on origin/${SKIA_BASE_BRANCH}" \
-            || echo "  ⚠️ SHA is NOT on origin/${SKIA_BASE_BRANCH} — submodule pointer may be stale"
+          # The agent job can't read pre_activation's outputs (it only `needs:`
+          # activation), so re-run the same committed detector to recover base_branch /
+          # skia_base_branch, then align the submodule. skia-sync-detect.sh is the single
+          # source of truth — no branch logic is duplicated here.
+          OUT=$(mktemp)
+          SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh
+          set -a; . "$OUT"; set +a
+          bash .github/scripts/skia-sync-align-submodule.sh
         env:
           GH_HOST: localhost:18443
           GH_REPO: ${{ github.repository }}
@@ -697,9 +551,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9b1865f00eeb8608_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f0e0572f06c64611_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9b1865f00eeb8608_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f0e0572f06c64611_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -897,7 +751,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_22666b6fb299eac2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_dedffa87e7764a75_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -945,7 +799,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_22666b6fb299eac2_EOF
+          GH_AW_MCP_CONFIG_dedffa87e7764a75_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1541,123 +1395,13 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
+      - name: Check out detection scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/scripts
       - name: Detect milestone
         id: detect
-        run: |
-          if [ -n "$INPUT_MODE" ]; then
-            MODE="$INPUT_MODE"
-          elif [ "$SCHEDULE" = "0 7 * * *" ]; then
-            MODE=current
-          elif [ "$SCHEDULE" = "0 17 * * *" ]; then
-            MODE=latest
-          else
-            MODE=next
-          fi
-          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
-
-          # main's milestone — the basis for `current`/`next` mode math.
-          MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
-            --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-
-          NEXT=$((MAIN_MS + 1))
-          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-
-          LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
-            | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' \
-            | sort -n | tail -1)
-          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
-
-          # Explicit milestone input overrides mode
-          if [ -n "$INPUT_MILESTONE" ]; then
-            TARGET="$INPUT_MILESTONE"
-            MODE="explicit"
-          elif [ "$MODE" = "latest" ]; then
-            TARGET="$LATEST"
-          elif [ "$MODE" = "current" ]; then
-            TARGET="$MAIN_MS"
-          else
-            TARGET="$NEXT"
-          fi
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-
-          # -- Resolve the target line: `main` (newest, in-development) or a release line.
-          # A maintenance line lives as `release/<major>.<TARGET>.x` in BOTH mono/SkiaSharp
-          # and mono/skia. We only look for one when TARGET is older than main's milestone —
-          # the newest line is always served by `main`. The release branch itself is created
-          # by the release process (release-branch skill), NOT this sync; if the mono/skia
-          # side is missing we fail so branch ownership stays with the release process.
-          IS_RELEASE=false
-          BASE_BRANCH=main
-          SKIA_BASE_BRANCH=skiasharp
-          HEAD_BRANCH="skia-sync/m${TARGET}"
-          RELEASE_BRANCH=""
-          if [ "$TARGET" != "$MAIN_MS" ]; then
-            RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
-              | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
-          fi
-          if [ -n "$RELEASE_BRANCH" ]; then
-            IS_RELEASE=true
-            BASE_BRANCH="$RELEASE_BRANCH"
-            SKIA_BASE_BRANCH="$RELEASE_BRANCH"
-            HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
-
-            # The matching mono/skia release branch MUST already exist.
-            SKIA_BASE_SHA=$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')
-            if [ -z "$SKIA_BASE_SHA" ]; then
-              echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
-              exit 1
-            fi
-          fi
-          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
-          echo "skia_base_branch=$SKIA_BASE_BRANCH" >> "$GITHUB_OUTPUT"
-          echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
-
-          # `current` is the milestone of the BASE branch we're syncing INTO:
-          #  - main line → main's milestone
-          #  - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
-          if [ "$IS_RELEASE" = true ]; then
-            CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=${BASE_BRANCH}" \
-              --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-          else
-            CURRENT="$MAIN_MS"
-          fi
-          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-
-          UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
-          if [ -z "$UPSTREAM_SHA" ]; then
-            echo "::notice::upstream/chrome/m${TARGET} does not exist yet"
-            if [ "$MODE" = "explicit" ]; then
-              exit 1
-            fi
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Check whether there is anything new to merge from upstream. Compare upstream
-          # HEAD against the existing sync branch if present; otherwise, for release lines,
-          # against the release base branch. This avoids spinning up the expensive agent
-          # job when there's nothing new. (For a main milestone bump the sync branch won't
-          # exist yet and there is always new work, so we proceed.)
-          SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
-          COMPARE_REF=""
-          if [ -n "$SYNC_SHA" ]; then
-            COMPARE_REF="$HEAD_BRANCH"
-          elif [ "$IS_RELEASE" = true ]; then
-            COMPARE_REF="$SKIA_BASE_BRANCH"
-          fi
-          if [ -n "$COMPARE_REF" ]; then
-            BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" \
-              --jq '.behind_by' 2>/dev/null || echo "unknown")
-            if [ "$BEHIND" = "0" ]; then
-              echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
-          fi
-
-          echo "Will process: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH})"
+        run: bash .github/scripts/skia-sync-detect.sh --gate
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_MILESTONE: ${{ github.event.inputs.milestone }}

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3a223b93d31db74929a5ffb8f1555585301d36f6cbb17c6e31e62f578b585aca","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f08639f8efeb309cdf7cdec60cf594d07117d1c5f9e7b493d0e1c48f0f8bc964","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -140,7 +140,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
+          GH_AW_INFO_MODEL: "claude-opus-4.6"
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
           GH_AW_INFO_CLI_VERSION: "v0.71.5"
@@ -231,23 +231,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
+          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
           <system>
-          GH_AW_PROMPT_edc8624e8bd34a95_EOF
+          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
+          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_edc8624e8bd34a95_EOF
+          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
+          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_edc8624e8bd34a95_EOF
+          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
+          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -279,12 +279,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_edc8624e8bd34a95_EOF
+          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_edc8624e8bd34a95_EOF'
+          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_edc8624e8bd34a95_EOF
+          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -454,10 +454,6 @@ jobs:
           NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - name: Align submodule to the base branch
         run: |
-          # The agent job can't read pre_activation's outputs (it only `needs:`
-          # activation), so re-run the same committed detector to recover base_branch /
-          # skia_base_branch, then align the submodule. skia-sync-detect.sh is the single
-          # source of truth — no branch logic is duplicated here.
           OUT=$(mktemp)
           SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh
           set -a; . "$OUT"; set +a
@@ -551,9 +547,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f0e0572f06c64611_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4f6b9850ef01f656_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f0e0572f06c64611_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4f6b9850ef01f656_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -751,7 +747,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dedffa87e7764a75_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_41024a5bd69a6a88_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -799,7 +795,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dedffa87e7764a75_EOF
+          GH_AW_MCP_CONFIG_41024a5bd69a6a88_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -839,7 +835,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: claude-opus-4.6
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1300,7 +1296,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: claude-opus-4.6
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.71.5
@@ -1423,7 +1419,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_MODEL: "claude-opus-4.6"
       GH_AW_ENGINE_VERSION: "1.0.40"
       GH_AW_SAFE_OUTPUTS_STAGED: "true"
       GH_AW_WORKFLOW_ID: "auto-skia-sync"

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f08639f8efeb309cdf7cdec60cf594d07117d1c5f9e7b493d0e1c48f0f8bc964","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"23520ea9dfe94887804849d1637be2d607317b1b23d8364b0262cee491d4d6b9","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -140,7 +140,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "claude-opus-4.6"
+          GH_AW_INFO_MODEL: "claude-opus-4.7"
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
           GH_AW_INFO_CLI_VERSION: "v0.71.5"
@@ -231,23 +231,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
+          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
           <system>
-          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
+          GH_AW_PROMPT_318360b86911c4d8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
+          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
+          GH_AW_PROMPT_318360b86911c4d8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
+          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
+          GH_AW_PROMPT_318360b86911c4d8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
+          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -279,12 +279,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
+          GH_AW_PROMPT_318360b86911c4d8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5007c09cb1edeb9_EOF'
+          cat << 'GH_AW_PROMPT_318360b86911c4d8_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_b5007c09cb1edeb9_EOF
+          GH_AW_PROMPT_318360b86911c4d8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -547,9 +547,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4f6b9850ef01f656_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a35deaa2484fa3b2_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4f6b9850ef01f656_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a35deaa2484fa3b2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -747,7 +747,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_41024a5bd69a6a88_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2c5d7a4ccfdfe64e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -795,7 +795,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_41024a5bd69a6a88_EOF
+          GH_AW_MCP_CONFIG_2c5d7a4ccfdfe64e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -835,7 +835,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-opus-4.6
+          COPILOT_MODEL: claude-opus-4.7
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1296,7 +1296,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: claude-opus-4.6
+          COPILOT_MODEL: claude-opus-4.7
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.71.5
@@ -1419,7 +1419,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "claude-opus-4.6"
+      GH_AW_ENGINE_MODEL: "claude-opus-4.7"
       GH_AW_ENGINE_VERSION: "1.0.40"
       GH_AW_SAFE_OUTPUTS_STAGED: "true"
       GH_AW_WORKFLOW_ID: "auto-skia-sync"

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f837ac9c789c59020f6a17a866aa3a43e2086a6421e464b3bf1f406c03a15937","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cd20e5a36642ecbadd9af4a79e85a6349ca1d4e6273785f00f9fca538424015a","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -65,12 +65,15 @@ name: "Skia Upstream Sync"
       # sparse-checkout: .github/scripts
   # - env:
       # GH_TOKEN: ${{ github.token }}
-      # INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
-      # INPUT_MODE: ${{ github.event.inputs.mode }}
-      # SCHEDULE: ${{ github.event.schedule }}
+      # MILESTONE: ${{ github.event.inputs.milestone }}
+      # MODE: |-
+        # ${{ github.event.inputs.mode
+            # || (github.event.schedule == '0 7 * * *' && 'current')
+            # || (github.event.schedule == '0 17 * * *' && 'latest')
+            # || 'next' }}
     # id: detect
     # name: Detect milestone
-    # run: bash .github/scripts/skia-sync-detect.sh --gate
+    # run: bash .github/scripts/skia-sync-detect.sh --gate --mode "$MODE" --milestone "$MILESTONE"
   workflow_dispatch:
     inputs:
       aw_context:
@@ -231,23 +234,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
+          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
           <system>
-          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
+          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
+          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
+          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
+          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
+          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
+          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -279,12 +282,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
+          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF'
+          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_d9ac9aa4ffbf489f_EOF
+          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -455,7 +458,7 @@ jobs:
       - name: Align submodule to the base branch
         run: |
           OUT=$(mktemp)
-          SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh
+          SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh --mode "$MODE" --milestone "$MILESTONE"
           set -a; . "$OUT"; set +a
           bash .github/scripts/skia-sync-align-submodule.sh
         env:
@@ -464,10 +467,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_API_URL: https://localhost:18443/api/v3
           GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
-          INPUT_MODE: ${{ github.event.inputs.mode }}
+          MILESTONE: ${{ github.event.inputs.milestone }}
+          MODE: |-
+            ${{ github.event.inputs.mode
+                || (github.event.schedule == '0 7 * * *' && 'current')
+                || (github.event.schedule == '0 17 * * *' && 'latest')
+                || 'next' }}
           NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
-          SCHEDULE: ${{ github.event.schedule }}
       - name: Copy push script for post-step
         run: cp .github/scripts/skia-sync-push-prs.sh /tmp/gh-aw/skia-sync-push-prs.sh
         env:
@@ -547,9 +553,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_23016918b95809af_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_282d84f8ec931f90_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_23016918b95809af_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_282d84f8ec931f90_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -747,7 +753,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_81e9d30c8bfb6908_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e17cf7bba83b9a58_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -795,7 +801,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_81e9d30c8bfb6908_EOF
+          GH_AW_MCP_CONFIG_e17cf7bba83b9a58_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1397,12 +1403,15 @@ jobs:
           sparse-checkout: .github/scripts
       - name: Detect milestone
         id: detect
-        run: bash .github/scripts/skia-sync-detect.sh --gate
+        run: bash .github/scripts/skia-sync-detect.sh --gate --mode "$MODE" --milestone "$MILESTONE"
         env:
           GH_TOKEN: ${{ github.token }}
-          INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
-          INPUT_MODE: ${{ github.event.inputs.mode }}
-          SCHEDULE: ${{ github.event.schedule }}
+          MILESTONE: ${{ github.event.inputs.milestone }}
+          MODE: |-
+            ${{ github.event.inputs.mode
+                || (github.event.schedule == '0 7 * * *' && 'current')
+                || (github.event.schedule == '0 17 * * *' && 'latest')
+                || 'next' }}
 
   safe_outputs:
     needs:

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6c9eafdff2e1546bd8645fa801fb42c9301e9f2305a09e3d7e27ab9a405be143","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c6bbf9789260e93f5f0c4327813b2def5a3da617e56dff527364a7e3f268a448","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -77,11 +77,11 @@ name: "Skia Upstream Sync"
       # fi
       # echo "mode=$MODE" >> "$GITHUB_OUTPUT"
       # 
-      # CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
+      # # main's milestone — the basis for `current`/`next` mode math.
+      # MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
         # --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-      # echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
       # 
-      # NEXT=$((CURRENT + 1))
+      # NEXT=$((MAIN_MS + 1))
       # echo "next=$NEXT" >> "$GITHUB_OUTPUT"
       # 
       # LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
@@ -96,11 +96,55 @@ name: "Skia Upstream Sync"
       # elif [ "$MODE" = "latest" ]; then
         # TARGET="$LATEST"
       # elif [ "$MODE" = "current" ]; then
-        # TARGET="$CURRENT"
+        # TARGET="$MAIN_MS"
       # else
         # TARGET="$NEXT"
       # fi
       # echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+      # 
+      # # -- Resolve the target line: `main` (newest, in-development) or a release line.
+      # # A maintenance line lives as `release/<major>.<TARGET>.x` in BOTH mono/SkiaSharp
+      # # and mono/skia. We only look for one when TARGET is older than main's milestone —
+      # # the newest line is always served by `main`. The release branch itself is created
+      # # by the release process (release-branch skill), NOT this sync; if the mono/skia
+      # # side is missing we fail so branch ownership stays with the release process.
+      # IS_RELEASE=false
+      # BASE_BRANCH=main
+      # SKIA_BASE_BRANCH=skiasharp
+      # HEAD_BRANCH="skia-sync/m${TARGET}"
+      # RELEASE_BRANCH=""
+      # if [ "$TARGET" != "$MAIN_MS" ]; then
+        # RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
+          # | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
+      # fi
+      # if [ -n "$RELEASE_BRANCH" ]; then
+        # IS_RELEASE=true
+        # BASE_BRANCH="$RELEASE_BRANCH"
+        # SKIA_BASE_BRANCH="$RELEASE_BRANCH"
+        # HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
+      # 
+        # # The matching mono/skia release branch MUST already exist.
+        # SKIA_BASE_SHA=$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')
+        # if [ -z "$SKIA_BASE_SHA" ]; then
+          # echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
+          # exit 1
+        # fi
+      # fi
+      # echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+      # echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+      # echo "skia_base_branch=$SKIA_BASE_BRANCH" >> "$GITHUB_OUTPUT"
+      # echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+      # 
+      # # `current` is the milestone of the BASE branch we're syncing INTO:
+      # #  - main line → main's milestone
+      # #  - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
+      # if [ "$IS_RELEASE" = true ]; then
+        # CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=${BASE_BRANCH}" \
+          # --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
+      # else
+        # CURRENT="$MAIN_MS"
+      # fi
+      # echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
       # 
       # UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
       # if [ -z "$UPSTREAM_SHA" ]; then
@@ -112,21 +156,30 @@ name: "Skia Upstream Sync"
         # exit 0
       # fi
       # 
-      # # Check if the sync branch already contains all upstream commits.
-      # # This avoids spinning up the expensive agent job when there's nothing new.
-      # SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/skia-sync/m${TARGET}" | awk '{print $1}')
+      # # Check whether there is anything new to merge from upstream. Compare upstream
+      # # HEAD against the existing sync branch if present; otherwise, for release lines,
+      # # against the release base branch. This avoids spinning up the expensive agent
+      # # job when there's nothing new. (For a main milestone bump the sync branch won't
+      # # exist yet and there is always new work, so we proceed.)
+      # SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
+      # COMPARE_REF=""
       # if [ -n "$SYNC_SHA" ]; then
-        # BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...skia-sync/m${TARGET}" \
+        # COMPARE_REF="$HEAD_BRANCH"
+      # elif [ "$IS_RELEASE" = true ]; then
+        # COMPARE_REF="$SKIA_BASE_BRANCH"
+      # fi
+      # if [ -n "$COMPARE_REF" ]; then
+        # BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" \
           # --jq '.behind_by' 2>/dev/null || echo "unknown")
         # if [ "$BEHIND" = "0" ]; then
-          # echo "::notice::chrome/m${TARGET} already fully merged into skia-sync/m${TARGET} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
+          # echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
           # echo "skip=true" >> "$GITHUB_OUTPUT"
           # exit 0
         # fi
-        # echo "Sync branch exists but is ${BEHIND} commits behind upstream"
+        # echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
       # fi
       # 
-      # echo "Will process: m${TARGET} (mode=${MODE}, current=m${CURRENT}, latest=m${LATEST})"
+      # echo "Will process: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH})"
   workflow_dispatch:
     inputs:
       aw_context:
@@ -277,29 +330,33 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_BASE_BRANCH: ${{ needs.pre_activation.outputs.base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_CURRENT: ${{ needs.pre_activation.outputs.current }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH: ${{ needs.pre_activation.outputs.head_branch }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: ${{ needs.pre_activation.outputs.is_release }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: ${{ needs.pre_activation.outputs.skia_base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: ${{ needs.pre_activation.outputs.target }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9a538b67d4f587c5_EOF'
+          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
           <system>
-          GH_AW_PROMPT_9a538b67d4f587c5_EOF
+          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9a538b67d4f587c5_EOF'
+          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_9a538b67d4f587c5_EOF
+          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_9a538b67d4f587c5_EOF'
+          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_9a538b67d4f587c5_EOF
+          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9a538b67d4f587c5_EOF'
+          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -331,19 +388,23 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_9a538b67d4f587c5_EOF
+          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9a538b67d4f587c5_EOF'
+          cat << 'GH_AW_PROMPT_a175c22ffc6eacbc_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_9a538b67d4f587c5_EOF
+          GH_AW_PROMPT_a175c22ffc6eacbc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "copilot"
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_BASE_BRANCH: ${{ needs.pre_activation.outputs.base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_CURRENT: ${{ needs.pre_activation.outputs.current }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH: ${{ needs.pre_activation.outputs.head_branch }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: ${{ needs.pre_activation.outputs.is_release }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: ${{ needs.pre_activation.outputs.skia_base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: ${{ needs.pre_activation.outputs.target }}
         with:
           script: |
@@ -365,7 +426,11 @@ jobs:
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_BASE_BRANCH: ${{ needs.pre_activation.outputs.base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_CURRENT: ${{ needs.pre_activation.outputs.current }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH: ${{ needs.pre_activation.outputs.head_branch }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: ${{ needs.pre_activation.outputs.is_release }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: ${{ needs.pre_activation.outputs.skia_base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: ${{ needs.pre_activation.outputs.target }}
         with:
           script: |
@@ -388,7 +453,11 @@ jobs:
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
                 GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_BASE_BRANCH: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_BASE_BRANCH,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_CURRENT: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_CURRENT,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET
               }
             });
@@ -475,14 +544,88 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Start DIFC Proxy
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"none","repos":["mono/skia","mono/skiasharp"]}}'
+          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.6'
+        run: |
+          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
       - name: Set up agent output directory
         run: |
           mkdir -p /tmp/gh-aw/agent
-      - name: Align submodule to origin/main
-        run: "# The checkout uses the workflow branch, so the submodule may be at a\n# different SHA than what origin/main expects. Fix it before the agent runs.\n# Note: the submodule tracks the `skiasharp` branch in mono/skia, so this\n# SHA should be a commit on origin/skiasharp.\nMAIN_SUB_SHA=$(git ls-tree origin/main -- externals/skia | awk '{print $3}')\necho \"origin/main submodule SHA: $MAIN_SUB_SHA\"\ngit -C externals/skia fetch origin skiasharp 2>&1\ngit -C externals/skia checkout \"$MAIN_SUB_SHA\" 2>&1\necho \"Verifying SHA is on skiasharp branch:\"\ngit -C externals/skia branch -r --contains \"$MAIN_SUB_SHA\" | grep -q 'origin/skiasharp' \\\n  && echo \"  ✅ SHA is on origin/skiasharp\" \\\n  || echo \"  ⚠️ SHA is NOT on origin/skiasharp — submodule pointer may be stale\"\n"
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
+      - name: Align submodule to the base branch
+        run: |
+          # Re-derive the sync base branch here (same rules as the pre-activation
+          # `Detect milestone` step, which stays the source of truth). We can't read
+          # its outputs: this step runs in the agent job, which only `needs:`
+          # activation, and the cheap pre-activation job has no checkout to share a
+          # script from. github.event inputs ARE available in any job, so we redo the
+          # small base-branch resolution from them.
+          if [ -n "$INPUT_MODE" ]; then MODE="$INPUT_MODE";
+          elif [ "$SCHEDULE" = "0 7 * * *" ]; then MODE=current;
+          elif [ "$SCHEDULE" = "0 17 * * *" ]; then MODE=latest;
+          else MODE=next; fi
+          MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
+            --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
+          if [ -n "$INPUT_MILESTONE" ]; then TARGET="$INPUT_MILESTONE";
+          elif [ "$MODE" = "latest" ]; then
+            TARGET=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
+              | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1);
+          elif [ "$MODE" = "current" ]; then TARGET="$MAIN_MS";
+          else TARGET="$((MAIN_MS + 1))"; fi
+
+          BASE_BRANCH=main
+          SKIA_BASE_BRANCH=skiasharp
+          if [ "$TARGET" != "$MAIN_MS" ]; then
+            RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
+              | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
+            if [ -n "$RELEASE_BRANCH" ]; then
+              BASE_BRANCH="$RELEASE_BRANCH"
+              SKIA_BASE_BRANCH="$RELEASE_BRANCH"
+            fi
+          fi
+
+          # The checkout uses the workflow branch (main), so the submodule may be at a
+          # different SHA than the base branch expects. Fix it before the agent runs.
+          # The submodule tracks `${SKIA_BASE_BRANCH}` in mono/skia (skiasharp for a
+          # main sync, release/<major>.<milestone>.x for a release sync), so the
+          # base-branch submodule SHA should be a commit on that branch.
+          echo "Aligning submodule to origin/${BASE_BRANCH} (mono/skia ${SKIA_BASE_BRANCH})"
+          git fetch origin "$BASE_BRANCH" 2>&1 || true
+          BASE_SUB_SHA=$(git ls-tree "origin/${BASE_BRANCH}" -- externals/skia | awk '{print $3}')
+          echo "origin/${BASE_BRANCH} submodule SHA: $BASE_SUB_SHA"
+          git -C externals/skia fetch origin "$SKIA_BASE_BRANCH" 2>&1
+          git -C externals/skia checkout "$BASE_SUB_SHA" 2>&1
+          echo "Verifying SHA is on ${SKIA_BASE_BRANCH} branch:"
+          git -C externals/skia branch -r --contains "$BASE_SUB_SHA" | grep -q "origin/${SKIA_BASE_BRANCH}" \
+            && echo "  ✅ SHA is on origin/${SKIA_BASE_BRANCH}" \
+            || echo "  ⚠️ SHA is NOT on origin/${SKIA_BASE_BRANCH} — submodule pointer may be stale"
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
+          SCHEDULE: ${{ github.event.schedule }}
       - name: Copy push script for post-step
         run: cp .github/scripts/skia-sync-push-prs.sh /tmp/gh-aw/skia-sync-push-prs.sh
-
+        env:
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -523,6 +666,10 @@ jobs:
           GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
+      - name: Stop DIFC Proxy
+        if: always()
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -550,9 +697,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_270162c4ead1b8eb_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9b1865f00eeb8608_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_270162c4ead1b8eb_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9b1865f00eeb8608_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -750,7 +897,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_43a43904c0849692_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_22666b6fb299eac2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -798,7 +945,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_43a43904c0849692_EOF
+          GH_AW_MCP_CONFIG_22666b6fb299eac2_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1358,13 +1505,17 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      base_branch: ${{ steps.detect.outputs.base_branch }}
       current: ${{ steps.detect.outputs.current }}
       detect_result: ${{ steps.detect.outcome }}
+      head_branch: ${{ steps.detect.outputs.head_branch }}
+      is_release: ${{ steps.detect.outputs.is_release }}
       latest: ${{ steps.detect.outputs.latest }}
       matched_command: ''
       mode: ${{ steps.detect.outputs.mode }}
       next: ${{ steps.detect.outputs.next }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
+      skia_base_branch: ${{ steps.detect.outputs.skia_base_branch }}
       skip: ${{ steps.detect.outputs.skip }}
       target: ${{ steps.detect.outputs.target }}
     steps:
@@ -1404,11 +1555,11 @@ jobs:
           fi
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
-          CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
+          # main's milestone — the basis for `current`/`next` mode math.
+          MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
             --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
-          NEXT=$((CURRENT + 1))
+          NEXT=$((MAIN_MS + 1))
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
 
           LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
@@ -1423,11 +1574,55 @@ jobs:
           elif [ "$MODE" = "latest" ]; then
             TARGET="$LATEST"
           elif [ "$MODE" = "current" ]; then
-            TARGET="$CURRENT"
+            TARGET="$MAIN_MS"
           else
             TARGET="$NEXT"
           fi
           echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+          # -- Resolve the target line: `main` (newest, in-development) or a release line.
+          # A maintenance line lives as `release/<major>.<TARGET>.x` in BOTH mono/SkiaSharp
+          # and mono/skia. We only look for one when TARGET is older than main's milestone —
+          # the newest line is always served by `main`. The release branch itself is created
+          # by the release process (release-branch skill), NOT this sync; if the mono/skia
+          # side is missing we fail so branch ownership stays with the release process.
+          IS_RELEASE=false
+          BASE_BRANCH=main
+          SKIA_BASE_BRANCH=skiasharp
+          HEAD_BRANCH="skia-sync/m${TARGET}"
+          RELEASE_BRANCH=""
+          if [ "$TARGET" != "$MAIN_MS" ]; then
+            RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
+              | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
+          fi
+          if [ -n "$RELEASE_BRANCH" ]; then
+            IS_RELEASE=true
+            BASE_BRANCH="$RELEASE_BRANCH"
+            SKIA_BASE_BRANCH="$RELEASE_BRANCH"
+            HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
+
+            # The matching mono/skia release branch MUST already exist.
+            SKIA_BASE_SHA=$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')
+            if [ -z "$SKIA_BASE_SHA" ]; then
+              echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
+              exit 1
+            fi
+          fi
+          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "skia_base_branch=$SKIA_BASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+
+          # `current` is the milestone of the BASE branch we're syncing INTO:
+          #  - main line → main's milestone
+          #  - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
+          if [ "$IS_RELEASE" = true ]; then
+            CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=${BASE_BRANCH}" \
+              --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
+          else
+            CURRENT="$MAIN_MS"
+          fi
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
           UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
           if [ -z "$UPSTREAM_SHA" ]; then
@@ -1439,21 +1634,30 @@ jobs:
             exit 0
           fi
 
-          # Check if the sync branch already contains all upstream commits.
-          # This avoids spinning up the expensive agent job when there's nothing new.
-          SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/skia-sync/m${TARGET}" | awk '{print $1}')
+          # Check whether there is anything new to merge from upstream. Compare upstream
+          # HEAD against the existing sync branch if present; otherwise, for release lines,
+          # against the release base branch. This avoids spinning up the expensive agent
+          # job when there's nothing new. (For a main milestone bump the sync branch won't
+          # exist yet and there is always new work, so we proceed.)
+          SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
+          COMPARE_REF=""
           if [ -n "$SYNC_SHA" ]; then
-            BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...skia-sync/m${TARGET}" \
+            COMPARE_REF="$HEAD_BRANCH"
+          elif [ "$IS_RELEASE" = true ]; then
+            COMPARE_REF="$SKIA_BASE_BRANCH"
+          fi
+          if [ -n "$COMPARE_REF" ]; then
+            BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" \
               --jq '.behind_by' 2>/dev/null || echo "unknown")
             if [ "$BEHIND" = "0" ]; then
-              echo "::notice::chrome/m${TARGET} already fully merged into skia-sync/m${TARGET} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
+              echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "Sync branch exists but is ${BEHIND} commits behind upstream"
+            echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
           fi
 
-          echo "Will process: m${TARGET} (mode=${MODE}, current=m${CURRENT}, latest=m${LATEST})"
+          echo "Will process: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH})"
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_MILESTONE: ${{ github.event.inputs.milestone }}

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -164,9 +164,19 @@ steps:
 # carry into the chroot — the agent must run it itself.
 pre-agent-steps:
   - name: Install native build dependencies
+    # These run on the HOST and are visible to the agent's AWF chroot via the shared
+    # filesystem. The agent itself CANNOT apt-install anything (no apt inside the chroot,
+    # and the firewall blocks the Ubuntu archives), so every native build dependency must
+    # be installed here.
+    #
+    # libc++: native/linux/build.cake builds libSkiaSharp/libHarfBuzzSharp with
+    # `-stdlib=libc++` (clang's LLVM C++ runtime). On the real CI this comes from the
+    # .NET cross-compilation image; for this host build we must install libc++-dev +
+    # libc++abi-dev or the compile fails with "cannot find <libc++ headers>". Keep this in
+    # sync with native/linux/build.cake's extra_cflags/extra_ldflags.
     run: |
       sudo apt-get update -qq
-      sudo apt-get install -y clang fontconfig libfontconfig1-dev ninja-build fonts-dejavu-core ttf-ancient-fonts
+      sudo apt-get install -y clang libc++-dev libc++abi-dev fontconfig libfontconfig1-dev ninja-build fonts-dejavu-core ttf-ancient-fonts
       fc-cache -f
       dotnet workload install android --skip-sign-check
     env:
@@ -219,6 +229,13 @@ Release-line sync: `${{ needs.pre_activation.outputs.is_release }}`.
   parent-repo change is `cgmanifest.json`'s commit hash. Do NOT advance the milestone.
 - **Build platform**: use Linux x64 (`dotnet cake --target=externals-linux --arch=x64`). Clang is pre-configured via env vars.
   This also applies to Phase 10 if a native rebuild is needed.
+- **Native build environment is fully provisioned by the workflow** (clang, `libc++-dev`/`libc++abi-dev`,
+  fontconfig, ninja). Do NOT modify any native build files (`native/**/build.cake`, `scripts/infra/native/**`)
+  and do NOT change compiler/linker flags (e.g. `-stdlib=libc++`) to work around a build error. You also CANNOT
+  install packages (no apt/sudo inside the sandbox, and the firewall blocks OS package mirrors). If a native
+  build genuinely fails because a dependency is missing from the host, that is a workflow bug: STOP, do not hack
+  the build, and record it in the mono/SkiaSharp summary under "items needing human attention" so the
+  `Install native build dependencies` step can be fixed.
 - **NEVER run `externals-download`** in this workflow — not even for debugging or baseline comparison. Build from source only.
 - **Phase 9 reminder**: a green C# build is NOT sufficient - run the new-function diff check from Phase 9 step 1.
 - **Phase 11 — do NOT execute it.** Replace it entirely with the file writes below.

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -45,12 +45,20 @@ on:
         sparse-checkout: .github/scripts
     - name: Detect milestone
       id: detect
+      # The cron→mode mapping lives HERE, next to the cron declarations:
+      # 7 AM → current, 5 PM → latest, everything else (12 PM cron + the
+      # workflow_dispatch default) → next. Staged into env vars rather than
+      # interpolated straight into `run:`, so the free-form `milestone` input
+      # can't inject shell — the script consumes them as real --mode/--milestone args.
       env:
-        INPUT_MODE: ${{ github.event.inputs.mode }}
-        INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
-        SCHEDULE: ${{ github.event.schedule }}
+        MODE: >-
+          ${{ github.event.inputs.mode
+              || (github.event.schedule == '0 7 * * *' && 'current')
+              || (github.event.schedule == '0 17 * * *' && 'latest')
+              || 'next' }}
+        MILESTONE: ${{ github.event.inputs.milestone }}
         GH_TOKEN: ${{ github.token }}
-      run: bash .github/scripts/skia-sync-detect.sh --gate
+      run: bash .github/scripts/skia-sync-detect.sh --gate --mode "$MODE" --milestone "$MILESTONE"
 
 # -- Pre-activation outputs ------------------------------------------
 # Expose detect step outputs for use in the prompt and other jobs.
@@ -140,18 +148,21 @@ steps:
     run: |
       mkdir -p /tmp/gh-aw/agent
   - name: Align submodule to the base branch
+    # Same cron→mode resolution as the pre_activation detect step (see there). The
+    # agent job can't read pre_activation's outputs (it only `needs:` activation), so
+    # re-run the same committed detector to recover base_branch / skia_base_branch,
+    # then align the submodule. skia-sync-detect.sh is the single source of truth.
     env:
-      INPUT_MODE: ${{ github.event.inputs.mode }}
-      INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
-      SCHEDULE: ${{ github.event.schedule }}
+      MODE: >-
+        ${{ github.event.inputs.mode
+            || (github.event.schedule == '0 7 * * *' && 'current')
+            || (github.event.schedule == '0 17 * * *' && 'latest')
+            || 'next' }}
+      MILESTONE: ${{ github.event.inputs.milestone }}
       GH_TOKEN: ${{ github.token }}
-    # The agent job can't read pre_activation's outputs (it only `needs:`
-    # activation), so re-run the same committed detector to recover base_branch /
-    # skia_base_branch, then align the submodule. skia-sync-detect.sh is the single
-    # source of truth — no branch logic is duplicated here.
     run: |
       OUT=$(mktemp)
-      SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh
+      SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh --mode "$MODE" --milestone "$MILESTONE"
       set -a; . "$OUT"; set +a
       bash .github/scripts/skia-sync-align-submodule.sh
   - name: Copy push script for post-step

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -1,6 +1,14 @@
 ---
 description: "Daily upstream Skia milestone sync - merges new commits, resolves conflicts, builds, tests, and creates PRs."
 
+# -- Engine ------------------------------------------------------------
+# Use Claude Opus (instead of the default Sonnet) for this workflow: the
+# upstream merge/conflict-resolution and build-fix reasoning is hard and
+# benefits from the stronger model, despite the higher AI-credit cost.
+engine:
+  id: copilot
+  model: claude-opus-4.6
+
 # -- Triggers ----------------------------------------------------------
 # Three daily crons: current (7 AM), next (12 PM), latest (5 PM UTC).
 # Manual dispatch with mode selector.
@@ -137,11 +145,11 @@ steps:
       INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
       SCHEDULE: ${{ github.event.schedule }}
       GH_TOKEN: ${{ github.token }}
+    # The agent job can't read pre_activation's outputs (it only `needs:`
+    # activation), so re-run the same committed detector to recover base_branch /
+    # skia_base_branch, then align the submodule. skia-sync-detect.sh is the single
+    # source of truth — no branch logic is duplicated here.
     run: |
-      # The agent job can't read pre_activation's outputs (it only `needs:`
-      # activation), so re-run the same committed detector to recover base_branch /
-      # skia_base_branch, then align the submodule. skia-sync-detect.sh is the single
-      # source of truth — no branch logic is duplicated here.
       OUT=$(mktemp)
       SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh
       set -a; . "$OUT"; set +a

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -7,7 +7,7 @@ description: "Daily upstream Skia milestone sync - merges new commits, resolves 
 # benefits from the stronger model, despite the higher AI-credit cost.
 engine:
   id: copilot
-  model: claude-opus-4.6
+  model: claude-opus-4.7
 
 # -- Triggers ----------------------------------------------------------
 # Three daily crons: current (7 AM), next (12 PM), latest (5 PM UTC).

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -23,11 +23,18 @@ on:
         type: string
 
   # -- Pre-activation step -------------------------------------------
-  # Runs BEFORE the agent job. Detects the target milestone.
-  # Exit 1 = hard failure (explicit milestone input doesn't exist).
+  # Runs BEFORE the agent job. Detects the target milestone + branch line.
+  # All resolution logic lives in the committed .github/scripts/skia-sync-detect.sh
+  # (the single source of truth, sparse-checked-out below); --gate adds the
+  # "is there anything to sync?" check.
+  # Exit 1 = hard failure (explicit milestone input doesn't exist / branch missing).
   # skip=true output = nothing to sync (graceful skip, workflow shows green).
   # Outputs are available in the prompt via ${{ needs.pre_activation.outputs.* }}.
   steps:
+    - name: Check out detection scripts
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github/scripts
     - name: Detect milestone
       id: detect
       env:
@@ -35,121 +42,7 @@ on:
         INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
         SCHEDULE: ${{ github.event.schedule }}
         GH_TOKEN: ${{ github.token }}
-      run: |
-        if [ -n "$INPUT_MODE" ]; then
-          MODE="$INPUT_MODE"
-        elif [ "$SCHEDULE" = "0 7 * * *" ]; then
-          MODE=current
-        elif [ "$SCHEDULE" = "0 17 * * *" ]; then
-          MODE=latest
-        else
-          MODE=next
-        fi
-        echo "mode=$MODE" >> "$GITHUB_OUTPUT"
-
-        # main's milestone — the basis for `current`/`next` mode math.
-        MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
-          --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-
-        NEXT=$((MAIN_MS + 1))
-        echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-
-        LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
-          | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' \
-          | sort -n | tail -1)
-        echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
-
-        # Explicit milestone input overrides mode
-        if [ -n "$INPUT_MILESTONE" ]; then
-          TARGET="$INPUT_MILESTONE"
-          MODE="explicit"
-        elif [ "$MODE" = "latest" ]; then
-          TARGET="$LATEST"
-        elif [ "$MODE" = "current" ]; then
-          TARGET="$MAIN_MS"
-        else
-          TARGET="$NEXT"
-        fi
-        echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-
-        # -- Resolve the target line: `main` (newest, in-development) or a release line.
-        # A maintenance line lives as `release/<major>.<TARGET>.x` in BOTH mono/SkiaSharp
-        # and mono/skia. We only look for one when TARGET is older than main's milestone —
-        # the newest line is always served by `main`. The release branch itself is created
-        # by the release process (release-branch skill), NOT this sync; if the mono/skia
-        # side is missing we fail so branch ownership stays with the release process.
-        IS_RELEASE=false
-        BASE_BRANCH=main
-        SKIA_BASE_BRANCH=skiasharp
-        HEAD_BRANCH="skia-sync/m${TARGET}"
-        RELEASE_BRANCH=""
-        if [ "$TARGET" != "$MAIN_MS" ]; then
-          RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
-            | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
-        fi
-        if [ -n "$RELEASE_BRANCH" ]; then
-          IS_RELEASE=true
-          BASE_BRANCH="$RELEASE_BRANCH"
-          SKIA_BASE_BRANCH="$RELEASE_BRANCH"
-          HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
-
-          # The matching mono/skia release branch MUST already exist.
-          SKIA_BASE_SHA=$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')
-          if [ -z "$SKIA_BASE_SHA" ]; then
-            echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
-            exit 1
-          fi
-        fi
-        echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-        echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
-        echo "skia_base_branch=$SKIA_BASE_BRANCH" >> "$GITHUB_OUTPUT"
-        echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
-
-        # `current` is the milestone of the BASE branch we're syncing INTO:
-        #  - main line → main's milestone
-        #  - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
-        if [ "$IS_RELEASE" = true ]; then
-          CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=${BASE_BRANCH}" \
-            --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-        else
-          CURRENT="$MAIN_MS"
-        fi
-        echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-
-        UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
-        if [ -z "$UPSTREAM_SHA" ]; then
-          echo "::notice::upstream/chrome/m${TARGET} does not exist yet"
-          if [ "$MODE" = "explicit" ]; then
-            exit 1
-          fi
-          echo "skip=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        # Check whether there is anything new to merge from upstream. Compare upstream
-        # HEAD against the existing sync branch if present; otherwise, for release lines,
-        # against the release base branch. This avoids spinning up the expensive agent
-        # job when there's nothing new. (For a main milestone bump the sync branch won't
-        # exist yet and there is always new work, so we proceed.)
-        SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
-        COMPARE_REF=""
-        if [ -n "$SYNC_SHA" ]; then
-          COMPARE_REF="$HEAD_BRANCH"
-        elif [ "$IS_RELEASE" = true ]; then
-          COMPARE_REF="$SKIA_BASE_BRANCH"
-        fi
-        if [ -n "$COMPARE_REF" ]; then
-          BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" \
-            --jq '.behind_by' 2>/dev/null || echo "unknown")
-          if [ "$BEHIND" = "0" ]; then
-            echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
-        fi
-
-        echo "Will process: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH})"
+      run: bash .github/scripts/skia-sync-detect.sh --gate
 
 # -- Pre-activation outputs ------------------------------------------
 # Expose detect step outputs for use in the prompt and other jobs.
@@ -245,51 +138,14 @@ steps:
       SCHEDULE: ${{ github.event.schedule }}
       GH_TOKEN: ${{ github.token }}
     run: |
-      # Re-derive the sync base branch here (same rules as the pre-activation
-      # `Detect milestone` step, which stays the source of truth). We can't read
-      # its outputs: this step runs in the agent job, which only `needs:`
-      # activation, and the cheap pre-activation job has no checkout to share a
-      # script from. github.event inputs ARE available in any job, so we redo the
-      # small base-branch resolution from them.
-      if [ -n "$INPUT_MODE" ]; then MODE="$INPUT_MODE";
-      elif [ "$SCHEDULE" = "0 7 * * *" ]; then MODE=current;
-      elif [ "$SCHEDULE" = "0 17 * * *" ]; then MODE=latest;
-      else MODE=next; fi
-      MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
-        --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-      if [ -n "$INPUT_MILESTONE" ]; then TARGET="$INPUT_MILESTONE";
-      elif [ "$MODE" = "latest" ]; then
-        TARGET=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
-          | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1);
-      elif [ "$MODE" = "current" ]; then TARGET="$MAIN_MS";
-      else TARGET="$((MAIN_MS + 1))"; fi
-
-      BASE_BRANCH=main
-      SKIA_BASE_BRANCH=skiasharp
-      if [ "$TARGET" != "$MAIN_MS" ]; then
-        RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
-          | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
-        if [ -n "$RELEASE_BRANCH" ]; then
-          BASE_BRANCH="$RELEASE_BRANCH"
-          SKIA_BASE_BRANCH="$RELEASE_BRANCH"
-        fi
-      fi
-
-      # The checkout uses the workflow branch (main), so the submodule may be at a
-      # different SHA than the base branch expects. Fix it before the agent runs.
-      # The submodule tracks `${SKIA_BASE_BRANCH}` in mono/skia (skiasharp for a
-      # main sync, release/<major>.<milestone>.x for a release sync), so the
-      # base-branch submodule SHA should be a commit on that branch.
-      echo "Aligning submodule to origin/${BASE_BRANCH} (mono/skia ${SKIA_BASE_BRANCH})"
-      git fetch origin "$BASE_BRANCH" 2>&1 || true
-      BASE_SUB_SHA=$(git ls-tree "origin/${BASE_BRANCH}" -- externals/skia | awk '{print $3}')
-      echo "origin/${BASE_BRANCH} submodule SHA: $BASE_SUB_SHA"
-      git -C externals/skia fetch origin "$SKIA_BASE_BRANCH" 2>&1
-      git -C externals/skia checkout "$BASE_SUB_SHA" 2>&1
-      echo "Verifying SHA is on ${SKIA_BASE_BRANCH} branch:"
-      git -C externals/skia branch -r --contains "$BASE_SUB_SHA" | grep -q "origin/${SKIA_BASE_BRANCH}" \
-        && echo "  ✅ SHA is on origin/${SKIA_BASE_BRANCH}" \
-        || echo "  ⚠️ SHA is NOT on origin/${SKIA_BASE_BRANCH} — submodule pointer may be stale"
+      # The agent job can't read pre_activation's outputs (it only `needs:`
+      # activation), so re-run the same committed detector to recover base_branch /
+      # skia_base_branch, then align the submodule. skia-sync-detect.sh is the single
+      # source of truth — no branch logic is duplicated here.
+      OUT=$(mktemp)
+      SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh
+      set -a; . "$OUT"; set +a
+      bash .github/scripts/skia-sync-align-submodule.sh
   - name: Copy push script for post-step
     run: |
       cp .github/scripts/skia-sync-push-prs.sh /tmp/gh-aw/skia-sync-push-prs.sh

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -47,11 +47,11 @@ on:
         fi
         echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
-        CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
+        # main's milestone — the basis for `current`/`next` mode math.
+        MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
           --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
-        echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
-        NEXT=$((CURRENT + 1))
+        NEXT=$((MAIN_MS + 1))
         echo "next=$NEXT" >> "$GITHUB_OUTPUT"
 
         LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
@@ -66,11 +66,55 @@ on:
         elif [ "$MODE" = "latest" ]; then
           TARGET="$LATEST"
         elif [ "$MODE" = "current" ]; then
-          TARGET="$CURRENT"
+          TARGET="$MAIN_MS"
         else
           TARGET="$NEXT"
         fi
         echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+        # -- Resolve the target line: `main` (newest, in-development) or a release line.
+        # A maintenance line lives as `release/<major>.<TARGET>.x` in BOTH mono/SkiaSharp
+        # and mono/skia. We only look for one when TARGET is older than main's milestone —
+        # the newest line is always served by `main`. The release branch itself is created
+        # by the release process (release-branch skill), NOT this sync; if the mono/skia
+        # side is missing we fail so branch ownership stays with the release process.
+        IS_RELEASE=false
+        BASE_BRANCH=main
+        SKIA_BASE_BRANCH=skiasharp
+        HEAD_BRANCH="skia-sync/m${TARGET}"
+        RELEASE_BRANCH=""
+        if [ "$TARGET" != "$MAIN_MS" ]; then
+          RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
+            | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
+        fi
+        if [ -n "$RELEASE_BRANCH" ]; then
+          IS_RELEASE=true
+          BASE_BRANCH="$RELEASE_BRANCH"
+          SKIA_BASE_BRANCH="$RELEASE_BRANCH"
+          HEAD_BRANCH="skia-sync/${RELEASE_BRANCH//\//-}"
+
+          # The matching mono/skia release branch MUST already exist.
+          SKIA_BASE_SHA=$(git ls-remote --heads https://github.com/mono/skia.git "refs/heads/${SKIA_BASE_BRANCH}" | awk '{print $1}')
+          if [ -z "$SKIA_BASE_SHA" ]; then
+            echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
+            exit 1
+          fi
+        fi
+        echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+        echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+        echo "skia_base_branch=$SKIA_BASE_BRANCH" >> "$GITHUB_OUTPUT"
+        echo "head_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+
+        # `current` is the milestone of the BASE branch we're syncing INTO:
+        #  - main line → main's milestone
+        #  - release   → that line's milestone (== TARGET ⇒ a bug-fix-only sync)
+        if [ "$IS_RELEASE" = true ]; then
+          CURRENT=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=${BASE_BRANCH}" \
+            --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
+        else
+          CURRENT="$MAIN_MS"
+        fi
+        echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
         UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
         if [ -z "$UPSTREAM_SHA" ]; then
@@ -82,21 +126,30 @@ on:
           exit 0
         fi
 
-        # Check if the sync branch already contains all upstream commits.
-        # This avoids spinning up the expensive agent job when there's nothing new.
-        SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/skia-sync/m${TARGET}" | awk '{print $1}')
+        # Check whether there is anything new to merge from upstream. Compare upstream
+        # HEAD against the existing sync branch if present; otherwise, for release lines,
+        # against the release base branch. This avoids spinning up the expensive agent
+        # job when there's nothing new. (For a main milestone bump the sync branch won't
+        # exist yet and there is always new work, so we proceed.)
+        SYNC_SHA=$(git ls-remote https://github.com/mono/skia.git "refs/heads/${HEAD_BRANCH}" | awk '{print $1}')
+        COMPARE_REF=""
         if [ -n "$SYNC_SHA" ]; then
-          BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...skia-sync/m${TARGET}" \
+          COMPARE_REF="$HEAD_BRANCH"
+        elif [ "$IS_RELEASE" = true ]; then
+          COMPARE_REF="$SKIA_BASE_BRANCH"
+        fi
+        if [ -n "$COMPARE_REF" ]; then
+          BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" \
             --jq '.behind_by' 2>/dev/null || echo "unknown")
           if [ "$BEHIND" = "0" ]; then
-            echo "::notice::chrome/m${TARGET} already fully merged into skia-sync/m${TARGET} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
+            echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Sync branch exists but is ${BEHIND} commits behind upstream"
+          echo "${COMPARE_REF} exists but is ${BEHIND} commits behind upstream"
         fi
 
-        echo "Will process: m${TARGET} (mode=${MODE}, current=m${CURRENT}, latest=m${LATEST})"
+        echo "Will process: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH})"
 
 # -- Pre-activation outputs ------------------------------------------
 # Expose detect step outputs for use in the prompt and other jobs.
@@ -110,6 +163,10 @@ jobs:
       target: ${{ steps.detect.outputs.target }}
       mode: ${{ steps.detect.outputs.mode }}
       skip: ${{ steps.detect.outputs.skip }}
+      is_release: ${{ steps.detect.outputs.is_release }}
+      base_branch: ${{ steps.detect.outputs.base_branch }}
+      skia_base_branch: ${{ steps.detect.outputs.skia_base_branch }}
+      head_branch: ${{ steps.detect.outputs.head_branch }}
 
 # -- Agent job gate --------------------------------------------------
 # Only run the agent if pre-activation succeeded and there's work to do.
@@ -181,20 +238,58 @@ steps:
   - name: Set up agent output directory
     run: |
       mkdir -p /tmp/gh-aw/agent
-  - name: Align submodule to origin/main
+  - name: Align submodule to the base branch
+    env:
+      INPUT_MODE: ${{ github.event.inputs.mode }}
+      INPUT_MILESTONE: ${{ github.event.inputs.milestone }}
+      SCHEDULE: ${{ github.event.schedule }}
+      GH_TOKEN: ${{ github.token }}
     run: |
-      # The checkout uses the workflow branch, so the submodule may be at a
-      # different SHA than what origin/main expects. Fix it before the agent runs.
-      # Note: the submodule tracks the `skiasharp` branch in mono/skia, so this
-      # SHA should be a commit on origin/skiasharp.
-      MAIN_SUB_SHA=$(git ls-tree origin/main -- externals/skia | awk '{print $3}')
-      echo "origin/main submodule SHA: $MAIN_SUB_SHA"
-      git -C externals/skia fetch origin skiasharp 2>&1
-      git -C externals/skia checkout "$MAIN_SUB_SHA" 2>&1
-      echo "Verifying SHA is on skiasharp branch:"
-      git -C externals/skia branch -r --contains "$MAIN_SUB_SHA" | grep -q 'origin/skiasharp' \
-        && echo "  ✅ SHA is on origin/skiasharp" \
-        || echo "  ⚠️ SHA is NOT on origin/skiasharp — submodule pointer may be stale"
+      # Re-derive the sync base branch here (same rules as the pre-activation
+      # `Detect milestone` step, which stays the source of truth). We can't read
+      # its outputs: this step runs in the agent job, which only `needs:`
+      # activation, and the cheap pre-activation job has no checkout to share a
+      # script from. github.event inputs ARE available in any job, so we redo the
+      # small base-branch resolution from them.
+      if [ -n "$INPUT_MODE" ]; then MODE="$INPUT_MODE";
+      elif [ "$SCHEDULE" = "0 7 * * *" ]; then MODE=current;
+      elif [ "$SCHEDULE" = "0 17 * * *" ]; then MODE=latest;
+      else MODE=next; fi
+      MAIN_MS=$(gh api "repos/$GITHUB_REPOSITORY/contents/scripts/VERSIONS.txt?ref=$GITHUB_REF" \
+        --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}')
+      if [ -n "$INPUT_MILESTONE" ]; then TARGET="$INPUT_MILESTONE";
+      elif [ "$MODE" = "latest" ]; then
+        TARGET=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
+          | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1);
+      elif [ "$MODE" = "current" ]; then TARGET="$MAIN_MS";
+      else TARGET="$((MAIN_MS + 1))"; fi
+
+      BASE_BRANCH=main
+      SKIA_BASE_BRANCH=skiasharp
+      if [ "$TARGET" != "$MAIN_MS" ]; then
+        RELEASE_BRANCH=$(git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/release/*.${TARGET}.x" \
+          | sed -n 's|.*refs/heads/\(release/[0-9][0-9.]*\.x\)$|\1|p' | head -1)
+        if [ -n "$RELEASE_BRANCH" ]; then
+          BASE_BRANCH="$RELEASE_BRANCH"
+          SKIA_BASE_BRANCH="$RELEASE_BRANCH"
+        fi
+      fi
+
+      # The checkout uses the workflow branch (main), so the submodule may be at a
+      # different SHA than the base branch expects. Fix it before the agent runs.
+      # The submodule tracks `${SKIA_BASE_BRANCH}` in mono/skia (skiasharp for a
+      # main sync, release/<major>.<milestone>.x for a release sync), so the
+      # base-branch submodule SHA should be a commit on that branch.
+      echo "Aligning submodule to origin/${BASE_BRANCH} (mono/skia ${SKIA_BASE_BRANCH})"
+      git fetch origin "$BASE_BRANCH" 2>&1 || true
+      BASE_SUB_SHA=$(git ls-tree "origin/${BASE_BRANCH}" -- externals/skia | awk '{print $3}')
+      echo "origin/${BASE_BRANCH} submodule SHA: $BASE_SUB_SHA"
+      git -C externals/skia fetch origin "$SKIA_BASE_BRANCH" 2>&1
+      git -C externals/skia checkout "$BASE_SUB_SHA" 2>&1
+      echo "Verifying SHA is on ${SKIA_BASE_BRANCH} branch:"
+      git -C externals/skia branch -r --contains "$BASE_SUB_SHA" | grep -q "origin/${SKIA_BASE_BRANCH}" \
+        && echo "  ✅ SHA is on origin/${SKIA_BASE_BRANCH}" \
+        || echo "  ⚠️ SHA is NOT on origin/${SKIA_BASE_BRANCH} — submodule pointer may be stale"
   - name: Copy push script for post-step
     run: |
       cp .github/scripts/skia-sync-push-prs.sh /tmp/gh-aw/skia-sync-push-prs.sh
@@ -225,20 +320,39 @@ post-steps:
 
 # Skia Upstream Sync
 
-Current: `m${{ needs.pre_activation.outputs.current }}`.  
-Target: `m${{ needs.pre_activation.outputs.target }}`.  
-Branch: `skia-sync/m${{ needs.pre_activation.outputs.target }}`.  
+Base milestone (current): `m${{ needs.pre_activation.outputs.current }}`.  
+Target milestone: `m${{ needs.pre_activation.outputs.target }}`.  
+Base branch (SkiaSharp): `${{ needs.pre_activation.outputs.base_branch }}` — mono/skia base: `${{ needs.pre_activation.outputs.skia_base_branch }}`.  
+Sync (head) branch: `${{ needs.pre_activation.outputs.head_branch }}` (same name in both repos).  
+Release-line sync: `${{ needs.pre_activation.outputs.is_release }}`.
+
+> **About the base branch.** Most syncs target `main` (the newest, in-development line) with
+> `skiasharp` as the mono/skia base. When an older milestone is requested AND a matching
+> `release/<major>.<milestone>.x` branch exists, this is a **release-line sync**: both PRs target
+> that release branch instead (mono/skia base = the same `release/<major>.<milestone>.x` branch,
+> which the release process guarantees exists). In that case `current == target`, so it is always a
+> **bug-fix-only sync** — do NOT bump the milestone, soname, or nuget versions; only the upstream
+> merge + `cgmanifest.json` commit hash change. Use the base/head branch values above everywhere
+> instead of hardcoding `main`/`skiasharp`/`skia-sync/m{target}`.
 
 **Read `.agents/skills/update-skia/SKILL.md` and follow Phases 2-10.** Notes specific to this automated workflow:
 
 - **Phase 1 is pre-computed** (above). Skip it — but you still need to add the `upstream` remote
   and fetch `chrome/m${{ needs.pre_activation.outputs.target }}` (Phase 1 step 4) since Phase 5 depends on it.
 - **First thing**: run `dotnet tool restore` (pre-agent-steps can't do this for the chroot).
-- **Phase 4**: Before creating a fresh branch, check if `origin/skia-sync/m${{ needs.pre_activation.outputs.target }}` already exists.
-  If so, check it out — the pre-activation step already verified new upstream commits exist.
-  Even when current == target, there may be new upstream bug-fix commits — a matching milestone does NOT mean no work.
-  **Skip Phase 4 step 5** (submodule SHA alignment) — the pre-agent step already aligned it.
+- **Phase 4**: The parent base branch is `origin/${{ needs.pre_activation.outputs.base_branch }}` and the
+  submodule base branch is mono/skia `${{ needs.pre_activation.outputs.skia_base_branch }}` — use these in
+  place of `origin/main` / `skiasharp` for every step. The sync branch in BOTH repos is
+  `${{ needs.pre_activation.outputs.head_branch }}`. Before creating a fresh branch, check if
+  `origin/${{ needs.pre_activation.outputs.head_branch }}` already exists; if so, check it out — the
+  pre-activation step already verified new upstream commits exist. Even when current == target there may
+  be new upstream bug-fix commits — a matching milestone does NOT mean no work.
+  **Skip Phase 4 step 5** (submodule SHA alignment) — the pre-agent step already aligned the submodule to
+  the base branch's pointer (on mono/skia `${{ needs.pre_activation.outputs.skia_base_branch }}`).
   Branch from the current HEAD when creating the submodule feature branch in step 6.
+- **Phase 6 (version files)**: For a release-line sync (`is_release == true`, so `current == target`) this is a
+  bug-fix-only sync — keep the release line's milestone/soname/nuget versions unchanged; the only expected
+  parent-repo change is `cgmanifest.json`'s commit hash. Do NOT advance the milestone.
 - **Build platform**: use Linux x64 (`dotnet cake --target=externals-linux --arch=x64`). Clang is pre-configured via env vars.
   This also applies to Phase 10 if a native rebuild is needed.
 - **NEVER run `externals-download`** in this workflow — not even for debugging or baseline comparison. Build from source only.
@@ -257,6 +371,10 @@ After Phase 10, write these files:
    cat > /tmp/gh-aw/agent/skia-sync-env.sh << EOF
    TARGET=${{ needs.pre_activation.outputs.target }}
    CURRENT=${{ needs.pre_activation.outputs.current }}
+   IS_RELEASE=${{ needs.pre_activation.outputs.is_release }}
+   BASE_BRANCH=${{ needs.pre_activation.outputs.base_branch }}
+   SKIA_BASE_BRANCH=${{ needs.pre_activation.outputs.skia_base_branch }}
+   HEAD_BRANCH=${{ needs.pre_activation.outputs.head_branch }}
    EOF
    ```
 
@@ -269,5 +387,5 @@ After Phase 10, write these files:
 All files written to `/tmp/gh-aw/agent/` are automatically uploaded as workflow artifacts.
 Write test output there too (`/tmp/gh-aw/agent/test-output.txt`) so failures can be inspected after the run.
 
-Commit submodule changes inside `externals/skia` on `skia-sync/m${{ needs.pre_activation.outputs.target }}`.
-Commit parent repo changes on `skia-sync/m${{ needs.pre_activation.outputs.target }}` in the parent.
+Commit submodule changes inside `externals/skia` on `${{ needs.pre_activation.outputs.head_branch }}`.
+Commit parent repo changes on `${{ needs.pre_activation.outputs.head_branch }}` in the parent.


### PR DESCRIPTION
## What

Extends the daily **Skia upstream sync** automation (`auto-skia-sync`) so it can target a maintenance line — `release/{major}.{milestone}.x` — instead of only `main`, refactors the milestone/branch resolution out of inline workflow YAML into committed, testable scripts, runs the agent on **Claude Opus 4.7**, and fixes a native-build regression that broke the sync's Linux build.

Example: dispatching the workflow with milestone `148` now opens PRs against `release/4.148.x` in **both** mono/SkiaSharp and mono/skia, rather than `main`/`skiasharp`.

## Why

Release lines need ongoing bug-fix syncs from upstream Skia, but the sync workflow only knew how to target `main`. The branch-resolution logic also lived as two large duplicated inline bash blocks in the workflow source, which was hard to read, review, and test.

## How it works

**Branch-line resolution** (`skia-sync-detect.sh`, the single source of truth):
- Picks the target milestone from the trigger mode (`current`/`next`/`latest` cron, or an explicit `milestone` dispatch input).
- Only looks for a release line when the target is **numerically older** than `main`'s milestone (the newest line is always served by `main`).
- A maintenance line uses the **same** branch name in both repos (`release/{major}.{milestone}.x`); `main` ⇄ mono/skia `skiasharp`.
- **Fails fast** if the matching mono/skia release branch is missing — release branches are owned by the separate release process, not this sync.
- **Hard-fails** (rather than guessing) if a milestone matches multiple release branches.

**Submodule alignment** (`skia-sync-align-submodule.sh`): points `externals/skia` at the SHA the base branch records before the agent runs, since the agent checks out the workflow branch (usually `main`).

## Refactor

The milestone/branch logic was extracted from two inline YAML bash blocks into committed scripts, collapsing the workflow `run:` blocks to ~1 and ~5 lines and removing the duplicated derivation:

- `pre_activation` (`--gate`) runs the detector and writes job outputs; it now sparse-checks-out `.github/scripts` so it can call the script.
- The agent's align step re-runs the **same** detector (without `--gate`) and sources its output — necessary because the agent job can't read `pre_activation` outputs in gh-aw.

The extraction also folds in two release-resolution review fixes: numeric `-lt` (was `!=`) and hard-fail on multi-match (was silent `head -1`).

A follow-up moved the **cron→mode mapping out of the detector and into the workflow**: the 7 AM / 12 PM / 5 PM → `current` / `next` / `latest` decision is now a single GitHub Actions expression next to where the crons are declared, and `skia-sync-detect.sh` takes real `--mode`/`--milestone` **arguments** instead of reading `INPUT_MODE`/`INPUT_MILESTONE`/`SCHEDULE` env vars. The script no longer knows anything about cron, so it is self-contained and unit-testable (`--mode latest` instead of faking `SCHEDULE='0 17 * * *'`). The free-form `milestone` input is still staged via env (not interpolated into `run:`) to avoid shell injection.

## Model: Claude Opus 4.7

The workflow now pins the agent engine to `claude-opus-4.7` via the `engine.model` block (was the gh-aw default Sonnet). Opus is materially more reliable on this multi-repo, submodule-heavy task — across validation it produced cleaner runs with no failed commands, retries, or self-introduced build hacks. Opus 4.6 and 4.7 carry the same AI-credit multiplier, so 4.7 is a free upgrade to the latest snapshot.

## Native build fix (libc++)

The sync's pre-agent **"Install native build dependencies"** step now also installs `libc++-dev libc++abi-dev`.

**Root cause:** PR #4062 ("Migrate Linux Docker builds to .NET official cross-compilation images") moved the Linux native build into the `mcr.microsoft.com/dotnet-buildtools/prereqs` cross images, which ship Clang + libc++. `native/linux/build.cake` consequently hardcodes `-stdlib=libc++` in its `extra_cflags`/`extra_ldflags`. The sync workflow builds on a bare `ubuntu-latest` host (not inside that Docker image), so libc++ was absent and the agent's `dotnet cake --target=externals-linux` failed to link. The agent could not self-remediate — there is no apt/sudo inside the AWF chroot, and the firewall blocks OS package mirrors — so it got stuck. Installing libc++ on the host (visible to the chroot via the shared filesystem) resolves it.

The agent prompt was also hardened to **forbid patching native build files or compiler/linker flags and attempting package installs**; if a host dependency is genuinely missing it must STOP and report it under "items needing human attention" rather than work around it.

## Files

- `.github/scripts/skia-sync-detect.sh` (new) — milestone/branch-line resolution + gate checks; takes `--mode`/`--milestone` args
- `.github/scripts/skia-sync-align-submodule.sh` (new) — submodule alignment
- `.github/scripts/skia-sync-push-prs.sh` — release-aware `--base` targeting and PR titles
- `.github/workflows/auto-skia-sync.md` / `.lock.yml` — slimmed steps, new outputs, sparse checkout, cron→mode expression, `engine.model: claude-opus-4.7`, libc++ install, hardened prompt
- `.agents/skills/update-skia/SKILL.md` — documents release-target mode

> Note: `release-branch` skill changes are intentionally **out of scope** here and will land in a separate PR.

## Validation

**Static / unit:**
- `gh aw compile auto-skia-sync` → 0 errors (4 pre-existing warnings); lock verified to reflect the source (model in all 4 places, libc++ in the apt line, `--mode`/`--milestone` at both call sites, no stale `INPUT_*`/`SCHEDULE`).
- `bash -n` clean on all scripts.
- `skia-sync-detect.sh` exercised against stubbed `gh`/`git`: `--mode current/next/latest`, the default, explicit `--milestone` override, empty `--milestone`, and unknown-arg rejection all resolve as before; plus main-line vs release-line resolution, mono/skia-branch-missing fail, ambiguous-match fail, and missing-upstream fail.
- Reviewed by GPT-5.5 and Opus 4.7; design and `set -euo pipefail` hazards confirmed sound.

**Live end-to-end** (dispatched against `release/4.148.x`, real upstream, real native build + tests):

| Scenario | Trigger | Expected | Result |
|---|---|---|---|
| explicit milestone, up to date | `milestone=150` | skip | ✅ gate SKIP (already merged), workflow green |
| latest cron mode | `mode=latest` | skip | ✅ gate SKIP, workflow green |
| re-run same line | `milestone=148` (already synced) | idempotent | ✅ gate SKIP, existing PR untouched (no dup/close-reopen) |
| missing upstream | `milestone=151` (no `chrome/m151` yet) | hard fail | ✅ pre_activation exits 1, nothing downstream runs, no PRs |
| **full sync** | `milestone=148`, 2 commits behind | **PR to `release/4.148.x`** | ✅ libc++ installed (34s); native build clean in ~15 min with **no build.cake hacks**; **5544 tests pass / 0 fail / 172 skip**; bug-fix-only PRs (cgmanifest hash + submodule pointer) opened on `release/4.148.x` in both repos |

The full-sync run (`28203686018`) transcript was audited line-by-line: 0 failed commands, 0 retries, 0 self-introduced build hacks — the agent built, regenerated bindings (no-op), ran the full test suite, and committed only `cgmanifest.json` + the submodule pointer. Validation PRs were closed and their branches deleted after verification.

Co-authored-by: Matthew Leibowitz <mattleibow@live.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>