### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b16789ec352c37e02ad38dbac55e6f47d22ff87f"
+          "commitHash": "cd67ad79830bdf6fd7f09f2e5328cf85aa06b10d"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0"
+      "upstream_merge_commit": "e793ca20f32abea8f96876d33c7ddabd3e5ed2d8"
     }
   ]
 }


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/267

## SkiaSharp side of Skia `main` tip sync (m150 tip, no version bump)

This PR is the parent-repo half of a bleeding-edge sync from `google/skia` `main`. The
companion mono/skia PR (head branch `skia-sync/main`) carries the actual upstream merge.

Because `main` is the in-development upstream tip rather than a `chrome/m<N>` milestone
branch, and `CURRENT == TARGET == 150`, **this is NOT a version bump.** The milestone,
soname, and NuGet versions are deliberately left alone. The only parent-repo changes are
`cgmanifest.json` (commit hash + upstream merge commit) and the `externals/skia` submodule
pointer.

### Parent-repo changes

| File | Change |
|---|---|
| `externals/skia` (submodule pointer) | `b16789ec3540beaa43e8a71b050d9d328eb68025` → `cd67ad79830bdf6fd7f09f2e5328cf85aa06b10d` |
| `cgmanifest.json` mono/skia `commitHash` | → `cd67ad79830bdf6fd7f09f2e5328cf85aa06b10d` |
| `cgmanifest.json` `upstream_merge_commit` | `14d05ec761901b6e9e9193af8b347ab3a7f6fed0` → `e793ca20f32abea8f96876d33c7ddabd3e5ed2d8` |

Untouched (intentionally — this is **not** a milestone bump):
- `scripts/VERSIONS.txt` (milestone, soname, NuGet versions)
- `scripts/azure-templates-variables.yml` (SKIASHARP_VERSION)
- `cgmanifest.json` `chrome_milestone` (stays at `150`) and `version` (stays at `chrome/m150`)
- `externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT` stays at `0`)

### Version files audit

```
libSkiaSharp     milestone    150     ← unchanged
libSkiaSharp     increment    0       ← unchanged (no new C API exports this sync)
SK_C_INCREMENT   0                    ← unchanged
SK_MILESTONE     150                  ← pinned in submodule (upstream had flipped to 151)
chrome_milestone 150                  ← unchanged
version          chrome/m150          ← unchanged
```

### Binding changes

`regenerate-bindings.ps1` ran cleanly. **No SkiaApi.generated.cs diff** — the C API surface
is byte-for-byte unchanged versus `origin/main`. (Header-rename churn upstream did not touch
any of the C API entry points; the only adjustment our shim needed was an
`#include "include/private/SkTemplates.h"` path fix in `src/c/sk_font.cpp`.)

HarfBuzz generated bindings were reverted as required (HarfBuzz updates are always separate
from Skia milestone updates).

### C# wrapper changes

None. No new `internal static` P/Invoke declarations were generated, so there is nothing to
wrap. ABI surface unchanged.

### Breaking change analysis

**No breaking changes** to the public SkiaSharp surface introduced by this sync.

Behavioural notes for downstream consumers:
- Upstream `AtlasTextOp` stride-mismatch handling was tightened from "log + early-return" to
  `SkASSERTF_RELEASE`. This is internal to the Ganesh text op path; SkiaSharp does not expose
  it directly, and the condition has historically not fired in tests, but a release-mode hit
  would now abort rather than silently skip. Recorded under "items needing human attention".
- LCD-on-SDF disabling: upstream's `95dbfa24e0` uses
  `sk_ieee_float_divide(1.f, getMinScale())` where our pre-merge cherry-pick had
  `getMaxScale()`. Upstream's form is the authoritative one going forward; visible behaviour
  is equivalent on regular-scale draws and slightly different for extreme-anisotropic-scale
  draws. No SkiaSharp test regressions.

### Build & test results (Linux x64)

| Step | Result |
|---|---|
| `dotnet tool restore` | ✅ |
| `dotnet cake --target=externals-linux --arch=x64 --gnArgs "skia_use_partition_alloc=false"` | ✅ libSkiaSharp.so + libHarfBuzzSharp.so |
| `pwsh ./utils/generate.ps1` (via `regenerate-bindings.ps1`) | ✅ no API diff |
| `dotnet build binding/SkiaSharp/SkiaSharp.csproj` | ✅ 0 warnings, 0 errors |
| `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` | ✅ **Passed: 5569 / Skipped: 172 / Failed: 0** (`net10.0|x64`, 2m 43s) |

Test output is preserved at `/tmp/gh-aw/agent/test-output.txt` (uploaded as workflow artifact).

### Items needing human attention

1. **Upstream is on milestone 151; SkiaSharp is still on 150.** Upstream `main`'s
   `SkMilestone.h` was flipped from 150 → 151 by `chrome-branch-day` (commit `d30d2a1958`).
   The companion mono/skia PR pins it back to 150 inside the submodule so the build's
   internal version check passes. A reviewer should decide whether the next sync should:
   - keep the pin (continuing to track tip without promoting our line); **or**
   - graduate SkiaSharp to m151 (would touch `scripts/VERSIONS.txt`, `cgmanifest.json`
     `chrome_milestone`/`version`, soname, and ~30 NuGet version lines, plus drop the
     `SkMilestone.h` pin in mono/skia). The existing `update-versions.ps1` script handles
     all of that automatically when invoked with `-Current 150 -Target 151`.
2. **`skia_use_partition_alloc=false` is passed as a CLI gn arg, not baked into
   `native/**/build.cake`.** This works (and complies with the workflow rule against
   modifying native build files) but is not durable — the next time someone runs
   `dotnet cake --target=externals-linux` without that flag, the build will fail because
   `partition_alloc.gni` is missing from our fork's DEPS. Recommend a follow-up to either
   (a) re-enable `partition_alloc` in `externals/skia/DEPS`, or (b) wire
   `skia_use_partition_alloc=false` into the platform `build.cake` files once the next
   real milestone bump rolls in.
3. **All in-tree `[M150]` cherry-picks were upstreamed and dropped by the merge.** This is
   the *expected* outcome of catching up to main, but it does mean any downstream consumers
   carrying additional patches on top of `skiasharp` should rebase carefully.

### Other notes

- Native build environment was already provisioned (clang, libc++-dev/libc++abi-dev,
  fontconfig, ninja). No host packages were installed during the sync.
- `externals-download` was **not** used at any point during this sync. The shipped native
  binary comes from a fresh source build off the new merge.
- depot_tools' `gclient_paths.py` was touched by `git-sync-deps` (cache artifact); not
  committed.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).