### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "e1be35b25f2a32371d9a1924ef4d18e62ccff1f3"
+          "commitHash": "4b006a0206c1d7016ac3ea6efa224eb09161b463"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "79e2e1538e94bb1d6b5bbbc56279036aa7574b10"
+      "upstream_merge_commit": "803eadd7c957dd62c23771ab829209730afa7e8c"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "98877992a585d9fd60e398871b9293483db53eb8"
+          "commitHash": "90a2d04943f22e0ae38554c2fe2f67491c4e4425"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
+      "upstream_merge_commit": "919956953af68d2288ca5fbe8cdc54b3c8f8825e"
     }
   ]
 }


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/279

## SkiaSharp sync (mono/SkiaSharp `skia-sync/main`)

Follow-up to the mono/skia PR that merges upstream `google/skia@main` into `mono/skia@skiasharp` on `skia-sync/main`.

- **Base branch:** `main`
- **Head branch:** `skia-sync/main`
- **Skia submodule:** `4b006a0206c1d7016ac3ea6efa224eb09161b463`
  (fork branch `skia-sync/main`, on top of upstream merge `803eadd7c9…`).
- **Milestone:** stays at **151** (main-tip sync, not a version bump).

Mode: **`main`/tip sync, `is_release == false`, `current == target == 151`**.

### Version files

Only two lines actually changed in this parent PR (plus the submodule pointer):

| File | Change |
| --- | --- |
| `cgmanifest.json` | `commitHash` → `4b006a0206c1d7016ac3ea6efa224eb09161b463` |
| `cgmanifest.json` | `upstream_merge_commit` → `803eadd7c957dd62c23771ab829209730afa7e8c` |
| `cgmanifest.json` | `chrome_milestone` unchanged at **151** |
| `externals/skia` (submodule) | pointer bump to `4b006a0206…` |
| `scripts/VERSIONS.txt` | **unchanged** (main-tip sync, same milestone) |
| `binding/**/*.assemblyinfo.cs` and NuGet package versions | **unchanged** |

### Binding changes

**Zero binding diff.** `pwsh utils/generate.ps1` (invoked directly against
`utils/SkiaSharpGenerator/SkiaSharpGenerator.csproj` via `dotnet run`, because
this Linux container's PowerShell has a broken Utility module — see "Items
needing human attention") produced no changes to
`binding/SkiaSharp/**/*.generated.cs` (SkiaSharp or HarfBuzzSharp).

That matches the upstream diff: no `include/c/*.h` or `src/c/*.cpp` file changed in the 41 upstream commits, so there are no new/renamed/removed exported symbols.

Verified with `git diff origin/main -- binding/SkiaSharp/` after full regeneration: **no output**.

### Breaking-change analysis

- **Public managed API surface: unchanged.** No `binding/SkiaSharp/**/*.generated.cs` or `binding/SkiaSharp/**/*.cs` change.
- **P/Invoke ABI: unchanged.** No new/removed/renamed native exports; no signature drift.
- **Native soname: unchanged** at `libSkiaSharp.so.151`.
- **Managed strong-name version: unchanged.**
- **Runtime version compat contract (`SkiaSharpVersion.CheckNativeLibraryCompatible`) preserved.** Upstream advanced `SK_MILESTONE` to 152, but per the workflow's "main-tip mode is not a version bump" rule the fork keeps it at 151 (see mono/skia summary). This keeps the runtime check `current in [min, max)` satisfied against managed `VersionConstants.Milestone = 151`.

No `[Obsolete]` additions, no new APIs to bind, no removals — this sync is entirely "under the hood" from a C# consumer's perspective.

### Build / test results (Linux x64)

- **Native build:** `dotnet cake --target=externals-linux --arch=x64` — ✅ success (~11 min).
  Produced `libSkiaSharp.so.151.0.0` (Skia + fork glue) and `libHarfBuzzSharp.so.0.61421.0`.
  Required an intermediate DEPS commit in the submodule to bump the VMA pin from
  `c788c521…` (3.2.1) to `eb744ea7a2b17…` (3.3.x) — see mono/skia summary for full rationale.
- **Binding regeneration:** ran generator for all 5 configs (SkiaSharp linux/macos/windows +
  HarfBuzzSharp linux/windows). **Zero output diff.**
- **C# build:** `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — ✅ 0 warnings, 0 errors, all TFMs built.
- **Tests:** `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` — ✅ **5584 passed, 0 failed, 172 skipped, 5756 total** in 2 min 39 s. Full log at `/tmp/gh-aw/agent/test-output.txt` (uploaded as workflow artifact). Skipped tests are the expected hardware/platform gates (no GPU, no display, non-matching OS).

### Items needing human attention

1. **`include/core/SkMilestone.h` fork override (SK_MILESTONE = 151):** upstream `main` is on m152 (commit `3149a8f0ac`). Kept at 151 as a fork patch — the runtime version check gates on this. This patch will need to be dropped in the eventual real m152 sync (or a decision made now to bump SkiaSharp to m152 formally, which would touch `scripts/VERSIONS.txt`, `binding/SkiaSharp/SkiaSharpVersion.cs`, the soname, and the NuGet package version).

2. **VMA pin bumped in the fork's `DEPS` from 3.2.1 to 3.3.x** (see mono/skia summary). Only **Linux x64** was built here; the Vulkan backend is also enabled on macOS/iOS/Android/Windows. **Please rebuild and smoke-test Vulkan on those platforms in CI** before merging to confirm nothing else broke.

3. **PowerShell workarounds in the workflow environment:** `pwsh 7.6.2` in the Ubuntu clang-provisioned container is missing autoloaded Utility/Management cmdlets (`Get-Content`, `Write-Host`, `Set-Content`, `Select-Object`, etc.) and `Import-Module` didn't fix it. Fell back to Python for `cgmanifest.json` updates and bash for the generator loop. **The workflow itself would benefit from a small fix** (install `powershell` module packages, or invoke via `dotnet script`/Python) so future syncs don't need this workaround. Nothing in this PR requires the workaround at runtime — it only affected the sync automation.

4. **`bazel/deps.json` desync** (auto-merged with upstream's newer hashes for `dawn`, `vulkanmemoryallocator`, `spirv_tools`, `vulkan_headers`, `vulkan_tools`) — inconsistent with `DEPS` for VMA / spirv_tools / vulkan_headers. Historically the fork has always tolerated this (Bazel isn't a supported build path). Documented for future reference.

5. **Cross-platform native rebuild required in CI** before merge: macOS ARM64, macOS x64, Windows x64, iOS, Android (arm64/arm/x64/x86), WASM. This workflow's environment can only build Linux x64.

### Merge order

Merge the **mono/skia** PR (`skia-sync/main`) **first**, then this PR. This PR's submodule pointer references the head commit on the mono/skia branch.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).