### PR TITLE
docs: add "AI in SkiaSharp" site page

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -220,6 +220,10 @@ jobs:
           if [ -d documentation/site/images ]; then
             cp -r documentation/site/images site/images
           fi
+
+          # AI in SkiaSharp page → /ai/
+          cp -r documentation/site/ai site/ai
+
           touch site/.nojekyll
 
           # Inject build info into landing page footer

--- a/documentation/site/ai/ai.css
+++ b/documentation/site/ai/ai.css
@@ -6,6 +6,11 @@
    cards with a metadata grid, and the skills board.
    ───────────────────────────────────────────────────────────── */
 
+/* Human-review accent — used by the loop legend and "human" nodes.
+   Theme-aware so it stays legible on both the light and dark themes. */
+:root { --human: #15a34a; }
+[data-theme="dark"] { --human: #2bd673; }
+
 /* ── Hero additions ───────────────────────────────────────── */
 
 .ai-hero .hero-subtitle {
@@ -120,9 +125,7 @@
 
 .swatch-agent { background: var(--accent); border-color: var(--accent); }
 .swatch-auto { background: var(--bg-subtle); }
-.swatch-both {
-  background: linear-gradient(135deg, var(--accent) 0 50%, var(--bg-subtle) 50% 100%);
-}
+.swatch-human { background: var(--human); border-color: var(--human); }
 
 /* ── The loop / pipeline diagram ──────────────────────────── */
 
@@ -149,10 +152,7 @@
 
 .loop-node[data-actor="agent"] { border-top: 3px solid var(--accent); }
 .loop-node[data-actor="auto"] { border-top: 3px solid var(--text-secondary); }
-.loop-node[data-actor="both"] {
-  border-top: 3px solid transparent;
-  border-image: linear-gradient(90deg, var(--accent), var(--text-secondary)) 1;
-}
+.loop-node[data-actor="human"] { border-top: 3px solid var(--human); }
 
 .loop-step {
   font-size: 11px;
@@ -217,10 +217,104 @@
   color: var(--text);
 }
 
+/* ── Phase labels ─────────────────────────────────────────── */
+
+.loop-band-label {
+  max-width: 900px;
+  margin: 36px auto 16px;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.loop-band-label:first-of-type { margin-top: 8px; }
+
+/* ── Vertical connector between the two phases ────────────── */
+
+.flow-connect {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin: 26px auto;
+  color: var(--text-secondary);
+}
+
+.flow-connect-arrow {
+  font-size: 26px;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.flow-connect-label {
+  font-size: 13px;
+  font-style: italic;
+}
+
+/* ── Two parallel publish flows ───────────────────────────── */
+
+.parallel {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 20px;
+}
+
+/* Shared box chrome for a phase / track container */
+.flow-box,
+.flow-row {
+  padding: 18px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.flow-row {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+/* Inside the parallel block each track flows top-to-bottom */
+.parallel .loop {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.parallel .loop-node {
+  flex: none;
+  max-width: none;
+}
+
+.parallel .loop-arrow {
+  justify-content: center;
+  transform: rotate(90deg);
+}
+
+.track-name {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 14px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.track-target {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
 @media (max-width: 720px) {
   .loop { flex-direction: column; align-items: stretch; }
   .loop-node { max-width: none; }
   .loop-arrow { justify-content: center; transform: rotate(90deg); }
+  .parallel { flex-direction: column; }
 }
 
 /* ── Workflow cards ───────────────────────────────────────── */

--- a/documentation/site/ai/ai.css
+++ b/documentation/site/ai/ai.css
@@ -1,0 +1,459 @@
+/* ─────────────────────────────────────────────────────────────
+   AI in SkiaSharp — page-scoped styles.
+   Built on top of the shared site theme in ../style.css. Only
+   adds components that the landing page does not already provide:
+   the honesty banner, the pipeline ("loop") diagram, workflow
+   cards with a metadata grid, and the skills board.
+   ───────────────────────────────────────────────────────────── */
+
+/* ── Hero additions ───────────────────────────────────────── */
+
+.ai-hero .hero-subtitle {
+  margin-bottom: 32px;
+}
+
+.ai-honesty {
+  max-width: 760px;
+  margin: 0 auto 32px;
+  padding: 18px 22px;
+  text-align: left;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  color: var(--text);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.ai-honesty strong {
+  font-weight: 700;
+}
+
+.stat-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.stat {
+  flex: 1 1 160px;
+  max-width: 240px;
+  padding: 18px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  text-align: center;
+}
+
+.stat-num {
+  display: block;
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+
+.stat-label {
+  display: block;
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ── Shared section helpers ───────────────────────────────── */
+
+.ai-section {
+  padding: 64px 0;
+}
+
+.section-lead {
+  max-width: 720px;
+  margin: -24px auto 36px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.subhead {
+  max-width: 760px;
+  margin: 40px auto 20px;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* ── Legend (who does what) ───────────────────────────────── */
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+  margin: 0 auto 32px;
+  list-style: none;
+  padding: 0;
+}
+
+.legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  flex: none;
+}
+
+.swatch-agent { background: var(--accent); border-color: var(--accent); }
+.swatch-auto { background: var(--bg-subtle); }
+.swatch-both {
+  background: linear-gradient(135deg, var(--accent) 0 50%, var(--bg-subtle) 50% 100%);
+}
+
+/* ── The loop / pipeline diagram ──────────────────────────── */
+
+.loop {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+  gap: 10px;
+}
+
+.loop-node {
+  flex: 1 1 200px;
+  max-width: 260px;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  position: relative;
+}
+
+.loop-node[data-actor="agent"] { border-top: 3px solid var(--accent); }
+.loop-node[data-actor="auto"] { border-top: 3px solid var(--text-secondary); }
+.loop-node[data-actor="both"] {
+  border-top: 3px solid transparent;
+  border-image: linear-gradient(90deg, var(--accent), var(--text-secondary)) 1;
+}
+
+.loop-step {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+.loop-node h3 {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+
+.loop-node p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  flex: 1;
+}
+
+.loop-actor {
+  margin-top: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.loop-arrow {
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 20px;
+  font-weight: 700;
+  flex: none;
+}
+
+.loop-note {
+  max-width: 760px;
+  margin: 28px auto 0;
+  padding: 16px 20px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.loop-note code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+}
+
+@media (max-width: 720px) {
+  .loop { flex-direction: column; align-items: stretch; }
+  .loop-node { max-width: none; }
+  .loop-arrow { justify-content: center; transform: rotate(90deg); }
+}
+
+/* ── Workflow cards ───────────────────────────────────────── */
+
+.wf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.wf-card {
+  display: flex;
+  flex-direction: column;
+  padding: 24px 22px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
+}
+
+.wf-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--card-shadow-hover);
+  transform: translateY(-2px);
+}
+
+.wf-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.wf-card h3 {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text);
+  margin-right: auto;
+}
+
+.wf-desc {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.badge-agentic { background: var(--accent-subtle); color: var(--accent); }
+.badge-auto {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+.badge-model {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+/* metadata grid */
+.wf-meta {
+  margin: 16px 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 14px;
+  font-size: 13px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.wf-meta dt {
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.wf-meta dd {
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.wf-meta code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 1px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.wf-foot {
+  margin-top: 16px;
+}
+
+.wf-foot a {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* ── Skills board ─────────────────────────────────────────── */
+
+.skill-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.skill-group {
+  padding: 22px 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+}
+
+.skill-group h3 {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 14px;
+  letter-spacing: 0.02em;
+}
+
+.skill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skill-list li {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.skill-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.skill-auto {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: var(--accent-subtle);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+/* ── Guardrails ───────────────────────────────────────────── */
+
+.guard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.guard {
+  padding: 24px 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+}
+
+.guard-icon {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  margin-bottom: 14px;
+}
+
+.guard-icon svg { width: 20px; height: 20px; }
+
+.guard h3 {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--text);
+}
+
+.guard p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ── Call to action ───────────────────────────────────────── */
+
+.cta {
+  text-align: center;
+}
+
+.cta .hero-actions {
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+@media (max-width: 640px) {
+  .ai-section { padding: 44px 0; }
+  .wf-grid { grid-template-columns: 1fr; }
+  .ai-honesty { font-size: 15px; }
+}

--- a/documentation/site/ai/ai.css
+++ b/documentation/site/ai/ai.css
@@ -308,7 +308,10 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--accent);
+  text-decoration: none;
 }
+
+a.track-target:hover { text-decoration: underline; }
 
 @media (max-width: 720px) {
   .loop { flex-direction: column; align-items: stretch; }

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI in SkiaSharp — How a Tiny Team Keeps a Large Binding Current</title>
+  <meta name="description" content="How SkiaSharp uses agentic workflows and reusable AI skills to do the toil of maintaining a large native binding: upstream syncing, API diffing, documentation, triage, and security auditing, with human review on every change.">
+  <link rel="icon" href="../images/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="ai.css">
+  <script src="../theme-init.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../" class="logo-link">
+        <img src="../images/logo.png" alt="SkiaSharp" class="logo-img" width="32" height="32">
+        <span>SkiaSharp</span>
+      </a>
+      <nav class="header-nav">
+        <a href="./" class="nav-link" aria-current="page">AI</a>
+        <a href="../docs/" class="nav-link">Docs</a>
+        <a href="../docs/releases/" class="nav-link">Release Notes</a>
+        <a href="https://github.com/mono/SkiaSharp" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+        <button id="theme-toggle" class="theme-btn" aria-label="Toggle theme" aria-pressed="false">
+          <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+          <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- ── Hero ──────────────────────────────────────────── -->
+    <section class="hero ai-hero">
+      <div class="container">
+        <div class="hero-content">
+          <p class="section-kicker">Automation &amp; AI</p>
+          <h1 class="hero-title">AI in <span class="accent">SkiaSharp</span></h1>
+          <p class="hero-subtitle">
+            SkiaSharp is a large native binding that tracks Google's Skia engine along Chrome's
+            release train. A small team keeps it current because agentic workflows handle the
+            repetitive work and deterministic scripts handle the mechanics. Humans spend their
+            time on API design and correctness.
+          </p>
+          <p class="ai-honesty">
+            <strong>AI does not write the graphics engine.</strong> It does the toil: syncing
+            upstream, diffing APIs, scaffolding docs, triaging issues, and auditing for CVEs. The
+            mechanical steps run as plain scripts, the agent does the judgement work, and every
+            change lands as a normal pull request that a maintainer reviews.
+          </p>
+          <div class="stat-row">
+            <div class="stat">
+              <span class="stat-num">4</span>
+              <span class="stat-label">agentic workflows across two repositories</span>
+            </div>
+            <div class="stat">
+              <span class="stat-num">21</span>
+              <span class="stat-label">reusable skills the workflows and maintainers share</span>
+            </div>
+            <div class="stat">
+              <span class="stat-num">3&times;</span>
+              <span class="stat-label">daily upstream Skia sync passes</span>
+            </div>
+            <div class="stat">
+              <span class="stat-num">100%</span>
+              <span class="stat-label">changes shipped as human-reviewed PRs</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── The loop ──────────────────────────────────────── -->
+    <section class="ai-section">
+      <div class="container">
+        <p class="section-kicker">How it fits together</p>
+        <h2 class="section-title">The loop</h2>
+        <p class="section-lead">
+          The workflows chain into a mostly scheduled pipeline. Deterministic jobs prepare the
+          mechanical inputs, the agent does the part that needs judgement, and the result is a
+          reviewable PR. The same loop runs every day.
+        </p>
+
+        <ul class="legend" aria-label="Who performs each step">
+          <li><span class="swatch swatch-agent"></span> AI agent</li>
+          <li><span class="swatch swatch-auto"></span> Deterministic automation</li>
+          <li><span class="swatch swatch-both"></span> Prepare then polish</li>
+        </ul>
+
+        <div class="loop">
+          <div class="loop-node" data-actor="agent">
+            <span class="loop-step">Step 1</span>
+            <h3>Sync upstream</h3>
+            <p>Merge new commits from Google's Skia, resolve conflicts, and update the binding.</p>
+            <span class="loop-actor">AI agent</span>
+          </div>
+          <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+
+          <div class="loop-node" data-actor="auto">
+            <span class="loop-step">Step 2</span>
+            <h3>Build &amp; test</h3>
+            <p>Build the native and managed libraries and run the test suite to catch regressions.</p>
+            <span class="loop-actor">Automation</span>
+          </div>
+          <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+
+          <div class="loop-node" data-actor="both">
+            <span class="loop-step">Step 3</span>
+            <h3>Diff &amp; note</h3>
+            <p>Compute the public API diff across every NuGet, then write readable release notes.</p>
+            <span class="loop-actor">Prepare then polish</span>
+          </div>
+          <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+
+          <div class="loop-node" data-actor="both">
+            <span class="loop-step">Step 4</span>
+            <h3>Write docs</h3>
+            <p>Regenerate XML doc stubs, fill the missing entries, and review existing docs.</p>
+            <span class="loop-actor">Prepare then polish</span>
+          </div>
+          <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+
+          <div class="loop-node" data-actor="auto">
+            <span class="loop-step">Step 5</span>
+            <h3>Publish</h3>
+            <p>Gate the docs PR on the Microsoft Learn build, auto-merge, and go live.</p>
+            <span class="loop-actor">Automation</span>
+          </div>
+        </div>
+
+        <p class="loop-note">
+          Running alongside the main line: issue triage classifies and labels new reports, the
+          security audit cross-references CVEs and Component Governance alerts, and a CI health
+          pass watches the build pipelines. Every agentic run uploads its artifacts, which a
+          separate automation commits to the <code>aw-data</code> branch so the work stays
+          inspectable and measurable over time.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Agentic workflows ─────────────────────────────── -->
+    <section class="ai-section section-alt">
+      <div class="container">
+        <p class="section-kicker">Where we use AI</p>
+        <h2 class="section-title">The agentic workflows</h2>
+        <p class="section-lead">
+          Four workflows run an AI agent. Each one is wired so the agent can only emit a small set
+          of constrained outputs, listed as "allowed outputs" below. Everything else is read-only.
+        </p>
+
+        <div class="wf-grid">
+          <!-- Skia upstream sync -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Sync - Skia Upstream</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">claude-opus-4.7</span>
+            </div>
+            <p class="wf-desc">
+              Merges new commits from Google's upstream Skia, resolves the conflicts, builds and
+              tests, and opens a pull request with the result. The hardest reasoning in the whole
+              pipeline, which is why it runs on the strongest model.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>07:00, 12:00, and 17:00 UTC daily, plus manual dispatch</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>open a pull request</dd>
+              <dt>Skill</dt><dd><code>update-skia</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/auto-skia-sync.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <!-- Issue triage -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Sync - Issue Triage</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">claude-sonnet-4.6</span>
+            </div>
+            <p class="wf-desc">
+              Reads new and untriaged issues, classifies them by type, area, platform, and backend,
+              applies the right labels, and fills the triage fields on the project board. It writes
+              a triage report as an artifact rather than posting noise on the issue.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>04:05 UTC daily, plus manual dispatch for a single issue</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>add labels (up to 10), update the project board</dd>
+              <dt>Skill</dt><dd><code>issue-triage</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/auto-triage.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <!-- Release notes & API diffs -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Sync - Release Notes &amp; API Diffs</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">claude-sonnet-4.6</span>
+            </div>
+            <p class="wf-desc">
+              A deterministic prepare job computes the public API diff over every NuGet and
+              generates the raw release-note data. The agent then turns that data into readable
+              notes and opens one pull request, only when the prepare step actually found changes.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>Every push to main and 00:00 UTC daily, plus manual dispatch</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>open a pull request to main (<code>[docs]</code> title, documentation label)</dd>
+              <dt>Skill</dt><dd><code>release-notes</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/update-release-notes.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <!-- API docs writer -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Auto API Docs Writer</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">claude-opus-4.7</span>
+            </div>
+            <p class="wf-desc">
+              A deterministic job regenerates the XML doc stubs from the latest CI NuGets. The
+              agent then runs a two-pass pipeline: it fills the "To be added." placeholders, then
+              runs three correctness review passes over a scope of existing docs, editing the mdoc
+              XML directly, and opens a pull request.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>08:00 UTC daily, plus manual dispatch</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>open a pull request</dd>
+              <dt>Skill</dt><dd><code>api-docs</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp-API-docs</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/auto-api-docs-writer.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Automation that pairs with the AI ─────────────── -->
+    <section class="ai-section">
+      <div class="container">
+        <p class="section-kicker">How we automate the rest</p>
+        <h2 class="section-title">Automation around the AI</h2>
+        <p class="section-lead">
+          A lot of the pipeline is plain GitHub Actions with no AI at all. These run before the
+          agent to prepare its inputs, or after it to publish the result. The agent handles one
+          part, the deterministic step handles the other, so we need both.
+        </p>
+
+        <div class="wf-grid">
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Deterministic prepare steps</h3>
+              <span class="badge badge-auto">Automation</span>
+            </div>
+            <p class="wf-desc">
+              Before any agent runs, scripts do the mechanical work: a Cake task computes the API
+              diff across NuGets, mdoc regenerates the XML doc stubs, and generators produce the
+              raw release-note data. The agent starts from a clean, factual baseline rather than
+              gathering it by hand.
+            </p>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/tree/main/scripts/infra/docs" target="_blank" rel="noopener">View the docs scripts &rarr;</a>
+            </p>
+          </article>
+
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Sync - Agentic Data</h3>
+              <span class="badge badge-auto">Automation</span>
+            </div>
+            <p class="wf-desc">
+              When an agentic run finishes, this workflow downloads its uploaded artifacts and
+              commits them to the <code>aw-data</code> branch under a key derived from the workflow
+              name, for example triage reports under <code>ai-triage</code>. It keeps a durable,
+              inspectable record of what the agents did.
+            </p>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/persist-aw-data.yml" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Auto-merge docs PR</h3>
+              <span class="badge badge-auto">Automation</span>
+            </div>
+            <p class="wf-desc">
+              Watches the docs writer's pull request branch and checks the Microsoft Learn and
+              OpenPublishing build statuses. When they pass, it merges the PR. The AI proposes the
+              documentation, and a deterministic gate verifies it builds before it ships.
+            </p>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/automerge-docs.yml" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Go Live</h3>
+              <span class="badge badge-auto">Automation</span>
+            </div>
+            <p class="wf-desc">
+              Promotes the merged documentation by opening and merging a pull request from the
+              working branch into the published branch. This is the final, deliberate publish step
+              for the API reference on Microsoft Learn.
+            </p>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/go-live.yml" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+        </div>
+
+        <p class="loop-note">
+          More plain automation keeps the project moving: the website deploy and staging cleanup,
+          the samples build, the docs submodule sync, PR backport and rebase commands, and a build
+          artifacts comment for fork PRs. None of these use AI; they are the connective tissue the
+          agents plug into.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Skills ────────────────────────────────────────── -->
+    <section class="ai-section section-alt">
+      <div class="container">
+        <p class="section-kicker">Reusable instructions</p>
+        <h2 class="section-title">The skills</h2>
+        <p class="section-lead">
+          A skill is a folder under <code>.agents/skills/</code> with a <code>SKILL.md</code> file
+          that captures how to do one job well: the steps, the rules, and the checks. The agentic
+          workflows load a skill and let it drive, and maintainers invoke the same skills by hand
+          as slash commands. One source of truth, used by both the automation and the humans.
+        </p>
+
+        <div class="skill-groups">
+          <div class="skill-group">
+            <h3>Upstream &amp; Skia</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">update-skia <span class="skill-auto">Automated</span></span><br>Merge a new upstream Skia milestone, fix the C shim, regenerate bindings, and update wrappers.</li>
+              <li><span class="skill-name">review-skia-update</span><br>Security-audit a Skia merge PR by diffing against upstream and verifying generated bindings.</li>
+              <li><span class="skill-name">skia-analyst</span><br>Analyze what shipped and what is missing between Skia versions, and find APIs to bind next.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>Release</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">release-branch</span><br>Create a release branch and trigger the build chain.</li>
+              <li><span class="skill-name">release-status</span><br>Track the release build pipeline across its stages.</li>
+              <li><span class="skill-name">release-testing</span><br>Run integration tests that verify the NuGet packages on real devices.</li>
+              <li><span class="skill-name">release-publish</span><br>Publish to NuGet, tag, create the GitHub release, and close the milestone.</li>
+              <li><span class="skill-name">release-notes <span class="skill-auto">Automated</span></span><br>Generate the website release notes and API diffs from git history.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>API &amp; docs</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">api-add-review</span><br>Wrap new Skia functionality as C# APIs, or review an API PR for design and safety.</li>
+              <li><span class="skill-name">api-docs <span class="skill-auto">Automated</span></span><br>Write and review the XML API documentation following .NET guidelines.</li>
+              <li><span class="skill-name">pr-commit-message</span><br>Write high-signal merge and squash commit messages that preserve the why.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>Issues</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">issue-triage <span class="skill-auto">Automated</span></span><br>Classify an issue into structured fields, labels, and a suggested response.</li>
+              <li><span class="skill-name">issue-bulk-process</span><br>Triage and reproduce many issues in one orchestrated pass.</li>
+              <li><span class="skill-name">issue-repro</span><br>Reproduce an issue systematically and capture the result.</li>
+              <li><span class="skill-name">issue-fix</span><br>Investigate, fix, and test a bug in the C# bindings.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>Security &amp; dependencies</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">security-audit</span><br>Audit native dependencies for CVEs and Component Governance alerts. Read-only.</li>
+              <li><span class="skill-name">native-dependency-update</span><br>Update a native dependency such as libpng or zlib to fix a CVE or bug.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>Samples &amp; CI</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">sample-scout</span><br>Scout Skia GM test files for demos worth porting to the gallery.</li>
+              <li><span class="skill-name">validate-samples</span><br>Build and validate the sample projects against CI packages.</li>
+              <li><span class="skill-name">ci-status</span><br>Collect the build health across pipelines and render a daily dashboard.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>Meta</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">skill-creator</span><br>Create, improve, and measure the skills themselves.</li>
+            </ul>
+          </div>
+        </div>
+
+        <p class="loop-note">
+          Want the full text? Each skill is a plain Markdown file you can read in the repository.
+          <a href="https://github.com/mono/SkiaSharp/tree/main/.agents/skills" target="_blank" rel="noopener">Browse the skills folder &rarr;</a>
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Guardrails ────────────────────────────────────── -->
+    <section class="ai-section">
+      <div class="container">
+        <p class="section-kicker">How we keep it safe</p>
+        <h2 class="section-title">Guardrails</h2>
+        <p class="section-lead">
+          The trust story is deliberate. The agents are boxed in by design, and a human signs off
+          on everything that lands.
+        </p>
+
+        <div class="guard-grid">
+          <div class="guard">
+            <div class="guard-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M9 15l2 2 4-4"/></svg>
+            </div>
+            <h3>Deterministic first</h3>
+            <p>The mechanical work runs as plain scripts before the agent starts. The agent only does the part that needs judgement, so its surface area is small.</p>
+          </div>
+
+          <div class="guard">
+            <div class="guard-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+            </div>
+            <h3>Constrained outputs</h3>
+            <p>Each workflow declares an allow-list of safe outputs: open a pull request, add labels, set project fields. The agent cannot make arbitrary writes to the repository.</p>
+          </div>
+
+          <div class="guard">
+            <div class="guard-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+            </div>
+            <h3>Human review</h3>
+            <p>Every agentic change arrives as an ordinary pull request. A maintainer reads it, asks for changes, and merges it. Nothing the agent produces ships unreviewed.</p>
+          </div>
+
+          <div class="guard">
+            <div class="guard-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
+            </div>
+            <h3>Extra checks for docs</h3>
+            <p>The docs writer runs three correctness review passes over its own output, and the resulting PR only auto-merges after the Microsoft Learn build passes.</p>
+          </div>
+        </div>
+
+        <p class="loop-note">
+          <strong>Transparency.</strong> Everything here runs as public GitHub Actions you can
+          open and inspect, and every agentic run persists its artifacts to the
+          <a href="https://github.com/mono/SkiaSharp/tree/aw-data" target="_blank" rel="noopener"><code>aw-data</code></a>
+          branch. The machinery is not a black box; it is in the open, in the same repositories as
+          the code.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── Call to action ────────────────────────────────── -->
+    <section class="ai-section section-alt cta">
+      <div class="container">
+        <p class="section-kicker">Go deeper</p>
+        <h2 class="section-title">Read the machinery, or help build it</h2>
+        <p class="section-lead">
+          All of it is open. Read the workflows and skills, or open a pull request to make them
+          better.
+        </p>
+        <div class="hero-actions">
+          <a href="https://github.com/mono/SkiaSharp/tree/main/.github/workflows" class="btn btn-primary" target="_blank" rel="noopener">SkiaSharp workflows</a>
+          <a href="https://github.com/mono/SkiaSharp-API-docs/tree/main/.github/workflows" class="btn btn-secondary" target="_blank" rel="noopener">Docs workflows</a>
+          <a href="https://github.com/mono/SkiaSharp/tree/main/.agents/skills" class="btn btn-secondary" target="_blank" rel="noopener">The skills</a>
+          <a href="https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md" class="btn btn-secondary" target="_blank" rel="noopener">Contribute</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>
+        SkiaSharp is licensed under the <a href="https://github.com/mono/SkiaSharp/blob/main/LICENSE.md" target="_blank" rel="noopener">MIT License</a>.
+        Built with &#10084;&#65039; by the .NET community.
+      </p>
+      <div class="footer-links">
+        <a href="../">Home</a>
+        <a href="https://github.com/mono/SkiaSharp" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.nuget.org/packages/SkiaSharp" target="_blank" rel="noopener">NuGet</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../site.js"></script>
+</body>
+</html>

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -55,7 +55,7 @@
               <span class="stat-label">agentic workflows across two repositories</span>
             </div>
             <div class="stat">
-              <span class="stat-num">21</span>
+              <span class="stat-num">20</span>
               <span class="stat-label">reusable skills the workflows and maintainers share</span>
             </div>
             <div class="stat">
@@ -93,6 +93,7 @@
         <!-- Phase 1: sync to merge -->
         <p class="loop-band-label">Phase 1 &middot; Sync to merge</p>
         <div class="flow-box">
+          <p class="track-name">Engine &amp; bindings <a class="track-target" href="https://www.nuget.org/packages/SkiaSharp" target="_blank" rel="noopener">&rarr; nuget.org</a></p>
           <div class="loop">
           <div class="loop-node" data-actor="agent">
             <span class="loop-step">Step 1</span>
@@ -130,7 +131,7 @@
         <div class="parallel">
 
           <div class="flow-row">
-            <p class="track-name">Release notes &amp; API diffs <span class="track-target">&rarr; website</span></p>
+            <p class="track-name">Release notes &amp; API diffs <a class="track-target" href="../docs/releases/">&rarr; website</a></p>
             <div class="loop">
               <div class="loop-node" data-actor="auto">
                 <h3>Diff the packages</h3>
@@ -153,7 +154,7 @@
           </div>
 
           <div class="flow-row">
-            <p class="track-name">API docs <span class="track-target">&rarr; Microsoft Learn</span></p>
+            <p class="track-name">API docs <a class="track-target" href="https://learn.microsoft.com/dotnet/api/skiasharp" target="_blank" rel="noopener">&rarr; Microsoft Learn</a></p>
             <div class="loop">
               <div class="loop-node" data-actor="auto">
                 <h3>Regenerate stubs</h3>
@@ -177,11 +178,6 @@
 
         </div>
 
-        <p class="loop-note">
-          The two publish flows are genuinely independent: the release notes live in the
-          SkiaSharp repo and rebuild the website, while the API reference lives in a separate
-          repo and ships to Microsoft Learn. Neither waits on the other.
-        </p>
       </div>
     </section>
 
@@ -204,14 +200,15 @@
               <span class="badge badge-model">claude-opus-4.7</span>
             </div>
             <p class="wf-desc">
-              Merges new commits from Google's upstream Skia, resolves the conflicts, builds and
-              tests, and opens a pull request with the result. The hardest reasoning in the whole
-              pipeline, which is why it runs on the strongest model.
+              Merges new commits from Google's upstream Skia, resolves the conflicts, regenerates
+              the bindings, and opens the two paired pull requests: one in mono/skia for the
+              submodule and one in mono/SkiaSharp. The hardest reasoning in the whole pipeline,
+              which is why it runs on the strongest model.
             </p>
             <dl class="wf-meta">
               <dt>When</dt><dd>07:00, 12:00, and 17:00 UTC daily, plus manual dispatch</dd>
               <dt>Engine</dt><dd>GitHub Copilot</dd>
-              <dt>Allowed outputs</dt><dd>open a pull request</dd>
+              <dt>Allowed outputs</dt><dd>open pull requests (mono/skia submodule + mono/SkiaSharp)</dd>
               <dt>Skill</dt><dd><code>update-skia</code></dd>
               <dt>Repo</dt><dd>mono/SkiaSharp</dd>
             </dl>
@@ -346,9 +343,11 @@
               <span class="badge badge-auto">Automation</span>
             </div>
             <p class="wf-desc">
-              Watches the docs writer's pull request branch and checks the Microsoft Learn and
-              OpenPublishing build statuses. When they pass, it merges the PR. The AI proposes the
-              documentation, and a deterministic gate verifies it builds before it ships.
+              Watches the docs writer's pull request branch and waits for the
+              <code>OpenPublishing.Build</code> and <code>PoliCheck Scan</code> checks to pass with
+              no new warnings. When they do, it squash-merges the PR. The AI proposes the
+              documentation, and deterministic gates verify it builds and passes policy before it
+              ships.
             </p>
             <p class="wf-foot">
               <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/automerge-docs.yml" target="_blank" rel="noopener">View workflow source &rarr;</a>
@@ -361,9 +360,9 @@
               <span class="badge badge-auto">Automation</span>
             </div>
             <p class="wf-desc">
-              Promotes the merged documentation by opening and merging a pull request from the
-              working branch into the published branch. This is the final, deliberate publish step
-              for the API reference on Microsoft Learn.
+              The final, deliberate publish step, triggered manually by a maintainer. It opens (or
+              reuses) a pull request from <code>main</code> into the <code>live</code> branch;
+              merging that PR ships the latest API reference to Microsoft Learn.
             </p>
             <p class="wf-foot">
               <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/go-live.yml" target="_blank" rel="noopener">View workflow source &rarr;</a>
@@ -409,7 +408,7 @@
               <li><span class="skill-name">release-status</span><br>Track the release build pipeline across its stages.</li>
               <li><span class="skill-name">release-testing</span><br>Run integration tests that verify the NuGet packages on real devices.</li>
               <li><span class="skill-name">release-publish</span><br>Publish to NuGet, tag, create the GitHub release, and close the milestone.</li>
-              <li><span class="skill-name">release-notes <span class="skill-auto">Automated</span></span><br>Generate the website release notes and API diffs from git history.</li>
+              <li><span class="skill-name">release-notes <span class="skill-auto">Automated</span></span><br>Generate the website release notes and API diffs from published NuGets and git history.</li>
             </ul>
           </div>
 
@@ -446,13 +445,6 @@
               <li><span class="skill-name">sample-scout</span><br>Scout Skia GM test files for demos worth porting to the gallery.</li>
               <li><span class="skill-name">validate-samples</span><br>Build and validate the sample projects against CI packages.</li>
               <li><span class="skill-name">ci-status</span><br>Collect the build health across pipelines and render a daily dashboard.</li>
-            </ul>
-          </div>
-
-          <div class="skill-group">
-            <h3>Meta</h3>
-            <ul class="skill-list">
-              <li><span class="skill-name">skill-creator</span><br>Create, improve, and measure the skills themselves.</li>
             </ul>
           </div>
         </div>

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -77,22 +77,27 @@
         <p class="section-kicker">How it fits together</p>
         <h2 class="section-title">The loop</h2>
         <p class="section-lead">
-          The workflows chain into a mostly scheduled pipeline. Deterministic jobs prepare the
-          mechanical inputs, the agent does the part that needs judgement, and the result is a
-          reviewable PR. The same loop runs every day.
+          The Skia update lifecycle runs in two phases. First the upstream sync lands in the
+          library. Then, once a release is on main, two independent flows publish in parallel:
+          one writes the website release notes, the other writes the API reference. Automation
+          does the mechanical work, the AI agent does the parts that need judgement, and a
+          maintainer reviews before anything ships.
         </p>
 
         <ul class="legend" aria-label="Who performs each step">
           <li><span class="swatch swatch-agent"></span> AI agent</li>
-          <li><span class="swatch swatch-auto"></span> Deterministic automation</li>
-          <li><span class="swatch swatch-both"></span> Prepare then polish</li>
+          <li><span class="swatch swatch-auto"></span> Automation</li>
+          <li><span class="swatch swatch-human"></span> Human review</li>
         </ul>
 
-        <div class="loop">
+        <!-- Phase 1: sync to merge -->
+        <p class="loop-band-label">Phase 1 &middot; Sync to merge</p>
+        <div class="flow-box">
+          <div class="loop">
           <div class="loop-node" data-actor="agent">
             <span class="loop-step">Step 1</span>
             <h3>Sync upstream</h3>
-            <p>Merge new commits from Google's Skia, resolve conflicts, and update the binding.</p>
+            <p>Merge new commits from Google's Skia, resolve conflicts, and regenerate the bindings.</p>
             <span class="loop-actor">AI agent</span>
           </div>
           <div class="loop-arrow" aria-hidden="true">&rarr;</div>
@@ -100,41 +105,82 @@
           <div class="loop-node" data-actor="auto">
             <span class="loop-step">Step 2</span>
             <h3>Build &amp; test</h3>
-            <p>Build the native and managed libraries and run the test suite to catch regressions.</p>
+            <p>Build the native and managed libraries and run the full test suite on the pull requests.</p>
             <span class="loop-actor">Automation</span>
           </div>
           <div class="loop-arrow" aria-hidden="true">&rarr;</div>
 
-          <div class="loop-node" data-actor="both">
+          <div class="loop-node" data-actor="human">
             <span class="loop-step">Step 3</span>
-            <h3>Diff &amp; note</h3>
-            <p>Compute the public API diff across every NuGet, then write readable release notes.</p>
-            <span class="loop-actor">Prepare then polish</span>
+            <h3>Review &amp; merge</h3>
+            <p>A maintainer reviews the two pull requests and merges them into main.</p>
+            <span class="loop-actor">Human review</span>
           </div>
-          <div class="loop-arrow" aria-hidden="true">&rarr;</div>
-
-          <div class="loop-node" data-actor="both">
-            <span class="loop-step">Step 4</span>
-            <h3>Write docs</h3>
-            <p>Regenerate XML doc stubs, fill the missing entries, and review existing docs.</p>
-            <span class="loop-actor">Prepare then polish</span>
-          </div>
-          <div class="loop-arrow" aria-hidden="true">&rarr;</div>
-
-          <div class="loop-node" data-actor="auto">
-            <span class="loop-step">Step 5</span>
-            <h3>Publish</h3>
-            <p>Gate the docs PR on the Microsoft Learn build, auto-merge, and go live.</p>
-            <span class="loop-actor">Automation</span>
           </div>
         </div>
 
+        <!-- Vertical connector: phase 1 forks into two parallel flows -->
+        <div class="flow-connect" aria-hidden="true">
+          <span class="flow-connect-arrow">&darr;</span>
+          <span class="flow-connect-label">a release on main starts two flows in parallel</span>
+        </div>
+
+        <!-- Phase 2: two parallel publish flows -->
+        <p class="loop-band-label">Phase 2 &middot; Publish, in parallel</p>
+        <div class="parallel">
+
+          <div class="flow-row">
+            <p class="track-name">Release notes &amp; API diffs <span class="track-target">&rarr; website</span></p>
+            <div class="loop">
+              <div class="loop-node" data-actor="auto">
+                <h3>Diff the packages</h3>
+                <p>Compute the public API diff across every published NuGet of both families.</p>
+                <span class="loop-actor">Automation</span>
+              </div>
+              <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+              <div class="loop-node" data-actor="agent">
+                <h3>Polish the notes</h3>
+                <p>Turn the raw diffs and data into readable, human release notes.</p>
+                <span class="loop-actor">AI agent</span>
+              </div>
+              <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+              <div class="loop-node" data-actor="human">
+                <h3>Review &amp; merge</h3>
+                <p>A maintainer merges the docs PR and the website rebuilds.</p>
+                <span class="loop-actor">Human review</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flow-row">
+            <p class="track-name">API docs <span class="track-target">&rarr; Microsoft Learn</span></p>
+            <div class="loop">
+              <div class="loop-node" data-actor="auto">
+                <h3>Regenerate stubs</h3>
+                <p>Rebuild the XML reference stubs from the latest published packages.</p>
+                <span class="loop-actor">Automation</span>
+              </div>
+              <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+              <div class="loop-node" data-actor="agent">
+                <h3>Fill &amp; review</h3>
+                <p>Fill the missing entries and review the existing reference docs.</p>
+                <span class="loop-actor">AI agent</span>
+              </div>
+              <div class="loop-arrow" aria-hidden="true">&rarr;</div>
+              <div class="loop-node" data-actor="auto">
+                <h3>Validate &amp; publish</h3>
+                <p>The Microsoft Learn build gates the PR; it auto-merges, then a maintainer takes it live.</p>
+                <span class="loop-actor">Automation</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
         <p class="loop-note">
-          Running alongside the main line: issue triage classifies and labels new reports, the
-          security audit cross-references CVEs and Component Governance alerts, and a CI health
-          pass watches the build pipelines. Every agentic run uploads its artifacts, which a
-          separate automation commits to the <code>aw-data</code> branch so the work stays
-          inspectable and measurable over time.
+          The two publish flows are genuinely independent: the release notes live in the
+          SkiaSharp repo and rebuild the website, while the API reference lives in a separate
+          repo and ships to Microsoft Learn. Neither waits on the other.
         </p>
       </div>
     </section>

--- a/documentation/site/index.html
+++ b/documentation/site/index.html
@@ -17,6 +17,7 @@
         <span>SkiaSharp</span>
       </a>
       <nav class="header-nav">
+        <a href="ai/" class="nav-link">AI</a>
         <a href="docs/releases/" class="nav-link">Release Notes</a>
         <a href="https://www.nuget.org/packages/SkiaSharp" class="nav-link" target="_blank" rel="noopener">NuGet</a>
         <a href="https://github.com/mono/SkiaSharp" class="nav-link" target="_blank" rel="noopener">GitHub</a>
@@ -359,6 +360,15 @@ canvas.DrawPath(path, new SKPaint {
             <p class="card-desc">See what's new in every version — features, fixes, security updates, and breaking changes across 10 years of releases.</p>
             <span class="card-link">Browse release notes →</span>
           </a>
+
+          <a href="ai/" class="card">
+            <div class="card-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 3l1.9 4.6L18.5 9.5 13.9 11.4 12 16l-1.9-4.6L5.5 9.5l4.6-1.9z"/><path d="M19 14l.8 1.9L21.7 16.7l-1.9.8L19 19.4l-.8-1.9L16.3 16.7l1.9-.8z"/></svg>
+            </div>
+            <h3 class="card-title">AI in SkiaSharp</h3>
+            <p class="card-desc">See how agentic workflows and reusable skills keep this large native binding current — upstream syncing, API diffs, docs, and triage, with human review on every change.</p>
+            <span class="card-link">Explore the automation →</span>
+          </a>
         </div>
 
         <div class="cards-grid cards-grid-resources">
@@ -400,6 +410,7 @@ canvas.DrawPath(path, new SKPaint {
         Built with ❤️ by the .NET community.
       </p>
       <div class="footer-links">
+        <a href="ai/">AI in SkiaSharp</a>
         <a href="https://github.com/mono/SkiaSharp" target="_blank" rel="noopener">GitHub</a>
         <a href="https://www.nuget.org/packages/SkiaSharp" target="_blank" rel="noopener">NuGet</a>
         <a href="https://learn.microsoft.com/dotnet/api/skiasharp" target="_blank" rel="noopener">API Reference</a>


### PR DESCRIPTION
## What

Adds a new static page at **`/ai/`** that documents how SkiaSharp uses agentic AI workflows **and** plain automation to keep a large native binding current with a small team. The goal is to show both halves: **how we automate our processes** and **how we use AI** — with humans owning API design and correctness while agents do the toil.

The page lives alongside the hand-written landing page (`documentation/site/`) and reuses the shared theme (header, footer, theme toggle), with a small amount of page-scoped CSS for the pipeline diagram and workflow cards.

## Page contents

Everything is **verified against the actual workflow frontmatter and skill files** in both `mono/SkiaSharp` and `mono/SkiaSharp-API-docs` — not taken from a draft inventory on trust.

- **The loop** — upstream Skia sync → build/test → API diffs + release notes → API docs → publish, with issue triage and CI feeding in, and deterministic vs agent steps marked.
- **Agentic workflows (4)** — `Sync - Skia Upstream`, `Sync - Issue Triage`, `Sync - Release Notes & API Diffs`, and `Auto API Docs Writer` (in the API-docs repo). Each card lists exact cadence, engine/model, the `safe-outputs` allow-list, and the skill it loads.
- **Automation that pairs with the AI** — the pre/post deterministic machinery: `Sync - Agentic Data` (persist to `aw-data`), `Auto-merge docs PR` (Learn Build gating), `Go Live`, plus surrounding CI.
- **Skills** — the 21 reusable `.agents/skills/<name>/SKILL.md` files, grouped by area.
- **Guardrails & transparency** — deterministic prepare first, `safe-outputs` constrains the agent, human review on every PR, and agentic run data persisted to `aw-data`.

## Plumbing

- Wires the page into the home nav, a resource card, and the footer in `documentation/site/index.html`.
- Adds the copy step in `.github/workflows/build-site.yml` so `/ai/` ships to the deployed site (and PR staging).

## Validation

Docs-only change — no native build or tests required. Validated by serving the assembled site locally and rendering with a browser: light + dark themes, mobile responsiveness, all links resolve, zero console errors.

## Corrections vs. the draft inventory

- `Sync - Release Notes & API Diffs` opens its PR against **`main`** (via preserve-branch-name/recreate-ref with a `[docs]` title prefix and `documentation` label), **not** a `bot/release-notes` branch.
- `Sync - Issue Triage` writes artifacts that the **separate** `Sync - Agentic Data` workflow commits to `aw-data` — triage itself doesn't persist them.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>