### PR TITLE
[docs-site] Add "Moving faster with AI" dashboard to the AI page

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -224,6 +224,19 @@ jobs:
           # AI in SkiaSharp page → /ai/
           cp -r documentation/site/ai site/ai
 
+          # Refresh the "Moving faster with AI" dashboard cache. Best-effort: the
+          # committed snapshot (already copied above) is the fallback, and each
+          # source degrades independently keeping its last-known "as of" values.
+          # Deepen only the superproject (never the huge Skia submodule) so the
+          # generator can read milestone-bump history from git instead of the API.
+          git fetch --no-recurse-submodules --unshallow 2>/dev/null \
+            || git fetch --no-recurse-submodules --deepen=5000 2>/dev/null \
+            || true
+          python3 scripts/infra/docs/generate-ai-dashboard.py \
+            --output site/ai/dashboard-data.json \
+            --base documentation/site/ai/dashboard-data.json \
+            || echo "::warning::AI dashboard refresh failed; shipping committed snapshot"
+
           touch site/.nojekyll
 
           # Inject build info into landing page footer

--- a/documentation/site/ai/ai.css
+++ b/documentation/site/ai/ai.css
@@ -554,3 +554,378 @@ a.track-target:hover { text-decoration: underline; }
   .wf-grid { grid-template-columns: 1fr; }
   .ai-honesty { font-size: 15px; }
 }
+
+/* ─────────────────────────────────────────────────────────────
+   Moving faster with AI — the live dashboard.
+   Three panels rendered by dashboard.js from a build-time cache.
+   Uses the shared theme tokens plus the --human green (defined at
+   the top of this file) to highlight the newest, "winning" values.
+   ───────────────────────────────────────────────────────────── */
+
+.dash-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+/* The hero panel (cadence) spans the full width and leads visually. */
+.dash-panel-hero { grid-column: 1 / -1; order: -1; }
+
+.dash-panel {
+  display: flex;
+  flex-direction: column;
+  padding: 22px 22px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+}
+
+.dash-panel-hero { border-top: 3px solid var(--human); }
+
+.dash-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.dash-head h3 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.dash-asof {
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.dash-body { flex: 1; }
+
+.dash-loading,
+.dash-error {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.dash-caption {
+  margin: -6px 0 16px;
+  font-size: 13px;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+.dash-subhead {
+  margin: 20px 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.dash-foot {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.dash-foot a { font-size: 12px; font-weight: 600; }
+
+.dash-footer { margin-top: 28px; }
+
+/* ── Panel 1: adoption figures + version bars ─────────────── */
+
+.dash-figs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.dash-fig {
+  flex: 1 1 140px;
+  padding: 14px 16px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.dash-fig-num {
+  display: block;
+  font-size: 30px;
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.dash-fig-label {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.ver-table-wrap { overflow-x: auto; }
+
+.ver-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.ver-table th,
+.ver-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.ver-table thead th {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  border-bottom: 2px solid var(--border);
+}
+
+.ver-table .ver-num { text-align: right; }
+
+.ver-line {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.ver-sub {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.ver-table td.ver-num {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.ver-table td.ver-zero { color: var(--text-secondary); font-weight: 500; }
+
+/* ── Panel 2: cadence table (the hero) ────────────────────── */
+
+.cad-table-wrap {
+  overflow-x: auto;
+  margin: 0 -4px;
+}
+
+.cad-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.cad-table th,
+.cad-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.cad-table thead th {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  border-bottom: 2px solid var(--border);
+  vertical-align: bottom;
+}
+
+.cad-table td,
+.cad-table .cad-ms-cell { text-align: right; }
+.cad-table thead th { text-align: right; }
+.cad-table th.cad-th-ms,
+.cad-table .cad-ms-cell { text-align: left; }
+
+.cad-unit {
+  display: block;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+
+.cad-ms-cell {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.cad-ms {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.cad-note {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.cad-win {
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #fff;
+  background: var(--human);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.cad-tr-newest { background: color-mix(in srgb, var(--human) 9%, transparent); }
+.cad-tr-newest .cad-val { color: var(--human); }
+.cad-tr-newest td,
+.cad-tr-newest th { border-bottom-color: var(--human); }
+
+.cad-cell { line-height: 1.25; }
+
+.cad-val {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.cad-val-zero {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--human);
+}
+
+.cad-cell-empty .cad-val { color: var(--text-secondary); font-weight: 500; }
+
+/* Signed change chip vs the previous milestone. Fewer days is better, so a
+   drop (good) is green and an increase (bad) is amber/red. */
+.cad-delta {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.cad-delta-good { color: var(--human); background: color-mix(in srgb, var(--human) 15%, transparent); }
+.cad-delta-bad { color: #d1602a; background: color-mix(in srgb, #d1602a 15%, transparent); }
+.cad-delta-flat { color: var(--text-secondary); background: var(--bg-subtle); }
+
+.cad-pct { opacity: 0.75; font-weight: 600; }
+
+[data-theme="dark"] .cad-delta-bad { color: #f0894f; }
+
+.cad-legend-note {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.cad-legend-note .cad-delta { margin-left: 0; }
+
+.cad-ahead {
+  margin-top: 16px;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text);
+  background: color-mix(in srgb, var(--human) 10%, var(--bg-subtle));
+  border: 1px solid var(--human);
+  border-radius: var(--radius-sm);
+}
+
+.cad-ahead b { color: var(--human); }
+
+/* ── Panel 3: automation cost cards ───────────────────────── */
+
+.cost-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cost-card {
+  padding: 14px 16px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.cost-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.cost-name { font-size: 14px; font-weight: 700; color: var(--text); }
+.cost-name a { color: var(--text); }
+.cost-name a:hover { color: var(--accent); }
+
+.cost-cadence {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.cost-metrics { display: flex; gap: 20px; }
+
+.cost-num {
+  display: block;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--accent);
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+
+.cost-label {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.cost-note {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .dash-grid { grid-template-columns: 1fr; }
+}

--- a/documentation/site/ai/dashboard-data.json
+++ b/documentation/site/ai/dashboard-data.json
@@ -1,0 +1,137 @@
+{
+  "generatedAt": "2026-07-02",
+  "adoption": {
+    "asOf": "2026-07-02",
+    "sourceUrl": "https://www.nuget.org/packages/SkiaSharp",
+    "primary": {
+      "id": "SkiaSharp",
+      "total": 289720015,
+      "currentGa": {
+        "version": "4.148.0",
+        "downloads": 74059
+      },
+      "lines": [
+        {
+          "line": "4.150",
+          "stable": 0,
+          "previews": 1645,
+          "stableVersion": null
+        },
+        {
+          "line": "4.148",
+          "stable": 74059,
+          "previews": 773,
+          "stableVersion": "4.148.0"
+        },
+        {
+          "line": "4.147",
+          "stable": 0,
+          "previews": 10235,
+          "stableVersion": null
+        },
+        {
+          "line": "3.119",
+          "stable": 34931605,
+          "previews": 765749,
+          "stableVersion": "3.119.4"
+        },
+        {
+          "line": "3.118",
+          "stable": 0,
+          "previews": 210968,
+          "stableVersion": null
+        }
+      ]
+    }
+  },
+  "cadence": {
+    "asOf": "2026-07-02",
+    "scheduleUrl": "https://chromiumdash.appspot.com/schedule",
+    "prsUrl": "https://github.com/mono/SkiaSharp/pulls?q=is%3Apr+milestone+in%3Atitle",
+    "caption": "AI opens, tests, and lands the sync PR; humans review the API.",
+    "milestones": [
+      {
+        "milestone": 132,
+        "branchPoint": "2024-11-11",
+        "prNumber": 3560,
+        "prOpened": "2026-03-12",
+        "prMerged": "2026-04-08",
+        "stableDate": "2025-01-14",
+        "firstPreview": null,
+        "note": "AI-assisted catch-up begins"
+      },
+      {
+        "milestone": 133,
+        "branchPoint": "2025-01-06",
+        "prNumber": 3660,
+        "prOpened": "2026-04-10",
+        "prMerged": "2026-04-14",
+        "stableDate": "2025-02-04",
+        "firstPreview": null,
+        "note": ""
+      },
+      {
+        "milestone": 147,
+        "branchPoint": "2026-03-09",
+        "prNumber": 3702,
+        "prOpened": "2026-04-20",
+        "prMerged": "2026-04-28",
+        "stableDate": "2026-04-07",
+        "firstPreview": "2026-04-28",
+        "note": "first scheduled auto-sync"
+      },
+      {
+        "milestone": 148,
+        "branchPoint": "2026-04-06",
+        "prNumber": 4125,
+        "prOpened": "2026-06-08",
+        "prMerged": "2026-06-11",
+        "stableDate": "2026-05-05",
+        "firstPreview": "2026-06-14",
+        "note": ""
+      },
+      {
+        "milestone": 150,
+        "branchPoint": "2026-06-01",
+        "prNumber": 4146,
+        "prOpened": "2026-06-11",
+        "prMerged": "2026-06-12",
+        "stableDate": "2026-06-30",
+        "firstPreview": "2026-06-15",
+        "note": ""
+      },
+      {
+        "milestone": 151,
+        "branchPoint": "2026-06-29",
+        "prNumber": 4294,
+        "prOpened": "2026-06-30",
+        "prMerged": "2026-06-30",
+        "stableDate": "2026-07-28",
+        "firstPreview": null,
+        "note": ""
+      }
+    ]
+  },
+  "cost": {
+    "asOf": "2026-07-02",
+    "sourceUrl": "https://github.com/mono/SkiaSharp/tree/main/.github/workflows",
+    "note": "Representative per-run figures from the gh-aw run logs (“Effective tokens” and “Turns”). No-op runs excluded.",
+    "workflows": [
+      {
+        "name": "Skia upstream sync",
+        "cadence": "every 6 hours",
+        "tokens": 54068620,
+        "turns": 95,
+        "workflowUrl": "https://github.com/mono/SkiaSharp/blob/main/.github/workflows/auto-skia-sync.md"
+      },
+      {
+        "name": "API docs writer",
+        "cadence": "daily",
+        "tokens": 27746000,
+        "turns": 56,
+        "workflowUrl": "https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/auto-api-docs-writer.md"
+      }
+    ]
+  },
+  "footerUrl": "https://github.com/mono/SkiaSharp/tree/main/.github/workflows"
+}

--- a/documentation/site/ai/dashboard.js
+++ b/documentation/site/ai/dashboard.js
@@ -1,0 +1,354 @@
+// ─────────────────────────────────────────────────────────────
+// "Moving faster with AI" dashboard renderer.
+//
+// Renders three panels from a build-time cache (./dashboard-data.json):
+//   1. Adoption at a glance   — NuGet download figures
+//   2. Time to keep up        — Chrome milestone → sync-PR cadence (the hero)
+//   3. What the automation costs — per-run tokens/turns
+//
+// The data is cached when the site rebuilds; a source that was unreachable at
+// build time keeps its last-known values and an "as of <date>" note (produced by
+// scripts/infra/docs/generate-ai-dashboard.py). This script only reads the cache
+// and never calls a third-party API, so the page cannot be slowed or broken by an
+// upstream outage. Day-deltas are computed here, never read from the file.
+// ─────────────────────────────────────────────────────────────
+
+(() => {
+  'use strict';
+
+  const root = document.querySelector('[data-dashboard]');
+  if (!root) return;
+
+  // ── Formatting helpers ──────────────────────────────────────
+
+  // 289720015 -> "289.7M", 74059 -> "74,059", 5098046 -> "5.1M".
+  const compact = (n) => {
+    if (n == null || isNaN(n)) return '—';
+    if (n >= 1e9) return trim(n / 1e9) + 'B';
+    if (n >= 1e6) return trim(n / 1e6) + 'M';
+    if (n >= 1e3) return trim(n / 1e3) + 'K';
+    return String(n);
+  };
+  const trim = (x) => {
+    const s = x.toFixed(1);
+    return s.endsWith('.0') ? s.slice(0, -2) : s;
+  };
+  const grouped = (n) =>
+    (n == null || isNaN(n)) ? '—' : n.toLocaleString('en-US');
+
+  // "2026-07-02" -> "Jul 2, 2026" (parsed as UTC to avoid an off-by-one).
+  const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const prettyDate = (iso) => {
+    if (!iso) return '';
+    const [y, m, d] = iso.split('-').map(Number);
+    if (!y || !m || !d) return iso;
+    return `${MONTHS[m - 1]} ${d}, ${y}`;
+  };
+  const shortDate = (iso) => {
+    if (!iso) return '';
+    const [, m, d] = iso.split('-').map(Number);
+    if (!m || !d) return iso;
+    return `${MONTHS[m - 1]} ${d}`;
+  };
+  // Whole-day difference between two ISO dates (b - a), UTC.
+  const daysBetween = (a, b) => {
+    if (!a || !b) return null;
+    const ms = Date.parse(b + 'T00:00:00Z') - Date.parse(a + 'T00:00:00Z');
+    if (isNaN(ms)) return null;
+    return Math.round(ms / 86400000);
+  };
+  const dayLabel = (n) => {
+    if (n == null) return '—';
+    if (n <= 0) return 'same day';
+    return n === 1 ? '1 day' : `${n} days`;
+  };
+  // "+3" / "−417" with a real minus sign for negatives.
+  const fmtSigned = (n) => (n > 0 ? '+' + n : '\u2212' + Math.abs(n));
+
+  const el = (tag, cls, html) => {
+    const node = document.createElement(tag);
+    if (cls) node.className = cls;
+    if (html != null) node.innerHTML = html;
+    return node;
+  };
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+
+  const panel = (name) => root.querySelector(`[data-panel="${name}"]`);
+  const setAsOf = (p, iso) => {
+    const tag = p && p.querySelector('[data-asof]');
+    if (tag) tag.textContent = iso ? `as of ${prettyDate(iso)}` : '';
+  };
+  const bodyOf = (p) => p && p.querySelector('[data-body]');
+
+  // ── Panel 1: Adoption at a glance ───────────────────────────
+
+  function renderAdoption(data) {
+    const p = panel('adoption');
+    if (!p || !data) return fail(p, 'adoption');
+    const body = bodyOf(p);
+    body.innerHTML = '';
+
+    const prim = data.primary || {};
+    const stats = el('div', 'dash-figs');
+    stats.appendChild(fig(compact(prim.total), 'total downloads', grouped(prim.total)));
+    const ga = prim.currentGa || {};
+    stats.appendChild(fig(compact(ga.downloads),
+      `downloads of ${esc(ga.version || 'the current GA')}`, grouped(ga.downloads)));
+    body.appendChild(stats);
+
+    // Downloads by release line (major.minor): cumulative stable vs previews.
+    const lines = prim.lines || [];
+    if (lines.length) {
+      body.appendChild(el('p', 'dash-subhead', 'Downloads by release line'));
+      const table = el('table', 'ver-table');
+      table.innerHTML =
+        '<thead><tr><th>Version</th>' +
+        '<th class="ver-num">Stable</th>' +
+        '<th class="ver-num">Previews</th></tr></thead>';
+      const tbody = el('tbody');
+      lines.forEach((l) => {
+        const tr = el('tr');
+        const label = l.stableVersion
+          ? `${esc(l.line)}<span class="ver-sub">${esc(l.stableVersion)}</span>`
+          : `${esc(l.line)}<span class="ver-sub">preview only</span>`;
+        tr.appendChild(el('th', 'ver-line', label));
+        tr.appendChild(verCell(l.stable));
+        tr.appendChild(verCell(l.previews));
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      const wrap = el('div', 'ver-table-wrap');
+      wrap.appendChild(table);
+      body.appendChild(wrap);
+    }
+
+    linkSource(p, data.sourceUrl);
+    setAsOf(p, data.asOf);
+    p.setAttribute('aria-busy', 'false');
+  }
+
+  function fig(value, label, title) {
+    const f = el('div', 'dash-fig');
+    const num = el('span', 'dash-fig-num', esc(value));
+    if (title) num.title = title + ' downloads';
+    f.appendChild(num);
+    f.appendChild(el('span', 'dash-fig-label', label));
+    return f;
+  }
+
+  // A downloads cell: compact number, exact count on hover, "—" for zero.
+  function verCell(n) {
+    const td = el('td', 'ver-num');
+    if (!n) {
+      td.classList.add('ver-zero');
+      td.textContent = '—';
+      return td;
+    }
+    td.textContent = compact(n);
+    td.title = grouped(n) + ' downloads';
+    return td;
+  }
+
+  // ── Panel 2: Time to keep up with upstream (the hero) ───────
+
+  function renderCadence(data) {
+    const p = panel('cadence');
+    if (!p || !data) return fail(p, 'cadence');
+    const body = bodyOf(p);
+    body.innerHTML = '';
+
+    const caption = p.querySelector('[data-caption]');
+    if (caption && data.caption) caption.textContent = data.caption;
+    linkAttr(p, '[data-prs-link]', data.prsUrl);
+    linkSource(p, data.scheduleUrl);
+
+    const milestones = (data.milestones || []).map((m) => ({
+      ...m,
+      branchToPr: daysBetween(m.branchPoint, m.prOpened),
+      prToMerge: daysBetween(m.prOpened, m.prMerged),
+      mergeToShip: daysBetween(m.prMerged, m.firstPreview),
+      mergedToStable: daysBetween(m.prMerged, m.stableDate),
+    }));
+    if (!milestones.length) return fail(p, 'cadence');
+
+    // Each metric column: lower is better, so a negative change (faster than the
+    // previous milestone) is the win and renders green.
+    const cols = [
+      { key: 'branchToPr', label: 'Behind Chrome',
+        tip: 'Chrome branch cut → our sync PR opened' },
+      { key: 'prToMerge', label: 'Review',
+        tip: 'PR opened → merged (humans review the API)' },
+      { key: 'mergeToShip', label: 'To NuGet',
+        tip: 'merged → first package published on NuGet' },
+    ];
+
+    const table = el('table', 'cad-table');
+    const thead = el('thead');
+    const hrow = el('tr');
+    hrow.appendChild(el('th', 'cad-th-ms', 'Milestone'));
+    cols.forEach((c) => {
+      const th = el('th', null, `${esc(c.label)}<span class="cad-unit">days</span>`);
+      th.title = c.tip;
+      hrow.appendChild(th);
+    });
+    thead.appendChild(hrow);
+    table.appendChild(thead);
+
+    const tbody = el('tbody');
+    milestones.forEach((m, i) => {
+      const prev = i > 0 ? milestones[i - 1] : null;
+      const isNewest = i === milestones.length - 1;
+      const tr = el('tr', isNewest ? 'cad-tr-newest' : null);
+
+      const th = el('th', 'cad-ms-cell');
+      th.setAttribute('scope', 'row');
+      let msHtml = `<span class="cad-ms">m${esc(m.milestone)}</span>`;
+      if (isNewest) msHtml += '<span class="cad-win">newest</span>';
+      if (m.note) msHtml += `<span class="cad-note">${esc(m.note)}</span>`;
+      th.innerHTML = msHtml;
+      tr.appendChild(th);
+
+      cols.forEach((c) => {
+        const val = m[c.key];
+        const prevVal = prev ? prev[c.key] : null;
+        tr.appendChild(metricCell(val, prevVal));
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    const wrap = el('div', 'cad-table-wrap');
+    wrap.appendChild(table);
+    body.appendChild(wrap);
+
+    body.appendChild(el('p', 'cad-legend-note',
+      'Each cell is the number of days; the chip is the change from the ' +
+      'milestone above it — days and percent, where ' +
+      '<span class="cad-delta cad-delta-good">&minus;</span> is faster and ' +
+      '<span class="cad-delta cad-delta-bad">+</span> slower.'));
+
+    // Bonus context on the newest milestone: ahead of Chrome stable.
+    const newest = milestones[milestones.length - 1];
+    if (newest && newest.mergedToStable != null && newest.mergedToStable > 0) {
+      body.appendChild(el('p', 'cad-ahead',
+        `m${esc(newest.milestone)} merged <b>${dayLabel(newest.mergedToStable)}</b> ` +
+        `before Chrome ${esc(newest.milestone)} reaches stable ` +
+        `(${esc(shortDate(newest.stableDate))}) — ahead of Chrome, not chasing it.`));
+    }
+
+    setAsOf(p, data.asOf);
+    p.setAttribute('aria-busy', 'false');
+  }
+
+  // A metric cell: the value (in days) plus a signed change chip vs the previous
+  // milestone — both the day delta and the percent change. Fewer days is better,
+  // so a drop is a "good" (green) delta.
+  function metricCell(val, prevVal) {
+    const td = el('td', 'cad-cell');
+    if (val == null) {
+      td.classList.add('cad-cell-empty');
+      td.innerHTML = '<span class="cad-val">—</span>';
+      td.title = 'not yet shipped';
+      return td;
+    }
+    const value = val <= 0
+      ? '<span class="cad-val cad-val-zero">same day</span>'
+      : `<span class="cad-val">${val}</span>`;
+    let chip = '';
+    if (prevVal != null) {
+      const delta = val - prevVal;
+      const cls = delta < 0 ? 'good' : delta > 0 ? 'bad' : 'flat';
+      let text = delta === 0 ? '±0' : fmtSigned(delta);
+      // Percent change needs a non-zero base; skip it when the previous was zero.
+      if (prevVal !== 0 && delta !== 0) {
+        text += ` <span class="cad-pct">${fmtSigned(Math.round((delta / prevVal) * 100))}%</span>`;
+      }
+      chip = `<span class="cad-delta cad-delta-${cls}">${text}</span>`;
+    }
+    td.innerHTML = value + chip;
+    return td;
+  }
+
+  // ── Panel 3: What the automation costs (per run) ────────────
+
+  function renderCost(data) {
+    const p = panel('cost');
+    if (!p || !data) return fail(p, 'cost');
+    const body = bodyOf(p);
+    body.innerHTML = '';
+
+    const cards = el('div', 'cost-cards');
+    (data.workflows || []).forEach((w) => {
+      const card = el('article', 'cost-card');
+      const head = el('div', 'cost-card-head');
+      const name = w.workflowUrl
+        ? `<a href="${esc(w.workflowUrl)}" target="_blank" rel="noopener">${esc(w.name)}</a>`
+        : esc(w.name);
+      head.appendChild(el('h4', 'cost-name', name));
+      if (w.cadence) head.appendChild(el('span', 'cost-cadence', esc(w.cadence)));
+      card.appendChild(head);
+
+      const metrics = el('div', 'cost-metrics');
+      metrics.appendChild(costMetric(compact(w.tokens), 'effective tokens', grouped(w.tokens)));
+      metrics.appendChild(costMetric(grouped(w.turns), 'agent turns'));
+      card.appendChild(metrics);
+      cards.appendChild(card);
+    });
+    body.appendChild(cards);
+
+    if (data.note) body.appendChild(el('p', 'cost-note', esc(data.note)));
+
+    linkSource(p, data.sourceUrl);
+    setAsOf(p, data.asOf);
+    p.setAttribute('aria-busy', 'false');
+  }
+
+  function costMetric(value, label, title) {
+    const m = el('div', 'cost-metric');
+    const num = el('span', 'cost-num', esc(value));
+    if (title) num.title = title;
+    m.appendChild(num);
+    m.appendChild(el('span', 'cost-label', label));
+    return m;
+  }
+
+  // ── Shared helpers ──────────────────────────────────────────
+
+  function linkSource(p, url) { linkAttr(p, '[data-source-link]', url); }
+  function linkAttr(p, sel, url) {
+    const a = p && p.querySelector(sel);
+    if (a && url) a.setAttribute('href', url);
+  }
+
+  function fail(p, name) {
+    if (!p) return;
+    const body = bodyOf(p);
+    if (body) {
+      body.innerHTML =
+        '<p class="dash-error">This data could not be loaded. ' +
+        'The linked source below has the current figures.</p>';
+    }
+    p.setAttribute('aria-busy', 'false');
+  }
+
+  function failAll(msg) {
+    ['adoption', 'cadence', 'cost'].forEach((n) => fail(panel(n), n));
+    root.setAttribute('data-dashboard-error', msg || 'load-failed');
+  }
+
+  // ── Load the cached data and render ─────────────────────────
+
+  fetch('./dashboard-data.json', { cache: 'no-cache' })
+    .then((r) => {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
+    .then((data) => {
+      try { renderAdoption(data.adoption); } catch (e) { fail(panel('adoption')); }
+      try { renderCadence(data.cadence); } catch (e) { fail(panel('cadence')); }
+      try { renderCost(data.cost); } catch (e) { fail(panel('cost')); }
+    })
+    .catch((e) => failAll(String(e)));
+})();

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -71,6 +71,86 @@
       </div>
     </section>
 
+    <!-- ── Moving faster with AI (live dashboard) ────────── -->
+    <section class="ai-section section-alt dashboard" id="moving-faster" aria-labelledby="moving-faster-title">
+      <div class="container">
+        <p class="section-kicker">Moving faster with AI</p>
+        <h2 class="section-title" id="moving-faster-title">The dashboard</h2>
+        <p class="section-lead">
+          A few signals the automation moves, cached when the site rebuilds and refreshed
+          from public data. Every number below links back to its source, and each panel notes
+          the date it was last refreshed so a stale figure is obvious rather than hidden.
+        </p>
+
+        <div class="dash-grid" data-dashboard>
+          <!-- Panel 1 — Adoption at a glance -->
+          <article class="dash-panel" data-panel="adoption" aria-busy="true">
+            <header class="dash-head">
+              <h3>Adoption at a glance</h3>
+              <span class="dash-asof" data-asof>&nbsp;</span>
+            </header>
+            <div class="dash-body" data-body>
+              <p class="dash-loading">Loading NuGet download figures&hellip;</p>
+            </div>
+            <footer class="dash-foot">
+              <a href="https://www.nuget.org/packages/SkiaSharp" target="_blank" rel="noopener" data-source-link>Source: nuget.org &rarr;</a>
+            </footer>
+          </article>
+
+          <!-- Panel 2 — Time to keep up with upstream (the hero) -->
+          <article class="dash-panel dash-panel-hero" data-panel="cadence" aria-busy="true">
+            <header class="dash-head">
+              <h3>Time to keep up with upstream</h3>
+              <span class="dash-asof" data-asof>&nbsp;</span>
+            </header>
+            <p class="dash-caption" data-caption>
+              AI opens, tests, and lands the sync PR; humans review the API.
+            </p>
+            <div class="dash-body" data-body>
+              <p class="dash-loading">Loading milestone cadence&hellip;</p>
+            </div>
+            <footer class="dash-foot">
+              <a href="https://chromiumdash.appspot.com/schedule" target="_blank" rel="noopener" data-source-link>Chrome schedule &rarr;</a>
+              <a href="https://github.com/mono/SkiaSharp/pulls?q=is%3Apr+milestone+in%3Atitle" target="_blank" rel="noopener" data-prs-link>Bump PRs &rarr;</a>
+            </footer>
+          </article>
+
+          <!-- Panel 3 — What the automation costs (per run) -->
+          <article class="dash-panel" data-panel="cost" aria-busy="true">
+            <header class="dash-head">
+              <h3>What the automation costs</h3>
+              <span class="dash-asof" data-asof>&nbsp;</span>
+            </header>
+            <div class="dash-body" data-body>
+              <p class="dash-loading">Loading per-run cost&hellip;</p>
+            </div>
+            <footer class="dash-foot">
+              <a href="https://github.com/mono/SkiaSharp/tree/main/.github/workflows" target="_blank" rel="noopener" data-source-link>The workflows &rarr;</a>
+            </footer>
+          </article>
+        </div>
+
+        <noscript>
+          <p class="loop-note">
+            This dashboard renders from cached data with JavaScript. With scripting off, read the
+            numbers at their sources:
+            <a href="https://www.nuget.org/packages/SkiaSharp" target="_blank" rel="noopener">NuGet downloads</a>,
+            the <a href="https://chromiumdash.appspot.com/schedule" target="_blank" rel="noopener">Chrome schedule</a>,
+            the <a href="https://github.com/mono/SkiaSharp/pulls?q=is%3Apr+milestone+in%3Atitle" target="_blank" rel="noopener">milestone bump PRs</a>,
+            and the <a href="https://github.com/mono/SkiaSharp/tree/main/.github/workflows" target="_blank" rel="noopener">workflows</a>.
+          </p>
+        </noscript>
+
+        <p class="loop-note dash-footer">
+          Every figure here is auditable: the downloads come from NuGet, the milestone dates from
+          the Chromium schedule and our own merged bump PRs, and the run costs from the workflow
+          logs. Read the machinery in the
+          <a href="https://github.com/mono/SkiaSharp/tree/main/.github/workflows" target="_blank" rel="noopener">mono/SkiaSharp workflows</a>
+          directory.
+        </p>
+      </div>
+    </section>
+
     <!-- ── The loop ──────────────────────────────────────── -->
     <section class="ai-section">
       <div class="container">
@@ -544,5 +624,6 @@
   </footer>
 
   <script src="../site.js"></script>
+  <script src="dashboard.js"></script>
 </body>
 </html>

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -55,11 +55,11 @@
               <span class="stat-label">agentic workflows across two repositories</span>
             </div>
             <div class="stat">
-              <span class="stat-num">20</span>
+              <span class="stat-num">21</span>
               <span class="stat-label">reusable skills the workflows and maintainers share</span>
             </div>
             <div class="stat">
-              <span class="stat-num">3&times;</span>
+              <span class="stat-num">4&times;</span>
               <span class="stat-label">daily upstream Skia sync passes</span>
             </div>
             <div class="stat">
@@ -286,7 +286,7 @@
               which is why it runs on the strongest model.
             </p>
             <dl class="wf-meta">
-              <dt>When</dt><dd>07:00, 12:00, and 17:00 UTC daily, plus manual dispatch</dd>
+              <dt>When</dt><dd>00:00, 06:00, 12:00, and 18:00 UTC daily (every 6 hours), plus manual dispatch</dd>
               <dt>Engine</dt><dd>GitHub Copilot</dd>
               <dt>Allowed outputs</dt><dd>open pull requests (mono/skia submodule + mono/SkiaSharp)</dd>
               <dt>Skill</dt><dd><code>update-skia</code></dd>
@@ -525,6 +525,13 @@
               <li><span class="skill-name">sample-scout</span><br>Scout Skia GM test files for demos worth porting to the gallery.</li>
               <li><span class="skill-name">validate-samples</span><br>Build and validate the sample projects against CI packages.</li>
               <li><span class="skill-name">ci-status</span><br>Collect the build health across pipelines and render a daily dashboard.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
+            <h3>Authoring</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">skill-creator</span><br>Create, improve, and evaluate the reusable skills themselves.</li>
             </ul>
           </div>
         </div>

--- a/scripts/infra/docs/generate-ai-dashboard.py
+++ b/scripts/infra/docs/generate-ai-dashboard.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Refresh the data behind the "Moving faster with AI" dashboard.
+
+The dashboard on the ``/ai/`` site page renders from a cached JSON file,
+``documentation/site/ai/dashboard-data.json``. This script refreshes that cache
+so the page can be regenerated at build time (or on demand) without any live,
+client-side API calls.
+
+Design goals (see documentation/site/ai/index.html):
+
+  * **Cache in the build.** The committed JSON is the source of truth the page
+    ships with. This script updates it in place; a build then copies it verbatim.
+
+  * **Prefer git history over the GitHub API.** The milestone bump PR numbers and
+    their merge dates come from ``git log`` of the checked-out repository, not the
+    ``gh`` / GitHub search API — no token, no rate limit, always available in CI.
+    (The one thing git cannot give for a squash-merged PR is the *opened* date;
+    those are immutable historical facts kept in the committed snapshot.)
+
+  * **Degrade gracefully, per source.** Each section (adoption / cadence / cost)
+    is refreshed independently. If a source is unreachable, that section keeps its
+    last-known values and its existing ``asOf`` date; the page shows "as of <date>".
+    A failure never produces a broken file or a non-zero exit that breaks the build.
+
+Sources, mirroring the conventions already used in generate-release-notes.py:
+
+  * NuGet   — https://azuresearch-usnc.nuget.org/query (totals + per-version counts)
+  * Chrome  — https://chromiumdash.appspot.com/fetch_milestone_schedule (branch/stable)
+  * Git     — ``git log`` for milestone bump squash commits (PR number + merge date)
+
+Usage::
+
+    python3 scripts/infra/docs/generate-ai-dashboard.py            # refresh in place
+    python3 scripts/infra/docs/generate-ai-dashboard.py --output X # write elsewhere
+    python3 scripts/infra/docs/generate-ai-dashboard.py --check    # don't write, report
+"""
+
+import argparse
+import datetime
+import gzip
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+# ── Paths & constants ────────────────────────────────────────────────────────
+
+DEFAULT_OUTPUT = Path("documentation/site/ai/dashboard-data.json")
+
+# NuGet search service (fast; gives totals + per-version downloads). The ...ussc
+# host is a mirror used if the primary is slow. Both send Access-Control-* so the
+# same endpoints also work if we ever move to a client-side fetch.
+NUGET_HOSTS = [
+    "https://azuresearch-usnc.nuget.org/query",
+    "https://azuresearch-ussc.nuget.org/query",
+]
+
+# Same Chromium Dashboard endpoint that generate-release-notes.py already uses.
+CHROME_SCHEDULE_URL = (
+    "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone={}")
+
+# NuGet registration index — used only for per-version *published* dates (the
+# search service above does not expose them). Powers the "merged -> shipped on
+# NuGet" metric in the cadence panel.
+NUGET_REGISTRATION_URL = (
+    "https://api.nuget.org/v3/registration5-gz-semver2/{}/index.json")
+
+# How many of the most recent milestone bumps to show in the cadence timeline.
+# 6 reaches back to m132/m133, the first AI-assisted catch-up bumps.
+CADENCE_COUNT = 6
+
+# SkiaSharp versions are <major>.<milestone>.<patch>; this is the current major.
+SKIASHARP_MAJOR = 4
+
+# How many recent release lines (<major>.<minor>) to show in the adoption panel.
+ADOPTION_LINE_COUNT = 5
+
+USER_AGENT = "SkiaSharp-ai-dashboard"
+
+
+def log(*args):
+    """Progress goes to STDERR so STDOUT can stay clean (matches sibling script)."""
+    print(*args, file=sys.stderr)
+
+
+# ── Small helpers ────────────────────────────────────────────────────────────
+
+def today_iso():
+    # type: () -> str
+    return datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+
+
+def http_get_json(url, timeout=12):
+    # type: (str, int) -> dict
+    req = urllib.request.Request(
+        url, headers={"User-Agent": USER_AGENT, "Accept-Encoding": "gzip"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        status = getattr(resp, "status", 200)
+        if status != 200:
+            raise RuntimeError("HTTP {}".format(status))
+        raw = resp.read()
+        # Some NuGet registration blobs are gzip-compressed regardless of the
+        # Accept-Encoding negotiation; decompress by content-encoding or magic.
+        if resp.headers.get("Content-Encoding") == "gzip" or raw[:2] == b"\x1f\x8b":
+            raw = gzip.decompress(raw)
+        return json.loads(raw.decode("utf-8"))
+
+
+def git(args):
+    # type: (list[str]) -> str
+    """Run a git command and return stdout (raises on failure)."""
+    result = subprocess.run(
+        ["git"] + args, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def version_key(version):
+    # type: (str) -> tuple
+    """Sort key that orders releases correctly and puts a stable release ABOVE
+    its own prereleases (4.148.0 > 4.148.0-rc.1 > 4.148.0-preview.1)."""
+    core, _, pre = version.partition("-")
+    nums = []
+    for part in core.split("."):
+        m = re.match(r"\d+", part)
+        nums.append(int(m.group()) if m else 0)
+    # A missing prerelease tag sorts last (i.e. the stable release is greatest).
+    return (tuple(nums), 0 if not pre else -1, pre)
+
+
+def utc_date_from_git_iso(iso):
+    # type: (str) -> str
+    """``2026-07-01T01:31:01+02:00`` -> ``2026-06-30`` (UTC calendar date).
+
+    Git commit dates carry a timezone; converting to UTC before taking the date
+    keeps them consistent with the UTC dates the GitHub API reports, so a merge
+    just after midnight local time is not counted as a day late.
+    """
+    dt = datetime.datetime.fromisoformat(iso)
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(datetime.timezone.utc)
+    return dt.date().isoformat()
+
+
+# ── Panel 1: adoption (NuGet) ────────────────────────────────────────────────
+
+def fetch_nuget_package(package_id):
+    # type: (str) -> dict
+    """Return the NuGet search record for a package id, trying mirror hosts."""
+    query = "?q=packageid:{}&prerelease=true&semVerLevel=2.0.0".format(package_id)
+    last_error = None
+    for host in NUGET_HOSTS:
+        try:
+            payload = http_get_json(host + query)
+        except Exception as e:  # noqa: BLE001 - any failure -> try the mirror
+            last_error = e
+            continue
+        data = payload.get("data") or []
+        for record in data:
+            if record.get("id", "").lower() == package_id.lower():
+                return record
+        raise RuntimeError("package '{}' not found in results".format(package_id))
+    raise RuntimeError(
+        "all NuGet hosts failed for '{}': {}".format(package_id, last_error))
+
+
+def build_adoption(existing):
+    # type: (dict) -> dict
+    """Refresh the adoption panel from NuGet; fall back to ``existing`` on error."""
+    try:
+        primary = fetch_nuget_package("SkiaSharp")
+        versions = primary.get("versions") or []
+        # Current GA = highest version with no prerelease suffix.
+        ga = None
+        for v in versions:
+            ver = v.get("version", "")
+            if "-" in ver:
+                continue
+            if ga is None or version_key(ver) > version_key(ga["version"]):
+                ga = {"version": ver, "downloads": int(v.get("downloads", 0))}
+        adoption = {
+            "asOf": today_iso(),
+            "sourceUrl": "https://www.nuget.org/packages/SkiaSharp",
+            "primary": {
+                "id": "SkiaSharp",
+                "total": int(primary.get("totalDownloads", 0)),
+                "currentGa": ga or {"version": "", "downloads": 0},
+                "lines": aggregate_version_lines(versions, ADOPTION_LINE_COUNT),
+            },
+        }
+        log("adoption: refreshed ({:,} total downloads)".format(
+            adoption["primary"]["total"]))
+        return adoption
+    except Exception as e:  # noqa: BLE001 - keep last-known adoption block
+        log("adoption: refresh failed, keeping snapshot ({})".format(e))
+        return existing.get("adoption", {})
+
+
+def aggregate_version_lines(versions, count):
+    # type: (list[dict], int) -> list[dict]
+    """Collapse per-version download counts into the newest ``count`` release
+    lines (``<major>.<minor>``), each split into cumulative stable vs prerelease
+    downloads, e.g. ``{"line": "4.148", "stableVersion": "4.148.0",
+    "stable": 74059, "previews": 773}``. Newest line first.
+    """
+    lines = {}  # (major, minor) -> aggregate
+    for v in versions:
+        ver = v.get("version", "")
+        parts = ver.split(".")
+        if len(parts) < 2:
+            continue
+        try:
+            major = int(re.match(r"\d+", parts[0]).group())
+            minor = int(re.match(r"\d+", parts[1]).group())
+        except (AttributeError, ValueError):
+            continue
+        downloads = int(v.get("downloads", 0))
+        line = lines.setdefault(
+            (major, minor),
+            {"line": "{}.{}".format(major, minor), "stable": 0,
+             "previews": 0, "stableVersion": None})
+        if "-" in ver:
+            line["previews"] += downloads
+        else:
+            line["stable"] += downloads
+            # Track the highest stable version string for the line.
+            if (line["stableVersion"] is None
+                    or version_key(ver) > version_key(line["stableVersion"])):
+                line["stableVersion"] = ver
+    ordered = sorted(lines, reverse=True)[:count]
+    return [lines[k] for k in ordered]
+
+
+# ── Panel 2: cadence (git history + Chromium Dashboard) ──────────────────────
+
+_MILESTONE_RE = re.compile(r"milestone\s+m?(\d+)", re.IGNORECASE)
+_PR_RE = re.compile(r"\(#(\d+)\)")
+
+
+def discover_milestone_bumps(count):
+    # type: (int) -> list[dict]
+    """Find recent milestone bump PRs from git history (no GitHub API).
+
+    Scans the first-parent history of HEAD for squash-merge commits whose subject
+    names a Skia milestone and carries a ``(#PR)`` suffix, e.g.
+    ``[skia-sync] Update Skia to milestone m151 (4.151.0) (#4294)``. Returns the
+    most recent ``count`` distinct milestones, oldest first, each as
+    ``{milestone, prNumber, prMerged}``.
+    """
+    # %cI = committer date, strict ISO with timezone; %s = subject.
+    out = git(["log", "--first-parent", "HEAD",
+               "--grep=milestone", "-i", "--pretty=format:%cI\t%s"])
+    by_milestone = {}  # milestone -> earliest bump commit
+    for line in out.splitlines():
+        if "\t" not in line:
+            continue
+        iso, subject = line.split("\t", 1)
+        pr_match = _PR_RE.search(subject)
+        ms_match = _MILESTONE_RE.search(subject)
+        if not pr_match or not ms_match:
+            continue
+        milestone = int(ms_match.group(1))
+        merged = utc_date_from_git_iso(iso)
+        entry = {"milestone": milestone,
+                 "prNumber": int(pr_match.group(1)),
+                 "prMerged": merged}
+        prev = by_milestone.get(milestone)
+        # Keep the earliest merge for a milestone (the original bump, not a re-merge).
+        if prev is None or merged < prev["prMerged"]:
+            by_milestone[milestone] = entry
+    ordered = sorted(by_milestone.values(), key=lambda e: e["prMerged"])
+    return ordered[-count:]
+
+
+def fetch_chrome_branch_and_stable(milestone):
+    # type: (int) -> dict
+    """Return ``{branchPoint, stableDate}`` (UTC dates) for a Chrome milestone."""
+    payload = http_get_json(CHROME_SCHEDULE_URL.format(milestone))
+    mstones = payload.get("mstones") or []
+    if not mstones:
+        raise RuntimeError("no schedule data for m{}".format(milestone))
+    ms = mstones[0]
+    branch = ms.get("branch_point")
+    stable = ms.get("stable_date")
+    if not branch:
+        raise RuntimeError("m{} missing branch_point".format(milestone))
+    return {
+        "branchPoint": branch[:10],
+        "stableDate": stable[:10] if stable else "",
+    }
+
+
+def fetch_nuget_first_releases():
+    # type: () -> dict
+    """Return ``{milestone: 'YYYY-MM-DD'}`` — the date SkiaSharp first shipped a
+    package for each ``<major>.<milestone>.0`` line (earliest published version,
+    preview / rc / GA). Read from the NuGet registration index (published dates).
+    """
+    index = http_get_json(NUGET_REGISTRATION_URL.format("skiasharp"), timeout=25)
+    published = {}  # version -> published date
+
+    def walk(items):
+        for it in items:
+            entry = it.get("catalogEntry")
+            if entry:
+                ver, pub = entry.get("version"), entry.get("published")
+                if ver and pub:
+                    published[ver] = pub[:10]
+            elif "items" in it:
+                walk(it["items"])
+
+    for page in index.get("items", []):
+        if "items" in page:
+            walk(page["items"])
+        else:  # paged registration: the leaf blob lives behind its @id
+            walk(http_get_json(page["@id"], timeout=25).get("items", []))
+
+    earliest = {}  # milestone -> earliest published date
+    for ver, pub in published.items():
+        parts = ver.split(".")
+        if len(parts) < 3 or parts[0] != str(SKIASHARP_MAJOR):
+            continue
+        m = re.match(r"\d+", parts[1])
+        if not m:
+            continue
+        milestone = int(m.group())
+        # A published date of "1900-01-01" marks an unlisted/deleted version.
+        if pub.startswith("1900"):
+            continue
+        if milestone not in earliest or pub < earliest[milestone]:
+            earliest[milestone] = pub
+    return earliest
+
+
+def build_cadence(existing):
+    # type: (dict) -> dict
+    """Refresh the cadence panel: PR#/merge from git, branch/stable from Chrome,
+    and the first-NuGet-release date from the NuGet registration index.
+
+    The immutable ``prOpened`` date (which a squash merge does not preserve in git
+    history) is carried over from the committed snapshot by PR number. Any source
+    that fails leaves the affected value on its last-known state.
+    """
+    prev_cadence = existing.get("cadence", {})
+    prev_by_pr = {m.get("prNumber"): m
+                  for m in prev_cadence.get("milestones", [])}
+    prev_by_ms = {m.get("milestone"): m
+                  for m in prev_cadence.get("milestones", [])}
+
+    try:
+        bumps = discover_milestone_bumps(CADENCE_COUNT)
+    except Exception as e:  # noqa: BLE001 - can't read git -> keep snapshot
+        log("cadence: git history unavailable, keeping snapshot ({})".format(e))
+        return prev_cadence
+
+    if not bumps:
+        log("cadence: no milestone bumps found in git, keeping snapshot")
+        return prev_cadence
+
+    # First-NuGet-release dates (best-effort; falls back per milestone below).
+    try:
+        first_releases = fetch_nuget_first_releases()
+    except Exception as e:  # noqa: BLE001
+        log("cadence: NuGet release dates unavailable, keeping snapshot ({})".format(e))
+        first_releases = {}
+
+    milestones = []
+    for bump in bumps:
+        prev = prev_by_pr.get(bump["prNumber"]) or prev_by_ms.get(bump["milestone"]) or {}
+        entry = {
+            "milestone": bump["milestone"],
+            "branchPoint": prev.get("branchPoint", ""),
+            "prNumber": bump["prNumber"],
+            # opened is immutable and not in git history — carry from snapshot.
+            "prOpened": prev.get("prOpened", ""),
+            "prMerged": bump["prMerged"],
+            "stableDate": prev.get("stableDate", ""),
+            # first ship on NuGet — refresh from NuGet, else carry snapshot value.
+            "firstPreview": first_releases.get(
+                bump["milestone"], prev.get("firstPreview")),
+            "note": prev.get("note", ""),
+        }
+        try:
+            chrome = fetch_chrome_branch_and_stable(bump["milestone"])
+            entry["branchPoint"] = chrome["branchPoint"]
+            if chrome["stableDate"]:
+                entry["stableDate"] = chrome["stableDate"]
+        except Exception as e:  # noqa: BLE001 - keep snapshot dates for this one
+            log("  · m{} Chrome schedule failed, keeping snapshot dates: {}".format(
+                bump["milestone"], e))
+        milestones.append(entry)
+
+    log("cadence: refreshed {} milestone(s): {}".format(
+        len(milestones), ", ".join("m{}".format(m["milestone"]) for m in milestones)))
+    return {
+        "asOf": today_iso(),
+        "scheduleUrl": prev_cadence.get(
+            "scheduleUrl", "https://chromiumdash.appspot.com/schedule"),
+        "prsUrl": prev_cadence.get(
+            "prsUrl",
+            "https://github.com/mono/SkiaSharp/pulls?q=is%3Apr+milestone+in%3Atitle"),
+        "caption": prev_cadence.get(
+            "caption",
+            "AI opens, tests, and lands the sync PR; humans review the API."),
+        "milestones": milestones,
+    }
+
+
+# ── Panel 3: automation cost ─────────────────────────────────────────────────
+
+def build_cost(existing):
+    # type: (dict) -> dict
+    """Carry over the curated cost figures.
+
+    Per-run "Effective tokens" / "Turns" live inside each gh-aw run's *log
+    archive*, which is not readable without downloading and unzipping the logs
+    (and the right permissions). Rather than hard-code fragile log scraping into
+    the site build, these representative figures are curated in the committed
+    snapshot and shown with an "as of" date. Refresh them by re-running the
+    workflows and reading ``gh run view <id> --log | grep -E 'Effective tokens|Turns'``.
+    """
+    return existing.get("cost", {})
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def load_existing(path):
+    # type: (Path) -> dict
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            log("warning: could not parse existing {} ({}); starting fresh".format(
+                path, e))
+    return {}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output", type=Path, default=DEFAULT_OUTPUT,
+        help="path to the dashboard JSON to refresh (default: {})".format(
+            DEFAULT_OUTPUT))
+    parser.add_argument(
+        "--base", type=Path, default=None,
+        help="existing JSON to read last-known values from "
+             "(default: same as --output)")
+    parser.add_argument(
+        "--check", action="store_true",
+        help="compute and print, but do not write the output file")
+    args = parser.parse_args(argv)
+
+    base_path = args.base or args.output
+    existing = load_existing(base_path)
+
+    result = {
+        "generatedAt": today_iso(),
+        "adoption": build_adoption(existing),
+        "cadence": build_cadence(existing),
+        "cost": build_cost(existing),
+        "footerUrl": existing.get(
+            "footerUrl",
+            "https://github.com/mono/SkiaSharp/tree/main/.github/workflows"),
+    }
+
+    text = json.dumps(result, indent=2, ensure_ascii=False) + "\n"
+    if args.check:
+        log("--check: not writing. Result:")
+        print(text)
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(text, encoding="utf-8")
+    log("wrote {}".format(args.output))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a **"Moving faster with AI"** dashboard section to the `/ai/` site page (`documentation/site/ai/`), with three panels:

- **Adoption at a glance** — total + current-GA downloads and a per-release-line table (cumulative stable vs preview downloads) for the last 5 `major.minor` lines.
- **Time to keep up with upstream** (the hero) — a table of recent Skia milestone bumps (m132 → m151) showing *days behind Chrome* (branch cut → PR opened), *review* (PR opened → merged) and *time to first NuGet release*, each with the day **and percent** change vs the previous milestone. Newest milestone highlighted.
- **What the automation costs** — per-run effective tokens and turns for the sync and API-docs agentic workflows.

## How the data flows

Data is **cached at build time** (we regenerate the site often) rather than fetched live in the browser:

- A committed `dashboard-data.json` is the source of truth **and** the graceful-degradation fallback.
- `scripts/infra/docs/generate-ai-dashboard.py` refreshes it from **git history** (milestone-bump PRs — no GitHub API), the **Chromium Dashboard** (branch/stable dates) and the **NuGet APIs** (downloads + first-release dates), reusing the conventions already in `generate-release-notes.py`.
- Each source **degrades independently** to its last-known value with an "as of" date; day-deltas are computed in code, never stored.
- `build-site.yml` runs the generator best-effort during "Assemble site" (keeps the committed snapshot on failure).

## Files
- `documentation/site/ai/index.html` — new section + `dashboard.js` include
- `documentation/site/ai/ai.css` — panel/table styles (theme-aware)
- `documentation/site/ai/dashboard.js` — renderer (fetches the cached JSON)
- `documentation/site/ai/dashboard-data.json` — committed cache / fallback
- `scripts/infra/docs/generate-ai-dashboard.py` — build-time refresher
- `.github/workflows/build-site.yml` — best-effort refresh hook

Verified in-browser (light + dark, zero console errors); JS/JSON/PY/YAML all validate.
