### PR TITLE
Auto-apply milestone labels to the mono/skia sync PR too (#4317)

### DIFF
--- a/.github/scripts/skia-sync-push-prs.sh
+++ b/.github/scripts/skia-sync-push-prs.sh
@@ -46,10 +46,11 @@ SS_SUMMARY=""
 [ -f /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md ] && SS_SUMMARY=$(cat /tmp/gh-aw/agent/skia-sync-skiasharp-summary.md)
 
 # --- Determine PR titles based on sync kind (tip / same-milestone / milestone bump) ---
-# Every skia-sync PR gets the `type/milestone-sync` label. The one case that also
-# changes the `libSkiaSharp milestone` line in scripts/VERSIONS.txt additionally gets
-# the `type/milestone-bump` label.
-SS_IS_MILESTONE_BUMP=false
+# Every skia-sync PR (in both mono/skia and mono/SkiaSharp) gets the `type/milestone-sync`
+# label. The one case that advances the milestone number — i.e. changes `SK_MILESTONE` in
+# mono/skia's include/core/SkMilestone.h and the `libSkiaSharp milestone` line in
+# mono/SkiaSharp's scripts/VERSIONS.txt — additionally gets the `type/milestone-bump` label.
+IS_MILESTONE_BUMP=false
 if [ "$UPSTREAM_REF" = "main" ]; then
     SS_TITLE="[skia-sync] Merge upstream Skia main (tip)"
     SS_BODY_INTRO="Automated bleeding-edge sync from the tip of upstream Skia (google/skia main)."
@@ -59,7 +60,7 @@ elif [ "$CURRENT" = "$TARGET" ]; then
 else
     SS_TITLE="[skia-sync] Update skia to milestone ${TARGET}"
     SS_BODY_INTRO="Automated Skia milestone bump from m${CURRENT} to m${TARGET}."
-    SS_IS_MILESTONE_BUMP=true
+    IS_MILESTONE_BUMP=true
 fi
 if [ "$IS_RELEASE" = "true" ]; then
     SS_BODY_INTRO="${SS_BODY_INTRO} Targeting release branch \`${SS_BASE}\` (mono/skia \`${SKIA_BASE}\`)."
@@ -90,12 +91,22 @@ push_skia() {
 
     local pr
     pr=$(gh pr list --repo mono/skia --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+    # Every skia-sync PR carries type/milestone-sync; milestone bumps (those that change
+    # SK_MILESTONE in include/core/SkMilestone.h) additionally carry type/milestone-bump.
+    # Both labels must already exist in the repo.
+    local skia_label_args=(--label "type/milestone-sync")
+    if [ "$IS_MILESTONE_BUMP" = "true" ]; then
+        skia_label_args+=(--label "type/milestone-bump")
+    fi
+
     if [ -z "$pr" ]; then
         echo "Creating mono/skia PR..."
         gh pr create --repo mono/skia \
             --head "$BRANCH" --base "$SKIA_BASE" \
             --title "$SKIA_TITLE" \
             --draft \
+            "${skia_label_args[@]}" \
             --body "${SKIA_BODY_INTRO}
 
 ${SKIA_SUMMARY}
@@ -103,6 +114,11 @@ ${SKIA_SUMMARY}
 Created by ${WORKFLOW_LINK}." || echo "::warning::Failed to create mono/skia PR"
     else
         echo "Updating mono/skia PR #${pr}..."
+        local skia_add_labels="type/milestone-sync"
+        if [ "$IS_MILESTONE_BUMP" = "true" ]; then
+            skia_add_labels="type/milestone-sync,type/milestone-bump"
+        fi
+        gh pr edit "$pr" --repo mono/skia --add-label "$skia_add_labels" || true
         gh pr edit "$pr" --repo mono/skia \
             --body "${SKIA_BODY_INTRO}
 
@@ -135,7 +151,7 @@ push_skiasharp() {
     # the milestone in scripts/VERSIONS.txt) additionally carry type/milestone-bump. Both
     # labels must already exist in the repo.
     local ss_label_args=(--label "type/milestone-sync")
-    if [ "$SS_IS_MILESTONE_BUMP" = "true" ]; then
+    if [ "$IS_MILESTONE_BUMP" = "true" ]; then
         ss_label_args+=(--label "type/milestone-bump")
     fi
 
@@ -156,7 +172,7 @@ Created by ${WORKFLOW_LINK}." || echo "::warning::Failed to create mono/SkiaShar
     else
         echo "Updating mono/SkiaSharp PR #${ss_pr}..."
         local ss_add_labels="type/milestone-sync"
-        if [ "$SS_IS_MILESTONE_BUMP" = "true" ]; then
+        if [ "$IS_MILESTONE_BUMP" = "true" ]; then
             ss_add_labels="type/milestone-sync,type/milestone-bump"
         fi
         gh pr edit "$ss_pr" --repo mono/SkiaSharp --add-label "$ss_add_labels" || true


### PR DESCRIPTION
Follow-up to #4327 (which handled the `mono/SkiaSharp` PR). Also part of #4317.

The skia-sync workflow opens a **companion PR in `mono/skia`** (the `push_skia()` function in `.github/scripts/skia-sync-push-prs.sh`), in addition to the `mono/SkiaSharp` PR. This applies the same labeling there.

## Workflow change

- Every skia-sync PR (both repos) gets **`type/milestone-sync`**.
- Milestone-number bumps additionally get **`type/milestone-bump`**. On the `mono/skia` side, "bump" means the merge advances `SK_MILESTONE` in `include/core/SkMilestone.h` (the analog of `scripts/VERSIONS.txt` on the parent).
- Renamed the shared flag `SS_IS_MILESTONE_BUMP` → `IS_MILESTONE_BUMP`, since it now drives labels for both PRs.
- Labels applied on both the create and update paths.

> Created both labels in `mono/skia` (colors matching `mono/SkiaSharp`: bump `#6f42c1`, sync `#a371f7`).

## Backfill (mono/skia)

Classified every merged sync PR by whether it changed `SK_MILESTONE`:

| Kind | PRs | `bump` | `sync` |
|------|-----|:---:|:---:|
| Bumps | #122(m116), #138(m117), #139(m118), #148(m119), #171(m132), #179(m133), #184(m147), #250(m148), #253(m150), #274(m151) | ✅ (10) | ✅ |
| Re-syncs / backport | #242(m147), #255(m150 Tizen backport), #259(m150), #268(m148), #278(m151) | — | ✅ |

Final counts: **10** `type/milestone-bump`, **15** `type/milestone-sync`.

Notes:
- No `mono/skia` PR set m115 (it was a direct push to `skiasharp`), so scope starts at m116 — mirroring the parent side.
- The ancient 2016 `m53` PRs (#15, #17) predate modern milestone tracking and were intentionally left out.
- `bash -n` passes; script is run directly by the workflow (no `.lock.yml` regeneration needed).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>