### PR TITLE
Optimize SKColor hex parsing and add ReadOnlySpan<char> overloads

### DIFF
--- a/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SKColorParseBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SKColorParseBenchmark.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks;
+
+// SKColor.TryParse turns hex color strings ("#RGB", "#ARGB", "#RRGGBB", "#AARRGGBB", with or
+// without a leading '#') into an SKColor. It sits on hot paths for anyone hydrating colors from
+// XAML/CSS/JSON/theme files, so the per-call cost and allocations matter when thousands of colors
+// are parsed at startup.
+//
+// This benchmark compares the shipped SKColor.TryParse (a branch-per-length manual hex parser)
+// against the previous implementation, which leaned on byte.TryParse/uint.TryParse with
+// NumberStyles.HexNumber + CultureInfo.InvariantCulture. The old span-based path is reproduced
+// verbatim below as the baseline so both are measured in the same process/TFM.
+//
+// Inputs cover every supported shape plus an invalid string, since the length switch means each
+// shape takes a different branch.
+[MemoryDiagnoser]
+public class SKColorParseBenchmark
+{
+	[Params("#FFFFFFFF", "#FFFFFF", "#FFF", "#FFFF", "#A7A8A9A0", "Red")]
+	public string Input { get; set; }
+
+	// New: the shipped implementation.
+	[Benchmark]
+	public uint New()
+	{
+		SKColor.TryParse(Input, out var color);
+		return (uint)color;
+	}
+
+	// Baseline: the previous span-based implementation using byte/uint.TryParse.
+	[Benchmark(Baseline = true)]
+	public uint Old()
+	{
+		OldTryParse(Input, out var color);
+		return (uint)color;
+	}
+
+	// Verbatim copy of the previous SKColor.TryParse span path (NETCOREAPP3_1_OR_GREATER branch).
+	private static bool OldTryParse(string hexString, out SKColor color)
+	{
+		if (string.IsNullOrWhiteSpace(hexString))
+		{
+			color = SKColor.Empty;
+			return false;
+		}
+
+		var hexSpan = hexString.AsSpan().Trim().TrimStart('#');
+
+		var len = hexSpan.Length;
+		if (len == 3 || len == 4)
+		{
+			byte a;
+			if (len == 4)
+			{
+				if (!byte.TryParse(hexSpan.Slice(0, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a))
+				{
+					color = SKColor.Empty;
+					return false;
+				}
+				a = (byte)(a << 4 | a);
+			}
+			else
+			{
+				a = 255;
+			}
+
+			if (!byte.TryParse(hexSpan.Slice(len - 3, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
+				!byte.TryParse(hexSpan.Slice(len - 2, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
+				!byte.TryParse(hexSpan.Slice(len - 1, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+			{
+				color = SKColor.Empty;
+				return false;
+			}
+
+			color = new SKColor((byte)(r << 4 | r), (byte)(g << 4 | g), (byte)(b << 4 | b), a);
+			return true;
+		}
+
+		if (len == 6 || len == 8)
+		{
+			if (!uint.TryParse(hexSpan, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var number))
+			{
+				color = SKColor.Empty;
+				return false;
+			}
+
+			color = (SKColor)number;
+
+			if (len == 6)
+			{
+				color = color.WithAlpha(255);
+			}
+			return true;
+		}
+
+		color = SKColor.Empty;
+		return false;
+	}
+}

--- a/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SKColorParseSpanBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SKColorParseSpanBenchmark.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks;
+
+// Does it matter whether SKColor.TryParse walks the input as a string (indexing hexString[i] with
+// manually tracked start/end offsets) or as a ReadOnlySpan<char> (like the old
+// "#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER" branch, which used
+// hexString.AsSpan().Trim().TrimStart('#'))?
+//
+// Both variants below use the identical if-chain nibble conversion and produce identical results
+// (GlobalSetup asserts each matches the shipped SKColor.TryParse before timing). The ONLY difference
+// is trimming + character access: manual index loops over the string vs Trim()/TrimStart() slicing
+// and span indexing. The Mixed stream is a diverse set of 24 real colors so results reflect a real
+// workload rather than one repeated input.
+//
+// RESULTS (net10.0, Apple M3 Pro, BenchmarkDotNet 0.13.5), ns per parse over the Mixed stream,
+// two runs:
+//
+// | Variant     | Run 1 | Run 2 | Notes                                            |
+// |-------------|------:|------:|--------------------------------------------------|
+// | StringIndex |  7.07 |  7.11 | manual index + string[i]                          |
+// | SpanTrim    |  6.69 |  6.94 | ~2-3% faster, no allocations (ADOPTED)           |
+//
+// The span variant is consistently a hair faster (~0.2 ns / ~2-3%). The likely reason is bounds-check
+// elimination: after `switch (s.Length) { case 8: ... }` the JIT knows s.Length == 8 and can prove
+// s[0]..s[7] are all in range, so it drops the per-access bounds checks. With the string variant the
+// index is hexString[start + k] where `start` is a runtime value, so the JIT keeps the checks.
+//
+// Based on this, SKColor.TryParse was moved to the span form and now also exposes public
+// TryParse(ReadOnlySpan<char>) / Parse(ReadOnlySpan<char>) overloads (the string overloads delegate
+// via AsSpan()). The old #if guard only existed because that path also called the byte/uint.TryParse
+// span overloads (netstandard2.1+); this trimming-only span code compiles on every TFM.
+[MemoryDiagnoser]
+public class SKColorParseSpanBenchmark
+{
+	private static readonly string[] Mixed =
+	{
+		"#1B4F8C", "#A7A8A9A0", "#ff8800", "#3E7", "#abcdef", "#12345678", "#0a0", "#DEADBE",
+		"#c0ffee", "#123", "#9B2D5F", "#FFAA0080", "#4682b4", "#7f7f7f", "#e91e63", "#0d1b2a",
+		"#F0A", "#5566", "#00ff7f", "#8a2be2", "#Cd5C5c", "#2F4F4F", "#adff2f", "#ABCDEF01",
+	};
+	private const int MixedCount = 24;
+
+	[GlobalSetup]
+	public void Validate()
+	{
+		string[] vectors =
+		{
+			"#FFFFFFFF", "#ffffffff", "#fFfFfFfF", "#FFF", "#FFFF", "#FFFFFF",
+			"#a4C5e6", "#ABC", "#ABCD", "#AAABACAD", "ABCDEF", "A7A8A9A0",
+			"  #ABC  ", "#123456ug", "12sd", "#ABCDE", "Red", "", null, "#", "# 12345",
+		};
+
+		foreach (var v in vectors)
+		{
+			var shippedOk = SKColor.TryParse(v, out var expected);
+			var e = (uint)expected;
+
+			Check("StringIndex", ParseStringIndex(v, out var sc), sc, shippedOk, e, v);
+			Check("SpanTrim", ParseSpanTrim(v, out var pc), pc, shippedOk, e, v);
+		}
+	}
+
+	private static void Check(string name, bool ok, uint got, bool shippedOk, uint expected, string input)
+	{
+		if (ok != shippedOk)
+			throw new InvalidOperationException($"{name} accept/reject mismatch on '{input ?? "<null>"}' (variant={ok}, shipped={shippedOk})");
+		if (ok && got != expected)
+			throw new InvalidOperationException($"{name} value mismatch on '{input}': got {got:X8} want {expected:X8}");
+	}
+
+	[Benchmark(Baseline = true, OperationsPerInvoke = MixedCount)]
+	public uint StringIndex()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			ParseStringIndex(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint SpanTrim()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			ParseSpanTrim(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	// Variant A: index into the string with manually tracked offsets (the shipped approach).
+	private static bool ParseStringIndex(string hexString, out uint color)
+	{
+		color = 0;
+		if (string.IsNullOrEmpty(hexString))
+			return false;
+
+		var start = 0;
+		var end = hexString.Length;
+		while (start < end && char.IsWhiteSpace(hexString[start])) start++;
+		while (end > start && char.IsWhiteSpace(hexString[end - 1])) end--;
+		while (start < end && hexString[start] == '#') start++;
+
+		switch (end - start)
+		{
+			case 3:
+				if (!N(hexString[start], out var r3) || !N(hexString[start + 1], out var g3) || !N(hexString[start + 2], out var b3))
+					return false;
+				color = 0xFF000000u | (uint)((r3 << 4 | r3) << 16 | (g3 << 4 | g3) << 8 | (b3 << 4 | b3));
+				return true;
+			case 4:
+				if (!N(hexString[start], out var a4) || !N(hexString[start + 1], out var r4) || !N(hexString[start + 2], out var g4) || !N(hexString[start + 3], out var b4))
+					return false;
+				color = (uint)((a4 << 4 | a4) << 24 | (r4 << 4 | r4) << 16 | (g4 << 4 | g4) << 8 | (b4 << 4 | b4));
+				return true;
+			case 6:
+				if (!B(hexString[start], hexString[start + 1], out var r6) || !B(hexString[start + 2], hexString[start + 3], out var g6) || !B(hexString[start + 4], hexString[start + 5], out var b6))
+					return false;
+				color = 0xFF000000u | (uint)((r6 << 16) | (g6 << 8) | b6);
+				return true;
+			case 8:
+				if (!B(hexString[start], hexString[start + 1], out var a8) || !B(hexString[start + 2], hexString[start + 3], out var r8) || !B(hexString[start + 4], hexString[start + 5], out var g8) || !B(hexString[start + 6], hexString[start + 7], out var b8))
+					return false;
+				color = (uint)((a8 << 24) | (r8 << 16) | (g8 << 8) | b8);
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	// Variant B: trim with spans, then index the span (the old NETCOREAPP3_1/NETSTANDARD2_1 shape).
+	private static bool ParseSpanTrim(string hexString, out uint color)
+	{
+		color = 0;
+		if (string.IsNullOrEmpty(hexString))
+			return false;
+
+		var s = hexString.AsSpan().Trim().TrimStart('#');
+
+		switch (s.Length)
+		{
+			case 3:
+				if (!N(s[0], out var r3) || !N(s[1], out var g3) || !N(s[2], out var b3))
+					return false;
+				color = 0xFF000000u | (uint)((r3 << 4 | r3) << 16 | (g3 << 4 | g3) << 8 | (b3 << 4 | b3));
+				return true;
+			case 4:
+				if (!N(s[0], out var a4) || !N(s[1], out var r4) || !N(s[2], out var g4) || !N(s[3], out var b4))
+					return false;
+				color = (uint)((a4 << 4 | a4) << 24 | (r4 << 4 | r4) << 16 | (g4 << 4 | g4) << 8 | (b4 << 4 | b4));
+				return true;
+			case 6:
+				if (!B(s[0], s[1], out var r6) || !B(s[2], s[3], out var g6) || !B(s[4], s[5], out var b6))
+					return false;
+				color = 0xFF000000u | (uint)((r6 << 16) | (g6 << 8) | b6);
+				return true;
+			case 8:
+				if (!B(s[0], s[1], out var a8) || !B(s[2], s[3], out var r8) || !B(s[4], s[5], out var g8) || !B(s[6], s[7], out var b8))
+					return false;
+				color = (uint)((a8 << 24) | (r8 << 16) | (g8 << 8) | b8);
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static bool N(char c, out int value)
+	{
+		if (c >= '0' && c <= '9') { value = c - '0'; return true; }
+		if (c >= 'a' && c <= 'f') { value = c - 'a' + 10; return true; }
+		if (c >= 'A' && c <= 'F') { value = c - 'A' + 10; return true; }
+		value = 0;
+		return false;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static bool B(char hi, char lo, out int value)
+	{
+		if (N(hi, out var h) && N(lo, out var l)) { value = h << 4 | l; return true; }
+		value = 0;
+		return false;
+	}
+}

--- a/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SKColorParseStrategyBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks/Benchmarks/SKColorParseStrategyBenchmark.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks;
+
+// Strategy shootout for the hex-nibble conversion at the heart of SKColor.TryParse.
+//
+// Every strategy shares the SAME outer structure (trim whitespace + leading '#', switch on the
+// trimmed length, read each channel) and differs ONLY in how a hex char becomes a 0-15 nibble.
+// The outer loop is a generic method specialized over a struct strategy, which RyuJIT devirtualizes
+// and inlines, so we measure the conversion itself, not delegate/interface overhead.
+//
+// All strategies are case-insensitive (accept 'f', 'F', and mixed like 'fF'). GlobalSetup asserts
+// every strategy agrees with the shipped SKColor.TryParse across a vector set before timing, so a
+// fast-but-wrong strategy can't win.
+//
+// RESULTS (net10.0, Apple M3 Pro, BenchmarkDotNet 0.13.5), ns per parse; lower is better. Every
+// candidate is validated against the shipped SKColor.TryParse in GlobalSetup before timing, so all
+// rows are known-correct and case-insensitive.
+//
+// The "Mixed" column parses a diverse, varied stream of 24 real-world colors in a loop
+// (OperationsPerInvoke) - this is the number that matters for real workloads. The two single-input
+// columns are kept from earlier runs to show WHY: an all-same input like "#FFFFFFFF" flatters a
+// jump-table switch (its indirect jump always hits one target -> perfectly predicted), while a varied
+// stream exposes the misprediction cost.
+//
+// | Strategy                                | Mixed (real) | #FFFFFFFF (all-same) | #FFF (all-same) |
+// |-----------------------------------------|-------------:|---------------------:|----------------:|
+// | Old (byte/uint.TryParse baseline)       |        15.65 |                10.72 |           15.15 |
+// | GiantSwitch (jump table)                |        14.00 |    4.63  (best here!) |    2.59 (best!) |
+// | AccumLookup (single uint loop + table)  |         8.71 |                 7.61 |            4.86 |
+// | FoldRange (fold then range)             |         8.58 |                 6.50 |            3.46 |
+// | Branchless (c|0x20 fold, branch-free)   |         8.14 |                 7.99 |            4.14 |
+// | IfRange (range checks) ** SHIPPED **    |         8.09 |                 7.73 |            4.15 |
+// | LookupTable (256-entry) ** FASTEST **   |         7.54 |                 7.60 |            3.58 |
+//
+// KEY INSIGHT: GiantSwitch looks fastest on all-same inputs but is ~2x SLOWER on realistic varied
+// input because its indirect jump mispredicts. The 256-entry LookupTable is the outright fastest
+// (data-driven, no data-dependent branch, most consistent). SKColor.TryParseNibble ships the IfRange
+// strategy instead: it is within ~7% of the table on real input, still ~2x faster than the old
+// TryParse-based code, and needs no static data. The LookupTable remains the choice if this ever
+// becomes a hot enough path to justify the 256-byte table.
+[MemoryDiagnoser]
+public class SKColorParseStrategyBenchmark
+{
+	// A realistic, varied stream of colors (mixed lengths, cases, and digits) parsed in a loop. This
+	// is the number that matters for real workloads: consecutive parses see different digits, so any
+	// strategy that relies on a well-predicted indirect branch (a jump-table switch) pays its true
+	// cost here, unlike an all-same input such as "#FFFFFFFF" which the branch predictor nails.
+	private static readonly string[] Mixed =
+	{
+		"#1B4F8C", "#A7A8A9A0", "#ff8800", "#3E7", "#abcdef", "#12345678", "#0a0", "#DEADBE",
+		"#c0ffee", "#123", "#9B2D5F", "#FFAA0080", "#4682b4", "#7f7f7f", "#e91e63", "#0d1b2a",
+		"#F0A", "#5566", "#00ff7f", "#8a2be2", "#Cd5C5c", "#2F4F4F", "#adff2f", "#ABCDEF01",
+	};
+	private const int MixedCount = 24;
+
+	[GlobalSetup]
+	public void Validate()
+	{
+		string[] vectors =
+		{
+			"#FFFFFFFF", "#ffffffff", "#fFfFfFfF", "#FFF", "#FFFF", "#FFFFFF",
+			"#a4C5e6", "#ABC", "#ABCD", "#AAABACAD", "ABCDEF", "A7A8A9A0",
+			"  #ABC  ", "#123456ug", "12sd", "#ABCDE", "Red", "", null, "#", "# 12345",
+		};
+
+		foreach (var v in vectors)
+		{
+			var shippedOk = SKColor.TryParse(v, out var expected);
+			var e = (uint)expected;
+
+			// Note: "Old" is the baseline and intentionally differs from shipped on whitespace-after-'#'
+			// (e.g. "# 12345"), so it is not cross-checked here. Every candidate strategy must match shipped.
+			CheckOne("Lookup", Parse<Lookup>(v, out var lc), lc, shippedOk, e, v);
+			CheckOne("Branchless", Parse<Branchless>(v, out var bc), bc, shippedOk, e, v);
+			CheckOne("GiantSwitch", Parse<GiantSwitch>(v, out var sc), sc, shippedOk, e, v);
+			CheckOne("FoldRange", Parse<FoldRange>(v, out var fc), fc, shippedOk, e, v);
+			CheckOne("IfRange", Parse<IfRange>(v, out var ic), ic, shippedOk, e, v);
+			CheckOne("Accum", ParseAccum(v, out var ac), ac, shippedOk, e, v);
+		}
+	}
+
+	private static void CheckOne(string name, bool ok, uint got, bool shippedOk, uint expected, string input)
+	{
+		if (ok != shippedOk)
+			throw new InvalidOperationException($"{name} accept/reject mismatch on '{input ?? "<null>"}' (strategy={ok}, shipped={shippedOk})");
+		if (ok && got != expected)
+			throw new InvalidOperationException($"{name} value mismatch on '{input}': got {got:X8} want {expected:X8}");
+	}
+
+	// ---- Benchmarks (each parses the whole Mixed stream; OperationsPerInvoke normalizes to ns/parse) --
+
+	[Benchmark(Baseline = true, OperationsPerInvoke = MixedCount)]
+	public uint Shipped()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			SKColor.TryParse(s, out var c);
+			acc ^= (uint)c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint Old()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			OldTryParse(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint LookupTable()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			Parse<Lookup>(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint Branchless_()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			Parse<Branchless>(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint GiantSwitch_()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			Parse<GiantSwitch>(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint FoldRange_()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			Parse<FoldRange>(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint IfRange_()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			Parse<IfRange>(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	[Benchmark(OperationsPerInvoke = MixedCount)]
+	public uint AccumLookup()
+	{
+		uint acc = 0;
+		foreach (var s in Mixed)
+		{
+			ParseAccum(s, out var c);
+			acc ^= c;
+		}
+		return acc;
+	}
+
+	// ---- Shared generic outer parser -------------------------------------------------------
+
+	private interface INibble
+	{
+		bool TryNibble(char c, out int value);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static bool Parse<T>(string hexString, out uint color) where T : struct, INibble
+	{
+		color = 0;
+		if (string.IsNullOrEmpty(hexString))
+			return false;
+
+		var start = 0;
+		var end = hexString.Length;
+		while (start < end && char.IsWhiteSpace(hexString[start])) start++;
+		while (end > start && char.IsWhiteSpace(hexString[end - 1])) end--;
+		while (start < end && hexString[start] == '#') start++;
+
+		var s = default(T);
+		switch (end - start)
+		{
+			case 3:
+			{
+				if (!s.TryNibble(hexString[start], out var r) ||
+					!s.TryNibble(hexString[start + 1], out var g) ||
+					!s.TryNibble(hexString[start + 2], out var b))
+					return false;
+				color = 0xFF000000u | (uint)((r << 4 | r) << 16 | (g << 4 | g) << 8 | (b << 4 | b));
+				return true;
+			}
+			case 4:
+			{
+				if (!s.TryNibble(hexString[start], out var a) ||
+					!s.TryNibble(hexString[start + 1], out var r) ||
+					!s.TryNibble(hexString[start + 2], out var g) ||
+					!s.TryNibble(hexString[start + 3], out var b))
+					return false;
+				color = (uint)((a << 4 | a) << 24 | (r << 4 | r) << 16 | (g << 4 | g) << 8 | (b << 4 | b));
+				return true;
+			}
+			case 6:
+			{
+				if (!s.TryNibble(hexString[start], out var r1) || !s.TryNibble(hexString[start + 1], out var r0) ||
+					!s.TryNibble(hexString[start + 2], out var g1) || !s.TryNibble(hexString[start + 3], out var g0) ||
+					!s.TryNibble(hexString[start + 4], out var b1) || !s.TryNibble(hexString[start + 5], out var b0))
+					return false;
+				color = 0xFF000000u | (uint)((r1 << 20) | (r0 << 16) | (g1 << 12) | (g0 << 8) | (b1 << 4) | b0);
+				return true;
+			}
+			case 8:
+			{
+				if (!s.TryNibble(hexString[start], out var a1) || !s.TryNibble(hexString[start + 1], out var a0) ||
+					!s.TryNibble(hexString[start + 2], out var r1) || !s.TryNibble(hexString[start + 3], out var r0) ||
+					!s.TryNibble(hexString[start + 4], out var g1) || !s.TryNibble(hexString[start + 5], out var g0) ||
+					!s.TryNibble(hexString[start + 6], out var b1) || !s.TryNibble(hexString[start + 7], out var b0))
+					return false;
+				color = (uint)((a1 << 28) | (a0 << 24) | (r1 << 20) | (r0 << 16) | (g1 << 12) | (g0 << 8) | (b1 << 4) | b0);
+				return true;
+			}
+			default:
+				return false;
+		}
+	}
+
+	// ---- Nibble strategies -----------------------------------------------------------------
+
+	private struct IfRange : INibble
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool TryNibble(char c, out int value)
+		{
+			if (c >= '0' && c <= '9') { value = c - '0'; return true; }
+			if (c >= 'a' && c <= 'f') { value = c - 'a' + 10; return true; }
+			if (c >= 'A' && c <= 'F') { value = c - 'A' + 10; return true; }
+			value = 0;
+			return false;
+		}
+	}
+
+	// 256-entry table: index by char, 0xFF means invalid.
+	private static ReadOnlySpan<byte> HexTable => new byte[]
+	{
+		//0     1     2     3     4     5     6     7     8     9     A     B     C     D     E     F
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 0x
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 1x
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 2x
+		   0,    1,    2,    3,    4,    5,    6,    7,    8,    9, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 3x  '0'-'9'
+		0xFF,   10,   11,   12,   13,   14,   15, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 4x  'A'-'F'
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 5x
+		0xFF,   10,   11,   12,   13,   14,   15, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 6x  'a'-'f'
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 7x
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	};
+
+	private struct Lookup : INibble
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool TryNibble(char c, out int value)
+		{
+			if (c > 0xFF) { value = 0; return false; }
+			int v = HexTable[c];
+			value = v;
+			return v != 0xFF;
+		}
+	}
+
+	private struct Branchless : INibble
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool TryNibble(char c, out int value)
+		{
+			// Fold letters to lowercase (digits unaffected: they already have bit 0x20 set).
+			uint x = (uint)c;
+			uint digit = x - '0';           // 0..9 for '0'-'9'
+			uint alpha = (x | 0x20) - 'a';  // 0..5 for 'a'-'f'/'A'-'F'
+			bool isDigit = digit < 10u;
+			bool isAlpha = alpha < 6u;
+			value = (int)(isDigit ? digit : alpha + 10u);
+			return isDigit | isAlpha;
+		}
+	}
+
+	private struct GiantSwitch : INibble
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool TryNibble(char c, out int value)
+		{
+			switch (c)
+			{
+				case '0': value = 0; return true;
+				case '1': value = 1; return true;
+				case '2': value = 2; return true;
+				case '3': value = 3; return true;
+				case '4': value = 4; return true;
+				case '5': value = 5; return true;
+				case '6': value = 6; return true;
+				case '7': value = 7; return true;
+				case '8': value = 8; return true;
+				case '9': value = 9; return true;
+				case 'a': case 'A': value = 10; return true;
+				case 'b': case 'B': value = 11; return true;
+				case 'c': case 'C': value = 12; return true;
+				case 'd': case 'D': value = 13; return true;
+				case 'e': case 'E': value = 14; return true;
+				case 'f': case 'F': value = 15; return true;
+				default: value = 0; return false;
+			}
+		}
+	}
+
+	private struct FoldRange : INibble
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool TryNibble(char c, out int value)
+		{
+			if (c >= '0' && c <= '9') { value = c - '0'; return true; }
+			var lower = (char)(c | 0x20); // fold 'A'-'F' to 'a'-'f'
+			if (lower >= 'a' && lower <= 'f') { value = lower - 'a' + 10; return true; }
+			value = 0;
+			return false;
+		}
+	}
+
+	// ---- uint-accumulation variant (single loop, lookup table) -----------------------------
+
+	private static bool ParseAccum(string hexString, out uint color)
+	{
+		color = 0;
+		if (string.IsNullOrEmpty(hexString))
+			return false;
+
+		var start = 0;
+		var end = hexString.Length;
+		while (start < end && char.IsWhiteSpace(hexString[start])) start++;
+		while (end > start && char.IsWhiteSpace(hexString[end - 1])) end--;
+		while (start < end && hexString[start] == '#') start++;
+
+		var len = end - start;
+		if (len != 3 && len != 4 && len != 6 && len != 8)
+			return false;
+
+		uint acc = 0;
+		for (var i = start; i < end; i++)
+		{
+			char c = hexString[i];
+			if (c > 0xFF)
+				return false;
+			int v = HexTable[c];
+			if (v == 0xFF)
+				return false;
+			acc = (acc << 4) | (uint)v;
+		}
+
+		switch (len)
+		{
+			case 3:
+				color = 0xFF000000u |
+					((acc & 0xF00u) << 12) | ((acc & 0xF00u) << 8) |
+					((acc & 0x0F0u) << 8) | ((acc & 0x0F0u) << 4) |
+					((acc & 0x00Fu) << 4) | (acc & 0x00Fu);
+				return true;
+			case 4:
+				color =
+					((acc & 0xF000u) << 16) | ((acc & 0xF000u) << 12) |
+					((acc & 0x0F00u) << 12) | ((acc & 0x0F00u) << 8) |
+					((acc & 0x00F0u) << 8) | ((acc & 0x00F0u) << 4) |
+					((acc & 0x000Fu) << 4) | (acc & 0x000Fu);
+				return true;
+			case 6:
+				color = 0xFF000000u | acc;
+				return true;
+			default: // 8
+				color = acc;
+				return true;
+		}
+	}
+
+	// ---- Old baseline (verbatim old span path) ---------------------------------------------
+
+	private static bool OldTryParse(string hexString, out uint color)
+	{
+		color = 0;
+		if (string.IsNullOrWhiteSpace(hexString))
+			return false;
+
+		var hexSpan = hexString.AsSpan().Trim().TrimStart('#');
+		var len = hexSpan.Length;
+		if (len == 3 || len == 4)
+		{
+			byte a;
+			if (len == 4)
+			{
+				if (!byte.TryParse(hexSpan.Slice(0, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a))
+					return false;
+				a = (byte)(a << 4 | a);
+			}
+			else a = 255;
+			if (!byte.TryParse(hexSpan.Slice(len - 3, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
+				!byte.TryParse(hexSpan.Slice(len - 2, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
+				!byte.TryParse(hexSpan.Slice(len - 1, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+				return false;
+			color = (uint)((a << 24) | ((r << 4 | r) << 16) | ((g << 4 | g) << 8) | (b << 4 | b));
+			return true;
+		}
+		if (len == 6 || len == 8)
+		{
+			if (!uint.TryParse(hexSpan, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var number))
+				return false;
+			if (len == 6) number |= 0xFF000000u;
+			color = number;
+			return true;
+		}
+		return false;
+	}
+}

--- a/binding/SkiaSharp/SKColor.cs
+++ b/binding/SkiaSharp/SKColor.cs
@@ -1,7 +1,7 @@
 ﻿#nullable disable
 
 using System;
-using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace SkiaSharp
 {
@@ -120,125 +120,113 @@ namespace SkiaSharp
 		public static explicit operator uint (SKColor color) =>
 			color.color;
 
-		public static SKColor Parse (string hexString)
+		public static SKColor Parse (string hexString) =>
+			Parse (hexString.AsSpan ());
+
+		public static SKColor Parse (ReadOnlySpan<char> hexString)
 		{
 			if (!TryParse (hexString, out var color))
 				throw new ArgumentException ("Invalid hexadecimal color string.", nameof (hexString));
 			return color;
 		}
 
-		public static bool TryParse (string hexString, out SKColor color)
+		public static bool TryParse (string hexString, out SKColor color) =>
+			TryParse (hexString.AsSpan (), out color);
+
+		public static bool TryParse (ReadOnlySpan<char> hexString, out SKColor color)
 		{
-			if (string.IsNullOrWhiteSpace (hexString)) {
-				// error
-				color = SKColor.Empty;
-				return false;
-			}
-
-#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-			// clean up string
-			var hexSpan = hexString.AsSpan ().Trim ().TrimStart ('#');
-
-			var len = hexSpan.Length;
-			if (len == 3 || len == 4) {
-				byte a;
-				// parse [A]
-				if (len == 4) {
-					if (!byte.TryParse (hexSpan.Slice (0, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a)) {
-						// error
-						color = SKColor.Empty;
-						return false;
-					}
-					a = (byte)(a << 4 | a);
-				} else {
-					a = 255;
-				}
-
-				// parse RGB
-				if (!byte.TryParse (hexSpan.Slice (len - 3, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
-					!byte.TryParse (hexSpan.Slice (len - 2, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
-					!byte.TryParse (hexSpan.Slice (len - 1, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b)) {
-					// error
-					color = SKColor.Empty;
-					return false;
-				}
-
-				// success
-				color = new SKColor ((byte)(r << 4 | r), (byte)(g << 4 | g), (byte)(b << 4 | b), a);
-				return true;
-			}
-
-			if (len == 6 || len == 8) {
-				// parse [AA]RRGGBB
-				if (!uint.TryParse (hexSpan, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var number)) {
-					// error
-					color = SKColor.Empty;
-					return false;
-				}
-
-				// success
-				color = (SKColor)number;
-
-				// alpha was not provided, so use 255
-				if (len == 6) {
-					color = color.WithAlpha (255);
-				}
-				return true;
-			}
-#else
-			// clean up string
-			hexString = hexString.Trim ();
-			var startIndex = hexString[0] == '#' ? 1 : 0;
-
-			var len = hexString.Length - startIndex;
-			if (len == 3 || len == 4) {
-				byte a;
-				// parse [A]
-				if (len == 4) {
-					if (!byte.TryParse (string.Concat (new string (hexString[len - 4 + startIndex], 2)), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a)) {
-						// error
-						color = SKColor.Empty;
-						return false;
-					}
-				} else {
-					a = 255;
-				}
-
-				// parse RGB
-				if (!byte.TryParse (new string (hexString[len - 3 + startIndex], 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) ||
-					!byte.TryParse (new string (hexString[len - 2 + startIndex], 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) ||
-					!byte.TryParse (new string (hexString[len - 1 + startIndex], 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b)) {
-					// error
-					color = SKColor.Empty;
-					return false;
-				}
-
-				// success
-				color = new SKColor (r, g, b, a);
-				return true;
-			}
-
-			if (len == 6 || len == 8) {
-				// parse [AA]RRGGBB
-				if (!uint.TryParse (hexString.Substring (startIndex), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var number)) {
-					// error
-					color = SKColor.Empty;
-					return false;
-				}
-
-				// success
-				color = (SKColor)number;
-
-				// alpha was not provided, so use 255
-				if (len == 6) {
-					color = color.WithAlpha (255);
-				}
-				return true;
-			}
-#endif
-
-			// error
 			color = SKColor.Empty;
+
+			// Trim surrounding whitespace and any leading '#'. Re-basing the span to index 0 also lets
+			// the JIT prove the fixed-length indexes below are in range and drop the bounds checks.
+			hexString = hexString.Trim ().TrimStart ('#');
+
+			switch (hexString.Length) {
+				case 3: {
+					// #RGB -> each nibble is duplicated (e.g. "F" -> 0xFF)
+					if (!TryParseNibble (hexString[0], out var r) ||
+						!TryParseNibble (hexString[1], out var g) ||
+						!TryParseNibble (hexString[2], out var b))
+						return false;
+
+					color = new SKColor (
+						(byte)(r << 4 | r),
+						(byte)(g << 4 | g),
+						(byte)(b << 4 | b));
+					return true;
+				}
+				case 4: {
+					// #ARGB -> each nibble is duplicated (e.g. "F" -> 0xFF)
+					if (!TryParseNibble (hexString[0], out var a) ||
+						!TryParseNibble (hexString[1], out var r) ||
+						!TryParseNibble (hexString[2], out var g) ||
+						!TryParseNibble (hexString[3], out var b))
+						return false;
+
+					color = new SKColor (
+						(byte)(r << 4 | r),
+						(byte)(g << 4 | g),
+						(byte)(b << 4 | b),
+						(byte)(a << 4 | a));
+					return true;
+				}
+				case 6: {
+					// #RRGGBB
+					if (!TryParseByte (hexString[0], hexString[1], out var r) ||
+						!TryParseByte (hexString[2], hexString[3], out var g) ||
+						!TryParseByte (hexString[4], hexString[5], out var b))
+						return false;
+
+					color = new SKColor (r, g, b);
+					return true;
+				}
+				case 8: {
+					// #AARRGGBB
+					if (!TryParseByte (hexString[0], hexString[1], out var a) ||
+						!TryParseByte (hexString[2], hexString[3], out var r) ||
+						!TryParseByte (hexString[4], hexString[5], out var g) ||
+						!TryParseByte (hexString[6], hexString[7], out var b))
+						return false;
+
+					color = new SKColor (r, g, b, a);
+					return true;
+				}
+				default:
+					return false;
+			}
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static bool TryParseNibble (char c, out byte value)
+		{
+			// Convert a single ASCII hex digit to its 0-15 value, case-insensitively
+			// ('a'-'f' and 'A'-'F' both map to 10-15).
+			if (c >= '0' && c <= '9') {
+				value = (byte)(c - '0');
+				return true;
+			}
+			if (c >= 'a' && c <= 'f') {
+				value = (byte)(c - 'a' + 10);
+				return true;
+			}
+			if (c >= 'A' && c <= 'F') {
+				value = (byte)(c - 'A' + 10);
+				return true;
+			}
+
+			value = 0;
+			return false;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static bool TryParseByte (char hi, char lo, out byte value)
+		{
+			if (TryParseNibble (hi, out var h) && TryParseNibble (lo, out var l)) {
+				value = (byte)(h << 4 | l);
+				return true;
+			}
+
+			value = 0;
 			return false;
 		}
 	}

--- a/tests/Tests/SkiaSharp/SKColorTest.cs
+++ b/tests/Tests/SkiaSharp/SKColorTest.cs
@@ -178,6 +178,107 @@ namespace SkiaSharp.Tests
 			}
 		}
 
+		[Theory]
+		[InlineData("  #ABC  ", 0xFFAABBCC)]
+		[InlineData("\t#A2C3\n", 0xAA22CC33)]
+		[InlineData("  ABCDEF  ", 0xFFABCDEF)]
+		[InlineData(" #AAABACAD ", 0xAAABACAD)]
+		public void HexWithWhitespaceIsTrimmed(string hex, uint expected)
+		{
+			Assert.True(SKColor.TryParse(hex, out var color), hex);
+			Assert.Equal((SKColor)expected, color);
+		}
+
+		[Theory]
+		[InlineData("#abc", "#ABC")]
+		[InlineData("#abcd", "#ABCD")]
+		[InlineData("#abcdef", "#ABCDEF")]
+		[InlineData("#aabbccdd", "#AABBCCDD")]
+		public void HexParsingIsCaseInsensitive(string lower, string upper)
+		{
+			Assert.True(SKColor.TryParse(lower, out var lowerColor), lower);
+			Assert.True(SKColor.TryParse(upper, out var upperColor), upper);
+			Assert.Equal(upperColor, lowerColor);
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData("")]
+		[InlineData("   ")]
+		[InlineData("#")]
+		public void NullOrEmptyHexFailsToParse(string hex)
+		{
+			Assert.False(SKColor.TryParse(hex, out var color));
+			Assert.Equal(SKColor.Empty, color);
+			Assert.Throws<ArgumentException>(() => SKColor.Parse(hex));
+		}
+
+		[Theory]
+		[InlineData("Red")]
+		[InlineData("Blue")]
+		[InlineData("Transparent")]
+		public void NamedColorsAreNotParsed(string name)
+		{
+			// SKColor.TryParse only understands hex strings; named colors are not supported.
+			Assert.False(SKColor.TryParse(name, out var color), name);
+			Assert.Equal(SKColor.Empty, color);
+		}
+
+		[Theory]
+		[InlineData("# 12345")]
+		[InlineData("#  ABCD")]
+		[InlineData("# 1234567")]
+		[InlineData("#12 345")]
+		public void WhitespaceInsideHexIsRejected(string hex)
+		{
+			// Only whitespace surrounding the whole value is trimmed. Whitespace between the
+			// '#' and the digits (or anywhere inside the value) is not valid hex and is rejected.
+			Assert.False(SKColor.TryParse(hex, out var color), hex);
+			Assert.Equal(SKColor.Empty, color);
+		}
+
+		[Theory]
+		[InlineData("#ABC", 0xFFAABBCC)]
+		[InlineData("ABCDEF", 0xFFABCDEF)]
+		[InlineData("#A7A8A9A0", 0xA7A8A9A0)]
+		[InlineData("  #a4C5e6  ", 0xFFA4C5E6)]
+		public void ParseSpanOverloadMatchesString(string hex, uint expected)
+		{
+			// ReadOnlySpan<char> TryParse
+			Assert.True(SKColor.TryParse(hex.AsSpan(), out var spanColor), hex);
+			Assert.Equal((SKColor)expected, spanColor);
+
+			// ReadOnlySpan<char> Parse
+			Assert.Equal((SKColor)expected, SKColor.Parse(hex.AsSpan()));
+
+			// and it agrees with the string overload
+			Assert.True(SKColor.TryParse(hex, out var stringColor), hex);
+			Assert.Equal(stringColor, spanColor);
+		}
+
+		[Fact]
+		public void ParseSpanWorksOnSliceWithoutAllocating()
+		{
+			// A color embedded in a larger buffer can be parsed from a slice, no substring needed.
+			var buffer = "color: #1a2b3c;".AsSpan();
+			var slice = buffer.Slice(7, 7); // "#1a2b3c"
+
+			Assert.True(SKColor.TryParse(slice, out var color));
+			Assert.Equal((SKColor)0xFF1A2B3C, color);
+		}
+
+		[Fact]
+		public void ParseSpanRejectsInvalidAndEmpty()
+		{
+			Assert.False(SKColor.TryParse("nope".AsSpan(), out var color));
+			Assert.Equal(SKColor.Empty, color);
+
+			Assert.False(SKColor.TryParse(ReadOnlySpan<char>.Empty, out color));
+			Assert.Equal(SKColor.Empty, color);
+
+			Assert.Throws<ArgumentException>(() => SKColor.Parse("nope".AsSpan()));
+		}
+
 		[Fact]
 		public void PremultipliedColorsHaveCorrectBitShift()
 		{


### PR DESCRIPTION
## What

Rewrites `SKColor.TryParse` to parse hex color strings with a manual, allocation-free hex parser instead of `byte.TryParse`/`uint.TryParse` + `NumberStyles.HexNumber`, and adds public `ReadOnlySpan<char>` overloads for `Parse`/`TryParse`.

## Why

`SKColor.Parse`/`TryParse` sit on hot paths for anyone hydrating colors from XAML/CSS/JSON/theme files. The old implementation:
- called `byte.TryParse` per channel and `uint.TryParse` for the 6/8-digit forms (culture + `NumberStyles` overhead), and
- had a `#if` split where the net4x/netstandard2.0 path allocated a `new string(char, 2)` per channel.

## Changes

- **Unified, allocation-free parser** on `ReadOnlySpan<char>` (`Trim().TrimStart('#')` + a length switch, with small case-insensitive nibble helpers). Removes the `#if` split — one implementation for all TFMs.
- **New public overloads** (ABI-safe additions; the `string` overloads delegate via `.AsSpan()`, matching the existing pattern in `SKFont`/`SKTextBlob`/etc.):
  ```csharp
  public static SKColor Parse (ReadOnlySpan<char> hexString);
  public static bool TryParse (ReadOnlySpan<char> hexString, out SKColor color);
  ```
  These let callers parse a color out of a larger buffer without allocating a substring.
- **Tests**: whitespace trimming, case-insensitivity (`ff`/`FF`/`fF`), null/empty/`#`, named-color rejection, span/string agreement, slice parsing, invalid/empty span rejection. 35 `SKColorTest` cases pass, 0 failed.
- **Benchmarks** (`benchmarks/`) documenting the work: a strategy shootout (if-chain vs lookup table vs branchless vs switch), the span-vs-string comparison, and the public New-vs-Old numbers.

## Interop / native surface

**None.** This is a pure-managed change with **no P/Invoke involved anywhere**:

- `SKColor` is a `readonly struct` wrapping a single `uint` — it has no native handle and no `SKObject`/`IntPtr` backing.
- `Parse`/`TryParse` and the private `TryParseNibble`/`TryParseByte` helpers are 100% managed C#: no `SkiaApi.*`/`sk_*` calls, no `DllImport`/`LibraryImport`, no `Marshal`, no `stackalloc`/`fixed`, no native memory.
- Parsing a color string therefore never crosses into native Skia — the input goes char-by-char straight into the `uint`.
- No C API (`externals/skia/**`) or generated bindings (`*.generated.cs`) are touched, so `externals-download` is sufficient for local builds and there is no native rebuild requirement.

## Behavior

Preserved for every input the old code accepted, with **one intentional tightening**: whitespace immediately after `#` in the 6/8-digit forms (e.g. `"# 12345"`) was previously accepted as a side effect of `NumberStyles.HexNumber`'s `AllowLeadingWhite`, and is now rejected — matching the stricter behavior the 3/4-digit path already had. Parsing stays case-insensitive.

## Performance

net10.0, Apple M3 Pro, BenchmarkDotNet — zero allocations, ~1.4–2.3× faster across all shapes:

| Input | New | Old | Speedup |
|---|---:|---:|---:|
| `#FFF` | 3.8 ns | 8.4 ns | 2.2× |
| `#FFFF` | 4.0 ns | 9.4 ns | 2.3× |
| `#FFFFFF` | 4.8 ns | 7.0 ns | 1.4× |
| `#FFFFFFFF` | 6.0 ns | 8.9 ns | 1.5× |
| `#A7A8A9A0` (varying) | 5.1 ns | 9.3 ns | 1.8× |
| `Red` (invalid) | 1.7 ns | 3.7 ns | 2.2× |

## Notes

- Builds clean on all TFMs (net462/netstandard2.0 included). The old `#if` guard existed only because that path used the `byte`/`uint.TryParse` span overloads (netstandard2.1+); this trimming-only span code compiles everywhere.
- The new public overloads will need XML/mdoc documentation entries — left for the docs generation (CI/api-docs).