### PR TITLE
release-notes: manual notes sidecar + AI-summarized breaking changes

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -117,12 +117,14 @@ script** (module + function docstrings in `generate-release-notes.py`) and are i
 NOT restated here, so this skill can never drift from the code.
 
 **Your job is narrow: rewrite the body of each file in the "Files to polish" list**, using
-that file's embedded raw-data block, and nothing else. Do **not** create files, rename
-files, compute diff ranges, or reason about released-vs-unreleased or rollup-vs-delta — if
-you catch yourself doing any of that, stop: the script already did it. **Never edit the
-script.** If a page you expect is missing (or an unexpected one exists, or any data looks
-wrong), **stop and report it** — do not work around it and do not touch the script. A
-maintainer decides whether the script needs fixing; the Polish phase only polishes.
+that file's raw-data block **plus the companion files that block references** (see
+[Companion files](#companion-files-open-and-read-them) below), and nothing else. Do **not**
+create files, rename files, compute diff ranges, or reason about released-vs-unreleased or
+rollup-vs-delta — if you catch yourself doing any of that, stop: the script already did it.
+**Never edit the script, and never edit a companion file.** If a page you expect is missing
+(or an unexpected one exists, or any data looks wrong), **stop and report it** — do not work
+around it and do not touch the script. A maintainer decides whether the script needs fixing;
+the Polish phase only polishes.
 
 The one structural fact you **consume** (never compute) while polishing: when a page rolls
 up tagged previews, the script delivers the PRs already **grouped into per-preview buckets**
@@ -137,6 +139,34 @@ reorder, or recompute any of this; it is the script's output.
 The file starts with an HTML comment block containing both metadata (version, status, branch,
 diff range, PR count) AND the raw PR list. Below the comment is a skeleton heading with a
 placeholder for polished content. The raw data comment must be preserved in the final file.
+
+#### Companion files (open and read them)
+
+The raw-data block is still your **primary** input, and it remains the reason you never touch
+git or the gh API — it carries the PR titles, authors, and numbers. On top of that, the block
+may list a **companions** manifest: extra files, already on disk, that you should **open and
+read** while polishing, then **summarize**. There are up to three, all referenced by
+page-relative path (see `release-notes-and-api-diffs.md` §4.7):
+
+| Companion | What it is | Use it for |
+| --- | --- | --- |
+| `<stem>.notes.md` | **Manual additions sidecar** — freeform Markdown the maintainer wrote to bring something out (not always breaking). | Weave its editorial points into Highlights; surface any behavioral breaking notes under Breaking Changes. |
+| `<line>/index.md` (+ per-assembly files) | The **full public-API diff**. | Draw richer, accurate highlights (what was added/changed). Do **not** paste it — summarize. |
+| `<line>/…/*.breaking.md` | The **API breaking diff** — present only when signatures actually broke. | The "what" of Breaking Changes: obsoleted / removed / changed signatures. |
+
+Rules for companions:
+
+- **Open and read** each one the manifest lists, then **summarize** — never paste a diff
+  verbatim or dump the whole file. A human summary ("obsoleted several APIs in `SKPaint` and
+  `SKFont`"; "`SKFooBar` was removed — use `SKBaz`") with a small migration code example where
+  it helps is the goal.
+- **Behavioral breaking changes** (same signature, different runtime behavior — e.g.
+  `new SKFont()` now carries an empty typeface) will **not** appear in the API breaking diff.
+  The `<stem>.notes.md` sidecar is the **only** channel for them — read it carefully.
+- You may **read** these files but **never edit them** — they are inputs/artifacts, owned by
+  the maintainer and the Prepare script. Still no git, no gh API, no other files.
+- If the manifest lists a companion but the file is missing (or vice-versa), **stop and
+  report it** — do not work around it.
 
 **IMPORTANT:** The list of files to polish is **always** at `output/files-to-polish.txt`
 (one repo-relative path per line, nothing else). For a **manual** run the Prepare script
@@ -246,7 +276,13 @@ Follow these rules:
 5. **Omit noise** — Skip version bumps, CI-only fixes, doc updates, workflow/skill changes.
    If many, mention as: "Plus several CI and documentation improvements."
 
-6. **Breaking changes** — If any, list under `### ⚠️ Breaking Changes` after Highlights.
+6. **Breaking changes** — Always include a `## Breaking Changes` section (say
+   *"None in this release."* when there are none). When the raw block lists an api
+   **breaking** companion and/or a manual notes sidecar, **summarize** from them: the
+   `.breaking.md` gives the "what" (obsoleted/removed/changed signatures), the
+   `<stem>.notes.md` gives behavioral breaks and migration "how". Keep it concise — a small
+   migration code example is welcome; point at the API diff for the exhaustive list. Do not
+   dump the diff. (See [Companion files](#companion-files-open-and-read-them) and TEMPLATE.md.)
 
 7. **PR links** — Every item links to its PR.
 

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -151,8 +151,8 @@ page-relative path (see `release-notes-and-api-diffs.md` §4.7):
 | Companion | What it is | Use it for |
 | --- | --- | --- |
 | `<stem>.notes.md` | **Manual additions sidecar** — freeform Markdown the maintainer wrote to bring something out (not always breaking). | Weave its editorial points into Highlights; surface any behavioral breaking notes under Breaking Changes. |
-| `<line>/index.md` (+ per-assembly files) | The **full public-API diff**. | Draw richer, accurate highlights (what was added/changed). Do **not** paste it — summarize. |
-| `<line>/…/*.breaking.md` | The **API breaking diff** — present only when signatures actually broke. | The "what" of Breaking Changes: obsoleted / removed / changed signatures. |
+| `<line>/index.md` (indexes every per-assembly diff; flags breaking) | The **full public-API diff** landing page — one door to the whole folder. | Open it, follow the assemblies that matter, draw richer/accurate highlights. Do **not** paste it — summarize. |
+| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes: obsoleted / removed / changed signatures, summarized across all listed files. |
 
 Rules for companions:
 

--- a/.github/workflows/update-release-notes.lock.yml
+++ b/.github/workflows/update-release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"411a26c5b940a5391a831f5bd3d7e33cafa88734ce89b594e6fc08bf4c763d99","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6132ead32a5d4f84a9012fccf1de244ed589c0bde0dd610dff8459c879861bb8","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -118,7 +118,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
+          GH_AW_INFO_MODEL: "claude-opus-4.7"
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
           GH_AW_INFO_CLI_VERSION: "v0.71.5"
@@ -203,23 +203,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
+          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
           <system>
-          GH_AW_PROMPT_e4335b5e35f43524_EOF
+          GH_AW_PROMPT_c7c367dd492f9839_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
+          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_e4335b5e35f43524_EOF
+          GH_AW_PROMPT_c7c367dd492f9839_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
+          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_e4335b5e35f43524_EOF
+          GH_AW_PROMPT_c7c367dd492f9839_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
+          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -251,12 +251,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_e4335b5e35f43524_EOF
+          GH_AW_PROMPT_c7c367dd492f9839_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e4335b5e35f43524_EOF'
+          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
           </system>
           {{#runtime-import .github/workflows/update-release-notes.md}}
-          GH_AW_PROMPT_e4335b5e35f43524_EOF
+          GH_AW_PROMPT_c7c367dd492f9839_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -461,9 +461,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_67945bc866cf0c5f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_55c5959e85769c8b_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"draft":false,"labels":["documentation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true,"title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_67945bc866cf0c5f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_55c5959e85769c8b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -671,7 +671,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dca3e62519becd90_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_104ab0949ab014c8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -712,7 +712,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dca3e62519becd90_EOF
+          GH_AW_MCP_CONFIG_104ab0949ab014c8_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -777,7 +777,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: claude-opus-4.7
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1236,7 +1236,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: claude-opus-4.7
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.71.5
@@ -1449,7 +1449,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_MODEL: "claude-opus-4.7"
       GH_AW_ENGINE_VERSION: "1.0.40"
       GH_AW_WORKFLOW_ID: "update-release-notes"
       GH_AW_WORKFLOW_NAME: "Sync - Release Notes & API Diffs"

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -1,5 +1,12 @@
 ---
 description: "Regenerate website release notes AND API diffs daily (and on every main push) — new tags, releases, and release-branch commits are discovered automatically. One pipeline, one PR."
+# ENGINE — pin the stronger model for the Polish phase. Polishing now reads the
+# companion files (manual notes sidecar + API diff + API breaking diff) and writes
+# concise summaries with migration code examples, so it benefits from Opus (same
+# rationale as auto-skia-sync.md). Recompile the .lock.yml after changing this.
+engine:
+  id: copilot
+  model: claude-opus-4.7
 # TRIGGERS — main is the single source of truth for EVERY version/branch.
 # Deliberately NOT triggered by `release/**` pushes or `v*` tags: a push/tag event
 # runs the workflow copy that lives on THAT ref, not main's, so those triggers can

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -54,6 +54,7 @@ thing.
   - §3.4 The HarfBuzz tree shape
   - §3.5 Ownership — who writes and clears what
   - §3.6 The co-release map sidecar (Cake → Python)
+  - §3.7 The manual additions sidecar (maintainer → Python → Polish AI)
 - **§4 — Release-notes engine (`generate-release-notes.py`)**
   - §4.1 Inputs & outputs
   - §4.2 Released vs unreleased — two coexisting pages
@@ -61,6 +62,7 @@ thing.
   - §4.4 Division of responsibility — the script structures, the AI only polishes
   - §4.5 The HarfBuzz family pages
   - §4.6 How it runs
+  - §4.7 Manual additions & breaking-change summaries (companion files)
 - **§5 — API-diff engine (`api-diff.cake`)**
   - §5.1 Inputs & outputs
   - §5.2 Behavior
@@ -334,8 +336,10 @@ Polish phase reads (§2.3).
 
 **Polish.** The AI (the skill) rewrites only the *prose* of the listed human pages
 (§4.4). It never creates, renames, or deletes files, never writes structural content or
-links, and never edits either script. Polish is never part of the script — it is the AI's
-job afterwards.
+links, and never edits either script. It **may open, read-only,** the companion files a
+page's raw-data block references — the manual additions sidecar (§3.7) and the API-diff /
+breaking-diff files (§3.3) — and **summarize** them into the prose (§4.7); it never writes
+to a companion. Polish is never part of the script — it is the AI's job afterwards.
 
 So consumers see just two phases — **Prepare** (run the one script) then **Polish** (the
 AI) — and never juggle the individual generators by hand.
@@ -378,7 +382,10 @@ the working-tree changes are re-applied and the list is placed back at
 `output/files-to-polish.txt` — the **same path a manual Prepare run writes** — so the
 Polish phase reads it from one place regardless of how it was triggered. The agent then
 runs the **Polish** phase (§2.2) with **no network and no `python3`/`cake` access** — it
-reads `output/files-to-polish.txt` first and edits only the prose of the listed pages.
+reads `output/files-to-polish.txt` first and edits only the prose of the listed pages
+(it may additionally open, **read-only**, the companion files those pages reference — the
+manual additions sidecar and the API-diff / breaking-diff files, §4.7 — which are already
+present in the restored working tree).
 The `create-pull-request` safe-output captures the *combined* working-tree diff (restored
 Prepare output + agent prose edits) into the single PR, so both artifacts always ship
 together. The agent job is **gated on Prepare having produced changes**
@@ -496,6 +503,7 @@ paths and only ever clears its own:
 | `releases/harfbuzzsharp/<hb-line>/…` | Cake | Cake (generated files only, §5.2) |
 | `releases/<line>/index.md`, `releases/harfbuzzsharp/<hb-line>/index.md` (per-line diff landings, §3.3/§3.4) | Cake | Cake (marker-managed; regenerated each run, §5.2) |
 | `releases/co-release-map.json` (§3.6) | Cake | Cake (rewritten each run) |
+| `releases/<line>.notes.md`, `releases/harfbuzzsharp/<hb-line>.notes.md` (manual additions sidecar, §3.7) | **Maintainer** (hand-authored input) | **Never machine-cleared** — read (path+hash) by Python, read (content) by the Polish AI; docfx-excluded, not rendered |
 
 The Cake engine clears **only the generated API-diff files** it owns. A file is treated
 as generated — and therefore deleted before the rebuild — only when **both** of these
@@ -646,6 +654,47 @@ map to an as-yet-unpublished `hb_line` that has no folder and instead drives an 
 HarfBuzz page (§4.5). This sidecar is cross-engine; it is distinct from a page's **raw-data
 block** (§4.3), the in-page structured region Python writes for the AI to polish.
 
+### 3.7 The manual additions sidecar (maintainer → Python → Polish AI)
+
+`releases/<line>.notes.md` (SkiaSharp) or `releases/harfbuzzsharp/<hb-line>.notes.md`
+(HarfBuzz) is an **optional, maintainer-authored** companion to a hub page. It is the one
+place a human injects hand-written material — a breaking-change call-out, a migration note,
+an editorial "bring this out" highlight — that must survive regeneration and re-polish.
+Editing the final `<line>.md` directly does not survive, because Polish rewrites the body
+(§4.4); the sidecar does, because no engine ever writes it.
+
+It is **freeform Markdown, not a schema.** There is no JSON and no required structure: the
+maintainer writes natural-language notes and the Polish AI parses, understands, and weaves
+them into the page (§4.7). Not all of it is "breaking" — some is simply material to surface.
+
+#### Ownership & lifecycle
+
+- **Maintainer-owned input.** Only a human creates or edits it. Neither engine ever writes,
+  renames, clears, or reformats it — it is an *input/artifact*, like a source image, not a
+  generated file (contrast the co-release map §3.6, which Cake owns and rewrites).
+- **Co-located, never a page.** It sits beside its `<line>.md` hub and shares the stem, so
+  it is trivially discoverable and travels with the release it annotates. It is **excluded
+  from the docfx render** (`**/*.notes.md`) so it never becomes its own published page, and
+  the §4.6 version-discovery loops skip it so it is never mistaken for a release line.
+- **Read by Python (hash only), read by the AI (content).** Python records its page-relative
+  path + a `sha256` of its bytes in the hub's raw-data block **companions manifest**
+  (§4.3/§4.7) and folds that hash into the content key (§4.6), so editing it re-polishes
+  exactly that page. Python never reads its *content*. The Polish AI opens and reads it and
+  summarizes / weaves it into the prose (§4.7).
+- **Orphan handling.** A `.notes.md` with no matching hub page (neither `<line>.md` nor
+  `<line>-unreleased.md` exists for its stem) is a maintainer typo; Python **warns** and
+  ignores it, writing nothing on its behalf.
+
+#### It forces a real page
+
+A `.notes.md` present for a line makes that line's hub a **polished** page even where the
+generator would otherwise emit a deterministic *No changes* HarfBuzz page (§4.5): the manual
+content is exactly what needs surfacing, so the *No changes* short-circuit is bypassed and
+the page gets a raw-data block for the AI.
+
+This sidecar is a maintainer→engine input; it is distinct from the co-release map (§3.6,
+Cake→Python) and from a page's own **raw-data block** (§4.3), which Python writes.
+
 ---
 
 ## 4. Release-notes engine (`generate-release-notes.py`)
@@ -655,6 +704,12 @@ block** (§4.3), the in-page structured region Python writes for the AI to polis
 - **Inputs:** `git log` over a diff range (merged-PR subjects `… (#1234)`), published
   `v*` release tags (for preview milestones + dates), `versions.json`, and the §1.5
   co-release map sidecar (§3.6) written by the Cake generator.
+- **Companion files (Polish inputs).** The optional **manual additions sidecar**
+  `<line>.notes.md` (§3.7) and the API-diff / breaking-diff files (§3.3). Python records
+  each present companion's page-relative path (+ a `sha256` of the manual + breaking ones)
+  in the raw-data block companions manifest (§4.3/§4.7) and folds those hashes into the
+  content key (§4.6); it never reads their *content*. The Polish AI reads their content and
+  **summarizes** them into the prose (§4.7).
 - **Two families, one engine** (§1.5). The same machinery runs over both families. The
   SkiaSharp family discovers its lines from `release/*` branches + `v*` tags as usual.
   The **HarfBuzz** family has no tags of its own, so it discovers its lines and their git
@@ -707,6 +762,13 @@ shipped in. The buckets exhaustively partition the range (every PR in exactly on
 they *are* the full list; there is no separate flat list. Pages with no previews (an
 unreleased delta, a plain stable patch) carry one flat list instead.
 
+The raw-data block also carries a **companions manifest** (§4.7): for each companion file
+that exists — the manual additions sidecar (§3.7) and the API-diff / breaking-diff files
+(§3.3) — a page-relative path the Polish AI opens, plus content hashes (`notes:`,
+`breaking:`) folded into the content key (§4.6). Companion *content* is **referenced, never
+embedded** — the block records only paths and hashes, so it stays small even when a breaking
+diff is large.
+
 ### 4.4 Division of responsibility — the script structures, the AI only polishes
 
 **Division of responsibility:**
@@ -714,7 +776,7 @@ unreleased delta, a plain stable patch) carry one flat list instead.
 | Owner | Responsibility |
 |---|---|
 | **Scripts** | Everything structural and deterministic: every filename, diff range, released-vs-unreleased split, rollup-vs-delta, supersession banner, preview bucketing, stale-page pruning, and **all links** (including the §1.5 HarfBuzz page→folder link). |
-| **AI / skill** | Only rewrites **prose** in the files the script lists under "Files to polish". Never creates, renames, or deletes pages; never writes structural content or links; never edits either script. On any anomaly (a missing/unexpected page, data that looks wrong) it **stops and reports** instead of working around it. |
+| **AI / skill** | Only rewrites **prose** in the files the script lists under "Files to polish". Never creates, renames, or deletes pages; never writes structural content or links; never edits either script. It **may read (never write)** the companion files a page's raw-data block references — the manual additions sidecar and the API-diff / breaking-diff files — and summarize them into the prose (§4.7). On any anomaly (a missing/unexpected page, data that looks wrong) it **stops and reports** instead of working around it. |
 
 A maintainer then fixes the *script* (and this spec), never the output. See
 `.agents/skills/release-notes/SKILL.md`.
@@ -781,9 +843,11 @@ All of this is deterministic and script-owned.
   writes a deterministic *No changes* page — a stable, fully-rendered page (status banner
   + script-owned API-changes link + a short "No HarfBuzz changes in this release" body)
   with **no** AI raw-data block, so it is never listed under "Files to polish". A page
-  whose filtered set is non-empty is polished like any SkiaSharp page. (This *No changes*
-  rule is general — it just never triggers for SkiaSharp, whose lines always have
-  commits.)
+  whose filtered set is non-empty is polished like any SkiaSharp page. A **manual additions
+  sidecar** (§3.7) present for the line **overrides** this short-circuit — the hand-written
+  content is exactly what needs surfacing, so the page gets a raw-data block and is polished.
+  (This *No changes* rule is general — it just never triggers for SkiaSharp, whose lines
+  always have commits.)
 - **Released vs unreleased** (§4.2) and **content-key idempotency** (§4.6) apply
   unchanged, per family. A HarfBuzz line that shipped inside a released SkiaSharp line gets
   a permanent `<hb-line>.md`, **dated by its canonical (introducing) SkiaSharp release**
@@ -807,16 +871,106 @@ All of this is deterministic and script-owned.
 Always the full, idempotent pass: fetch `main` + every `release/*`, regenerate each
 line's raw-data block (§4.3), prune orphaned `-unreleased` pages (§4.2), and **write only files
 whose content key changed** — the key compares PR count, diff range, the
-supersession metadata (`status`, `superseded_by`, `supersedes`), **and the script-owned
+supersession metadata (`status`, `superseded_by`, `supersedes`), the **script-owned
 API-changes link** (whether this line has an API-diff folder, its HarfBuzz co-release
-mapping, and — for a HarfBuzz page — its canonical SkiaSharp back-link target, §4.4). Toggling a version's supersession in `versions.json` rewrites its banner
+mapping, and — for a HarfBuzz page — its canonical SkiaSharp back-link target, §4.4),
+**and the companion-file hashes** (`notes:` and `breaking:`, §4.7). Toggling a version's supersession in `versions.json` rewrites its banner
 even when the PR set is identical; likewise, a page that newly gains (or loses) an
 API-diff folder is rewritten to inject (or drop) the API-changes link — which is what
-backfills the link across historical pages on first run. Then regenerate `TOC.yml` +
+backfills the link across historical pages on first run; and editing a `.notes.md` or a
+change appearing in a line's breaking diff flips its hash and re-polishes **only** that
+page (§4.7). The full non-breaking API diff is deliberately **not** folder-hashed — its
+change signal is already carried by the PR set and the API-changes link, so a routine diff
+refresh forces no spurious re-polish. Then regenerate `TOC.yml` +
 `index.md`. The "Files to polish" list — written to the `files-to-polish.txt` file the
 Polish phase reads (§2.3) — names only genuinely-changed pages, so the AI never
 re-polishes an up-to-date page. When it is empty and the tree is unchanged, the workflow
 opens no PR (§2.3).
+
+### 4.7 Manual additions & breaking-change summaries (companion files)
+
+This section ties together the two problems that motivate the companion model: how a
+**breaking change** reaches the notes, and how a maintainer injects **hand-written** material
+that survives re-polish. Both are solved the same way — the raw-data block **references
+companion files by path**, and the Polish AI **reads and summarizes** them. Content is
+*referenced, never embedded*.
+
+#### The three companion files
+
+Each is a "sidecar" in this repo's terminology (like the co-release map, §3.6). For a given
+hub page the raw-data block lists whichever of these exist:
+
+| Companion | Path (page-relative) | Owner | Present when |
+|---|---|---|---|
+| **Manual additions** (§3.7) | `<line>.notes.md` | maintainer (freeform md) | a human wrote one |
+| **API diff** (§3.3) | `<line>/index.md` (+ per-assembly `<pkg>/<assembly>.md`) | Cake | the line has an API-diff folder |
+| **API breaking diff** (§3.3) | `<line>/<pkg>/<assembly>.breaking.md` | Cake | **real breaking changes exist** (Cake deletes an empty one, §5.2) |
+
+The API diff and breaking diff already exist (§3.3), and the API-diff *index* is already
+linked from the page (§4.4). What §4.7 adds is: **(a)** the maintainer-authored **manual
+additions** companion (§3.7); **(b)** teaching the Polish AI to **open and read all three**
+and summarize; **(c)** hashing the manual + breaking companions into the content key (§4.6)
+so a companion-only edit re-polishes exactly that page.
+
+Because `.breaking.md` exists **only when real breaking changes exist** (§5.2), its mere
+presence in the manifest is the signal that this line broke something, and its `###` member
+headings are the changed/removed list the AI summarizes from.
+
+#### The companions manifest (in the raw-data block)
+
+For each present companion, Python writes into the raw-data block:
+
+- a human-readable **manifest** naming the page-relative file(s) to open, e.g.
+
+  ```
+    companions (open and read these during polish, §4.7 — summarize, don't dump):
+      - notes:    4.150.0.notes.md  (manual additions)
+      - api diff: 4.150.0/index.md  (full public-API diff)
+      - breaking: 4.150.0/SkiaSharp/SkiaSharp.breaking.md  (breaking signatures)
+  ```
+
+- content-key metadata lines — `notes:  sha256:…` and `breaking:  sha256:…` (empty when the
+  companion is absent) — parsed by §4.6 exactly like the `api:` link.
+
+Python **never inlines companion content** — only the page-relative path and a `sha256` of
+the bytes. This keeps the block small even when a breaking diff is large, and removes any
+need to escape a companion's own `-->` (the loader only hashes bytes).
+
+#### What the Polish AI does with them
+
+The AI reads the page's raw-data block, then **opens and reads** the manifest's companions
+and writes a **summary**, not a dump:
+
+- **Breaking changes → a concise `## ⚠️ Breaking Changes` section.** From the `.breaking.md`
+  (the signature "what") plus any behavioral items in `.notes.md` (the "why / how"), the AI
+  summarizes — e.g. "Obsoleted several APIs in `SKPaint` and `SKFont`", "`SKFooBar` was
+  removed — use `SKBaz` instead" — and may include small **migration code examples**. It is
+  not required to enumerate every changed member; it surfaces the ones that matter and points
+  at the diff for the exhaustive list.
+- **Behavioral breaking changes** (same signature, different runtime behavior — e.g.
+  `new SKPaint().Typeface` now returning `Default` instead of `null`) never appear in a
+  signature diff, so they reach the notes **only** through `.notes.md`; the AI folds them into
+  the same section.
+- **Editorial "bring this out" notes** from `.notes.md` are woven into Highlights / a callout
+  as the maintainer intends — kept close to verbatim where the wording clearly matters,
+  summarized where they are rough notes.
+- **Richer highlights** may draw on the full API diff for context, but the PR list in the raw
+  block remains the primary source for "what's new".
+
+The AI still writes **no links or structure** (§4.4), **never edits a companion**, and never
+touches git or the gh API. When neither the breaking diff nor the manual notes has any
+breaking content, the section reads *"None in this release."* (TEMPLATE.md).
+
+#### Idempotency
+
+Reading a companion does not by itself change the page; deterministic re-polish is preserved
+by the content-key hashes (§4.6). Editing `.notes.md` flips `notes:`; a breaking change
+appearing or changing flips `breaking:`. Either re-polishes **only** the affected page. The
+full non-breaking API diff is deliberately **not** folder-hashed (§4.6): its change signal is
+already carried by the PR set (`prs:` / `diff:`) and the `api:` link, so a routine diff
+refresh does not force a spurious re-polish, while the small, stable `.breaking.md` subset is
+safe to hash and is what closes today's gap (a break that lands inside a single *Bump skia* PR
+now re-polishes the page).
 
 ---
 
@@ -1000,3 +1154,13 @@ page links straight to its API diffs.
     `ok`/`warn`/`drift` — detection only; the fix is a manual edit, never auto-written.
     An absent/empty block degrades to the legacy "every 3.x+ line is top-level" layout,
     so the grouping stays purely additive.
+
+11. **Companion files are referenced, never embedded (§4.7).** A hub page's raw-data block
+    records each present companion (manual additions sidecar §3.7, API diff §3.3, breaking
+    diff §3.3) as a page-relative **path + `sha256`**, never inlined content. The manual +
+    breaking hashes join the content key (§4.6) so a companion-only edit re-polishes exactly
+    that page; the full non-breaking diff is not folder-hashed. The `.notes.md` sidecar is a
+    **maintainer-owned freeform-Markdown input**: never machine-written, renamed, or cleared;
+    docfx-excluded; skipped by version discovery. The Polish AI may **read** the referenced
+    companions (a bounded allow-list) and summarize them, but writes only page prose — never a
+    companion, never git/gh (§2.2/§4.4).

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -925,9 +925,19 @@ For each present companion, Python writes into the raw-data block:
   ```
     companions (open and read these during polish, §4.7 — summarize, don't dump):
       - notes:    4.150.0.notes.md  (manual additions)
-      - api diff: 4.150.0/index.md  (full public-API diff)
+      - api diff: 4.150.0/index.md  (index of all per-assembly diffs; flags breaking)
       - breaking: 4.150.0/SkiaSharp/SkiaSharp.breaking.md  (breaking signatures)
   ```
+
+  The **api diff** is a single `index.md` entry on purpose: that landing page (§3.3)
+  already links *every* per-assembly diff and tags the breaking ones `⚠️ breaking`, so
+  it is the one door to the whole folder — the AI need not have each `<assembly>.md`
+  spelled out. **Breaking is different: one `- breaking:` line is emitted per broken
+  assembly** (a release like `3.116.0` lists all twelve), because a `.breaking.md`
+  exists only where signatures actually broke and each is worth summarizing. Every path
+  keeps its package folder prefix, so two assemblies that share a file name (e.g.
+  `SkiaSharp.Views.Windows.breaking.md` under both `SkiaSharp.Views.Uno.WinUI/` and
+  `SkiaSharp.Views.WinUI/`) stay distinct.
 
 - content-key metadata lines — `notes:  sha256:…` and `breaking:  sha256:…` (empty when the
   companion is absent) — parsed by §4.6 exactly like the `api:` link.

--- a/documentation/docfx/docfx.json
+++ b/documentation/docfx/docfx.json
@@ -7,7 +7,8 @@
           "**/*.yml"
         ],
         "exclude": [
-          "releases/TEMPLATE.md"
+          "releases/TEMPLATE.md",
+          "**/*.notes.md"
         ]
       }
     ],

--- a/documentation/docfx/releases/TEMPLATE.md
+++ b/documentation/docfx/releases/TEMPLATE.md
@@ -22,6 +22,16 @@
      "No changes" pages (a HarfBuzz line with no HarfBuzz-touching changes) are written
      in full by the GENERATOR and are NOT in your "Files to polish" list — never author
      or edit one.
+
+     COMPANION FILES (see release-notes-and-api-diffs.md §4.7): the raw-data block at the
+     top of a page may list "companions — open and read these during polish":
+       - the manual additions sidecar (<stem>.notes.md) — freeform maintainer notes;
+       - the full API diff (<line>/index.md, + per-assembly files); and
+       - the API breaking diff (*.breaking.md) — present only when signatures broke.
+     OPEN and READ each listed companion, then SUMMARIZE — never paste it verbatim or dump
+     the whole diff. Weave the manual notes into Highlights / Breaking Changes; summarize
+     breaking changes from the breaking diff. You may READ these files but NEVER edit them,
+     and never touch git or the gh API.
 -->
 
 # Version 3.119.2
@@ -61,15 +71,39 @@
 
 ## Highlights
 
-<!-- 1-3 sentences. Lead with what matters most. Mention community contributors. -->
+<!-- 1-3 sentences. Lead with what matters most. Mention community contributors.
+     If the manual additions sidecar (<stem>.notes.md, see §4.7) has editorial points
+     the maintainer wants brought out, weave them in here in your own words. -->
 
 This release focuses on hardening the native libraries against common exploit techniques on Windows and Linux. Spectre mitigations, Control Flow Guard, and BufferSecurityCheck are now enabled across all Windows and Linux native builds. Three community contributors drove every user-facing change in this release.
 
 ## Breaking Changes
 
-<!-- Always include. If none, say so explicitly. -->
+<!-- Always include. SUMMARIZE from the companions the raw-data block lists (§4.7):
+     - the API breaking diff (*.breaking.md) — the changed / removed signatures; and
+     - any behavioral breaking notes in the manual additions sidecar (<stem>.notes.md)
+       (same signature, different runtime behavior — these NEVER appear in a signature
+       diff, so the sidecar is the only channel for them).
+     Summarize, don't dump: e.g. "Obsoleted several APIs in SKPaint and SKFont" or
+     "SKFooBar was removed — use SKBaz instead". Small migration code examples are welcome.
+     Point at the API diff link (above) for the exhaustive list. If NEITHER companion has
+     anything, say so explicitly. -->
 
 *None in this release.*
+
+<!-- Example when there ARE breaking changes:
+- **`SKFont` default typeface** — `new SKFont()` now carries an empty typeface instead of
+  the default. Pass one explicitly when you need the default face:
+
+  ```csharp
+  // Before: implicitly the default typeface
+  var font = new SKFont();
+  // After: pass the typeface you want
+  var font = new SKFont(SKTypeface.Default);
+  ```
+- **Removed Vulkan fields** — several `GRVkBackendContext` fields were removed; see the API
+  diff for the full list.
+-->
 
 ## New Features
 
@@ -158,4 +192,9 @@ Added missing tvOS `SKSurface.Create` overloads, plus build system improvements.
        links. The script injects the "> **API changes**" line under the banner on every
        emitted page; keep it verbatim and add nothing. No block means no folder yet — a
        hand-written link would dangle.
+     - Companions (§4.7): if the raw-data block lists "companions", open and read each one
+       (manual notes sidecar, full API diff, breaking diff) and SUMMARIZE. Weave manual
+       notes into Highlights/Breaking Changes; summarize breaking changes from the breaking
+       diff with a small migration example where it helps. Never dump a diff verbatim, and
+       never edit a companion file.
 -->

--- a/documentation/docfx/releases/TEMPLATE.md
+++ b/documentation/docfx/releases/TEMPLATE.md
@@ -26,8 +26,10 @@
      COMPANION FILES (see release-notes-and-api-diffs.md §4.7): the raw-data block at the
      top of a page may list "companions — open and read these during polish":
        - the manual additions sidecar (<stem>.notes.md) — freeform maintainer notes;
-       - the full API diff (<line>/index.md, + per-assembly files); and
-       - the API breaking diff (*.breaking.md) — present only when signatures broke.
+       - the full API diff — <line>/index.md indexes every per-assembly diff and flags
+         the breaking ones; open it, then follow the assemblies that matter; and
+       - the API breaking diff (*.breaking.md) — one per broken assembly, present only
+         when signatures broke (a big release can list many; summarize across them).
      OPEN and READ each listed companion, then SUMMARIZE — never paste it verbatim or dump
      the whole diff. Weave the manual notes into Highlights / Breaking Changes; summarize
      breaking changes from the breaking diff. You may READ these files but NEVER edit them,

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -92,6 +92,7 @@ Requirements: git, Python 3.7+
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -366,6 +367,59 @@ def harfbuzz_lines_from_map():
     return result
 
 
+def _sha256_bytes(data):
+    # type: (bytes) -> str
+    """``sha256:<hex>`` digest of raw bytes (companion-file content key, §4.7)."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def load_notes_sidecar(stem, base_dir):
+    # type: (str, Path) -> Optional[dict]
+    """The maintainer-authored manual additions sidecar (spec §3.7).
+
+    A ``<stem>.notes.md`` co-located with the hub page: freeform Markdown a human
+    injects to survive re-polish. Returns ``{'path': <page-relative>, 'sha256':
+    <hash>}`` when present, else None. Only the BYTES are hashed — Python never
+    parses the content (the Polish AI reads it, §4.7). The path is page-relative
+    (same directory as the hub), so the AI resolves it straight from the page.
+    """
+    notes_path = base_dir / "{}.notes.md".format(stem)
+    if not notes_path.is_file():
+        return None
+    return {"path": "{}.notes.md".format(stem),
+            "sha256": _sha256_bytes(notes_path.read_bytes())}
+
+
+def load_breaking_companions(line, base_dir):
+    # type: (str, Path) -> Optional[dict]
+    """The API breaking-diff companions for a line (spec §3.3/§4.7).
+
+    Globs ``<line>/**/<assembly>.breaking.md`` under the line's API-diff folder.
+    ``api-diff.cake`` writes a ``.breaking.md`` ONLY when real breaking changes
+    exist (it deletes an empty one, §5.2), so any match means this line broke
+    something. Returns ``{'paths': [<page-relative>, …], 'sha256': <combined
+    hash>}`` or None. The combined hash covers the sorted ``(path, bytes)`` pairs,
+    so it is order-stable and flips when any breaking file is added, removed, or
+    changed — which is what re-polishes the page (§4.6).
+    """
+    folder = base_dir / line
+    if not folder.is_dir():
+        return None
+    files = sorted(folder.glob("**/*.breaking.md"))
+    if not files:
+        return None
+    h = hashlib.sha256()
+    paths = []  # type: list[str]
+    for f in files:
+        rel = f.relative_to(base_dir).as_posix()
+        paths.append(rel)
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(f.read_bytes())
+        h.update(b"\0")
+    return {"paths": paths, "sha256": "sha256:" + h.hexdigest()}
+
+
 def _api_signature(metadata):
     # type: (dict) -> str
     """Compact, deterministic signature of a page's script-owned API-changes line.
@@ -398,8 +452,9 @@ def _api_signature(metadata):
 
 def _is_content_unchanged(output_path, new_prs_count, new_diff_range,
                           new_status=None, new_superseded_by=None,
-                          new_supersedes=None, new_api_sig=None):
-    # type: (Path, int, str, Optional[str], Optional[str], Optional[list[str]], Optional[str]) -> bool
+                          new_supersedes=None, new_api_sig=None,
+                          new_notes_hash=None, new_breaking_hash=None):
+    # type: (Path, int, str, Optional[str], Optional[str], Optional[list[str]], Optional[str], Optional[str], Optional[str]) -> bool
     """Check whether the existing file already encodes identical raw data.
 
     Compares the fields the script controls: PR count, diff range, the
@@ -414,7 +469,10 @@ def _is_content_unchanged(output_path, new_prs_count, new_diff_range,
     loses) an API-diff folder, or whose HarfBuzz mapping changes, must be
     rewritten to inject (or drop) the API-changes line even when its PRs are
     identical. Returns True only when every tracked field matches, so those
-    metadata-only changes still force a rewrite.
+    metadata-only changes still force a rewrite. The companion-file hashes
+    (``notes:`` and ``breaking:``, §4.7) are compared for the same reason: editing
+    the manual additions sidecar or a change in the line's breaking diff must
+    re-polish the page even when its PR set is unchanged.
 
     Reads the metadata from the HTML comment block at the top of the file.
     """
@@ -460,6 +518,23 @@ def _is_content_unchanged(output_path, new_prs_count, new_diff_range,
         m_api = re.search(r"^\s*api:\s*(.*)$", content, re.MULTILINE)
         existing_api = m_api.group(1).strip() if m_api else ""
         if existing_api != (new_api_sig or ""):
+            return False
+
+    # notes: <hash> / breaking: <hash> — the companion-file content key (§4.7).
+    # These are emitted only when the companion exists, so an absent line means
+    # "no companion"; treat it as "" so a page that newly GAINS a sidecar or a
+    # breaking diff is rewritten to backfill the manifest (§4.6). NOTE: use
+    # ``[ \t]*`` (never ``\s*``) around the value — in MULTILINE mode ``\s*``
+    # would span the newline and swallow the next line for an empty value.
+    if new_notes_hash is not None:
+        m_notes = re.search(r"^[ \t]*notes:[ \t]*(\S+)", content, re.MULTILINE)
+        existing_notes = m_notes.group(1) if m_notes else ""
+        if existing_notes != (new_notes_hash or ""):
+            return False
+    if new_breaking_hash is not None:
+        m_brk = re.search(r"^[ \t]*breaking:[ \t]*(\S+)", content, re.MULTILINE)
+        existing_brk = m_brk.group(1) if m_brk else ""
+        if existing_brk != (new_breaking_hash or ""):
             return False
 
     return True
@@ -1687,6 +1762,41 @@ def format_pr_list(prs, metadata):
     for i, extra in enumerate(meta_extra):
         lines.insert(8 + i, extra)
 
+    # Companion files (spec §4.7): record each present companion's content hash
+    # (notes/breaking — the content key, §4.6) and a human-readable manifest of
+    # page-relative paths the Polish AI opens and SUMMARIZES. Content is
+    # referenced, never embedded, so the block stays small.
+    companions = metadata.get("companions") or {}
+    notes = companions.get("notes")
+    apidiff = companions.get("apidiff")
+    breaking = companions.get("breaking")
+    comp_block = []  # type: list[str]
+    if notes:
+        comp_block.append("  notes:     {}".format(notes["sha256"]))
+    if breaking:
+        comp_block.append("  breaking:  {}".format(breaking["sha256"]))
+    if notes or apidiff or breaking:
+        comp_block.append("")
+        comp_block.append(
+            "  companions (open and read these during polish, §4.7 — "
+            "summarize, don't dump):")
+        if notes:
+            comp_block.append("    - notes:    {}  (manual additions)".format(
+                notes["path"]))
+        if apidiff:
+            comp_block.append("    - api diff: {}  (full public-API diff)".format(
+                apidiff["path"]))
+        if breaking:
+            for p in breaking["paths"]:
+                comp_block.append("    - breaking: {}  (breaking signatures)".format(p))
+    # Splice just before the trailing blank separator (the last element of
+    # `lines`) so the hashes sit with the metadata and the manifest leads into
+    # the PR list.
+    insert_at = len(lines) - 1
+    for extra in comp_block:
+        lines.insert(insert_at, extra)
+        insert_at += 1
+
     if not prs:
         lines.append("  *No changes found.*")
     else:
@@ -1893,7 +2003,8 @@ def get_version_files():
     versions = []
     next_versions = []
     for f in RELEASES_DIR.iterdir():
-        if f.suffix == ".md" and f.name not in ("index.md", "TEMPLATE.md"):
+        if (f.suffix == ".md" and f.name not in ("index.md", "TEMPLATE.md")
+                and not f.name.endswith(".notes.md")):
             stem = f.stem
             if stem.endswith("-unreleased"):
                 next_versions.append(stem[:-11])  # strip "-unreleased"
@@ -1918,7 +2029,8 @@ def get_harfbuzz_version_files():
     next_versions = []  # type: list[str]
     if hb_dir.is_dir():
         for f in hb_dir.iterdir():
-            if not f.is_file() or f.suffix != ".md" or f.name == "index.md":
+            if (not f.is_file() or f.suffix != ".md" or f.name == "index.md"
+                    or f.name.endswith(".notes.md")):
                 continue
             stem = f.stem
             if stem.endswith("-unreleased"):
@@ -1969,13 +2081,45 @@ def cleanup_stale_unreleased():
 
     removed = []
     for f in sorted(RELEASES_DIR.iterdir()):
-        if f.suffix != ".md" or not f.stem.endswith("-unreleased"):
+        if (f.suffix != ".md" or not f.stem.endswith("-unreleased")
+                or f.name.endswith(".notes.md")):
             continue
         version = f.stem[:-len("-unreleased")]
         if version not in live:
             f.unlink()
             removed.append(str(f))
     return removed
+
+
+def warn_orphan_notes_sidecars():
+    # type: () -> list[str]
+    """Warn about ``*.notes.md`` sidecars with no matching hub page (spec §3.7).
+
+    A manual additions sidecar attaches to a page by sharing its stem: it is
+    ``<stem>.notes.md`` beside ``<stem>.md``. A sidecar whose ``<stem>.md`` hub
+    page does not exist (neither a released ``<line>.md`` nor an in-flight
+    ``<line>-unreleased.md``, since either would be the stem) is a maintainer typo
+    — Python **warns** and ignores it, writing nothing on its behalf. Call this at
+    the end of a generation run, once every page that will exist is on disk.
+
+    Checks both families: SkiaSharp sidecars under ``releases/`` and HarfBuzz
+    sidecars under ``releases/harfbuzzsharp/``. Returns the orphan paths (for
+    tests); the side effect is the warning log.
+    """
+    orphans = []  # type: list[str]
+    for base_dir in (RELEASES_DIR, RELEASES_DIR / "harfbuzzsharp"):
+        if not base_dir.is_dir():
+            continue
+        for f in sorted(base_dir.iterdir()):
+            if not f.is_file() or not f.name.endswith(".notes.md"):
+                continue
+            stem = f.name[:-len(".notes.md")]
+            if not (base_dir / "{}.md".format(stem)).is_file():
+                log("WARNING: orphan manual notes sidecar {} has no matching "
+                    "page {}.md — ignoring it (spec §3.7). Did you mean a "
+                    "different stem?".format(f.name, stem))
+                orphans.append(str(f))
+    return orphans
 
 
 def _toc_folded_section(title, groups, stable_groups, unreleased_groups):
@@ -2543,9 +2687,21 @@ def _write_page(branch, all_branches, verbose=False, force=False):
     api_sig = _api_signature({"api_diff_link": api_diff_link,
                               "harfbuzz": harfbuzz})
 
+    # Companion files (spec §3.7/§4.7): the manual additions sidecar (keyed by the
+    # page STEM so it attaches to this exact page) and the API breaking-diff
+    # (under the line's <version>/ folder). Their hashes join the content key so a
+    # companion-only edit re-polishes just this page (§4.6). Computed BEFORE the
+    # unchanged check for the same backfill reason as api_sig.
+    stem = _page_filename(branch, version)[:-len(".md")]
+    notes_comp = load_notes_sidecar(stem, RELEASES_DIR)
+    breaking_comp = (load_breaking_companions(version, RELEASES_DIR)
+                     if not is_head else None)
+    notes_hash = notes_comp["sha256"] if notes_comp else ""
+    breaking_hash = breaking_comp["sha256"] if breaking_comp else ""
+
     if not force and _is_content_unchanged(output_path, len(prs), diff_range_str,
                                            status, superseded_by, supersedes,
-                                           api_sig):
+                                           api_sig, notes_hash, breaking_hash):
         log("  Skipping {} (unchanged)".format(output_path))
         return None
 
@@ -2600,6 +2756,19 @@ def _write_page(branch, all_branches, verbose=False, force=False):
         metadata["api_diff_link"] = api_diff_link
     if harfbuzz:
         metadata["harfbuzz"] = harfbuzz
+
+    # Companion-file manifest for the raw-data block (§4.7). The api-diff index is
+    # a companion the AI reads too, listed via api_diff_link (not hashed — its
+    # change signal is carried by prs/diff/api, §4.6).
+    companions = {}  # type: dict
+    if notes_comp:
+        companions["notes"] = notes_comp
+    if api_diff_link:
+        companions["apidiff"] = {"path": api_diff_link}
+    if breaking_comp:
+        companions["breaking"] = breaking_comp
+    if companions:
+        metadata["companions"] = companions
 
     RELEASES_DIR.mkdir(parents=True, exist_ok=True)
     output_path.write_text(format_pr_list(prs, metadata))
@@ -2718,10 +2887,17 @@ def _write_harfbuzz_page(hb, all_branches, force=False):
     output_path = hb_dir / owned
     api_diff_link = "{}/index.md".format(hb_line) if published else None
 
+    # The manual additions sidecar (spec §3.7), keyed by this page's STEM. When a
+    # maintainer has written one, it OVERRIDES both No-changes short-circuits
+    # below (§4.5): the hand-written content is exactly what needs surfacing, so
+    # the line gets a real polished page instead of a prune / deterministic page.
+    stem = owned[:-len(".md")]
+    notes_comp = load_notes_sidecar(stem, hb_dir)
+
     # An in-flight HarfBuzz line earns a page ONLY when its introducing SkiaSharp
     # head actually carries HarfBuzz changes (spec §4.5). An empty delta means the
     # head merely rebuilds an already-released HarfBuzz — no page; prune a stale one.
-    if not published and not prs:
+    if not published and not prs and not notes_comp:
         if output_path.exists():
             output_path.unlink()
             log("  Removed empty {} (nothing unreleased)".format(output_path))
@@ -2729,7 +2905,7 @@ def _write_harfbuzz_page(hb, all_branches, force=False):
 
     # Published line, no HarfBuzz-touching PRs -> deterministic *No changes* page
     # (no AI block, never polished; spec §4.5). Idempotent by exact text equality.
-    if published and not prs:
+    if published and not prs and not notes_comp:
         text = _render_harfbuzz_no_changes(hb_line, canonical_skia, api_diff_link)
         if not force and output_path.exists() and output_path.read_text() == text:
             log("  Skipping {} (unchanged, no changes)".format(output_path))
@@ -2766,9 +2942,17 @@ def _write_harfbuzz_page(hb, all_branches, force=False):
         metadata["supersedes"] = supersedes
     api_sig = _api_signature(metadata)
 
+    # Companion files (spec §3.7/§4.7), same as the SkiaSharp path: the manual
+    # additions sidecar (resolved above) plus the API breaking-diff under this
+    # HarfBuzz line's folder. Hashes join the content key (§4.6).
+    breaking_comp = (load_breaking_companions(hb_line, hb_dir)
+                     if published else None)
+    notes_hash = notes_comp["sha256"] if notes_comp else ""
+    breaking_hash = breaking_comp["sha256"] if breaking_comp else ""
+
     if not force and _is_content_unchanged(output_path, len(prs), diff_range_str,
                                            status, superseded_by, supersedes,
-                                           api_sig):
+                                           api_sig, notes_hash, breaking_hash):
         log("  Skipping {} (unchanged)".format(output_path))
         return None, owned
 
@@ -2788,6 +2972,17 @@ def _write_harfbuzz_page(hb, all_branches, force=False):
         metadata["preview_milestones"] = preview_milestones
         metadata["pr_buckets"] = bucket_prs_by_milestone(
             prs, preview_milestones, from_ref)
+
+    # Companion-file manifest for the raw-data block (§4.7).
+    companions = {}  # type: dict
+    if notes_comp:
+        companions["notes"] = notes_comp
+    if api_diff_link:
+        companions["apidiff"] = {"path": api_diff_link}
+    if breaking_comp:
+        companions["breaking"] = breaking_comp
+    if companions:
+        metadata["companions"] = companions
 
     hb_dir.mkdir(parents=True, exist_ok=True)
     output_path.write_text(format_pr_list(prs, metadata))
@@ -2844,6 +3039,8 @@ def cmd_branch(branch, force=False, polish_list_path=None):
         files_to_polish.extend(_regen_unreleased(target, all_branches, force=force))
 
     cmd_update_toc()
+
+    warn_orphan_notes_sidecars()
 
     log("")
     write_polish_list(files_to_polish, polish_list_path)
@@ -3008,6 +3205,10 @@ def cmd_all(force=False, polish_list_path=None):
 
     # Regenerate TOC and index
     cmd_update_toc()
+
+    # Every page that will exist is now on disk — flag any manual notes sidecar
+    # whose hub page is missing (a maintainer typo, spec §3.7).
+    warn_orphan_notes_sidecars()
 
     # Print summary for the AI agent
     log("")

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -1784,7 +1784,7 @@ def format_pr_list(prs, metadata):
             comp_block.append("    - notes:    {}  (manual additions)".format(
                 notes["path"]))
         if apidiff:
-            comp_block.append("    - api diff: {}  (full public-API diff)".format(
+            comp_block.append("    - api diff: {}  (index of all per-assembly diffs; flags breaking)".format(
                 apidiff["path"]))
         if breaking:
             for p in breaking["paths"]:


### PR DESCRIPTION
## What

Adds two tied capabilities to the spec-driven release-notes system, and refines how the API-diff/breaking companions are surfaced.

### 1. Manual additions sidecar (`<stem>.notes.md`)
A maintainer-authored, freeform-Markdown sidecar co-located with a version's hub page. It **survives regeneration and re-polish**: the generator never overwrites it, hashes its bytes into the page content key (`notes:`), and the Polish AI reads + weaves it into the prose. This is the channel for **behavioral** breaking changes (same signature, different runtime behavior — e.g. `new SKFont()` empty typeface, `SKPaint().Typeface` returning Default) that can never appear in a signature diff.

### 2. AI-summarized breaking changes (companion model)
The page's raw-data block now **references companion files by path + hash** (never embeds them) and the Polish AI **opens and summarizes** them into a `## ⚠️ Breaking Changes` section:
- **API diff** → a single `index.md` entry — the version folder's landing page that links *every* per-assembly diff and flags the breaking ones.
- **API breaking diff** → **one `- breaking:` line per broken assembly** (a release like `3.116.0` lists all twelve), folded into one order-stable combined `breaking:` hash. Each path keeps its package-folder prefix so identically-named files (e.g. `SkiaSharp.Views.Windows.breaking.md` under both `Uno.WinUI/` and `WinUI/`) stay distinct.

## How it behaves
- **Content key** (`_is_content_unchanged`) now includes `notes:` and `breaking:` hashes, so a companion-only edit re-polishes exactly that page. Everything stays idempotent.
- **One-time backfill:** pages that predate the feature but carry a breaking diff (25 versions) gain the `breaking:` manifest + section on the first `--all` run; unaffected pages are skipped.
- `.notes.md` is docfx-excluded and discovery-guarded (never a version page / TOC entry).

## Spec-first
Changes made in spec-first order: spec (§3.7 sidecar, §4.7 companions) → generator → docfx exclusion → TEMPLATE.md → SKILL.md → workflow (Polish pinned to a stronger model for companion summarization).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>