### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e1be35b25f2a32371d9a1924ef4d18e62ccff1f3"
+          "commitHash": "de2e431eb3533193f077ad8a038a0a8239147db8"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
+      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/277

## Sync SkiaSharp with upstream chrome/m151 (bug-fix only)

**Mode:** Same-milestone bug-fix sync (`CURRENT == TARGET == m151`, `is_release == false`).
No milestone/version bump — this only re-syncs the `externals/skia` submodule to pick up
2 new bug-fix commits merged into mono/skia's `skiasharp` branch.

**Companion PR:** [mono/skia #NNN — Merge upstream chrome/m151 bug fixes](../../mono/skia)
(created by the same automation run).

### Breaking change analysis

**None.** The 2 upstream commits merged into mono/skia are:

| SHA | Subject | SkiaSharp impact |
|---|---|---|
| `1536d39750` | Merge 3 release notes into RELEASE_NOTES.md | none (docs only) |
| `ac3c0d3fcd` | Filter unsupported CQ try jobs on chrome/m151 | none (upstream CI config only) |

No C++ API changes, no C API changes, no header changes, no DEPS changes, no
third-party dependency changes. `SK_C_INCREMENT` remains at `0`.

### Version updates

**None** — same-milestone sync. `.agents/skills/update-skia/scripts/update-versions.ps1
-Current 151 -Target 151` was run and gated ✅ with output:

> `Same-milestone sync (m151 -> m151) — skipping stale-reference check`
> `(only commitHash/upstream_merge_commit were updated)`

- `scripts/VERSIONS.txt` — unchanged (milestone `151`, increment `0`, soname `151.0.0`, nuget `4.151.0`)
- `scripts/azure-templates-variables.yml` — unchanged (`SKIASHARP_VERSION: 4.151.0`)
- `externals/skia/include/c/sk_types.h` — `SK_C_INCREMENT` remains `0`

### Parent-repo changes (this PR)

| File | Change |
|---|---|
| `cgmanifest.json` | mono/skia `commitHash` → `de2e431eb3533193f077ad8a038a0a8239147db8` |
| `cgmanifest.json` | `upstream_merge_commit` → `1536d3975057297af8087d22419f6c95dc96305d` (upstream chrome/m151 tip) |
| `externals/skia` | submodule pointer → `de2e431eb3` (new mono/skia merge commit) |

Full parent-repo diff:

```diff
diff --git a/cgmanifest.json b/cgmanifest.json
@@ -216,7 +216,7 @@
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e1be35b25f2a32371d9a1924ef4d18e62ccff1f3"
+          "commitHash": "de2e431eb3533193f077ad8a038a0a8239147db8"
@@ -231,7 +231,7 @@
       "chrome_milestone": 151,
-      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
+      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"

diff --git a/externals/skia b/externals/skia
-Subproject commit e1be35b25f2a32371d9a1924ef4d18e62ccff1f3
+Subproject commit de2e431eb3533193f077ad8a038a0a8239147db8
```

### Bindings regeneration

`.agents/skills/update-skia/scripts/regenerate-bindings.ps1` was run and reported:

> `--- Binding diff summary ---`
> `  No changes to bindings (C API signatures unchanged)`
> `--- New generated functions (may need C# wrappers) ---`
> `  No new functions found`
> `✅ Phase 8 complete`

`binding/SkiaSharp/SkiaApi.generated.cs`, `binding/SkiaSharp.Skottie/SkottieApi.generated.cs`,
`binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs`, and
`binding/SkiaSharp.Resources/ResourcesApi.generated.cs` regenerated with no diff.
HarfBuzz bindings reverted (as always in a Skia sync).

Phase 9 verification also clean:

```bash
git diff origin/main -- binding/SkiaSharp/SkiaApi.generated.cs | grep "^+.*internal static"
# (no output)
```

### C# wrapper changes

**None.** No new C API functions → no wrappers needed.

### Build & test results (Linux x64)

| Step | Result |
|---|---|
| `dotnet cake --target=externals-linux --arch=x64` | ✅ Success in 15m 51s (`libSkiaSharp.so.151.0.0`, `libHarfBuzzSharp.so.0.61421.0` built) |
| `dotnet build binding/SkiaSharp/SkiaSharp.csproj` | ✅ 0 errors, 0 warnings (38.3 s) |
| Full test suite | ✅ **Passed: 5584, Failed: 0, Skipped: 172, Total: 5756** (~2m 36s) |

Full test output is uploaded as workflow artifact `test-output.txt`.
Native build log is uploaded as workflow artifact `native-build.log`.

### Items needing human attention

**None.** This is a pure bug-fix sync with no code changes, no conflicts, no C API
work, no new upstream gn args, and a fully green build + test run. Cross-platform CI
on this PR will validate Windows/macOS/iOS/Android/WASM builds as usual.

### Notes

- Only Linux x64 was built in the automation runner. The upstream commits merged
  touch only release notes and CI infra, so cross-platform impact is zero.
- The sandbox runner had an unrelated environmental patch on
  `externals/depot_tools/gclient_paths.py` (`@functools.lru_cache` → `@functools.lru_cache()`
  for older Python compatibility). It was deliberately not committed as it's not part of
  this sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).