### PR TITLE
Auto-apply milestone labels in the Skia sync workflow

### DIFF
--- a/.github/scripts/skia-sync-push-prs.sh
+++ b/.github/scripts/skia-sync-push-prs.sh
@@ -46,6 +46,10 @@ SS_SUMMARY=""
 [ -f /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md ] && SS_SUMMARY=$(cat /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md)
 
 # --- Determine PR titles based on sync kind (tip / same-milestone / milestone bump) ---
+# Every skia-sync PR gets the `type/milestone-sync` label. The one case that also
+# changes the `libSkiaSharp milestone` line in scripts/VERSIONS.txt additionally gets
+# the `type/milestone-bump` label.
+SS_IS_MILESTONE_BUMP=false
 if [ "$UPSTREAM_REF" = "main" ]; then
     SS_TITLE="[skia-sync] Merge upstream Skia main (tip)"
     SS_BODY_INTRO="Automated bleeding-edge sync from the tip of upstream Skia (google/skia main)."
@@ -55,6 +59,7 @@ elif [ "$CURRENT" = "$TARGET" ]; then
 else
     SS_TITLE="[skia-sync] Update skia to milestone ${TARGET}"
     SS_BODY_INTRO="Automated Skia milestone bump from m${CURRENT} to m${TARGET}."
+    SS_IS_MILESTONE_BUMP=true
 fi
 if [ "$IS_RELEASE" = "true" ]; then
     SS_BODY_INTRO="${SS_BODY_INTRO} Targeting release branch \`${SS_BASE}\` (mono/skia \`${SKIA_BASE}\`)."
@@ -125,12 +130,22 @@ push_skiasharp() {
     [ -n "$skia_pr" ] && skia_pr_link="**Companion skia PR:** https://github.com/mono/skia/pull/$skia_pr"
 
     ss_pr=$(gh pr list --repo mono/SkiaSharp --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+    # Every skia-sync PR carries type/milestone-sync; milestone bumps (those that change
+    # the milestone in scripts/VERSIONS.txt) additionally carry type/milestone-bump. Both
+    # labels must already exist in the repo.
+    local ss_label_args=(--label "type/milestone-sync")
+    if [ "$SS_IS_MILESTONE_BUMP" = "true" ]; then
+        ss_label_args+=(--label "type/milestone-bump")
+    fi
+
     if [ -z "$ss_pr" ]; then
         echo "Creating mono/SkiaSharp PR..."
         gh pr create --repo mono/SkiaSharp \
             --head "$BRANCH" --base "$SS_BASE" \
             --title "$SS_TITLE" \
             --draft \
+            "${ss_label_args[@]}" \
             --body "${SS_BODY_INTRO}
 
 $skia_pr_link
@@ -140,6 +155,11 @@ ${SS_SUMMARY}
 Created by ${WORKFLOW_LINK}." || echo "::warning::Failed to create mono/SkiaSharp PR"
     else
         echo "Updating mono/SkiaSharp PR #${ss_pr}..."
+        local ss_add_labels="type/milestone-sync"
+        if [ "$SS_IS_MILESTONE_BUMP" = "true" ]; then
+            ss_add_labels="type/milestone-sync,type/milestone-bump"
+        fi
+        gh pr edit "$ss_pr" --repo mono/SkiaSharp --add-label "$ss_add_labels" || true
         gh pr edit "$ss_pr" --repo mono/SkiaSharp \
             --body "${SS_BODY_INTRO}
 


### PR DESCRIPTION
Fixes #4317.

## What

The `mono/SkiaSharp` sync PR is created by `.github/scripts/skia-sync-push-prs.sh` (using `SKIASHARP_AUTOBUMP_TOKEN`), **not** the gh-aw `create-pull-request` safe-output — so it never picked up the `type/milestone-bump` label automatically and it had to be applied by hand each milestone.

This wires labeling into that script and introduces a companion label so *all* sync PRs are findable, not just bumps:

- **`type/milestone-sync`** — applied to **every** skia-sync PR (milestone bump, same-milestone bug-fix re-sync, and tip sync).
- **`type/milestone-bump`** — applied **additionally** to the one case that changes the `libSkiaSharp milestone` line in `scripts/VERSIONS.txt` (an actual milestone-number bump).

Labels are set on both the **create** and **update** paths, so re-runs on an existing PR still ensure they're present.

> `type/milestone-sync` was created in the repo (color `#a371f7`) as part of this work.

## Backfill

Applied the labels retroactively to every merged sync PR:

| Kind | PRs | `milestone-bump` | `milestone-sync` |
|------|-----|:---:|:---:|
| Bumps (m115–m151) | #2547, #2829, #3047, #3048, #3062, #3560, #3660, #3702, #4125, #4146, #4294 | ✅ (11) | ✅ |
| Bug-fix re-syncs | #4044, #4081, #4262, #4190, #4312 | — | ✅ |

The four pre-m119 bumps (#2547/m115, #2829/m116, #3047/m117, #3048/m118) were missing the label entirely and are now covered. Final counts: **11** `type/milestone-bump`, **16** `type/milestone-sync`.

## Notes
- `gh pr create --label` / `gh pr edit --add-label` require the labels to already exist — they do now.
- The script is `cp`'d and run directly by the workflow (not inlined into `auto-skia-sync.lock.yml`), so no lock-file regeneration is needed.
- `bash -n` syntax check passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>