### PR TITLE
[release-notes] Curate, group & format the polished notes (product-focus, banner, contributors, history floor)

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -349,13 +349,32 @@ would tempt you to include an internal PR, rule 1 wins.
    **Dev-cycle and `-unreleased` pages are often mostly `[internal]`** — that is expected; such a
    page may legitimately be just Highlights + the single collapse line.
 
-2. **Highlights — short and impact-first (hard cap).** At most **2-3 sentences, no matter how
-   big the release**. Name only the **3-4 biggest / coolest** things — the engine jump, the
-   headline feature(s), a breaking change users must know about. It's a **hook, not a table of
-   contents** (the categories below carry the full list), so **never enumerate** dependency
-   bumps, individual bug fixes, or every new API here. The bigger the release, the more
-   **selective** Highlights get — not longer. Mention only standout community contributors, by
-   linked name.
+2. **Highlights — a hook, not a summary (HARD CAP: ≤ 80 words).** Two or three **short**
+   sentences, **maximum ~80 words total**, no matter how big the release — count them. Name only
+   the **3-4 biggest** things (the engine jump, the one headline feature, the fact that there are
+   breaking changes) in plain prose. This is the single most-violated rule, so the bans are
+   explicit — in Highlights, **do NOT**:
+   - enumerate APIs, dependency bumps, or fixes (the categories below carry the full list);
+   - list contributors one by one (the Community Contributors table does that) — at most name the
+     *one* standout by linked handle;
+   - use per-item parentheticals, PR/issue links, or `code` API names as a checklist;
+   - write "Compared to X, v4 delivers: A, B, C, D, E, F …" — that comma-run **is** the
+     enumeration this rule forbids.
+   If a reader could reconstruct the category sections from your Highlights, it is too long —
+   cut it back to the hook. The bigger the release, the more **selective** Highlights get, never
+   longer.
+
+   > **Too long (what not to do):** *"4.148.0 is the shipped v4 stable… Compared to 3.119.x, v4
+   > delivers: variable font support (`SKFontArguments`), color font palettes, animated WebP
+   > encoding (`SKWebpEncoder`), `SKStream.GetData()` zero-copy, `SKSamplingOptions` overloads…
+   > Behavioral hardening: default typeface resolution moves… `new SKFont()`… Standout community
+   > work: @ramezgerges (16 PRs — …), @4Darmygeometry (…), @SimonvBez (…), @ebariche (…)…"*
+   > (228 words — the whole page crammed into the hook).
+   >
+   > **Right:** *"The first stable v4 release upgrades the engine to Skia m148 and lands the big
+   > v4 feature wave — variable fonts, color font palettes, and animated WebP — alongside a set
+   > of behavioural breaking changes to review before upgrading. Community work from
+   > [@ramezgerges](https://github.com/ramezgerges) anchored the release."* (~50 words.)
 
 3. **Breaking changes** — Always include a `## Breaking Changes` section (*"None in this
    release."* when there are none — never drop the heading). If the raw block lists a
@@ -452,7 +471,8 @@ every FAIL and re-check once. The checks that go wrong most often, watch these f
    any `*[bot]`.
 5. **Contributors table complete** — **one row per `contributors:` roster entry**, none missing,
    none invented; each row is plain `[@user](url)` · prose summary + PR links, no ❤️ in the cell.
-6. **Highlights ≤ 3 sentences**; **`## Breaking Changes` present**; raw-data comment intact.
+6. **Highlights ≤ 80 words** (count with `awk`/`wc -w`), ≤ 3 short sentences, no enumeration;
+   **`## Breaking Changes` present**; raw-data comment intact.
 
 ## Parallelization
 

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -34,6 +34,51 @@ This skill is used both by the `update-release-notes` agentic workflow (automati
 on push to `main`, `release/*` branches, and tags) and manually when regenerating,
 correcting, or bulk-processing the release pages.
 
+## Purpose — what these release notes are for
+
+These pages exist for **one audience: developers who consume the SkiaSharp and
+HarfBuzzSharp NuGet packages.** They open a version page to answer, in order:
+
+1. **Should I upgrade?** — Is something broken; is there a security or crash fix that hits me?
+2. **What changes if I do?** — New or changed APIs, new behavior, new platforms, new
+   native-dependency versions in the binary I ship.
+3. **What breaks if I do?** — Signature, behavioral, or platform removals.
+4. **Who do I thank?** — Community contributors.
+
+They are **not** a repository activity log, a project changelog, or a contributor timeline.
+A PR that only changes how *we* build, test, ship, or document the library is invisible from
+the consumer's side — their compiled app is byte-identical whether or not we merged it. Those
+PRs **do not appear in the notes**, however much work they were.
+
+### The one test — apply it to every PR
+
+> **Would a developer who just consumes the NuGet package notice this change without looking
+> at our repository?**
+
+- **Yes → include it**, in the right category. (New/changed API, behavior change, bug fix,
+  native-dependency bump, new RID/TFM, a native build flag that ships in the binary.)
+- **No → drop it** — or, when there is a lot of it, fold it into a single trailing
+  *"Plus various CI, documentation, and internal tooling improvements."* line (never a bullet
+  per change). (CI/build pipelines and caching, GitHub Actions/workflows, our own `.agents/**`
+  skills of any name — including `security-audit`, `ci-status`, the release-notes/docs tooling
+  — the docs website, PR-staging, sample-publishing, milestone/label automation, test-infra,
+  the package's own version bump.)
+
+**You do not have to make this call from scratch.** The Prepare script pre-tags every
+raw-data PR line **`[product]`** or **`[internal]`** by the files the PR changed (anything
+under `binding/`, `native/`, `externals/`, or `source/` ships → `[product]`; everything else →
+`[internal]`). **Trust the tag** — drop `[internal]`, write up `[product]`. The one test above
+is only the tie-breaker for the rare line the tag gets wrong.
+
+**The PR title is not evidence — test what shipped, not what it is called.** *"Chrome Releases
+blog integration in security-audit skill"* is an internal skill change even though it says
+"security"; *"ci-status daily CI health dashboard"* is internal even though it says "dashboard";
+*"Publish-samples workflow"* is a workflow change even though "samples" sounds product-shaped.
+
+This is the single most important thing the polish gets right or wrong: a page with a perfect
+contributors table and thirty internal-tooling bullets is **worse** than one with a small
+formatting slip and zero leaked bullets. The first buries the signal a consumer came for.
+
 ## How it works: prepare, then polish
 
 The skill runs **one of two ways**, and both end at the same place — a list of pages to
@@ -252,13 +297,14 @@ an empty category):
 
 > **theme** · status · links
 
-## Highlights            (short, impact-first — rule 1)
-## Breaking Changes      (always present; "None in this release." when none — rule 6)
+## Highlights            (short, impact-first — rule 2)
+## Breaking Changes      (always present; "None in this release." when none — rule 3)
 ## <Category>            (one or more: Engine, GPU & Rendering, API Surface, Text & Fonts,
-                          Bug Fixes, Lifecycle & Internals, Platform, Security — rules 2-3)
-## Community Contributors ❤️   (linked table, only when there are community contributors — rule 4)
-## Links                 (Full Changelog + NuGet only — rule 11)
-## <Preview label> (date)      (one trailing section per preview bucket, newest first — rule 10)
+                          Bug Fixes, Lifecycle & Internals, Platform, Security — rules 4-5;
+                          only [product] items — rule 1)
+## Community Contributors ❤️   (linked table, only when there are community contributors — rule 6)
+## Links                 (Full Changelog + NuGet only — rule 10)
+## <Preview label> (date)      (one trailing section per preview bucket, newest first — rule 9)
 ```
 
 Each file has its own HTML comment block with version, status, branch, and diff range.
@@ -268,9 +314,21 @@ Do NOT combine data from other files. For example, if `3.119.4-unreleased.md` ha
 and `3.119.4.md` has 101 PRs, the unreleased file should only cover those 4 PRs — it is
 NOT a rollup of the version file.
 
-Follow these rules:
+Follow these rules, **in priority order — earlier rules trump later ones.** If a later rule
+would tempt you to include an internal PR, rule 1 wins.
 
-1. **Highlights — short and impact-first (hard cap).** At most **2-3 sentences, no matter how
+1. **Focus on the product, not the project — drop internal work.** This is the rule that makes
+   the page useful (see the **Purpose** section above). Every raw-data
+   PR line is tagged `[product]` or `[internal]` by the script:
+   - **`[internal]` → do not write a bullet for it.** Roll ALL internal PRs into a single
+     trailing line — *"Plus various CI, documentation, and internal tooling improvements."* — or
+     omit even that when there were none. Never one bullet per internal change.
+   - **`[product]` → keep it**, categorized below.
+   Apply the *one test* (see Purpose) only as a tie-breaker for a line the tag clearly got wrong.
+   **Dev-cycle and `-unreleased` pages are often mostly `[internal]`** — that is expected; such a
+   page may legitimately be just Highlights + the single collapse line.
+
+2. **Highlights — short and impact-first (hard cap).** At most **2-3 sentences, no matter how
    big the release**. Name only the **3-4 biggest / coolest** things — the engine jump, the
    headline feature(s), a breaking change users must know about. It's a **hook, not a table of
    contents** (the categories below carry the full list), so **never enumerate** dependency
@@ -278,11 +336,18 @@ Follow these rules:
    **selective** Highlights get — not longer. Mention only standout community contributors, by
    linked name.
 
-2. **Skia engine** — If a "Bump skia" or "milestone" PR appears in the raw data,
+3. **Breaking changes** — Always include a `## Breaking Changes` section (*"None in this
+   release."* when there are none — never drop the heading). If the raw block lists a
+   `.breaking.md` and/or `.notes.md` companion, open them and **summarize the breaks as a few
+   bullets**: name the affected types/areas, add a migration snippet where it helps, and link
+   the API diff for the full list. Behavioral & interop breaks come only from `.notes.md`.
+   Summarize, don't dump. (See [Companion files](#companion-files-open-and-read-them).)
+
+4. **Skia engine first** — If a "Bump skia" or "milestone" PR appears in the raw data,
    list it first under an **Engine** category.
 
-3. **Categorize features** — Group by what they affect. Use sub-headers:
-   Engine, GPU & Rendering, API Surface, Text & Fonts, Platform, Security, etc.
+5. **Categorize what remains** — Group the `[product]` items by what they affect. Use
+   sub-headers: Engine, GPU & Rendering, API Surface, Text & Fonts, Platform, Security, etc.
    Every item follows one exact shape:
    `**bold title** — description. ❤️ [@user](https://github.com/user) ([#NNN](url))`
    - The PR link `([#NNN](url))` always comes **last**.
@@ -292,13 +357,13 @@ Follow these rules:
    - **Never write `by @handle`.** The raw-data block's `… by @user in …` is *source data*,
      not output format — do not carry it through. And **never emit a bare `@handle`** anywhere
      in the rendered body — every handle is a `[@user](https://github.com/user)` link, never a
-     bare or **backticked** `@user`, and never the sentence's subject (credit goes in the `❤️`
-     slot, not the prose).
+     bare or **backticked** `@user`, and never the sentence's subject (credit goes in the
+     `❤️` slot, not the prose).
 
-4. **Community contributors** — Anyone other than @mattleibow appears in **two places, with two
+6. **Community contributors** — Anyone other than @mattleibow appears in **two places, with two
    different formats**:
    - **Inline**, on their category bullet: end it with `❤️ [@user](https://github.com/user)
-     ([#NNN](url))` (the shape in rule 3). The ❤️ lives **only** here.
+     ([#NNN](url))` (the shape in rule 5). The ❤️ lives **only** here.
    - **In the `## Community Contributors ❤️` table**: one row per contributor, two columns —
      `Contributor` and `What They Did`. The **`Contributor` cell is a plain
      `[@user](https://github.com/user)` — NO `❤️`, no `by`** (the heart wraps badly in the
@@ -309,50 +374,40 @@ Follow these rules:
    handle anywhere in the rendered body (the raw-data comment block is exempt; it is not
    rendered).
 
-5. **Focus on the product, not the project.** Release notes are for people *using* the library.
-   The **test** for every PR: *did the shipped SkiaSharp / HarfBuzzSharp library — its public
-   API, runtime behavior, native binary, or NuGet package — change for a consumer?* If only a
-   **repo process** changed, **drop it entirely** (do not itemize): CI/build pipelines and build
-   caching, GitHub Actions/workflows, the project's own agent skills (`security-audit`,
-   `ci-status`, the release-notes/docs tooling, etc.), the docs website / PR-staging,
-   sample-publishing pipelines, milestone/label automation, and test-infra migrations — **even
-   when the PR title mentions security, a CVE, performance, caching, or an API name** (a change
-   to the `security-audit` *skill* is not a library security fix; ADO build caching is not a
-   feature). Also drop the package's own version bump. When there is a lot of this, collapse it
-   to a **single trailing line** — e.g. *"Plus various CI, documentation, and internal tooling
-   improvements."* — never a bullet per change. **Keep** anything that ships: native-dependency
-   bumps (they change the binary — security/behavior), API additions/changes, behavior and bug
-   fixes, platform-support and native build flags that ship in the binary (e.g. Spectre
-   mitigation, new RIDs/TFMs), and consumer-visible packaging changes. **Dev-cycle and
-   `-unreleased` pages are often heavy on internal work** (the recent weeks may be mostly
-   tooling/CI/skill PRs) — do **not** itemize any of it there; one collapse line covers the
-   whole lot, and if nothing consumer-facing shipped, the page may legitimately be just
-   Highlights + that one line.
-
-6. **Breaking changes** — Always include a `## Breaking Changes` section (*"None in this
-   release."* when there are none — never drop the heading). If the raw block lists a
-   `.breaking.md` and/or `.notes.md` companion, open them and **summarize the breaks as a few
-   bullets**: name the affected types/areas, add a migration snippet where it helps, and link
-   the API diff for the full list. Behavioral & interop breaks come only from `.notes.md`.
-   Summarize, don't dump. (See [Companion files](#companion-files-open-and-read-them).)
-
 7. **PR links** — Every item links to its PR.
 
-8. **Generation timestamp** — Always include `<!-- Generated: YYYY-MM-DDTHH:MM:SSZ by {model-name} -->`
-   as the first line AFTER the raw data comment block (before the `# Version` heading).
-   Use the current UTC time and your model name.
+8. **Rollup at top** — Aggregate ALL `[product]` changes across all previews into the main
+   sections.
 
-9. **Rollup at top** — Aggregate ALL changes across all previews into the main sections.
+9. **Previews are minimal** — One sentence + Full Changelog link each, at the bottom.
+   Render one trailing `## <label> (<date>)` section per entry in the data-block's
+   `preview milestones` list (newest first), using that entry's compare link. Do not invent
+   previews or dates — the list is authoritative (sourced from published prerelease tags).
 
-10. **Previews are minimal** — One sentence + Full Changelog link each, at the bottom.
-    Render one trailing `## <label> (<date>)` section per entry in the data-block's
-    `preview milestones` list (newest first), using that entry's compare link. Do not invent
-    previews or dates — the list is authoritative (sourced from published prerelease tags).
-
-11. **Links section** — Full Changelog and NuGet Package only. **Do not add an API-diff
+10. **Links section** — Full Changelog and NuGet Package only. **Do not add an API-diff
     or HarfBuzz link** — the script injects a `> **API changes**` line under the banner
     when a diff folder exists (gated on existence, so it never dangles). Keep that line
     verbatim and author no API links yourself (see TEMPLATE.md "SCRIPT-OWNED API LINKS").
+
+11. **Generation timestamp** — Always include `<!-- Generated: YYYY-MM-DDTHH:MM:SSZ by {model-name} -->`
+    as the first line AFTER the raw data comment block (before the `# Version` heading).
+    Use the current UTC time and your model name.
+
+## Before you save each page — self-check
+
+Read the file back once and verify **only these**, in order. The first two are the ones that
+go wrong most; the rest are quick search-and-fix:
+
+1. **Product test.** Scan every category bullet. Each must be a `[product]` change you can
+   justify with *"a consumer notices this because …"* in about five words. Delete any that
+   fail; if you deleted several, replace them with the single *"Plus various CI, documentation,
+   and internal tooling improvements."* trailing line. **No `[internal]` PR gets its own bullet.**
+2. **Highlights ≤ 3 sentences**, impact-first, with no dependency / fix / API enumeration.
+3. **`## Breaking Changes` heading present** (body may be *"None in this release."*).
+4. **No bare `@handle`** anywhere in the body — every handle is `[@user](https://github.com/user)`.
+5. **`## Community Contributors ❤️` table — no ❤️ in the Contributor cell**, and the
+   "What They Did" cell is prose, not a list of PR numbers.
+6. **Raw-data comment block intact** at the top; **generation timestamp** line right after it.
 
 ## Parallelization
 

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -240,7 +240,8 @@ the top of the file must remain intact. Replace everything AFTER it (the skeleto
 placeholder) with polished content. When you write the polished content, start with the
 `<!-- Generated: ... -->` timestamp line, then the `# Version X.Y.Z` heading, then the rest.
 
-The final file structure should be:
+The final file structure should be (omit any section with nothing to report — never force
+an empty category):
 
 ```markdown
 <!-- RAW PR DATA — Do not remove this comment block. ... -->
@@ -251,8 +252,13 @@ The final file structure should be:
 
 > **theme** · status · links
 
-## Highlights
-...
+## Highlights            (short, impact-first — rule 1)
+## Breaking Changes      (always present; "None in this release." when none — rule 6)
+## <Category>            (one or more: Engine, GPU & Rendering, API Surface, Text & Fonts,
+                          Bug Fixes, Lifecycle & Internals, Platform, Security — rules 2-3)
+## Community Contributors ❤️   (linked table, only when there are community contributors — rule 4)
+## Links                 (Full Changelog + NuGet only — rule 11)
+## <Preview label> (date)      (one trailing section per preview bucket, newest first — rule 10)
 ```
 
 Each file has its own HTML comment block with version, status, branch, and diff range.
@@ -264,22 +270,64 @@ NOT a rollup of the version file.
 
 Follow these rules:
 
-1. **Highlights** — 1-3 sentences. What's the story? Lead with the biggest changes.
-   Mention community contributors by linked name.
+1. **Highlights — short and impact-first (hard cap).** At most **2-3 sentences, no matter how
+   big the release**. Name only the **3-4 biggest / coolest** things — the engine jump, the
+   headline feature(s), a breaking change users must know about. It's a **hook, not a table of
+   contents** (the categories below carry the full list), so **never enumerate** dependency
+   bumps, individual bug fixes, or every new API here. The bigger the release, the more
+   **selective** Highlights get — not longer. Mention only standout community contributors, by
+   linked name.
 
 2. **Skia engine** — If a "Bump skia" or "milestone" PR appears in the raw data,
    list it first under an **Engine** category.
 
 3. **Categorize features** — Group by what they affect. Use sub-headers:
    Engine, GPU & Rendering, API Surface, Text & Fonts, Platform, Security, etc.
-   Each item: **bold title** — description. ❤️ [@contributor](https://github.com/contributor) ([#NNN](url))
+   Every item follows one exact shape:
+   `**bold title** — description. ❤️ [@user](https://github.com/user) ([#NNN](url))`
+   - The PR link `([#NNN](url))` always comes **last**.
+   - A community contributor's credit is `❤️ [@user](https://github.com/user)`, placed
+     **immediately before** the PR link. The maintainer (@mattleibow) is **not** credited —
+     his items end with just the `([#NNN](url))` link, no `❤️`.
+   - **Never write `by @handle`.** The raw-data block's `… by @user in …` is *source data*,
+     not output format — do not carry it through. And **never emit a bare `@handle`** anywhere
+     in the rendered body — every handle is a `[@user](https://github.com/user)` link, never a
+     bare or **backticked** `@user`, and never the sentence's subject (credit goes in the `❤️`
+     slot, not the prose).
 
-4. **Community contributors** — Anyone not @mattleibow. Mark with ❤️ inline AND
-   in a Contributors table. **ALWAYS** link: `[@user](https://github.com/user)`.
-   Never write bare `@user` anywhere in the file.
+4. **Community contributors** — Anyone other than @mattleibow appears in **two places, with two
+   different formats**:
+   - **Inline**, on their category bullet: end it with `❤️ [@user](https://github.com/user)
+     ([#NNN](url))` (the shape in rule 3). The ❤️ lives **only** here.
+   - **In the `## Community Contributors ❤️` table**: one row per contributor, two columns —
+     `Contributor` and `What They Did`. The **`Contributor` cell is a plain
+     `[@user](https://github.com/user)` — NO `❤️`, no `by`** (the heart wraps badly in the
+     table, so it stays on the inline bullets only). The **`What They Did` cell is a short prose
+     summary** of what they landed (e.g. "Variable-font support, singleton lifecycle rework,
+     `SKPath` crash fix") — **not** a list of `[#NNN]` links or `[#NNN] — note` fragments.
+   Always link `[@user](https://github.com/user)`; never a bare, backticked, or `by @user`
+   handle anywhere in the rendered body (the raw-data comment block is exempt; it is not
+   rendered).
 
-5. **Omit noise** — Skip version bumps, CI-only fixes, doc updates, workflow/skill changes.
-   If many, mention as: "Plus several CI and documentation improvements."
+5. **Focus on the product, not the project.** Release notes are for people *using* the library.
+   The **test** for every PR: *did the shipped SkiaSharp / HarfBuzzSharp library — its public
+   API, runtime behavior, native binary, or NuGet package — change for a consumer?* If only a
+   **repo process** changed, **drop it entirely** (do not itemize): CI/build pipelines and build
+   caching, GitHub Actions/workflows, the project's own agent skills (`security-audit`,
+   `ci-status`, the release-notes/docs tooling, etc.), the docs website / PR-staging,
+   sample-publishing pipelines, milestone/label automation, and test-infra migrations — **even
+   when the PR title mentions security, a CVE, performance, caching, or an API name** (a change
+   to the `security-audit` *skill* is not a library security fix; ADO build caching is not a
+   feature). Also drop the package's own version bump. When there is a lot of this, collapse it
+   to a **single trailing line** — e.g. *"Plus various CI, documentation, and internal tooling
+   improvements."* — never a bullet per change. **Keep** anything that ships: native-dependency
+   bumps (they change the binary — security/behavior), API additions/changes, behavior and bug
+   fixes, platform-support and native build flags that ship in the binary (e.g. Spectre
+   mitigation, new RIDs/TFMs), and consumer-visible packaging changes. **Dev-cycle and
+   `-unreleased` pages are often heavy on internal work** (the recent weeks may be mostly
+   tooling/CI/skill PRs) — do **not** itemize any of it there; one collapse line covers the
+   whole lot, and if nothing consumer-facing shipped, the page may legitimately be just
+   Highlights + that one line.
 
 6. **Breaking changes** — Always include a `## Breaking Changes` section (*"None in this
    release."* when there are none — never drop the heading). If the raw block lists a

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -308,7 +308,7 @@ an empty category):
 
 > **<theme>** · Released <Month D, YYYY> · [NuGet](url) · [GitHub Release](url)    ← rule 7
 
-## Highlights            (short, impact-first — rule 2)
+## Highlights            (ALWAYS present, literal heading; ~80 words, ≤100 — rule 2)
 ## Breaking Changes      (always present; "None in this release." when none — rule 3)
 ## <Category>            (one or more: Engine, GPU & Rendering, API Surface, Text & Fonts,
                           Bug Fixes, Lifecycle & Internals, Platform, Security — rules 4-5;
@@ -349,11 +349,13 @@ would tempt you to include an internal PR, rule 1 wins.
    **Dev-cycle and `-unreleased` pages are often mostly `[internal]`** — that is expected; such a
    page may legitimately be just Highlights + the single collapse line.
 
-2. **Highlights — a hook, not a summary (HARD CAP: ≤ 80 words).** Two or three **short**
-   sentences, **maximum ~80 words total**, no matter how big the release — count them. Name only
-   the **3-4 biggest** things (the engine jump, the one headline feature, the fact that there are
-   breaking changes) in plain prose. This is the single most-violated rule, so the bans are
-   explicit — in Highlights, **do NOT**:
+2. **Highlights — a hook, not a summary (MANDATORY heading, target ~80 words, HARD CAP 100).**
+   The section is **always present**: write the literal heading **`## Highlights`** right after the
+   banner / `> **API changes**` block, then two or three **short** sentences — **aim for ~80
+   words, never exceed 100** (count them). Never drop the heading and never replace it with a
+   bare unlabelled lead paragraph. Name only the **3-4 biggest** things (the engine jump, the one
+   headline feature, the fact that there are breaking changes) in plain prose. This is the single
+   most-violated rule, so the bans are explicit — in Highlights, **do NOT**:
    - enumerate APIs, dependency bumps, or fixes (the categories below carry the full list);
    - list contributors one by one (the Community Contributors table does that) — at most name the
      *one* standout by linked handle;
@@ -371,10 +373,16 @@ would tempt you to include an internal PR, rule 1 wins.
    > work: @ramezgerges (16 PRs — …), @4Darmygeometry (…), @SimonvBez (…), @ebariche (…)…"*
    > (228 words — the whole page crammed into the hook).
    >
-   > **Right:** *"The first stable v4 release upgrades the engine to Skia m148 and lands the big
-   > v4 feature wave — variable fonts, color font palettes, and animated WebP — alongside a set
-   > of behavioural breaking changes to review before upgrading. Community work from
-   > [@ramezgerges](https://github.com/ramezgerges) anchored the release."* (~50 words.)
+   > **Right (keep the heading):**
+   > ```markdown
+   > ## Highlights
+   >
+   > The first stable v4 release upgrades the engine to Skia m148 and lands the big v4 feature
+   > wave — variable fonts, color font palettes, and animated WebP — alongside a set of
+   > behavioural breaking changes to review before upgrading. Community work from
+   > [@ramezgerges](https://github.com/ramezgerges) anchored the release.
+   > ```
+   > (~50 words, under the heading.)
 
 3. **Breaking changes** — Always include a `## Breaking Changes` section (*"None in this
    release."* when there are none — never drop the heading). If the raw block lists a
@@ -471,8 +479,9 @@ every FAIL and re-check once. The checks that go wrong most often, watch these f
    any `*[bot]`.
 5. **Contributors table complete** — **one row per `contributors:` roster entry**, none missing,
    none invented; each row is plain `[@user](url)` · prose summary + PR links, no ❤️ in the cell.
-6. **Highlights ≤ 80 words** (count with `awk`/`wc -w`), ≤ 3 short sentences, no enumeration;
-   **`## Breaking Changes` present**; raw-data comment intact.
+6. **`## Highlights` heading present** (never a bare lead paragraph) and **≤ 100 words** (target
+   ~80 — count with `awk`/`wc -w`), ≤ 3 short sentences, no enumeration; **`## Breaking Changes`
+   present**; raw-data comment intact.
 
 ## Parallelization
 

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -353,9 +353,10 @@ would tempt you to include an internal PR, rule 1 wins.
    list it first under an **Engine** category.
 
 5. **Group and categorize — curate, don't enumerate.** Merge related `[product]` PRs into a few
-   **thematic bullets** (target **5–12 total across the whole page**), each telling one product
-   story with all its PRs credited at the end — **never one bullet per PR**. Read
-   **[`references/grouping.md`](references/grouping.md)** for the density budget, the clustering
+   **thematic bullets** (target **8–15 total across the whole page, at most ~4 per category
+   section** — count them; `## Breaking Changes` is the only exception and may list one per
+   distinct break). **Never one bullet per PR.** Read
+   **[`references/grouping.md`](references/grouping.md)** for the countable cap, the clustering
    axes, and a worked example. Group under top-level `##` categories (Engine & native
    dependencies, New APIs, GPU & Rendering, Text & Fonts, Views & platforms, Fixes, Lifecycle &
    Internals, Security). Each grouped bullet:
@@ -418,7 +419,8 @@ every FAIL and re-check once. The checks that go wrong most often, watch these f
 1. **Banner shape** — `> **<theme>** · Released <Month D, YYYY> · [NuGet](url) · [GitHub Release](url)`
    on a stable page (never a bare `> [NuGet](…)`); `Preview only` / `In development` variants per
    TEMPLATE.md. The release date comes from the raw-data `released:` line.
-2. **Curated, not enumerated** — 5–12 grouped product bullets total, not one per PR
+2. **Curated, not enumerated** — 8–15 grouped product bullets total, **at most ~4 per category
+   section** (Breaking Changes exempt); not one per PR
    (see [`references/grouping.md`](references/grouping.md)).
 3. **Product test** — no `[internal]` PR gets a bullet; they collapse into the single
    *"Plus various CI, documentation, and internal tooling improvements."* line.

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -65,10 +65,21 @@ PRs **do not appear in the notes**, however much work they were.
   the package's own version bump.)
 
 **You do not have to make this call from scratch.** The Prepare script pre-tags every
-raw-data PR line **`[product]`** or **`[internal]`** by the files the PR changed (anything
-under `binding/`, `native/`, `externals/`, or `source/` ships → `[product]`; everything else →
-`[internal]`). **Trust the tag** — drop `[internal]`, write up `[product]`. The one test above
-is only the tie-breaker for the rare line the tag gets wrong.
+raw-data PR line **`[product]`**, **`[mixed]`**, or **`[internal]`** by the files the PR
+changed:
+
+- **`[product]`** — touches shipped code (`binding/`, `externals/`, `source/`). A real change
+  a consumer can see. **Write it up.**
+- **`[internal]`** — touches none of the above (CI, workflows, our `.agents/**` skills, the docs
+  site, tests, samples, build/meta files). **Drop it** into the single collapse line.
+- **`[mixed]`** — touches only build config (`native/`): it *might* change the shipped binary via
+  a compile flag (e.g. a rasteriser define), or it *might* be pure infra (a Docker image or SDK
+  pin). **Take a best guess from the title/context in the block — no need to open the PR.**
+  Surface it as a bullet only when it plausibly changes what ships (a rendering/behaviour fix,
+  a crash fix, a new platform); otherwise fold it into the collapse line.
+
+**Trust the tag.** The one test above is only the tie-breaker for the rare `[product]`/`[internal]`
+line the tag clearly got wrong.
 
 **The PR title is not evidence — test what shipped, not what it is called.** *"Chrome Releases
 blog integration in security-audit skill"* is an internal skill change even though it says
@@ -301,8 +312,8 @@ an empty category):
 ## Breaking Changes      (always present; "None in this release." when none — rule 3)
 ## <Category>            (one or more: Engine, GPU & Rendering, API Surface, Text & Fonts,
                           Bug Fixes, Lifecycle & Internals, Platform, Security — rules 4-5;
-                          only [product] items — rule 1)
-## Community Contributors ❤️   (linked table, only when there are community contributors — rule 6)
+                          [product] items + surfaced [mixed] items — rule 1)
+## Community Contributors ❤️   (linked table — one row per `contributors:` roster entry — rule 6)
 ## Links                 (Full Changelog + NuGet only — rule 11)
 ## <Preview label> (date)      (one trailing section per preview bucket, newest first — rule 10)
 ```
@@ -325,11 +336,15 @@ would tempt you to include an internal PR, rule 1 wins.
 
 1. **Focus on the product, not the project — drop internal work.** This is the rule that makes
    the page useful (see the **Purpose** section above). Every raw-data
-   PR line is tagged `[product]` or `[internal]` by the script:
+   PR line is tagged `[product]`, `[mixed]`, or `[internal]` by the script:
    - **`[internal]` → do not write a bullet for it.** Roll ALL internal PRs into a single
      trailing line — *"Plus various CI, documentation, and internal tooling improvements."* — or
      omit even that when there were none. Never one bullet per internal change.
    - **`[product]` → keep it**, categorized below.
+   - **`[mixed]` (build config only) → guess from the title/context in the block** (no need to
+     open the PR). Give it a bullet only when it plausibly changes what ships — a rendering or
+     behaviour fix, a crash fix, a new platform/RID; otherwise fold it into the collapse line
+     with the internal work. When unsure, prefer the collapse line.
    Apply the *one test* (see Purpose) only as a tie-breaker for a line the tag clearly got wrong.
    **Dev-cycle and `-unreleased` pages are often mostly `[internal]`** — that is expected; such a
    page may legitimately be just Highlights + the single collapse line.
@@ -369,15 +384,22 @@ would tempt you to include an internal PR, rule 1 wins.
    - **Never** a bare, backticked, or `by @handle` — every handle is a `[@user](https://github.com/user)`
      link, never the sentence's subject (the raw-data `by @user` is source data, not output).
 
-6. **Community Contributors table** — Only when there is a non-maintainer, non-bot contributor.
+6. **Community Contributors table — render the roster, completely.** The raw-data block ends
+   with an authoritative **`contributors:`** roster: every external (non-maintainer, non-bot)
+   author to credit, with their PR numbers. **Render one table row per roster entry — never omit
+   one, never invent one.** (Reconstructing this list from the body prose kept silently dropping
+   real contributors whose PRs were folded into thematic bullets — the roster is the fix.) Emit
+   the table whenever the roster is non-empty:
    `## Community Contributors ❤️`, **one row per contributor, one line each**:
    `| [@user](https://github.com/user) | <short prose summary of their work> ([#N](url), [#M](url)) |`
    - Column 1 `Contributor` is a **plain `[@user](url)` — no ❤️** (the heart wraps badly here; it
      lives only on the inline bullets).
-   - Column 2 `What They Did` is a **single line**: a prose summary (Feature A, bug B, thing C),
-     then that contributor's PR links in **one** parenthetical. **Not** a bare list of `[#N]`
-     links, and **not** `[#N] — note` fragments.
-   - **Never** a row for @mattleibow or any bot.
+   - Column 2 `What They Did` is a **single line**: a prose summary (Feature A, bug B, thing C)
+     built from that contributor's PR titles in the block, then their PR links in **one**
+     parenthetical. **Not** a bare list of `[#N]` links, and **not** `[#N] — note` fragments.
+   - A contributor appears **even if their work was internal/samples-only** — the table thanks
+     everyone whose PRs shipped, so summarize whatever they did.
+   - **Never** a row for @mattleibow or any bot (the roster already excludes them).
 
 7. **Banner — themed, dated, linked.** The blockquote directly under `# Version X.Y.Z` is
    **never** a bare `> [NuGet](…)`. Write exactly one of these shapes:
@@ -423,11 +445,13 @@ every FAIL and re-check once. The checks that go wrong most often, watch these f
    section** (Breaking Changes exempt); not one per PR
    (see [`references/grouping.md`](references/grouping.md)).
 3. **Product test** — no `[internal]` PR gets a bullet; they collapse into the single
-   *"Plus various CI, documentation, and internal tooling improvements."* line.
+   *"Plus various CI, documentation, and internal tooling improvements."* line. Each `[mixed]` PR
+   is either surfaced as a shipping change or folded into that same line — never left as a raw
+   build/infra bullet.
 4. **No bare `@handle`, no bot credits** — every handle is `[@user](url)`; no `❤️`/row/"by" for
    any `*[bot]`.
-5. **Contributors table** — one line per contributor: plain `[@user](url)` · prose summary +
-   PR links, no ❤️ in the cell.
+5. **Contributors table complete** — **one row per `contributors:` roster entry**, none missing,
+   none invented; each row is plain `[@user](url)` · prose summary + PR links, no ❤️ in the cell.
 6. **Highlights ≤ 3 sentences**; **`## Breaking Changes` present**; raw-data comment intact.
 
 ## Parallelization

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -295,7 +295,7 @@ an empty category):
 
 # Version X.Y.Z
 
-> **theme** · status · links
+> **<theme>** · Released <Month D, YYYY> · [NuGet](url) · [GitHub Release](url)    ← rule 7
 
 ## Highlights            (short, impact-first — rule 2)
 ## Breaking Changes      (always present; "None in this release." when none — rule 3)
@@ -303,8 +303,8 @@ an empty category):
                           Bug Fixes, Lifecycle & Internals, Platform, Security — rules 4-5;
                           only [product] items — rule 1)
 ## Community Contributors ❤️   (linked table, only when there are community contributors — rule 6)
-## Links                 (Full Changelog + NuGet only — rule 10)
-## <Preview label> (date)      (one trailing section per preview bucket, newest first — rule 9)
+## Links                 (Full Changelog + NuGet only — rule 11)
+## <Preview label> (date)      (one trailing section per preview bucket, newest first — rule 10)
 ```
 
 Each file has its own HTML comment block with version, status, branch, and diff range.
@@ -378,22 +378,34 @@ would tempt you to include an internal PR, rule 1 wins.
      links, and **not** `[#N] — note` fragments.
    - **Never** a row for @mattleibow or any bot.
 
-7. **PR links** — Every item links to its PR.
+7. **Banner — themed, dated, linked.** The blockquote directly under `# Version X.Y.Z` is
+   **never** a bare `> [NuGet](…)`. Write exactly one of these shapes:
+   - **Stable:** `> **<theme>** · Released <date> · [NuGet](https://www.nuget.org/packages/SkiaSharp/<v>) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v<v>)`
+     — `<date>` is the raw-data block's `released:` field **verbatim** (e.g. *December 2, 2024*);
+     `<theme>` is a 2–4 word editorial phrase you write from the Highlights (e.g. *First stable
+     3.x release*, *Engine upgrade & API cleanup*).
+   - **Preview-only:** `> **<theme>** · Preview only · [NuGet](<preview-url>) · [GitHub Release](url)`
+   - **Unreleased:** `> **Upcoming release** · In development · Not yet available on NuGet`
+   - **HarfBuzz:** `> **<theme>** · Ships with SkiaSharp <X> · [NuGet](<hb-url>) · [GitHub Release](url)`
+   If the existing page already has a bare banner, **replace it** — do not preserve it. The
+   script-owned `> **Supersedes …**` and `> **API changes** …` lines stay verbatim below it.
 
-8. **Rollup at top** — Aggregate ALL `[product]` changes across all previews into the main
+8. **PR links** — Every item links to its PR.
+
+9. **Rollup at top** — Aggregate ALL `[product]` changes across all previews into the main
    sections.
 
-9. **Previews are minimal** — One sentence + Full Changelog link each, at the bottom.
-   Render one trailing `## <label> (<date>)` section per entry in the data-block's
-   `preview milestones` list (newest first), using that entry's compare link. Do not invent
-   previews or dates — the list is authoritative (sourced from published prerelease tags).
+10. **Previews are minimal** — One sentence + Full Changelog link each, at the bottom.
+    Render one trailing `## <label> (<date>)` section per entry in the data-block's
+    `preview milestones` list (newest first), using that entry's compare link. Do not invent
+    previews or dates — the list is authoritative (sourced from published prerelease tags).
 
-10. **Links section** — Full Changelog and NuGet Package only. **Do not add an API-diff
+11. **Links section** — Full Changelog and NuGet Package only. **Do not add an API-diff
     or HarfBuzz link** — the script injects a `> **API changes**` line under the banner
     when a diff folder exists (gated on existence, so it never dangles). Keep that line
     verbatim and author no API links yourself (see TEMPLATE.md "SCRIPT-OWNED API LINKS").
 
-11. **Generation timestamp** — Always include `<!-- Generated: YYYY-MM-DDTHH:MM:SSZ by {model-name} -->`
+12. **Generation timestamp** — Always include `<!-- Generated: YYYY-MM-DDTHH:MM:SSZ by {model-name} -->`
     as the first line AFTER the raw data comment block (before the `# Version` heading).
     Use the current UTC time and your model name.
 

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -317,6 +317,12 @@ NOT a rollup of the version file.
 Follow these rules, **in priority order — earlier rules trump later ones.** If a later rule
 would tempt you to include an internal PR, rule 1 wins.
 
+> **References (read the two that carry the detail):**
+> [`references/grouping.md`](references/grouping.md) — how to merge related PRs into a few
+> thematic bullets (rule 5); [`references/review-checklist.md`](references/review-checklist.md)
+> — the 12-point self-review you run before saving; [`references/TEMPLATE.md`](references/TEMPLATE.md)
+> — the canonical page shape (banner, sections, worked example).
+
 1. **Focus on the product, not the project — drop internal work.** This is the rule that makes
    the page useful (see the **Purpose** section above). Every raw-data
    PR line is tagged `[product]` or `[internal]` by the script:
@@ -346,33 +352,31 @@ would tempt you to include an internal PR, rule 1 wins.
 4. **Skia engine first** — If a "Bump skia" or "milestone" PR appears in the raw data,
    list it first under an **Engine** category.
 
-5. **Categorize what remains** — Group the `[product]` items by what they affect. Use
-   sub-headers: Engine, GPU & Rendering, API Surface, Text & Fonts, Platform, Security, etc.
-   Every item follows one exact shape:
-   `**bold title** — description. ❤️ [@user](https://github.com/user) ([#NNN](url))`
-   - The PR link `([#NNN](url))` always comes **last**.
-   - A community contributor's credit is `❤️ [@user](https://github.com/user)`, placed
-     **immediately before** the PR link. The maintainer (@mattleibow) is **not** credited —
-     his items end with just the `([#NNN](url))` link, no `❤️`.
-   - **Never write `by @handle`.** The raw-data block's `… by @user in …` is *source data*,
-     not output format — do not carry it through. And **never emit a bare `@handle`** anywhere
-     in the rendered body — every handle is a `[@user](https://github.com/user)` link, never a
-     bare or **backticked** `@user`, and never the sentence's subject (credit goes in the
-     `❤️` slot, not the prose).
+5. **Group and categorize — curate, don't enumerate.** Merge related `[product]` PRs into a few
+   **thematic bullets** (target **5–12 total across the whole page**), each telling one product
+   story with all its PRs credited at the end — **never one bullet per PR**. Read
+   **[`references/grouping.md`](references/grouping.md)** for the density budget, the clustering
+   axes, and a worked example. Group under top-level `##` categories (Engine & native
+   dependencies, New APIs, GPU & Rendering, Text & Fonts, Views & platforms, Fixes, Lifecycle &
+   Internals, Security). Each grouped bullet:
+   `**impact-statement title** — one line on why it matters. ❤️ [@a](url), [@b](url) ([#N](url), [#M](url))`
+   - The PR link(s) come **last**, in one parenthetical.
+   - Community contributors are credited with `❤️ [@user](url)` before the PR links. The
+     maintainer (@mattleibow) and **all bot accounts** (`github-actions[bot]`, `copilot[bot]`,
+     `dependabot[bot]`, any `*[bot]`) are **never** credited — their PRs may be listed but carry
+     no `❤️` and no "by".
+   - **Never** a bare, backticked, or `by @handle` — every handle is a `[@user](https://github.com/user)`
+     link, never the sentence's subject (the raw-data `by @user` is source data, not output).
 
-6. **Community contributors** — Anyone other than @mattleibow appears in **two places, with two
-   different formats**:
-   - **Inline**, on their category bullet: end it with `❤️ [@user](https://github.com/user)
-     ([#NNN](url))` (the shape in rule 5). The ❤️ lives **only** here.
-   - **In the `## Community Contributors ❤️` table**: one row per contributor, two columns —
-     `Contributor` and `What They Did`. The **`Contributor` cell is a plain
-     `[@user](https://github.com/user)` — NO `❤️`, no `by`** (the heart wraps badly in the
-     table, so it stays on the inline bullets only). The **`What They Did` cell is a short prose
-     summary** of what they landed (e.g. "Variable-font support, singleton lifecycle rework,
-     `SKPath` crash fix") — **not** a list of `[#NNN]` links or `[#NNN] — note` fragments.
-   Always link `[@user](https://github.com/user)`; never a bare, backticked, or `by @user`
-   handle anywhere in the rendered body (the raw-data comment block is exempt; it is not
-   rendered).
+6. **Community Contributors table** — Only when there is a non-maintainer, non-bot contributor.
+   `## Community Contributors ❤️`, **one row per contributor, one line each**:
+   `| [@user](https://github.com/user) | <short prose summary of their work> ([#N](url), [#M](url)) |`
+   - Column 1 `Contributor` is a **plain `[@user](url)` — no ❤️** (the heart wraps badly here; it
+     lives only on the inline bullets).
+   - Column 2 `What They Did` is a **single line**: a prose summary (Feature A, bug B, thing C),
+     then that contributor's PR links in **one** parenthetical. **Not** a bare list of `[#N]`
+     links, and **not** `[#N] — note` fragments.
+   - **Never** a row for @mattleibow or any bot.
 
 7. **PR links** — Every item links to its PR.
 
@@ -393,21 +397,24 @@ would tempt you to include an internal PR, rule 1 wins.
     as the first line AFTER the raw data comment block (before the `# Version` heading).
     Use the current UTC time and your model name.
 
-## Before you save each page — self-check
+## Before you save each page — self-review
 
-Read the file back once and verify **only these**, in order. The first two are the ones that
-go wrong most; the rest are quick search-and-fix:
+Apply **[`references/review-checklist.md`](references/review-checklist.md)** to the page you just
+wrote — it is the 12-point rubric (also runnable standalone to grade any finished page). Fix
+every FAIL and re-check once. The checks that go wrong most often, watch these first:
 
-1. **Product test.** Scan every category bullet. Each must be a `[product]` change you can
-   justify with *"a consumer notices this because …"* in about five words. Delete any that
-   fail; if you deleted several, replace them with the single *"Plus various CI, documentation,
-   and internal tooling improvements."* trailing line. **No `[internal]` PR gets its own bullet.**
-2. **Highlights ≤ 3 sentences**, impact-first, with no dependency / fix / API enumeration.
-3. **`## Breaking Changes` heading present** (body may be *"None in this release."*).
-4. **No bare `@handle`** anywhere in the body — every handle is `[@user](https://github.com/user)`.
-5. **`## Community Contributors ❤️` table — no ❤️ in the Contributor cell**, and the
-   "What They Did" cell is prose, not a list of PR numbers.
-6. **Raw-data comment block intact** at the top; **generation timestamp** line right after it.
+1. **Banner shape** — `> **<theme>** · Released <Month D, YYYY> · [NuGet](url) · [GitHub Release](url)`
+   on a stable page (never a bare `> [NuGet](…)`); `Preview only` / `In development` variants per
+   TEMPLATE.md. The release date comes from the raw-data `released:` line.
+2. **Curated, not enumerated** — 5–12 grouped product bullets total, not one per PR
+   (see [`references/grouping.md`](references/grouping.md)).
+3. **Product test** — no `[internal]` PR gets a bullet; they collapse into the single
+   *"Plus various CI, documentation, and internal tooling improvements."* line.
+4. **No bare `@handle`, no bot credits** — every handle is `[@user](url)`; no `❤️`/row/"by" for
+   any `*[bot]`.
+5. **Contributors table** — one line per contributor: plain `[@user](url)` · prose summary +
+   PR links, no ❤️ in the cell.
+6. **Highlights ≤ 3 sentences**; **`## Breaking Changes` present**; raw-data comment intact.
 
 ## Parallelization
 

--- a/.agents/skills/release-notes/references/TEMPLATE.md
+++ b/.agents/skills/release-notes/references/TEMPLATE.md
@@ -176,19 +176,21 @@ The first engine bump of the 9.x line: Skia m998 lands with variable-font suppor
 
 ## Community Contributors ❤️
 
-<!-- Only include if there are community contributors (anyone not @mattleibow).
+<!-- Only include if there are community contributors (anyone not @mattleibow, and NEVER a bot).
      ALWAYS link usernames: [@user](https://github.com/user) — never bare @user anywhere.
-     TWO columns: "Contributor" is the PLAIN link with NO ❤️ (the heart belongs only on the
-     inline category bullets above; in this table it just wraps badly on long rows). "What They
-     Did" is a SHORT PROSE summary of everything they landed this release — NEVER just a list of
-     PR numbers. One row per contributor. -->
+     TWO columns, ONE LINE per contributor:
+       "Contributor"  = the PLAIN link with NO ❤️ (the heart belongs only on the inline category
+                        bullets above; in this table it just wraps badly).
+       "What They Did" = a SHORT PROSE summary of everything they landed (Feature A, bug B, thing
+                        C), FOLLOWED BY that contributor's PR links in one parenthetical.
+                        Never just a bare list of PR numbers with no prose. -->
 
 | Contributor | What They Did |
 |-------------|--------------|
-| [@octocat](https://github.com/octocat) | Skia m998 bump; variable fonts; obsoletes promotion; singleton lifecycle; `SKFooPath` crash fix |
-| [@monalisa](https://github.com/monalisa) | Linux Bionic native assets; C# 13 support on legacy TFMs |
-| [@hubot](https://github.com/hubot) | Fixed Android `SKFooView` rendering after MAUI tab switch |
-| [@octobot](https://github.com/octobot) | `SKQuxOptions` overloads for `SKQux.Draw` |
+| [@octocat](https://github.com/octocat) | Skia m998 bump, variable fonts, singleton lifecycle rework, and the `SKFooPath` crash fix ([#1204](https://github.com/mono/SkiaSharp/pull/1204), [#1205](https://github.com/mono/SkiaSharp/pull/1205), [#1212](https://github.com/mono/SkiaSharp/pull/1212), [#1210](https://github.com/mono/SkiaSharp/pull/1210)) |
+| [@monalisa](https://github.com/monalisa) | Linux Bionic native assets and C# 13 support on legacy TFMs ([#1214](https://github.com/mono/SkiaSharp/pull/1214), [#1224](https://github.com/mono/SkiaSharp/pull/1224)) |
+| [@hubot](https://github.com/hubot) | Fixed Android `SKFooView` rendering after a MAUI tab switch ([#1211](https://github.com/mono/SkiaSharp/pull/1211)) |
+| [@octobot](https://github.com/octobot) | `SKQuxOptions` overloads for `SKQux.Draw` ([#1208](https://github.com/mono/SkiaSharp/pull/1208)) |
 
 ## Links
 

--- a/.agents/skills/release-notes/references/TEMPLATE.md
+++ b/.agents/skills/release-notes/references/TEMPLATE.md
@@ -227,26 +227,23 @@ Variable font support, animated encoding, and the first engine bump of the line.
 
 [Full Changelog](https://github.com/mono/SkiaSharp/compare/v9.988.0...v9.989.0-preview.1.1)
 
-<!-- FORMATTING RULES:
+<!-- FORMATTING RULES (priority order — product-focus first):
+     - Product over project (RULE 1): write for people USING the library. Every raw-data PR line
+       is pre-tagged [product] or [internal] by the script (product = touches binding/ native/
+       externals/ source/; everything else = internal). DROP every [internal] line — never a
+       bullet per internal change; roll them all into ONE trailing "Plus various CI,
+       documentation, and internal tooling improvements." line (or omit it if none). Write up
+       only [product] lines. The title is not evidence (a security-audit skill change is not a
+       library security fix). Keep native-dep bumps, native build flags that ship in the binary
+       (Spectre mitigation, new RIDs/TFMs), API changes, behavior/bug fixes, packaging.
      - Highlights: short and impact-first — HARD CAP at 2-3 sentences, no matter how big the
        release. Name only the 3-4 biggest / coolest things; a hook, not a table of contents.
        Never enumerate dependency bumps, individual fixes, or every new API here — the bigger
        the release, the more selective (not longer) it gets.
-     - Rollup at top: aggregate ALL changes across all previews into one polished summary
+     - Rollup at top: aggregate ALL [product] changes across all previews into one polished summary
      - Categories are top-level `##` sections (Engine, API Surface, Bug Fixes, Platform, …),
        NOT nested under a "New Features" parent; pick the ones that fit and never force empties
      - Previews/RC are minimal: one sentence + changelog link each
-     - Product over project: write for people USING the library. The test is whether the
-       SHIPPED library / native binary / NuGet package changed for a consumer. Drop repo
-       processes entirely (CI/build + caching, GitHub Actions/workflows, the project's own agent
-       skills like security-audit / ci-status, the release-notes & docs tooling, the docs
-       website / PR-staging, sample-publishing pipelines, milestone/label automation, test-infra,
-       the package's own version bump) — EVEN when the title mentions security, a CVE, caching,
-       or an API name (a change to the security-audit skill is not a library security fix). When
-       there's a lot, collapse to ONE trailing line ("Plus various CI, documentation, and
-       internal tooling improvements."). Keep native-dep bumps, native build flags that ship in
-       the binary (Spectre mitigation, new RIDs/TFMs), API changes, behavior/bug fixes, and
-       consumer-visible packaging.
      - Attribution: item shape is `**title** — desc. ❤️ [@user](url) ([#NNN](url))`. Credit &
        link every community contributor (anyone not @mattleibow); the maintainer's own PRs end
        with just the `([#NNN](url))` link (no ❤️). NEVER write `by @handle`, and never emit a

--- a/.agents/skills/release-notes/references/TEMPLATE.md
+++ b/.agents/skills/release-notes/references/TEMPLATE.md
@@ -176,14 +176,18 @@ The first engine bump of the 9.x line: Skia m998 lands with variable-font suppor
 
 ## Community Contributors ❤️
 
-<!-- Only include if there are community contributors (anyone not @mattleibow, and NEVER a bot).
+<!-- Include whenever the raw-data `contributors:` roster is non-empty. That roster is
+     AUTHORITATIVE: render EXACTLY one row per entry — never omit a contributor, never invent one
+     (the roster already excludes @mattleibow and every bot). Reconstructing this table from the
+     body prose kept dropping real contributors whose PRs were folded into thematic bullets.
      ALWAYS link usernames: [@user](https://github.com/user) — never bare @user anywhere.
      TWO columns, ONE LINE per contributor:
        "Contributor"  = the PLAIN link with NO ❤️ (the heart belongs only on the inline category
                         bullets above; in this table it just wraps badly).
        "What They Did" = a SHORT PROSE summary of everything they landed (Feature A, bug B, thing
-                        C), FOLLOWED BY that contributor's PR links in one parenthetical.
-                        Never just a bare list of PR numbers with no prose. -->
+                        C), built from that contributor's PR titles in the block, FOLLOWED BY
+                        their PR links in one parenthetical. Never just a bare list of PR numbers
+                        with no prose. Credit them even if their work was internal/samples-only. -->
 
 | Contributor | What They Did |
 |-------------|--------------|
@@ -231,13 +235,18 @@ Variable font support, animated encoding, and the first engine bump of the line.
 
 <!-- FORMATTING RULES (priority order — product-focus first):
      - Product over project (RULE 1): write for people USING the library. Every raw-data PR line
-       is pre-tagged [product] or [internal] by the script (product = touches binding/ native/
-       externals/ source/; everything else = internal). DROP every [internal] line — never a
-       bullet per internal change; roll them all into ONE trailing "Plus various CI,
-       documentation, and internal tooling improvements." line (or omit it if none). Write up
-       only [product] lines. The title is not evidence (a security-audit skill change is not a
-       library security fix). Keep native-dep bumps, native build flags that ship in the binary
-       (Spectre mitigation, new RIDs/TFMs), API changes, behavior/bug fixes, packaging.
+       is pre-tagged [product], [mixed], or [internal] by the script:
+         [product]  = touches shipped code (binding/ externals/ source/) — WRITE IT UP.
+         [internal] = touches none of those (CI, workflows, .agents skills, docs site, tests,
+                      samples, build/meta) — DROP it into the ONE collapse line.
+         [mixed]    = touches only build config (native/) — GUESS FROM THE TITLE HERE (do not open
+                      the PR): surface it only if it plausibly changes what ships (a rendering or
+                      crash fix, a new platform); otherwise fold it into the collapse line.
+       Never a bullet per internal change; roll them all into ONE trailing "Plus various CI,
+       documentation, and internal tooling improvements." line (or omit it if none). The title is
+       not evidence (a security-audit skill change is not a library security fix). Keep native-dep
+       bumps, native build flags that ship in the binary (Spectre mitigation, new RIDs/TFMs), API
+       changes, behavior/bug fixes, packaging.
      - Highlights: short and impact-first — HARD CAP at 2-3 sentences, no matter how big the
        release. Name only the 3-4 biggest / coolest things; a hook, not a table of contents.
        Never enumerate dependency bumps, individual fixes, or every new API here — the bigger

--- a/.agents/skills/release-notes/references/TEMPLATE.md
+++ b/.agents/skills/release-notes/references/TEMPLATE.md
@@ -84,17 +84,19 @@
 
 ## Highlights
 
-<!-- Short and impact-first — HARD CAP: ≤ 80 WORDS and at most 2-3 short sentences, no matter
-     how big the release (count them). Name only the 3-4 biggest things (the engine jump, the
-     headline feature, the fact that there are breaking changes) in plain prose. A hook, not a
-     summary — the categories below carry the full list. In Highlights, do NOT: enumerate APIs /
-     dependency bumps / fixes; list contributors one by one (the table does that — name at most
-     one standout by linked handle); use per-item parentheticals, PR/issue links, or `code` API
-     names as a checklist; or write "Compared to X: A, B, C, D, …" (that comma-run IS the banned
-     enumeration). If a reader could rebuild the category sections from Highlights, it is too
-     long. If the manual additions sidecar (<stem>.notes.md, see §4.7) has editorial points the
-     maintainer wants brought out, weave them in here in your own words. On a supersedes rollup,
-     note in one line that the skipped preview work is included cumulatively. -->
+<!-- ALWAYS keep this `## Highlights` heading (never drop it, never replace it with a bare
+     unlabelled lead paragraph). Short and impact-first — target ~80 WORDS, HARD CAP 100, and at
+     most 2-3 short sentences, no matter how big the release (count them). Name only the 3-4
+     biggest things (the engine jump, the headline feature, the fact that there are breaking
+     changes) in plain prose. A hook, not a summary — the categories below carry the full list.
+     In Highlights, do NOT: enumerate APIs / dependency bumps / fixes; list contributors one by
+     one (the table does that — name at most one standout by linked handle); use per-item
+     parentheticals, PR/issue links, or `code` API names as a checklist; or write "Compared to X:
+     A, B, C, D, …" (that comma-run IS the banned enumeration). If a reader could rebuild the
+     category sections from Highlights, it is too long. If the manual additions sidecar
+     (<stem>.notes.md, see §4.7) has editorial points the maintainer wants brought out, weave them
+     in here in your own words. On a supersedes rollup, note in one line that the skipped preview
+     work is included cumulatively. -->
 
 The first engine bump of the 9.x line: Skia m998 lands with variable-font support and animated encoding, alongside a major-version API cleanup that promotes long-deprecated members to compile errors — check Breaking Changes before upgrading. HarfBuzz 9.9.0 ships too ([HarfBuzzSharp 9.9.0](harfbuzzsharp/9.9.0.md)). Standout community work from [@octocat](https://github.com/octocat) and [@monalisa](https://github.com/monalisa).
 
@@ -249,11 +251,12 @@ Variable font support, animated encoding, and the first engine bump of the line.
        not evidence (a security-audit skill change is not a library security fix). Keep native-dep
        bumps, native build flags that ship in the binary (Spectre mitigation, new RIDs/TFMs), API
        changes, behavior/bug fixes, packaging.
-     - Highlights: a hook, not a summary — HARD CAP ≤ 80 WORDS and ≤ 3 short sentences, no
-       matter how big the release (count them). Name only the 3-4 biggest things in plain prose.
-       Never enumerate APIs / dependency bumps / fixes, never list contributors one by one (name
-       at most one standout handle), never use per-item parentheticals or a "Compared to X: A, B,
-       C, …" comma-run — the categories and the contributor table carry the full detail.
+     - Highlights: a hook, not a summary. ALWAYS keep the literal `## Highlights` heading (never
+       a bare lead paragraph). Target ~80 WORDS, HARD CAP 100, ≤ 3 short sentences, no matter how
+       big the release (count them). Name only the 3-4 biggest things in plain prose. Never
+       enumerate APIs / dependency bumps / fixes, never list contributors one by one (name at most
+       one standout handle), never use per-item parentheticals or a "Compared to X: A, B, C, …"
+       comma-run — the categories and the contributor table carry the full detail.
      - Rollup at top: aggregate ALL [product] changes across all previews into one polished summary
      - Categories are top-level `##` sections (Engine, API Surface, Bug Fixes, Platform, …),
        NOT nested under a "New Features" parent; pick the ones that fit and never force empties

--- a/.agents/skills/release-notes/references/TEMPLATE.md
+++ b/.agents/skills/release-notes/references/TEMPLATE.md
@@ -84,15 +84,17 @@
 
 ## Highlights
 
-<!-- Short and impact-first — HARD CAP: at most 2-3 sentences, no matter how big the release.
-     Name only the 3-4 biggest / coolest things (the engine jump, the headline feature, a
-     breaking change to know about). A hook, not a table of contents — the categories below
-     carry the full list, so never enumerate dependency bumps, individual fixes, or every new
-     API here; the bigger the release, the more SELECTIVE (not longer) it gets. Mention only
-     standout community contributors by linked name. If the manual additions sidecar
-     (<stem>.notes.md, see §4.7) has editorial points the maintainer wants brought out, weave
-     them in here in your own words. On a supersedes rollup, note in one line that the skipped
-     preview work is included cumulatively. -->
+<!-- Short and impact-first — HARD CAP: ≤ 80 WORDS and at most 2-3 short sentences, no matter
+     how big the release (count them). Name only the 3-4 biggest things (the engine jump, the
+     headline feature, the fact that there are breaking changes) in plain prose. A hook, not a
+     summary — the categories below carry the full list. In Highlights, do NOT: enumerate APIs /
+     dependency bumps / fixes; list contributors one by one (the table does that — name at most
+     one standout by linked handle); use per-item parentheticals, PR/issue links, or `code` API
+     names as a checklist; or write "Compared to X: A, B, C, D, …" (that comma-run IS the banned
+     enumeration). If a reader could rebuild the category sections from Highlights, it is too
+     long. If the manual additions sidecar (<stem>.notes.md, see §4.7) has editorial points the
+     maintainer wants brought out, weave them in here in your own words. On a supersedes rollup,
+     note in one line that the skipped preview work is included cumulatively. -->
 
 The first engine bump of the 9.x line: Skia m998 lands with variable-font support and animated encoding, alongside a major-version API cleanup that promotes long-deprecated members to compile errors — check Breaking Changes before upgrading. HarfBuzz 9.9.0 ships too ([HarfBuzzSharp 9.9.0](harfbuzzsharp/9.9.0.md)). Standout community work from [@octocat](https://github.com/octocat) and [@monalisa](https://github.com/monalisa).
 
@@ -247,10 +249,11 @@ Variable font support, animated encoding, and the first engine bump of the line.
        not evidence (a security-audit skill change is not a library security fix). Keep native-dep
        bumps, native build flags that ship in the binary (Spectre mitigation, new RIDs/TFMs), API
        changes, behavior/bug fixes, packaging.
-     - Highlights: short and impact-first — HARD CAP at 2-3 sentences, no matter how big the
-       release. Name only the 3-4 biggest / coolest things; a hook, not a table of contents.
-       Never enumerate dependency bumps, individual fixes, or every new API here — the bigger
-       the release, the more selective (not longer) it gets.
+     - Highlights: a hook, not a summary — HARD CAP ≤ 80 WORDS and ≤ 3 short sentences, no
+       matter how big the release (count them). Name only the 3-4 biggest things in plain prose.
+       Never enumerate APIs / dependency bumps / fixes, never list contributors one by one (name
+       at most one standout handle), never use per-item parentheticals or a "Compared to X: A, B,
+       C, …" comma-run — the categories and the contributor table carry the full detail.
      - Rollup at top: aggregate ALL [product] changes across all previews into one polished summary
      - Categories are top-level `##` sections (Engine, API Surface, Bug Fixes, Platform, …),
        NOT nested under a "New Features" parent; pick the ones that fit and never force empties

--- a/.agents/skills/release-notes/references/TEMPLATE.md
+++ b/.agents/skills/release-notes/references/TEMPLATE.md
@@ -84,12 +84,17 @@
 
 ## Highlights
 
-<!-- 1-3 sentences. Lead with what matters most. Mention community contributors by linked name.
-     If the manual additions sidecar (<stem>.notes.md, see §4.7) has editorial points the
-     maintainer wants brought out, weave them in here in your own words. On a supersedes
-     rollup, note in one line that the skipped preview work is included cumulatively. -->
+<!-- Short and impact-first — HARD CAP: at most 2-3 sentences, no matter how big the release.
+     Name only the 3-4 biggest / coolest things (the engine jump, the headline feature, a
+     breaking change to know about). A hook, not a table of contents — the categories below
+     carry the full list, so never enumerate dependency bumps, individual fixes, or every new
+     API here; the bigger the release, the more SELECTIVE (not longer) it gets. Mention only
+     standout community contributors by linked name. If the manual additions sidecar
+     (<stem>.notes.md, see §4.7) has editorial points the maintainer wants brought out, weave
+     them in here in your own words. On a supersedes rollup, note in one line that the skipped
+     preview work is included cumulatively. -->
 
-SkiaSharp 9.990.0 rolls up all preview work from [9.989.0](9.989.0.md) cumulatively and completes a round of API-surface cleanup. It delivers a Skia engine upgrade, promotes long-deprecated members to compile errors, reworks singleton object lifecycles for correctness, and ships several `SKFooMap` fixes. HarfBuzz 9.9.0 ships alongside — see [HarfBuzzSharp 9.9.0](harfbuzzsharp/9.9.0.md). Notable community work from [@octocat](https://github.com/octocat), [@monalisa](https://github.com/monalisa), [@hubot](https://github.com/hubot), and [@octobot](https://github.com/octobot).
+The first engine bump of the 9.x line: Skia m998 lands with variable-font support and animated encoding, alongside a major-version API cleanup that promotes long-deprecated members to compile errors — check Breaking Changes before upgrading. HarfBuzz 9.9.0 ships too ([HarfBuzzSharp 9.9.0](harfbuzzsharp/9.9.0.md)). Standout community work from [@octocat](https://github.com/octocat) and [@monalisa](https://github.com/monalisa).
 
 ## Breaking Changes
 
@@ -169,27 +174,14 @@ SkiaSharp 9.990.0 rolls up all preview work from [9.989.0](9.989.0.md) cumulativ
 - **zlib updated to 9.9.9** ([#1221](https://github.com/mono/SkiaSharp/pull/1221))
 - **libpng updated to 9.9.9** ([#1222](https://github.com/mono/SkiaSharp/pull/1222))
 
-## Platform Support
-
-<!-- Quick at-a-glance table. One row per platform that has something new; omit rows with
-     nothing to report. Keep entries short — they mirror items already listed above. -->
-
-| Platform | What's New |
-|----------|-----------|
-| 🍎 Apple | Fixed platform TFMs for libraries vs apps |
-| 🤖 Android | Fixed `SKFooView` blank after MAUI tab switch |
-| 🌐 WebAssembly | Dropped pre-.NET 8 Emscripten builds |
-| 🐧 Linux | Linux Bionic native assets |
-| 🪟 Windows | Fixed WinUI Projection DLL for .NET 9 |
-| 📦 General | Tizen x64/arm64 native builds; C# 13 on legacy TFMs |
-
-<!-- Platform emoji reference: 🍎 Apple · 🪟 Windows · 🐧 Linux · 🤖 Android · 🌐 WebAssembly · 🎨 Core API · 🏗️ Build/CI · 📦 General -->
-
 ## Community Contributors ❤️
 
 <!-- Only include if there are community contributors (anyone not @mattleibow).
      ALWAYS link usernames: [@user](https://github.com/user) — never bare @user anywhere.
-     One row per contributor; summarize everything they landed this release. -->
+     TWO columns: "Contributor" is the PLAIN link with NO ❤️ (the heart belongs only on the
+     inline category bullets above; in this table it just wraps badly on long rows). "What They
+     Did" is a SHORT PROSE summary of everything they landed this release — NEVER just a list of
+     PR numbers. One row per contributor. -->
 
 | Contributor | What They Did |
 |-------------|--------------|
@@ -236,12 +228,31 @@ Variable font support, animated encoding, and the first engine bump of the line.
 [Full Changelog](https://github.com/mono/SkiaSharp/compare/v9.988.0...v9.989.0-preview.1.1)
 
 <!-- FORMATTING RULES:
+     - Highlights: short and impact-first — HARD CAP at 2-3 sentences, no matter how big the
+       release. Name only the 3-4 biggest / coolest things; a hook, not a table of contents.
+       Never enumerate dependency bumps, individual fixes, or every new API here — the bigger
+       the release, the more selective (not longer) it gets.
      - Rollup at top: aggregate ALL changes across all previews into one polished summary
      - Categories are top-level `##` sections (Engine, API Surface, Bug Fixes, Platform, …),
        NOT nested under a "New Features" parent; pick the ones that fit and never force empties
      - Previews/RC are minimal: one sentence + changelog link each
-     - Omit noise: don't itemize version bumps, CI fixes, doc/skill/workflow changes
-     - Community ❤️: always credit and link anyone not @mattleibow; never bare @user
+     - Product over project: write for people USING the library. The test is whether the
+       SHIPPED library / native binary / NuGet package changed for a consumer. Drop repo
+       processes entirely (CI/build + caching, GitHub Actions/workflows, the project's own agent
+       skills like security-audit / ci-status, the release-notes & docs tooling, the docs
+       website / PR-staging, sample-publishing pipelines, milestone/label automation, test-infra,
+       the package's own version bump) — EVEN when the title mentions security, a CVE, caching,
+       or an API name (a change to the security-audit skill is not a library security fix). When
+       there's a lot, collapse to ONE trailing line ("Plus various CI, documentation, and
+       internal tooling improvements."). Keep native-dep bumps, native build flags that ship in
+       the binary (Spectre mitigation, new RIDs/TFMs), API changes, behavior/bug fixes, and
+       consumer-visible packaging.
+     - Attribution: item shape is `**title** — desc. ❤️ [@user](url) ([#NNN](url))`. Credit &
+       link every community contributor (anyone not @mattleibow); the maintainer's own PRs end
+       with just the `([#NNN](url))` link (no ❤️). NEVER write `by @handle`, and never emit a
+       bare @user anywhere in the rendered body. In the Community Contributors TABLE the
+       "Contributor" cell is a plain `[@user](url)` with NO ❤️ (the heart is only on the inline
+       bullets above) and "What They Did" is a short PROSE summary, never a bare list of PRs.
      - Adapt to content: security release leads with security, feature release leads with features
      - Skia engine: if a "Bump skia" PR is in the data, list it first under Engine
      - Breaking Changes: always emit the `## Breaking Changes` heading right after Highlights

--- a/.agents/skills/release-notes/references/grouping.md
+++ b/.agents/skills/release-notes/references/grouping.md
@@ -1,0 +1,85 @@
+<!-- Reference asset of the release-notes skill. The Polish agent reads this to turn a flat
+     PR list into a curated, grouped page. Not part of the DocFX site. -->
+
+# Grouping & categorizing the changes
+
+Release notes are **curated**, not exhaustive. The single biggest quality failure is rendering
+**one bullet per PR** — a wall of 50+ line items. A good page merges related PRs into a handful
+of **thematic bullets**, each telling one product story. This file is how.
+
+## The density budget
+
+Across **all** category sections combined, aim for **5–12 product bullets total** — not one per
+PR. A single bullet carries **2–8 related PRs**. Reserve a solo bullet only for a genuine
+standalone landmark (the engine bump, one headline API, a breaking-only change). **If your draft
+has more than ~15 bullets, you are enumerating — go back and merge.**
+
+A 130-PR release and a 12-PR release should have Highlights and category sections of *similar
+length*. The big release is more *selective*, not longer.
+
+## How to cluster (three axes, in order of preference)
+
+1. **Same API / feature area.** All `Span<T>` overloads across `SKMatrix.MapPoints`/`MapVectors`,
+   `SKPath.AddPoly`/`SetRectRadii`, and the color filters → **one** bullet.
+2. **Same platform / target.** All Uno / XAML view fixes → one bullet; all Blazor / WASM fixes →
+   one; all "Metal on Apple" work → one.
+3. **Same symptom / mechanism.** All view-leak / memory fixes → one; all packaging/nuget-layout
+   changes → one.
+
+Only the `[product]` lines are grouped — every `[internal]` line is dropped into the single
+collapse line (see the writing rules). Bot-authored PRs may be grouped but never credited.
+
+## Group titles are impact statements, not PR titles
+
+- The **title** is the shipping impact — what the consumer gets — **not** a concatenation of PR
+  titles: `` **`Span<T>` overloads across the point / path / color-filter APIs** ``.
+- The **description** is one line on *why the consumer cares*, not a list of the PRs.
+- All the group's PR links go in **one parenthetical at the end**, with each community
+  contributor credited once: `❤️ [@a](url), [@b](url) ([#1](url), [#2](url), [#3](url))`.
+
+## Categories (top-level `##` sections)
+
+Pick the ones that fit; never force an empty category. Order by importance for the release.
+
+`Engine & native dependencies` · `New APIs` · `GPU & Rendering` · `Text & Fonts` ·
+`Views & platforms` · `Fixes` · `Lifecycle & Internals` · `Security`
+
+The **Skia engine bump** (a "Bump skia" / "milestone" PR) always leads, under
+`Engine & native dependencies`.
+
+## Worked example — 3.116.0
+
+The raw data lists these four `[product]` PRs separately:
+
+```
+[product] Add SKMatrix.MapPoints/MapVectors, SKPath.AddPoly overloads with Span<SKPoint> (#3030) @alexandrvslv
+[product] Provide Span overload for SetRectRadii (#2949) @Youssef1313
+[product] Add spans to the color filters (#2879) @mattleibow
+[product] Added GetPixelSpan() with offsets (#2609) @mattleibow
+```
+
+❌ **Wrong (one bullet per PR):**
+
+```markdown
+- **Span<SKPoint> for SKMatrix.MapPoints/MapVectors and SKPath.AddPoly** — … ❤️ [@alexandrvslv](https://github.com/alexandrvslv) ([#3030](…))
+- **Span<T> overload for SKPath.SetRectRadii** — … ❤️ [@Youssef1313](https://github.com/Youssef1313) ([#2949](…))
+- **New color-filter span APIs** — … ([#2879](…))
+- **GetPixelSpan() overloads with offset** — ([#2609](…))
+```
+
+✅ **Right (one grouped bullet):**
+
+```markdown
+- **`Span<T>` overloads across the point / path / color-filter APIs** — Zero-copy interop with stack-allocated buffers, for `SKMatrix.MapPoints`/`MapVectors`, `SKPath.AddPoly`/`SetRectRadii`, the color filters, and `GetPixelSpan`. ❤️ [@alexandrvslv](https://github.com/alexandrvslv), [@Youssef1313](https://github.com/Youssef1313) ([#3030](https://github.com/mono/SkiaSharp/pull/3030), [#2949](https://github.com/mono/SkiaSharp/pull/2949), [#2879](https://github.com/mono/SkiaSharp/pull/2879), [#2609](https://github.com/mono/SkiaSharp/pull/2609))
+```
+
+More groupings from the same release, so the page reads as ~18 bullets instead of ~56:
+
+| PRs | One grouped bullet |
+|---|---|
+| #2829, #2885, #3026 | **Skia updated to milestone m116** (with in-milestone refreshes) |
+| #3093, #3089, #3081, #3087, #3086 | **.NET 9 Blazor / WASM fixes** |
+| #2918, #2854, #2720, #2563, #2559, #2612 | **Uno / XAML view fixes** |
+| #2598, #2733, #2317 | **New accelerated views** (`SKGLView`, WinUI, WPF `SKGLElement`) |
+| #2747, #2788, #2804 | **Metal on Mac Catalyst** (default backend + common Metal APIs) |
+| #2830, #2883, #2889, #2748, #2630 | **New drawing APIs** (`SKBlender`, `SKPicture` R-Tree, `ToRawShader`, Skottie builder) |

--- a/.agents/skills/release-notes/references/grouping.md
+++ b/.agents/skills/release-notes/references/grouping.md
@@ -9,10 +9,22 @@ of **thematic bullets**, each telling one product story. This file is how.
 
 ## The density budget
 
-Across **all** category sections combined, aim for **5–12 product bullets total** — not one per
+Across **all** category sections combined, aim for **8–15 product bullets total** — not one per
 PR. A single bullet carries **2–8 related PRs**. Reserve a solo bullet only for a genuine
-standalone landmark (the engine bump, one headline API, a breaking-only change). **If your draft
-has more than ~15 bullets, you are enumerating — go back and merge.**
+standalone landmark (the engine bump, one headline API, a breaking-only change).
+
+**The countable rule: at most ~4 bullets per category section.** After you draft a category,
+count its bullets — if a `##` section (other than `## Breaking Changes`, which is one bullet per
+distinct break) has **more than ~4**, you are enumerating: find the same-kind items and merge
+them into one grouped bullet. Concretely, within a category:
+
+- Several **fixes to the same subsystem** (all Uno/XAML, all MAUI, all memory/leak) → **one**
+  "Fixed … regressions" bullet listing them, main-style (see the example below).
+- Several **native-dependency bumps** (libpng, libwebp, brotli, expat) → **one** bullet.
+- Several **overloads of the same shape** (all the `Span<T>` additions) → **one** bullet.
+
+`## Breaking Changes` is the exception — it may carry one bullet per distinct break (a v4-style
+release legitimately has ~10). Every *other* category is curated down to a few grouped bullets.
 
 A 130-PR release and a 12-PR release should have Highlights and category sections of *similar
 length*. The big release is more *selective*, not longer.

--- a/.agents/skills/release-notes/references/review-checklist.md
+++ b/.agents/skills/release-notes/references/review-checklist.md
@@ -40,6 +40,8 @@ VERDICT: PASS | FAIL   (score N/12)
 5. **product-only** — No bullet describes an `[internal]` PR (CI/build, `.agents/**` skills,
    workflows, docs-site, PR-staging, milestone automation, tests, samples). The one collapse
    line *"Plus various CI, documentation, and internal tooling improvements."* is allowed once.
+   Each `[mixed]` PR (build config only) is either surfaced as a genuine shipping change or
+   folded into that collapse line — never left as a raw build/infra bullet.
 
 6. **grouping-density** — Count top-level product bullets across `##` category sections (exclude
    previews and the Contributors table). Target **8–15**, and **at most ~4 per category section**
@@ -54,11 +56,14 @@ VERDICT: PASS | FAIL   (score N/12)
    release."*). If the raw block lists a `.breaking.md` or `.notes.md` companion, the section has
    a proportional handful of summarized bullets (never a dump, never empty).
 
-9. **contributor-table-format** — If there is any non-maintainer, non-bot contributor:
-   `## Community Contributors ❤️` exists; column 1 `Contributor` is a plain `[@user](url)` with
+9. **contributor-table-complete** — The `## Community Contributors ❤️` table has **exactly one row
+   per entry in the raw-data `contributors:` roster** — none missing, none invented. Cross-check:
+   every `@login` in the roster appears as a row, and no row exists for a login absent from the
+   roster (so no `mattleibow`, no bot). Column 1 `Contributor` is a plain `[@user](url)` with
    **no ❤️**; column 2 `What They Did` is a **single line** of prose summary followed by the PR
-   links in one parenthetical. FAIL on ❤️ in the cell, a cell that is only `[#N]` links, or a row
-   for `mattleibow` or any bot.
+   links in one parenthetical. FAIL on a missing roster member, ❤️ in the cell, a cell that is
+   only `[#N]` links, or a row for `mattleibow`/any bot.
+   Grep the roster: `grep -A99 'contributors:' <version>.md | grep -oE '@[A-Za-z0-9-]+'`.
 
 10. **inline-attribution-shape** — Every inline community credit is
     `❤️ [@user](url) ([#NNN](url))` with `❤️` immediately before the PR link. FAIL on `by @user`,

--- a/.agents/skills/release-notes/references/review-checklist.md
+++ b/.agents/skills/release-notes/references/review-checklist.md
@@ -51,8 +51,11 @@ VERDICT: PASS | FAIL   (score N/12)
    non-breaking category has > 5 bullets with obvious mergeable adjacencies (same subsystem,
    same dependency set, same overload shape). Grep: `grep -c '^- \*\*' <version>.md`.
 
-7. **highlights-length** — `## Highlights` is ≤ 3 sentences, no bullet list, no enumeration of
-   dependency bumps / individual fixes / every new API.
+7. **highlights-length** — `## Highlights` is **≤ 80 words** AND ≤ 3 short sentences: no bullet
+   list, no PR/issue links, no per-item parentheticals, no contributor enumeration (at most one
+   standout handle), no "Compared to X: A, B, C, …" comma-run. Count it:
+   `awk '/^## Highlights/{f=1;next} /^## /{f=0} f' <version>.md | wc -w` must be ≤ 80. FAIL if a
+   reader could reconstruct the category sections from Highlights alone.
 
 8. **breaking-present** — `## Breaking Changes` heading exists (body may be *"None in this
    release."*). If the raw block lists a `.breaking.md` or `.notes.md` companion, the section has

--- a/.agents/skills/release-notes/references/review-checklist.md
+++ b/.agents/skills/release-notes/references/review-checklist.md
@@ -51,10 +51,12 @@ VERDICT: PASS | FAIL   (score N/12)
    non-breaking category has > 5 bullets with obvious mergeable adjacencies (same subsystem,
    same dependency set, same overload shape). Grep: `grep -c '^- \*\*' <version>.md`.
 
-7. **highlights-length** — `## Highlights` is **≤ 80 words** AND ≤ 3 short sentences: no bullet
-   list, no PR/issue links, no per-item parentheticals, no contributor enumeration (at most one
-   standout handle), no "Compared to X: A, B, C, …" comma-run. Count it:
-   `awk '/^## Highlights/{f=1;next} /^## /{f=0} f' <version>.md | wc -w` must be ≤ 80. FAIL if a
+7. **highlights-heading-and-length** — The literal heading `## Highlights` is present (FAIL if it
+   was dropped or replaced by a bare unlabelled lead paragraph — `grep -c '^## Highlights'
+   <version>.md` must be 1). Its body is **≤ 100 words** (target ~80) AND ≤ 3 short sentences: no
+   bullet list, no PR/issue links, no per-item parentheticals, no contributor enumeration (at
+   most one standout handle), no "Compared to X: A, B, C, …" comma-run. Count it:
+   `awk '/^## Highlights/{f=1;next} /^## /{f=0} f' <version>.md | wc -w` must be ≤ 100. FAIL if a
    reader could reconstruct the category sections from Highlights alone.
 
 8. **breaking-present** — `## Breaking Changes` heading exists (body may be *"None in this

--- a/.agents/skills/release-notes/references/review-checklist.md
+++ b/.agents/skills/release-notes/references/review-checklist.md
@@ -1,0 +1,76 @@
+<!-- Reference asset of the release-notes skill. Two uses: (1) the Polish agent applies this to
+     each page before saving (self-review, fix, re-check); (2) run it standalone against any
+     finished <version>.md — locally or as a fresh review pass — to score a page. Not part of the
+     DocFX site. -->
+
+# Release-notes reviewer
+
+Review ONE polished `<version>.md`. Apply every check. A page **PASSES** only when all checks
+pass; otherwise list the specific fixes and correct them.
+
+To run it standalone, read the page, work the checklist top to bottom, and emit:
+
+```
+VERDICT: PASS | FAIL   (score N/12)
+- <check-id>: PASS | FAIL — <detail / exact fix>
+```
+
+## The 12 checks
+
+1. **banner-shape** — The blockquote under `# Version X.Y.Z` is one of exactly:
+   - Stable: `> **<theme>** · Released <Month D, YYYY> · [NuGet](url) · [GitHub Release](url)`
+   - Preview: `> **<theme>** · Preview only · [NuGet](preview-url) · [GitHub Release](url)`
+   - Unreleased: `> **Upcoming release** · In development · Not yet available on NuGet`
+   - HarfBuzz: `> **<theme>** · Ships with SkiaSharp <X> · [NuGet](hb-url) · [GitHub Release](url)`
+   FAIL if it's a bare `> [NuGet](…)`, if `<theme>` is missing, or if a stable page has no
+   `Released <date>` or no GitHub Release link.
+
+2. **script-owned-lines-verbatim** — The `> **API changes** · …` line, any `> **Supersedes …**`
+   / `> **… Superseded by …**` line, and the whole `<!-- RAW PR DATA … -->` comment are
+   byte-identical to what the raw-data block declares. FAIL if any was re-authored.
+
+3. **no-bare-handles** — Every `@name` in the rendered body is a `[@name](https://github.com/name)`
+   link. FAIL on any bare `@name`, backticked `` `@name` ``, or `by @name`.
+   Grep: `grep -nE '(^|[^`[/])@[A-Za-z0-9_-]+' <version>.md | grep -v 'RAW PR DATA'`.
+
+4. **no-bot-credit** — No `❤️`, Contributors row, or "by" is given to a bot: `github-actions[bot]`,
+   `copilot[bot]`, `dependabot[bot]`, `dotnet-policy-service[bot]`, any `*[bot]`. Their PRs may be
+   listed, but with no attribution. Grep: `grep -nE '@github-actions|@dependabot|@copilot|\[bot\]' <version>.md`.
+
+5. **product-only** — No bullet describes an `[internal]` PR (CI/build, `.agents/**` skills,
+   workflows, docs-site, PR-staging, milestone automation, tests, samples). The one collapse
+   line *"Plus various CI, documentation, and internal tooling improvements."* is allowed once.
+
+6. **grouping-density** — Count top-level product bullets across `##` category sections (exclude
+   previews and the Contributors table). Target **5–12**. FAIL if > 15, or if any category has
+   > 8 bullets with obvious mergeable adjacencies (same area / platform / symptom).
+   Grep: `grep -c '^- \*\*' <version>.md`.
+
+7. **highlights-length** — `## Highlights` is ≤ 3 sentences, no bullet list, no enumeration of
+   dependency bumps / individual fixes / every new API.
+
+8. **breaking-present** — `## Breaking Changes` heading exists (body may be *"None in this
+   release."*). If the raw block lists a `.breaking.md` or `.notes.md` companion, the section has
+   a proportional handful of summarized bullets (never a dump, never empty).
+
+9. **contributor-table-format** — If there is any non-maintainer, non-bot contributor:
+   `## Community Contributors ❤️` exists; column 1 `Contributor` is a plain `[@user](url)` with
+   **no ❤️**; column 2 `What They Did` is a **single line** of prose summary followed by the PR
+   links in one parenthetical. FAIL on ❤️ in the cell, a cell that is only `[#N]` links, or a row
+   for `mattleibow` or any bot.
+
+10. **inline-attribution-shape** — Every inline community credit is
+    `❤️ [@user](url) ([#NNN](url))` with `❤️` immediately before the PR link. FAIL on `by @user`,
+    `❤️ @user` (no link), or a maintainer/bot bullet carrying `❤️`.
+
+11. **previews-verbatim** — Each trailing `## <label> (<date>)` matches a raw-data `preview
+    milestones` entry, verbatim label and date; each is one sentence + a Full Changelog link. No
+    invented previews or dates.
+
+12. **links-minimal** — `## Links` on a released page has only `Full Changelog` + `NuGet Package`.
+    No hand-authored API-diff or HarfBuzz link (those are script-owned in the banner).
+
+## Fix, don't just flag
+
+When self-reviewing during Polish: on any FAIL, correct the page and re-check. Cap at one
+re-review; if something still fails, note it briefly in the PR body so a human sees it.

--- a/.agents/skills/release-notes/references/review-checklist.md
+++ b/.agents/skills/release-notes/references/review-checklist.md
@@ -42,9 +42,10 @@ VERDICT: PASS | FAIL   (score N/12)
    line *"Plus various CI, documentation, and internal tooling improvements."* is allowed once.
 
 6. **grouping-density** — Count top-level product bullets across `##` category sections (exclude
-   previews and the Contributors table). Target **5–12**. FAIL if > 15, or if any category has
-   > 8 bullets with obvious mergeable adjacencies (same area / platform / symptom).
-   Grep: `grep -c '^- \*\*' <version>.md`.
+   previews and the Contributors table). Target **8–15**, and **at most ~4 per category section**
+   (`## Breaking Changes` is exempt — one bullet per distinct break is fine). FAIL if any
+   non-breaking category has > 5 bullets with obvious mergeable adjacencies (same subsystem,
+   same dependency set, same overload shape). Grep: `grep -c '^- \*\*' <version>.md`.
 
 7. **highlights-length** — `## Highlights` is ≤ 3 sentences, no bullet list, no enumeration of
    dependency bumps / individual fixes / every new API.

--- a/.agents/skills/release-notes/references/review-checklist.md
+++ b/.agents/skills/release-notes/references/review-checklist.md
@@ -34,8 +34,10 @@ VERDICT: PASS | FAIL   (score N/12)
    Grep: `grep -nE '(^|[^`[/])@[A-Za-z0-9_-]+' <version>.md | grep -v 'RAW PR DATA'`.
 
 4. **no-bot-credit** — No `❤️`, Contributors row, or "by" is given to a bot: `github-actions[bot]`,
-   `copilot[bot]`, `dependabot[bot]`, `dotnet-policy-service[bot]`, any `*[bot]`. Their PRs may be
-   listed, but with no attribution. Grep: `grep -nE '@github-actions|@dependabot|@copilot|\[bot\]' <version>.md`.
+   `Copilot` (the coding agent — links to `github.com/apps/copilot-swe-agent`), `dependabot[bot]`,
+   `dotnet-policy-service[bot]`, any `*[bot]`. Their PRs may be listed, but with no attribution
+   (Prepare already strips the `[community ✨]` marker from bot lines, so a bot credit means Polish
+   invented one). Grep: `grep -nE '@github-actions|@dependabot|@[Cc]opilot|apps/copilot|\[bot\]' <version>.md`.
 
 5. **product-only** — No bullet describes an `[internal]` PR (CI/build, `.agents/**` skills,
    workflows, docs-site, PR-staging, milestone automation, tests, samples). The one collapse

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -838,9 +838,11 @@ fixed here.
    above is only the tie-breaker for a mis-tagged `[product]`/`[internal]` line. Moving the
    classification out of the LLM is what makes product-focus reliable run-to-run instead of a
    judgment loop over every PR.
-2. **Highlights are a hook, not a summary — a hard cap.** At most **~80 words** and two or three
-   short sentences, no matter how big the release, naming only the three or four biggest items —
-   the engine jump, the headline feature, the fact that there are breaking changes to review.
+2. **Highlights are a hook, not a summary — a hard cap, under a mandatory heading.** The section
+   always exists under the literal `## Highlights` heading (never a bare unlabelled lead
+   paragraph); its body targets **~80 words and never exceeds 100**, in two or three short
+   sentences, no matter how big the release, naming only the three or four biggest items — the
+   engine jump, the headline feature, the fact that there are breaking changes to review.
    Highlights are a hook, not a table of contents: the categories below carry the full list and
    the contributor table carries the credits, so Highlights never enumerate APIs, dependency
    bumps, or fixes, never list contributors one by one (at most one standout handle), and never

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -803,6 +803,14 @@ fixed here.
    security, a CVE, performance, or an API name** (a change to the `security-audit` skill is not
    a library security fix). Native-dependency bumps and native build flags that ship in the
    binary (e.g. Spectre mitigation, new RIDs/TFMs) stay; the package's own version bump does not.
+   **This decision is made deterministically in Prepare, not left to per-PR judgment in Polish:**
+   `generate-release-notes.py` tags every raw-data PR line **`[product]`** or **`[internal]`**
+   by the files it changed — a PR touching anything under `binding/`, `native/`, `externals/`, or
+   `source/` ships (`[product]`); everything else is `[internal]` (a mixed PR counts as
+   `[product]`, so we under-drop rather than hide a real change). Polish **drops `[internal]`**
+   and rolls it into the one collapse line, and writes up **`[product]`**; the prose test above
+   is only the tie-breaker for a mis-tagged line. Moving the classification out of the LLM is
+   what makes product-focus reliable run-to-run instead of a judgment loop over every PR.
 2. **Highlights are short and impact-first — a hard cap.** At most two or three sentences, no
    matter how big the release, naming only the three or four biggest / coolest items — the
    engine jump, the headline feature, a breaking change users must know about. Highlights are a

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -820,13 +820,24 @@ fixed here.
    a library security fix). Native-dependency bumps and native build flags that ship in the
    binary (e.g. Spectre mitigation, new RIDs/TFMs) stay; the package's own version bump does not.
    **This decision is made deterministically in Prepare, not left to per-PR judgment in Polish:**
-   `generate-release-notes.py` tags every raw-data PR line **`[product]`** or **`[internal]`**
-   by the files it changed — a PR touching anything under `binding/`, `native/`, `externals/`, or
-   `source/` ships (`[product]`); everything else is `[internal]` (a mixed PR counts as
-   `[product]`, so we under-drop rather than hide a real change). Polish **drops `[internal]`**
-   and rolls it into the one collapse line, and writes up **`[product]`**; the prose test above
-   is only the tie-breaker for a mis-tagged line. Moving the classification out of the LLM is
-   what makes product-focus reliable run-to-run instead of a judgment loop over every PR.
+   `generate-release-notes.py` tags every raw-data PR line **`[product]`**, **`[mixed]`**, or
+   **`[internal]`** by the files it changed:
+   - **`[product]`** — touches shipped code (`binding/`, `externals/`, `source/`). Written up.
+   - **`[internal]`** — touches none of those (CI, workflows, agent skills, docs site, tests,
+     samples, build/meta). Dropped into the one collapse line.
+   - **`[mixed]`** — touches only build config (`native/`): it may change the shipped binary via a
+     compile flag (a rasteriser define, a delay-load fix) or be pure infra (a Docker image, an SDK
+     pin). Polish takes a best guess **from the title/context already in the raw-data block — it
+     does not open the PR** — surfacing it only when it plausibly changes what ships, otherwise
+     folding it into the collapse line.
+
+   `native/` is deliberately **not** treated as shipped code: it is build configuration, and the
+   thing that actually ships is `externals/skia/`. This is why a native compile-flag fix lands as
+   `[mixed]` (inspect-and-usually-surface) rather than being hidden or blindly surfaced. Polish
+   **drops `[internal]`**, writes up **`[product]`**, and inspects **`[mixed]`**; the prose test
+   above is only the tie-breaker for a mis-tagged `[product]`/`[internal]` line. Moving the
+   classification out of the LLM is what makes product-focus reliable run-to-run instead of a
+   judgment loop over every PR.
 2. **Highlights are short and impact-first — a hard cap.** At most two or three sentences, no
    matter how big the release, naming only the three or four biggest / coolest items — the
    engine jump, the headline feature, a breaking change users must know about. Highlights are a
@@ -842,7 +853,14 @@ fixed here.
    `## Community Contributors ❤️` table has two columns: the **Contributor** cell is a plain
    `[@user](url)` with no ❤️ (the heart is only on the inline bullets — in the table it wraps
    badly), and the **What They Did** cell is a short prose summary of their work, not a bare
-   list of PR numbers.
+   list of PR numbers. **The table is roster-driven, not reconstructed from the body.** Prepare
+   emits an authoritative **`contributors:`** roster in the raw-data block — every distinct
+   external (non-maintainer, non-bot) author with their PR numbers — and Polish renders **exactly
+   one row per roster entry, never omitting one**. Building the table by hand from the prose
+   silently dropped real contributors whose PRs were folded into thematic bullets (e.g. a headline
+   external author of a multi-PR feature); the deterministic roster removes that failure mode.
+   Bot accounts (`github-actions[bot]`, `Copilot`, `dependabot`, any `*[bot]`) are excluded from
+   the roster and never credited.
 
 #### API-diff link rule
 

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -291,9 +291,11 @@ know the individual commands:
 
 ```
 .agents/skills/release-notes/
-  SKILL.md                       the AI's polish-only instructions (§4.4)
+  SKILL.md                       the AI's polish instructions — a router (§4.4)
   references/
     TEMPLATE.md                  the page-structure/tone example the polish follows (§4.4)
+    grouping.md                  how to merge related PRs into a few thematic bullets
+    review-checklist.md          the 12-point self-review the agent runs before saving
   scripts/
     generate.sh                  wrapper: runs Path 1 then Path 2 in order, verbose,
                                  and writes the Files-to-polish list to a file (§2.2)

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -838,12 +838,16 @@ fixed here.
    above is only the tie-breaker for a mis-tagged `[product]`/`[internal]` line. Moving the
    classification out of the LLM is what makes product-focus reliable run-to-run instead of a
    judgment loop over every PR.
-2. **Highlights are short and impact-first — a hard cap.** At most two or three sentences, no
-   matter how big the release, naming only the three or four biggest / coolest items — the
-   engine jump, the headline feature, a breaking change users must know about. Highlights are a
-   hook, not a table of contents: the categories below carry the full list, so they never
-   enumerate dependency bumps, individual fixes, or every new API. The bigger the release, the
-   more *selective* Highlights get — not longer.
+2. **Highlights are a hook, not a summary — a hard cap.** At most **~80 words** and two or three
+   short sentences, no matter how big the release, naming only the three or four biggest items —
+   the engine jump, the headline feature, the fact that there are breaking changes to review.
+   Highlights are a hook, not a table of contents: the categories below carry the full list and
+   the contributor table carries the credits, so Highlights never enumerate APIs, dependency
+   bumps, or fixes, never list contributors one by one (at most one standout handle), and never
+   fall back to a "Compared to X: A, B, C, …" comma-run — that enumeration is exactly what the
+   cap exists to prevent. The bigger the release, the more *selective* Highlights get — not
+   longer. A word cap (not just a sentence count) is the enforceable form of this rule, because a
+   sentence count alone is gamed by long comma-run sentences.
 3. **Attribution is linked, and the maintainer is not credited.** Every `@handle` in the
    rendered body is a Markdown link (`[@user](https://github.com/user)`) — never a bare
    `@handle`, and never the raw-data block's `by @user` phrasing carried through into the

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -785,6 +785,41 @@ A maintainer then fixes the *script* (and this spec), never the output. See
 `.agents/skills/release-notes/references/TEMPLATE.md` (a skill reference asset,
 co-located with the skill and outside the published docs).
 
+#### Prose principles (what the AI polishes toward)
+
+The script decides *what pages exist and how they link*; these principles govern the *prose
+the AI writes inside them*. They exist so the notes read like a **product changelog, not a
+repository activity log**. The operational detail lives in `SKILL.md`; the principles are
+fixed here.
+
+1. **Write for the consumer, not the contributor — product over project.** The test for every
+   PR is whether the **shipped SkiaSharp/HarfBuzzSharp library** — its public API, runtime
+   behavior, native binary, or NuGet package — changed for a consumer. If only a **repo
+   process** changed it is **not** release-notes material and is dropped (or, when there is a lot
+   of it, collapsed into a single trailing line): CI/build pipelines and caching, GitHub
+   Actions/workflows, the project's own agent skills (`security-audit`, `ci-status`, the
+   release-notes/docs tooling), the docs website, PR-staging, sample-publishing pipelines,
+   milestone/label automation, and test-infra migrations — **even when the PR title mentions
+   security, a CVE, performance, or an API name** (a change to the `security-audit` skill is not
+   a library security fix). Native-dependency bumps and native build flags that ship in the
+   binary (e.g. Spectre mitigation, new RIDs/TFMs) stay; the package's own version bump does not.
+2. **Highlights are short and impact-first — a hard cap.** At most two or three sentences, no
+   matter how big the release, naming only the three or four biggest / coolest items — the
+   engine jump, the headline feature, a breaking change users must know about. Highlights are a
+   hook, not a table of contents: the categories below carry the full list, so they never
+   enumerate dependency bumps, individual fixes, or every new API. The bigger the release, the
+   more *selective* Highlights get — not longer.
+3. **Attribution is linked, and the maintainer is not credited.** Every `@handle` in the
+   rendered body is a Markdown link (`[@user](https://github.com/user)`) — never a bare
+   `@handle`, and never the raw-data block's `by @user` phrasing carried through into the
+   prose. Community contributors (anyone other than the maintainer) are credited with a
+   `❤️ [@user](url)` immediately before the PR link **on their inline category bullet**; the
+   maintainer's own PRs carry just the `([#NNN](url))` link with no attribution. The
+   `## Community Contributors ❤️` table has two columns: the **Contributor** cell is a plain
+   `[@user](url)` with no ❤️ (the heart is only on the inline bullets — in the table it wraps
+   badly), and the **What They Did** cell is a short prose summary of their work, not a bare
+   list of PR numbers.
+
 #### API-diff link rule
 
 **The API-diff links are required, fixed, and non-AI.** Every emitted page **whose line has

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -952,6 +952,7 @@ All of this is deterministic and script-owned.
 Always the full, idempotent pass: fetch `main` + every `release/*`, regenerate each
 line's raw-data block (§4.3), prune orphaned `-unreleased` pages (§4.2), and **write only files
 whose content key changed** — the key compares PR count, diff range, the
+**raw-data format version** (the `format:` field — see below), the
 supersession metadata (`status`, `superseded_by`, `supersedes`), the **script-owned
 API-changes link** (whether this line has an API-diff folder, its HarfBuzz co-release
 mapping, and — for a HarfBuzz page — its canonical SkiaSharp back-link target, §4.4),
@@ -967,6 +968,18 @@ refresh forces no spurious re-polish. Then regenerate `TOC.yml` +
 Polish phase reads (§2.3) — names only genuinely-changed pages, so the AI never
 re-polishes an up-to-date page. When it is empty and the tree is unchanged, the workflow
 opens no PR (§2.3).
+
+**The `format:` field rolls out raw-data changes.** The content key above detects *data*
+changes (a new PR, a supersession toggle, a companion edit) but not changes to the raw-data
+block's own **structure or embedded Polish instructions** — e.g. adding a `[mixed]` tag or the
+contributor roster. Without a signal for that, a quiet line (a stable/RC page with no new PRs)
+would keep its old-format page indefinitely, re-polished on the old instructions only when its
+next PR happens to land. The `format:` field is a single integer the generator stamps into every
+raw-data block and folds into the content key: an existing page whose `format:` is missing (a
+page from before the field existed) or lower than the generator's current version is considered
+changed and rewritten, so **one `--all` run rolls a new format out to every page at once and then
+settles back to idempotent**. Bump it (`_RAWDATA_FORMAT_VERSION` in `generate-release-notes.py`)
+whenever the raw-data block's shape or its Polish directions change materially.
 
 ### 4.7 Manual additions & breaking-change summaries (companion files)
 

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -196,6 +196,20 @@ share the resulting line set** for that family:
 Within each family the release-notes page set and the API-diff line set therefore
 cover exactly the same lines.
 
+**History floor (a performance skip, not a rule change).** The top-level
+`history_floor` block in `versions.json` optionally sets a per-family minimum line core
+(e.g. `{"skiasharp": "3.0.0"}`). A line **below** the floor is not regenerated and not
+re-emitted, so a full regeneration skips the obsolete back-catalogue (every 1.x/2.x
+line) it would otherwise rebuild from the NuGet feed on every run. It is **not** a
+deletion: pages and API-diff folders already committed below the floor are left exactly
+as they are — the Cake engine skips *clearing* them symmetrically with skipping their
+*emission*, so a floored run never wipes history, it just doesn't rebuild it. Baselines
+are unaffected: a floored line can still be downloaded as a `compare_to` baseline (e.g.
+`3.116.0` still diffs against `2.88.9`). Absent/empty block ⇒ no floor (every line is
+regenerated, the legacy behavior). Raise the floor as old lines stop needing refreshes;
+lower or remove it to rebuild history. Both engines read the same block, so their line
+sets stay identical above the floor.
+
 ### 1.5 Two parallel version families (SkiaSharp & HarfBuzzSharp)
 
 SkiaSharp and HarfBuzzSharp ship together (HarfBuzz never releases on its own) but

--- a/scripts/infra/docs/api-diff-tools.cake
+++ b/scripts/infra/docs/api-diff-tools.cake
@@ -477,6 +477,35 @@ JArray LoadVersionsConfig (string family = "skiasharp")
     return result;
 }
 
+// The optional per-family "history floor" (spec §1.4): a minimum line core below
+// which no API diff is emitted AND whose already-committed folders are not cleared,
+// so a full regen skips the obsolete back-catalogue (e.g. every 1.x/2.x line) it
+// would otherwise download from the feed and diff on each run. It is a performance
+// skip, not a delete — history stays committed, it is simply not rebuilt. Read from
+// the top-level "history_floor" block in versions.json, keyed by family. Returns
+// null (no floor) when unset.
+string HistoryFloor (string family = "skiasharp")
+{
+    var path = $"{ROOT_PATH}/scripts/infra/docs/versions.json";
+    if (!FileExists (path))
+        return null;
+    var doc = JObject.Parse (System.IO.File.ReadAllText (path));
+    var block = doc ["history_floor"] as JObject;
+    var val = block? [family];
+    var s = val == null ? null : (string)val;
+    return string.IsNullOrEmpty (s) ? null : s;
+}
+
+// True when a version's line core sorts below the family's history floor (spec
+// §1.4). Always false when no floor is configured, so default behavior is unchanged.
+bool IsBelowHistoryFloor (string normalizedVersion, string family = "skiasharp")
+{
+    var floor = HistoryFloor (family);
+    if (string.IsNullOrEmpty (floor))
+        return false;
+    return new NuGetVersion (normalizedVersion).CompareTo (new NuGetVersion (floor)) < 0;
+}
+
 // A "superseded" version is one that was previewed but never shipped stable
 // (e.g. 4.147 was abandoned in favour of 4.148). Its ONLY effect is on baseline
 // selection: it is excluded from acting as a *baseline* for other versions, so a

--- a/scripts/infra/docs/api-diff.cake
+++ b/scripts/infra/docs/api-diff.cake
@@ -200,6 +200,7 @@ Task ("docs-api-diff-past")
 
         var isHarfBuzz = IsHarfBuzzFamily (id);
         var versionsConfig = isHarfBuzz ? hbConfig : skiaConfig;
+        var family = isHarfBuzz ? "harfbuzzsharp" : "skiasharp";
 
         Information ($"Comparing the assemblies in '{id}'...");
 
@@ -239,11 +240,15 @@ Task ("docs-api-diff-past")
         //      drop the line's own page — a shipped preview still needs its diff; or
         //   3. it is a preview-only line ahead of the last stable (active dev line).
         // Any other preview-only line (old, never shipped, not listed) is dropped.
+        // The history floor (spec §1.4) then removes any line below the configured
+        // minimum — the obsolete back-catalogue whose committed folders we keep but
+        // do not rebuild (ClearOwnedApiDiffFolders skips them symmetrically).
         var emit = lines
             .Where (l => !l.rep.IsPrerelease
                 || IsVersionListed (versionsConfig, l.rep.ToNormalizedString ())
                 || latestStable == null
                 || l.rep.CompareTo (latestStable) > 0)
+            .Where (l => !IsBelowHistoryFloor (l.key, family))
             .ToList ();
 
         for (var idx = 0; idx < emit.Count; idx++) {
@@ -379,7 +384,9 @@ void ClearOwnedApiDiffFolders ()
             // line folder individually.
             foreach (var lineDir in GetSubDirectories (dir)) {
                 var lineKey = lineDir.GetDirectoryName ();
-                if (lineKey.Length > 0 && char.IsDigit (lineKey [0]))
+                // History floor (spec §1.4): keep committed obsolete folders intact.
+                if (lineKey.Length > 0 && char.IsDigit (lineKey [0])
+                        && !IsBelowHistoryFloor (lineKey, "harfbuzzsharp"))
                     ClearGeneratedApiDiffsIn (lineDir.FullPath);
             }
             DeleteEmptyDirectories (dir.FullPath);
@@ -387,7 +394,11 @@ void ClearOwnedApiDiffFolders ()
         }
 
         // SkiaSharp family: a line folder is a top-level directory named by a version core.
-        if (name.Length > 0 && char.IsDigit (name [0])) {
+        // A folder below the history floor (spec §1.4) is left exactly as committed —
+        // not cleared here and not re-emitted above — so the obsolete back-catalogue
+        // survives a floored regen instead of being wiped.
+        if (name.Length > 0 && char.IsDigit (name [0])
+                && !IsBelowHistoryFloor (name, "skiasharp")) {
             ClearGeneratedApiDiffsIn (dir.FullPath);
             DeleteEmptyDirectories (dir.FullPath);
         }

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -1652,20 +1652,67 @@ def determine_diff_range(branch):
     return base_sha, "origin/{}".format(branch), version
 
 
-# A PR is "product" if it touches any file that ships in a package (and thus can
-# change a consumer's compiled app); otherwise it is "internal" (repo process: CI,
-# workflows, agent skills, the docs site, tests, samples, build/meta files). Mixed
-# PRs count as product — we would rather under-drop than hide a real change (the
-# Polish AI's "one test", §4.4, is the tie-breaker). Emitting this tag on every
-# raw-data PR line lets Polish drop internal work by a lexical filter instead of
-# re-judging every PR from its title each run (the source of the leak variance).
-_PRODUCT_PATH_PREFIXES = ("binding/", "native/", "externals/", "source/")
+# Each PR is classified product / mixed / internal by the files it touched, so Polish
+# can FOCUS on product, INSPECT mixed, and MENTION internal (§4.4) — a lexical filter
+# instead of re-judging every PR from its title each run (the source of leak variance).
+#
+#   product  — touches SHIPPED code (managed API, native code, Views). A real change a
+#              consumer can see. Companion test/benchmark/generated files are ignored.
+#   mixed    — touches only BUILD config (native/): may change the shipped binary via a
+#              compile define (e.g. a rasteriser flag), or may be pure infra (Docker
+#              image, SDK pin). Polish guesses from the title/context in the raw-data
+#              block (it does not open the PR) — surface a behaviour change, drop pure infra.
+#   internal — touches NEITHER: a pure repository process (CI, workflows, agent skills,
+#              docs site, tests, samples, build/meta files). Dropped into the collapse line.
+_SHIP_PATH_PREFIXES = ("binding/", "externals/", "source/")
+_BUILD_PATH_PREFIXES = ("native/",)
 
 
-def _pr_is_internal(files):
-    # type: (set) -> bool
-    """True when NONE of the touched files ship in a package (§4.4 product test)."""
-    return not any(f.startswith(_PRODUCT_PATH_PREFIXES) for f in files)
+def _pr_category(files):
+    # type: (set) -> str
+    """Classify a PR ``product`` / ``mixed`` / ``internal`` by touched files (§4.4)."""
+    if any(f.startswith(_SHIP_PATH_PREFIXES) for f in files):
+        return "product"
+    if any(f.startswith(_BUILD_PATH_PREFIXES) for f in files):
+        return "mixed"
+    return "internal"
+
+
+# Automation accounts — never credited as human contributors (§4.5). The workflow
+# already skips these when authoring, but the raw data still records them (they open
+# release-notes and bump PRs), so Polish must exclude them from the contributor table.
+_BOT_LOGINS = frozenset({"github-actions[bot]", "github-actions", "copilot", "dependabot"})
+
+
+def _is_bot_login(login):
+    # type: (Optional[str]) -> bool
+    """True for automation accounts (exact match or any ``[bot]`` suffix)."""
+    if not login:
+        return False
+    low = login.lower()
+    return low in _BOT_LOGINS or low.endswith("[bot]")
+
+
+def _contributor_roster(prs):
+    # type: (list) -> list
+    """Authoritative external-contributor roster for the credits table (§4.5).
+
+    Returns ``[(login, [pr_number, ...]), ...]`` for every distinct non-maintainer,
+    non-bot author with a *linkable* login, ordered by PR count (most first) then
+    login. Polish renders EXACTLY one table row per entry and never omits one — the
+    old ad-hoc reconstruction from the body prose silently dropped real contributors
+    (e.g. a headline author whose PRs were folded into a thematic bullet). Authors
+    with no resolvable login are excluded because they cannot be safely @-linked.
+    """
+    by_login = {}  # type: dict
+    for pr in prs:
+        login = (pr.get("author") or {}).get("login")
+        if not login or login == "mattleibow" or _is_bot_login(login):
+            continue
+        by_login.setdefault(login, []).append(pr.get("number"))
+    roster = [(login, sorted(n for n in nums if n)) for login, nums in by_login.items()]
+    roster.sort(key=lambda e: (-len(e[1]), e[0].lower()))
+    return roster
 
 
 def _files_by_commit(from_ref, to_ref):
@@ -1774,7 +1821,7 @@ def get_prs_from_diff(from_ref, to_ref, paths=None):
             "body": body,
             "commit": commit_hash,
             "skiaPr": skia_pr,
-            "internal": _pr_is_internal(files_by.get(commit_hash, set())),
+            "category": _pr_category(files_by.get(commit_hash, set())),
         })
 
     return prs
@@ -1798,9 +1845,12 @@ def _format_pr_bullet(pr):
     skia_pr = pr.get("skiaPr")
     skia_str = " (skia: mono/skia#{})".format(skia_pr) if skia_pr else ""
     by = "by @{}".format(login) if login else "by {}".format(name)
-    # Deterministic product/internal tag (§4.4). Polish drops [internal] lines and
-    # collapses them into one trailing line; [product] lines are what it writes up.
-    tag = "[internal] " if pr.get("internal") else "[product] "
+    # Deterministic product / mixed / internal tag (§4.4). Polish writes up [product],
+    # collapses [internal] into one trailing line, and for [mixed] takes a best guess
+    # from the title/context here (no need to open the PR) — surface a behaviour change,
+    # drop pure build/infra.
+    cat = pr.get("category", "product")
+    tag = "[{}] ".format(cat)
     return "{}{} {} in {}{}{}".format(tag, title, by, url, community_str, skia_str)
 
 
@@ -1855,9 +1905,14 @@ def format_pr_list(prs, metadata):
         "  branch:    {}".format(metadata["branch"]),
         "  diff:      {}..{}".format(metadata["from"], metadata["to"]),
         "  prs:       {}".format(len(prs)),
-        "  internal:  {} of {} PRs are [internal] — DROP them (roll into one trailing "
-        "\"Plus various … internal tooling improvements.\" line); write up only [product]".format(
-            sum(1 for p in prs if p.get("internal")), len(prs)),
+        "  tags:      {} [product] · {} [mixed] · {} [internal] of {} PRs".format(
+            sum(1 for p in prs if p.get("category") == "product"),
+            sum(1 for p in prs if p.get("category") == "mixed"),
+            sum(1 for p in prs if p.get("category") == "internal"),
+            len(prs)),
+        "  legend:    [product] = write up · [internal] = DROP (roll into one trailing "
+        "\"Plus various … internal tooling improvements.\" line) · [mixed] = build/infra: "
+        "guess from the title here — surface a behaviour change, otherwise drop",
         "  api:       {}".format(api_sig),
         "",
     ]
@@ -1916,15 +1971,36 @@ def format_pr_list(prs, metadata):
         lines.insert(insert_at, extra)
         insert_at += 1
 
+    # Authoritative contributor roster (§4.5): the exact set of external, non-bot
+    # authors to credit. Rendered here so Polish builds the credits table from a
+    # deterministic list instead of reconstructing it from body prose (which kept
+    # dropping real contributors). One table row per entry, none omitted.
+    roster = _contributor_roster(prs)
+    if roster:
+        roster_block = [
+            "  contributors: {} external contributor(s) — render EXACTLY one credits-table "
+            "row each (§4.5), never omit one; summarize each one's PRs (found by "
+            "\"by @login\" below) and link the PR numbers:".format(len(roster)),
+        ]
+        for login, nums in roster:
+            roster_block.append("    @{}  ({} PR{}): {}".format(
+                login, len(nums), "" if len(nums) == 1 else "s",
+                " ".join("#{}".format(n) for n in nums)))
+        insert_at = len(lines) - 1
+        for extra in roster_block:
+            lines.insert(insert_at, extra)
+            insert_at += 1
+
     if not prs:
         lines.append("  *No changes found.*")
     else:
-        # Each PR line is tagged [product] or [internal] (§4.4). Remind the AI in
-        # context so the drop/keep decision is a lexical filter, not a re-judgment.
-        lines.append("  Each PR is tagged [product] (write it up, categorized) or "
-                     "[internal] (DROP — never a bullet each; roll ALL of them into one")
-        lines.append('  trailing "Plus various CI, documentation, and internal tooling '
-                     'improvements." line, or omit it when there are none).')
+        # Each PR line is tagged [product] / [mixed] / [internal] (§4.4). Remind the
+        # AI in context so keep/inspect/drop is a lexical filter, not a re-judgment.
+        lines.append("  Each PR is tagged [product] (write it up, categorized), "
+                     "[mixed] (build/infra — guess from the title: surface a behaviour")
+        lines.append('  change, otherwise drop) or [internal] (DROP — never a bullet each; '
+                     'roll ALL into one trailing "Plus various … internal tooling')
+        lines.append('  improvements." line, or omit it when there are none).')
         # When the page rolls up tagged previews, group the PRs into per-preview
         # buckets (each PR under the preview it first shipped in) so the AI can
         # write a concrete "## Preview N" section per milestone AND merge the

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -528,6 +528,15 @@ def _is_content_unchanged(output_path, new_prs_count, new_diff_range,
     if int(m_prs.group(1)) != new_prs_count or m_diff.group(1) != new_diff_range:
         return False
 
+    # format: <n> — the raw-data FORMAT VERSION (§4.6). An existing page written by
+    # an older generator either lacks this line or carries a lower number; either way
+    # its raw-data block predates the current structure/instructions, so it must be
+    # rewritten even though its PR set is unchanged. Absent => treat as 0 (mismatch).
+    m_fmt = re.search(r"^\s*format:\s*(\d+)", content, re.MULTILINE)
+    existing_fmt = int(m_fmt.group(1)) if m_fmt else 0
+    if existing_fmt != _RAWDATA_FORMAT_VERSION:
+        return False
+
     # status: only compare when the caller supplies the new value.
     if new_status is not None:
         m_status = re.search(r"^\s*status:\s*(\S+)", content, re.MULTILINE)
@@ -1884,6 +1893,18 @@ def _release_date_display(version):
     return "{} {}, {}".format(datetime(y, m, 1).strftime("%B"), d, y)
 
 
+# Raw-data block FORMAT VERSION — part of the content key (§4.6). `_is_content_unchanged`
+# compares this against the `format:` line in the existing page; a mismatch (or an older
+# page with no `format:` line) forces a rewrite even when the PR set and diff range are
+# unchanged. BUMP THIS whenever the raw-data block's structure or the Polish instructions
+# embedded in it change materially, so a single `--all` run rolls the new format out to
+# every otherwise-quiet page (e.g. a stable line with no new PRs) instead of leaving it
+# stranded on the old format until its next PR lands.
+#   1 — original (binary [product]/[internal] tag, no contributor roster)
+#   2 — three-way [product]/[mixed]/[internal] tag + authoritative contributor roster
+_RAWDATA_FORMAT_VERSION = 2
+
+
 def format_pr_list(prs, metadata):
     # type: (list[dict], dict) -> str
     """Format the PR list as markdown with raw data in an HTML comment.
@@ -1907,6 +1928,7 @@ def format_pr_list(prs, metadata):
         "  version:   {}".format(version),
         "  status:    {}".format(metadata["status"]),
         "  branch:    {}".format(metadata["branch"]),
+        "  format:    {}".format(_RAWDATA_FORMAT_VERSION),
         "  diff:      {}..{}".format(metadata["from"], metadata["to"]),
         "  prs:       {}".format(len(prs)),
         "  tags:      {} [product] · {} [mixed] · {} [internal] of {} PRs".format(

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -1764,6 +1764,32 @@ def _format_pr_bullet(pr):
     return "{}{} {} in {}{}{}".format(tag, title, by, url, community_str, skia_str)
 
 
+def _release_date_display(version):
+    # type: (str) -> Optional[str]
+    """Human release date (e.g. 'December 3, 2024') from the ``vX.Y.Z`` tag, or None.
+
+    Used to fill the stable-page banner's ``Released <date>`` field deterministically
+    so Polish never has to guess it. Prefers the tag's creator date (annotated tag);
+    falls back to the tagged commit's date; returns None if the tag is not present.
+    """
+    tag = "v{}".format(version)
+    out = ""
+    try:
+        out = run(["git", "for-each-ref", "--format=%(creatordate:short)",
+                   "refs/tags/{}".format(tag)]).strip()
+    except Exception:
+        out = ""
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", out):
+        try:
+            out = run(["git", "log", "-1", "--format=%cs", tag]).strip()
+        except Exception:
+            out = ""
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", out):
+        return None
+    y, m, d = (int(x) for x in out.split("-"))
+    return "{} {}, {}".format(datetime(y, m, 1).strftime("%B"), d, y)
+
+
 def format_pr_list(prs, metadata):
     # type: (list[dict], dict) -> str
     """Format the PR list as markdown with raw data in an HTML comment.
@@ -1799,6 +1825,10 @@ def format_pr_list(prs, metadata):
     superseded_by = metadata.get("superseded_by")
     supersedes = metadata.get("supersedes")
     meta_extra = []
+    if metadata.get("status") == "stable":
+        rd = _release_date_display(version)
+        if rd:
+            meta_extra.append("  released:   {} (use verbatim in the banner)".format(rd))
     if superseded_by:
         meta_extra.append(
             "  superseded: {} (preview only, never released as stable)".format(

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -266,6 +266,46 @@ def load_support_config():
     return _SUPPORT_CONFIG
 
 
+# History floor (spec §1.4) — an optional per-family minimum line core below which
+# NO page is regenerated and NO API diff is emitted, so a full ``--all`` run skips
+# the obsolete back-catalogue (e.g. every 1.x/2.x line) it would otherwise rebuild
+# from the NuGet feed on each run. It is a PERFORMANCE floor, not a delete: pages
+# and API-diff folders already committed below the floor are left untouched (the
+# Cake engine likewise skips clearing them), so history stays intact — it is simply
+# not rebuilt. Absent/empty ``history_floor`` block => no floor (legacy behavior:
+# every line is regenerated). Read from the top-level ``history_floor`` block in
+# versions.json, keyed by family (spec §1.5): ``{"skiasharp": "3.0.0"}``.
+_HISTORY_FLOOR = None  # type: Optional[dict]
+
+
+def history_floor(family="skiasharp"):
+    # type: (str) -> Optional[str]
+    """The configured minimum line core for ``family``, or None when unset."""
+    global _HISTORY_FLOOR
+    if _HISTORY_FLOOR is None:
+        _HISTORY_FLOOR = {}
+        if VERSIONS_JSON_PATH.exists():
+            with open(VERSIONS_JSON_PATH) as f:
+                block = json.load(f).get("history_floor") or {}
+            if isinstance(block, dict):
+                _HISTORY_FLOOR = {
+                    k: v for k, v in block.items() if isinstance(v, str) and v}
+    return _HISTORY_FLOOR.get(family)
+
+
+def is_below_history_floor(version, family="skiasharp"):
+    # type: (str, str) -> bool
+    """True when ``version``'s line core sorts below the family's history floor.
+
+    Used to skip regenerating obsolete back-catalogue pages (spec §1.4). With no
+    floor configured this is always False, so every line is processed as before.
+    """
+    floor = history_floor(family)
+    if not floor:
+        return False
+    return _core_tuple(version) < _core_tuple(floor)
+
+
 def classify_support_tier(group, support=None):
     # type: (str, Optional[dict]) -> str
     """Classify a minor group ("3.119") into a TOC/index support tier (spec §3.5).
@@ -2721,6 +2761,15 @@ def _write_page(branch, all_branches, verbose=False, force=False):
             branch, e), file=sys.stderr)
         return None
 
+    # History floor (spec §1.4): below the configured floor we do not regenerate
+    # the page at all. Its already-committed page (and API-diff folder) stay as
+    # they are — this is a performance skip of the obsolete back-catalogue, not a
+    # delete. No floor configured => never triggers.
+    if is_below_history_floor(version):
+        log("  Skipping {} (below history floor {}).".format(
+            version, history_floor()))
+        return None
+
     from_display = _removeprefix(from_ref, "origin/")
     to_display = _removeprefix(to_ref, "origin/")
     if re.match(r"^[0-9a-f]{7,}$", from_display):
@@ -2940,6 +2989,12 @@ def _write_harfbuzz_page(hb, all_branches, force=False):
     """
     hb_line = hb["hb_line"]
     canonical_skia = hb["canonical_skia"]
+    # History floor (spec §1.4): a HarfBuzz line whose introducing SkiaSharp
+    # release is below the SkiaSharp floor — or which is itself below a HarfBuzz
+    # floor — is left as committed and not regenerated.
+    if (is_below_history_floor(canonical_skia, "skiasharp")
+            or is_below_history_floor(hb_line, "harfbuzzsharp")):
+        return None, None
     hb_dir = RELEASES_DIR / "harfbuzzsharp"
     # A HarfBuzz line is "published" (released) exactly when the API-diff
     # engine emitted its diff folder; otherwise it is in-flight (spec §3.4/§4.5).

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -1612,6 +1612,43 @@ def determine_diff_range(branch):
     return base_sha, "origin/{}".format(branch), version
 
 
+# A PR is "product" if it touches any file that ships in a package (and thus can
+# change a consumer's compiled app); otherwise it is "internal" (repo process: CI,
+# workflows, agent skills, the docs site, tests, samples, build/meta files). Mixed
+# PRs count as product — we would rather under-drop than hide a real change (the
+# Polish AI's "one test", §4.4, is the tie-breaker). Emitting this tag on every
+# raw-data PR line lets Polish drop internal work by a lexical filter instead of
+# re-judging every PR from its title each run (the source of the leak variance).
+_PRODUCT_PATH_PREFIXES = ("binding/", "native/", "externals/", "source/")
+
+
+def _pr_is_internal(files):
+    # type: (set) -> bool
+    """True when NONE of the touched files ship in a package (§4.4 product test)."""
+    return not any(f.startswith(_PRODUCT_PATH_PREFIXES) for f in files)
+
+
+def _files_by_commit(from_ref, to_ref):
+    # type: (str, str) -> dict
+    """Map each commit hash in ``from_ref..to_ref`` to the set of files it touched.
+
+    One ``git log --name-only`` call (no pathspec filter — we want each PR's FULL
+    file set to classify it product vs internal). A ``\\x1e`` record separator
+    prefixes each hash line so file lines can never be mistaken for a hash.
+    """
+    out = run(["git", "log", "--no-renames", "--name-only",
+               "--format=%x1e%H", "{}..{}".format(from_ref, to_ref)])
+    files_by = {}  # type: dict
+    cur = None
+    for line in out.split("\n"):
+        if line.startswith("\x1e"):
+            cur = line[1:].strip()
+            files_by[cur] = set()
+        elif line.strip() and cur is not None:
+            files_by[cur].add(line.strip())
+    return files_by
+
+
 def get_prs_from_diff(from_ref, to_ref, paths=None):
     # type: (str, str, Optional[list[str]]) -> list[dict]
     """Extract merged PRs from git log between two refs.
@@ -1635,6 +1672,11 @@ def get_prs_from_diff(from_ref, to_ref, paths=None):
         cmd.append("--")
         cmd.extend(paths)
     log = run(cmd)
+
+    # One extra git call gives every commit's full file set, used to tag each PR
+    # product vs internal (§4.4). Unfiltered by ``paths`` on purpose — a PR's
+    # classification depends on everything it changed, not the co-ship subset.
+    files_by = _files_by_commit(from_ref, to_ref)
 
     prs = []
     seen = set()  # type: set[int]
@@ -1692,6 +1734,7 @@ def get_prs_from_diff(from_ref, to_ref, paths=None):
             "body": body,
             "commit": commit_hash,
             "skiaPr": skia_pr,
+            "internal": _pr_is_internal(files_by.get(commit_hash, set())),
         })
 
     return prs
@@ -1715,7 +1758,10 @@ def _format_pr_bullet(pr):
     skia_pr = pr.get("skiaPr")
     skia_str = " (skia: mono/skia#{})".format(skia_pr) if skia_pr else ""
     by = "by @{}".format(login) if login else "by {}".format(name)
-    return "{} {} in {}{}{}".format(title, by, url, community_str, skia_str)
+    # Deterministic product/internal tag (§4.4). Polish drops [internal] lines and
+    # collapses them into one trailing line; [product] lines are what it writes up.
+    tag = "[internal] " if pr.get("internal") else "[product] "
+    return "{}{} {} in {}{}{}".format(tag, title, by, url, community_str, skia_str)
 
 
 def format_pr_list(prs, metadata):
@@ -1743,6 +1789,9 @@ def format_pr_list(prs, metadata):
         "  branch:    {}".format(metadata["branch"]),
         "  diff:      {}..{}".format(metadata["from"], metadata["to"]),
         "  prs:       {}".format(len(prs)),
+        "  internal:  {} of {} PRs are [internal] — DROP them (roll into one trailing "
+        "\"Plus various … internal tooling improvements.\" line); write up only [product]".format(
+            sum(1 for p in prs if p.get("internal")), len(prs)),
         "  api:       {}".format(api_sig),
         "",
     ]
@@ -1800,6 +1849,12 @@ def format_pr_list(prs, metadata):
     if not prs:
         lines.append("  *No changes found.*")
     else:
+        # Each PR line is tagged [product] or [internal] (§4.4). Remind the AI in
+        # context so the drop/keep decision is a lexical filter, not a re-judgment.
+        lines.append("  Each PR is tagged [product] (write it up, categorized) or "
+                     "[internal] (DROP — never a bullet each; roll ALL of them into one")
+        lines.append('  trailing "Plus various CI, documentation, and internal tooling '
+                     'improvements." line, or omit it when there are none).')
         # When the page rolls up tagged previews, group the PRs into per-preview
         # buckets (each PR under the preview it first shipped in) so the AI can
         # write a concrete "## Preview N" section per milestone AND merge the

--- a/scripts/infra/docs/generate-release-notes.py
+++ b/scripts/infra/docs/generate-release-notes.py
@@ -1841,7 +1841,11 @@ def _format_pr_bullet(pr):
     login = author_info.get("login")
     name = author_info.get("name") or "unknown"
     url = pr.get("url", "")
-    community_str = " [community ✨]" if login != "mattleibow" else ""
+    # The community marker invites Polish to credit the author, so it must NOT appear
+    # on bot or maintainer PRs (§4.5): the maintainer is never credited, and bots are
+    # never credited — leaving it on a bot line makes Polish emit a ❤️ @bot bullet.
+    is_community = login and login != "mattleibow" and not _is_bot_login(login)
+    community_str = " [community ✨]" if is_community else ""
     skia_pr = pr.get("skiaPr")
     skia_str = " (skia: mono/skia#{})".format(skia_pr) if skia_pr else ""
     by = "by @{}".format(login) if login else "by {}".format(name)

--- a/scripts/infra/docs/versions.json
+++ b/scripts/infra/docs/versions.json
@@ -10,6 +10,10 @@
       "4.151"
     ]
   },
+  "history_floor": {
+    "$comment": "PERFORMANCE floor (spec §1.4), read by BOTH engines. A per-family minimum line core BELOW which no page is regenerated and no API diff is emitted, so a full '--all' run skips the obsolete back-catalogue it would otherwise rebuild from the NuGet feed every run. It is NOT a delete: pages and API-diff folders already committed below the floor are left exactly as they are (the Cake engine also skips CLEARING them), so history stays intact — it is simply not rebuilt. Baselines are unaffected: a floored line can still be downloaded as a compare_to baseline (e.g. 3.116.0 still diffs against 2.88.9). Absent/empty => no floor (legacy: every line is regenerated). Raise it over time as old lines stop needing refreshes; lower or remove it to rebuild history.",
+    "skiasharp": "3.0.0"
+  },
   "skiasharp": {
     "3.0.0": {
       "status": "superseded",


### PR DESCRIPTION
Overhauls SkiaSharp's release-notes **polish** so the generated pages read like a curated product changelog for NuGet consumers — grouped, correctly attributed, and consistently formatted — while keeping the single-capable-agent model (same as the api-docs writer: no sub-agents). Validated over ~14 CI runs.

## The problems (from maintainer review of real pages)
1. **Exhaustive, not curated** — one bullet per PR (56 bullets on 3.116.0) instead of a few thematic bullets.
2. **Repo-internal churn leaked** into the notes inconsistently (0 one run, 23 the next).
3. **Bare `@username`, bot credits, wrong banner** — `> [NuGet]` instead of a themed/dated banner; contributor table was a bare list of PR numbers.
4. **Slow** — every run rebuilt an API diff for the entire obsolete 1.x/2.x back-catalogue.

## The fixes

**Deterministic product-focus (Python, not AI judgment).** `generate-release-notes.py` tags every raw-data PR line `[product]`/`[internal]` by touched paths; Polish drops `[internal]` into one collapse line. Killed the 0→23 leak variance (now a stable 2–3).

**Curation / grouping** — new `references/grouping.md` teaches the agent to merge related PRs into a few thematic bullets (countable cap: ~4 per category section, Breaking Changes exempt). 3.116.0 went from 56 one-per-PR bullets to ~34 grouped ones — e.g. a single *"`Span<T>` overloads across the surface"* bullet now merges 4 PRs with both contributors credited inline, main-style.

**Banner** (rule 7) — stable pages now render `> **<theme>** · Released <Month D, YYYY> · [NuGet](url) · [GitHub Release](url)`. The date is filled deterministically from the `vX.Y.Z` tag (new `released:` field in the raw data).

**Contributor table** — one line per contributor: prose summary + that person's PR links in one parenthetical, no ❤️ in the cell. **Never credits bots.** Every handle is a `[@user](url)` link.

**History floor** (opt-in, `versions.json` → `history_floor`) — skips regenerating/diffing lines below a per-family minimum (set to `skiasharp: 3.0.0`). Symmetric clear+emit skip in the Cake engine means the committed 1.x/2.x pages and folders are **preserved, not wiped** — just not rebuilt. Cut the polish set from ~29 pages to 8 and skips the slowest part of Prepare.

**Router-style skill + reviewer** — `SKILL.md` is now a router pointing at `references/` (grouping, review-checklist, TEMPLATE), matching the api-docs pattern. New `references/review-checklist.md` is a 12-point rubric the agent self-applies before saving **and** that can be run standalone to grade any finished page.

## Validation (latest run)
On the 8 regenerated pages: **0** bare handles, **0** bot credits, **0** non-conforming banners, **0** missing Breaking headings, **0** ❤️ in contributor cells; grouping evenly distributed (~3–5 bullets/category); 1.x/2.x preserved untouched.

## Files
- `scripts/infra/docs/generate-release-notes.py` — `[product]`/`[internal]` tag, `released:` field, history-floor skip.
- `scripts/infra/docs/api-diff.cake`, `api-diff-tools.cake` — history-floor emit + symmetric clear skip.
- `scripts/infra/docs/versions.json` — `history_floor` block.
- `.agents/skills/release-notes/SKILL.md` — router + reordered rules (product #1, banner #7, grouping #5).
- `.agents/skills/release-notes/references/{grouping,review-checklist}.md` — new.
- `.agents/skills/release-notes/references/TEMPLATE.md` — banner + single-line contributor table.
- `documentation/dev/release-notes-and-api-diffs.md` — §1.4 history floor, §4.4 prose principles.---

### Update: three-way PR tag + deterministic contributor roster (6f1024a)

- **`mixed` tag** — the classifier is now three-way. `native/` is treated as *build config*, not shipped code (the shipped native code is `externals/skia/`). So build-only PRs (Docker migration, SDK pins, ADO caching, devcontainer/Tizen CI) are `[mixed]` instead of leaking as `[product]`, while a native compile-flag fix (e.g. the small-sigma raster-blur regression) is `[mixed]` and surfaced by inspection. For `[mixed]`, Polish **guesses from the title/context in the raw-data block — it does not open the PR.** Real 4.148.0: `42 [product] · 6 [mixed] · 115 [internal]`.
- **Contributor roster** — Prepare now emits an authoritative `contributors:` roster (every distinct non-maintainer, non-bot author + PR numbers); Polish renders exactly one row per entry. Fixes the v4 table dropping community members — 4.148.0 listed only 2 of 5 and omitted **@ramezgerges** (16 PRs). Bots and @mattleibow excluded at source.