### PR TITLE
[skia-sync] Merge upstream chrome/m148 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1a155bae3ac86db6d3efbd996f00e774b6a7b722"
+          "commitHash": "0ea9171b7f89b9876b835814b89f2dc366eeee95"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m148. Targeting release branch `release/4.148.x` (mono/skia `release/4.148.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/264

# mono/SkiaSharp PR: Merge upstream chrome/m148 bug fixes

**Branch:** `skia-sync/release-4.148.x` → `release/4.148.x`

## Summary

Bug-fix-only sync of the m148 release line. Two upstream cherry-picks merged with zero conflicts and no C API changes.

## Breaking Change Analysis

**None.** Both upstream commits are internal bug fixes:

| Change | Risk | SkiaSharp Impact |
|--------|------|-----------------|
| Mac typeface data race fix (`SkTypeface_mac_ct`) | ⚪ NONE | Internal thread-safety fix, no API change |
| Graphite pipeline fix (`DawnGraphicsPipeline`) | ⚪ SKIP | Graphite-only, SkiaSharp uses Ganesh |

## Version/Binding Updates

- **Milestone:** Unchanged (m148)
- **VERSIONS.txt:** Unchanged
- **cgmanifest.json:** `commitHash` updated to `0ea9171b7f89b9876b835814b89f2dc366eeee95`
- **Generated bindings:** No changes (no C API diff)

## C# Changes

None required — no new functions, no signature changes.

## Build/Test Results

- **Native build:** ✅ Passed (Linux x64)
- **C# build:** ✅ 0 errors, 0 warnings
- **Tests:** ✅ Passed: 5544, Skipped: 172, Failed: 0, Total: 5716

## Items Needing Human Attention

None — clean sync with all tests passing.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).