### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "5209f4a49b55104de2c521fc6f605aee530e4cd8"
+          "commitHash": "67d4e950785b19ffa49ff1a8fd5f440ec628340d"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
+      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/275

# mono/SkiaSharp — Merge upstream `chrome/m151` bug fixes

Companion to the mono/skia PR (`skia-sync/m151`) that merges 2 new
upstream commits (docs + infra) on top of our current m151 base.

- **Base branch:** `main`
- **Head branch:** `skia-sync/m151`
- **Submodule pointer:** `5209f4a49b` → `67d4e950785b19ffa49ff1a8fd5f440ec628340d`

## Breaking change analysis

**None.** `CURRENT == TARGET == m151`, so this is a same-milestone
bug-fix sync. The 2 upstream commits picked up (see the mono/skia PR
summary) touch only `RELEASE_NOTES.md`, `relnotes/*.md`, and
`infra/bots/*.json` — no C++, no C API headers/implementations, no
`DEPS`. Consequently there is no risk of API surface, ABI, or behaviour
regression for downstream consumers.

## Version file updates

Because it is a same-milestone sync, **no version bumps** were made:

| File | Change |
|------|--------|
| `scripts/VERSIONS.txt` | *(unchanged)* — milestone / soname / assembly / file / nuget lines all stay at 151 / 151.0.0 / … |
| `scripts/azure-templates-variables.yml` | *(unchanged)* |
| `externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT`) | *(unchanged, still 0)* |
| `cgmanifest.json` (`commitHash` for `mono/skia`) | `5209f4a49b55104de2c521fc6f605aee530e4cd8` → `67d4e950785b19ffa49ff1a8fd5f440ec628340d` |
| `cgmanifest.json` (`upstream_merge_commit` for CVE tracking) | `79e2e1538e94bb1d6b5bbbc56279036aa7574b10` → `1536d3975057297af8087d22419f6c95dc96305d` |

`chrome_milestone` stays at `151`.

## Binding regeneration

Ran `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1`:

```
--- Binding diff summary ---
  No changes to bindings (C API signatures unchanged)

--- New generated functions (may need C# wrappers) ---
  No new functions found

✅ Phase 8 complete
```

`git status` after regeneration is clean apart from the already-known
`cgmanifest.json` / submodule-pointer edits — no `*.generated.cs` files
were modified. HarfBuzz bindings were auto-reverted by the script as
usual (unchanged in practice).

## C# wrapper changes

**None.** No new C API functions ⇒ no new wrappers needed.

## Build & test results (Linux x64)

- **Native build (Phase 7):** `dotnet cake --target=externals-linux --arch=x64` — **success** (15m 43s total; libSkiaSharp 14m 16s, libHarfBuzzSharp 1m 11s). Both `libSkiaSharp.so.151.0.0` and `libHarfBuzzSharp.so.0.61421.0` produced in `output/native/linux/x64/`.
- **C# build (Phase 9):** `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — **success**, 0 warnings, 0 errors across all TFMs (netstandard2.0/2.1, net462/48, net6.0, net9.0, net10.0, net9.0-android35.0, net10.0-android36.0).
- **Tests (Phase 10):** `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` (net10.0 / x64):

  ```
  Passed! - Failed: 0, Passed: 5584, Skipped: 172, Total: 5756, Duration: 2m 41s
  ```

  Full log at `/tmp/gh-aw/agent/test-output.txt` (uploaded as workflow
  artifact). Note: a `--filter "Category=Smoke"` was requested but the
  new `Microsoft.Testing.Platform` runner emitted `MTP0001 warning
  VSTest-specific properties are set but will be ignored` and executed
  the full suite instead — which is the stronger signal we actually
  need, so no re-run was necessary.

## Items needing human attention

None. This is a low-risk, docs/infra-only upstream sync with a green
full build + test on Linux x64. Other platforms
(Windows/macOS/iOS/Android/WASM) will be exercised by CI on this PR.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).