### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e1be35b25f2a32371d9a1924ef4d18e62ccff1f3"
+          "commitHash": "205c36a8afdb8504a6bdaa602996b44a6b1bcc70"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
+      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "205c36a8afdb8504a6bdaa602996b44a6b1bcc70"
+          "commitHash": "98877992a585d9fd60e398871b9293483db53eb8"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/278

## `[skia-sync] Merge upstream chrome/m151 bug fixes`

Same-milestone (m151 → m151) bug-fix sync — bumps the `externals/skia`
submodule to the mono/skia PR head so we pick up the two new upstream
`chrome/m151` commits (release-notes + CI-config only).

Pairs with the mono/skia PR: `[skia-sync] Merge upstream chrome/m151`
(head branch `skia-sync/m151`, target `skiasharp`).

### Breaking change analysis

**None.** Upstream carried only:

- `RELEASE_NOTES.md` — promoted three `relnotes/*.md` bullets under a
  "Milestone 151" heading. These describe already-shipped m151 APIs
  (`PrecompileContext::containsExternalFormat`, `SkPngRustEncoder::Options`
  `fGainmap`/`fGainmapInfo`, `SkStrikeRef::getWidthsStrided`) — none of
  which are exposed through our C API, so there is nothing to bind here.
- `infra/bots/{jobs,tasks}.json` — Skia CI try-job filtering.

No C++ headers, source files, `BUILD.gn`, or `DEPS` changed.

### Version / binding updates

Because `CURRENT == TARGET == 151`, this is a bug-fix-only sync:

| File | Change |
|------|--------|
| `cgmanifest.json` | `commitHash` `e1be35b25f…` → `205c36a8af…`; `upstream_merge_commit` `79e2e1538e…` → `1536d39750…` |
| `externals/skia` submodule | pointer bumped to `205c36a8afdb8504a6bdaa602996b44a6b1bcc70` (the mono/skia merge commit on `skia-sync/m151`) |

**Not** touched (as expected for a same-milestone sync):

- `scripts/VERSIONS.txt` (milestone/soname/nuget versions unchanged)
- `scripts/azure-templates-variables.yml` (`SKIASHARP_VERSION` unchanged)
- `externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT` still `0`)
- `binding/SkiaSharp/SkiaApi.generated.cs` (regenerated → identical output)
- Any `*.generated.cs`, `binding/**/*.cs`, or `documentation/**`

The Phase 6 script (`update-versions.ps1 -Current 151 -Target 151
-UpstreamRef chrome/m151`) exited with `✅ GATE PASSED — same-milestone
sync, version numbers unchanged`.

### C# changes

None. Phase 8's regenerate step reported:

```
--- Binding diff summary ---
  No changes to bindings (C API signatures unchanged)

--- New generated functions (may need C# wrappers) ---
  No new functions found
```

Phase 9 is therefore a no-op — no wrappers needed.

### Build / test results (Linux x64)

| Phase | Command | Result |
|-------|---------|--------|
| 7 | `dotnet cake --target=externals-linux --arch=x64` | ✅ 15m 27s, `libSkiaSharp.so.151.0.0` + `libHarfBuzzSharp.so.0.61421.0` produced |
| 8 | `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` | ✅ No binding diff |
| 10 (C# build) | `dotnet build binding/SkiaSharp/SkiaSharp.csproj` | ✅ 0 warnings, 0 errors |
| 10 (tests) | `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` | ✅ **Passed 5584, Failed 0, Skipped 172** (2m 38s, `net10.0\|x64`) |

Full test log is uploaded as the `test-output.txt` workflow artifact.
Only Linux x64 was built here (workflow constraint); other platforms
(Windows/macOS/iOS/Android/WASM) will be exercised by CI on the PR.

### Items needing human attention

None. The sync is limited to metadata; there are no risky surface changes
and every gate passed on the first attempt.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).