### PR TITLE
[docs-site] Skip PR staging previews for non-site file changes

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -6,6 +6,43 @@ on:
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
+    # Skip building a staging preview when a PR touches ONLY files that can never
+    # change the rendered site. This is a conservative EXCLUDE list (paths-ignore),
+    # which is fail-safe: the full build still runs unless EVERY changed file matches
+    # a pattern below, so anything we did not anticipate still gets a preview.
+    #
+    # The site is built from:
+    #   documentation/docfx/**  -> /docs/ and the release notes
+    #   documentation/site/**   -> the landing page and /ai/
+    #   samples/**              -> the /gallery/, /gallery-uno/ and /fiddle/ apps,
+    #                              which ProjectReference binding/** + source/** and
+    #                              load WASM native libs built from native/wasm/**,
+    #                              scripts/infra/native/{wasm,shared}/** + externals/skia
+    # None of the paths below feed any of those, so they cannot alter the preview.
+    # (Applies to PR previews only; pushes to main always redeploy the root site.)
+    paths-ignore:
+      - 'tests/**'                     # test projects — never built for the site
+      - 'benchmarks/**'                # benchmark projects — not on the site
+      - 'documentation/dev/**'         # dev docs — NOT in the docfx content root
+      - 'native/android/**'            # non-WASM native — galleries are WASM only
+      - 'native/ios/**'
+      - 'native/maccatalyst/**'
+      - 'native/macos/**'
+      - 'native/tvos/**'
+      - 'native/tizen/**'
+      - 'native/windows/**'
+      - 'native/winui/**'
+      - 'native/winui-angle/**'
+      - 'native/linux/**'
+      - 'native/linux-clang-cross/**'
+      - 'native/linuxnodeps/**'
+      - 'native/nanoserver/**'
+      - 'README.md'                    # repo meta docs — not rendered on the site
+      - 'CONTRIBUTING.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'SECURITY.md'
+      - '.agents/**'                   # agent skills/workflows — not built into the site
+      - 'cgmanifest.json'              # component-governance manifest — not a site input
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Problem

The **Pages - Deploy** workflow builds a full **~470 MB** staging preview (DocFX + 3 WASM apps) for **every** PR — there is no path filter. In practice most open PRs change `tests/`, `native/`, `scripts/`, `benchmarks/` or `.github/` — none of which alter the rendered site — yet each still produced a preview. The previews accumulated to **5.6 GB** on the `docs-live` branch and pushed the aggregate GitHub Pages artifact past the **1 GB limit**, which broke the `Pages - Go Live!` deploy (upload-size warning → timeout).

I analysed the 11 staging previews that existed at the time: **0 of 11** touched rendered docs, release notes, `/ai/`, or gallery samples; **4 of 11** changed nothing on the site at all.

## Change

Add a **conservative `paths-ignore` exclude** to the `pull_request` trigger. This is deliberately fail-safe — `paths-ignore` skips the run **only if EVERY changed file matches** the list, so anything we did not anticipate still gets a full preview. We start with the exclude (not a positive `paths:` allow-list) precisely so a missed path fails toward *building*, not toward *skipping*.

Only paths **verified** to never feed any site output are excluded:

- `tests/**`, `benchmarks/**` — not built for the site
- `documentation/dev/**` — not in the DocFX content root (`docfx.json` renders `documentation/docfx/**` only)
- non-WASM `native/*` platforms (ios, macos, tvos, tizen, android, linux*, windows, winui*, maccatalyst, nanoserver) — the galleries are WASM only; the WASM native libs come from `native/wasm/**`, `scripts/infra/native/{wasm,shared}/**` and `externals/skia`
- repo meta docs: `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
- `.agents/**`, `cgmanifest.json`

**Not excluded** (so they still build a preview): `documentation/docfx/**` (incl. release notes), `documentation/site/**` (landing + `/ai/`), `samples/**`, `binding/**`, `source/**`, `native/wasm/**`, `scripts/infra/native/{wasm,shared}/**`, `externals/skia`, and `.github/workflows/build-site.yml`.

`push: main` is intentionally **not** filtered, so the live site always redeploys.

## Safety notes

- **Not a required check** — `Build Site` is not in branch protection (`license/cla` and `SkiaSharp (Public)` are), so a skipped run cannot block a merge.
- Replaying the 11 recent PRs against this list: only the tests-only PR (#4106) would have skipped its preview; every other PR still builds because it also touches a non-excluded path. That is the intended cautious behaviour for a first pass.

## Follow-ups (not in this PR)

- Widen the exclude (e.g. specific `scripts/**` subtrees, other root metadata) once we are comfortable.
- Optionally slim previews: ~52 % of each 470 MB folder is the 3 WASM apps; docs-only PRs could skip the gallery/fiddle builds and stage just `/docs/`.
- Make the stale-sweep size-aware (cap the number of live previews), since the 90-day window alone can't prevent a size pileup from many active PRs.
