### PR TITLE
Skip Xcode version validation in MAUI integration test builds

### DIFF
--- a/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
@@ -140,7 +140,12 @@ public abstract class MauiTestBase(ITestOutputHelper output) : PlatformTestBase(
         
         // Always run from TestDir (which has global.json) using relative path
         var relativeProjectDir = Path.GetRelativePath(TestDir, projectDir);
-        await Run("dotnet", $"build {relativeProjectDir} -c {BuildConfiguration} -f {TargetFramework}", timeoutSeconds: 600);
+        // ValidateXcodeVersion=false: the generated MAUI app is built in a temp dir outside the repo,
+        // so it does NOT inherit tests/Directory.Build.props (which sets this for the harness project).
+        // Skip the .NET for iOS/Mac Catalyst Xcode major.minor check so the harness keeps working when
+        // the installed Xcode is newer than the version the pinned workload recommends — release-testing
+        // validates SkiaSharp rendering, not toolchain matching. Ignored (harmless) on Android.
+        await Run("dotnet", $"build {relativeProjectDir} -c {BuildConfiguration} -f {TargetFramework} -p:ValidateXcodeVersion=false", timeoutSeconds: 600);
         
         var appPath = FindAppArtifact(projectDir, projectName);
         Assert.NotNull(appPath);


### PR DESCRIPTION
## Problem

While running the `release-testing` matrix for **4.150.0** on a machine with **Xcode 26.3** (while the installed .NET `ios`/`maccatalyst` workloads were `26.2.10217`, pinned to Xcode 26.2), the MAUI **Mac Catalyst** and **iOS** integration tests failed to *build* — before SkiaSharp was ever exercised:

```
error : This version of .NET for MacCatalyst (26.2.10217) requires Xcode 26.2.
The current version of Xcode is 26.3. Either install Xcode 26.2, or use a
different version of .NET for MacCatalyst.
```

## Root cause

`tests/Directory.Build.props` already sets `<ValidateXcodeVersion>false</ValidateXcodeVersion>`, but the harness generates its throwaway MAUI apps in a **temp directory outside the repo** (`/private/var/folders/...`), so those projects don't inherit it. The `.NET for iOS/Mac Catalyst` SDK's `_ValidateXcodeVersion` target (guarded by `Condition="'$(ValidateXcodeVersion)' != 'false'"`) therefore still ran and hard-failed on the major.minor mismatch.

Previously this was worked around with a machine-specific `ValidateXcodeVersion=false` env override (noted in the 4.148.0 harness-fix commit dbac5f7), but that had to be remembered and applied by hand each release.

## Fix

Pass `-p:ValidateXcodeVersion=false` on the harness's `dotnet build` of the generated MAUI app (`MauiTestBase.RunMauiTest`, the single Apple build point shared by iOS + Mac Catalyst). Release-testing validates SkiaSharp **rendering**, not toolchain version matching, so skipping the Xcode major.minor check is appropriate here. The property is harmless (ignored) on Android.

## Verification

Re-ran the full local release-testing matrix for `4.150.0-stable.1` — all green, including a Mac Catalyst run with the `ValidateXcodeVersion` env var **unset** to confirm the baked-in property works on its own:

| Test | Platform | Result |
|------|----------|--------|
| Mac Catalyst | macOS 26.5 / Xcode 26.3 | ✅ (env override no longer needed) |
| iOS | 16.2 + 26.3 | ✅ |
| Android | API 23 + API 36 | ✅ (unaffected) |
| Smoke / Console / Linux (Docker) / Blazor | — | ✅ |

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>