### PR TITLE
[release-notes] Itemize breaking diffs during polish; add 4.148.0 notes sidecar

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -152,7 +152,7 @@ page-relative path (see `release-notes-and-api-diffs.md` §4.7):
 | --- | --- | --- |
 | `<stem>.notes.md` | **Manual additions sidecar** — freeform Markdown the maintainer wrote to bring something out (not always breaking). | Weave its editorial points into Highlights; surface any behavioral breaking notes under Breaking Changes. |
 | `<line>/index.md` (indexes every per-assembly diff; flags breaking) | The **full public-API diff** landing page — one door to the whole folder. | Open it, follow the assemblies that matter, draw richer/accurate highlights. Do **not** paste it — summarize. |
-| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes: obsoleted / removed / changed signatures, summarized across all listed files. |
+| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes. **Open every listed file** and turn each concrete entry (removed interface, removed / changed / obsoleted member, retyped property) into a prose bullet — grouped, but nothing dropped. A link is **not** a substitute for reading it. |
 
 Rules for companions:
 
@@ -160,9 +160,15 @@ Rules for companions:
   verbatim or dump the whole file. A human summary ("obsoleted several APIs in `SKPaint` and
   `SKFont`"; "`SKFooBar` was removed — use `SKBaz`") with a small migration code example where
   it helps is the goal.
-- **Behavioral breaking changes** (same signature, different runtime behavior — e.g.
-  `new SKFont()` now carries an empty typeface) will **not** appear in the API breaking diff.
-  The `<stem>.notes.md` sidecar is the **only** channel for them — read it carefully.
+- **Itemize the breaking diff — don't just link it.** The `## Breaking Changes` section must
+  reflect the **actual entries** in each `.breaking.md` (every distinct removed / changed /
+  obsoleted type or member), grouped and summarized. A section that only links the diff and
+  lists PR titles has **not** done the job.
+- **Some real breaks never appear in any `.breaking.md`** — behavioral changes (same signature,
+  different runtime behavior, e.g. `new SKFont()` now carrying an empty typeface) and
+  interop / native structs outside the public-API surface (e.g. removed `GRVkBackendContextNative`
+  fields). The `<stem>.notes.md` sidecar is the **only** channel for these — read it carefully
+  and fold it into Breaking Changes alongside the diff itemization.
 - You may **read** these files but **never edit them** — they are inputs/artifacts, owned by
   the maintainer and the Prepare script. Still no git, no gh API, no other files.
 - If the manifest lists a companion but the file is missing (or vice-versa), **stop and
@@ -278,11 +284,14 @@ Follow these rules:
 
 6. **Breaking changes** — Always include a `## Breaking Changes` section (say
    *"None in this release."* when there are none). When the raw block lists an api
-   **breaking** companion and/or a manual notes sidecar, **summarize** from them: the
-   `.breaking.md` gives the "what" (obsoleted/removed/changed signatures), the
-   `<stem>.notes.md` gives behavioral breaks and migration "how". Keep it concise — a small
-   migration code example is welcome; point at the API diff for the exhaustive list. Do not
-   dump the diff. (See [Companion files](#companion-files-open-and-read-them) and TEMPLATE.md.)
+   **breaking** companion and/or a manual notes sidecar, **open them and summarize — do not
+   just link them.** The `.breaking.md` gives the "what": reflect **every distinct** entry it
+   contains (obsoleted/removed/changed signatures), grouped but not dropped. The
+   `<stem>.notes.md` gives behavioral breaks, interop-struct breaks the diff can't see (e.g.
+   removed `GRVkBackendContextNative` fields), and migration "how". Keep it concise — a small
+   migration code example is welcome; point at the API diff for the exhaustive member list. Do
+   not dump the diff, and do not reduce the section to a bare link plus PR titles. (See
+   [Companion files](#companion-files-open-and-read-them) and TEMPLATE.md.)
 
 7. **PR links** — Every item links to its PR.
 

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -951,16 +951,25 @@ need to escape a companion's own `-->` (the loader only hashes bytes).
 The AI reads the page's raw-data block, then **opens and reads** the manifest's companions
 and writes a **summary**, not a dump:
 
-- **Breaking changes → a concise `## ⚠️ Breaking Changes` section.** From the `.breaking.md`
-  (the signature "what") plus any behavioral items in `.notes.md` (the "why / how"), the AI
-  summarizes — e.g. "Obsoleted several APIs in `SKPaint` and `SKFont`", "`SKFooBar` was
-  removed — use `SKBaz` instead" — and may include small **migration code examples**. It is
-  not required to enumerate every changed member; it surfaces the ones that matter and points
-  at the diff for the exhaustive list.
-- **Behavioral breaking changes** (same signature, different runtime behavior — e.g.
-  `new SKPaint().Typeface` now returning `Default` instead of `null`) never appear in a
-  signature diff, so they reach the notes **only** through `.notes.md`; the AI folds them into
-  the same section.
+- **Breaking changes → a concise `## ⚠️ Breaking Changes` section.** The AI must **open every
+  `.breaking.md` the manifest lists** and turn its concrete entries — each removed interface,
+  removed / changed / obsoleted member, and retyped property under its `####`/`###` headings —
+  into prose. **A link to the breaking diff is not a substitute for reading it, and PR titles
+  are not a substitute for the diff's actual entries:** never emit a section that only links the
+  file and then lists PRs. Summarize rather than dump (group related members — "obsoleted the
+  text/font members on `SKPaint`"; "`SKFooBar` was removed — use `SKBaz`"), but every
+  **distinct** break in the diff must be represented, not silently dropped; add small
+  **migration code examples** where they help and point at the API-diff index for the exhaustive
+  member list.
+- **Breaks the signature diff cannot see** reach the notes **only** through `.notes.md`, and the
+  AI folds them into the same section:
+  - **behavioral changes** — same signature, different runtime behavior (e.g.
+    `new SKPaint().Typeface` now returning `Default` instead of `null`); and
+  - **interop / native structs** outside the public-API surface the diff compares (e.g. removed
+    `GRVkBackendContextNative` fields) — real compile-time breaks that never show in any
+    `.breaking.md`.
+  Treat the breaking diff and the notes sidecar as **complementary**: include both, and never
+  let one substitute for the other.
 - **Editorial "bring this out" notes** from `.notes.md` are woven into Highlights / a callout
   as the maintainer intends — kept close to verbatim where the wording clearly matters,
   summarized where they are rough notes.

--- a/documentation/docfx/releases/4.148.0.notes.md
+++ b/documentation/docfx/releases/4.148.0.notes.md
@@ -1,0 +1,141 @@
+# Manual additions for 4.148.0
+
+> Maintainer-authored. Freeform Markdown — the Polish AI **reads** this and weaves it into the
+> page (mainly the `## Breaking Changes` section), summarizing/migrating rather than pasting it
+> verbatim. It is never machine-overwritten and survives regeneration and re-polish.
+>
+> Scope: 4.148.0 is the first stable **v4** line (rolls up the 4.147.x previews), so it lands
+> the bulk of the v4 breaking changes from the Skia m132/m147 upgrade. The items below are the
+> ones the API signature diff **cannot** show — behavioral changes and interop-struct changes —
+> and so must be documented here by hand. Signature breaks that *are* in the diff (the
+> `GRVkImageInfo`/`GrVkYcbcrConversionInfo` retype + loss of value-equality, and the
+> `SKNativeObject` setter) are summarized from `SkiaSharp/SkiaSharp.breaking.md`.
+
+## Behavioral breaking changes (same signature, different runtime behavior)
+
+These compile unchanged but behave differently at runtime, so they never appear in a signature
+diff. Test text layout and stream seeking after upgrading from 3.x.
+
+### `new SKFont()` now has an empty typeface (#3735)
+
+Upstream m132 removed the lazy "resolve default at draw time" pattern; the `SkFont`
+constructor now eagerly stores an empty typeface when given none.
+
+- **Before (3.x):** `new SKFont().Typeface` was `null` and resolved to the platform default at
+  draw time — `new SKFont().MeasureText("Hello")` returned a real width.
+- **After (4.x):** the typeface is `SKTypeface.Empty` (0 glyphs), so `MeasureText("Hello")`
+  returns `0` and nothing is drawn. Setting `font.Typeface = null` likewise yields
+  `SKTypeface.Empty`.
+- **Migration:** construct with an explicit typeface, and detect "unset" with `IsEmpty`:
+
+  ```csharp
+  // Before (3.x) — worked via lazy default
+  var font = new SKFont();
+  var width = font.MeasureText("Hello"); // > 0
+
+  // After (4.x) — pass the typeface you want
+  var font = new SKFont(SKTypeface.Default);
+  var width = font.MeasureText("Hello"); // > 0
+
+  // Detecting "no typeface set"
+  bool unset = font.Typeface.IsEmpty; // was: font.Typeface == null
+  ```
+
+### `new SKPaint().Typeface` returns Default instead of null (#3736)
+
+The underlying `SkCompatPaint` moved from `SkFont()` (null → lazy default) to
+`SkFont(MakeEmpty())`. SkiaSharp mitigates this so text still works out of the box, but the
+null semantics changed.
+
+- **Before (3.x):** `new SKPaint().Typeface` was `null` (lazy default).
+- **After (4.x):** it is `SKTypeface.Default` (non-null). Text measurement and drawing still
+  work — SkiaSharp seeds a default font — and `SKPaint.Reset()` also restores that default.
+- **Only observable break:** code that used `paint.Typeface == null` to detect "no typeface
+  set" no longer fires. Use `paint.Typeface.IsEmpty`, or drop the check (a usable default is
+  always present).
+
+### `SKTypeface.FromFamilyName("missing")` returns Default, not null, on Android (#3737)
+
+The old per-platform `legacyMakeTypeface()` path (which returned `null` on Android for an
+unknown family) was replaced by `SKFontManager.Default.MatchFamily(name, style) ?? Default`,
+making every platform consistent.
+
+- **Before (3.x):** Android returned `null` for a missing family; other platforms returned a
+  fallback face.
+- **After (4.x):** all platforms return `SKTypeface.Default` — `FromFamilyName` is now never
+  null.
+- **Migration:** for a strict "was the font actually found?" check, use the font manager, which
+  still returns `null` on no match:
+
+  ```csharp
+  // Strict null semantics (all platforms)
+  var tf = SKFontManager.Default.MatchFamily("MissingFont");
+  if (tf is null) { /* font not found — apply your own fallback */ }
+  ```
+
+### `SKTypeface.Default` now resolves through the font manager (#3738)
+
+`SkTypeface::RefDefault()`/`MakeDefault()` were removed upstream in m132. Default resolution
+moved to `matchFamilyStyle(null, Normal)` with an empty-typeface fallback.
+
+- **Before (3.x):** implemented via `sk_typeface_ref_default()`.
+- **After (4.x):** implemented via the font manager; `SKTypeface.Default` is now **guaranteed
+  non-null** on every platform, and Android API 36+ (where the manager could return null — the
+  original #3693) falls back to `SKTypeface.Empty` instead of crashing.
+- **Migration:** none needed. Behavior is unchanged on macOS/Windows/Linux; Android API 36+ now
+  works instead of failing.
+
+### `SKStream.Move(long)` now throws and is obsolete (#3740)
+
+The native `sk_stream_move` offset is a 32-bit `int`. The `Move(long)` overload always did an
+unchecked `(int)` cast, silently truncating large offsets — a latent data-corruption bug.
+
+- **Before (3.x):** `stream.Move((long)int.MaxValue + 1)` silently truncated (wrapping
+  negative); no warning.
+- **After (4.x):** the cast is `checked((int)offset)`, so out-of-range offsets throw
+  `OverflowException`, and the overload is `[Obsolete]` (compiler warning **CS0618**).
+- **Migration:** call `Move(int)` with an in-range offset (validate/clamp large values
+  yourself first). Most callers already pass int-range values and only need to change the call
+  to silence the obsolete warning.
+
+## Interop / native-struct breaking changes (not in any API diff)
+
+`GRVkBackendContextNative` is an interop struct outside the public-API surface the diff tool
+compares, so its field removals appear in **no** `*.breaking.md` — they must be documented here.
+
+### Vulkan `GRVkBackendContextNative` — five fields removed (#3741)
+
+Upstream simplified `GrVkBackendContext`; the redundant legacy fields were dropped.
+
+- **Removed:** `fMinAPIVersion`, `fInstanceVersion`, `fExtensions`, `fFeatures`,
+  `fOwnsInstanceAndDevice`.
+- **Migration:** delete those assignments. Use the typed `fVkExtensions` in place of
+  `fExtensions`, and `fDeviceFeatures` / `fDeviceFeatures2` in place of `fFeatures`. Skia no
+  longer manages instance/device ownership through the backend context, so
+  `fOwnsInstanceAndDevice` has no replacement.
+
+  ```csharp
+  var ctx = new GRVkBackendContextNative
+  {
+      fInstance = instance,
+      fPhysicalDevice = physicalDevice,
+      fDevice = device,
+      fQueue = queue,
+      fGraphicsQueueIndex = queueIndex,
+      fMaxAPIVersion = maxVersion,
+      fVkExtensions = extensions,      // instead of fExtensions
+      fDeviceFeatures = features,      // instead of fFeatures
+      fGetProc = getProc,
+      // fMinAPIVersion / fInstanceVersion / fExtensions /
+      // fFeatures / fOwnsInstanceAndDevice — removed, delete these
+  };
+  ```
+
+### Vulkan `GrVkYcbcrConversionInfo` layout change (#3741)
+
+A new `Components` field (and a new `GRVkYcbcrComponents` struct) was added to the Ycbcr
+conversion info, changing its layout. Code that manually constructs the struct or relies on its
+layout must account for the new field. (The related `GRVkImageInfo.YcbcrConversionInfo` retype
+from `GrVkYcbcrConversionInfo` to `GRVkYcbcrConversionInfo`, and the loss of value-equality on
+that type, *are* captured by the signature diff — the polish step summarizes those from
+`SkiaSharp.breaking.md`.)

--- a/documentation/docfx/releases/TEMPLATE.md
+++ b/documentation/docfx/releases/TEMPLATE.md
@@ -81,15 +81,19 @@ This release focuses on hardening the native libraries against common exploit te
 
 ## Breaking Changes
 
-<!-- Always include. SUMMARIZE from the companions the raw-data block lists (§4.7):
-     - the API breaking diff (*.breaking.md) — the changed / removed signatures; and
-     - any behavioral breaking notes in the manual additions sidecar (<stem>.notes.md)
-       (same signature, different runtime behavior — these NEVER appear in a signature
-       diff, so the sidecar is the only channel for them).
+<!-- Always include. OPEN and SUMMARIZE from the companions the raw-data block lists (§4.7):
+     - the API breaking diff (*.breaking.md) — OPEN every listed file and turn each concrete
+       entry (removed interface, removed / changed / obsoleted member, retyped property) into a
+       bullet; group related ones but drop nothing. A link is NOT a substitute for reading it,
+       and PR titles are NOT a substitute for the diff's actual entries; and
+     - the manual additions sidecar (<stem>.notes.md) — behavioral breaks (same signature,
+       different runtime behavior) AND interop / native-struct breaks (e.g. removed
+       GRVkBackendContextNative fields) that NEVER appear in a signature diff. The sidecar is
+       the only channel for these — fold them in alongside the diff items.
      Summarize, don't dump: e.g. "Obsoleted several APIs in SKPaint and SKFont" or
      "SKFooBar was removed — use SKBaz instead". Small migration code examples are welcome.
-     Point at the API diff link (above) for the exhaustive list. If NEITHER companion has
-     anything, say so explicitly. -->
+     Point at the API diff link (above) for the exhaustive member list. If NEITHER companion
+     has anything, say so explicitly. -->
 
 *None in this release.*
 


### PR DESCRIPTION
## Why

Builds on #4334 (the companion-files release-notes model). That PR taught the polish AI to *read* each `.breaking.md`, but the guidance was soft ("not required to enumerate every changed member"). In practice the AI reduced `## Breaking Changes` to a **link** to the diff plus a list of **PR titles** — so the diff's actual entries never reached the page.

Concretely, 4.148.0's polished breaking section links `SkiaSharp.breaking.md` but never itemizes the three entries it contains (the `GRVkImageInfo` retype, the `GrVkYcbcrConversionInfo` value-equality removal, the `SKNativeObject` setter removal).

Two more classes of break are invisible to the signature diff entirely, so they can only reach the notes via the manual sidecar:
- **behavioral** — same signature, different runtime behavior (e.g. `new SKPaint().Typeface` now returns `Default` instead of `null`); and
- **interop / native structs** outside the public-API surface the diff compares (e.g. the five `GRVkBackendContextNative` fields removed for #3741) — these appear in **no** `.breaking.md`.

## What changed (spec-first)

**Strengthen the polish phase**
- **Spec §4.7** (`documentation/dev/release-notes-and-api-diffs.md`) — the AI must **open every listed `.breaking.md`** and turn each concrete entry into prose; a link is not a substitute for reading it, and PR titles are not a substitute for the diff's entries. Every distinct break must be represented (grouped/summarized, not dumped). Adds the behavioral + interop-struct channel and frames the diff and the sidecar as **complementary**.
- **SKILL.md** (`.agents/skills/release-notes/SKILL.md`) — companion table + rules + step 6 reworded to "itemize, don't just link"; calls out the breaks that never appear in any `.breaking.md`.
- **TEMPLATE.md** — Breaking Changes comment now says OPEN and itemize every breaking file; link/PR-titles are not substitutes; fold in the sidecar's behavioral/interop breaks.

**Validated 4.148.0 manual sidecar**
- `documentation/docfx/releases/4.148.0.notes.md` documents the seven v4 behavioral/interop breaks (#3734–#3738, #3740, #3741) that the signature diff cannot show, with before/after + migration snippets lifted from the issue bodies. Freeform Markdown. The generator (unchanged here) discovers it, folds its hash into the content key (so an edit re-polishes only that page), and lists it in the raw block's companions manifest. Partly closes #3683.

## Scope / safety
- **Docs, skill, and one sidecar only** — no generator (`.py`) or native changes; manifest behavior is unchanged.
- Verified the already-merged generator discovers the new sidecar and the breaking companion for `4.148.0` (both resolve to a path + hash), so the `notes:` hash flips and the page re-polishes on the next run.
- Regenerated version pages are intentionally **not** committed — the bot owns those.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>