### PR TITLE
[skia-sync] Merge upstream chrome/m148 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1a155bae3ac86db6d3efbd996f00e774b6a7b722"
+          "commitHash": "6d45d9aed12bacb599261ccebcf4a9764b0467ea"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 148,
-      "upstream_merge_commit": "54851b68b7a1d49bc4b4361f12786a7d7ad91fff"
+      "upstream_merge_commit": "46f2e16555cac1211f4087cf24728fd741ac6495"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "6d45d9aed12bacb599261ccebcf4a9764b0467ea"
+          "commitHash": "9bf10f9f96b2b36ada8d6dd3bc1958193a9cb787"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m148. Targeting release branch `release/4.148.x` (mono/skia `release/4.148.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/268

## Summary

Release-line bug-fix sync onto `release/4.148.x`. Bumps the `externals/skia` submodule pointer to pick up 2 new upstream `chrome/m148` bug fixes and updates the matching `cgmanifest.json` SHAs.

This is **not** a milestone bump — `CURRENT == TARGET == 148`. No version files change: `scripts/VERSIONS.txt`, `scripts/azure-templates-variables.yml`, `SkMilestone.h`, `SK_C_INCREMENT` are all left exactly as they are on `release/4.148.x`. The only file changes in this PR are:

- `externals/skia` submodule pointer: `1a155bae3a` → `6d45d9aed1`
- `cgmanifest.json` mono/skia `commitHash`: `1a155bae3ac86db6d3efbd996f00e774b6a7b722` → `6d45d9aed12bacb599261ccebcf4a9764b0467ea`
- `cgmanifest.json` Skia-core `upstream_merge_commit`: `54851b68b7a1d49bc4b4361f12786a7d7ad91fff` → `46f2e16555cac1211f4087cf24728fd741ac6495`

`chrome_milestone` stays at `148`.

## Companion mono/skia PR

`mono/skia` PR on branch `skia-sync/release-4.148.x` targeting `release/4.148.x`. That PR carries the actual upstream merge commit `6d45d9aed1`. Per the skill's merge sequence, the mono/skia PR must be merged first; then the parent repo's submodule pointer must be re-pointed at the squashed `release/4.148.x` SHA before merging this PR.

## Upstream commits pulled in (via submodule bump)

| SHA | Subject | Files |
| --- | --- | --- |
| `46f2e16555` | `[m148] Resolved a Data Race on fStream in SkTypeface_Mac` | `src/ports/SkTypeface_mac_ct.{cpp,h}` |
| `3a90f6662a` | `[graphite] Use stable collection for static bindings` | `src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp` |

Both are upstream cherry-picks already on `chrome/m148`. The macOS typeface fix is the user-visible one (eliminates a `gTFCache`/`fStream` data race in `SkTypeface_Mac`); the Graphite change is benign for SkiaSharp because we ship Ganesh, not Graphite/Dawn.

## Breaking change analysis

**None.** Because this is a release-line bug-fix sync (`current == target == 148`):

- No public C++ API was added, removed, or renamed by these two commits.
- No C API (`externals/skia/src/c/**`, `include/c/**`) files changed.
- The binding generator re-ran and reports `No changes to bindings (C API signatures unchanged)` and `No new functions found`. `binding/SkiaSharp/SkiaApi.generated.cs` and the other `*Api.generated.cs` files are byte-identical to `origin/release/4.148.x`.
- No managed C# wrapper changes required.
- No `[Obsolete]` markers to add — no deprecations.
- ABI / soname stay at `libSkiaSharp.so.148.0.0`.

## Version / binding updates

| File | Change |
| --- | --- |
| `scripts/VERSIONS.txt` | unchanged (milestone 148, increment 0, soname 148.0.0) |
| `scripts/azure-templates-variables.yml` | unchanged |
| `externals/skia/include/core/SkMilestone.h` | unchanged (`SK_MILESTONE 148`) |
| `externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT`) | unchanged (`0`) |
| `binding/SkiaSharp/SkiaApi.generated.cs` | unchanged (regenerated, no diff vs base) |
| `binding/SkiaSharp.Skottie/SkottieApi.generated.cs` | unchanged |
| `binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs` | unchanged |
| `binding/SkiaSharp.Resources/ResourcesApi.generated.cs` | unchanged |
| `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` | unchanged (HarfBuzz regen is reverted by the regenerate-bindings script per policy) |
| `cgmanifest.json` | mono/skia `commitHash` + Skia-core `upstream_merge_commit` bumped |
| `externals/skia` (submodule pointer) | bumped to `6d45d9aed1` |

## C# changes

**None required.** No managed code was modified, no test code was modified.

## Build / test results (Linux x64)

The agent used `dotnet cake --target=externals-linux --arch=x64` (NOT `externals-download`, per the skill's hard rule for milestone-touching work). Other platforms (macOS, Windows, iOS, Android, WASM) will rebuild on the release-line CI pipelines once both PRs land.

| Stage | Result |
| --- | --- |
| `dotnet tool restore` | ✅ all tools restored |
| `git submodule status` | ✅ aligned to base before merge |
| Upstream merge (in submodule) | ✅ clean, no conflicts, `git diff --check` empty |
| `cgmanifest.json` edit | ✅ |
| `dotnet cake --target=externals-linux --arch=x64` | ✅ produced `output/native/linux/x64/libSkiaSharp.so.148.0.0` (11.3 MB) and `libHarfBuzzSharp.so.0.61420.0` (3.0 MB) — total native build ≈ 16 min |
| `regenerate-bindings.ps1` | ✅ `No changes to bindings`, `No new functions found`, HarfBuzz revert applied |
| `dotnet build binding/SkiaSharp/SkiaSharp.csproj` | ✅ 0 errors, 0 warnings, all TFMs (net462/net48/netstandard2.0/2.1/net6.0/net9.0/net9.0-android35.0/net10.0/net10.0-android36.0) |
| Smoke tests (`Category=Smoke`) | ✅ 32 passed, 0 failed, 0 skipped (131 ms) |
| Full test suite | ✅ **5544 passed, 0 failed, 172 skipped (HW-dependent), 5716 total — 2 m 32 s** |

The full suite was first attempted with xUnit's default parallel test execution and crashed in test discovery with `PAL_SEHException: Out of memory` on the 16 GB CI runner. Re-running with `xUnit.MaxParallelThreads=1 xUnit.ParallelizeTestCollections=false` (serial execution) completed cleanly with 0 failures. This is an environmental constraint of this CI runner, not a regression introduced by the merge.

## Items needing human attention

- **Cross-platform reviewers, please double-check** the macOS native build picks up the new `SkTypeface_mac_ct.cpp` mutex correctly on the `release/4.148.x` macOS / iOS / Mac Catalyst pipelines. The change is upstream-mainline and small (8 line diff), so risk is low, but the agent only built Linux x64 here.
- **Merge sequence** (from the skill, repeated for the human merger):
  1. Merge the mono/skia `skia-sync/release-4.148.x` → `release/4.148.x` PR first (squash).
  2. In this repo, `git -C externals/skia fetch origin && git -C externals/skia checkout <new-squashed-sha-on-release/4.148.x>`, commit, push to this PR branch.
  3. Re-run CI; merge this PR last.
  Skipping step 2 would orphan the submodule onto the unsquashed branch commit.
- No native-build dependency issues, no `gn` arg changes, no compiler/linker flag changes were required for this sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).