### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b9afcef1e0037600bb3eb9c568fae603c167ea93"
+          "commitHash": "eb3ae7b2a21821a5bf3211baa821d2c91d614b89"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "b68567542f81de33434b16f8600cd6db7240b0ee"
+      "upstream_merge_commit": "71db7c06c5fedcba160f1d15f2b17decb1b6c32e"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "eb3ae7b2a21821a5bf3211baa821d2c91d614b89"
+          "commitHash": "83f37f3534fb10a183cc441cd96a229e3036268b"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "71db7c06c5fedcba160f1d15f2b17decb1b6c32e"
+      "upstream_merge_commit": "1ff92f8798156dd20a19e9cf6f4418890fa2839a"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "076a10989777172d1a327f1d8386430ae8f40b15"
+          "commitHash": "200837b410787c822ddaf36afc5723d891ff76ea"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "707bd0f94a6c13f85df182a17dc7f8bf368989e6"
+      "upstream_merge_commit": "6a541bef31d1d03747e53fb2d6b750c82a43ff6e"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "0b5ac8725c459de88f571ace7f3ebaf4e1a1484d"
+          "commitHash": "1187357ea096de8aecd74802dda5fb83f6424a7d"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "8bf65996caba83032c76f9abeb998bcc201bef0f"
+      "upstream_merge_commit": "653a691cf2156a9ff99de9637b44280e1f3843a3"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "83f37f3534fb10a183cc441cd96a229e3036268b"
+          "commitHash": "d6233fe4dc9077cf21e0f258505eb979726375da"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "1ff92f8798156dd20a19e9cf6f4418890fa2839a"
+      "upstream_merge_commit": "7b42d1251d546f39dbc07cb8a7489d969635eb5d"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "d7029e14c904429f0dab5678aa949380eeeca024"
+          "commitHash": "119babb5a4b64f8d65295cd9d09aa9834add1958"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "8c5eb079d3359b4e498746c2e1d717ab3367ff05"
+      "upstream_merge_commit": "75a4bf6706bd9c13b06975864fd941e495aac848"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "d6233fe4dc9077cf21e0f258505eb979726375da"
+          "commitHash": "076a10989777172d1a327f1d8386430ae8f40b15"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "7b42d1251d546f39dbc07cb8a7489d969635eb5d"
+      "upstream_merge_commit": "707bd0f94a6c13f85df182a17dc7f8bf368989e6"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "98877992a585d9fd60e398871b9293483db53eb8"
+          "commitHash": "f800c860812cea8d19aae0888f4644a81c45ce0a"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
+      "upstream_merge_commit": "919956953af68d2288ca5fbe8cdc54b3c8f8825e"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "119babb5a4b64f8d65295cd9d09aa9834add1958"
+          "commitHash": "b9afcef1e0037600bb3eb9c568fae603c167ea93"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "75a4bf6706bd9c13b06975864fd941e495aac848"
+      "upstream_merge_commit": "b68567542f81de33434b16f8600cd6db7240b0ee"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "f800c860812cea8d19aae0888f4644a81c45ce0a"
+          "commitHash": "d7029e14c904429f0dab5678aa949380eeeca024"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "919956953af68d2288ca5fbe8cdc54b3c8f8825e"
+      "upstream_merge_commit": "8c5eb079d3359b4e498746c2e1d717ab3367ff05"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "200837b410787c822ddaf36afc5723d891ff76ea"
+          "commitHash": "0b5ac8725c459de88f571ace7f3ebaf4e1a1484d"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "6a541bef31d1d03747e53fb2d6b750c82a43ff6e"
+      "upstream_merge_commit": "8bf65996caba83032c76f9abeb998bcc201bef0f"
     }
   ]
 }


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/280

## `[skia-sync] Merge upstream chrome/m151 bug fixes`

Companion PR to mono/skia's `skia-sync/main`. Bumps SkiaSharp's `externals/skia` submodule pointer to the merge commit that absorbed google/skia's `main` tip into our `skiasharp` branch.

- **Sync branch:** `skia-sync/main` (this PR)
- **Base branch:** `main`
- **Companion PR:** [mono/skia `skia-sync/main`](https://github.com/mono/skia/tree/skia-sync/main) — see that PR for merge details, conflict resolution, and the VMA compat fork-patch.
- **Mode:** `main`/tip merge, CURRENT == TARGET == **m151**. **Not** a version bump.

## Version files — unchanged

Since this is a same-milestone sync (bug-fix pull from upstream's main tip), all SkiaSharp version numbers stay put:

| File | Value | Change? |
|---|---|---|
| `scripts/VERSIONS.txt` — `libSkiaSharp milestone` | 151 | No |
| `scripts/VERSIONS.txt` — `SkiaSharp` nuget | 4.151.0 | No |
| `scripts/VERSIONS.txt` — `libSkiaSharp increment` | 0 | No |
| `scripts/azure-templates-variables.yml` — `SKIASHARP_VERSION` | 4.151.0 | No |
| `cgmanifest.json` — `chrome_milestone` | 151 | No |
| `externals/skia/include/c/sk_types.h` — `SK_C_INCREMENT` | 0 | No |
| `externals/skia/include/core/SkMilestone.h` — `SK_MILESTONE` | 151 | No (fork-patched to keep at 151 — see companion PR) |

Only `cgmanifest.json`'s **submodule commitHash** and **upstream_merge_commit** move:

```diff
-          "commitHash": "98877992a585d9fd60e398871b9293483db53eb8"
+          "commitHash": "f800c860812cea8d19aae0888f4644a81c45ce0a"
       "chrome_milestone": 151,
-      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
+      "upstream_merge_commit": "919956953af68d2288ca5fbe8cdc54b3c8f8825e"
```

## C# bindings & wrappers — unchanged

- `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` produced a **zero diff** — upstream did not modify the C API (`src/c/`, `include/c/`) between merge-base and tip.
- `git diff origin/main -- binding/SkiaSharp/SkiaApi.generated.cs …` shows no new `internal static extern` declarations.
- No new C# wrappers required.

## Native build

- Rebuilt from source on Linux x64: `dotnet cake --target=externals-linux --arch=x64`.
- **Never** used `externals-download` in this workflow.
- First build failed with 3 errors in `VulkanAMDMemoryAllocator.cpp` (VMA API skew — see companion mono/skia PR for the compat patch and rationale). After the fork patch was committed to the submodule and the submodule pointer refreshed, the second build succeeded cleanly.
- Artifacts produced:
  - `output/native/linux/x64/libSkiaSharp.so.151.0.0` — 11 MB (soname 151.0.0 = our tracked milestone)
  - `output/native/linux/x64/libHarfBuzzSharp.so.0.61421.0` — 2.8 MB
- Build durations: libSkiaSharp 9:47, libHarfBuzzSharp 1:13, total 11:06.

## C# build

`dotnet build binding/SkiaSharp/SkiaSharp.csproj` — **succeeded**, 0 warnings, 0 errors, built for all target frameworks (net48/net462/netstandard2.0/2.1/net6.0/net9.0/net10.0/net10.0-android36.0/net9.0-android35.0/…).

## Tests

`dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` on Linux x64:

- **Failed: 0**
- **Passed: 5584**
- **Skipped: 172** (hardware-capability skips — GPU/Vulkan/Metal/D3D not present in the sandbox)
- **Total: 5756**
- **Duration: 2m 44s**

Full log uploaded as workflow artifact `test-output.txt`.

## Breaking-change analysis

- **Public C++ headers touched by upstream:** only `SkMilestone.h` (kept at 151 via fork patch), `SkSpan.h` (additive `SkPreIncrementSpan` / `SkPostIncrementSpan` template helpers), `include/gpu/graphite/ContextOptions.h` (additive `fAvoidDepthMode` field on Graphite, which SkiaSharp doesn't use).
- **C API surface (`src/c/`, `include/c/`):** unchanged. No SkiaSharp binding, wrapper, or public API impact.
- **ABI:** unchanged. libSkiaSharp soname stays `151.0.0`.

## Items needing human attention

1. **VMA 3.2.1 compat patch is a stopgap.** See the mono/skia PR — the follow-up is a `/native-dependency-update` for VMA, then revert commit `f800c86081`.
2. **Only Linux x64 built here.** Windows / macOS / iOS / Android / WASM / Mac Catalyst builds will run in CI on this PR; expect them to succeed since (a) no C API changes, (b) the VMA compat patch applies to all clang platforms that build the Vulkan allocator, and (c) no new `--gnArgs` were needed. Watch CI output.
3. **`tools/gpu/vk/VkTestMemoryAllocator.cpp`** (in the submodule) still carries upstream's VMA 3.3+ additions. It's not compiled by libSkiaSharp, but any tool build will fail with the same 3 errors until VMA is bumped or the compat patch is extended.
4. **Next SkMilestone bump (to m152).** The fork patch that keeps SkMilestone.h at 151 will become a no-op on the milestone bump. No special action needed — it just naturally disappears.

## Where changes live

- **Parent** (this PR — `mono/SkiaSharp` @ `skia-sync/main`, 1 commit on top of `main`):
  - `cgmanifest.json` — submodule hash + upstream_merge_commit
  - `externals/skia` — submodule pointer bumped to the new merge commit
- **Submodule** (companion PR — `mono/skia` @ `skia-sync/main`, 2 commits on top of `skiasharp`):
  - Merge commit absorbing google/skia main tip
  - VMA compat fork patch on top

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).