### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "98877992a585d9fd60e398871b9293483db53eb8"
+          "commitHash": "ff9099d9964f0b7f5871287cf1d05be570cd0ff4"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "1536d3975057297af8087d22419f6c95dc96305d"
+      "upstream_merge_commit": "0208108c7aed5f4e0faa525cbba52c238005a1ef"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "ff9099d9964f0b7f5871287cf1d05be570cd0ff4"
+          "commitHash": "cd6e9269149b4d242445b2ac36ae7f68e851d083"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/282

Automated upstream bug-fix sync for m151. Targets `main` (mono/skia `skiasharp`).

# [skia-sync] Merge upstream chrome/m151 bug fixes — mono/SkiaSharp

**Base branch:** `main`
**Head branch:** `skia-sync/m151`
**Mode:** same-milestone bug-fix sync (`CURRENT == TARGET == m151`, `IS_RELEASE == false`)
**Companion mono/skia PR:** `[skia-sync] Merge upstream chrome/m151 bug fixes` on
`skia-sync/m151` (submodule pointer advanced to reflect it)

## Breaking-change analysis

**None.** Only one new upstream commit was pulled in
(`0208108c7a [M151] Fix Use-After-Free in SubRunAllocator`), and it is a pure
internal C++ fix in `src/text/gpu/SubRunAllocator.h` — it changes the
destruction order of an internal allocator return type from `std::tuple` to a
custom struct.

| Category | Risk | Findings |
|----------|------|----------|
| Removed APIs | 🔴 HIGH | None |
| Renamed/Moved APIs | 🟡 MEDIUM | None |
| New APIs | 🟢 LOW | None |
| Behavior changes | 🟡 MEDIUM | None (bug fix restores correct behavior) |
| Graphite-only | ⚪ SKIP | N/A |

No C API impact (`grep SubRunAllocator src/c/ include/c/` returns nothing), no
header changes reachable from `include/c/*.h`, no binding regeneration delta.

This is the same fix that already landed on `chrome/m150` and was pulled into
our fork on the `release/4.150.x` branch (companion sync PRs
[mono/skia#281](https://github.com/mono/skia/pull/281) /
[mono/SkiaSharp#4379](https://github.com/mono/SkiaSharp/pull/4379)); it has now
been cherry-picked to `chrome/m151` upstream and is being brought into the
`main` line here.

## Version / binding updates

**No version bump** — this is a same-milestone sync, so `scripts/VERSIONS.txt`
and `scripts/azure-templates-variables.yml` are untouched (verified: `git diff`
on both files is empty after running the Phase 6 script with
`-Current 151 -Target 151 -UpstreamRef chrome/m151`).

**`cgmanifest.json`:**

- `commitHash`: `98877992a5…` → `ff9099d996…` (new mono/skia merge commit)
- `upstream_merge_commit`: `1536d39750…` → `0208108c7a…` (new upstream tip)
- `chrome_milestone`: `151` (unchanged)

**`externals/skia` submodule pointer:** `98877992a5` → `ff9099d996` (points at
the new merge commit on `skia-sync/m151`).

## C# changes

**None.** Binding regeneration (`pwsh
.agents/skills/update-skia/scripts/regenerate-bindings.ps1`) produced **zero
diff** across `binding/SkiaSharp/SkiaApi.generated.cs` and the
Skottie/SceneGraph/Resources generated files. The Phase 9 new-function check
(`git diff origin/main -- binding/SkiaSharp/SkiaApi.generated.cs | grep '^+.*internal static'`)
returned zero matches, so no C# wrappers need to be added.

## Build & test results (Linux x64)

| Step | Result |
|------|--------|
| Native build (`dotnet cake --target=externals-linux --arch=x64`) | ✅ Succeeded (15m 40s; libSkiaSharp 14:16, libHarfBuzzSharp 1:11, git-sync-deps 0:10) |
| Binding regeneration | ✅ Succeeded, zero binding diff |
| C# build (`dotnet build binding/SkiaSharp/SkiaSharp.csproj`) | ✅ Succeeded (0 warnings, 0 errors, all target frameworks) |
| Test suite (all `SkiaSharp.Tests.Console` tests) | ✅ **Passed: 5614, Failed: 0, Skipped: 182, Total: 5796** (2m 39s) |

Both native artifacts produced as expected:

- `output/native/linux/x64/libSkiaSharp.so` → `libSkiaSharp.so.151.0.0` (11 MB — soname 151.0.0 = our tracked milestone)
- `output/native/linux/x64/libHarfBuzzSharp.so` → `libHarfBuzzSharp.so.0.61421.0` (2.8 MB)

Full test log uploaded as `test-output.txt` workflow artifact.

## Items needing human attention

None. This is a minimal internal C++ bug fix from upstream Skia's m151 branch
with:

- Zero API surface impact
- Zero binding delta
- Zero C# code changes
- Zero test regressions (5614 passed)

Only Linux x64 was built and tested in this automated sync — macOS, Windows,
iOS, Android, WASM, and Tizen are covered by the normal CI matrix on the PR.

## Companion mono/skia PR

The submodule now points at commit `ff9099d996` on the `skia-sync/m151` branch
of `mono/skia`. That PR must merge first; then this PR's submodule pointer will
be re-fetched to the squashed SHA before merging here.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).