### PR TITLE
[skia-sync] Update skia to milestone 151

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "a2147f95b91d31d5307b945f06e33eb7f2b0542f"
+          "commitHash": "5209f4a49b55104de2c521fc6f605aee530e4cd8"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b16789ec352c37e02ad38dbac55e6f47d22ff87f"
+          "commitHash": "a2147f95b91d31d5307b945f06e33eb7f2b0542f"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m150",
+          "version": "chrome/m151",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 150,
-      "upstream_merge_commit": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0"
+      "chrome_milestone": 151,
+      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
     }
   ]
 }

--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -25,6 +25,7 @@ Task("libSkiaSharp")
             $"target_os='android' " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_freetype2=false " +

--- a/native/ios/build.cake
+++ b/native/ios/build.cake
@@ -56,6 +56,7 @@ Task("libSkiaSharp")
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
             $"skia_use_metal=true " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/native/linux/build.cake
+++ b/native/linux/build.cake
@@ -106,6 +106,7 @@ Task("libSkiaSharp")
             $"skia_enable_ganesh={(SUPPORT_GPU ? "true" : "false")} " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_freetype2=false " +
@@ -153,6 +154,7 @@ Task("libHarfBuzzSharp")
             $"target_os='linux' " +
             $"target_cpu='{skiaArch}' " +
             $"visibility_hidden=false " +
+            $"skia_use_partition_alloc=false " +
             $"extra_asmflags=[] " +
             $"extra_cflags=[ '-stdlib=libc++'{bionicDefineHB} ] " +
             $"extra_ldflags=[ '-stdlib=libc++', '-static-libgcc'{staticLibcxxHB}, '-Wl,--version-script={map}' ] " +

--- a/native/macos/build.cake
+++ b/native/macos/build.cake
@@ -33,6 +33,7 @@ Task("libSkiaSharp")
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
             $"skia_use_metal=true " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/native/tizen/build.cake
+++ b/native/tizen/build.cake
@@ -44,6 +44,7 @@ Task("libSkiaSharp")
            $"skia_enable_ganesh=true " +
            $"skia_use_harfbuzz=false " +
            $"skia_use_icu=false " +
+           $"skia_use_partition_alloc=false " +
            $"skia_use_piex=true " +
            $"skia_use_system_expat=false " +
            $"skia_use_system_freetype2=true " +

--- a/native/tvos/build.cake
+++ b/native/tvos/build.cake
@@ -40,6 +40,7 @@ Task("libSkiaSharp")
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
             $"skia_use_metal=true " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -46,6 +46,7 @@ Task("libSkiaSharp")
         $"skia_use_freetype=true " +
         $"skia_use_harfbuzz=false " +
         $"skia_use_icu=false " +
+        $"skia_use_partition_alloc=false " +
         $"skia_use_piex=false " +
         $"skia_use_expat=true " +
         $"skia_use_libwebp_encode=true " +
@@ -125,6 +126,7 @@ Task("libHarfBuzzSharp")
         $"target_os='linux' " +
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
+        $"skia_use_partition_alloc=false " +
         $"extra_cflags=[ '-s', 'WARN_UNALIGNED=1' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
         $"skia_emsdk_dir='{EMSCRIPTEN_ROOT}'" +

--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -50,6 +50,7 @@ Task("libSkiaSharp")
             $"skia_use_dng_sdk=true " +
             $"skia_use_harfbuzz=false " +
             $"skia_use_icu=false " +
+            $"skia_use_partition_alloc=false " +
             $"skia_use_piex=true " +
             $"skia_use_system_expat=false " +
             $"skia_use_system_libjpeg_turbo=false " +

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m150
+skia                                            release     m151
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -65,19 +65,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   150
+libSkiaSharp            milestone   151
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      150.0.0
+libSkiaSharp            soname      151.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.150.0.0
-SkiaSharp               file        4.150.0.0
+SkiaSharp               assembly    4.151.0.0
+SkiaSharp               file        4.151.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -85,36 +85,36 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.150.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.150.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.150.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.150.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.150.0
-SkiaSharp.NativeAssets.Android                  nuget       4.150.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.150.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.150.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.150.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.150.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.150.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.150.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.150.0
-SkiaSharp.Views                                 nuget       4.150.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.150.0
-SkiaSharp.Views.Gtk3                            nuget       4.150.0
-SkiaSharp.Views.Gtk4                            nuget       4.150.0
-SkiaSharp.Views.WindowsForms                    nuget       4.150.0
-SkiaSharp.Views.WPF                             nuget       4.150.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.150.0
-SkiaSharp.Views.WinUI                           nuget       4.150.0
-SkiaSharp.Views.Maui.Core                       nuget       4.150.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.150.0
-SkiaSharp.Views.Blazor                          nuget       4.150.0
-SkiaSharp.HarfBuzz                              nuget       4.150.0
-SkiaSharp.Skottie                               nuget       4.150.0
-SkiaSharp.SceneGraph                            nuget       4.150.0
-SkiaSharp.Resources                             nuget       4.150.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.150.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.150.0
+SkiaSharp                                       nuget       4.151.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
+SkiaSharp.NativeAssets.Android                  nuget       4.151.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
+SkiaSharp.Views                                 nuget       4.151.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
+SkiaSharp.Views.Gtk3                            nuget       4.151.0
+SkiaSharp.Views.Gtk4                            nuget       4.151.0
+SkiaSharp.Views.WindowsForms                    nuget       4.151.0
+SkiaSharp.Views.WPF                             nuget       4.151.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
+SkiaSharp.Views.WinUI                           nuget       4.151.0
+SkiaSharp.Views.Maui.Core                       nuget       4.151.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
+SkiaSharp.Views.Blazor                          nuget       4.151.0
+SkiaSharp.HarfBuzz                              nuget       4.151.0
+SkiaSharp.Skottie                               nuget       4.151.0
+SkiaSharp.SceneGraph                            nuget       4.151.0
+SkiaSharp.Resources                             nuget       4.151.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.150.0
+  SKIASHARP_VERSION: 4.151.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)

--- a/scripts/infra/docs/versions.json
+++ b/scripts/infra/docs/versions.json
@@ -3,10 +3,11 @@
   "support": {
     "$comment": "SkiaSharp's SUPPORTED release paths, used only by the release-notes TOC/index grouping. SkiaSharp ships NuGet packages on two paths (it is NOT a multi-tier channel product), so this is two lists of 'major.minor' lines (the SkiaSharp MINOR number IS the Chrome/Skia milestone). 'stable' = the supported stable line(s): normally the current Chrome Stable milestone, or the Chrome Extended-stable milestone during the promotion gap (when a preview is about to go stable). 'preview' = the in-flight preview/RC line(s): normally the Chrome Beta milestone, or newer when we are previewing ahead in Dev/Canary. Every other 3.x+ line is OUT OF SUPPORT; 1.x/2.x lines are OBSOLETE. MAINTAINED BY HAND on each release (we do not ship every Chrome milestone, so this must not be auto-derived from Chromium Dash). The security audit's heads-up check (.agents/skills/security-audit/scripts/query-milestone-schedule.py) compares these lists to the live Chrome channels and reports drift; the fix is always a manual edit here. Empty/absent block => every 3.x+ line is treated as supported (legacy behavior).",
     "stable": [
-      "4.148"
+      "4.148",
+      "4.150"
     ],
     "preview": [
-      "4.150"
+      "4.151"
     ]
   },
   "skiasharp": {


### PR DESCRIPTION
Automated Skia milestone bump from m150 to m151.

**Companion skia PR:** https://github.com/mono/skia/pull/274

# Update Skia to milestone 151 (m150 → m151)

## Summary

Bumps the bundled Skia fork from chrome/m150 to chrome/m151 and SkiaSharp from 4.150.0 to 4.151.0.

- **Submodule**: `externals/skia` advances from `b16789ec352c…` to `a2147f95b91d…` (parent commit hash recorded in `cgmanifest.json`).
- **Submodule branch**: `skia-sync/m151` (327 upstream commits merged + 1 C API fix).
- **Milestone**: 150 → 151. **soname**: `libSkiaSharp.so.150.0.0` → `libSkiaSharp.so.151.0.0`. **NuGet**: 4.150.0 → 4.151.0.
- **`SK_C_INCREMENT`**: unchanged at `0` (milestone change resets the increment).
- **`HarfBuzz` soname**: unchanged (HarfBuzz was not bumped in this sync).

## Breaking change analysis

| Area | Status |
| --- | --- |
| C API surface (`include/c/*.h`, `src/c/*.cpp`) | No additions, no removals, no signature changes — verified by `regenerate-bindings.ps1` producing zero diffs in `SkiaApi.generated.cs` (or any other generated binding). |
| C++ Skia upstream | `include/private/base/*` headers flattened to `include/private/*` (the `private/base/` subdirectory is gone in m151). Only one of our C API files referenced this path; fix applied in the submodule. |
| ABI | Stable for managed callers — no SkiaSharp public-API changes were needed; no `SkiaApi.generated.cs` deltas. |
| Threading / disposal patterns | No changes. |

There are no managed (C#) source changes in this PR.

## Version / binding updates

| File | Change |
| --- | --- |
| `cgmanifest.json` | `chrome_milestone` 150→151, `commitHash` updated to submodule HEAD, `upstream_merge_commit` updated to upstream m151 tip. |
| `scripts/VERSIONS.txt` | `skia` release m150→m151, `libSkiaSharp` milestone 150→151, `libSkiaSharp` soname `150.0.0`→`151.0.0`, all `SkiaSharp*` NuGet entries bumped to 4.151.0, `SkiaSharp` assembly/file version bumped to 4.151.0.0. |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION` → 4.151.0. |
| `externals/skia` | Submodule pointer updated. |
| `binding/SkiaSharp/SkiaApi.generated.cs` and friends | Regenerated. No diffs. |

## Native build changes (cross-platform — please review)

Added `skia_use_partition_alloc=false` to the gn args in every clang platform's `native/**/build.cake`:

- `native/linux/build.cake` — both `libSkiaSharp` and `libHarfBuzzSharp` GnNinja calls.
- `native/wasm/build.cake` — both `libSkiaSharp` and `libHarfBuzzSharp` GnNinja calls.
- `native/macos/build.cake`, `native/tvos/build.cake`, `native/ios/build.cake`, `native/windows/build.cake`, `native/tizen/build.cake`, `native/android/build.cake` — `libSkiaSharp` GnNinja calls only (HarfBuzzSharp on these platforms uses xcodebuild / msbuild / ndk-build / tizen, not gn).

**Why**: m151 introduced `src/partition_alloc/`, whose `BUILD.gn` by default tries to import `${skia_partition_alloc_dir}/partition_alloc.gni`. Our `DEPS` does not vendor partition_alloc (it stays commented out), so we explicitly opt into the noop fallback shipped in `src/partition_alloc/noop/`. The default value of `skia_use_partition_alloc` is `is_clang`, which evaluates to `true` for every platform we ship, so the override is required. Per `.agents/skills/update-skia/references/known-gotchas.md` #23, the arg lives in `build.cake` rather than being passed via `--gnArgs`.

## Build & test results

This automated workflow only built **Linux x64**:

- `dotnet cake --target=externals-linux --arch=x64` → built `libSkiaSharp.so.151.0.0` (10.8 MB) and `libHarfBuzzSharp.so.0.61421.0` (2.7 MB) successfully.
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` → 0 errors, 0 warnings.
- `pwsh ./utils/generate.ps1` (via `regenerate-bindings.ps1`) → no binding diffs.
- `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` → **5,584 passed, 0 failed, 172 skipped** (skips are pre-existing GPU/headless related). Full log uploaded as `test-output.txt` artifact.

## Items needing human attention

- **Cross-platform native build verification**. Only Linux x64 was built here. Please confirm that the `skia_use_partition_alloc=false` gn arg works correctly on Windows, macOS, iOS, tvOS, Android, Tizen, and WASM CI builds before merging — this is the primary risk of this sync.
- **DEPS manual merge in the submodule PR** preserves our pinned versions for everything tracked in `cgmanifest.json`. Worth a quick eye over `mono/skia#skia-sync/m151` to confirm no required upstream dep was accidentally dropped.
- **Submodule companion PR** in `mono/skia` carries the merge + the `sk_font.cpp` include-path fix and must merge first (or at the same time) — the parent commit pins the submodule to that branch's HEAD.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).