### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b16789ec352c37e02ad38dbac55e6f47d22ff87f"
+          "commitHash": "b38065ae120a8c5cef6ecd54d18f128429a65866"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m150",
+          "version": "chrome/m151",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 150,
-      "upstream_merge_commit": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0"
+      "chrome_milestone": 151,
+      "upstream_merge_commit": "6d89b67e641382d98c3b0eaa693b023b9b5c4f56"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b38065ae120a8c5cef6ecd54d18f128429a65866"
+          "commitHash": "be3b5cac3a8e21707f7fd903c07d717b85da8f13"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "6d89b67e641382d98c3b0eaa693b023b9b5c4f56"
+      "upstream_merge_commit": "e47bb0549c20841e6c5681d1890d0436e3d5ecf8"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "be3b5cac3a8e21707f7fd903c07d717b85da8f13"
+          "commitHash": "f1e0d6e222891ad2461006596cf6baa561d3378a"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "e47bb0549c20841e6c5681d1890d0436e3d5ecf8"
+      "upstream_merge_commit": "94dd812d73bf43160bdcff57e1bc09bb09c24e0e"
     }
   ]
 }

--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -25,6 +25,7 @@ Task("libSkiaSharp")
             $"target_os='android' " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_freetype2=false " +

--- a/native/ios/build.cake
+++ b/native/ios/build.cake
@@ -56,6 +56,7 @@ Task("libSkiaSharp")
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
             $"skia_use_metal=true " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/native/linux/build.cake
+++ b/native/linux/build.cake
@@ -106,6 +106,7 @@ Task("libSkiaSharp")
             $"skia_enable_ganesh={(SUPPORT_GPU ? "true" : "false")} " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_freetype2=false " +
@@ -152,6 +153,7 @@ Task("libHarfBuzzSharp")
         GnNinja($"{VARIANT}/{arch}", "HarfBuzzSharp",
             $"target_os='linux' " +
             $"target_cpu='{skiaArch}' " +
+            $"skia_use_partition_alloc=false " +
             $"visibility_hidden=false " +
             $"extra_asmflags=[] " +
             $"extra_cflags=[ '-stdlib=libc++'{bionicDefineHB} ] " +

--- a/native/macos/build.cake
+++ b/native/macos/build.cake
@@ -33,6 +33,7 @@ Task("libSkiaSharp")
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
             $"skia_use_metal=true " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -44,6 +44,7 @@ Task("libSkiaSharp")
            $"skia_enable_ganesh=true " +
            $"skia_use_harfbuzz=false " +
            $"skia_use_icu=false " +
+           $"skia_use_partition_alloc=false " +
            $"skia_use_piex=true " +
            $"skia_use_system_expat=false " +
            $"skia_use_system_freetype2=true " +

--- a/native/tvos/build.cake
+++ b/native/tvos/build.cake
@@ -40,6 +40,7 @@ Task("libSkiaSharp")
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
             $"skia_use_metal=true " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -46,6 +46,7 @@ Task("libSkiaSharp")
         $"skia_use_freetype=true " +
         $"skia_use_harfbuzz=false " +
         $"skia_use_icu=false " +
+        $"skia_use_partition_alloc=false " +
         $"skia_use_piex=false " +
         $"skia_use_expat=true " +
         $"skia_use_libwebp_encode=true " +
@@ -125,6 +126,7 @@ Task("libHarfBuzzSharp")
         $"target_os='linux' " +
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
+        $"skia_use_partition_alloc=false " +
         $"extra_cflags=[ '-s', 'WARN_UNALIGNED=1' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"skia_emsdk_dir='{EMSCRIPTEN_ROOT}'" +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -50,6 +50,7 @@ Task("libSkiaSharp")
             $"skia_use_dng_sdk=true " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m150
+skia                                            release     m151
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -65,19 +65,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   150
+libSkiaSharp            milestone   151
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      150.0.0
+libSkiaSharp            soname      151.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.150.0.0
-SkiaSharp               file        4.150.0.0
+SkiaSharp               assembly    4.151.0.0
+SkiaSharp               file        4.151.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -85,36 +85,36 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.150.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.150.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.150.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.150.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.150.0
-SkiaSharp.NativeAssets.Android                  nuget       4.150.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.150.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.150.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.150.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.150.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.150.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.150.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.150.0
-SkiaSharp.Views                                 nuget       4.150.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.150.0
-SkiaSharp.Views.Gtk3                            nuget       4.150.0
-SkiaSharp.Views.Gtk4                            nuget       4.150.0
-SkiaSharp.Views.WindowsForms                    nuget       4.150.0
-SkiaSharp.Views.WPF                             nuget       4.150.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.150.0
-SkiaSharp.Views.WinUI                           nuget       4.150.0
-SkiaSharp.Views.Maui.Core                       nuget       4.150.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.150.0
-SkiaSharp.Views.Blazor                          nuget       4.150.0
-SkiaSharp.HarfBuzz                              nuget       4.150.0
-SkiaSharp.Skottie                               nuget       4.150.0
-SkiaSharp.SceneGraph                            nuget       4.150.0
-SkiaSharp.Resources                             nuget       4.150.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.150.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.150.0
+SkiaSharp                                       nuget       4.151.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
+SkiaSharp.NativeAssets.Android                  nuget       4.151.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
+SkiaSharp.Views                                 nuget       4.151.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
+SkiaSharp.Views.Gtk3                            nuget       4.151.0
+SkiaSharp.Views.Gtk4                            nuget       4.151.0
+SkiaSharp.Views.WindowsForms                    nuget       4.151.0
+SkiaSharp.Views.WPF                             nuget       4.151.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
+SkiaSharp.Views.WinUI                           nuget       4.151.0
+SkiaSharp.Views.Maui.Core                       nuget       4.151.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
+SkiaSharp.Views.Blazor                          nuget       4.151.0
+SkiaSharp.HarfBuzz                              nuget       4.151.0
+SkiaSharp.Skottie                               nuget       4.151.0
+SkiaSharp.SceneGraph                            nuget       4.151.0
+SkiaSharp.Resources                             nuget       4.151.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.150.0
+  SKIASHARP_VERSION: 4.151.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/269

## SkiaSharp tip-merge sync — `main` ← `skia-sync/main`

Automated sync via `auto-skia-sync` workflow.

### Summary

| Field | Value |
| --- | --- |
| Base branch | `main` @ `0d83945c9` |
| Submodule before | mono/skia @ `b16789ec3540beaa43e8a71b050d9d328eb68025` (`skiasharp`) |
| Submodule after | mono/skia @ `b38065ae120a8c5cef6ecd54d18f128429a65866` (`skia-sync/main`) |
| Upstream merge commit | google/skia `main` @ `6d89b67e641382d98c3b0eaa693b023b9b5c4f56` |
| Upstream commits merged | 303 |

### ⚠ Milestone boundary crossed

The workflow was scheduled as a `main` (tip) sync with `CURRENT == TARGET == 150`,
which is normally **not** a version bump. However, upstream `main` has moved past
the m150 → m151 milestone boundary (`#define SK_MILESTONE 151` in
`include/core/SkMilestone.h`). The native build aborts when the milestone in
`SkMilestone.h` does not match `scripts/VERSIONS.txt`, so this sync **does** bump
the SkiaSharp version line:

- `scripts/VERSIONS.txt`: `milestone 150 → 151`, `soname 150.0.0 → 151.0.0`, all `4.150.0 → 4.151.0`
- `scripts/azure-templates-variables.yml`: `SKIASHARP_VERSION 4.150.0 → 4.151.0`
- `cgmanifest.json`: `chrome_milestone 150 → 151`, `version "chrome/m150" → "chrome/m151"`,
  `commitHash`, `upstream_merge_commit`
- `SK_C_INCREMENT`: unchanged (`0`) — no new C API functions in this sync

This is effectively a `m150 → m151` milestone bump even though it was scheduled as
a tip-mode sync. The companion mono/skia PR is `chrome/m151`-equivalent.

### Build args changed (cross-platform impact)

Upstream Skia's `BUILD.gn` now imports `//src/partition_alloc` unconditionally, but
our `DEPS` does not vendor the `third_party/externals/partition_alloc` source tree.
Per [skill Phase 7 / gotcha #23](.agents/skills/update-skia/references/known-gotchas.md),
a required upstream gn arg goes in `native/**/build.cake`, not a one-off
`--gnArgs` flag, and must be applied to every clang platform.

`skia_use_partition_alloc=false` added to:

- `native/android/build.cake`
- `native/ios/build.cake`
- `native/linux/build.cake` (both `libSkiaSharp` and `libHarfBuzzSharp` targets)
- `native/macos/build.cake`
- `native/tizen/build.cake`
- `native/tvos/build.cake`
- `native/wasm/build.cake` (both `libSkiaSharp` and `libHarfBuzzSharp` targets)
- `native/windows/build.cake`

(`native/{linuxnodeps,maccatalyst,linux-clang-cross,nanoserver,winui,winui-angle}/build.cake`
delegate to one of the above, so they inherit the flag automatically.)

**Only the Linux x64 native build was exercised here** — the other clang platforms
need human verification that the same flag is sufficient (it should be: the failure
is from BUILD.gn's top-level `partition_alloc` import, which is platform-independent).

### C API changes

- `externals/skia/src/c/sk_font.cpp`: `#include "include/private/base/SkTemplates.h"`
  → `#include "include/private/SkTemplates.h"` (upstream `d2b9e48baf` header move).

This is the only C API change in this sync. Committed in the submodule as
`b38065ae12`.

### Breaking-change analysis

- **C API:** No signature changes. Regenerated `binding/SkiaSharp/SkiaApi.generated.cs`
  produced **zero diff** (`git diff --stat -- binding/` was empty).
- **C# wrappers:** No changes required — no new functions to wrap.
- **ABI:** Stable; soname bumped 150.0.0 → 151.0.0 as expected for a milestone bump.

### Build & test results (Linux x64)

| Step | Result |
| --- | --- |
| `dotnet cake --target=externals-linux --arch=x64` | ✅ `libSkiaSharp.so.151.0.0` + `libHarfBuzzSharp.so.0.61421.0` produced |
| `pwsh utils/generate.ps1` (via `regenerate-bindings.ps1`) | ✅ no binding diff |
| `dotnet build binding/SkiaSharp/SkiaSharp.csproj` | ✅ 0 warnings, 0 errors |
| `dotnet test tests/SkiaSharp.Tests.Console/...` | ✅ **5571 passed, 0 failed, 172 skipped** (2m 43s) |

Full test log uploaded as `test-output.txt` artifact.

### Items needing human attention

1. **Milestone boundary** — this PR effectively bumps SkiaSharp to m151 even though
   the workflow was triggered as a tip-mode sync. Please confirm the version line
   is the intended direction (alternative would be to skip this sync until upstream
   cuts a `chrome/m151` branch and run a proper milestone-bump workflow).
2. **`skia_use_partition_alloc=false` added to 8 platforms × 2 targets (Skia + HarfBuzz)**
   but only Linux x64 was exercised. Please verify Android, iOS, macOS, MacCatalyst,
   tvOS, tizen, wasm and Windows still build via CI before merging.
3. **`bazel/external/dawn/dawn_files.bzl` deletion** in the submodule — informational
   (we do not build via Bazel), but noted in the mono/skia PR.
4. **303 upstream commits** — large diff, please review for any
   behavioural/API changes that should be called out in release notes.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).