### PR TITLE
Fix integration test harness Docker detection + command timeout, and release-testing skill filter syntax

### DIFF
--- a/.agents/skills/release-testing/SKILL.md
+++ b/.agents/skills/release-testing/SKILL.md
@@ -233,19 +233,27 @@ dotnet test -p:SkiaSharpVersion={version} -p:HarfBuzzSharpVersion={hb-version}
 
 ### Test Commands
 
+> **Note:** This project uses **Microsoft.Testing.Platform (MTP)** with xUnit v3 (since #4143).
+> The legacy VSTest `--filter "FullyQualifiedName~..."` syntax is **silently ignored** under MTP
+> and runs ALL tests. Use the MTP filter args after the `--` separator instead:
+> `--filter-class`, `--filter-method`, `--filter-namespace` (and `--filter-not-class`, etc.),
+> with `*` wildcards. MSBuild `-p:` properties (e.g. `-p:SkiaSharpVersion=`, `-p:iOSDevice=`)
+> must stay BEFORE the `--`; only the test-platform filter args go AFTER it.
+
 ```bash
 # Run by category
-dotnet test --filter "FullyQualifiedName~SmokeTests" ...
-dotnet test --filter "FullyQualifiedName~ConsoleTests" ...
-dotnet test --filter "FullyQualifiedName~LinuxConsoleTests" ...
-dotnet test --filter "FullyQualifiedName~BlazorTests" ...
-dotnet test --filter "FullyQualifiedName~MauiiOSTests" ... -p:iOSDevice="iPhone 14 Pro" -p:iOSVersion="16.2"
-dotnet test --filter "FullyQualifiedName~MauiMacCatalystTests" ...
+dotnet test ... -- --filter-class "*SmokeTests"
+dotnet test ... -- --filter-class "*ConsoleTests"
+dotnet test ... -- --filter-class "*LinuxConsoleTests"
+dotnet test ... -- --filter-class "*BlazorTests"
+dotnet test -p:iOSDevice="iPhone 14 Pro" -p:iOSVersion="16.2" ... -- --filter-class "*MauiiOSTests"
+dotnet test ... -- --filter-class "*MauiMacCatalystTests"
 
 # Android: specify device ID and expected API level for validation
-dotnet test --filter "FullyQualifiedName~MauiAndroidTests" ... \
+dotnet test ... \
   -p:AndroidDeviceId="emulator-5554" \
-  -p:AndroidApiLevel="23"
+  -p:AndroidApiLevel="23" \
+  -- --filter-class "*MauiAndroidTests"
 ```
 
 ### Android Emulator Workflow
@@ -278,11 +286,12 @@ dotnet test --filter "FullyQualifiedName~MauiAndroidTests" ... \
    DEVICE_ID=$(adb devices | grep emulator | awk '{print $1}')
    API_LEVEL=$(adb -s $DEVICE_ID shell getprop ro.build.version.sdk | tr -d '\r')
    
-   dotnet test --filter "FullyQualifiedName~MauiAndroidTests" \
+   dotnet test \
      -p:AndroidDeviceId="$DEVICE_ID" \
      -p:AndroidApiLevel="$API_LEVEL" \
      -p:SkiaSharpVersion={version} \
-     -p:HarfBuzzSharpVersion={hb-version}
+     -p:HarfBuzzSharpVersion={hb-version} \
+     -- --filter-class "*MauiAndroidTests"
    ```
 
 4. **Shut down emulator before next test:**

--- a/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/LinuxConsoleTests.cs
@@ -19,7 +19,16 @@ public class LinuxConsoleTests(ITestOutputHelper output) : PlatformTestBase(outp
                 UseShellExecute = false
             };
             using var process = System.Diagnostics.Process.Start(psi)!;
-            process.WaitForExit(10000);
+            // Drain both pipes concurrently so a large `docker info` payload can't
+            // fill the OS buffer and deadlock the child against WaitForExit.
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(10000))
+            {
+                try { process.Kill(true); } catch { }
+                return false;
+            }
+            System.Threading.Tasks.Task.WaitAll(stdout, stderr);
             return process.ExitCode == 0;
         }
         catch

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -216,14 +216,19 @@ public abstract class PlatformTestBase : IDisposable
         
         using var process = Process.Start(psi)!;
         
-        var output = await process.StandardOutput.ReadToEndAsync();
-        var error = await process.StandardError.ReadToEndAsync();
+        // Start draining both pipes immediately so neither can fill and deadlock,
+        // then enforce the timeout via WaitForExit while the reads are in flight.
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
         
         if (!process.WaitForExit(timeoutSeconds * 1000))
         {
-            process.Kill();
+            try { process.Kill(true); } catch { }
             throw new TimeoutException($"Command timed out after {timeoutSeconds}s");
         }
+        
+        var output = await outputTask;
+        var error = await errorTask;
         
         Output.WriteLine($"Process exited with code {process.ExitCode}");
 


### PR DESCRIPTION
## Summary

Three reliability fixes to the SkiaSharp integration test harness (`tests/SkiaSharp.Tests.Integration`) and the `release-testing` skill, all discovered during **4.150.0-preview.2** release testing.

## Fixes

### 1. `IsDockerAvailable()` deadlock — Linux container tests always skipped
`LinuxConsoleTests.IsDockerAvailable()` set `RedirectStandardOutput`/`Error = true` but never drained the streams before `WaitForExit(10000)`. `docker info` can emit more than the 64KB OS pipe buffer, so the child blocked on write while the parent's 10s `WaitForExit` returned `false` → `ExitCode` access failed → Docker was reported **unavailable even when running**. Net effect: the Linux container tests were **always silently skipped**.

**Fix:** start `ReadToEndAsync()` on both pipes *before* `WaitForExit`, kill on timeout, then `Task.WaitAll` the reads so a large payload can't deadlock the child.

### 2. `Run()` helper timeout never enforced
`PlatformTestBase.Run(...)` awaited `StandardOutput.ReadToEndAsync()` / `StandardError.ReadToEndAsync()` **before** `WaitForExit(timeoutSeconds * 1000)`. `ReadToEndAsync` only completes when the stream closes (process exit), so the await blocked until the process finished — the timeout was **effectively never enforced** (a hung `docker build` ran unbounded). Fully reading stdout before starting stderr could also deadlock if stderr filled.

**Fix:** start both pipe reads first, enforce the timeout via `WaitForExit` while reads are in flight (kill on timeout), then `await` the drained output. The rest of the method (combined output, exit-code check, return) is unchanged.

### 3. release-testing skill — stale `--filter` syntax ignored under MTP
The project migrated to **Microsoft.Testing.Platform (xUnit v3)** in #4143. Under MTP the VSTest-style `dotnet test --filter "FullyQualifiedName~X"` is **silently ignored** and runs **ALL** tests. The skill's Test Commands still used that syntax.

**Fix:** updated every occurrence to the MTP form — `dotnet test ... -- --filter-class "*X"` — keeping MSBuild `-p:` properties (`-p:SkiaSharpVersion=`, `-p:iOSDevice=`, `-p:AndroidDeviceId=`, etc.) **before** the `--` separator and only the test-platform filter args after it. Added a note explaining that this project uses MTP so the legacy `--filter "FullyQualifiedName~..."` syntax must be replaced by `--filter-class`/`--filter-method`/`--filter-namespace` (after `--`).

## Verification
- `dotnet build tests/SkiaSharp.Tests.Integration/SkiaSharp.Tests.Integration.csproj` succeeds (0 errors; only pre-existing obsolete-API / xUnit analyzer warnings).
- The Linux/Docker container path **could not be executed in-session** because Docker is unavailable / disk-full in this environment, so verification was limited to compilation. The skill change is docs-only.