### PR TITLE
Teach memory-leak-fixer to use SKObject.Referenced/KeepAliveObjects instead of hand-rolled fields

### DIFF
--- a/.agents/skills/memory-leak-fixer/SKILL.md
+++ b/.agents/skills/memory-leak-fixer/SKILL.md
@@ -252,7 +252,8 @@ instead of pushed and reverted. If any box can't be ticked, **fix it or stand do
 - [ ] The matching focus area's **Watch out (❌ don't):** note in
       [`references/types-of-leaks.md`](references/types-of-leaks.md) does **not** describe
       what you just did (no unconditional same-instance `Dispose`, no blind `owns:` flip, no
-      field nulled before dispose, no pinned `GCHandle` where a plain field suffices, …).
+      field nulled before dispose, no pinned `GCHandle` or hand-rolled keep-alive field/`List<T>`
+      where `SKObject.Referenced(...)` / `KeepAliveObjects` (or a plain field) suffices, …).
 - [ ] This is a real leak with a citable path — not hardened, documented code rationalised
       as a "decoy," and not a finding manufactured to avoid a quiet run.
 - [ ] Not already covered by an open issue/PR (§1.3).

--- a/.agents/skills/memory-leak-fixer/references/types-of-leaks.md
+++ b/.agents/skills/memory-leak-fixer/references/types-of-leaks.md
@@ -294,9 +294,9 @@ may be used to match a class's **existing local convention** — e.g. the `SKReg
 a `private readonly SKRegion` field, so a new sibling there should follow suit rather than mix styles.
 
 For a **set** of rooted children that changes over time (e.g. `SKNWayCanvas.AddCanvas` /
-`RemoveCanvas`), use the dictionary directly instead of a hand-rolled `List<T>`: `Referenced(this,
-child)` to root, and `KeepAliveObjects.TryRemove(child.Handle, out _)` / `KeepAliveObjects.Clear()`
-to un-root.
+`RemoveCanvas`), use the helper family instead of a hand-rolled `List<T>`: `Referenced(this, child)`
+to root, `Unreferenced(this, child)` to drop one, and `UnreferencedAll(this)` to drop them all —
+never reach into `KeepAliveObjects` directly from a derived type.
 
 For a one-shot P/Invoke (no stored child), `GC.KeepAlive(parent)` after the call is enough.
 
@@ -308,7 +308,8 @@ prime suspect. Prove it before believing it (Phase 2).
 
 **Watch out (❌ don't):** don't root the parent with a pinned `GCHandle` — `Referenced(this, parent)`
 (or a plain managed field) is enough, and a pinned handle is its own leak (area 9). Don't hand-roll a
-`List<T>`/field when `KeepAliveObjects` already exists for exactly this. And don't lean on
+`List<T>`/field — or reach into `KeepAliveObjects` directly from a derived type — when
+`Referenced` / `Unreferenced` / `UnreferencedAll` already exist for exactly this. And don't lean on
 `GC.KeepAlive` for a *long-lived* child (an iterator you hold across calls); KeepAlive only covers the
 current method, so a stored child needs `Referenced(...)` (or the field).
 

--- a/.agents/skills/memory-leak-fixer/references/types-of-leaks.md
+++ b/.agents/skills/memory-leak-fixer/references/types-of-leaks.md
@@ -249,7 +249,7 @@ API); the ownership model in `documentation/dev/memory-management.md`.
 
 ## 5 — Finalizer / collection ordering
 
-**Where to look.** `binding/SkiaSharp/**`. `grep -rnE "GC.KeepAlive|internal .* Handle" binding/SkiaSharp`, and compare sibling wrappers — one that keeps no parent field where the others do is suspect.
+**Where to look.** `binding/SkiaSharp/**`. `grep -rnE "GC.KeepAlive|Referenced\(|KeepAliveObjects|internal .* Handle" binding/SkiaSharp`, and compare sibling wrappers — one that keeps no reference to its parent (no field **and** no `Referenced(...)`) where the others do is suspect.
 
 **What it is.** A child wrapper holds a **raw** pointer into a parent's native object but
 keeps no managed reference to the parent. Finalization order is non-deterministic, so the
@@ -271,29 +271,46 @@ public class ChildCursor : SKObject, ISKSkipObjectRegistration
 }
 ```
 
-**Fix (✓):** root the parent in a managed field for the child's whole lifetime:
+**Fix (✓):** root the parent for the child's whole lifetime using the framework's built-in
+keep-alive mechanism — **`SKObject.Referenced(owner, child)`**, which parks `child` in the owner's
+`KeepAliveObjects` dictionary so the GC can't collect it while the owner lives, and releases it
+automatically when the owner is disposed. This is the same helper `SKDocument` (output stream),
+`SKColorSpace` (ICC profile), and `SKSVG` (stream) already use — no hand-rolled field required:
 ```csharp
 public class ChildCursor : SKObject, ISKSkipObjectRegistration
 {
-    private readonly SKParent parent;    // keep the parent alive
     internal ChildCursor(SKParent parent)
         : base(SkiaApi.sk_parent_cursor_new(parent.Handle), owns: true)
     {
-        this.parent = parent;
+        Referenced(this, parent);   // parked in this.KeepAliveObjects → rooted for our lifetime
     }
 }
 ```
+**Prefer `Referenced(...)` over hand-rolling a `private readonly SKParent parent;` field or a
+`List<T>` of children** — the helper is purpose-built (documented in
+[`memory-management.md`](../../../../documentation/dev/memory-management.md#keeping-related-objects-alive-owned--ownedby--referenced)),
+needs no extra field, and clears on dispose. A plain `private readonly` field is still *correct* and
+may be used to match a class's **existing local convention** — e.g. the `SKRegion` iterators all keep
+a `private readonly SKRegion` field, so a new sibling there should follow suit rather than mix styles.
+
+For a **set** of rooted children that changes over time (e.g. `SKNWayCanvas.AddCanvas` /
+`RemoveCanvas`), use the dictionary directly instead of a hand-rolled `List<T>`: `Referenced(this,
+child)` to root, and `KeepAliveObjects.TryRemove(child.Handle, out _)` / `KeepAliveObjects.Clear()`
+to un-root.
+
 For a one-shot P/Invoke (no stored child), `GC.KeepAlive(parent)` after the call is enough.
 
-**How to find it.** Look for wrapper types constructed from a parent's `.Handle` that keep
-**no** field referencing that parent — especially when *sibling* wrappers of the same parent
-type DO keep such a field (e.g. one iterator/cursor stores `private readonly SKParent` and
-another doesn't). The odd one out is the prime suspect. Prove it before believing it (Phase 2).
+**How to find it.** Look for wrapper types constructed from a parent's `.Handle` that keep **no**
+managed reference to that parent — neither a field nor a `Referenced(...)` / `KeepAliveObjects`
+entry — especially when *sibling* wrappers of the same parent type DO root it (e.g. one
+iterator/cursor stores/`Referenced`s its `SKParent` and another doesn't). The odd one out is the
+prime suspect. Prove it before believing it (Phase 2).
 
-**Watch out (❌ don't):** don't root the parent with a pinned `GCHandle` — a plain managed
-field is enough and a pinned handle is its own leak (area 9). And don't lean on
-`GC.KeepAlive` for a *long-lived* child (an iterator you hold across calls); KeepAlive only
-covers the current method, so a stored child needs the field.
+**Watch out (❌ don't):** don't root the parent with a pinned `GCHandle` — `Referenced(this, parent)`
+(or a plain managed field) is enough, and a pinned handle is its own leak (area 9). Don't hand-roll a
+`List<T>`/field when `KeepAliveObjects` already exists for exactly this. And don't lean on
+`GC.KeepAlive` for a *long-lived* child (an iterator you hold across calls); KeepAlive only covers the
+current method, so a stored child needs `Referenced(...)` (or the field).
 
 **Real cases:** #3796 (SKPath/SKPathBuilder finalizer race), #3291 (SKAutoCanvasRestore).
 

--- a/documentation/dev/memory-management.md
+++ b/documentation/dev/memory-management.md
@@ -115,6 +115,55 @@ The `HandleDictionary` maintains a mapping from native `IntPtr` handles to C# wr
 - On dispose: removes handle from dictionary
 - Thread-safe via reader/writer lock
 
+## Keeping Related Objects Alive (Owned / OwnedBy / Referenced)
+
+When one wrapper depends on another — because native code stores a raw pointer into it, or
+because it created a child that must be torn down with it — **do not hand-roll a
+`private readonly` field or a `List<T>`** to keep the dependency reachable. `SKObject` has three
+built-in helpers (see `binding/SkiaSharp/SKObject.cs`) that record the relationship in one of two
+per-object dictionaries, so the runtime manages it for you:
+
+| Helper | Stored in | Keeps child alive? | Disposes child with owner? | Use when |
+|--------|-----------|--------------------|-----------------------------|----------|
+| `Referenced(owner, child)` | `KeepAliveObjects` | Yes | **No** | Owner holds a raw/borrowed pointer into `child` and just needs it rooted; the caller still owns `child`. |
+| `OwnedBy(child, owner)` | `OwnedObjects` | Yes | Yes | `child` is a native-owned sub-object (`owns:false`) that should be disposed when the owner is (e.g. a cached getter result). Returns `child`. |
+| `Owned(owner, child)` | `OwnedObjects` | Yes | Yes | `child` was created by managed code and should be disposed with the owner (e.g. a wrapped stream). Returns `owner`. |
+
+Both dictionaries are released when the owner is disposed: `OwnedObjects` entries are disposed
+then cleared, `KeepAliveObjects` entries are only cleared (never disposed).
+
+**`Referenced` — root without owning (the "avoid collection" case).** A child that holds a raw
+pointer into a parent must root that parent for its whole lifetime, or non-deterministic
+finalization can free the parent first → use-after-free. `Referenced` is exactly this:
+
+```csharp
+// Idiomatic: park the parent in this.KeepAliveObjects, rooted for the child's lifetime,
+// released automatically on dispose. No extra field needed.
+internal SpanIterator(SKRegion region, int y, int left, int right)
+    : base(SkiaApi.sk_region_spanerator_new(region.Handle, y, left, right), owns: true)
+{
+    Referenced(this, region);
+}
+```
+
+Real uses: `SKDocument` roots its output stream, `SKColorSpace` its ICC profile, `SKSVG` its
+stream — all via `Referenced(...)`. For a **mutable set** of rooted children, add with
+`Referenced(this, child)` and remove with `KeepAliveObjects.TryRemove(child.Handle, out _)` /
+`KeepAliveObjects.Clear()` — again, no hand-rolled `List<T>`.
+
+**`Owned` / `OwnedBy` — root *and* dispose.** When the owner should also dispose the child:
+
+```csharp
+// OwnedBy: borrowed getter result that must die with the owner (returns the child).
+canvas = OwnedBy(SKCanvas.GetObject(SkiaApi.sk_surface_get_canvas(Handle), owns: false), this);
+
+// Owned: managed-created child disposed with the owner (returns the owner).
+return Owned(CreatePdf(managedStream), managedStream);
+```
+
+For a **one-shot** P/Invoke that stores nothing, a plain `GC.KeepAlive(parent)` after the call is
+enough — no dictionary entry is needed.
+
 ## Common Mistakes
 
 ### 1. Wrong cleanup for ref-counted types

--- a/documentation/dev/memory-management.md
+++ b/documentation/dev/memory-management.md
@@ -126,6 +126,8 @@ per-object dictionaries, so the runtime manages it for you:
 | Helper | Stored in | Keeps child alive? | Disposes child with owner? | Use when |
 |--------|-----------|--------------------|-----------------------------|----------|
 | `Referenced(owner, child)` | `KeepAliveObjects` | Yes | **No** | Owner holds a raw/borrowed pointer into `child` and just needs it rooted; the caller still owns `child`. |
+| `Unreferenced(owner, child)` | `KeepAliveObjects` | — | — | Inverse of `Referenced`: drops one keep-alive root so `child` can be collected again. |
+| `UnreferencedAll(owner)` | `KeepAliveObjects` | — | — | Drops **all** keep-alive roots on `owner` (e.g. a "remove all" operation). |
 | `OwnedBy(child, owner)` | `OwnedObjects` | Yes | Yes | `child` is a native-owned sub-object (`owns:false`) that should be disposed when the owner is (e.g. a cached getter result). Returns `child`. |
 | `Owned(owner, child)` | `OwnedObjects` | Yes | Yes | `child` was created by managed code and should be disposed with the owner (e.g. a wrapped stream). Returns `owner`. |
 
@@ -148,8 +150,9 @@ internal SpanIterator(SKRegion region, int y, int left, int right)
 
 Real uses: `SKDocument` roots its output stream, `SKColorSpace` its ICC profile, `SKSVG` its
 stream — all via `Referenced(...)`. For a **mutable set** of rooted children, add with
-`Referenced(this, child)` and remove with `KeepAliveObjects.TryRemove(child.Handle, out _)` /
-`KeepAliveObjects.Clear()` — again, no hand-rolled `List<T>`.
+`Referenced(this, child)`, drop one with `Unreferenced(this, child)`, and drop them all with
+`UnreferencedAll(this)` — again, no hand-rolled `List<T>` and no reaching into the dictionaries
+from derived types.
 
 **`Owned` / `OwnedBy` — root *and* dispose.** When the owner should also dispose the child:
 


### PR DESCRIPTION
## Problem

The `memory-leak-fixer` skill's **area 5 (finalizer / collection ordering)** taught fixing native use-after-free by hand-rolling a `private readonly` field (or a `List<T>`) to root a related object so the GC can't collect it. But `SKObject` already provides this exact mechanism, and it was undocumented and unused by the skill.

As a result, recent generated fixes added redundant fields/lists:
- #4372 hand-rolled a `List<SKCanvas>` + a `private readonly SKCanvas` field
- #4355 added a `private readonly SKRegion` field

## The built-in feature

`SKObject` (binding/SkiaSharp/SKObject.cs) has three helpers backed by two per-object dictionaries:

| Helper | Backing store | Roots child? | Disposes child with owner? |
|---|---|---|---|
| `Referenced(owner, child)` | `KeepAliveObjects` | ✅ | ❌ (keep-alive only) |
| `OwnedBy(child, owner)` | `OwnedObjects` | ✅ | ✅ |
| `Owned(owner, child)` | `OwnedObjects` | ✅ | ✅ |

`Referenced()` is the "avoid collection" mechanism — already used idiomatically by `SKDocument` (streams), `SKColorSpace` (ICC profile), and `SKSVG` (stream) — but it was never documented in `memory-management.md` (which the skill cites as the authoritative model) nor taught by the skill.

## Changes

- **`documentation/dev/memory-management.md`** — new *Keeping Related Objects Alive* section documenting `Owned`/`OwnedBy`/`Referenced` and the two dictionaries.
- **`references/types-of-leaks.md` area 5** — teach `Referenced(this, parent)` / `KeepAliveObjects` as the idiomatic fix; keep a plain field as an accepted local-convention fallback; add the mutable-collection (`SKNWayCanvas`) variant; update *Where to look* / *How to find it* / *Watch out*.
- **`SKILL.md`** — self-review gate now flags hand-rolled keep-alive fields/`List<T>` where `Referenced()` / `KeepAliveObjects` suffices.

Docs/skill only — no binding code changes. The follow-up PRs #4372 and #4355 are being updated to use the feature.

<sub>🤖 Generated with the help of Copilot.</sub>