### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e1be35b25f2a32371d9a1924ef4d18e62ccff1f3"
+          "commitHash": "0e4c4c4a1fabc94cbe82835ae41292f37ce92751"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
+      "upstream_merge_commit": "0fc8ba72e802af1003cf3e8cbbcda1fffdad88c1"
     }
   ]
 }


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/276

# [skia-sync] Merge upstream `main` bug fixes for m151

This is a **main-tip sync** (`upstream/main` → `skia-sync/main`), not a
milestone bump. Both current and target milestones stay at **m151**; only
the submodule pointer, its DEPS/VMA fork patches, and `cgmanifest.json`
change on the SkiaSharp side.

Companion mono/skia PR: `skia-sync/main` on mono/skia (see that PR's
summary for merge/conflict/fork-patch details).

## Version updates

**None.** This is a same-milestone sync:

- `scripts/VERSIONS.txt` — unchanged (`skia=151`).
- `scripts/azure-templates-variables.yml` — `SKIASHARP_VERSION` unchanged
  (`4.151.0`).
- `SkMilestone.h` — kept at 151 (upstream mid-cycle bumped to 152; we
  reverted to keep the C API version-compat smoke test green).
- soname / NuGet version — unchanged.

## Parent-repo changes

Only `cgmanifest.json` changed:

| Field | Before | After |
|---|---|---|
| `commitHash` (skia submodule) | `e1be35b25f2a32371d9a1924ef4d18e62ccff1f3` | `0e4c4c4a1fabc94cbe82835ae41292f37ce92751` |
| `upstream_merge_commit` | `79e2e1538e94bb1d6b5bbbc56279036aa7574b10` | `0fc8ba72e802af1003cf3e8cbbcda1fffdad88c1` |
| `chrome_milestone` | `151` | `151` (unchanged) |

Plus the submodule pointer bump (`externals/skia`) to match.

## Binding / C# changes

**None.** `regenerate-bindings.ps1` reported "No new functions found";
`binding/SkiaSharp/SkiaApi.generated.cs` had no diff vs `origin/main`. Diff
check on `binding/**/*.generated.cs` came back empty. No new C# wrappers
needed.

## Build & test results

Linux x64 only (per workflow policy — Windows/macOS/iOS/Android/WASM builds
are the domain of other pipelines):

- ✅ **Native build:** `dotnet cake --target=externals-linux --arch=x64` —
  succeeded in 11m 21s after the VMA fork-patch was applied. Produces
  `libSkiaSharp.so.151.0.0` (11.3 MB) and `libHarfBuzzSharp.so.0.61421.0`
  (2.9 MB).
- ✅ **C# build:** `dotnet build binding/SkiaSharp/SkiaSharp.csproj` —
  succeeded (0 errors, 0 warnings across all TFMs incl. `net10.0`,
  `netstandard2.1`, `net462`, `net9.0`, `net48`, `net9.0-android35.0`,
  `net10.0-android36.0`).
- ✅ **Test suite:**
  `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` —
  **Passed! - Failed: 0, Passed: 5584, Skipped: 172, Total: 5756**,
  duration 2m 45s (net10.0|x64). Full log: `test-output.txt` artifact.

## Breaking-change analysis

**No API-surface changes.** The C API is byte-identical, the generated
bindings are byte-identical, and no new public C# API needs review. Only a
submodule pointer + `cgmanifest.json` metadata bump reach downstream.

## Items needing human attention

- **Cross-platform verification for VMA fork patch.** Only Linux x64 was
  built here. Windows / macOS / iOS / Android / WASM native pipelines should
  verify the fork-patched `VulkanAMDMemoryAllocator.cpp` still builds and
  behaves correctly on their toolchains (it removes two struct-field writes
  and one function-pointer copy — no runtime behavior expected to change on
  VMA 3.2.1).
- **Consider bumping the VMA pin in a follow-up.** Upstream is starting to
  depend on newer VMA API (`priority`, `minAlignment`,
  `vkGetPhysicalDeviceProperties2KHR`). If we bump
  `vulkanmemoryallocator` in `DEPS` to `eb744ea7` (or a tagged version that
  includes those fields), the `[skiasharp]` fork patch on
  `VulkanAMDMemoryAllocator.cpp` can be dropped.
- **`update-versions.ps1` in tip mode.** The Phase 6 helper wrote the
  literal ref string `upstream/chrome/m151` into
  `cgmanifest.json`'s `upstream_merge_commit` when invoked with
  `-Current 151 -Target 151` against a `main`-tip merge; had to be manually
  overwritten with the actual `upstream/main` HEAD SHA. Consider fixing the
  script to resolve the ref before writing.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).