### PR TITLE
Add cross-version benchmarks CI workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -184,7 +184,7 @@ jobs:
           dotnet run -c Release \
             --project benchmarks/SkiaSharp.Benchmarks.Compare \
             -p:SkiaSharpBenchmarkVersion="$VERSION" \
-            "${FEED_ARGS[@]}" \
+            ${FEED_ARGS[@]+"${FEED_ARGS[@]}"} \
             -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$OUT"
 
           printf '{"os":"%s","version":"%s"}\n' "$OSLABEL" "$VERSION" > "$OUT/meta.json"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -169,11 +169,12 @@ jobs:
           echo "oslabel=$OSLABEL" >> "$GITHUB_OUTPUT"
 
           OUT="$GITHUB_WORKSPACE/bench-out"
-          ART="$OUT/results"
-          mkdir -p "$ART"
+          mkdir -p "$OUT"
 
-          FILTER_ARGS=()
-          for f in $FILTER; do FILTER_ARGS+=(--filter "$f"); done
+          # BenchmarkDotNet takes multiple filter globs as values of a single --filter
+          # option; repeating the option is rejected as "defined multiple times".
+          FILTER_ARGS=(--filter)
+          for f in $FILTER; do FILTER_ARGS+=("$f"); done
 
           FEED_ARGS=()
           if [ -n "$EXTRA_FEED" ]; then
@@ -184,7 +185,7 @@ jobs:
             --project benchmarks/SkiaSharp.Benchmarks.Compare \
             -p:SkiaSharpBenchmarkVersion="$VERSION" \
             "${FEED_ARGS[@]}" \
-            -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$ART"
+            -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$OUT"
 
           printf '{"os":"%s","version":"%s"}\n' "$OSLABEL" "$VERSION" > "$OUT/meta.json"
 
@@ -262,15 +263,16 @@ jobs:
           echo "oslabel=$OSLABEL" >> "$GITHUB_OUTPUT"
 
           OUT="$GITHUB_WORKSPACE/bench-out"
-          ART="$OUT/results"
-          mkdir -p "$ART"
+          mkdir -p "$OUT"
 
-          FILTER_ARGS=()
-          for f in $FILTER; do FILTER_ARGS+=(--filter "$f"); done
+          # BenchmarkDotNet takes multiple filter globs as values of a single --filter
+          # option; repeating the option is rejected as "defined multiple times".
+          FILTER_ARGS=(--filter)
+          for f in $FILTER; do FILTER_ARGS+=("$f"); done
 
           dotnet run -c Release \
             --project benchmarks/SkiaSharp.Benchmarks \
-            -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$ART"
+            -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$OUT"
 
           printf '{"os":"%s","version":"current"}\n' "$OSLABEL" > "$OUT/meta.json"
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,11 +11,16 @@ name: "Benchmarks"
 #   * published  - the SkiaSharp.Benchmarks.Compare harness restores a published NuGet
 #                  version (e.g. the latest stable preview and a 3.x release) from nuget.org.
 #                  This path is fast and reliable and always reports real numbers.
-#   * current    - the in-repo SkiaSharp.Benchmarks project benchmarks the working tree
-#                  after building the native libSkiaSharp from source for a single
-#                  architecture. This is best-effort (continue-on-error) because a full
-#                  native build on a hosted runner is slow and can fail for reasons
-#                  unrelated to the benchmarks; when it succeeds it adds a "current" column.
+#   * current    - benchmarks the working tree's native code. The native libSkiaSharp is
+#                  built from source for a single architecture and then swapped in for the
+#                  baseline version's published native binary inside the same Compare
+#                  harness. The managed binding stays a known published version (the
+#                  baseline) while the native library is the one built from this PR, so the
+#                  column measures the effect of native changes (the common case for perf
+#                  PRs). This avoids building the multi-targeted in-repo binding graph,
+#                  which needs mobile workloads that are not present on the runners.
+#                  It is best-effort (continue-on-error) because a full native build on a
+#                  hosted runner is slow and can fail for reasons unrelated to benchmarks.
 
 on:
   pull_request:
@@ -234,6 +239,28 @@ jobs:
         shell: bash
         run: scripts/infra/native/linux/docker/glibc/build-local.sh x64
 
+      - name: Install MSVC Spectre-mitigated libs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # The Windows native build links against the Spectre-mitigated MSVC libs, which
+          # are not installed on the hosted image by default. Best-effort: install them and
+          # export VS_INSTALL so windows-shared.cake can find lib/spectre/<arch>.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -property installationPath
+          Write-Host "VS install path: $vsPath"
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+          $components = @(
+            'Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre',
+            'Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre'
+          )
+          $addArgs = $components | ForEach-Object { @('--add', $_) }
+          $args = @('modify', '--installPath', $vsPath, '--quiet', '--norestart', '--nocache') + $addArgs
+          Write-Host "vs_installer $($args -join ' ')"
+          $p = Start-Process -FilePath $installer -ArgumentList $args -Wait -PassThru
+          Write-Host "vs_installer exit code: $($p.ExitCode)"
+          "VS_INSTALL=$vsPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Build native (Windows x64)
         if: runner.os == 'Windows'
         shell: bash
@@ -247,6 +274,7 @@ jobs:
       - name: Run benchmarks
         id: run
         env:
+          BASELINE: ${{ needs.setup.outputs.baseline }}
           FILTER: ${{ needs.setup.outputs.filter }}
           JOB: ${{ needs.setup.outputs.job }}
         shell: bash
@@ -254,13 +282,35 @@ jobs:
           set -euo pipefail
           set -f
 
+          # Map the runner to: the benchmark label, the freshly built native library, and
+          # the published native-asset package whose binary it replaces.
+          OSLABEL="$RUNNER_OS"; BUILT=""; PKG=""; CACHE_REL=""
           case "$RUNNER_OS" in
-            Linux)   OSLABEL=linux-x64 ;;
-            Windows) OSLABEL=windows-x64 ;;
-            macOS)   OSLABEL=osx-arm64 ;;
-            *)       OSLABEL="$RUNNER_OS" ;;
+            Linux)
+              OSLABEL=linux-x64
+              BUILT="$GITHUB_WORKSPACE/output/native/linux/x64/libSkiaSharp.so"
+              PKG=skiasharp.nativeassets.linux.nodependencies
+              CACHE_REL=runtimes/linux-x64/native/libSkiaSharp.so ;;
+            Windows)
+              OSLABEL=windows-x64
+              BUILT="$GITHUB_WORKSPACE/output/native/windows/x64/libSkiaSharp.dll"
+              PKG=skiasharp.nativeassets.win32
+              CACHE_REL=runtimes/win-x64/native/libSkiaSharp.dll ;;
+            macOS)
+              OSLABEL=osx-arm64
+              BUILT="$GITHUB_WORKSPACE/output/native/osx/libSkiaSharp.dylib"
+              PKG=skiasharp.nativeassets.macos
+              CACHE_REL=runtimes/osx/native/libSkiaSharp.dylib ;;
+            *)
+              OSLABEL="$RUNNER_OS" ;;
           esac
           echo "oslabel=$OSLABEL" >> "$GITHUB_OUTPUT"
+
+          if [ ! -f "$BUILT" ]; then
+            echo "::error::Native library not found at $BUILT — the native build did not produce it."
+            ls -R "$GITHUB_WORKSPACE/output/native" 2>/dev/null || true
+            exit 1
+          fi
 
           OUT="$GITHUB_WORKSPACE/bench-out"
           mkdir -p "$OUT"
@@ -270,8 +320,31 @@ jobs:
           FILTER_ARGS=(--filter)
           for f in $FILTER; do FILTER_ARGS+=("$f"); done
 
-          dotnet run -c Release \
-            --project benchmarks/SkiaSharp.Benchmarks \
+          NUGET_PKGS="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+
+          # Restore the Compare harness for the baseline published managed package so the
+          # managed binding is a known, stable version. BenchmarkDotNet generates and builds
+          # a child project at run time that copies the native asset from the global package
+          # cache, so replacing the cached binary makes the benchmark exercise the native
+          # library built from this PR while keeping the published managed API.
+          dotnet restore benchmarks/SkiaSharp.Benchmarks.Compare \
+            -p:SkiaSharpBenchmarkVersion="$BASELINE"
+
+          DEST="$NUGET_PKGS/$PKG/$BASELINE/$CACHE_REL"
+          if [ ! -f "$DEST" ]; then
+            echo "::error::Published native asset not found at $DEST"
+            find "$NUGET_PKGS/$PKG" -name 'libSkiaSharp*' 2>/dev/null || true
+            exit 1
+          fi
+          echo "Replacing published native with the working-tree build:"
+          echo "  built: $BUILT ($(shasum -a 256 "$BUILT" 2>/dev/null | cut -d' ' -f1 || echo n/a))"
+          echo "  cache: $DEST ($(shasum -a 256 "$DEST" 2>/dev/null | cut -d' ' -f1 || echo n/a))"
+          cp -f "$BUILT" "$DEST"
+          echo "  after: $(shasum -a 256 "$DEST" 2>/dev/null | cut -d' ' -f1 || echo n/a)"
+
+          dotnet run -c Release --no-restore \
+            --project benchmarks/SkiaSharp.Benchmarks.Compare \
+            -p:SkiaSharpBenchmarkVersion="$BASELINE" \
             -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$OUT"
 
           printf '{"os":"%s","version":"current"}\n' "$OSLABEL" > "$OUT/meta.json"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,324 @@
+name: "Benchmarks"
+
+# Runs the SkiaSharp micro-benchmarks across several SkiaSharp versions and merges the
+# results into a single comparison report.
+#
+# BenchmarkDotNet cannot host two different versions of the same assembly in one process,
+# so each (operating system, version) combination is benchmarked in its own job and the
+# JSON exports are merged afterwards by scripts/benchmarks/merge-benchmarks.py.
+#
+# Two sets of numbers are produced:
+#   * published  - the SkiaSharp.Benchmarks.Compare harness restores a published NuGet
+#                  version (e.g. the latest stable preview and a 3.x release) from nuget.org.
+#                  This path is fast and reliable and always reports real numbers.
+#   * current    - the in-repo SkiaSharp.Benchmarks project benchmarks the working tree
+#                  after building the native libSkiaSharp from source for a single
+#                  architecture. This is best-effort (continue-on-error) because a full
+#                  native build on a hosted runner is slow and can fail for reasons
+#                  unrelated to the benchmarks; when it succeeds it adds a "current" column.
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - 'benchmarks/**'
+      - 'scripts/benchmarks/**'
+      - '.github/workflows/benchmarks.yml'
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Comma-separated published SkiaSharp versions to compare'
+        required: false
+        default: '4.150.0-preview.2.1,3.119.4'
+        type: string
+      filter:
+        description: 'BenchmarkDotNet filter glob(s), space separated'
+        required: false
+        default: '*BlurImageFilterBenchmark* *SurfaceCanvasBenchmark*'
+        type: string
+      job:
+        description: 'BenchmarkDotNet job (short = quick CI run, default = full run)'
+        required: false
+        default: 'short'
+        type: string
+      build_current:
+        description: 'Build the native library and benchmark the working tree'
+        required: false
+        default: true
+        type: boolean
+      extra_feed:
+        description: 'Optional extra NuGet feed (e.g. a PR preview package source)'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Default to no permissions — each job declares only what it needs.
+permissions: {}
+
+env:
+  DOTNET_NOLOGO: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  # ── Resolve the matrix inputs into JSON arrays ───────────────
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      versions: ${{ steps.vars.outputs.versions }}
+      oses: ${{ steps.vars.outputs.oses }}
+      baseline: ${{ steps.vars.outputs.baseline }}
+      filter: ${{ steps.vars.outputs.filter }}
+      job: ${{ steps.vars.outputs.job }}
+      build_current: ${{ steps.vars.outputs.build_current }}
+      extra_feed: ${{ steps.vars.outputs.extra_feed }}
+    steps:
+      - name: Compute matrix
+        id: vars
+        env:
+          VERSIONS_INPUT: ${{ inputs.versions }}
+          FILTER_INPUT: ${{ inputs.filter }}
+          JOB_INPUT: ${{ inputs.job }}
+          BUILD_CURRENT_INPUT: ${{ inputs.build_current }}
+          EXTRA_FEED_INPUT: ${{ inputs.extra_feed }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Defaults apply for the pull_request trigger, which has no inputs.
+          VERSIONS="${VERSIONS_INPUT:-4.150.0-preview.2.1,3.119.4}"
+          FILTER="${FILTER_INPUT:-*BlurImageFilterBenchmark* *SurfaceCanvasBenchmark*}"
+          JOB="${JOB_INPUT:-short}"
+          BUILD_CURRENT="${BUILD_CURRENT_INPUT:-true}"
+          EXTRA_FEED="${EXTRA_FEED_INPUT:-}"
+
+          # Comma-separated versions -> JSON array; the first entry is the baseline.
+          BASELINE=""
+          JSON="["
+          FIRST=1
+          IFS=',' read -ra PARTS <<< "$VERSIONS"
+          for raw in "${PARTS[@]}"; do
+            v="$(echo "$raw" | xargs)"   # trim whitespace
+            [ -z "$v" ] && continue
+            [ -z "$BASELINE" ] && BASELINE="$v"
+            if [ $FIRST -eq 1 ]; then FIRST=0; else JSON+=","; fi
+            JSON+="\"$v\""
+          done
+          JSON+="]"
+
+          echo "versions=$JSON" >> "$GITHUB_OUTPUT"
+          echo "oses=[\"ubuntu-latest\",\"windows-latest\",\"macos-14\"]" >> "$GITHUB_OUTPUT"
+          echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
+          echo "filter=$FILTER" >> "$GITHUB_OUTPUT"
+          echo "job=$JOB" >> "$GITHUB_OUTPUT"
+          echo "build_current=$BUILD_CURRENT" >> "$GITHUB_OUTPUT"
+          echo "extra_feed=$EXTRA_FEED" >> "$GITHUB_OUTPUT"
+
+          echo "Versions: $JSON (baseline $BASELINE)"
+          echo "Filter:   $FILTER"
+          echo "Job:      $JOB"
+
+  # ── Benchmark each published version on each OS ──────────────
+  published:
+    name: ${{ matrix.os }} · ${{ matrix.version }}
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.setup.outputs.oses) }}
+        version: ${{ fromJSON(needs.setup.outputs.versions) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+          global-json-file: global.json
+
+      - name: Run benchmarks
+        id: run
+        env:
+          VERSION: ${{ matrix.version }}
+          FILTER: ${{ needs.setup.outputs.filter }}
+          JOB: ${{ needs.setup.outputs.job }}
+          EXTRA_FEED: ${{ needs.setup.outputs.extra_feed }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -f   # the filter values are globs — keep the shell from expanding them
+
+          case "$RUNNER_OS" in
+            Linux)   OSLABEL=linux-x64 ;;
+            Windows) OSLABEL=windows-x64 ;;
+            macOS)   OSLABEL=osx-arm64 ;;
+            *)       OSLABEL="$RUNNER_OS" ;;
+          esac
+          echo "oslabel=$OSLABEL" >> "$GITHUB_OUTPUT"
+
+          OUT="$GITHUB_WORKSPACE/bench-out"
+          ART="$OUT/results"
+          mkdir -p "$ART"
+
+          FILTER_ARGS=()
+          for f in $FILTER; do FILTER_ARGS+=(--filter "$f"); done
+
+          FEED_ARGS=()
+          if [ -n "$EXTRA_FEED" ]; then
+            FEED_ARGS+=(-p:RestoreAdditionalProjectSources="$EXTRA_FEED")
+          fi
+
+          dotnet run -c Release \
+            --project benchmarks/SkiaSharp.Benchmarks.Compare \
+            -p:SkiaSharpBenchmarkVersion="$VERSION" \
+            "${FEED_ARGS[@]}" \
+            -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$ART"
+
+          printf '{"os":"%s","version":"%s"}\n' "$OSLABEL" "$VERSION" > "$OUT/meta.json"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ steps.run.outputs.oslabel }}-${{ matrix.version }}
+          path: bench-out
+          if-no-files-found: warn
+
+  # ── Benchmark the working tree (native built from source) ────
+  current:
+    name: ${{ matrix.os }} · current
+    needs: setup
+    if: needs.setup.outputs.build_current == 'true'
+    runs-on: ${{ matrix.os }}
+    # Best-effort: a from-source native build on a hosted runner is slow and can fail for
+    # reasons unrelated to the benchmarks, so it must never block the published comparison.
+    continue-on-error: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.setup.outputs.oses) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+          global-json-file: global.json
+
+      - name: Restore .NET tools
+        shell: bash
+        run: dotnet tool restore
+
+      - name: Build native (Linux x64)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: scripts/infra/native/linux/docker/glibc/build-local.sh x64
+
+      - name: Build native (Windows x64)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: dotnet cake --target=externals-windows --arch=x64
+
+      - name: Build native (macOS arm64)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: dotnet cake --target=externals-macos --arch=arm64
+
+      - name: Run benchmarks
+        id: run
+        env:
+          FILTER: ${{ needs.setup.outputs.filter }}
+          JOB: ${{ needs.setup.outputs.job }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -f
+
+          case "$RUNNER_OS" in
+            Linux)   OSLABEL=linux-x64 ;;
+            Windows) OSLABEL=windows-x64 ;;
+            macOS)   OSLABEL=osx-arm64 ;;
+            *)       OSLABEL="$RUNNER_OS" ;;
+          esac
+          echo "oslabel=$OSLABEL" >> "$GITHUB_OUTPUT"
+
+          OUT="$GITHUB_WORKSPACE/bench-out"
+          ART="$OUT/results"
+          mkdir -p "$ART"
+
+          FILTER_ARGS=()
+          for f in $FILTER; do FILTER_ARGS+=(--filter "$f"); done
+
+          dotnet run -c Release \
+            --project benchmarks/SkiaSharp.Benchmarks \
+            -- "${FILTER_ARGS[@]}" --job "$JOB" --artifacts "$ART"
+
+          printf '{"os":"%s","version":"current"}\n' "$OSLABEL" > "$OUT/meta.json"
+
+      - name: Upload results
+        if: always() && steps.run.outputs.oslabel != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ steps.run.outputs.oslabel }}-current
+          path: bench-out
+          if-no-files-found: warn
+
+  # ── Merge every run into one comparison report ───────────────
+  report:
+    name: Report
+    needs: [ setup, published, current ]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          path: all-results
+          pattern: bench-*
+
+      - name: Merge and summarize
+        env:
+          BASELINE: ${{ needs.setup.outputs.baseline }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d all-results ] || [ -z "$(ls -A all-results 2>/dev/null)" ]; then
+            echo "No benchmark artifacts were produced." | tee "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 scripts/benchmarks/merge-benchmarks.py all-results \
+            --baseline "$BASELINE" \
+            --output benchmark-report.md
+          cat benchmark-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-report
+          path: benchmark-report.md
+          if-no-files-found: warn

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,6 +21,19 @@ name: "Benchmarks"
 #                  which needs mobile workloads that are not present on the runners.
 #                  It is best-effort (continue-on-error) because a full native build on a
 #                  hosted runner is slow and can fail for reasons unrelated to benchmarks.
+#
+# IMPORTANT - reading the "current" column:
+#   The from-source `externals-*` native is NOT built with the same optimization/official
+#   build flags as the shipped NuGet native, so its ABSOLUTE timings are systematically
+#   different (typically slower) than the optimized published packages. Do not read a
+#   `current`-vs-`published` ratio as the effect of a PR's code. To measure a native change,
+#   compare two `current` runs built the same way (the PR branch and its base). The
+#   `published` columns are the apples-to-apples comparison across released versions.
+#
+#   Only the operating systems whose native library reliably builds from source on a hosted
+#   runner take part in `current` (Linux and macOS by default). The Windows hosted image
+#   currently cannot build the native library (missing Windows SDK / Spectre libs), so it is
+#   left out of `current` by default and still appears in the `published` comparison.
 
 on:
   pull_request:
@@ -52,6 +65,11 @@ on:
         required: false
         default: true
         type: boolean
+      current_oses:
+        description: 'Comma-separated runners to build the native library on for the current column'
+        required: false
+        default: 'ubuntu-latest,macos-14'
+        type: string
       extra_feed:
         description: 'Optional extra NuGet feed (e.g. a PR preview package source)'
         required: false
@@ -83,6 +101,7 @@ jobs:
       filter: ${{ steps.vars.outputs.filter }}
       job: ${{ steps.vars.outputs.job }}
       build_current: ${{ steps.vars.outputs.build_current }}
+      current_oses: ${{ steps.vars.outputs.current_oses }}
       extra_feed: ${{ steps.vars.outputs.extra_feed }}
     steps:
       - name: Compute matrix
@@ -92,6 +111,7 @@ jobs:
           FILTER_INPUT: ${{ inputs.filter }}
           JOB_INPUT: ${{ inputs.job }}
           BUILD_CURRENT_INPUT: ${{ inputs.build_current }}
+          CURRENT_OSES_INPUT: ${{ inputs.current_oses }}
           EXTRA_FEED_INPUT: ${{ inputs.extra_feed }}
         shell: bash
         run: |
@@ -102,6 +122,7 @@ jobs:
           FILTER="${FILTER_INPUT:-*BlurImageFilterBenchmark* *SurfaceCanvasBenchmark*}"
           JOB="${JOB_INPUT:-short}"
           BUILD_CURRENT="${BUILD_CURRENT_INPUT:-true}"
+          CURRENT_OSES="${CURRENT_OSES_INPUT:-ubuntu-latest,macos-14}"
           EXTRA_FEED="${EXTRA_FEED_INPUT:-}"
 
           # Comma-separated versions -> JSON array; the first entry is the baseline.
@@ -118,17 +139,31 @@ jobs:
           done
           JSON+="]"
 
+          # Comma-separated current runners -> JSON array.
+          CUR_JSON="["
+          FIRST=1
+          IFS=',' read -ra CUR_PARTS <<< "$CURRENT_OSES"
+          for raw in "${CUR_PARTS[@]}"; do
+            o="$(echo "$raw" | xargs)"
+            [ -z "$o" ] && continue
+            if [ $FIRST -eq 1 ]; then FIRST=0; else CUR_JSON+=","; fi
+            CUR_JSON+="\"$o\""
+          done
+          CUR_JSON+="]"
+
           echo "versions=$JSON" >> "$GITHUB_OUTPUT"
           echo "oses=[\"ubuntu-latest\",\"windows-latest\",\"macos-14\"]" >> "$GITHUB_OUTPUT"
           echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
           echo "filter=$FILTER" >> "$GITHUB_OUTPUT"
           echo "job=$JOB" >> "$GITHUB_OUTPUT"
           echo "build_current=$BUILD_CURRENT" >> "$GITHUB_OUTPUT"
+          echo "current_oses=$CUR_JSON" >> "$GITHUB_OUTPUT"
           echo "extra_feed=$EXTRA_FEED" >> "$GITHUB_OUTPUT"
 
           echo "Versions: $JSON (baseline $BASELINE)"
           echo "Filter:   $FILTER"
           echo "Job:      $JOB"
+          echo "Current:  $CUR_JSON"
 
   # ── Benchmark each published version on each OS ──────────────
   published:
@@ -216,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(needs.setup.outputs.oses) }}
+        os: ${{ fromJSON(needs.setup.outputs.current_oses) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/benchmarks/SkiaSharp.Benchmarks.Compare/Directory.Build.props
+++ b/benchmarks/SkiaSharp.Benchmarks.Compare/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <!--
+    Intentionally empty.
+
+    This stops MSBuild from walking up into benchmarks/Directory.Build.props (and the
+    rest of the SkiaSharp build infrastructure), which pins every SkiaSharp reference to
+    the locally built 1.0.0 packages. This comparison harness must instead resolve the
+    exact published SkiaSharp NuGet version it is asked to benchmark, so it deliberately
+    opts out of that infrastructure.
+  -->
+</Project>

--- a/benchmarks/SkiaSharp.Benchmarks.Compare/Directory.Build.targets
+++ b/benchmarks/SkiaSharp.Benchmarks.Compare/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Intentionally empty. See Directory.Build.props for the rationale. -->
+</Project>

--- a/benchmarks/SkiaSharp.Benchmarks.Compare/NuGet.config
+++ b/benchmarks/SkiaSharp.Benchmarks.Compare/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+    Self-contained feed list for the comparison harness. The repository root NuGet.config
+    clears all sources and only keeps the dotnet engineering feeds, which do not carry
+    published SkiaSharp releases, so this harness restores from nuget.org directly. The
+    benchmarks workflow appends the PR's local package feed via RestoreAdditionalProjectSources.
+  -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/benchmarks/SkiaSharp.Benchmarks.Compare/Program.cs
+++ b/benchmarks/SkiaSharp.Benchmarks.Compare/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using BenchmarkDotNet.Running;
 
 namespace SkiaSharp.Benchmarks;
@@ -7,8 +7,6 @@ public class Program
 {
 	public static void Main(string[] args)
 	{
-		// Use the switcher so a specific benchmark can be selected via args, e.g.:
-		//   dotnet run -c Release -- --filter *SurfaceCanvasBenchmark*
 		BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, BenchmarkConfig.Create());
 	}
 }

--- a/benchmarks/SkiaSharp.Benchmarks.Compare/SkiaSharp.Benchmarks.Compare.csproj
+++ b/benchmarks/SkiaSharp.Benchmarks.Compare/SkiaSharp.Benchmarks.Compare.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Comparison benchmark harness.
+
+    Runs the SAME benchmark sources as SkiaSharp.Benchmarks, but against a published
+    SkiaSharp NuGet version instead of the local source tree. The benchmarks CI workflow
+    invokes this once per version (e.g. the latest stable, a 3.x release, and a build of
+    the PR) and merges the results, because BenchmarkDotNet cannot host two different
+    versions of the same assembly in a single process.
+
+    Pass the version to benchmark with the SkiaSharpBenchmarkVersion MSBuild property, then
+    pass BenchmarkDotNet arguments after the run separator, for example a filter and a job.
+
+    The PR build is benchmarked by publishing its packages to a local feed and selecting
+    that version via SkiaSharpBenchmarkVersion plus RestoreAdditionalProjectSources.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <!--
+      The shared benchmarks deliberately use APIs that exist in every compared version
+      (e.g. SKPath rather than the newer SKPathBuilder); newer releases mark some of them
+      obsolete, so the obsoletion warning is suppressed to keep the source cross-version.
+    -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <SkiaSharpBenchmarkVersion Condition="'$(SkiaSharpBenchmarkVersion)' == ''">4.150.0-preview.2.1</SkiaSharpBenchmarkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="SkiaSharp" Version="$(SkiaSharpBenchmarkVersion)" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="$(SkiaSharpBenchmarkVersion)" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="$(SkiaSharpBenchmarkVersion)" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="$(SkiaSharpBenchmarkVersion)" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+  </ItemGroup>
+
+  <!-- Link the shared benchmark sources so there is a single source of truth. -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\SkiaSharp.Benchmarks\BenchmarkConfig.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\SkiaSharp.Benchmarks\Benchmarks\BlurImageFilterBenchmark.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\SkiaSharp.Benchmarks\Benchmarks\SurfaceCanvasBenchmark.cs" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/SkiaSharp.Benchmarks/BenchmarkConfig.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,19 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters.Json;
+
+namespace SkiaSharp.Benchmarks;
+
+// Shared BenchmarkDotNet configuration for both the in-repo benchmark project and the
+// cross-version comparison harness (SkiaSharp.Benchmarks.Compare).
+//
+// The benchmarks CI workflow runs each (operating system, SkiaSharp version) combination
+// in its own process and merges the results afterwards with scripts/benchmarks/merge-benchmarks.py.
+// That merge step reads BenchmarkDotNet's "*-report-full-compressed.json" export, which is
+// not emitted by the default configuration and cannot be selected through the command line
+// in this BenchmarkDotNet version, so it is added here in code to guarantee every run
+// produces the JSON the workflow consumes.
+public static class BenchmarkConfig
+{
+	public static IConfig Create() =>
+		DefaultConfig.Instance.AddExporter(JsonExporter.FullCompressed);
+}

--- a/benchmarks/SkiaSharp.Benchmarks/Benchmarks/BlurImageFilterBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/Benchmarks/BlurImageFilterBenchmark.cs
@@ -1,0 +1,96 @@
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks;
+
+// Measures CPU raster blur of 8888 (color) content via SKImageFilter.CreateBlur, the
+// exact path affected by the SK_AVOID_SLOW_RASTER_PIPELINE_BLURS native build flag.
+//
+// Skia's Raster8888BlurAlgorithm uses a slow per-pixel raster-pipeline GaussianPass for
+// small sigmas (< 2.0) and a fast ThreeBoxApproxPass for larger sigmas. The native flag
+// routes the small-sigma case to the fast approximation too, so this benchmark is split
+// across both regimes:
+//
+//   Sigma = 1.0  -> small-sigma path (changes with the flag)
+//   Sigma = 4.0  -> large-sigma path (already fast; acts as a control)
+//
+// The blur is applied to an image draw (8888 surface) rather than a mask filter, because
+// the flag only gates the 8888 GaussianPass and leaves the A8 mask path untouched. This
+// is a pure-CPU raster benchmark (no GPU) so it is comparable across all platforms and
+// across the SkiaSharp versions the CI workflow benchmarks.
+[MemoryDiagnoser]
+public class BlurImageFilterBenchmark
+{
+	[Params(256, 1024)]
+	public int Size { get; set; }
+
+	// 1.0 exercises the slow small-sigma raster-pipeline path; 4.0 is the fast control.
+	[Params(1.0f, 4.0f)]
+	public float Sigma { get; set; }
+
+	private SKSurface surface;
+	private SKImage source;
+	private SKPaint paint;
+
+	[GlobalSetup]
+	public void GlobalSetup()
+	{
+		var info = new SKImageInfo(Size, Size, SKColorType.Rgba8888, SKAlphaType.Premul);
+		surface = SKSurface.Create(info);
+
+		source = CreateSource(info);
+
+		paint = new SKPaint
+		{
+			IsAntialias = true,
+			ImageFilter = SKImageFilter.CreateBlur(Sigma, Sigma),
+		};
+	}
+
+	[GlobalCleanup]
+	public void GlobalCleanup()
+	{
+		paint?.Dispose();
+		source?.Dispose();
+		surface?.Dispose();
+	}
+
+	[Benchmark]
+	public void BlurImage()
+	{
+		var canvas = surface.Canvas;
+		canvas.Clear(SKColors.White);
+		// The simple DrawImage overload exists in every compared version; the newer
+		// SKSamplingOptions overload does not, so its obsoletion warning is suppressed.
+#pragma warning disable CS0618
+		canvas.DrawImage(source, 0, 0, paint);
+#pragma warning restore CS0618
+		canvas.Flush();
+	}
+
+	// A varied 8888 scene so the blur has real color content to process.
+	private static SKImage CreateSource(SKImageInfo info)
+	{
+		using var temp = SKSurface.Create(info);
+		var canvas = temp.Canvas;
+		canvas.Clear(SKColors.CornflowerBlue);
+
+		using var fill = new SKPaint { IsAntialias = true };
+		var rng = new System.Random(42);
+		var step = System.Math.Max(8, info.Width / 16);
+		for (var y = 0; y < info.Height; y += step)
+		{
+			for (var x = 0; x < info.Width; x += step)
+			{
+				fill.Color = new SKColor(
+					(byte)rng.Next(256),
+					(byte)rng.Next(256),
+					(byte)rng.Next(256),
+					255);
+				canvas.DrawRect(x, y, step * 0.8f, step * 0.8f, fill);
+			}
+		}
+
+		canvas.Flush();
+		return temp.Snapshot();
+	}
+}

--- a/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SurfaceCanvasBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SurfaceCanvasBenchmark.cs
@@ -131,9 +131,14 @@ public class SurfaceCanvasBenchmark
 		canvas.Restore();
 	}
 
+	// Uses SKPath (not SKPathBuilder) so the benchmark compiles against every SkiaSharp
+	// version the CI workflow compares, including older releases that predate SKPathBuilder.
+	// Newer releases mark the SKPath mutators obsolete in favour of SKPathBuilder, so the
+	// obsoletion warning is intentionally suppressed to keep the source cross-version.
+#pragma warning disable CS0618
 	private static SKPath CreateStar(float radius)
 	{
-		var builder = new SKPathBuilder();
+		var path = new SKPath();
 		const int points = 5;
 		for (var k = 0; k < points * 2; k++)
 		{
@@ -142,11 +147,12 @@ public class SurfaceCanvasBenchmark
 			var px = 20 + r * System.MathF.Sin(angle);
 			var py = 20 - r * System.MathF.Cos(angle);
 			if (k == 0)
-				builder.MoveTo(px, py);
+				path.MoveTo(px, py);
 			else
-				builder.LineTo(px, py);
+				path.LineTo(px, py);
 		}
-		builder.Close();
-		return builder.Detach();
+		path.Close();
+		return path;
 	}
+#pragma warning restore CS0618
 }

--- a/scripts/benchmarks/merge-benchmarks.py
+++ b/scripts/benchmarks/merge-benchmarks.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Merge BenchmarkDotNet JSON results from several runs into one Markdown report.
+
+The benchmarks CI workflow runs the benchmarks once per (operating system, SkiaSharp
+version) combination and uploads each run as an artifact. BenchmarkDotNet cannot host two
+versions of the same assembly in a single process, so the comparison is assembled here
+afterwards.
+
+Expected input layout (the workflow produces it):
+
+    <root>/
+        <any-artifact-folder>/
+            meta.json                         # {"os": "...", "version": "..."}
+            **/*-report-full-compressed.json  # BenchmarkDotNet JSON export
+
+Usage:
+    merge-benchmarks.py <root-dir> [--baseline <version>] [--output report.md]
+
+The baseline version (when present for a given OS) is used to compute a ratio column so
+regressions and improvements are obvious at a glance.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import OrderedDict, defaultdict
+
+
+def find_meta(folder):
+    meta_path = os.path.join(folder, "meta.json")
+    if not os.path.isfile(meta_path):
+        return None
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+def find_result_jsons(folder):
+    for dirpath, _dirs, files in os.walk(folder):
+        for name in files:
+            if name.endswith("-report-full-compressed.json"):
+                yield os.path.join(dirpath, name)
+
+
+def load_records(root):
+    """Return list of records: os, version, type, method, params, mean_ns."""
+    records = []
+    for entry in sorted(os.listdir(root)):
+        folder = os.path.join(root, entry)
+        if not os.path.isdir(folder):
+            continue
+        meta = find_meta(folder)
+        if meta is None:
+            continue
+        os_name = meta.get("os", "unknown")
+        version = meta.get("version", "unknown")
+        for json_path in find_result_jsons(folder):
+            try:
+                with open(json_path, encoding="utf-8") as f:
+                    data = json.load(f)
+            except (OSError, ValueError):
+                continue
+            for b in data.get("Benchmarks", []):
+                stats = b.get("Statistics") or {}
+                mean = stats.get("Mean")
+                if mean is None:
+                    continue
+                records.append({
+                    "os": os_name,
+                    "version": version,
+                    "type": b.get("Type", "?"),
+                    "method": b.get("Method", "?"),
+                    "params": b.get("Parameters", "") or "",
+                    "mean_ns": float(mean),
+                })
+    return records
+
+
+def fmt_us(mean_ns):
+    return f"{mean_ns / 1000.0:,.2f}"
+
+
+def build_report(records, baseline):
+    if not records:
+        return "No benchmark results were found."
+
+    # Preserve first-seen order for versions, then move baseline first if present.
+    versions = list(OrderedDict((r["version"], None) for r in records).keys())
+    if baseline in versions:
+        versions.remove(baseline)
+        versions.insert(0, baseline)
+
+    oses = list(OrderedDict((r["os"], None) for r in records).keys())
+
+    lines = []
+    lines.append("# Benchmark comparison")
+    lines.append("")
+    lines.append("Mean time per operation in microseconds (lower is better). "
+                 "Ratio is relative to the baseline column"
+                 + (f" (`{baseline}`)." if baseline else "."))
+    lines.append("")
+
+    for os_name in oses:
+        lines.append(f"## {os_name}")
+        lines.append("")
+
+        # rows keyed by (type, method, params); columns keyed by version
+        table = defaultdict(dict)
+        for r in records:
+            if r["os"] != os_name:
+                continue
+            key = (r["type"], r["method"], r["params"])
+            table[key][r["version"]] = r["mean_ns"]
+
+        os_versions = [v for v in versions if any(v in cols for cols in table.values())]
+
+        header = ["Benchmark", "Parameters"] + os_versions
+        if baseline in os_versions and len(os_versions) > 1:
+            header += ["vs baseline"]
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("|" + "|".join(["---"] * len(header)) + "|")
+
+        for key in sorted(table.keys()):
+            type_name, method, params = key
+            short_type = type_name.split(".")[-1]
+            cols = table[key]
+            row = [f"{short_type}.{method}", params or "—"]
+            for v in os_versions:
+                row.append(fmt_us(cols[v]) if v in cols else "—")
+            if baseline in os_versions and len(os_versions) > 1 and baseline in cols:
+                base = cols[baseline]
+                ratios = []
+                for v in os_versions:
+                    if v == baseline or v not in cols:
+                        continue
+                    ratios.append(f"{v}: {cols[v] / base:.2f}x")
+                row.append("; ".join(ratios) if ratios else "—")
+            elif baseline in os_versions and len(os_versions) > 1:
+                row.append("—")
+            lines.append("| " + " | ".join(row) + " |")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("root", help="Directory containing the downloaded result artifacts")
+    parser.add_argument("--baseline", default="", help="Version to treat as the baseline column")
+    parser.add_argument("--output", default="", help="Write the Markdown report to this file")
+    args = parser.parse_args(argv)
+
+    if not os.path.isdir(args.root):
+        print(f"error: not a directory: {args.root}", file=sys.stderr)
+        return 1
+
+    records = load_records(args.root)
+    report = build_report(records, args.baseline)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(report + "\n")
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -24,6 +24,7 @@
     "externals/.gitignore",
     "native/.gitignore",
     "scripts/get-skiasharp-pr.*",
+    "scripts/benchmarks/**",
     "scripts/infra/caching/**",
     "cgmanifest.json",
     "utils/SkiaSharpGenerator/**",


### PR DESCRIPTION
## What

Adds a PR-triggered **Benchmarks** workflow that runs the SkiaSharp micro-benchmarks across multiple SkiaSharp versions on Linux, Windows, and macOS, then merges the results into a single comparison report posted to the job summary.

This grew out of validating the native blur fix (`SK_AVOID_SLOW_RASTER_PIPELINE_BLURS`): there was no way to measure such changes with real numbers across versions and platforms. Now there is.

## Why a build matrix instead of one process

BenchmarkDotNet **cannot** host two different versions of the same assembly in a single process (type-identity clash — there is no built-in `WithNuGet`). So each `(os, version)` combination is benchmarked in its own job and the JSON exports are merged afterwards.

## How it works

```mermaid
flowchart LR
  setup[setup: resolve versions] --> pub[published matrix: os x version]
  setup --> cur[current matrix: linux + macos, native build]
  pub --> rep[report: merge -> job summary]
  cur --> rep
```

- **`published`** — `SkiaSharp.Benchmarks.Compare`, an isolated harness that links the same benchmark sources but restores a *published* SkiaSharp NuGet version from nuget.org. It deliberately opts out of the repo build infrastructure (empty `Directory.Build.props`/`.targets`) and carries its own `NuGet.config` so it resolves the exact released version requested. Fast and reliable — always reports real numbers on all three OSes. Default versions: `4.150.0-preview.2.1` (baseline) and `3.119.4`.
- **`current`** — benchmarks the **working tree's native code**. Rather than building the multi-targeted in-repo binding graph (which drags in the mobile native-asset projects and needs the Android/iOS workloads the runners don't have — `NETSDK1147`), it reuses the same `Compare` harness: it restores the baseline *published managed* package, then **replaces that package's `libSkiaSharp` in the NuGet global cache with the one freshly built from this PR**. BenchmarkDotNet builds its child project against that cache at run time, so the benchmark exercises this PR's native code with a known, stable managed API. The job logs the SHA before/after the swap to prove the working-tree binary is the one being measured. Best-effort (`continue-on-error`); scoped to the OSes whose native library reliably builds from source on a hosted runner (Linux + macOS).
- **`report`** — `scripts/benchmarks/merge-benchmarks.py` merges every run into one Markdown table (mean µs + ratio-vs-baseline) written to `$GITHUB_STEP_SUMMARY` and uploaded as an artifact.

## Reading the `current` column ⚠️

The from-source `externals-*` native is **not** built with the same optimization/official-build flags as the shipped NuGet native, so its **absolute** timings are systematically different (typically slower) than the optimized published packages. Do **not** read a `current`-vs-`published` ratio as the effect of a PR's code. To measure a native change, compare two `current` runs built the same way (the PR branch vs its base). The `published` columns are the apples-to-apples comparison across released versions.

The Windows hosted image currently cannot build the native library from source (missing Windows SDK `10.0.19041` and Spectre-mitigated MSVC libs on the VS preview image), so Windows is excluded from `current` by default and still appears in the `published` comparison. It can be opted back in via the `current_oses` dispatch input once the toolchain is available.

## Other changes

- **`BenchmarkConfig`** (shared) adds `JsonExporter.FullCompressed` — that export cannot be selected from the command line in this BenchmarkDotNet version, so it is configured in code to guarantee every run produces the JSON the merge step consumes.
- **`BlurImageFilterBenchmark`** exercises the 8888 raster blur path affected by the native flag (small-sigma slow path vs large-sigma control).
- **`SurfaceCanvasBenchmark`** switched to `SKPath` (CS0618 suppressed) so the shared sources compile against older releases that predate `SKPathBuilder`.

## Triggers

- `pull_request` touching `benchmarks/**`, `scripts/benchmarks/**`, or the workflow file.
- `workflow_dispatch` with inputs: `versions`, `filter`, `job` (short/default), `build_current`, `current_oses`, `extra_feed` (e.g. point at a PR preview package source).

## Validation — real CI numbers

Proven on real GitHub-hosted runners (run `28379961911`): all six `published` cells (3 OSes × 2 versions) plus both `current` cells (Linux x64, macOS arm64) succeeded and merged into one report. The `current` cells logged the native SHA swap, e.g. macOS built `726ab1f0…` replacing the published `4523f8db…`, confirming the working-tree binary was measured. Example (mean µs, baseline `4.150.0-preview.2.1`):

| OS | Benchmark | baseline | 3.119.4 | current |
|---|---|---|---|---|
| windows-x64 | BlurImage 1024/σ1 | 1,793 | 2,134 | — |
| linux-x64 | BlurImage 1024/σ1 | 4,199 | 3,955 | 4,502 |
| osx-arm64 | BlurImage 1024/σ1 | 414 | 472 | 643 |

(The macOS `current` being slower than `published` despite identical m150 code is exactly the build-flag caveat above.)

> Note: this is infrastructure only — no library code or public API changes.
