### PR TITLE
[release-notes] Never drop the Breaking Changes section; size it to the break

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -152,7 +152,7 @@ page-relative path (see `release-notes-and-api-diffs.md` §4.7):
 | --- | --- | --- |
 | `<stem>.notes.md` | **Manual additions sidecar** — freeform Markdown the maintainer wrote to bring something out (not always breaking). | Weave its editorial points into Highlights; surface any behavioral breaking notes under Breaking Changes. |
 | `<line>/index.md` (indexes every per-assembly diff; flags breaking) | The **full public-API diff** landing page — one door to the whole folder. | Open it, follow the assemblies that matter, draw richer/accurate highlights. Do **not** paste it — summarize. |
-| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes. **Open every listed file** and turn each concrete entry (removed interface, removed / changed / obsoleted member, retyped property) into a prose bullet — grouped, but nothing dropped. A link is **not** a substitute for reading it. |
+| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes. **Open every listed file** (skim large ones — `wc -l` + read the headings), then **size the summary to the break**: itemize a small/curated set; **group + summarize + link** a bulk mechanical sweep (hundreds of `[Obsolete]` removals). A link is **not** a substitute for reading it — but never drop the section. |
 
 Rules for companions:
 
@@ -160,10 +160,17 @@ Rules for companions:
   verbatim or dump the whole file. A human summary ("obsoleted several APIs in `SKPaint` and
   `SKFont`"; "`SKFooBar` was removed — use `SKBaz`") with a small migration code example where
   it helps is the goal.
-- **Itemize the breaking diff — don't just link it.** The `## Breaking Changes` section must
-  reflect the **actual entries** in each `.breaking.md` (every distinct removed / changed /
-  obsoleted type or member), grouped and summarized. A section that only links the diff and
-  lists PR titles has **not** done the job.
+- **Read the breaking diff — never just link it, never drop the section.** The
+  `## Breaking Changes` section must reflect what the `.breaking.md` files actually contain,
+  **sized to the break**:
+  - **Small / curated** (a handful of entries) → **itemize** each distinct removed / changed /
+    obsoleted type or member, with a migration snippet where it helps.
+  - **Bulk / mechanical sweep** (dozens-to-hundreds at once — the pre-3.0 `[Obsolete]` cull, a
+    dropped TFM) → **group + summarize in a sentence or two + link the API diff** for the full
+    list. Do **not** try to list every member — a grouped summary is the *complete* answer here.
+  Opening the files is mandatory (a skim of a large one is fine); a section that only links the
+  diff and lists PR titles has **not** done the job, and **omitting the section is never allowed** —
+  if "itemize everything" is infeasible, degrade to a grouped summary + link, never to silence.
 - **Some real breaks never appear in any `.breaking.md`** — behavioral changes (same signature,
   different runtime behavior, e.g. `new SKFont()` now carrying an empty typeface) and
   interop / native structs outside the public-API surface (e.g. removed `GRVkBackendContextNative`
@@ -282,15 +289,18 @@ Follow these rules:
 5. **Omit noise** — Skip version bumps, CI-only fixes, doc updates, workflow/skill changes.
    If many, mention as: "Plus several CI and documentation improvements."
 
-6. **Breaking changes** — Always include a `## Breaking Changes` section (say
-   *"None in this release."* when there are none). When the raw block lists an api
-   **breaking** companion and/or a manual notes sidecar, **open them and summarize — do not
-   just link them.** The `.breaking.md` gives the "what": reflect **every distinct** entry it
-   contains (obsoleted/removed/changed signatures), grouped but not dropped. The
+6. **Breaking changes** — **Always** include a `## Breaking Changes` section (say
+   *"None in this release."* only when there genuinely are none) — **never drop the heading.**
+   When the raw block lists an api **breaking** companion and/or a manual notes sidecar,
+   **open them and summarize — do not just link them.** Size the summary to the break: **itemize**
+   a small/curated set (obsoleted/removed/changed signatures) with migration snippets; **group +
+   summarize + link the diff** for a bulk mechanical sweep (hundreds of `[Obsolete]` removals) —
+   don't try to list every member. Opening the file is mandatory even when you only skim it. The
    `<stem>.notes.md` gives behavioral breaks, interop-struct breaks the diff can't see (e.g.
    removed `GRVkBackendContextNative` fields), and migration "how". Keep it concise — a small
    migration code example is welcome; point at the API diff for the exhaustive member list. Do
-   not dump the diff, and do not reduce the section to a bare link plus PR titles. (See
+   not dump the diff, do not reduce the section to a bare link plus PR titles, and **never omit
+   it** — degrade to a grouped summary, never to silence. (See
    [Companion files](#companion-files-open-and-read-them) and TEMPLATE.md.)
 
 7. **PR links** — Every item links to its PR.

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -951,16 +951,23 @@ need to escape a companion's own `-->` (the loader only hashes bytes).
 The AI reads the page's raw-data block, then **opens and reads** the manifest's companions
 and writes a **summary**, not a dump:
 
-- **Breaking changes → a concise `## ⚠️ Breaking Changes` section.** The AI must **open every
-  `.breaking.md` the manifest lists** and turn its concrete entries — each removed interface,
-  removed / changed / obsoleted member, and retyped property under its `####`/`###` headings —
-  into prose. **A link to the breaking diff is not a substitute for reading it, and PR titles
-  are not a substitute for the diff's actual entries:** never emit a section that only links the
-  file and then lists PRs. Summarize rather than dump (group related members — "obsoleted the
-  text/font members on `SKPaint`"; "`SKFooBar` was removed — use `SKBaz`"), but every
-  **distinct** break in the diff must be represented, not silently dropped; add small
-  **migration code examples** where they help and point at the API-diff index for the exhaustive
-  member list.
+- **Breaking changes → a concise `## ⚠️ Breaking Changes` section.** Always emit this heading —
+  **omitting the section is never acceptable.** **Open every `.breaking.md` the manifest lists**
+  (for a large one a skim is enough — a quick `wc -l` plus reading the `####`/`###` headings —
+  the rule is that you never *skip* opening it, not that you transcribe it). Then **size the
+  summary to the shape of the break**:
+  - **A small / curated set** (up to a handful of distinct entries) → **itemize** them: turn each
+    removed interface, removed / changed / obsoleted member, and retyped property into a prose
+    bullet, with a small **migration code example** where it helps.
+  - **A bulk / mechanical sweep** (dozens-to-hundreds of members removed at once — e.g. the
+    pre-3.0 `[Obsolete]` cull, a dropped target framework) → **group and summarize** it in a
+    sentence or two and **link the API diff** for the exhaustive list (e.g. *"Members obsoleted
+    before 3.0 were removed across `SKPaint`, `SKCanvas`, and others — see the API diff for the
+    full list"*). Do **not** try to list every member; a grouped summary **is** the complete,
+    correct answer for a sweep this large.
+  In every case, **a bare link plus PR titles is not enough** — read the diff, do not just point
+  at it — and when "itemize everything" is infeasible, **degrade to a grouped summary + link,
+  never to silence.** The section always says *something*.
 - **Breaks the signature diff cannot see** reach the notes **only** through `.notes.md`, and the
   AI folds them into the same section:
   - **behavioral changes** — same signature, different runtime behavior (e.g.

--- a/documentation/docfx/releases/TEMPLATE.md
+++ b/documentation/docfx/releases/TEMPLATE.md
@@ -81,19 +81,26 @@ This release focuses on hardening the native libraries against common exploit te
 
 ## Breaking Changes
 
-<!-- Always include. OPEN and SUMMARIZE from the companions the raw-data block lists (§4.7):
-     - the API breaking diff (*.breaking.md) — OPEN every listed file and turn each concrete
-       entry (removed interface, removed / changed / obsoleted member, retyped property) into a
-       bullet; group related ones but drop nothing. A link is NOT a substitute for reading it,
-       and PR titles are NOT a substitute for the diff's actual entries; and
+<!-- ALWAYS include this heading — never drop it. OPEN and SUMMARIZE from the companions the
+     raw-data block lists (§4.7):
+     - the API breaking diff (*.breaking.md) — OPEN every listed file (skim a large one: wc -l +
+       read the headings), then SIZE the summary to the break:
+         * small / curated set (a handful of entries) → itemize each removed / changed /
+           obsoleted member as a bullet, with a migration snippet where it helps;
+         * bulk / mechanical sweep (dozens-to-hundreds at once, e.g. the pre-3.0 [Obsolete] cull
+           or a dropped TFM) → GROUP + summarize in a sentence or two + LINK the API diff for the
+           full list. Do NOT list every member — a grouped summary IS the complete answer here.
+       A link is NOT a substitute for reading it, and PR titles are NOT a substitute for the
+       diff's entries; and
      - the manual additions sidecar (<stem>.notes.md) — behavioral breaks (same signature,
        different runtime behavior) AND interop / native-struct breaks (e.g. removed
        GRVkBackendContextNative fields) that NEVER appear in a signature diff. The sidecar is
        the only channel for these — fold them in alongside the diff items.
      Summarize, don't dump: e.g. "Obsoleted several APIs in SKPaint and SKFont" or
      "SKFooBar was removed — use SKBaz instead". Small migration code examples are welcome.
-     Point at the API diff link (above) for the exhaustive member list. If NEITHER companion
-     has anything, say so explicitly. -->
+     OMITTING this section is never acceptable — if you cannot itemize, degrade to a grouped
+     summary + link, never to silence. Only if NEITHER companion has anything, write
+     "None in this release." -->
 
 *None in this release.*
 


### PR DESCRIPTION
## Problem

The polish strengthening in #4337 over-rotated. Its wording — *"open every `.breaking.md`, turn **every distinct** entry into a bullet, **drop nothing**"* — is unachievable for a bulk breaking sweep, and the AI responded by **dropping the whole `## Breaking Changes` section** rather than summarizing.

The first production run under that wording (run `28683166739`, `bot/release-notes` @ `a93930782a0`) regressed **23 of the 24** pages that have `.breaking.md` companions: they lost their Breaking section entirely. Only **4.148.0** — the one page with a `.notes.md` sidecar — kept it.

**3.116.0 is the clearest case.** It previously had the *correct* grouped summary for a bulk sweep:

> - Obsolete 2.x APIs are gone in 3.x — upgrading from 2.88 may require source changes. (#2539)

and this run **deleted** it (the commit diff shows `-## Breaking Changes`). The agent log confirms the AI never opened a single 3.116.0 `.breaking.md` (its 1090-line `[Obsolete]` cull spans 12 assemblies); unable to "itemize everything", it skipped the companions and omitted the section — violating the *"always include"* rule right above it.

## Fix — graceful degradation (spec-first)

Replace the maximalist *"itemize everything / drop nothing"* framing with **size-to-the-break** guidance, applied spec-first (§4.7) then mirrored into the skill and template:

- **Never drop the heading.** Omitting the section is the one thing that is never acceptable; when itemizing is infeasible, degrade to a grouped summary + a diff link — never to silence.
- **Size the summary to the break.** *Itemize* a small/curated set (a handful of entries) with migration snippets; *group + summarize + link the API diff* for a bulk mechanical sweep (the pre-3.0 `[Obsolete]` cull, a dropped TFM) instead of trying to list hundreds of members.
- **Opening the breaking files stays mandatory**, but a skim (`wc -l` + headings) is explicitly enough for a large one — so the AI never has an excuse to skip it.

## Files
- `documentation/dev/release-notes-and-api-diffs.md` §4.7 (spec — first)
- `.agents/skills/release-notes/SKILL.md` (companion table, companion rules, step 6)
- `documentation/docfx/releases/TEMPLATE.md` (Breaking Changes comment)

## Verify after merge
Re-polish the existing breaking pages (they re-polish this run regardless while the breaking backfill #4336 is unmerged) and confirm **3.116.0**'s grouped Breaking bullet returns and no page drops the section.
