### PR TITLE
Add focus_family override to memory-leak-fixer workflow

### DIFF
--- a/.agents/skills/memory-leak-fixer/SKILL.md
+++ b/.agents/skills/memory-leak-fixer/SKILL.md
@@ -94,7 +94,11 @@ Run the phases in order. The skill has two entry points:
 
 ### 1.1 Choose a focus area (round-robin across runs)
 A full 11-family sweep every run is wasteful and the surface is mostly hardened, so start from
-ONE focus family and widen only if it's exhausted. Rotate the *starting* family on a
+ONE focus family and widen only if it's exhausted.
+
+**Override first.** If the run supplies an explicit focus family (a bare number 0–10 — e.g. a
+maintainer testing one family on demand), use that number directly as `FOCUS` and **skip the
+rotation below**. Otherwise rotate the *starting* family on a
 time-based **round-robin** so consecutive runs cover different families. This needs only
 `date`, so it behaves identically locally and in CI — no `$GITHUB_RUN_NUMBER` / `$RANDOM`
 (which don't exist or aren't deterministic outside GitHub Actions):

--- a/.github/workflows/memory-leak-fixer.lock.yml
+++ b/.github/workflows/memory-leak-fixer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"530ccc128b53a8a7cac58035d8646b3b03c74f0b61624221816a7f96b35dedcf","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.8"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9479b6f3e100a822b5a2202c2d58cbf5c91f4a7788827a8c5821937011db232a","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.8"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -69,6 +69,11 @@ name: "Fixer - Memory Leak"
         description: Do the full scan→prove→fix locally but do NOT open a PR/issue.
         required: false
         type: boolean
+      focus_family:
+        default: ""
+        description: Force a specific leak family 0-10 (see references/types-of-leaks.md) instead of the time-based round-robin. Leave blank to rotate.
+        required: false
+        type: string
 
 permissions: {}
 
@@ -199,6 +204,7 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_INPUTS_DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GH_AW_GITHUB_EVENT_INPUTS_FOCUS_FAMILY: ${{ github.event.inputs.focus_family }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
@@ -209,23 +215,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF'
+          cat << 'GH_AW_PROMPT_1b69b3eaace3a8c4_EOF'
           <system>
-          GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF
+          GH_AW_PROMPT_1b69b3eaace3a8c4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF'
+          cat << 'GH_AW_PROMPT_1b69b3eaace3a8c4_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF
+          GH_AW_PROMPT_1b69b3eaace3a8c4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF'
+          cat << 'GH_AW_PROMPT_1b69b3eaace3a8c4_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF
+          GH_AW_PROMPT_1b69b3eaace3a8c4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF'
+          cat << 'GH_AW_PROMPT_1b69b3eaace3a8c4_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,12 +263,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF
+          GH_AW_PROMPT_1b69b3eaace3a8c4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF'
+          cat << 'GH_AW_PROMPT_1b69b3eaace3a8c4_EOF'
           </system>
           {{#runtime-import .github/workflows/memory-leak-fixer.md}}
-          GH_AW_PROMPT_f3b4c6dfdadc92b1_EOF
+          GH_AW_PROMPT_1b69b3eaace3a8c4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -270,6 +276,7 @@ jobs:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_GITHUB_EVENT_INPUTS_DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GH_AW_GITHUB_EVENT_INPUTS_FOCUS_FAMILY: ${{ github.event.inputs.focus_family }}
           GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
         with:
           script: |
@@ -285,6 +292,7 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_INPUTS_DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GH_AW_GITHUB_EVENT_INPUTS_FOCUS_FAMILY: ${{ github.event.inputs.focus_family }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
@@ -308,6 +316,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
                 GH_AW_GITHUB_EVENT_INPUTS_DRY_RUN: process.env.GH_AW_GITHUB_EVENT_INPUTS_DRY_RUN,
+                GH_AW_GITHUB_EVENT_INPUTS_FOCUS_FAMILY: process.env.GH_AW_GITHUB_EVENT_INPUTS_FOCUS_FAMILY,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
                 GH_AW_GITHUB_EVENT_NAME: process.env.GH_AW_GITHUB_EVENT_NAME,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
@@ -465,9 +474,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_75e3faa6d0f7456d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b0dd1747ba89d376_EOF'
           {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1,"title_prefix":"[memory-leak] "},"create_pull_request":{"allowed_base_branches":["main"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"[memory-leak] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_75e3faa6d0f7456d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b0dd1747ba89d376_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -707,7 +716,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_37b454bef4d3683b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_69f5409922e9fb5d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -753,7 +762,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_37b454bef4d3683b_EOF
+          GH_AW_MCP_CONFIG_69f5409922e9fb5d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/memory-leak-fixer.md
+++ b/.github/workflows/memory-leak-fixer.md
@@ -27,8 +27,9 @@ engine:
 
 # -- Triggers ----------------------------------------------------------
 # Every 12h + manual + PR-driven self-test. Every run does the same full
-# scan→prove→fix→file pipeline; the only knob is `dry_run` (do everything but
-# open nothing). A `pull_request` that edits THIS workflow or its skill re-runs
+# scan→prove→fix→file pipeline; the knobs are `dry_run` (do everything but open
+# nothing) and `focus_family` (force one leak family instead of the time-based
+# rotation — for testing a specific family on demand). A `pull_request` that edits THIS workflow or its skill re-runs
 # the whole pipeline in FORCED DRY-RUN (see Step 2.6) so we can iterate on the
 # prompt/skill and watch the run without ever opening a real PR/issue.
 on:
@@ -40,6 +41,11 @@ on:
         required: false
         default: false
         type: boolean
+      focus_family:
+        description: "Force a specific leak family 0-10 (see references/types-of-leaks.md) instead of the time-based round-robin. Leave blank to rotate."
+        required: false
+        default: ""
+        type: string
   pull_request:
     paths:
       - ".github/workflows/memory-leak-fixer.md"
@@ -158,6 +164,12 @@ Read and follow `.agents/skills/memory-leak-fixer/SKILL.md` end-to-end.
 leak, prove it, fix it, then file the finding issue + linked fix PR. There is no per-issue target
 mode. The only variation is dry-run — forced on `pull_request`, opt-in via the `dry_run` input
 (see Guardrail 6).
+
+**Focus family override:** `${{ github.event.inputs.focus_family }}` — if that shows a bare
+number **0–10**, pass it to the skill's Phase 1.1 as the focus family and **skip the round-robin**
+computation. If it is blank (schedule / PR / dispatch without the input), use the normal
+time-based round-robin. This is only a testing knob to target a specific family on demand; it
+changes nothing else about the run.
 
 Persist all intermediate state (the `/tmp/leakprobe` project, notes) under `/tmp/gh-aw/agent/`.
 Each bash call is a fresh subshell — re-`cd` as needed.


### PR DESCRIPTION
## What

Adds an optional `focus_family` `workflow_dispatch` input (0–10, blank = rotate) to the **Fixer - Memory Leak** agentic workflow so a maintainer can force the scan onto one leak family on demand, instead of waiting for the time-based round-robin to drift onto it.

## Why

The first real run ([`28829268499`](https://github.com/mono/SkiaSharp/actions/runs/28829268499)) correctly emitted a `noop`: its round-robin focus landed on **family 1 (Wrong `owns:`)** — a hardened area — so nothing cleared the evidence bar. That's the designed quiet-run outcome, but it also means any *specific* family only gets a deep scan when the clock rotates onto it (~once every 11 hours). There was no way to target a family to exercise the finding‑issue → fix‑PR pairing end‑to‑end.

## How it works

- New `focus_family` input (default `""`). When set to a bare number `0–10`, **Step 1** passes it to the skill's **Phase 1.1**, which now honors an explicit override and **skips** the round-robin.
- When blank (`schedule` / `pull_request` / dispatch without it), the time-based rotation is **unchanged**.
- Independent of `dry_run` — so `focus_family=5 dry_run=false` forces a real run on the finalizer/collection-ordering family (covers the `SKRegion` iterators) to prove the pipeline files a linked issue + PR.

Rendered via the same gh-aw mechanism as the existing `dry_run`/`event_name` expressions (auto-wired `GH_AW_GITHUB_EVENT_INPUTS_FOCUS_FAMILY` env → runtime-imported prompt). Lock recompiled clean (0 errors, 0 warnings).

## Self-test

Opening this PR trips the `pull_request` self-test trigger → a **forced dry-run** of the workflow (focus stays on the round-robin since inputs are blank on PR events), validating the change end-to-end without opening anything real.

Produced with the `pr-commit-message`/workflow tooling; no product code changed (workflow + skill only, ABI-neutral).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>