### PR TITLE
[release-notes] Add a `force` re-polish dispatch input

### DIFF
--- a/.github/workflows/update-release-notes.lock.yml
+++ b/.github/workflows/update-release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6132ead32a5d4f84a9012fccf1de244ed589c0bde0dd610dff8459c879861bb8","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"36ca04dad861151b2fff8f856913636cd6743e07c72204432b3607efe2e99720","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.7"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9","version":"67a3573c9a986a3f9c594539f4ab511d57bb3ce9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -70,6 +70,11 @@ name: "Sync - Release Notes & API Diffs"
         description: Agent caller context (used internally by Agentic Workflows).
         required: false
         type: string
+      force:
+        default: false
+        description: Re-polish EVERY page even when its raw data is unchanged. Use once after a Polish skill/TEMPLATE change to re-flow the whole back-catalogue under the new instructions (e.g. to itemize breaking diffs on existing releases). Off for normal runs.
+        required: false
+        type: boolean
       source_branch:
         default: main
         description: Branch to generate from (its scripts + content). Defaults to main; override to validate a feature branch's pipeline before merge, or to refresh immediately after tagging instead of waiting for the daily run.
@@ -203,23 +208,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
+          cat << 'GH_AW_PROMPT_92eb31063e0c4a31_EOF'
           <system>
-          GH_AW_PROMPT_c7c367dd492f9839_EOF
+          GH_AW_PROMPT_92eb31063e0c4a31_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
+          cat << 'GH_AW_PROMPT_92eb31063e0c4a31_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_c7c367dd492f9839_EOF
+          GH_AW_PROMPT_92eb31063e0c4a31_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
+          cat << 'GH_AW_PROMPT_92eb31063e0c4a31_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_c7c367dd492f9839_EOF
+          GH_AW_PROMPT_92eb31063e0c4a31_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
+          cat << 'GH_AW_PROMPT_92eb31063e0c4a31_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -251,12 +256,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_c7c367dd492f9839_EOF
+          GH_AW_PROMPT_92eb31063e0c4a31_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c7c367dd492f9839_EOF'
+          cat << 'GH_AW_PROMPT_92eb31063e0c4a31_EOF'
           </system>
           {{#runtime-import .github/workflows/update-release-notes.md}}
-          GH_AW_PROMPT_c7c367dd492f9839_EOF
+          GH_AW_PROMPT_92eb31063e0c4a31_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -461,9 +466,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_55c5959e85769c8b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_88723bdb720e2bda_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"draft":false,"labels":["documentation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"preserve_branch_name":true,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"recreate_ref":true,"title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_55c5959e85769c8b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_88723bdb720e2bda_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -671,7 +676,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_104ab0949ab014c8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1b70c540d0c77442_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -712,7 +717,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_104ab0949ab014c8_EOF
+          GH_AW_MCP_CONFIG_1b70c540d0c77442_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1396,8 +1401,20 @@ jobs:
           # Single entry point: Cake (API diffs) then Python (raw data), both
           # VERBOSE. No args = --all; the "Files to polish" list lands at its
           # default location, output/files-to-polish.txt.
-          bash .agents/skills/release-notes/scripts/generate.sh
+          #
+          # A manual dispatch may set force=true to re-polish EVERY page even when
+          # its raw-data content key is unchanged (--force). This is the deliberate
+          # backfill lever for after a Polish skill/TEMPLATE change — the content
+          # key does not track the skill, so improving the instructions otherwise
+          # leaves existing pages untouched (spec §4.6). Off for push/schedule runs.
+          if [ "${FORCE_REPOLISH}" = "true" ]; then
+            echo "==> force re-polish: regenerating ALL pages regardless of content key (--force)"
+            bash .agents/skills/release-notes/scripts/generate.sh --all --force
+          else
+            bash .agents/skills/release-notes/scripts/generate.sh
+          fi
         env:
+          FORCE_REPOLISH: ${{ inputs.force || false }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
       - name: Package Prepare output

--- a/.github/workflows/update-release-notes.md
+++ b/.github/workflows/update-release-notes.md
@@ -40,6 +40,11 @@ on:
         required: false
         default: "main"
         type: string
+      force:
+        description: "Re-polish EVERY page even when its raw data is unchanged. Use once after a Polish skill/TEMPLATE change to re-flow the whole back-catalogue under the new instructions (e.g. to itemize breaking diffs on existing releases). Off for normal runs."
+        required: false
+        default: false
+        type: boolean
   skip-bots: [github-actions, copilot, dependabot]
 concurrency:
   group: update-release-notes
@@ -125,12 +130,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
+          FORCE_REPOLISH: ${{ inputs.force || false }}
         run: |
           set -euo pipefail
           # Single entry point: Cake (API diffs) then Python (raw data), both
           # VERBOSE. No args = --all; the "Files to polish" list lands at its
           # default location, output/files-to-polish.txt.
-          bash .agents/skills/release-notes/scripts/generate.sh
+          #
+          # A manual dispatch may set force=true to re-polish EVERY page even when
+          # its raw-data content key is unchanged (--force). This is the deliberate
+          # backfill lever for after a Polish skill/TEMPLATE change — the content
+          # key does not track the skill, so improving the instructions otherwise
+          # leaves existing pages untouched (spec §4.6). Off for push/schedule runs.
+          if [ "${FORCE_REPOLISH}" = "true" ]; then
+            echo "==> force re-polish: regenerating ALL pages regardless of content key (--force)"
+            bash .agents/skills/release-notes/scripts/generate.sh --all --force
+          else
+            bash .agents/skills/release-notes/scripts/generate.sh
+          fi
       - name: Package Prepare output
         id: package
         run: |

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -361,7 +361,8 @@ itself — it walks every `release/*` ref and reads `v*` tags during generation
 (§1.4, §3) — so a new release-branch commit or a freshly-pushed stable tag is picked up
 by the next daily run (within ~24h) with no per-branch/tag workflow. A manual
 `workflow_dispatch` refreshes immediately when waiting for the daily run is undesirable
-(e.g. right after tagging). (Walking a `release/*` ref is a *git source* for content,
+(e.g. right after tagging), and its **`force`** input re-polishes every page under a changed
+Polish skill/`TEMPLATE.md` (§4.6). (Walking a `release/*` ref is a *git source* for content,
 not an emission trigger; emission is governed solely by §1.4.)
 
 **Prepare runs as a standalone job; the agent only polishes.** The **Prepare** phase
@@ -886,6 +887,19 @@ refresh forces no spurious re-polish. Then regenerate `TOC.yml` +
 Polish phase reads (§2.3) — names only genuinely-changed pages, so the AI never
 re-polishes an up-to-date page. When it is empty and the tree is unchanged, the workflow
 opens no PR (§2.3).
+
+**Forcing a full re-polish.** The content key intentionally tracks only the *script-owned raw
+data* — it does **not** track the Polish skill or `TEMPLATE.md`. So improving the Polish
+instructions (e.g. teaching the AI to **itemize** every `.breaking.md` rather than just link it,
+§4.7) does **not** by itself re-flow existing pages: their raw data is unchanged, so they are
+skipped and keep their old prose. To re-apply improved instructions across the whole
+back-catalogue, the `update-release-notes` `workflow_dispatch` exposes a **`force`** input. When
+set, Prepare runs the generator with `--force`, which rewrites every line's raw-data block
+regardless of its content key and lists **every** page under "Files to polish", so the AI
+re-polishes the entire set once under the new skill/TEMPLATE. Leave it off for normal
+push/schedule runs — those stay idempotent (§4.6). Use it sparingly and deliberately: a forced
+pass re-polishes ~every version page in one agent run, so it is a manual, maintainer-initiated
+backfill, not an automatic reaction to editing the skill.
 
 ### 4.7 Manual additions & breaking-change summaries (companion files)
 


### PR DESCRIPTION
## Why

Follow-up to #4337. The release-notes polish **content key** (spec §4.6) intentionally tracks only *script-owned raw data* — PR count, diff range, supersession, the API-changes link, and the `notes:` / `breaking:` companion hashes. It does **not** track the Polish skill or `TEMPLATE.md`.

That keeps routine push/schedule runs idempotent, but it also means improving the polish instructions — like #4337 teaching the AI to **itemize** every `.breaking.md` instead of just linking it — does **not**, by itself, re-flow pages whose raw data is unchanged. Once the current breaking backfill merges, those pages would be skipped as "unchanged" and keep their old, un-itemized Breaking Changes prose. There was no lever to re-apply improved instructions across the existing back-catalogue.

## What changed

Adds a **`force`** boolean input to the `update-release-notes` `workflow_dispatch`. When set, the Prepare step runs the generator with `--all --force`, which rewrites every line's raw-data block regardless of its content key and lists **every** page under "Files to polish" — so the agent re-polishes the whole set once under the new skill/`TEMPLATE.md`.

- **Spec-first:** §4.6 documents the lever and *why* the content key excludes the skill; the §4.5 dispatch note cross-references it.
- `update-release-notes.md` gains the input and threads `FORCE_REPOLISH` into the Generate step.
- `update-release-notes.lock.yml` recompiled via `gh aw compile` (only the new input, the Generate-step branch, and expected gh-aw delimiter churn).

## Behaviour / safety

- **Default is `false`** — scheduled and push runs are byte-for-byte unchanged and stay idempotent (§4.6).
- It's a deliberate, maintainer-initiated backfill, used sparingly: one forced pass re-polishes ~every version page in a single agent run.
- No generator or native changes.

## How to use it

Actions → **Sync - Release Notes & API Diffs** → *Run workflow* → set **force** = `true`. Use it once after a Polish skill/`TEMPLATE.md` change (e.g. to itemize breaking diffs on existing releases).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>