### PR TITLE
[skia-sync] Merge upstream chrome/m148 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1a155bae3ac86db6d3efbd996f00e774b6a7b722"
+          "commitHash": "ac40acbd6aedbdd8249997d6ad9a7d5cc614890c"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 148,
-      "upstream_merge_commit": "54851b68b7a1d49bc4b4361f12786a7d7ad91fff"
+      "upstream_merge_commit": "46f2e16555cac1211f4087cf24728fd741ac6495"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m148. Targeting release branch `release/4.148.x` (mono/skia `release/4.148.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/266

## Summary

Release-line, **bug-fix-only** sync of `release/4.148.x` against
`upstream/chrome/m148` (`46f2e16555cac1211f4087cf24728fd741ac6495`).
Picks up 2 upstream cherry-picks since the last sync. Companion PR in
`mono/skia` carries the actual source changes; this PR only advances the
submodule pointer and refreshes `cgmanifest.json`.

`current == target == 148`, so no milestone/soname/NuGet version bumps —
see the Phase 6 release-line rule.

## Breaking change analysis

Both upstream commits are isolated to non-shim files and do not change any
header consumed by `binding/SkiaSharp/`. Categorisation:

| Commit | Category | Risk | Notes |
|--------|----------|------|-------|
| `46f2e16555` — Race fix in `SkTypeface_Mac` | Internal bug fix (private members only) | 🟢 LOW | Adds a `std::recursive_mutex` around `fStream` in `SkTypeface_Mac`; no public C++ API surface changes, no C API change |
| `3a90f6662a` — Graphite static-binding allocator switch | ⚪ SKIP | None | Graphite/Dawn-only — SkiaSharp ships Ganesh; the affected `DawnGraphicsPipeline.cpp` is not compiled into `libSkiaSharp` |

No removed or renamed APIs. Header diff against the previous tip confirmed
zero changes under `include/core/`, `include/gpu/ganesh/`, `include/c/`, or
`include/xamarin/`.

## Version / binding updates

| File | Change |
|------|--------|
| `cgmanifest.json` | `mono/skia` `commitHash` → `ac40acbd6aedbdd8249997d6ad9a7d5cc614890c`; `upstream_merge_commit` → `46f2e16555cac1211f4087cf24728fd741ac6495` |
| `externals/skia` submodule | Pointer advanced from `1a155bae3a` to `ac40acbd6a` (the merge commit on `skia-sync/release-4.148.x` in mono/skia) |
| `scripts/VERSIONS.txt` | **Unchanged** (release-line sync; milestone/soname/NuGet versions stay on the line's current values) |
| `scripts/azure-templates-variables.yml` | **Unchanged** (same reason) |
| `externals/skia/include/c/sk_types.h` `SK_C_INCREMENT` | **Unchanged** (no new C API functions added) |

## C# changes

None. `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1`
reported:

- `No changes to bindings (C API signatures unchanged)`
- `No new functions found`

`git diff origin/release/4.148.x -- binding/SkiaSharp/SkiaApi.generated.cs`
on `+.*internal static` lines: empty. No new C# wrappers required.

HarfBuzz bindings were proactively reverted by the script as per the
standard skill workflow.

## Build & test results (Linux x64)

| Step | Result | Detail |
|------|--------|--------|
| `dotnet tool restore` | ✅ | All tools restored |
| Native build (`externals-linux --arch=x64`) | ✅ | `libSkiaSharp.so.148.0.0` produced; total 15m28s. Log: `native-build.log` |
| Binding regeneration | ✅ | No changes (as expected). Log: `regen-bindings.log` |
| C# build (`binding/SkiaSharp/SkiaSharp.csproj`) | ✅ | 0 errors, 0 warnings, 00:00:36. Log: `csharp-build.log` |
| Smoke tests (`Category=Smoke`) | ✅ | 32 passed, 0 failed, 0 skipped (217 ms). Log: `smoke-test.log` |
| Full test suite (net10.0) | ✅ | **5544 passed, 0 failed, 172 skipped** (2m34s). Log: `test-output.txt` |

The 172 skipped tests are the usual platform/hardware-dependent ones
(non-Linux platforms, missing Vulkan/Direct3D, `Bgr101010xXR` / `Bgra10101010XR`
color types, etc.) — same baseline as `release/4.148.x` head.

## Items needing human attention

- **Multi-platform validation in CI.** The Mac-only `SkTypeface_Mac` race fix
  cannot be exercised on the Linux x64 agent. Confirm the macOS, iOS, Mac
  Catalyst, Windows, and Android legs of this PR's CI all stay green before
  merging.
- **Submodule merge order.** The mono/skia companion PR
  (`skia-sync/release-4.148.x`) MUST be squash-merged first; this parent PR
  must then be re-pointed to the resulting `release/4.148.x` SHA before its
  own merge — see the Phase 11 merge sequence in `SKILL.md`. The merge-bot
  tracks this automatically only when both PRs are linked.
- **No DEPS / third-party version changes.** All dependency pins
  (libpng 1.6.58, zlib 1.3.2, libjpeg-turbo 3.1.4.1, libwebp 1.6.0,
  ANGLE chromium/6275, harfbuzz 14.2.0, etc.) are unchanged — `cgmanifest.json`
  edits are limited to the skia `commitHash` / `upstream_merge_commit` fields.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).