### PR TITLE
docs: close the version milestone on every release (not just stable)

### DIFF
--- a/.agents/skills/release-publish/SKILL.md
+++ b/.agents/skills/release-publish/SKILL.md
@@ -45,7 +45,7 @@ Publish packages to NuGet.org and finalize releases.
 │  5. Refresh Web Notes    → Dispatch docs workflow (tag→stable flip)│
 │  6. Create GitHub Release→ Generate notes, set prerelease flag     │
 │  7. Customer Teaser      → Extract key bits from the generated log │
-│  8. Close Milestone      → Stable releases only                    │
+│  8. Close Milestone      → Close this version's milestone (all)    │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -58,7 +58,7 @@ Publish packages to NuGet.org and finalize releases.
 | 5. Website notes refresh | Dispatch (usually a no-op) | Dispatch — flips page to **stable** |
 | 6. GitHub Release | `--prerelease` flag | No flag, attach samples |
 | 7. Customer teaser | Breaking + What's New + Fixes (usually short) | + Dependency Updates + contributors |
-| 8. Milestone | Skip | Close milestone |
+| 8. Milestone | Close its milestone (`X.Y.Z-preview.N`) | Close its milestone (`X.Y.Z`) |
 
 ---
 
@@ -333,12 +333,31 @@ example. Process:
 
 ---
 
-## Step 8: Close Milestone (Stable only)
+## Step 8: Close Milestone (Every Release)
 
-**Skip for preview releases.**
+**Required for _every_ release — preview, rc, and stable.** SkiaSharp now creates a
+GitHub milestone for every version in the cadence, so each published version has its
+own milestone that must be closed once that version ships (otherwise it lingers open
+forever). The milestone title is the **exact release version** (no `v` prefix):
+
+| Release type | Milestone to close |
+|--------------|--------------------|
+| Preview | `X.Y.Z-preview.N` (e.g. `4.151.0-preview.1`) |
+| RC | `X.Y.Z-rc.N` (e.g. `4.151.0-rc.1`) |
+| Stable | `X.Y.Z` (e.g. `4.151.0`) |
+
+⚠️ **Move still-open issues forward first.** Never silently close a milestone that
+still has open issues. Reassign any open issues to the next appropriate milestone (the
+next preview/rc, or the stable milestone), or confirm with the user, **before** closing.
 
 ```bash
+# 1. Find the milestone whose title matches the exact release version
 gh api repos/:owner/:repo/milestones --jq '.[] | "\(.number): \(.title)"'
+
+# 2. Check for still-open issues in that milestone (should be empty before closing)
+gh issue list --repo mono/SkiaSharp --milestone "{version}" --state open
+
+# 3. After moving/confirming any open issues, close this version's milestone
 gh api repos/:owner/:repo/milestones/{number} -X PATCH -f state=closed
 ```
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -273,10 +273,8 @@ flowchart TB
     ∙ Mark pre-release if preview
     ∙ Attach samples if stable"]
     
-    RELEASE --> FINAL{Stable release?}
-    FINAL -->|No| DONE([Complete])
-    FINAL -->|Yes| MILESTONE[Close GitHub milestone]
-    MILESTONE --> DONE
+    RELEASE --> MILESTONE[Close this version's GitHub milestone]
+    MILESTONE --> DONE([Complete])
 
     classDef error fill:#ffebee,stroke:#c62828
     classDef endpoint fill:#f3e5f5,stroke:#7b1fa2


### PR DESCRIPTION
## Why

SkiaSharp now creates a GitHub milestone for **every** release in the cadence: `X.Y.Z-preview.N`, `X.Y.Z-rc.N`, and `X.Y.Z` (stable). Previously only stable releases had milestones, so the `release-publish` skill said "close milestone: stable only." That assumption is now **wrong** — every preview/rc has its own milestone that must be closed when that specific version publishes, or it lingers open forever.

A recent example: `4.151.0-preview.1` shipped to NuGet and got a GitHub Release, but its milestone `4.151.0-preview.1` was left **open** because the skill told us to skip milestone-closing for previews.

## What changed

**`.agents/skills/release-publish/SKILL.md`** — fixed all three places that encoded the stale "stable only" assumption:

1. **Workflow Overview box (Step 8):**
   - Before: `8. Close Milestone → Stable releases only`
   - After: `8. Close Milestone → Close this version's milestone (all)`

2. **Preview vs Stable differences table (row 8):**
   - Before: `| 8. Milestone | Skip | Close milestone |`
   - After: `| 8. Milestone | Close its milestone (X.Y.Z-preview.N) | Close its milestone (X.Y.Z) |`

3. **Step 8 section** — retitled to "Close Milestone (Every Release)", added a table mapping each release type to the exact milestone title to close (preview → `X.Y.Z-preview.N`, rc → `X.Y.Z-rc.N`, stable → `X.Y.Z`), kept the guidance to move still-open issues to the next milestone before closing, and added a `gh issue list` check for open issues.

**`documentation/dev/releasing.md`** — the release-flow mermaid diagram had a `Stable release?` decision that only closed the milestone on the `Yes` branch. Now it always closes the version's milestone.

## Constraints honored

- **Documentation/skill fix only** — no milestones were closed. The parent session handles live cleanup.
- Work done on a feature branch; no commits to `main`.

## Related skills checked

The `release-branch` skill's "milestone" references are about the **Skia engine milestone** (C++ version), not GitHub release milestones — left untouched. No other release skill carried the stale "stable only" GitHub-milestone assumption.