### PR TITLE
Fix small-sigma raster blur regression (define SK_AVOID_SLOW_RASTER_PIPELINE_BLURS)

### DIFF
--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -34,7 +34,7 @@ Task("libSkiaSharp")
             $"skia_use_system_zlib=false " +
             $"skia_use_vulkan=true " +
             $"skia_enable_skottie=true " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM', '-g', '-ggdb3' ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM', '-g', '-ggdb3' ] " +
             $"extra_ldflags=[ '-Wl,-z,max-page-size=16384' ] " +
             $"ndk='{ANDROID_NDK_HOME}' " +
             $"ndk_api=21");

--- a/native/ios/build.cake
+++ b/native/ios/build.cake
@@ -63,7 +63,7 @@ Task("libSkiaSharp")
             $"skia_use_system_libwebp=false " +
             $"skia_use_system_zlib=false " +
             $"skia_enable_skottie=true " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_ARC4RANDOM_BUF' ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DHAVE_ARC4RANDOM_BUF' ] " +
             ADDITIONAL_GN_ARGS);
 
         RunXCodeBuild("libSkiaSharp/libSkiaSharp.xcodeproj", "libSkiaSharp", sdk, xcodeArch, properties: new Dictionary<string, string> {

--- a/native/linux/build.cake
+++ b/native/linux/build.cake
@@ -117,7 +117,7 @@ Task("libSkiaSharp")
             $"skia_use_vulkan=true " +
             bionicArgs +
             $"extra_asmflags=[] " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM', '-stdlib=libc++'{spectreFlags}{wordSizeDefine}{bionicDefine} ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-stdlib=libc++'{spectreFlags}{wordSizeDefine}{bionicDefine} ] " +
             $"extra_ldflags=[ '-stdlib=libc++', '-static-libgcc'{staticLibcxx}, '-Wl,--version-script={map}' ] " +
             COMPILERS +
             $"linux_soname_version='{soname}' " +

--- a/native/macos/build.cake
+++ b/native/macos/build.cake
@@ -40,7 +40,7 @@ Task("libSkiaSharp")
             $"skia_use_system_libwebp=false " +
             $"skia_use_system_zlib=false " +
             $"skia_enable_skottie=true " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_ARC4RANDOM_BUF', '-stdlib=libc++' ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DHAVE_ARC4RANDOM_BUF', '-stdlib=libc++' ] " +
             $"extra_ldflags=[ '-stdlib=libc++' ]");
 
         RunXCodeBuild("libSkiaSharp/libSkiaSharp.xcodeproj", "libSkiaSharp", "macosx", arch, properties: new Dictionary<string, string> {

--- a/native/tizen/libSkiaSharp/project_def.prop
+++ b/native/tizen/libSkiaSharp/project_def.prop
@@ -14,6 +14,7 @@ APPNAME = SkiaSharp
 USER_INC_DIRS = $(skia_root)
 
 USER_DEFS = NDEBUG                                        \
+            SK_AVOID_SLOW_RASTER_PIPELINE_BLURS          \
             SK_BUILD_FOR_TIZEN                            \
             SK_CODEC_DECODES_JPEG                         \
             SK_CODEC_DECODES_PNG                          \

--- a/native/tvos/build.cake
+++ b/native/tvos/build.cake
@@ -47,7 +47,7 @@ Task("libSkiaSharp")
             $"skia_use_system_libwebp=false " +
             $"skia_use_system_zlib=false " +
             $"skia_enable_skottie=true " +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '-DHAVE_ARC4RANDOM_BUF' ] ");
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DHAVE_ARC4RANDOM_BUF' ] ");
 
         RunXCodeBuild("libSkiaSharp/libSkiaSharp.xcodeproj", "libSkiaSharp", sdk, arch, properties: new Dictionary<string, string> {
             { "TVOS_DEPLOYMENT_TARGET", GetDeploymentTarget(arch) },

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -59,7 +59,7 @@ Task("libSkiaSharp")
         $"skia_use_wuffs=true " +
         $"skia_enable_skottie=true " +
         $"extra_cflags=[ " +
-        $"  '-DSKIA_C_DLL', '-DXML_POOR_ENTROPY', " + 
+        $"  '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DXML_POOR_ENTROPY', " +
         $" {(!hasSimdEnabled ? "'-DSKNX_NO_SIMD', " : "")} '-DSK_DISABLE_AAA', '-DGR_GL_CHECK_ALLOC_WITH_GET_ERROR=0', " +
         $"  '-s', 'WARN_UNALIGNED=1' " + // '-s', 'USE_WEBGL2=1' (experimental)
         $"  { (hasSimdEnabled ? ", '-msimd128'" : "") } " +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -61,7 +61,7 @@ Task("libSkiaSharp")
             $"skia_use_direct3d={SUPPORT_DIRECT3D} ".ToLower () +
             clang +
             win_vcvars_version +
-            $"extra_cflags=[ '-DSKIA_C_DLL', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +
+            $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +
             $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP', '/guard:cf', '/LIBPATH:{spectreLibPath}', '/DELAYLOAD:d3d12.dll', '/DELAYLOAD:dxgi.dll', '/DELAYLOAD:D3DCOMPILER_47.dll', '/DEFAULTLIB:delayimp' ] " +
             ADDITIONAL_GN_ARGS);
 


### PR DESCRIPTION
Skia's SkBlurEngine refactor (~m129) routes small-sigma blurs of 8888 images through the raster-pipeline shader-based GaussianPass, which is dramatically slower than the old dedicated box-approximation path. Chromium mitigates this by defining SK_AVOID_SLOW_RASTER_PIPELINE_BLURS (skia/config/SkUserConfig.h), which makes Raster8888BlurAlgorithm skip GaussianPass and use ThreeBoxApproxPass / TentPass instead. SkiaSharp never defined it, so the CPU blur path is fully exposed to the regression.

Define SK_AVOID_SLOW_RASTER_PIPELINE_BLURS for all libSkiaSharp native builds (linux covers linuxnodeps; ios covers maccatalyst; plus macos, windows, android, tvos, wasm, and tizen's project_def.prop).

Measured on a Linux x64 source build, same-milestone A/B (stock m150 vs m150 + define): small-sigma image blur recovers ~6x (2.84 ms -> 455 us), beating the 3.119 baseline, with no measurable change to any other benchmark. The change is a pure compile-time define and is build-verified on Linux x64.

**Description of Change**

<!-- Describe your changes here. -->

**Bugs Fixed**

- Fixes #

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

**API Changes**

None.

<!-- REPLACE THIS COMMENT

List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`

-->

**Behavioral Changes**

None.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**Required skia PR**

None.

<!-- Replace this with the full URL to the skia PR. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Merged related skia PRs
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
