### PR TITLE
Add a main (tip) mode to the Skia upstream sync

### DIFF
--- a/.github/scripts/skia-sync-detect.sh
+++ b/.github/scripts/skia-sync-detect.sh
@@ -15,10 +15,14 @@
 #     (so GitHub renders annotations and the machine output stays clean for sourcing).
 #
 # Args:
-#   --mode <current|next|latest>   Which milestone line to track. The workflow resolves
+#   --mode <current|next|latest|main>  Which milestone line to track. The workflow resolves
 #                                  this from the dispatch input or the triggering cron
 #                                  (the cron→mode mapping lives in the workflow, next to
 #                                  where the crons are declared). Defaults to `next`.
+#                                  `main` is the bleeding-edge tip: it merges google/skia's
+#                                  `main` HEAD (not a chrome/m<N> branch) into the newest
+#                                  line. It is NOT a version bump — the target milestone
+#                                  stays equal to main's current milestone.
 #   --milestone <number>           Exact milestone override; when set, mode becomes
 #                                  `explicit` and the target is this number.
 #   --gate                         Also run the gating checks (does upstream exist? is it
@@ -60,21 +64,26 @@ milestone_of() {
 
 # -- Mode -------------------------------------------------------------
 # Resolved by the caller (workflow): the cron→mode mapping lives in the workflow,
-# next to where the crons are declared. Here it is simply a value in {current,next,latest}.
+# next to where the crons are declared. Here it is simply a value in
+# {current,next,latest,main}.
 MAIN_MS=$(milestone_of "$GITHUB_REF")
 NEXT=$((MAIN_MS + 1))
 LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
   | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1)
 
 # -- Target -----------------------------------------------------------
+# UPSTREAM_REF is the google/skia ref we merge FROM: a `chrome/m<N>` milestone branch
+# for every mode except `main`, which merges the very tip (`refs/heads/main` HEAD).
 if [ -n "$MILESTONE" ]; then
-  TARGET="$MILESTONE"; MODE="explicit"
+  TARGET="$MILESTONE"; MODE="explicit"; UPSTREAM_REF="chrome/m${TARGET}"
+elif [ "$MODE" = main ]; then
+  TARGET="$MAIN_MS"; UPSTREAM_REF="main"
 elif [ "$MODE" = latest ]; then
-  TARGET="$LATEST"
+  TARGET="$LATEST"; UPSTREAM_REF="chrome/m${TARGET}"
 elif [ "$MODE" = current ]; then
-  TARGET="$MAIN_MS"
+  TARGET="$MAIN_MS"; UPSTREAM_REF="chrome/m${TARGET}"
 else
-  TARGET="$NEXT"
+  TARGET="$NEXT"; UPSTREAM_REF="chrome/m${TARGET}"
 fi
 
 # -- Target line: `main` (newest) vs a release/<major>.<TARGET>.x maintenance line.
@@ -82,10 +91,19 @@ fi
 # mono/skia. We only look for one when TARGET is strictly OLDER than main's milestone;
 # the newest line is always served by `main`. The release branch itself is owned by
 # the release process (release-branch skill), NOT this sync.
+#
+# The `main` (tip) mode targets the newest line too (TARGET == MAIN_MS, so the
+# release-detection block below stays skipped), but uses a DISTINCT head branch
+# (`skia-sync/main`) so a bleeding-edge tip sync never collides with the `current`
+# milestone sync branch (`skia-sync/m${TARGET}`).
 IS_RELEASE=false
 BASE_BRANCH=main
 SKIA_BASE_BRANCH=skiasharp
-HEAD_BRANCH="skia-sync/m${TARGET}"
+if [ "$MODE" = main ]; then
+  HEAD_BRANCH="skia-sync/main"
+else
+  HEAD_BRANCH="skia-sync/m${TARGET}"
+fi
 RELEASE_BRANCH=""
 # `2>/dev/null` swallows the "integer expression expected" noise for a non-numeric
 # TARGET, which then falls through to the main line.
@@ -126,21 +144,22 @@ emit mode "$MODE"
 emit next "$NEXT"
 emit latest "$LATEST"
 emit target "$TARGET"
+emit upstream_ref "$UPSTREAM_REF"
 emit is_release "$IS_RELEASE"
 emit base_branch "$BASE_BRANCH"
 emit skia_base_branch "$SKIA_BASE_BRANCH"
 emit head_branch "$HEAD_BRANCH"
 emit current "$CURRENT"
 
-echo "Resolved: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH}, release=${IS_RELEASE})"
+echo "Resolved: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, upstream=${UPSTREAM_REF}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH}, release=${IS_RELEASE})"
 
 # Branch derivation is all the agent job needs; gating is pre_activation-only.
 $GATE || exit 0
 
 # -- Gate: only spin up the (expensive) agent when there is new upstream work ----
-UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/chrome/m${TARGET}" | awk '{print $1}')
+UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/${UPSTREAM_REF}" | awk '{print $1}')
 if [ -z "$UPSTREAM_SHA" ]; then
-  echo "::notice::upstream/chrome/m${TARGET} does not exist yet"
+  echo "::notice::upstream/${UPSTREAM_REF} does not exist yet"
   [ "$MODE" = explicit ] && exit 1
   emit skip true
   exit 0
@@ -159,7 +178,7 @@ fi
 if [ -n "$COMPARE_REF" ]; then
   BEHIND=$(gh api "repos/mono/skia/compare/${UPSTREAM_SHA}...${COMPARE_REF}" --jq '.behind_by' 2>/dev/null || echo unknown)
   if [ "$BEHIND" = 0 ]; then
-    echo "::notice::chrome/m${TARGET} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
+    echo "::notice::${UPSTREAM_REF} already fully merged into ${COMPARE_REF} (upstream HEAD: ${UPSTREAM_SHA:0:12}) — skipping"
     emit skip true
     exit 0
   fi

--- a/.github/scripts/skia-sync-push-prs.sh
+++ b/.github/scripts/skia-sync-push-prs.sh
@@ -34,15 +34,22 @@ BRANCH="${HEAD_BRANCH:-skia-sync/m${TARGET}}"
 SS_BASE="${BASE_BRANCH:-main}"
 SKIA_BASE="${SKIA_BASE_BRANCH:-skiasharp}"
 IS_RELEASE="${IS_RELEASE:-false}"
-echo "Sync branch: $BRANCH | SkiaSharp base: $SS_BASE | mono/skia base: $SKIA_BASE | release: $IS_RELEASE"
+# UPSTREAM_REF is the google/skia ref the sync merged FROM. For a `chrome/m<N>`
+# milestone sync it defaults to that branch (backward compat with older env files);
+# `main` denotes a bleeding-edge tip sync.
+UPSTREAM_REF="${UPSTREAM_REF:-chrome/m${TARGET}}"
+echo "Sync branch: $BRANCH | SkiaSharp base: $SS_BASE | mono/skia base: $SKIA_BASE | release: $IS_RELEASE | upstream: $UPSTREAM_REF"
 
 SKIA_SUMMARY=""
 SS_SUMMARY=""
 [ -f /tmp/gh-aw/agent/skia-sync-skia-summary.md ] && SKIA_SUMMARY=$(cat /tmp/gh-aw/agent/skia-sync-skia-summary.md)
 [ -f /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md ] && SS_SUMMARY=$(cat /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md)
 
-# --- Determine PR titles based on same-milestone or milestone bump ---
-if [ "$CURRENT" = "$TARGET" ]; then
+# --- Determine PR titles based on sync kind (tip / same-milestone / milestone bump) ---
+if [ "$UPSTREAM_REF" = "main" ]; then
+    SS_TITLE="[skia-sync] Merge upstream Skia main (tip)"
+    SS_BODY_INTRO="Automated bleeding-edge sync from the tip of upstream Skia (google/skia main)."
+elif [ "$CURRENT" = "$TARGET" ]; then
     SS_TITLE="[skia-sync] Merge upstream chrome/m${TARGET} bug fixes"
     SS_BODY_INTRO="Automated upstream bug-fix sync for m${TARGET}."
 else
@@ -51,6 +58,15 @@ else
 fi
 if [ "$IS_RELEASE" = "true" ]; then
     SS_BODY_INTRO="${SS_BODY_INTRO} Targeting release branch \`${SS_BASE}\` (mono/skia \`${SKIA_BASE}\`)."
+fi
+
+# --- mono/skia PR title + body intro (UPSTREAM_REF-aware) ---
+if [ "$UPSTREAM_REF" = "main" ]; then
+    SKIA_TITLE="[skia-sync] Merge upstream Skia main (tip)"
+    SKIA_BODY_INTRO="Automated upstream merge of google/skia main (tip)."
+else
+    SKIA_TITLE="[skia-sync] Merge upstream chrome/m${TARGET}"
+    SKIA_BODY_INTRO="Automated upstream merge of \`chrome/m${TARGET}\`."
 fi
 
 WORKFLOW_LINK="[skia-upstream-sync](https://github.com/${GITHUB_REPOSITORY:-mono/SkiaSharp}/actions/workflows/auto-skia-sync.lock.yml)"
@@ -73,9 +89,9 @@ push_skia() {
         echo "Creating mono/skia PR..."
         gh pr create --repo mono/skia \
             --head "$BRANCH" --base "$SKIA_BASE" \
-            --title "[skia-sync] Merge upstream chrome/m${TARGET}" \
+            --title "$SKIA_TITLE" \
             --draft \
-            --body "Automated upstream merge of \`chrome/m${TARGET}\`.
+            --body "${SKIA_BODY_INTRO}
 
 ${SKIA_SUMMARY}
 
@@ -83,7 +99,7 @@ Created by ${WORKFLOW_LINK}." || echo "::warning::Failed to create mono/skia PR"
     else
         echo "Updating mono/skia PR #${pr}..."
         gh pr edit "$pr" --repo mono/skia \
-            --body "Automated upstream merge of \`chrome/m${TARGET}\`.
+            --body "${SKIA_BODY_INTRO}
 
 ${SKIA_SUMMARY}
 

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cd20e5a36642ecbadd9af4a79e85a6349ca1d4e6273785f00f9fca538424015a","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ffc4715b79570f240cee5d95f662b42dde8eab167e8da2d2ca9a498f8cf53122","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -87,11 +87,12 @@ name: "Skia Upstream Sync"
         type: string
       mode:
         default: next
-        description: Which milestone to track
+        description: Which milestone to track. `main` syncs the very tip of upstream Skia (google/skia main HEAD) — dispatch-only, bleeding edge, NOT a version bump.
         options:
         - current
         - next
         - latest
+        - main
         required: false
         type: choice
 
@@ -230,27 +231,28 @@ jobs:
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: ${{ needs.pre_activation.outputs.is_release }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: ${{ needs.pre_activation.outputs.skia_base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: ${{ needs.pre_activation.outputs.target }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_UPSTREAM_REF: ${{ needs.pre_activation.outputs.upstream_ref }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
+          cat << 'GH_AW_PROMPT_9a46b533a7ecc461_EOF'
           <system>
-          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
+          GH_AW_PROMPT_9a46b533a7ecc461_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
+          cat << 'GH_AW_PROMPT_9a46b533a7ecc461_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
+          GH_AW_PROMPT_9a46b533a7ecc461_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
+          cat << 'GH_AW_PROMPT_9a46b533a7ecc461_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
+          GH_AW_PROMPT_9a46b533a7ecc461_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
+          cat << 'GH_AW_PROMPT_9a46b533a7ecc461_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -282,12 +284,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
+          GH_AW_PROMPT_9a46b533a7ecc461_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8ff49e7cd67c6b58_EOF'
+          cat << 'GH_AW_PROMPT_9a46b533a7ecc461_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_8ff49e7cd67c6b58_EOF
+          GH_AW_PROMPT_9a46b533a7ecc461_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -300,6 +302,7 @@ jobs:
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: ${{ needs.pre_activation.outputs.is_release }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: ${{ needs.pre_activation.outputs.skia_base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: ${{ needs.pre_activation.outputs.target }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_UPSTREAM_REF: ${{ needs.pre_activation.outputs.upstream_ref }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -326,6 +329,7 @@ jobs:
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: ${{ needs.pre_activation.outputs.is_release }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: ${{ needs.pre_activation.outputs.skia_base_branch }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: ${{ needs.pre_activation.outputs.target }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_UPSTREAM_REF: ${{ needs.pre_activation.outputs.upstream_ref }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -352,7 +356,8 @@ jobs:
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_HEAD_BRANCH,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_IS_RELEASE,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_SKIA_BASE_BRANCH,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_TARGET,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_UPSTREAM_REF: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_UPSTREAM_REF
               }
             });
       - name: Validate prompt placeholders
@@ -553,9 +558,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_282d84f8ec931f90_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e521f6ba33675018_EOF'
           {"create_issue":{"labels":["auto-skia-sync"],"max":1,"title_prefix":"[auto-skia-sync]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_282d84f8ec931f90_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e521f6ba33675018_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -753,7 +758,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e17cf7bba83b9a58_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_aeac60b37cf728ae_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -801,7 +806,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e17cf7bba83b9a58_EOF
+          GH_AW_MCP_CONFIG_aeac60b37cf728ae_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1374,6 +1379,7 @@ jobs:
       skia_base_branch: ${{ steps.detect.outputs.skia_base_branch }}
       skip: ${{ steps.detect.outputs.skip }}
       target: ${{ steps.detect.outputs.target }}
+      upstream_ref: ${{ steps.detect.outputs.upstream_ref }}
     steps:
       - name: Setup Scripts
         id: setup

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -20,11 +20,11 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Which milestone to track"
+        description: "Which milestone to track. `main` syncs the very tip of upstream Skia (google/skia main HEAD) — dispatch-only, bleeding edge, NOT a version bump."
         required: false
         type: choice
         default: next
-        options: [current, next, latest]
+        options: [current, next, latest, main]
       milestone:
         description: "Exact milestone number (e.g. 148) — overrides mode if set"
         required: false
@@ -70,6 +70,7 @@ jobs:
       next: ${{ steps.detect.outputs.next }}
       latest: ${{ steps.detect.outputs.latest }}
       target: ${{ steps.detect.outputs.target }}
+      upstream_ref: ${{ steps.detect.outputs.upstream_ref }}
       mode: ${{ steps.detect.outputs.mode }}
       skip: ${{ steps.detect.outputs.skip }}
       is_release: ${{ steps.detect.outputs.is_release }}
@@ -207,6 +208,7 @@ post-steps:
 
 Base milestone (current): `m${{ needs.pre_activation.outputs.current }}`.  
 Target milestone: `m${{ needs.pre_activation.outputs.target }}`.  
+Upstream ref (merge from): `${{ needs.pre_activation.outputs.upstream_ref }}` (google/skia) — `main` means the bleeding-edge tip.  
 Base branch (SkiaSharp): `${{ needs.pre_activation.outputs.base_branch }}` — mono/skia base: `${{ needs.pre_activation.outputs.skia_base_branch }}`.  
 Sync (head) branch: `${{ needs.pre_activation.outputs.head_branch }}` (same name in both repos).  
 Release-line sync: `${{ needs.pre_activation.outputs.is_release }}`.
@@ -219,11 +221,22 @@ Release-line sync: `${{ needs.pre_activation.outputs.is_release }}`.
 > **bug-fix-only sync** — do NOT bump the milestone, soname, or nuget versions; only the upstream
 > merge + `cgmanifest.json` commit hash change. Use the base/head branch values above everywhere
 > instead of hardcoding `main`/`skiasharp`/`skia-sync/m{target}`.
+>
+> **`main` (tip) mode.** When the upstream ref above is `main` (head branch `skia-sync/main`), this is a
+> **bleeding-edge sync from the very tip of upstream Skia** (google/skia `main` HEAD), not a `chrome/m<N>`
+> milestone branch. It targets the newest line (`main`/`skiasharp`) and `current == target`, so it is
+> **NOT a version bump** — keep the milestone, soname, and nuget versions unchanged. It may still include
+> new APIs / binding changes (regenerate + build + test as normal), and a tip merge can be large and
+> conflict-heavy because the submodule base is well behind google/skia main; resolve what you reasonably
+> can and record anything unresolved under "items needing human attention".
 
 **Read `.agents/skills/update-skia/SKILL.md` and follow Phases 2-10.** Notes specific to this automated workflow:
 
 - **Phase 1 is pre-computed** (above). Skip it — but you still need to add the `upstream` remote
-  and fetch `chrome/m${{ needs.pre_activation.outputs.target }}` (Phase 1 step 4) since Phase 5 depends on it.
+  and fetch the upstream ref `${{ needs.pre_activation.outputs.upstream_ref }}` (Phase 1 step 4) since Phase 5 depends on it.
+  For every mode except `main` this is a `chrome/m${{ needs.pre_activation.outputs.target }}` milestone branch;
+  for `main` (tip) mode it is google/skia's `main` HEAD (bleeding edge — may include new APIs/binding changes,
+  but it is NOT a version bump, and the head branch is `skia-sync/main`).
 - **First thing**: run `dotnet tool restore` (pre-agent-steps can't do this for the chroot).
 - **Phase 4**: The parent base branch is `origin/${{ needs.pre_activation.outputs.base_branch }}` and the
   submodule base branch is mono/skia `${{ needs.pre_activation.outputs.skia_base_branch }}` — use these in
@@ -263,6 +276,7 @@ After Phase 10, write these files:
    cat > /tmp/gh-aw/agent/skia-sync-env.sh << EOF
    TARGET=${{ needs.pre_activation.outputs.target }}
    CURRENT=${{ needs.pre_activation.outputs.current }}
+   UPSTREAM_REF=${{ needs.pre_activation.outputs.upstream_ref }}
    IS_RELEASE=${{ needs.pre_activation.outputs.is_release }}
    BASE_BRANCH=${{ needs.pre_activation.outputs.base_branch }}
    SKIA_BASE_BRANCH=${{ needs.pre_activation.outputs.skia_base_branch }}


### PR DESCRIPTION
## Summary

Adds a new `main` (tip) **mode** to the `auto-skia-sync` gh-aw workflow so we can sync from the very tip of upstream Skia (`google/skia` `main` HEAD) instead of only `chrome/m<N>` milestone branches. This is a bleeding-edge sync: it may include new APIs/binding changes (regenerated + built + tested as normal) but is **NOT a version bump** — the target milestone stays equal to `main`'s current milestone (no soname/nuget/milestone changes). It uses a distinct head branch (`skia-sync/main`) so it never collides with the `current` milestone sync branch.

`main` mode is **dispatch-only** — the cron schedule never selects it.

## Changes

### `.github/scripts/skia-sync-detect.sh` — `UPSTREAM_REF` generalization
- Accepts `main` as a valid `--mode`.
- Introduces an `UPSTREAM_REF` concept (the `google/skia` ref we merge **from**), resolved alongside `TARGET`:
  - `--milestone N` → `chrome/m${N}` (mode `explicit`)
  - `mode=main` → `main` (tip), `TARGET=MAIN_MS`
  - `mode=latest` → `chrome/m${LATEST}`
  - `mode=current` → `chrome/m${MAIN_MS}`
  - else (`next`) → `chrome/m${NEXT}`
- For `mode=main`, head branch is `skia-sync/main` (distinct from `skia-sync/m${TARGET}`); `IS_RELEASE=false`, base `main`/`skiasharp`. Release-detection stays skipped because `TARGET == MAIN_MS`. `current == target` (not a bump).
- Emits a new `upstream_ref` output, and the `--gate` upstream lookup now uses `${UPSTREAM_REF}` instead of a hardcoded `chrome/m${TARGET}`.

### `.github/workflows/auto-skia-sync.md`
- Adds `main` to the `workflow_dispatch` `mode` options and explains it in the input description.
- Surfaces `upstream_ref` as a `pre-activation` output, in the prompt header, and in the `skia-sync-env.sh` heredoc the agent writes.
- Phase 1 now fetches the resolved `${upstream_ref}` (milestone branch or `main` tip) instead of a hardcoded `chrome/m${target}`, with a note on tip-mode semantics. Recompiled the lock.

### `.github/scripts/skia-sync-push-prs.sh`
- Reads `UPSTREAM_REF` (defaults to `chrome/m${TARGET}` for backward compat) and makes PR titles/bodies tip-aware:
  - SkiaSharp PR: `[skia-sync] Merge upstream Skia main (tip)`
  - mono/skia PR: `[skia-sync] Merge upstream Skia main (tip)`
  - Otherwise keeps the existing milestone titles/bodies.

## Validation
- `gh aw compile auto-skia-sync` → **0 errors** (4 pre-existing warnings: `storage.googleapis.com` ecosystem hint + 3 fixed cron times). Lock still pins `claude-opus-4.7` and reflects the new option/output. Model and native-build setup unchanged.
- `shellcheck --severity=style` clean on all three scripts.
- Stub smoke test of `skia-sync-detect.sh` (faked `gh`/`git`, `GITHUB_REPOSITORY=mono/SkiaSharp`, `GITHUB_REF=main`): `current`/`next`/`latest`/`main`/default/`--milestone N`/empty-milestone all resolve correctly; unknown-arg exits 2; `mode=main` yields `upstream_ref=main`, `head_branch=skia-sync/main`, `target==current==`main's milestone; the `main` gate path proceeds (no skip).

The `release-branch` skill is out of scope.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>