### PR TITLE
Add milestone sync script aligned to Chrome release schedule

### DIFF
--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -25,6 +25,7 @@
     "native/.gitignore",
     "scripts/get-skiasharp-pr.*",
     "scripts/infra/caching/**",
+    "scripts/infra/milestones/**",
     "cgmanifest.json",
     "utils/SkiaSharpGenerator/**",
     "utils/Utils.sln",
@@ -33,55 +34,108 @@
   ],
   "jobs": {
     "native": {
-      "include": ["scripts/infra/native/shared/**"],
-      "submodules": ["externals/skia", "externals/depot_tools"],
+      "include": [
+        "scripts/infra/native/shared/**"
+      ],
+      "submodules": [
+        "externals/skia",
+        "externals/depot_tools"
+      ],
       "children": {
         "android": {
-          "include": ["native/android/**", "scripts/infra/native/android/**"]
+          "include": [
+            "native/android/**",
+            "scripts/infra/native/android/**"
+          ]
         },
         "ios": {
-          "include": ["native/ios/**", "scripts/infra/native/apple/**"]
+          "include": [
+            "native/ios/**",
+            "scripts/infra/native/apple/**"
+          ]
         },
         "macos": {
-          "include": ["native/macos/**", "scripts/infra/native/apple/**"]
+          "include": [
+            "native/macos/**",
+            "scripts/infra/native/apple/**"
+          ]
         },
         "maccatalyst": {
-          "include": ["native/maccatalyst/**", "scripts/infra/native/apple/**", "native/ios/**"]
+          "include": [
+            "native/maccatalyst/**",
+            "scripts/infra/native/apple/**",
+            "native/ios/**"
+          ]
         },
         "tvos": {
-          "include": ["native/tvos/**", "scripts/infra/native/apple/**"]
+          "include": [
+            "native/tvos/**",
+            "scripts/infra/native/apple/**"
+          ]
         },
         "windows": {
-          "include": ["native/windows/**", "scripts/infra/native/windows/**"]
+          "include": [
+            "native/windows/**",
+            "scripts/infra/native/windows/**"
+          ]
         },
         "winui": {
-          "include": ["native/winui/**", "scripts/infra/native/windows/**"]
+          "include": [
+            "native/winui/**",
+            "scripts/infra/native/windows/**"
+          ]
         },
         "winui_angle": {
-          "include": ["native/winui-angle/**", "scripts/infra/native/windows/**"]
+          "include": [
+            "native/winui-angle/**",
+            "scripts/infra/native/windows/**"
+          ]
         },
         "nanoserver": {
-          "include": ["native/nanoserver/**", "scripts/infra/native/windows/**", "native/windows/**"]
+          "include": [
+            "native/nanoserver/**",
+            "scripts/infra/native/windows/**",
+            "native/windows/**"
+          ]
         },
         "linux": {
-          "include": ["native/linux/**", "scripts/infra/native/linux/**"]
+          "include": [
+            "native/linux/**",
+            "scripts/infra/native/linux/**"
+          ]
         },
         "linux_cross": {
-          "include": ["native/linux-clang-cross/**", "scripts/infra/native/linux/**", "native/linux/**"]
+          "include": [
+            "native/linux-clang-cross/**",
+            "scripts/infra/native/linux/**",
+            "native/linux/**"
+          ]
         },
         "linuxnodeps": {
-          "include": ["native/linuxnodeps/**", "scripts/infra/native/linux/**", "native/linux/**"]
+          "include": [
+            "native/linuxnodeps/**",
+            "scripts/infra/native/linux/**",
+            "native/linux/**"
+          ]
         },
         "tizen": {
-          "include": ["native/tizen/**", "scripts/infra/native/tizen/**"]
+          "include": [
+            "native/tizen/**",
+            "scripts/infra/native/tizen/**"
+          ]
         },
         "wasm": {
-          "include": ["native/wasm/**", "scripts/infra/native/wasm/**"]
+          "include": [
+            "native/wasm/**",
+            "scripts/infra/native/wasm/**"
+          ]
         }
       }
     },
     "managed": {
-      "dependsOn": ["native"],
+      "dependsOn": [
+        "native"
+      ],
       "include": [
         "binding/**",
         "source/**",
@@ -92,17 +146,27 @@
         "images/nuget.png",
         "External-Dependency-Info.txt"
       ],
-      "submodules": ["docs"],
+      "submodules": [
+        "docs"
+      ],
       "children": {
         "libs": {},
         "package": {
-          "include": ["scripts/infra/package/**"],
+          "include": [
+            "scripts/infra/package/**"
+          ],
           "children": {
             "api_diff": {
-              "include": ["scripts/infra/docs/**", "documentation/docfx/releases/**"]
+              "include": [
+                "scripts/infra/docs/**",
+                "documentation/docfx/releases/**"
+              ]
             },
             "samples": {
-              "include": ["samples/**", "scripts/infra/samples/**"]
+              "include": [
+                "samples/**",
+                "scripts/infra/samples/**"
+              ]
             }
           }
         },

--- a/scripts/infra/milestones/audit-milestones.ps1
+++ b/scripts/infra/milestones/audit-milestones.ps1
@@ -1,0 +1,266 @@
+<#
+.SYNOPSIS
+    Audit and fix milestone assignments based on what shipped in each release branch.
+
+.DESCRIPTION
+    Determines what shipped in each release by comparing merge-bases of consecutive
+    release branches on main. For each PR found in a release range, ensures the PR
+    and any linked issues are assigned to the correct milestone.
+
+    Algorithm:
+    1. Find all release branches for the current version (e.g., 4.150.0-*)
+    2. Sort them in release order (preview.1, preview.2, rc.1, stable)
+    3. For consecutive branches, compute: merge-base(main, branchN) .. merge-base(main, branchN+1)
+    4. Commits in that range shipped in branchN+1
+    5. For main HEAD after the last branch: those go into the next milestone (rc.1 or stable)
+    6. Extract PR numbers from commit messages, resolve linked issues, fix milestones
+
+.PARAMETER DryRun
+    Print what would be done without making changes.
+
+.PARAMETER Repo
+    GitHub repo (default: mono/SkiaSharp).
+
+.PARAMETER Version
+    Version prefix to audit (e.g., "4.150.0"). Defaults to reading from VERSIONS.txt.
+
+.EXAMPLE
+    pwsh audit-milestones.ps1 -DryRun
+    pwsh audit-milestones.ps1 -Version 4.150.0
+#>
+
+param(
+    [switch]$DryRun,
+    [string]$Repo = "mono/SkiaSharp",
+    [string]$Version
+)
+
+$ErrorActionPreference = "Stop"
+
+# Resolve version from VERSIONS.txt if not provided
+if (-not $Version) {
+    $versionsPath = Join-Path $PSScriptRoot ".." ".." "VERSIONS.txt"
+    if (-not (Test-Path $versionsPath)) {
+        throw "VERSIONS.txt not found at $versionsPath"
+    }
+    $versionsPath = Resolve-Path $versionsPath
+    $major = $null
+    $milestone = $null
+    foreach ($line in Get-Content $versionsPath) {
+        $parts = $line.Trim() -split '\s+'
+        if ($parts.Count -ge 3) {
+            if ($parts[0] -eq "SkiaSharp" -and $parts[1] -eq "nuget") { $major = $parts[2].Split(".")[0] }
+            if ($parts[0] -eq "libSkiaSharp" -and $parts[1] -eq "milestone") { $milestone = $parts[2] }
+        }
+    }
+    if (-not $major -or -not $milestone) { throw "Could not read version from VERSIONS.txt" }
+    $Version = "$major.$milestone.0"
+}
+
+Write-Host "📋 Auditing milestone assignments for $Version"
+Write-Host "   Repo: $Repo"
+if ($DryRun) { Write-Host "   Mode: DRY RUN" }
+Write-Host ""
+
+# Fetch release branches, sorted in release order
+git fetch origin --quiet 2>/dev/null
+$rawBranches = git branch -r --list "origin/release/$Version*" | ForEach-Object { $_.Trim() }
+
+if ($rawBranches.Count -eq 0) {
+    throw "No release branches found matching origin/release/$Version*"
+}
+
+# Sort in proper release order: preview.1, preview.2, ..., rc.1, rc.2, ..., stable
+function Get-ReleaseRank([string]$BranchName) {
+    $suffix = $BranchName -replace "origin/release/$Version", ''
+    if (-not $suffix) { return @(2, 0) }  # stable (no suffix) comes last
+    $suffix = $suffix.TrimStart('-')
+    if ($suffix -match '^preview\.(\d+)$') { return @(0, [int]$Matches[1]) }
+    if ($suffix -match '^rc\.(\d+)$') { return @(1, [int]$Matches[1]) }
+    return @(3, 0)  # unknown suffix, sort last
+}
+
+$allBranches = $rawBranches | Sort-Object { $r = Get-ReleaseRank $_; $r[0] * 1000 + $r[1] }
+
+Write-Host "🔍 Found $($allBranches.Count) release branches:"
+$allBranches | ForEach-Object { Write-Host "   $_" }
+Write-Host ""
+
+# Find the previous version's stable branch to use as the "from" boundary for preview.1
+# Look for release branches with lower version numbers (skip *.x maintenance branches)
+$prevBranch = $null
+$allReleaseBranches = git branch -r --list "origin/release/*" | ForEach-Object { $_.Trim() }
+$prevCandidates = $allReleaseBranches | Where-Object {
+    # Match versioned branches like origin/release/4.148.0 but skip *.x maintenance branches
+    $_ -match 'origin/release/\d+\.\d+\.\d+' -and $_ -notmatch '\.x$' -and $_ -notlike "origin/release/$Version*"
+} | Sort-Object -Descending
+foreach ($candidate in $prevCandidates) {
+    $candidateVersion = ($candidate -replace 'origin/release/', '') -replace '-.*', ''
+    if ([version]$candidateVersion -lt [version]$Version) {
+        $prevBranch = $candidate
+        break
+    }
+}
+
+# Get merge-bases for each branch (the point on main where the branch was cut)
+$mergeBases = @()
+foreach ($branch in $allBranches) {
+    $mb = git merge-base origin/main $branch 2>/dev/null
+    if (-not $mb) { throw "Could not find merge-base for $branch" }
+    $mergeBases += $mb
+}
+
+# Get merge-base for previous version's stable branch (boundary for preview.1)
+$prevMergeBase = $null
+if ($prevBranch) {
+    $prevMergeBase = git merge-base origin/main $prevBranch 2>/dev/null
+    Write-Host "📌 Previous release: $prevBranch (boundary for first preview)"
+    Write-Host ""
+}
+
+# Get milestone map from GitHub
+$json = gh api --paginate --slurp "repos/$Repo/milestones?state=all&per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) { throw "Failed to fetch milestones: $json" }
+$msMap = @{}
+($json | ConvertFrom-Json) | ForEach-Object { $_ } | ForEach-Object { $msMap[$_.title] = $_.number }
+
+# Build ranges: each release branch contains commits between its merge-base and the previous one
+$ranges = @()
+
+for ($i = 0; $i -lt $allBranches.Count; $i++) {
+    $branch = $allBranches[$i]
+    $msTitle = ($branch -replace 'origin/release/', '')
+
+    if ($i -eq 0) {
+        # First branch — use previous version's stable branch merge-base as the "from" boundary
+        $ranges += @{ Branch = $branch; Title = $msTitle; From = $prevMergeBase; To = $mergeBases[$i] }
+    } else {
+        $ranges += @{ Branch = $branch; Title = $msTitle; From = $mergeBases[$i - 1]; To = $mergeBases[$i] }
+    }
+}
+
+# Also: commits on main after the last branch → next milestone
+$lastMb = $mergeBases[$mergeBases.Count - 1]
+$headSha = git rev-parse origin/main
+if ($lastMb -ne $headSha) {
+    # Find the next open milestone for this version by checking what exists
+    $lastTitle = ($allBranches[$allBranches.Count - 1] -replace 'origin/release/', '')
+    $lastRank = Get-ReleaseRank "origin/release/$lastTitle"
+
+    # Look through all milestones for this version, find the next one in release order
+    $nextTitle = $null
+    $candidates = $msMap.Keys | Where-Object { $_ -like "$Version*" } | Sort-Object {
+        $r = Get-ReleaseRank "origin/release/$_"; $r[0] * 1000 + $r[1]
+    }
+    foreach ($candidate in $candidates) {
+        $candidateRank = Get-ReleaseRank "origin/release/$candidate"
+        if (($candidateRank[0] * 1000 + $candidateRank[1]) -gt ($lastRank[0] * 1000 + $lastRank[1])) {
+            $nextTitle = $candidate
+            break
+        }
+    }
+
+    if ($nextTitle) {
+        $ranges += @{ Branch = "origin/main (HEAD)"; Title = $nextTitle; From = $lastMb; To = $headSha }
+    }
+}
+
+$fixed = 0
+$correct = 0
+
+foreach ($range in $ranges) {
+    $msTitle = $range.Title
+    if (-not $msMap.ContainsKey($msTitle)) {
+        Write-Host "⚠️  Milestone '$msTitle' not found on GitHub, skipping"
+        Write-Host ""
+        continue
+    }
+    $msId = $msMap[$msTitle]
+
+    if ($null -eq $range.From) {
+        Write-Host "⏭️  $msTitle — no previous release branch found, skipping (verify manually)"
+        Write-Host ""
+        continue
+    }
+
+    # Get PRs in this range
+    $log = git log --oneline --first-parent "$($range.From)..$($range.To)" 2>/dev/null
+    $prs = @()
+    foreach ($line in $log) {
+        if ($line -match '\(#(\d+)\)') {
+            $prs += [int]$Matches[1]
+        }
+    }
+
+    Write-Host "📦 $msTitle ($($prs.Count) PRs) — $($range.Branch)"
+
+    foreach ($pr in $prs) {
+        # Check PR milestone
+        $currentMs = gh api "repos/$Repo/issues/$pr" --jq '.milestone.title // ""' 2>/dev/null
+        if ($currentMs -ne $msTitle) {
+            Write-Host "  🔄 #$pr  $(if ($currentMs) { $currentMs } else { 'none' }) → $msTitle"
+            if (-not $DryRun) {
+                gh api "repos/$Repo/issues/$pr" -X PATCH -F milestone=$msId --silent 2>/dev/null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "  ❌ Failed to update #$pr"
+                    $errors++
+                    continue
+                }
+            }
+            $fixed++
+        } else {
+            $correct++
+        }
+
+        # Get linked issues via GraphQL (catches sidebar-linked + keyword-linked)
+        $linkedIssues = @()
+        $gqlResult = gh api graphql -f query="
+            query {
+                repository(owner: `"$($Repo.Split('/')[0])`", name: `"$($Repo.Split('/')[1])`") {
+                    pullRequest(number: $pr) {
+                        closingIssuesReferences(first: 50) {
+                            nodes { number }
+                        }
+                    }
+                }
+            }" --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number' 2>/dev/null
+        if ($LASTEXITCODE -eq 0 -and $gqlResult) {
+            $linkedIssues += $gqlResult -split "`n" | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ }
+        }
+
+        # Also check PR body for closing keywords (fallback)
+        $body = gh api "repos/$Repo/pulls/$pr" --jq '.body // ""' 2>/dev/null
+        if ($LASTEXITCODE -eq 0 -and $body) {
+            $closingPattern = '(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)'
+            $regexMatches = [regex]::Matches($body, $closingPattern)
+            foreach ($m in $regexMatches) {
+                $linkedIssues += [int]$m.Groups[1].Value
+            }
+        }
+        $linkedIssues = $linkedIssues | Sort-Object -Unique
+
+        foreach ($issue in $linkedIssues) {
+            $issueMs = gh api "repos/$Repo/issues/$issue" --jq '.milestone.title // ""' 2>/dev/null
+            if ($issueMs -ne $msTitle) {
+                Write-Host "  🔄 #$issue (via #$pr)  $(if ($issueMs) { $issueMs } else { 'none' }) → $msTitle"
+                if (-not $DryRun) {
+                    gh api "repos/$Repo/issues/$issue" -X PATCH -F milestone=$msId --silent 2>/dev/null
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Host "  ❌ Failed to update #$issue"
+                        $errors++
+                        continue
+                    }
+                }
+                $fixed++
+            } else {
+                $correct++
+            }
+        }
+    }
+    Write-Host ""
+}
+
+Write-Host ("=" * 60)
+Write-Host "Summary: $fixed to fix, $correct correct, $errors errors"
+if ($DryRun) { Write-Host "(DRY RUN — no actual changes were made)" }
+Write-Host ("=" * 60)

--- a/scripts/infra/milestones/sync-chrome-milestones.ps1
+++ b/scripts/infra/milestones/sync-chrome-milestones.ps1
@@ -1,0 +1,275 @@
+<#
+.SYNOPSIS
+    Sync SkiaSharp GitHub milestones with the Chrome/Skia release schedule.
+
+.DESCRIPTION
+    Fetches the Chromium release schedule from chromiumdash.appspot.com and
+    creates/updates GitHub milestones for the next N Skia milestones.
+
+    SkiaSharp release cadence (aligned to Chrome):
+      - Chrome Beta         -> SkiaSharp Preview.1  (starts work on Branch day)
+      - Chrome Early Stable -> SkiaSharp Preview.2  (starts work on Early Stable Cut day)
+      - Chrome Stable Cut   -> SkiaSharp RC         (starts work on Early Stable day)
+      - Chrome Stable       -> SkiaSharp Stable     (starts work on Stable Cut day)
+
+    Reads major version and current milestone from scripts/VERSIONS.txt.
+
+.PARAMETER DryRun
+    Print what would be done without making changes.
+
+.PARAMETER Count
+    Number of milestones ahead to sync (default: 5).
+
+.PARAMETER Repo
+    GitHub repo (default: mono/SkiaSharp).
+
+.EXAMPLE
+    pwsh sync-chrome-milestones.ps1 -DryRun -Count 3
+#>
+
+param(
+    [switch]$DryRun,
+    [int]$Count = 5,
+    [string]$Repo = "mono/SkiaSharp"
+)
+
+$ErrorActionPreference = "Stop"
+
+$SCHEDULE_URL = "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone={0}"
+
+# VERSIONS.txt is at scripts/VERSIONS.txt — two levels up from this script
+$VERSIONS_PATH = Join-Path $PSScriptRoot ".." ".." "VERSIONS.txt"
+if (-not (Test-Path $VERSIONS_PATH)) {
+    throw "VERSIONS.txt not found at $(Join-Path $PSScriptRoot '../../VERSIONS.txt')"
+}
+$VERSIONS_PATH = Resolve-Path $VERSIONS_PATH
+
+function Read-Versions {
+    $major = $null
+    $milestone = $null
+
+    foreach ($line in Get-Content $VERSIONS_PATH) {
+        $line = $line.Trim()
+        if (-not $line -or $line.StartsWith("#")) { continue }
+        $parts = $line -split '\s+'
+        if ($parts.Count -ge 3) {
+            if ($parts[0] -eq "SkiaSharp" -and $parts[1] -eq "nuget") {
+                $major = [int]($parts[2].Split(".")[0])
+            }
+            elseif ($parts[0] -eq "libSkiaSharp" -and $parts[1] -eq "milestone") {
+                $milestone = [int]$parts[2]
+            }
+        }
+    }
+
+    if ($null -eq $major) {
+        throw "Could not find 'SkiaSharp nuget X.Y.Z' in $VERSIONS_PATH — cannot determine major version."
+    }
+    if ($null -eq $milestone) {
+        throw "Could not find 'libSkiaSharp milestone N' in $VERSIONS_PATH — cannot determine current Skia milestone."
+    }
+
+    return @{ Major = $major; Milestone = $milestone }
+}
+
+function Get-ChromeSchedule([int]$Mstone) {
+    $url = $SCHEDULE_URL -f $Mstone
+    try {
+        $data = Invoke-RestMethod -Uri $url -TimeoutSec 15
+    }
+    catch {
+        throw "Failed to fetch Chrome schedule for m$Mstone from $url`: $_"
+    }
+
+    if (-not $data.mstones -or $data.mstones.Count -eq 0) {
+        throw "No schedule data returned for m$Mstone from $url — milestone may not exist yet."
+    }
+
+    $schedule = $data.mstones[0]
+    $required = @("branch_point", "earliest_beta", "early_stable_cut", "early_stable", "stable_cut", "stable_date")
+    foreach ($field in $required) {
+        if (-not $schedule.$field) {
+            throw "Chrome schedule for m$Mstone is missing required field '$field' — schedule may be incomplete."
+        }
+    }
+
+    return $schedule
+}
+
+function ConvertTo-Date([string]$IsoString) {
+    return [datetime]::SpecifyKind([datetime]::Parse($IsoString.Split("T")[0]), [System.DateTimeKind]::Utc)
+}
+
+function Format-DateDisplay([datetime]$Date) {
+    return $Date.ToString("ddd, MMM dd, yyyy", [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Format-DateIso([datetime]$Date) {
+    return $Date.ToString("yyyy-MM-ddT00:00:00Z")
+}
+
+function Get-SkiaMilestones($Chrome, [int]$Mstone, [int]$Major) {
+    $branch = ConvertTo-Date $Chrome.branch_point
+    $beta = ConvertTo-Date $Chrome.earliest_beta
+    $earlyStableCut = ConvertTo-Date $Chrome.early_stable_cut
+    $earlyStable = ConvertTo-Date $Chrome.early_stable
+    $stableCut = ConvertTo-Date $Chrome.stable_cut
+    $stable = ConvertTo-Date $Chrome.stable_date
+
+    return @(
+        @{
+            Title = "$Major.$Mstone.0-preview.1"
+            DueOn = $beta
+            Description = "Skia m$Mstone preview.1 · Start $(Format-DateDisplay $branch) · Merge Skia sync PR and ship preview."
+        },
+        @{
+            Title = "$Major.$Mstone.0-preview.2"
+            DueOn = $earlyStable
+            Description = "Skia m$Mstone preview.2 · Start $(Format-DateDisplay $earlyStableCut) · Bug fixes and API additions from preview.1 feedback."
+        },
+        @{
+            Title = "$Major.$Mstone.0-rc.1"
+            DueOn = $stableCut
+            Description = "Skia m$Mstone RC · Start $(Format-DateDisplay $earlyStable) · Critical bug fixes only, no new features."
+        },
+        @{
+            Title = "$Major.$Mstone.0"
+            DueOn = $stable
+            Description = "Skia m$Mstone stable · Start $(Format-DateDisplay $stableCut) · Ship to NuGet.org, tag and create GitHub Release."
+        }
+    )
+}
+
+function Get-ExistingMilestones([string]$Repo) {
+    $json = gh api --paginate --slurp "repos/$Repo/milestones?state=all&per_page=100" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to fetch milestones from GitHub: $json`nEnsure 'gh' CLI is authenticated and has access to $Repo."
+    }
+
+    $milestones = @{}
+    $pages = $json | ConvertFrom-Json
+    # --slurp wraps pages in an outer array: [[...page1...], [...page2...]]
+    $items = $pages | ForEach-Object { $_ }
+    foreach ($item in $items) {
+        $milestones[$item.title] = @{
+            Number      = $item.number
+            State       = $item.state
+            DueOn       = if ($item.due_on) { ([datetimeoffset]$item.due_on).UtcDateTime.ToString("yyyy-MM-dd") } else { "" }
+            Description = if ($item.description) { $item.description } else { "" }
+        }
+    }
+    return $milestones
+}
+
+function New-Milestone([string]$Repo, [string]$Title, [datetime]$DueOn, [string]$Description, [switch]$DryRun) {
+    if ($DryRun) {
+        Write-Host "  📝 CREATE  $Title  due $(Format-DateDisplay $DueOn)"
+        return
+    }
+
+    $body = @{ title = $Title; due_on = (Format-DateIso $DueOn); description = $Description } | ConvertTo-Json
+    $result = $body | gh api "repos/$Repo/milestones" -X POST --input - 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create milestone '$Title': $result"
+    }
+    $ms = $result | ConvertFrom-Json
+    Write-Host "  ✅ Created  $Title  ms #$($ms.number)  due $(Format-DateDisplay $DueOn)"
+}
+
+function Update-Milestone([string]$Repo, [int]$Number, [string]$Title, [datetime]$DueOn, [string]$Description, [string[]]$Changes, [switch]$DryRun) {
+    if ($DryRun) {
+        Write-Host "  🔄 UPDATE  $Title  ($($Changes -join ', '))"
+        return
+    }
+
+    $body = @{ due_on = (Format-DateIso $DueOn); description = $Description } | ConvertTo-Json
+    $result = $body | gh api "repos/$Repo/milestones/$Number" -X PATCH --input - 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to update milestone '$Title' (ms #$Number): $result"
+    }
+    Write-Host "  🔄 Updated  $Title  ($($Changes -join ', '))"
+}
+
+# Main
+$versions = Read-Versions
+$VERSIONS_MAJOR = $versions.Major
+$VERSIONS_MILESTONE = $versions.Milestone
+
+Write-Host "📅 Syncing Chrome schedule → SkiaSharp milestones"
+Write-Host "   Date: $(Get-Date -Format 'yyyy-MM-dd')"
+Write-Host "   Repo: $Repo"
+Write-Host "   Count: $Count milestones ahead"
+Write-Host "   Major version: $VERSIONS_MAJOR (from VERSIONS.txt)"
+Write-Host "   Current milestone: m$VERSIONS_MILESTONE (from VERSIONS.txt)"
+if ($DryRun) {
+    Write-Host "   Mode: DRY RUN (no changes will be made)"
+}
+Write-Host ""
+
+Write-Host "🌐 Starting from milestone: m$VERSIONS_MILESTONE"
+Write-Host ""
+
+$existing = Get-ExistingMilestones $Repo
+Write-Host "📋 Found $($existing.Count) existing GitHub milestones"
+Write-Host ""
+
+$created = 0
+$updated = 0
+$skipped = 0
+$today = [datetime]::UtcNow
+
+for ($mstone = $VERSIONS_MILESTONE; $mstone -lt ($VERSIONS_MILESTONE + $Count); $mstone++) {
+    $chrome = Get-ChromeSchedule $mstone
+
+    $beta = ConvertTo-Date $chrome.earliest_beta
+    $stable = ConvertTo-Date $chrome.stable_date
+    Write-Host "m$mstone`: Beta $(Format-DateDisplay $beta) → Stable $(Format-DateDisplay $stable)"
+
+    $skMilestones = Get-SkiaMilestones $chrome $mstone $VERSIONS_MAJOR
+
+    foreach ($ms in $skMilestones) {
+        $title = $ms.Title
+        $dueOn = $ms.DueOn
+        $description = $ms.Description
+
+        if ($existing.ContainsKey($title)) {
+            $ex = $existing[$title]
+            $changes = @()
+
+            $newDue = $dueOn.ToString("yyyy-MM-dd")
+            if ($ex.DueOn -ne $newDue) {
+                $changes += "due: $(if ($ex.DueOn) { $ex.DueOn } else { 'none' }) → $newDue"
+            }
+
+            if ($ex.Description -ne $description) {
+                $changes += "description updated"
+            }
+
+            if ($changes.Count -gt 0) {
+                Update-Milestone $Repo $ex.Number $title $dueOn $description $changes -DryRun:$DryRun
+                $updated++
+            }
+            else {
+                Write-Host "  ✓ $title — up to date"
+                $skipped++
+            }
+        }
+        elseif ($dueOn -ge $today.AddDays(-30)) {
+            New-Milestone $Repo $title $dueOn $description -DryRun:$DryRun
+            $created++
+        }
+        else {
+            Write-Host "  ⏭️  $title — past milestone, skipping"
+            $skipped++
+        }
+    }
+
+    Write-Host ""
+}
+
+Write-Host ("=" * 60)
+Write-Host "Summary: $created created, $updated updated, $skipped unchanged"
+if ($DryRun) {
+    Write-Host "(DRY RUN — no actual changes were made)"
+}
+Write-Host ("=" * 60)


### PR DESCRIPTION
Two PowerShell scripts for managing SkiaSharp milestones aligned to Chrome's release schedule.

## Scripts

### `sync-chrome-milestones.ps1`
Creates/updates GitHub milestones based on the Chromium release schedule.

| Chrome Event | SkiaSharp Milestone |
|---|---|
| Beta | Preview.1 |
| Early Stable | Preview.2 |
| Stable Cut | RC |
| Stable | Stable |

```powershell
pwsh scripts/infra/milestones/sync-chrome-milestones.ps1 -DryRun -Count 5
pwsh scripts/infra/milestones/sync-chrome-milestones.ps1 -Count 5
```

### `audit-milestones.ps1`
Verifies that merged PRs and their linked issues are in the correct milestone based on which release branch contains the commit.

```powershell
pwsh scripts/infra/milestones/audit-milestones.ps1 -DryRun
pwsh scripts/infra/milestones/audit-milestones.ps1 -Version 4.150.0
```

## Key features
- Reads major version and milestone from `scripts/VERSIONS.txt`
- All date handling in UTC
- Paginated milestone fetch (`--paginate --slurp`)
- GraphQL `closingIssuesReferences` for sidebar-linked issues
- Proper release-order sorting (not lexicographic)
- `$LASTEXITCODE` checked on all API calls
- `--DryRun` mode for both scripts
- Idempotent — safe to run weekly