### PR TITLE
[release-notes] Slim breaking-change guidance to restore the full page render

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -152,34 +152,24 @@ page-relative path (see `release-notes-and-api-diffs.md` §4.7):
 | --- | --- | --- |
 | `<stem>.notes.md` | **Manual additions sidecar** — freeform Markdown the maintainer wrote to bring something out (not always breaking). | Weave its editorial points into Highlights; surface any behavioral breaking notes under Breaking Changes. |
 | `<line>/index.md` (indexes every per-assembly diff; flags breaking) | The **full public-API diff** landing page — one door to the whole folder. | Open it, follow the assemblies that matter, draw richer/accurate highlights. Do **not** paste it — summarize. |
-| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes. **Open every listed file** (skim large ones — `wc -l` + read the headings), then **size the summary to the break**: itemize a small/curated set; **group + summarize + link** a bulk mechanical sweep (hundreds of `[Obsolete]` removals). A link is **not** a substitute for reading it — but never drop the section. |
+| `<line>/…/*.breaking.md` (**one per broken assembly**) | The **API breaking diff** — present only where signatures actually broke; a big release lists many. | The "what" of Breaking Changes. **Open every listed file** and **summarize the changes as a few bullets** — name the affected types/areas, link the API diff for the full list. |
 
 Rules for companions:
 
 - **Open and read** each one the manifest lists, then **summarize** — never paste a diff
-  verbatim or dump the whole file. A human summary ("obsoleted several APIs in `SKPaint` and
-  `SKFont`"; "`SKFooBar` was removed — use `SKBaz`") with a small migration code example where
-  it helps is the goal.
-- **Read the breaking diff — never just link it, never drop the section.** The
-  `## Breaking Changes` section must reflect what the `.breaking.md` files actually contain,
-  **sized to the break**:
-  - **Small / curated** (a handful of entries) → **itemize** each distinct removed / changed /
-    obsoleted type or member, with a migration snippet where it helps.
-  - **Bulk / mechanical sweep** (dozens-to-hundreds at once — the pre-3.0 `[Obsolete]` cull, a
-    dropped TFM) → **group + summarize in a sentence or two + link the API diff** for the full
-    list. Do **not** try to list every member — a grouped summary is the *complete* answer here.
-  Opening the files is mandatory (a skim of a large one is fine); a section that only links the
-  diff and lists PR titles has **not** done the job, and **omitting the section is never allowed** —
-  if "itemize everything" is infeasible, degrade to a grouped summary + link, never to silence.
-- **Some real breaks never appear in any `.breaking.md`** — behavioral changes (same signature,
-  different runtime behavior, e.g. `new SKFont()` now carrying an empty typeface) and
-  interop / native structs outside the public-API surface (e.g. removed `GRVkBackendContextNative`
-  fields). The `<stem>.notes.md` sidecar is the **only** channel for these — read it carefully
-  and fold it into Breaking Changes alongside the diff itemization.
-- You may **read** these files but **never edit them** — they are inputs/artifacts, owned by
-  the maintainer and the Prepare script. Still no git, no gh API, no other files.
-- If the manifest lists a companion but the file is missing (or vice-versa), **stop and
-  report it** — do not work around it.
+  verbatim or dump the whole file. A short human summary ("obsoleted several APIs in `SKPaint`
+  and `SKFont`"; "`SKFooBar` was removed — use `SKBaz`") with a small migration example where
+  it helps is the goal, for a bulk sweep as much as a curated set.
+- **Merge `.notes.md` neatly** — editorial "bring this out" notes into Highlights; behavioral
+  and interop breaks under Breaking Changes. It is the **only** channel for breaks the signature
+  diff can't see: behavioral changes (same signature, different runtime behavior, e.g.
+  `new SKFont()` carrying an empty typeface) and interop / native structs (e.g. removed
+  `GRVkBackendContextNative` fields).
+- **Summarize `.breaking.md` into a few bullets** under `## Breaking Changes`; never drop the
+  section. Readers follow the API-diff link for the exhaustive list.
+- You may **read** these files but **never edit them** — they are inputs/artifacts. Still no
+  git, no gh API, no other files. If the manifest lists a companion but the file is missing (or
+  vice-versa), **stop and report it** — do not work around it.
 
 **IMPORTANT:** The list of files to polish is **always** at `output/files-to-polish.txt`
 (one repo-relative path per line, nothing else). For a **manual** run the Prepare script
@@ -289,19 +279,12 @@ Follow these rules:
 5. **Omit noise** — Skip version bumps, CI-only fixes, doc updates, workflow/skill changes.
    If many, mention as: "Plus several CI and documentation improvements."
 
-6. **Breaking changes** — **Always** include a `## Breaking Changes` section (say
-   *"None in this release."* only when there genuinely are none) — **never drop the heading.**
-   When the raw block lists an api **breaking** companion and/or a manual notes sidecar,
-   **open them and summarize — do not just link them.** Size the summary to the break: **itemize**
-   a small/curated set (obsoleted/removed/changed signatures) with migration snippets; **group +
-   summarize + link the diff** for a bulk mechanical sweep (hundreds of `[Obsolete]` removals) —
-   don't try to list every member. Opening the file is mandatory even when you only skim it. The
-   `<stem>.notes.md` gives behavioral breaks, interop-struct breaks the diff can't see (e.g.
-   removed `GRVkBackendContextNative` fields), and migration "how". Keep it concise — a small
-   migration code example is welcome; point at the API diff for the exhaustive member list. Do
-   not dump the diff, do not reduce the section to a bare link plus PR titles, and **never omit
-   it** — degrade to a grouped summary, never to silence. (See
-   [Companion files](#companion-files-open-and-read-them) and TEMPLATE.md.)
+6. **Breaking changes** — Always include a `## Breaking Changes` section (*"None in this
+   release."* when there are none — never drop the heading). If the raw block lists a
+   `.breaking.md` and/or `.notes.md` companion, open them and **summarize the breaks as a few
+   bullets**: name the affected types/areas, add a migration snippet where it helps, and link
+   the API diff for the full list. Behavioral & interop breaks come only from `.notes.md`.
+   Summarize, don't dump. (See [Companion files](#companion-files-open-and-read-them).)
 
 7. **PR links** — Every item links to its PR.
 

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -948,44 +948,29 @@ need to escape a companion's own `-->` (the loader only hashes bytes).
 
 #### What the Polish AI does with them
 
-The AI reads the page's raw-data block, then **opens and reads** the manifest's companions
-and writes a **summary**, not a dump:
+The AI reads the page's raw-data block, then **opens and reads** each companion the manifest
+lists and writes a **short summary**, not a dump. Four rules cover it:
 
-- **Breaking changes → a concise `## ⚠️ Breaking Changes` section.** Always emit this heading —
-  **omitting the section is never acceptable.** **Open every `.breaking.md` the manifest lists**
-  (for a large one a skim is enough — a quick `wc -l` plus reading the `####`/`###` headings —
-  the rule is that you never *skip* opening it, not that you transcribe it). Then **size the
-  summary to the shape of the break**:
-  - **A small / curated set** (up to a handful of distinct entries) → **itemize** them: turn each
-    removed interface, removed / changed / obsoleted member, and retyped property into a prose
-    bullet, with a small **migration code example** where it helps.
-  - **A bulk / mechanical sweep** (dozens-to-hundreds of members removed at once — e.g. the
-    pre-3.0 `[Obsolete]` cull, a dropped target framework) → **group and summarize** it in a
-    sentence or two and **link the API diff** for the exhaustive list (e.g. *"Members obsoleted
-    before 3.0 were removed across `SKPaint`, `SKCanvas`, and others — see the API diff for the
-    full list"*). Do **not** try to list every member; a grouped summary **is** the complete,
-    correct answer for a sweep this large.
-  In every case, **a bare link plus PR titles is not enough** — read the diff, do not just point
-  at it — and when "itemize everything" is infeasible, **degrade to a grouped summary + link,
-  never to silence.** The section always says *something*.
-- **Breaks the signature diff cannot see** reach the notes **only** through `.notes.md`, and the
-  AI folds them into the same section:
-  - **behavioral changes** — same signature, different runtime behavior (e.g.
-    `new SKPaint().Typeface` now returning `Default` instead of `null`); and
-  - **interop / native structs** outside the public-API surface the diff compares (e.g. removed
-    `GRVkBackendContextNative` fields) — real compile-time breaks that never show in any
-    `.breaking.md`.
-  Treat the breaking diff and the notes sidecar as **complementary**: include both, and never
-  let one substitute for the other.
-- **Editorial "bring this out" notes** from `.notes.md` are woven into Highlights / a callout
-  as the maintainer intends — kept close to verbatim where the wording clearly matters,
-  summarized where they are rough notes.
-- **Richer highlights** may draw on the full API diff for context, but the PR list in the raw
-  block remains the primary source for "what's new".
+1. **Manual notes (`.notes.md`) — merge neatly.** Read it and fold its points into the prose:
+   editorial "bring this out" notes into Highlights (kept close to the maintainer's wording
+   where it matters), behavioral and interop breaks under Breaking Changes. This sidecar is the
+   **only** channel for breaks the signature diff cannot see — **behavioral changes** (same
+   signature, different runtime behavior, e.g. `new SKPaint().Typeface` now returning `Default`
+   instead of `null`) and **interop / native structs** (e.g. removed `GRVkBackendContextNative`
+   fields).
+2. **Breaking diff (`.breaking.md`) — summarize as a few bullets.** Open **every** file the
+   manifest lists (one per broken assembly) and write a handful of bullets under
+   `## Breaking Changes` naming the affected types/areas, with a small migration example where
+   it helps. Readers follow the API-diff link (already on the page, §4.4) for the exhaustive
+   member list — a few bullets is enough, for a bulk sweep as much as a curated set.
+3. **Summarize, don't transcribe.** Never paste a diff or list every member; a short human
+   summary is the goal.
+4. **Always emit the section.** `## Breaking Changes` is always present; when neither companion
+   has anything, it reads *"None in this release."* (TEMPLATE.md).
 
 The AI still writes **no links or structure** (§4.4), **never edits a companion**, and never
-touches git or the gh API. When neither the breaking diff nor the manual notes has any
-breaking content, the section reads *"None in this release."* (TEMPLATE.md).
+touches git or the gh API. Richer highlights may draw on the full API diff for context, but the
+PR list in the raw block remains the primary source for "what's new".
 
 #### Idempotency
 

--- a/documentation/docfx/releases/TEMPLATE.md
+++ b/documentation/docfx/releases/TEMPLATE.md
@@ -81,26 +81,15 @@ This release focuses on hardening the native libraries against common exploit te
 
 ## Breaking Changes
 
-<!-- ALWAYS include this heading — never drop it. OPEN and SUMMARIZE from the companions the
-     raw-data block lists (§4.7):
-     - the API breaking diff (*.breaking.md) — OPEN every listed file (skim a large one: wc -l +
-       read the headings), then SIZE the summary to the break:
-         * small / curated set (a handful of entries) → itemize each removed / changed /
-           obsoleted member as a bullet, with a migration snippet where it helps;
-         * bulk / mechanical sweep (dozens-to-hundreds at once, e.g. the pre-3.0 [Obsolete] cull
-           or a dropped TFM) → GROUP + summarize in a sentence or two + LINK the API diff for the
-           full list. Do NOT list every member — a grouped summary IS the complete answer here.
-       A link is NOT a substitute for reading it, and PR titles are NOT a substitute for the
-       diff's entries; and
+<!-- ALWAYS include this heading — never drop it. If the raw-data block lists companions (§4.7),
+     open them and SUMMARIZE the breaks as a few bullets:
+     - the API breaking diff (*.breaking.md) — open every listed file (one per broken assembly)
+       and name the affected types/areas in a few bullets, with a small migration snippet where
+       it helps. Summarize, don't dump — readers follow the API-diff link for the full list.
      - the manual additions sidecar (<stem>.notes.md) — behavioral breaks (same signature,
-       different runtime behavior) AND interop / native-struct breaks (e.g. removed
-       GRVkBackendContextNative fields) that NEVER appear in a signature diff. The sidecar is
-       the only channel for these — fold them in alongside the diff items.
-     Summarize, don't dump: e.g. "Obsoleted several APIs in SKPaint and SKFont" or
-     "SKFooBar was removed — use SKBaz instead". Small migration code examples are welcome.
-     OMITTING this section is never acceptable — if you cannot itemize, degrade to a grouped
-     summary + link, never to silence. Only if NEITHER companion has anything, write
-     "None in this release." -->
+       different runtime behavior) and interop / native-struct breaks (e.g. removed
+       GRVkBackendContextNative fields) that never appear in a signature diff. Fold them in here.
+     If NEITHER companion has anything, write "None in this release." -->
 
 *None in this release.*
 


### PR DESCRIPTION
## Why

The good, rich release-notes render **predates the breaking-change initiative**. `4.148.0` at #4224 had 9 sections including **Platform Support** and a **Community Contributors table with 21 linked handles**. The last three release-notes commits regressed the *whole page* while only meaning to tweak breaking changes.

## What went wrong

Over #4334 → #4337 → #4341 the breaking-change guidance grew large and became **triplicated**:
- spec §4.7 — four long bullets
- `SKILL.md` companion-rules — five long bullets
- `SKILL.md` step 6 — a 13-line paragraph
- `TEMPLATE.md` — a 20-line comment

…all repeating the same *"size to the break / itemize vs. sweep / open every file / never degrade to silence"* machinery.

None of that **removed** the good-render rules — `TEMPLATE.md` and `SKILL.md` still require Platform Support and a linked Contributors table. But the polish is a **single agentic pass over ~29 pages**, and the lopsided emphasis (breaking reinforced across dozens of lines; Platform Support **zero** lines in the skill) crowded out everything else. The render degraded **progressively and systemically** — this run dropped Platform Support and the Contributors table on **every** sampled page:

| Page | Platform Support | Contributors table | Linked `@` handles |
|---|---|---|---|
| 4.148.0 (good, #4224) | ✅ | ✅ | 21 |
| 3.116.0 / 3.119.4 / 4.147.0 / 3.0.0 (regressed run) | ❌ | ❌ | 0 |

## The fix

Collapse the breaking guidance to a lean **four-rule** shape, applied consistently **spec-first** (spec → TEMPLATE → SKILL):

1. **Manual notes (`.notes.md`) — merge neatly.** The only channel for behavioral and interop breaks the signature diff can't see.
2. **Breaking diff (`.breaking.md`) — summarize as a few bullets.** Open every listed file; link the API diff for the exhaustive list.
3. **Summarize, don't transcribe.**
4. **Always emit the `## Breaking Changes` section.**

Everything that works is **untouched**: the `.notes.md` / `.breaking.md` companion model, the content-key hashing, and the `claude-opus-4.7` Polish pin. This only removes the over-weighting so the single-pass AI treats every section evenly again. The few-bullet summary also makes the recent exhaustive-itemization nits (`SKGRVkImageInfo` / `Handle`) less likely.

**Net: −92 / +49 lines** across the three doc surfaces; no generator or workflow changes.

After merge, the next release-notes run re-polishes the breaking-bearing pages — watch that Platform Support + the linked Contributors table return alongside a lean Breaking Changes section.
