### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b16789ec352c37e02ad38dbac55e6f47d22ff87f"
+          "commitHash": "06f50d1c05cbbed5228c591ad4c4c2f991dc07be"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0"
+      "upstream_merge_commit": "3273c66a688fc8b9d72f739242e4050dd108df50"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "06f50d1c05cbbed5228c591ad4c4c2f991dc07be"
+          "commitHash": "ef2ebb78c8e230bb870d424583c4f871d2161c2e"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/281

# [skia-sync] Merge upstream chrome/m150 bug fixes — mono/SkiaSharp

**Base branch:** `release/4.150.x`
**Head branch:** `skia-sync/release-4.150.x`
**Mode:** release-line bug-fix sync (`CURRENT == TARGET == 150`)
**Companion mono/skia PR:** `[skia-sync] Merge upstream chrome/m150 bug fixes` on
`skia-sync/release-4.150.x` (submodule pointer advanced to reflect it)

## Breaking-change analysis

**None.** Only one new upstream commit was pulled in (`3273c66a68 [M150] Fix
Use-After-Free in SubRunAllocator`), and it is a pure internal C++ fix in
`src/text/gpu/SubRunAllocator.h` — it changes destruction order of an
internal allocator return type from `std::tuple` to a custom struct.

| Category | Risk | Findings |
|----------|------|----------|
| Removed APIs | 🔴 HIGH | None |
| Renamed/Moved APIs | 🟡 MEDIUM | None |
| New APIs | 🟢 LOW | None |
| Behavior changes | 🟡 MEDIUM | None (bug fix restores correct behavior) |
| Graphite-only | ⚪ SKIP | N/A |

No C API impact (`grep SubRunAllocator src/c/ include/c/` returns nothing),
no header changes reachable from `include/c/*.h`, no binding regeneration
delta.

## Version / binding updates

**No version bump** — this is a same-milestone release-line sync, so
`scripts/VERSIONS.txt` and `scripts/azure-templates-variables.yml` are
untouched (the Phase 6 script's version-downgrade side-effect was reverted
to preserve the branch's `4.150.1` post-release in-development number).

**`cgmanifest.json`:**
- `commitHash`: `b16789ec35…` → `06f50d1c05…` (new mono/skia merge commit)
- `upstream_merge_commit`: `14d05ec761…` → `3273c66a68…` (new upstream tip)
- `chrome_milestone`: `150` (unchanged)

**`externals/skia` submodule pointer:** `280ec21ada` → `06f50d1c05` (points
at the new merge commit on `skia-sync/release-4.150.x`).

## C# changes

**None.** Binding regeneration (`pwsh ./utils/generate.ps1`, via
`.agents/skills/update-skia/scripts/regenerate-bindings.ps1`) produced
**zero diff** across `binding/SkiaSharp/SkiaApi.generated.cs` and the
Skottie/SceneGraph/Resources generated files. The Phase 9 new-function
check (`git diff origin/release/4.150.x -- binding/SkiaSharp/SkiaApi.generated.cs
| grep '^+.*internal static'`) returned zero matches, so no C# wrappers
need to be added.

## Build & test results (Linux x64)

| Step | Result |
|------|--------|
| Native build (`dotnet cake --target=externals-linux --arch=x64`) | ✅ Succeeded (14m 21s; 1506/1506 targets) |
| Binding regeneration | ✅ Succeeded, zero binding diff |
| C# build (`dotnet build binding/SkiaSharp/SkiaSharp.csproj`) | ✅ Succeeded (0 warnings, 0 errors) |
| Test suite (all `SkiaSharp.Tests.Console` tests) | ✅ **Passed: 5584, Failed: 0, Skipped: 172, Total: 5756** (2m 47s) |

Both native artifacts produced as expected:
- `output/native/linux/x64/libSkiaSharp.so` → `libSkiaSharp.so.150.0.0`
- `output/native/linux/x64/libHarfBuzzSharp.so` → `libHarfBuzzSharp.so.0.61421.0`

Full test log uploaded as `test-output.txt` artifact.

## Items needing human attention

None. This is a minimal internal C++ bug fix from upstream Skia's m150
branch with:
- Zero API surface impact
- Zero binding delta
- Zero C# code changes
- Zero test regressions (5584 passed)

Only Linux x64 was built and tested in this automated sync — macOS,
Windows, iOS, Android, WASM, and Tizen are covered by the normal CI matrix
on the PR.

## Companion mono/skia PR

The submodule now points at commit `06f50d1c05` on the
`skia-sync/release-4.150.x` branch of `mono/skia`. That PR must merge
first; then this PR's submodule pointer will be re-fetched to the squashed
SHA before merging here.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).