### PR TITLE
[skia-sync] Merge upstream chrome/m148 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1a155bae3ac86db6d3efbd996f00e774b6a7b722"
+          "commitHash": "d5c1f3f66dfc7c41f32240191b9a33bb55758f89"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 148,
-      "upstream_merge_commit": "54851b68b7a1d49bc4b4361f12786a7d7ad91fff"
+      "upstream_merge_commit": "46f2e16555cac1211f4087cf24728fd741ac6495"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m148. Targeting release branch `release/4.148.x` (mono/skia `release/4.148.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/265

## Skia upstream sync — `release/4.148.x` (m148 bug fixes)

Companion PR to the `mono/skia` merge of `upstream/chrome/m148` into
`skia-sync/release-4.148.x`. This PR updates the SkiaSharp submodule
pointer and `cgmanifest.json` to record the new upstream SHA.

This is a **release-line / bug-fix-only sync** (`CURRENT == TARGET == 148`),
so per the `update-skia` skill no milestone, soname, nuget version, or
`SK_C_INCREMENT` changes are involved.

### Upstream merge summary

Two new upstream `chrome/m148` commits merged into the release line:

| SHA | Subject | Area |
|-----|---------|------|
| `3a90f6662a` | `[graphite] Use stable collection for static bindings` | Graphite/Dawn — not built into libSkiaSharp (we use Ganesh) |
| `46f2e16555` | `[m148] Resolved a Data Race on fStream in SkTypeface_Mac` | CoreText typeface backend on macOS — fixes a data race on `fStream` |

Submodule advanced:
`1a155bae3ac86db6d3efbd996f00e774b6a7b722` → `d5c1f3f66dfc7c41f32240191b9a33bb55758f89`.

### Breaking change analysis

**No breaking changes.** Both upstream commits are bug fixes within m148;
neither modifies any C++ public header that the SkiaSharp C API
(`externals/skia/include/c/` / `src/c/`) depends on:

- `SkTypeface_mac_ct.{cpp,h}` — internal Apple typeface backend, no public
  API surface change; the diff guards `fStream` access with the existing
  mutex.
- `DawnGraphicsPipeline.cpp` — Graphite backend implementation detail
  (binding-group static initializer), not exposed through any C API.

No removed / renamed / re-signed APIs. No header moves. No enum changes.
ABI is preserved for downstream consumers of `SkiaSharp` 4.148.x.

### Version / binding updates

- `cgmanifest.json`:
  - `commitHash`: `1a155bae3a…` → `d5c1f3f66d…` (the new mono/skia merge SHA)
  - `upstream_merge_commit`: `54851b68b7…` → `46f2e16555…` (upstream `chrome/m148` tip)
- `scripts/VERSIONS.txt` — **unchanged** (still `libSkiaSharp milestone 148`, `increment 0`)
- `scripts/azure-templates-variables.yml` — **unchanged** (`SKIASHARP_VERSION: 4.148.1`)
- `externals/skia/include/c/sk_types.h` — **unchanged** (`SK_C_INCREMENT 0`)
- `externals/skia/include/core/SkMilestone.h` — **unchanged** (`SK_MILESTONE 148`)

### C# changes

**None.**

`pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` reports
`No changes to bindings (C API signatures unchanged)` and
`No new functions found`. No C# wrappers require updates because the C API
shim itself is unchanged.

### Build & test results

| Step | Result |
|------|--------|
| `dotnet tool restore` | ✅ |
| `dotnet cake --target=externals-linux --arch=x64` | ✅ — `libSkiaSharp.so.148.0.0` (~10.8 MB) + `libHarfBuzzSharp.so.0.61420.0` (~2.9 MB) built in 15m34s |
| `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` | ✅ — no binding diff, HarfBuzz bindings reverted as expected |
| `dotnet build binding/SkiaSharp/SkiaSharp.csproj` | ✅ — 0 errors, 0 warnings |
| Smoke tests (`Category=Smoke`) | ✅ — Passed 32, Failed 0, Skipped 0 |
| Full test suite (`SkiaSharp.Tests.Console`) | ✅ — **Passed 5544, Failed 0, Skipped 172**, total 5716 in 2m40s |

Skipped tests are the standard set for a Linux x64 CI environment with no
GPU/Metal/Direct3D/Vulkan-on-display and no fonts that are macOS- or
Windows-specific. No tests were marked skip to dodge a failure.

Full test output is uploaded as the `test-output.txt` artifact for
inspection if needed.

### Items needing human attention

None. The sync is clean — no conflicts, no breaking changes, no shim
fixes, no binding diff, all tests pass.

The companion `mono/skia` PR must be merged first (so its squashed
SHA lands on `release/4.148.x`), then the submodule pointer in this PR
must be refreshed to that squashed SHA before this PR is merged.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).