### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0"
+      "upstream_merge_commit": "cebbc418885bf2d928b31fb3798da45cd31d4a7b"
     }
   ]
 }

--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -25,6 +25,7 @@ Task("libSkiaSharp")
             $"target_os='android' " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_freetype2=false " +

--- a/native/ios/build.cake
+++ b/native/ios/build.cake
@@ -55,6 +55,7 @@ Task("libSkiaSharp")
             $"ios_use_simulator={(isSim ? "true" : "false")} " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_metal=true " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +

--- a/native/linux/build.cake
+++ b/native/linux/build.cake
@@ -106,6 +106,7 @@ Task("libSkiaSharp")
             $"skia_enable_ganesh={(SUPPORT_GPU ? "true" : "false")} " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_freetype2=false " +
@@ -153,6 +154,7 @@ Task("libHarfBuzzSharp")
             $"target_os='linux' " +
             $"target_cpu='{skiaArch}' " +
             $"visibility_hidden=false " +
+            $"skia_use_partition_alloc=false " +
             $"extra_asmflags=[] " +
             $"extra_cflags=[ '-stdlib=libc++'{bionicDefineHB} ] " +
             $"extra_ldflags=[ '-stdlib=libc++', '-static-libgcc'{staticLibcxxHB}, '-Wl,--version-script={map}' ] " +

--- a/native/macos/build.cake
+++ b/native/macos/build.cake
@@ -32,6 +32,7 @@ Task("libSkiaSharp")
             $"min_macos_version='{GetDeploymentTarget(arch)}' " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_metal=true " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -44,6 +44,7 @@ Task("libSkiaSharp")
            $"skia_enable_ganesh=true " +
            $"skia_use_harfbuzz=false " +
            $"skia_use_icu=false " +
+           $"skia_use_partition_alloc=false " +
            $"skia_use_piex=true " +
            $"skia_use_system_expat=false " +
            $"skia_use_system_freetype2=true " +

--- a/native/tvos/build.cake
+++ b/native/tvos/build.cake
@@ -39,6 +39,7 @@ Task("libSkiaSharp")
             $"ios_use_simulator={(isSim ? "true" : "false")} " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_metal=true " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -46,6 +46,7 @@ Task("libSkiaSharp")
         $"skia_use_freetype=true " +
         $"skia_use_harfbuzz=false " +
         $"skia_use_icu=false " +
+        $"skia_use_partition_alloc=false " +
         $"skia_use_piex=false " +
         $"skia_use_expat=true " +
         $"skia_use_libwebp_encode=true " +
@@ -125,6 +126,7 @@ Task("libHarfBuzzSharp")
         $"target_os='linux' " +
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
+        $"skia_use_partition_alloc=false " +
         $"extra_cflags=[ '-s', 'WARN_UNALIGNED=1' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"skia_emsdk_dir='{EMSCRIPTEN_ROOT}'" +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -50,6 +50,7 @@ Task("libSkiaSharp")
             $"skia_use_dng_sdk=true " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/273

# Skia upstream main → mono/SkiaSharp `main` sync (tip mode)

This PR bumps SkiaSharp's `externals/skia` submodule to pick up upstream
google/skia `main` bug fixes (and the m151-in-progress refactor) without
advancing the SkiaSharp milestone or NuGet version.

It is the parent companion of the mono/skia PR for `skia-sync/main`.

## Mode summary

| | |
|---|---|
| Mode | **`main`/tip sync** (`upstream_ref = main`) |
| Base milestone (current) | m150 |
| Target milestone | m150 (**not a version bump**) |
| Is release-line sync | `false` |
| Base branch | `main` |
| Head branch | `skia-sync/main` |
| Submodule before | `280ec21adad7b21bdf8d8081a44c3191bb420fc3` (mono/skia `skiasharp` HEAD before the merge) |
| Submodule after | `cebbc418885bf2d928b31fb3798da45cd31d4a7b` (mono/skia `skia-sync/main` HEAD) |
| Submodule commits added | 3 (merge from upstream + SK_MILESTONE pin + sk_font.cpp include fix) |

## What changed in the parent repo

| File | Change |
|---|---|
| `externals/skia` | Submodule pointer: `280ec21ada` → `cebbc41888`. |
| `cgmanifest.json` | `upstream_merge_commit`: `14d05ec761…` → `cebbc41888…`. `chrome_milestone` stays `150`. |
| `native/android/build.cake` | Added `skia_use_partition_alloc=false` to the GnNinja call. |
| `native/ios/build.cake` | Added `skia_use_partition_alloc=false`. |
| `native/linux/build.cake` | Added `skia_use_partition_alloc=false` to **both** the `libSkiaSharp` and `libHarfBuzzSharp` GnNinja calls (the Linux build is the only one that GnNinja-builds HarfBuzz). |
| `native/macos/build.cake` | Added `skia_use_partition_alloc=false`. |
| `native/tizen/build.cake` | Added `skia_use_partition_alloc=false`. |
| `native/tvos/build.cake` | Added `skia_use_partition_alloc=false`. |
| `native/wasm/build.cake` | Added `skia_use_partition_alloc=false` to **both** the `libSkiaSharp` and `libHarfBuzzSharp` sections (WASM also GnNinja-builds HarfBuzz). |
| `native/windows/build.cake` | Added `skia_use_partition_alloc=false`. |

`linuxnodeps/build.cake` and `linux-clang-cross/build.cake` were not touched — they
delegate to `linux/build.cake`. Android/iOS/macOS/tvOS/Windows HarfBuzz are built
via NDK/Xcode/MSBuild rather than GnNinja, so no HarfBuzz-side flag is needed
there.

> **Why this gn arg is needed:** Upstream main added a `src/partition_alloc/BUILD.gn`
> target that pulls a `partition_alloc.gni` from `${skia_partition_alloc_dir}` — a path
> our `DEPS` does not vendor. The default `skia_use_partition_alloc = is_clang` would
> make every clang build pull it in. Forcing the arg to `false` keeps every clang
> platform building against our DEPS-pinned dependencies only. See skill gotcha #23.

## Version impact

None. This is explicitly **not a version bump**:

- `chrome_milestone` stays `150`.
- `scripts/VERSIONS.txt`: `skia release m150`, `libSkiaSharp milestone 150`, `soname 150.0.0`, `increment 0` — all unchanged.
- NuGet package versions: unchanged.
- The submodule pins `SK_MILESTONE` to `150` (upstream main has advanced to `151`) so the build's `git-sync-deps` task (which enforces SK_MILESTONE == VERSIONS.txt milestone) still passes.

## Bindings (Phase 8)

- `pwsh ./utils/generate.ps1` (via `.agents/skills/update-skia/scripts/regenerate-bindings.ps1`) ran cleanly.
- `git status` after regeneration: **no changes** to any `*.generated.cs` file.
- `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` auto-reverted by the script (skill gotcha #9 — HarfBuzz bindings are out-of-band).
- **Conclusion: no new C API functions were exposed**, so no C# wrapper work is required for this sync.

## C# changes (Phase 9)

None beyond the items above. C# build:

```
dotnet build binding/SkiaSharp/SkiaSharp.csproj
Build succeeded. 0 Warning(s) 0 Error(s)
```

## Build & test results (Phase 7 / Phase 10)

**Native build (Linux x64):**

```
dotnet cake --target=externals-linux --arch=x64
```

After adding `skia_use_partition_alloc=false` (see above), both libraries built cleanly:

- `output/native/linux/x64/libSkiaSharp.so.150.0.0` (~11 MB)
- `output/native/linux/x64/libHarfBuzzSharp.so.0.61421.0` (~2.8 MB)

Runtime deps verified (`ldd`): `libfontconfig`, `libc++/libc++abi`, `libunwind`, `libm`,
`libc`, `ld-linux` — same shape as before.

**Tests (net10.0 | x64 | Linux):**

```
dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj
```

| | |
|---|---|
| Passed | **5584** |
| Failed | **0** |
| Skipped | 172 (hardware/platform-specific: Metal, Tizen, DirectX, etc.) |
| Duration | 2m 46s |

Full test log is uploaded as the `test-output.txt` workflow artifact.

## Items needing human attention

> **Cross-platform native build verification (HIGH PRIORITY).** Only **Linux x64** was
> actually built in this workflow. The `skia_use_partition_alloc=false` change was added
> to every clang `build.cake` to keep behavior consistent across platforms, but please
> verify on macOS / iOS / tvOS / Android / Windows / WASM / Tizen that the gn arg is
> accepted and that the build still produces the expected artifacts before merging.

> **SK_MILESTONE pin (in the submodule PR).** Upstream main has bumped `SK_MILESTONE` to
> `151`. To honor "tip mode = not a version bump" the submodule PR includes a one-line
> fork patch pinning it back to `150`. If this sync was intended to actually bump SkiaSharp
> to m151, drop that pin in the submodule PR and update VERSIONS.txt, soname (`150.0.0` →
> `151.0.0`), NuGet versions, and `chrome_milestone` here in the parent PR.

> **Major upstream header refactor (FYI).** Upstream deleted `include/private/base/` and
> `src/base/` directories and moved the headers back to `include/private/` and `src/core/`.
> SkiaSharp's C API only referenced one such header (already fixed in the submodule PR).
> If you maintain extra native code outside the submodule that includes private Skia
> headers directly, you may need to update include paths there.

> **CG manifest update only — no other CG/security changes.** `chrome_milestone` stayed at
> 150, so no Skia CVE re-querying is needed for this sync. The `upstream_merge_commit`
> hash bump simply re-points the merge-base used by the security-audit skill.

## Verification checklist

- [x] Submodule pointer matches the head of mono/skia `skia-sync/main` (`cebbc41888`).
- [x] `cgmanifest.json` upstream_merge_commit matches the submodule HEAD.
- [x] No `*.generated.cs` files changed after regeneration.
- [x] `dotnet build binding/SkiaSharp/SkiaSharp.csproj` succeeds, 0 warnings.
- [x] `dotnet test tests/SkiaSharp.Tests.Console` passes 5584/5584 (172 skipped are hardware-only).
- [x] `scripts/VERSIONS.txt` unchanged (milestone, soname, increment).
- [ ] **macOS / iOS / tvOS / Android / Windows / WASM / Tizen builds verified after partition_alloc gn arg change.** ← Requires human / CI confirmation.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).