### PR TITLE
[skia-sync] Drive upstream sync from versions.json with a run-number rotation

### DIFF
--- a/.agents/skills/update-skia/SKILL.md
+++ b/.agents/skills/update-skia/SKILL.md
@@ -407,6 +407,11 @@ cd ../..  # back to parent repo (Phase 5 ends inside externals/skia)
 pwsh .agents/skills/update-skia/scripts/update-versions.ps1 -Current {CURRENT} -Target {TARGET}
 ```
 
+> **Main-tip sync?** When Phase 5 merged `upstream/main` (not a `chrome/m{TARGET}` branch),
+> add `-UpstreamRef main` so `cgmanifest.json`'s `upstream_merge_commit` is resolved from the
+> ref you actually merged. Without it the script defaults to `upstream/chrome/m{TARGET}`, which
+> does not exist on a tip merge, and `upstream_merge_commit` is left `UNKNOWN` for you to set by hand.
+
 The script handles all of these (so you don't have to do them manually):
 - `scripts/VERSIONS.txt`: milestone, increment→0, soname, assembly, file, ALL ~30 nuget lines
 - `cgmanifest.json`: commitHash, version, chrome_milestone, upstream_merge_commit

--- a/.agents/skills/update-skia/scripts/update-versions.ps1
+++ b/.agents/skills/update-skia/scripts/update-versions.ps1
@@ -18,8 +18,18 @@
 .PARAMETER Target
     The target Skia milestone number (e.g., 120)
 
+.PARAMETER UpstreamRef
+    The upstream ref that was actually merged, as named under the `upstream` remote
+    (without the `upstream/` prefix). Normally `chrome/m<Target>`; pass `main` for a
+    bleeding-edge main-tip sync (where no `chrome/m<Target>` branch is merged). Defaults
+    to `chrome/m<Target>`.
+
 .EXAMPLE
     pwsh .agents/skills/update-skia/scripts/update-versions.ps1 -Current 119 -Target 120
+
+.EXAMPLE
+    # main-tip sync (same milestone, merged from upstream/main):
+    pwsh .agents/skills/update-skia/scripts/update-versions.ps1 -Current 151 -Target 151 -UpstreamRef main
 #>
 
 param(
@@ -27,7 +37,9 @@ param(
     [int]$Current,
 
     [Parameter(Mandatory=$true)]
-    [int]$Target
+    [int]$Target,
+
+    [string]$UpstreamRef
 )
 
 $ErrorActionPreference = 'Stop'
@@ -69,13 +81,20 @@ $cgContent = Get-Content $cgPath -Raw
 $submoduleHash = git -C (Join-Path $repoRoot 'externals/skia') rev-parse HEAD
 Write-Host "  Submodule HEAD: $submoduleHash"
 
-# Get upstream merge commit
-$upstreamHash = git -C (Join-Path $repoRoot 'externals/skia') rev-parse "upstream/chrome/m$Target" 2>$null
-if (-not $upstreamHash) {
-    Write-Warning "  Could not resolve upstream/chrome/m$Target - set upstream_merge_commit manually"
+# Get upstream merge commit. Resolve the ref that was ACTUALLY merged: a chrome/m<N>
+# milestone branch normally, or `main` for a bleeding-edge tip sync. `--verify --quiet`
+# makes git fail cleanly (empty output + non-zero $LASTEXITCODE) when the ref is missing,
+# instead of echoing the literal argument back on stdout — without it, a wrong or absent
+# ref (e.g. upstream/chrome/m151 on a main-tip merge) would be written verbatim into
+# upstream_merge_commit as if it were a SHA. `^{commit}` peels the ref to its commit.
+if (-not $UpstreamRef) { $UpstreamRef = "chrome/m$Target" }
+$upstreamHash = git -C (Join-Path $repoRoot 'externals/skia') rev-parse --verify --quiet "upstream/$UpstreamRef^{commit}"
+if ($LASTEXITCODE -ne 0 -or -not $upstreamHash) {
+    Write-Warning "  Could not resolve upstream/$UpstreamRef - set upstream_merge_commit manually"
     $upstreamHash = "UNKNOWN"
 } else {
-    Write-Host "  Upstream m$Target tip: $upstreamHash"
+    $upstreamHash = $upstreamHash.Trim()
+    Write-Host "  Upstream ($UpstreamRef) tip: $upstreamHash"
 }
 
 # Update cgmanifest.json fields

--- a/.github/scripts/skia-sync-detect.sh
+++ b/.github/scripts/skia-sync-detect.sh
@@ -15,43 +15,41 @@
 #     (so GitHub renders annotations and the machine output stays clean for sourcing).
 #
 # Args:
-#   --mode <current|next|latest|main>  Which milestone line to track. The workflow resolves
-#                                  this from the dispatch input or the triggering cron
-#                                  (the cron→mode mapping lives in the workflow, next to
-#                                  where the crons are declared). Defaults to `next`.
-#                                  `main` is the bleeding-edge tip: it merges google/skia's
-#                                  `main` HEAD (not a chrome/m<N> branch) into the newest
-#                                  line. It is NOT a version bump — the target milestone
-#                                  stays equal to main's current milestone.
-#   --milestone <number>           Exact milestone override; when set, mode becomes
-#                                  `explicit` and the target is this number.
+#   --target <""|main|number>      What to sync. There are only two shapes:
+#                                    * empty  → ROTATE: pick one supported versions.json
+#                                               line per run, round-robin (rotate_select).
+#                                               This is the scheduled default.
+#                                    * main   → the bleeding-edge tip: merge google/skia's
+#                                               `main` HEAD (not a chrome/m<N> branch) into
+#                                               the newest line. NOT a version bump — the
+#                                               target milestone stays == main's milestone.
+#                                    * number → an exact milestone (e.g. 151); merge
+#                                               chrome/m<number>.
 #   --gate                         Also run the gating checks (does upstream exist? is it
 #                                  already merged?) and emit `skip=true` / exit
 #                                  accordingly. Only pre_activation needs this.
 #
 # Inputs (env):
-#   GITHUB_REPOSITORY owner/repo of this SkiaSharp checkout (default GitHub env)
-#   GITHUB_REF        ref whose scripts/VERSIONS.txt gives main's milestone
-#   GH_TOKEN          token for `gh api`
+#   GITHUB_REPOSITORY  owner/repo of this SkiaSharp checkout (default GitHub env)
+#   GITHUB_SHA         immutable triggering commit; main's config is read here so the two
+#                      detector invocations of a run agree (falls back to GITHUB_REF)
+#   GITHUB_REF         branch ref (fallback, and used for release-line reads)
+#   GITHUB_RUN_NUMBER  per-workflow run counter; the rotation round-robin index
+#   GH_TOKEN           token for `gh api`
 
 set -euo pipefail
 
 GATE=false
-MODE=""
-MILESTONE=""
+SYNC_TARGET=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --gate) GATE=true; shift ;;
-    --mode)
-      [ $# -ge 2 ] || { echo "::error::skia-sync-detect.sh: --mode requires a value"; exit 2; }
-      MODE="$2"; shift 2 ;;
-    --milestone)
-      [ $# -ge 2 ] || { echo "::error::skia-sync-detect.sh: --milestone requires a value"; exit 2; }
-      MILESTONE="$2"; shift 2 ;;
+    --target)
+      [ $# -ge 2 ] || { echo "::error::skia-sync-detect.sh: --target requires a value"; exit 2; }
+      SYNC_TARGET="$2"; shift 2 ;;
     *) echo "::error::skia-sync-detect.sh: unknown argument '$1'"; exit 2 ;;
   esac
 done
-MODE="${MODE:-next}"
 
 OUT="${SKIA_SYNC_OUT:-${GITHUB_OUTPUT:?SKIA_SYNC_OUT or GITHUB_OUTPUT must be set}}"
 emit() { printf '%s=%s\n' "$1" "$2" >>"$OUT"; }
@@ -62,28 +60,105 @@ milestone_of() {
     --jq '.content' | base64 -d | grep '^libSkiaSharp.*milestone' | awk '{print $NF}'
 }
 
-# -- Mode -------------------------------------------------------------
-# Resolved by the caller (workflow): the cron→mode mapping lives in the workflow,
-# next to where the crons are declared. Here it is simply a value in
-# {current,next,latest,main}.
-MAIN_MS=$(milestone_of "$GITHUB_REF")
+# -- Milestone facts --------------------------------------------------
+# SYNC_TARGET (the single dispatch input) is empty for scheduled/rotation runs, `main`
+# for a bleeding-edge tip sync, or an exact milestone number. MAIN_MS is main's shipped
+# milestone; NEXT (= MAIN_MS + 1) is the rotation's leading-edge fallback.
+#
+# Read main's config at the IMMUTABLE triggering commit ($GITHUB_SHA), not the branch
+# ref: both the pre_activation gate and the agent-job align step re-run this script, and
+# a branch (GITHUB_REF) could advance between them and make them disagree. (Release-line
+# reads below intentionally use the branch name, to pick up that line's own tip.)
+REF_IMMUTABLE="${GITHUB_SHA:-$GITHUB_REF}"
+MAIN_MS=$(milestone_of "$REF_IMMUTABLE")
 NEXT=$((MAIN_MS + 1))
-LATEST=$(git ls-remote --heads https://github.com/google/skia.git 'refs/heads/chrome/m*' \
-  | sed -n 's|.*refs/heads/chrome/m\([0-9]*\)$|\1|p' | sort -n | tail -1)
+
+# -- Rotation helpers -------------------------------------------------
+# The rotation (used by every scheduled run) drives the sync set from the hand-maintained
+# `support` block in scripts/infra/docs/versions.json — the single source of truth for
+# which lines we actually ship — instead of a fixed cron→mode map.
+
+# versions.json `support` block, read remotely at the immutable triggering commit
+# (pre_activation only sparse-checks out .github/scripts, so the file is not on disk).
+support_json() {
+  gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/infra/docs/versions.json?ref=${REF_IMMUTABLE}" \
+    --jq '.content' | base64 -d
+}
+# Has upstream cut the chrome/m<N> milestone branch yet? Fail hard on a lookup error so a
+# transient git failure can't be mistaken for "branch absent" and silently fall back to main.
+chrome_branch_exists() {
+  local out
+  if ! out=$(git ls-remote --heads https://github.com/google/skia.git "refs/heads/chrome/m$1"); then
+    echo "::error::git ls-remote failed while checking upstream chrome/m$1"
+    exit 1
+  fi
+  [ -n "$out" ]
+}
+
+# rotate_select: enumerate the supported lines (stables ascending, then previews
+# ascending, then the single leading-edge `next`) and pick ONE per run, round-robin.
+#
+# The picker is GITHUB_RUN_NUMBER, which increments by exactly 1 per run of THIS workflow
+# and is identical across every job/step of a run. So the round-robin is fully
+# deterministic between the pre_activation gate and the agent-job align step (separate
+# jobs that each re-run this script) — no wall-clock read, so no risk of the two steps
+# landing on different targets near a time boundary. It advances one line per run; with a
+# 6-hourly schedule that is one line every 6h, cycling through a list of ANY length.
+#
+# `next` = highest supported milestone + 1: if upstream has a chrome/m<N> branch it is
+# a real milestone bump into main; otherwise it falls back to the bleeding-edge main tip
+# (head skia-sync/main). The skip-gate no-ops any run that has nothing new, so a run
+# landing on an up-to-date line is essentially free.
+rotate_select() {
+  local support next_ms specs len idx chosen rest m run_number
+  local -a stable_ms preview_ms
+  support=$(support_json)
+  readarray -t stable_ms < <(printf '%s' "$support" \
+    | jq -r '[.support.stable[]?  | (split(".")[1]|tonumber)] | sort | .[]')
+  readarray -t preview_ms < <(printf '%s' "$support" \
+    | jq -r '[.support.preview[]? | (split(".")[1]|tonumber)] | sort | .[]')
+
+  specs=()
+  for m in "${stable_ms[@]}";  do [ -n "$m" ] && specs+=("stable|$m|chrome/m$m"); done
+  for m in "${preview_ms[@]}"; do [ -n "$m" ] && specs+=("preview|$m|chrome/m$m"); done
+
+  next_ms=$(printf '%s' "$support" \
+    | jq -r '[.support.stable[]?, .support.preview[]? | (split(".")[1]|tonumber)] | if length>0 then (max+1) else empty end')
+  [ -n "$next_ms" ] || next_ms="$NEXT"
+  if chrome_branch_exists "$next_ms"; then
+    specs+=("next|$next_ms|chrome/m$next_ms")
+  else
+    specs+=("main|$MAIN_MS|main")
+  fi
+
+  len=${#specs[@]}
+  if [ "$len" -eq 0 ]; then
+    echo "::error::rotation produced no targets — versions.json 'support' block is empty."
+    exit 1
+  fi
+
+  # Deterministic round-robin index — see the function header (GITHUB_RUN_NUMBER is stable
+  # across both detector invocations of a run). Defaults to 0 outside Actions.
+  run_number="${GITHUB_RUN_NUMBER:-0}"
+  idx=$(( run_number % len ))
+  chosen="${specs[$idx]}"
+  MODE="${chosen%%|*}"
+  rest="${chosen#*|}"
+  TARGET="${rest%%|*}"
+  UPSTREAM_REF="${rest#*|}"
+  echo "Rotation: ${len} target(s) [$(IFS=' '; echo "${specs[*]}")]; run=${run_number} idx=${idx} → ${chosen}"
+}
 
 # -- Target -----------------------------------------------------------
-# UPSTREAM_REF is the google/skia ref we merge FROM: a `chrome/m<N>` milestone branch
-# for every mode except `main`, which merges the very tip (`refs/heads/main` HEAD).
-if [ -n "$MILESTONE" ]; then
-  TARGET="$MILESTONE"; MODE="explicit"; UPSTREAM_REF="chrome/m${TARGET}"
-elif [ "$MODE" = main ]; then
-  TARGET="$MAIN_MS"; UPSTREAM_REF="main"
-elif [ "$MODE" = latest ]; then
-  TARGET="$LATEST"; UPSTREAM_REF="chrome/m${TARGET}"
-elif [ "$MODE" = current ]; then
-  TARGET="$MAIN_MS"; UPSTREAM_REF="chrome/m${TARGET}"
+# UPSTREAM_REF is the google/skia ref we merge FROM. Two shapes only (see --target):
+# empty ⇒ rotate over versions.json; `main` ⇒ upstream tip; a number ⇒ chrome/m<number>.
+INVALID=false
+if [ -z "$SYNC_TARGET" ]; then
+  rotate_select
+elif [ "$SYNC_TARGET" = main ]; then
+  MODE="main"; TARGET="$MAIN_MS"; UPSTREAM_REF="main"
 else
-  TARGET="$NEXT"; UPSTREAM_REF="chrome/m${TARGET}"
+  MODE="explicit"; TARGET="$SYNC_TARGET"; UPSTREAM_REF="chrome/m${TARGET}"
 fi
 
 # -- Target line: `main` (newest) vs a release/<major>.<TARGET>.x maintenance line.
@@ -94,8 +169,8 @@ fi
 #
 # The `main` (tip) mode targets the newest line too (TARGET == MAIN_MS, so the
 # release-detection block below stays skipped), but uses a DISTINCT head branch
-# (`skia-sync/main`) so a bleeding-edge tip sync never collides with the `current`
-# milestone sync branch (`skia-sync/m${TARGET}`).
+# (`skia-sync/main`) so a bleeding-edge tip sync never collides with a same-milestone
+# sync branch (`skia-sync/m${TARGET}`).
 IS_RELEASE=false
 BASE_BRANCH=main
 SKIA_BASE_BRANCH=skiasharp
@@ -129,6 +204,12 @@ if [ -n "$RELEASE_BRANCH" ]; then
     echo "::error::mono/skia branch '${SKIA_BASE_BRANCH}' does not exist. Release branches are owned by the release process (release-branch skill) — create it before running a release sync for m${TARGET}."
     exit 1
   fi
+elif [ "$TARGET" -lt "$MAIN_MS" ] 2>/dev/null; then
+  # A supported/rotation line older than main but with NO release/<major>.<TARGET>.x
+  # branch has no home — do NOT merge an older milestone into main. Flag it so the gate
+  # skips (fix versions.json 'support' if this milestone should still be synced).
+  INVALID=true
+  echo "::notice::milestone m${TARGET} is older than main (m${MAIN_MS}) but has no release/*.${TARGET}.x branch — nothing to sync."
 fi
 
 # `current` = milestone of the BASE branch we sync INTO:
@@ -141,8 +222,6 @@ else
 fi
 
 emit mode "$MODE"
-emit next "$NEXT"
-emit latest "$LATEST"
 emit target "$TARGET"
 emit upstream_ref "$UPSTREAM_REF"
 emit is_release "$IS_RELEASE"
@@ -151,10 +230,16 @@ emit skia_base_branch "$SKIA_BASE_BRANCH"
 emit head_branch "$HEAD_BRANCH"
 emit current "$CURRENT"
 
-echo "Resolved: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, upstream=${UPSTREAM_REF}, base milestone=m${CURRENT}, latest=m${LATEST}, head=${HEAD_BRANCH}, release=${IS_RELEASE})"
+echo "Resolved: m${TARGET} → ${BASE_BRANCH} (mode=${MODE}, upstream=${UPSTREAM_REF}, base milestone=m${CURRENT}, head=${HEAD_BRANCH}, release=${IS_RELEASE}, invalid=${INVALID})"
 
 # Branch derivation is all the agent job needs; gating is pre_activation-only.
 $GATE || exit 0
+
+# A supported/rotation line older than main with no release branch has nowhere to sync.
+if [ "$INVALID" = true ]; then
+  emit skip true
+  exit 0
+fi
 
 # -- Gate: only spin up the (expensive) agent when there is new upstream work ----
 UPSTREAM_SHA=$(git ls-remote https://github.com/google/skia.git "refs/heads/${UPSTREAM_REF}" | awk '{print $1}')

--- a/.github/workflows/auto-skia-sync.lock.yml
+++ b/.github/workflows/auto-skia-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fb2388bb266b109c5727d03cc4df6bff13263ccfd846bd1114b7e697d96e957b","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4d32e51a9e0bdb75f3ac5dd76c986d40b98d171fbe18dc9df900fc2b805d7791","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","SKIASHARP_AUTOBUMP_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,9 +55,7 @@
 name: "Sync - Skia Upstream"
 "on":
   schedule:
-  - cron: "0 7 * * *"
-  - cron: "0 12 * * *"
-  - cron: "0 17 * * *"
+  - cron: "0 */6 * * *"
   # steps: # Steps injected into pre-activation job
   # - name: Check out detection scripts
     # uses: actions/checkout@v4
@@ -65,15 +63,10 @@ name: "Sync - Skia Upstream"
       # sparse-checkout: .github/scripts
   # - env:
       # GH_TOKEN: ${{ github.token }}
-      # MILESTONE: ${{ github.event.inputs.milestone }}
-      # MODE: |-
-        # ${{ github.event.inputs.mode
-            # || (github.event.schedule == '0 7 * * *' && 'current')
-            # || (github.event.schedule == '0 17 * * *' && 'latest')
-            # || 'next' }}
+      # SYNC_TARGET: ${{ github.event.inputs.target }}
     # id: detect
     # name: Detect milestone
-    # run: bash .github/scripts/skia-sync-detect.sh --gate --mode "$MODE" --milestone "$MILESTONE"
+    # run: bash .github/scripts/skia-sync-detect.sh --gate --target "$SYNC_TARGET"
   workflow_dispatch:
     inputs:
       aw_context:
@@ -81,26 +74,16 @@ name: "Sync - Skia Upstream"
         description: Agent caller context (used internally by Agentic Workflows).
         required: false
         type: string
-      milestone:
-        description: Exact milestone number (e.g. 148) — overrides mode if set
+      target:
+        description: What to sync. Empty = rotate over the supported versions.json lines (the scheduled default). Or a milestone number (e.g. 151), or `main` for the very tip of upstream Skia (google/skia main HEAD — bleeding edge, NOT a version bump).
         required: false
         type: string
-      mode:
-        default: next
-        description: Which milestone to track. `main` syncs the very tip of upstream Skia (google/skia main HEAD) — dispatch-only, bleeding edge, NOT a version bump.
-        options:
-        - current
-        - next
-        - latest
-        - main
-        required: false
-        type: choice
 
 permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: skia-upstream-sync-${{ github.event.inputs.mode || github.event.schedule || 'manual' }}
+  group: skia-upstream-sync-${{ github.event.inputs.target || github.event.schedule || 'manual' }}
 
 run-name: "Sync - Skia Upstream"
 
@@ -236,23 +219,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_011236f10bc2c8a3_EOF'
+          cat << 'GH_AW_PROMPT_98d682d7e7519a45_EOF'
           <system>
-          GH_AW_PROMPT_011236f10bc2c8a3_EOF
+          GH_AW_PROMPT_98d682d7e7519a45_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_011236f10bc2c8a3_EOF'
+          cat << 'GH_AW_PROMPT_98d682d7e7519a45_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_011236f10bc2c8a3_EOF
+          GH_AW_PROMPT_98d682d7e7519a45_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_011236f10bc2c8a3_EOF'
+          cat << 'GH_AW_PROMPT_98d682d7e7519a45_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_011236f10bc2c8a3_EOF
+          GH_AW_PROMPT_98d682d7e7519a45_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_011236f10bc2c8a3_EOF'
+          cat << 'GH_AW_PROMPT_98d682d7e7519a45_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -284,12 +267,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_011236f10bc2c8a3_EOF
+          GH_AW_PROMPT_98d682d7e7519a45_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_011236f10bc2c8a3_EOF'
+          cat << 'GH_AW_PROMPT_98d682d7e7519a45_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-skia-sync.md}}
-          GH_AW_PROMPT_011236f10bc2c8a3_EOF
+          GH_AW_PROMPT_98d682d7e7519a45_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -463,7 +446,7 @@ jobs:
       - name: Align submodule to the base branch
         run: |
           OUT=$(mktemp)
-          SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh --mode "$MODE" --milestone "$MILESTONE"
+          SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh --target "$SYNC_TARGET"
           set -a; . "$OUT"; set +a
           bash .github/scripts/skia-sync-align-submodule.sh
         env:
@@ -472,13 +455,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_API_URL: https://localhost:18443/api/v3
           GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
-          MILESTONE: ${{ github.event.inputs.milestone }}
-          MODE: |-
-            ${{ github.event.inputs.mode
-                || (github.event.schedule == '0 7 * * *' && 'current')
-                || (github.event.schedule == '0 17 * * *' && 'latest')
-                || 'next' }}
           NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
+          SYNC_TARGET: ${{ github.event.inputs.target }}
       - name: Copy push script for post-step
         run: cp .github/scripts/skia-sync-push-prs.sh /tmp/gh-aw/skia-sync-push-prs.sh
         env:
@@ -558,9 +536,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1c0d66bd1e4f6d52_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4164d86e84e0ab14_EOF'
           {"create_pull_request":{"if_no_changes":"ignore","max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"staged":true},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1c0d66bd1e4f6d52_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4164d86e84e0ab14_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -766,7 +744,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_46ab8df01cc8e83e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_38116be08e821048_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -814,7 +792,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_46ab8df01cc8e83e_EOF
+          GH_AW_MCP_CONFIG_38116be08e821048_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1381,10 +1359,8 @@ jobs:
       detect_result: ${{ steps.detect.outcome }}
       head_branch: ${{ steps.detect.outputs.head_branch }}
       is_release: ${{ steps.detect.outputs.is_release }}
-      latest: ${{ steps.detect.outputs.latest }}
       matched_command: ''
       mode: ${{ steps.detect.outputs.mode }}
-      next: ${{ steps.detect.outputs.next }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       skia_base_branch: ${{ steps.detect.outputs.skia_base_branch }}
       skip: ${{ steps.detect.outputs.skip }}
@@ -1419,15 +1395,10 @@ jobs:
           sparse-checkout: .github/scripts
       - name: Detect milestone
         id: detect
-        run: bash .github/scripts/skia-sync-detect.sh --gate --mode "$MODE" --milestone "$MILESTONE"
+        run: bash .github/scripts/skia-sync-detect.sh --gate --target "$SYNC_TARGET"
         env:
           GH_TOKEN: ${{ github.token }}
-          MILESTONE: ${{ github.event.inputs.milestone }}
-          MODE: |-
-            ${{ github.event.inputs.mode
-                || (github.event.schedule == '0 7 * * *' && 'current')
-                || (github.event.schedule == '0 17 * * *' && 'latest')
-                || 'next' }}
+          SYNC_TARGET: ${{ github.event.inputs.target }}
 
   safe_outputs:
     needs:

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -10,23 +10,17 @@ engine:
   model: claude-opus-4.7
 
 # -- Triggers ----------------------------------------------------------
-# Three daily crons: current (7 AM), next (12 PM), latest (5 PM UTC).
-# Manual dispatch with mode selector.
+# One cron every 6h (`0 */6 * * *` → 00/06/12/18 UTC). Scheduled runs pass no target,
+# so the detector ROTATES: it picks ONE supported line from versions.json per run,
+# round-robin (see .github/scripts/skia-sync-detect.sh / rotate_select). Manual dispatch
+# may pin a specific `target` (a milestone number, or `main` for the upstream tip).
 on:
   schedule:
-    - cron: "0 7 * * *"
-    - cron: "0 12 * * *"
-    - cron: "0 17 * * *"
+    - cron: "0 */6 * * *"
   workflow_dispatch:
     inputs:
-      mode:
-        description: "Which milestone to track. `main` syncs the very tip of upstream Skia (google/skia main HEAD) — dispatch-only, bleeding edge, NOT a version bump."
-        required: false
-        type: choice
-        default: next
-        options: [current, next, latest, main]
-      milestone:
-        description: "Exact milestone number (e.g. 148) — overrides mode if set"
+      target:
+        description: "What to sync. Empty = rotate over the supported versions.json lines (the scheduled default). Or a milestone number (e.g. 151), or `main` for the very tip of upstream Skia (google/skia main HEAD — bleeding edge, NOT a version bump)."
         required: false
         type: string
 
@@ -45,20 +39,16 @@ on:
         sparse-checkout: .github/scripts
     - name: Detect milestone
       id: detect
-      # The cron→mode mapping lives HERE, next to the cron declarations:
-      # 7 AM → current, 5 PM → latest, everything else (12 PM cron + the
-      # workflow_dispatch default) → next. Staged into env vars rather than
-      # interpolated straight into `run:`, so the free-form `milestone` input
-      # can't inject shell — the script consumes them as real --mode/--milestone args.
+      # Scheduled runs pass an empty target — the detector then ROTATES: it reads
+      # versions.json's `support` block and picks one supported line per run, round-robin
+      # by GITHUB_RUN_NUMBER (stable across jobs, so this gate and the agent-job align step
+      # resolve the SAME target). Manual dispatch passes a milestone number or `main`.
+      # Staged into an env var rather than interpolated into `run:`, so the free-form input
+      # can't inject shell — the script consumes it as a real --target arg.
       env:
-        MODE: >-
-          ${{ github.event.inputs.mode
-              || (github.event.schedule == '0 7 * * *' && 'current')
-              || (github.event.schedule == '0 17 * * *' && 'latest')
-              || 'next' }}
-        MILESTONE: ${{ github.event.inputs.milestone }}
+        SYNC_TARGET: ${{ github.event.inputs.target }}
         GH_TOKEN: ${{ github.token }}
-      run: bash .github/scripts/skia-sync-detect.sh --gate --mode "$MODE" --milestone "$MILESTONE"
+      run: bash .github/scripts/skia-sync-detect.sh --gate --target "$SYNC_TARGET"
 
 # -- Pre-activation outputs ------------------------------------------
 # Expose detect step outputs for use in the prompt and other jobs.
@@ -67,8 +57,6 @@ jobs:
   pre-activation:
     outputs:
       current: ${{ steps.detect.outputs.current }}
-      next: ${{ steps.detect.outputs.next }}
-      latest: ${{ steps.detect.outputs.latest }}
       target: ${{ steps.detect.outputs.target }}
       upstream_ref: ${{ steps.detect.outputs.upstream_ref }}
       mode: ${{ steps.detect.outputs.mode }}
@@ -88,7 +76,7 @@ checkout:
     submodules: recursive
 timeout-minutes: 120
 concurrency:
-  group: skia-upstream-sync-${{ github.event.inputs.mode || github.event.schedule || 'manual' }}
+  group: skia-upstream-sync-${{ github.event.inputs.target || github.event.schedule || 'manual' }}
   cancel-in-progress: true
 
 # -- Agent tools -----------------------------------------------------
@@ -164,21 +152,19 @@ steps:
     run: |
       mkdir -p /tmp/gh-aw/agent
   - name: Align submodule to the base branch
-    # Same cron→mode resolution as the pre_activation detect step (see there). The
-    # agent job can't read pre_activation's outputs (it only `needs:` activation), so
-    # re-run the same committed detector to recover base_branch / skia_base_branch,
-    # then align the submodule. skia-sync-detect.sh is the single source of truth.
+    # Same target resolution as the pre_activation detect step (see there). The agent job
+    # can't read pre_activation's outputs (it only `needs:` activation), so re-run the
+    # same committed detector to recover base_branch / skia_base_branch, then align the
+    # submodule. For rotation runs (empty target) the detector picks the SAME line as
+    # pre_activation because the round-robin index is GITHUB_RUN_NUMBER (identical across
+    # jobs) and main's config is read at the immutable $GITHUB_SHA. skia-sync-detect.sh is
+    # the single source of truth.
     env:
-      MODE: >-
-        ${{ github.event.inputs.mode
-            || (github.event.schedule == '0 7 * * *' && 'current')
-            || (github.event.schedule == '0 17 * * *' && 'latest')
-            || 'next' }}
-      MILESTONE: ${{ github.event.inputs.milestone }}
+      SYNC_TARGET: ${{ github.event.inputs.target }}
       GH_TOKEN: ${{ github.token }}
     run: |
       OUT=$(mktemp)
-      SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh --mode "$MODE" --milestone "$MILESTONE"
+      SKIA_SYNC_OUT="$OUT" bash .github/scripts/skia-sync-detect.sh --target "$SYNC_TARGET"
       set -a; . "$OUT"; set +a
       bash .github/scripts/skia-sync-align-submodule.sh
   - name: Copy push script for post-step

--- a/.github/workflows/auto-skia-sync.md
+++ b/.github/workflows/auto-skia-sync.md
@@ -248,6 +248,10 @@ Release-line sync: `${{ needs.pre_activation.outputs.is_release }}`.
 - **Phase 6 (version files)**: For a release-line sync (`is_release == true`, so `current == target`) this is a
   bug-fix-only sync — keep the release line's milestone/soname/nuget versions unchanged; the only expected
   parent-repo change is `cgmanifest.json`'s commit hash. Do NOT advance the milestone.
+  Pass the ref you actually merged to `update-versions.ps1` so `cgmanifest.json`'s `upstream_merge_commit`
+  resolves to a real SHA: **`-UpstreamRef "${{ needs.pre_activation.outputs.upstream_ref }}"`**
+  (this is `chrome/m<N>` for a milestone sync, or `main` for a tip sync — the script defaults to
+  `chrome/m{target}`, which does NOT exist on a `main`-tip merge).
 - **Build platform**: use Linux x64 (`dotnet cake --target=externals-linux --arch=x64`). Clang is pre-configured via env vars.
   This also applies to Phase 10 if a native rebuild is needed.
 - **Native build environment is provisioned by the host workflow** (clang, `libc++-dev`/`libc++abi-dev`,


### PR DESCRIPTION
## What

Reworks the `auto-skia-sync` upstream-sync automation to be driven by
`scripts/infra/docs/versions.json` instead of a fixed `current`/`next`/`latest`/`main`
mode map, simplifies the trigger surface, and fixes a related `update-versions.ps1`
bug surfaced while validating the main-tip path.

## 1. versions.json-driven rotation

### Before
- Three daily crons mapped to `current` (main's milestone), `next` (+1), `latest`
  (highest upstream `chrome/m*`), plus dispatch-only `main`.
- The **supported stable lines were never auto-synced** — e.g. `release/4.148.x` and
  `release/4.150.x` only got bug-fix syncs if a human dispatched them by number.

### After
- **One `0 */6 * * *` cron.** Scheduled runs **rotate**: each run syncs one supported
  line from `versions.json`'s `support` block (`stable` ascending, then `preview`
  ascending), plus a trailing **`next`** = highest supported milestone + 1 (a real
  milestone bump into `main` if upstream cut `chrome/m<next>`, else the upstream `main`
  tip on `skia-sync/main`).
- **Single dispatch input `target`:** empty = rotate, `main` = upstream tip, or a
  milestone number (e.g. `151`) = explicit sync. The old `mode`/`milestone` inputs are gone.
- Round-robin index = `GITHUB_RUN_NUMBER % len`, so coverage self-adjusts to however many
  lines `versions.json` lists (verified for 2/4/5 lines).

### Correctness (from a GPT-5.5 review)
The detector runs twice per run — the pre_activation `--gate` step and the agent-job
align step (separate jobs that can't share outputs). Three fixes ensure they never diverge:
- Rotation keyed on `GITHUB_RUN_NUMBER` (identical across jobs) — no wall-clock read.
- Main's config read at the immutable `GITHUB_SHA`, not the mutable branch ref.
- `chrome_branch_exists` fails hard on a `git ls-remote` error instead of silently
  falling back to `main`.
- A supported line older than `main` with no `release/*.x` branch is skipped, not
  merged into `main`.

## 2. Fix `update-versions.ps1` writing a literal ref (tip mode)

Surfaced by the main-tip validation run: `update-versions.ps1` resolved the merged
upstream commit with a hardcoded `git rev-parse "upstream/chrome/m$Target"`. On a
main-tip sync the merged ref is `upstream/main`, so `upstream/chrome/m<Target>` doesn't
exist — and plain `git rev-parse` on a missing ref **echoes the literal argument to
stdout and exits non-zero**. The guard was only an empty-string check, so the literal
`upstream/chrome/m151` got written into `cgmanifest.json`'s `upstream_merge_commit` as
if it were a SHA (the agent had to correct it by hand).

- Add an optional `-UpstreamRef` parameter (defaults to `chrome/m<Target>`).
- Resolve via `git rev-parse --verify --quiet "upstream/<ref>^{commit}"` + `$LASTEXITCODE`,
  so a missing ref fails cleanly to `UNKNOWN` instead of writing the literal.
- Document it in the update-skia SKILL.md Phase 6 and pass `-UpstreamRef "${upstream_ref}"`
  from the workflow.

## Files
- `.github/scripts/skia-sync-detect.sh` — rotation logic, `--target` interface, hardening.
- `.github/workflows/auto-skia-sync.md` — single cron, single `target` input, Phase 6 note.
- `.github/workflows/auto-skia-sync.lock.yml` — recompiled via `gh aw compile` (frontmatter only;
  gh-aw materializes the prompt body at runtime, so body-only edits don't change the lock).
- `.agents/skills/update-skia/scripts/update-versions.ps1` — `-UpstreamRef` + robust ref resolution.
- `.agents/skills/update-skia/SKILL.md` — Phase 6 `-UpstreamRef` guidance.

## Testing
- `bash -n` clean; `rotate_select` simulated end-to-end (real `versions.json` + empty/missing
  `support` edge cases); PowerShell AST parse clean + resolution unit-tested (valid ref → SHA,
  missing ref → `UNKNOWN`); recompile is 0-error.
- Dispatched a rotate (`""`) run and a `151` run against this branch: both passes agreed on the
  target, produced the correct `skia-sync/main` / `skia-sync/m151` branch pairs, and finished
  green (native + C# build clean, tests **5584 passed / 0 failed**). Those throwaway validation
  PRs/branches have been closed and deleted.
