### PR TITLE
ci(docs): stop the PR-author cache from re-triggering the docs pipeline

### DIFF
--- a/.github/workflows/update-release-notes.lock.yml
+++ b/.github/workflows/update-release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b764d79804c82672f3233f9dea6d76bbc0f109e9d20efb7208b50f5c07622750","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"411a26c5b940a5391a831f5bd3d7e33cafa88734ce89b594e6fc08bf4c763d99","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -56,6 +56,7 @@ name: "Sync - Release Notes & API Diffs"
     - main
     paths-ignore:
     - documentation/docfx/releases/**
+    - scripts/infra/docs/pr-authors.json
   schedule:
   - cron: "0 0 * * *"
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
@@ -202,23 +203,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2d7533f6c3949899_EOF'
+          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
           <system>
-          GH_AW_PROMPT_2d7533f6c3949899_EOF
+          GH_AW_PROMPT_e4335b5e35f43524_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2d7533f6c3949899_EOF'
+          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_2d7533f6c3949899_EOF
+          GH_AW_PROMPT_e4335b5e35f43524_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_2d7533f6c3949899_EOF'
+          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_2d7533f6c3949899_EOF
+          GH_AW_PROMPT_e4335b5e35f43524_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2d7533f6c3949899_EOF'
+          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -250,12 +251,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_2d7533f6c3949899_EOF
+          GH_AW_PROMPT_e4335b5e35f43524_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2d7533f6c3949899_EOF'
+          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
           </system>
           {{#runtime-import .github/workflows/update-release-notes.md}}
-          GH_AW_PROMPT_2d7533f6c3949899_EOF
+          GH_AW_PROMPT_e4335b5e35f43524_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -460,9 +461,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_cf0ec75534594435_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_67945bc866cf0c5f_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"draft":false,"labels":["documentation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true,"title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_cf0ec75534594435_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_67945bc866cf0c5f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -670,7 +671,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3463591ff122fab1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_dca3e62519becd90_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -711,7 +712,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3463591ff122fab1_EOF
+          GH_AW_MCP_CONFIG_dca3e62519becd90_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -12,6 +12,13 @@ on:
     branches: [main]
     paths-ignore:
       - "documentation/docfx/releases/**"
+      # The pipeline rewrites this PR-author cache and commits it inside its own
+      # docs PR. It lives outside the releases tree, so without this entry merging
+      # that PR re-triggers the whole pipeline on its own commit (a wasted heavy
+      # prepare run). Ignore it: a change to ONLY the cache never needs a docs run,
+      # and the daily cron still picks the cache up. A push that also touches real
+      # sources still triggers (paths-ignore skips only when ALL files match).
+      - "scripts/infra/docs/pr-authors.json"
   schedule:
     # Daily. Catches new stable tags (vX.Y.Z → page flips to "stable"), new
     # release-branch commits (unreleased deltas), and newly published NuGets


### PR DESCRIPTION
## Problem

The `update-release-notes` pipeline (release notes + API diffs) rewrites and **commits** `scripts/infra/docs/pr-authors.json` — the PR-author cache produced by `save_author_cache()` in `generate-release-notes.py` — inside its own docs PR.

The workflow's `push` trigger only ignored the releases tree:

```yaml
push:
  branches: [main]
  paths-ignore:
    - "documentation/docfx/releases/**"
```

`pr-authors.json` lives under `scripts/infra/docs/`, **outside** that path, so merging a docs PR that touched the cache re-triggered the whole heavy pipeline on its own merge commit.

**Evidence:** docs PR #4283 merged at `f01a53667` (changed `pr-authors.json` plus the releases tree) and immediately spawned a new `push` run at that exact SHA. The self-triggered run is wasted work: the cache is already warm and the regenerated tree is byte-for-byte identical, so it produces an empty Prepare patch and no PR — but it still burns a 120-minute Prepare job that rebuilds API diffs over every NuGet. (`co-release-map.json` is already inside the ignored releases tree, so `pr-authors.json` was the only offender.)

## Fix

The cache *is* used (a warm cache keeps regenerations fully offline), so per the "if it's used, add it to the ignore" path it's added to `paths-ignore` rather than relocated. Moving it into the docfx releases tree would drop an infra cache file into published-docs sources and require changing the hardcoded path in `generate-release-notes.py` plus the dev docs.

- `update-release-notes.md` — add `scripts/infra/docs/pr-authors.json` to `paths-ignore` with an explanatory comment.
- `update-release-notes.lock.yml` — recompiled with `gh aw compile` (v0.71.5, matching the existing compiler version). The only functional change is the new path; the rest is gh-aw's deterministic heredoc-delimiter regeneration — no action-SHA or container-digest drift.

Because `paths-ignore` skips a push only when **all** changed files match, a push that also touches real sources still triggers, and the daily `cron` still picks up cache changes regardless.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>