### PR TITLE
Regenerate historical 1.x/2.x release notes (v2 format)

### DIFF
--- a/documentation/docfx/releases/1.49.0.md
+++ b/documentation/docfx/releases/1.49.0.md
@@ -1,28 +1,15 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:16Z by generate-release-notes.py
-  version:   1.49.0
-  status:    preview
-  branch:    release/1.49.0-preview1
-  diff:      ff9f7d81f4e6..release/1.49.0-preview1
-  prs:       0
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-16T18:45:00Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.49.0 -->
 # Version 1.49.0
-
-> **Preview release** · Preview only · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.0-preview)
+> **Initial preview** · [NuGet (prerelease)](https://www.nuget.org/packages/SkiaSharp/1.49.0-preview)
 
 ## Highlights
 
-An early preview build of SkiaSharp. No pull requests were recorded in this preview's diff range (`ff9f7d81f4e6..release/1.49.0-preview1`), so there are no itemised changes to report for this build.
+SkiaSharp 1.49.0 is the first public preview of the SkiaSharp binding for .NET.
 
-## Links
+## Breaking Changes
 
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.49.0-preview)
+*None in this preview line.*
+
+## Preview 1 (February 22, 2016)
+
+The first preview introduced the SkiaSharp binding to the public.

--- a/documentation/docfx/releases/1.49.1.md
+++ b/documentation/docfx/releases/1.49.1.md
@@ -1,36 +1,17 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:47Z by generate-release-notes.py
-  version:   1.49.1
-  status:    stable
-  branch:    release/1.49.1
-  diff:      6ab85368ed69..release/1.49.1
-  prs:       0
-  api:       self=1.49.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.49.1 -->
 # Version 1.49.1
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.1)
+> **First stable release** · Released April 19, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.1)
 
 > **API changes** · [SkiaSharp API diff](1.49.1/index.md)
 
 ## Highlights
 
-Initial release of SkiaSharp 1.49.1. No tracked pull requests for this version.
+SkiaSharp 1.49.1 is the first stable release of the binding.
 
 ## Breaking Changes
 
-*None*
+*None in this release.*
 
-## Links
+## Preview 1 (February 22, 2016)
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/6ab85368ed69...release/1.49.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.49.1)
+Preview 1 stabilised the initial API surface ahead of the first stable release.

--- a/documentation/docfx/releases/1.49.2.1.md
+++ b/documentation/docfx/releases/1.49.2.1.md
@@ -1,30 +1,23 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:16Z by generate-release-notes.py
-  version:   1.49.2.1
-  status:    stable
-  branch:    release/1.49.2.1-beta
-  diff:      release/1.49.1..release/1.49.2.1-beta
-  prs:       0
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-16T18:45:00Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.49.2.1 -->
 # Version 1.49.2.1
-
-> **Servicing release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.2.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.2.1)
+> **Servicing hotfix** · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.2.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.2.1)
 
 ## Highlights
 
-A packaging and servicing update over 1.49.1 with no user-facing code changes.
+SkiaSharp 1.49.2.1 is a hotfix on top of 1.49.2.
 
-## Links
+## Breaking Changes
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.2.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.49.2.1)
-- [API Diff](1.49.2.1/)
+*None in this release.*
+
+## Beta 0 (April 19, 2016)
+
+Beta build for the 1.49.2.1 hotfix.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2-beta...v1.49.2.1-beta)
+
+## Beta 0 (April 11, 2016)
+
+Beta build for the 1.49.2.1 hotfix.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.2-beta)

--- a/documentation/docfx/releases/1.49.2.md
+++ b/documentation/docfx/releases/1.49.2.md
@@ -1,29 +1,17 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:16Z by generate-release-notes.py
-  version:   1.49.2
-  status:    stable
-  branch:    release/1.49.2-beta
-  diff:      release/1.49.1..release/1.49.2-beta
-  prs:       0
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-16T18:38:00Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.49.2 -->
 # Version 1.49.2
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.2)
+> **Servicing update** · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.2)
 
 ## Highlights
 
-A small maintenance release. No tracked pull requests landed between `1.49.1` and this version; the build was published to refresh the packaged binaries.
+SkiaSharp 1.49.2 is a small servicing update on the 1.49 line.
 
-## Links
+## Breaking Changes
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.49.2)
+*None in this release.*
+
+## Beta 0 (April 11, 2016)
+
+Beta build on the way to the 1.49.2 servicing release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.2-beta)

--- a/documentation/docfx/releases/1.49.3.md
+++ b/documentation/docfx/releases/1.49.3.md
@@ -1,42 +1,33 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:18Z by generate-release-notes.py
-  version:   1.49.3
-  status:    stable
-  branch:    release/1.49.3-beta
-  diff:      release/1.49.1..release/1.49.3-beta
-  prs:       1
-
-  - Rename Native Library [#77] by @mattleibow in https://github.com/mono/SkiaSharp/pull/81 (9 commits, 2 days)
--->
-
-<!-- Generated: 2026-06-16T18:40:00Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.49.3 -->
 # Version 1.49.3
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.3)
+> **Native library rename** · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.3)
 
 ## Highlights
 
-This patch release renames the native library to align packaging and loading conventions across platforms.
+SkiaSharp 1.49.3 renames the bundled native library to avoid clashes with other Skia consumers.
 
-## New Features
+## Breaking Changes
 
-### Platform
+*None in this release.*
 
-- **Native library rename** — Renames the bundled native library for consistent naming across the supported platforms. ([#81](https://github.com/mono/SkiaSharp/pull/81))
+## Platform
 
-## Platform Support
+- **Bundled native library renamed** — The native library shipped inside the SkiaSharp package was renamed so it no longer collides with other Skia-based components loaded into the same process. ([#81](https://github.com/mono/SkiaSharp/pull/81))
 
-| Platform | What's New |
-|----------|-----------|
-| 📦 General | Native library renamed for consistent packaging |
+## Beta 0 (May 14, 2016)
 
-## Links
+Beta build carrying the native-library rename ahead of the 1.49.3 stable release.
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.3)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.49.3)
-- [API Diff](1.49.3/)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2.1-beta...v1.49.3-beta)
+
+## Beta 0 (April 19, 2016)
+
+Beta build carrying the native-library rename ahead of the 1.49.3 stable release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2-beta...v1.49.2.1-beta)
+
+## Beta 0 (April 11, 2016)
+
+Beta build carrying the native-library rename ahead of the 1.49.3 stable release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.2-beta)

--- a/documentation/docfx/releases/1.49.4.md
+++ b/documentation/docfx/releases/1.49.4.md
@@ -1,42 +1,35 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:19Z by generate-release-notes.py
-  version:   1.49.4
-  status:    stable
-  branch:    release/1.49.4-beta
-  diff:      release/1.49.1..release/1.49.4-beta
-  prs:       1
-
-  - Rename Native Library [#77] by @mattleibow in https://github.com/mono/SkiaSharp/pull/81 (9 commits, 2 days)
--->
-
-<!-- Generated: 2026-06-16T18:38:49Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.49.4 -->
 # Version 1.49.4
-
-> **Native library servicing release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.4) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.4)
+> **Servicing update** · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.49.4) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.49.4)
 
 ## Highlights
 
-This servicing release renames the bundled native library so it resolves consistently across all supported platforms.
+SkiaSharp 1.49.4 is a servicing update on the 1.49 line.
 
-## New Features
+## Breaking Changes
 
-### Platform
+*None in this release.*
 
-- **Consistent native library naming** — Renames the native library to a single, predictable name, improving native library resolution across platforms. ([#81](https://github.com/mono/SkiaSharp/pull/81))
+## Beta 0 (June 15, 2016)
 
-## Platform Support
+Beta build leading up to the 1.49.4 servicing release.
 
-| Platform | What's New |
-|----------|-----------|
-| 📦 General | Consistent native library naming |
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.3-beta...v1.49.4-beta)
 
-## Links
+## Beta 0 (May 14, 2016)
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.4)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.49.4)
-- [API Diff](1.49.4/)
+Beta build leading up to the 1.49.4 servicing release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2.1-beta...v1.49.3-beta)
+
+## Beta 0 (April 19, 2016)
+
+Beta build leading up to the 1.49.4 servicing release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2-beta...v1.49.2.1-beta)
+
+## Beta 0 (April 11, 2016)
+
+Beta build leading up to the 1.49.4 servicing release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.1...v1.49.2-beta)

--- a/documentation/docfx/releases/1.53.0.md
+++ b/documentation/docfx/releases/1.53.0.md
@@ -1,76 +1,39 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:48Z by generate-release-notes.py
-  version:   1.53.0
-  status:    stable
-  branch:    release/1.53.0
-  diff:      release/1.49.2-beta..release/1.53.0
-  prs:       1
-  api:       self=1.53.0/index.md
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Beta 0 · 1.49.4 · 2016-06-15 · https://github.com/mono/SkiaSharp/compare/v1.49.3-beta...v1.49.4-beta  (0 PRs)
-    *(no PRs)*
-
-  ## Beta 0 · 1.49.3 · 2016-05-14 · https://github.com/mono/SkiaSharp/compare/v1.49.2.1-beta...v1.49.3-beta  (1 PRs)
-    - Rename Native Library [#77] by @mattleibow in https://github.com/mono/SkiaSharp/pull/81
-
-  ## Beta 0 · 1.49.2.1 · 2016-04-19 · https://github.com/mono/SkiaSharp/compare/v1.49.2-beta...v1.49.2.1-beta  (0 PRs)
-    *(no PRs)*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.53.0 -->
 # Version 1.53.0
-
-> **Native library servicing release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.0)
+> **Skia m53 uplift** · Released July 29, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.0)
 
 > **API changes** · [SkiaSharp API diff](1.53.0/index.md)
 
 ## Highlights
 
-This release standardizes the bundled native library name so native assets resolve more predictably across supported platforms. It rolls up the 1.49.x beta-line packaging change into the 1.53.0 stable release.
+SkiaSharp 1.53.0 uplifts to Skia m53 and reshapes several core enums and APIs. This release realigns SkiaSharp with upstream Skia m53. Several enum values shift, decode overloads that took a preferred colour type are gone, and a handful of legacy image-decoder types are removed. Check the API diff below before upgrading.
 
 ## Breaking Changes
 
-If you load the native binaries manually or depend on the previous filename in custom packaging, update that logic for the renamed library. ([#81](https://github.com/mono/SkiaSharp/pull/81))
+- **Core enum values renumbered** — SKAlphaType and SKColorType members were renumbered to match Skia m53. Any code that persisted or compared the raw integer values (for example, from serialised data) needs to be re-checked; code that uses the named members is unaffected.
+- **Preferred-colour-type decode overloads removed** — The SKBitmap.Decode and DecodeBounds overloads that took an SKColorType hint are gone. Decode into the default colour type and convert with SKBitmap.CopyTo or SKPixmap if a specific format is needed.
+- **Parameterless SKCanvas.Save and single-argument clip/save-layer overloads removed** — Several thin SKCanvas overloads (Save(), ClipPath(path), ClipRect(rect), SaveLayer(paint), SaveLayer(limit, paint)) were removed in favour of the fuller signatures that take antialias / clip-op / bounds arguments. Pass the previous default values explicitly.
+- **SKImageDecoder family removed** — SKImageDecoder and its companion enums (SKImageDecoderFormat, SKImageDecoderMode, SKImageDecoderResult) were removed along with the upstream Skia type. Use SKBitmap.Decode or SKCodec instead.
+- **Miscellaneous API removals** — SKImageFilter.CreateDownSample, the public IntPtr-handle constructor on SKPictureRecorder, and the SKSurfaceProps.PixelGeometry setter were removed. See the SkiaSharp API diff for the full list.
 
-## New Features
+## Engine
 
-### Platform
+- **Uplift to Skia m53** — The bundled Skia engine moves to milestone 53, picking up upstream rendering fixes and API changes.
 
-- **Consistent native library naming** — Renames the bundled native library to a single, predictable name, improving native library resolution across platforms. ([#81](https://github.com/mono/SkiaSharp/pull/81))
+## Beta 0 (June 15, 2016)
 
-## Links
+Beta builds on the road to 1.53.0, uplifting the bundled Skia engine to milestone 53.
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.49.2-beta...release/1.53.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.53.0)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.3-beta...v1.49.4-beta)
 
----
+## Beta 0 (May 14, 2016)
 
-## Beta 0 · 1.49.4 (2016-06-15)
+Beta builds on the road to 1.53.0, uplifting the bundled Skia engine to milestone 53.
 
-No tracked pull requests were recorded for this beta milestone.
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2.1-beta...v1.49.3-beta)
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.3-beta...v1.49.4-beta)
+## Beta 0 (April 19, 2016)
 
----
+Beta builds on the road to 1.53.0, uplifting the bundled Skia engine to milestone 53.
 
-## Beta 0 · 1.49.3 (2016-05-14)
-
-Renamed the native library for more consistent packaging and resolution across platforms. ([#81](https://github.com/mono/SkiaSharp/pull/81))
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2.1-beta...v1.49.3-beta)
-
----
-
-## Beta 0 · 1.49.2.1 (2016-04-19)
-
-No tracked pull requests were recorded for this beta milestone.
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2-beta...v1.49.2.1-beta)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.49.2-beta...v1.49.2.1-beta)

--- a/documentation/docfx/releases/1.53.1.1.md
+++ b/documentation/docfx/releases/1.53.1.1.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:48Z by generate-release-notes.py
-  version:   1.53.1.1
-  status:    stable
-  branch:    release/1.53.1.1
-  diff:      release/1.53.1..release/1.53.1.1
-  prs:       0
-  api:       self=1.53.1.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.53.1.1 -->
 # Version 1.53.1.1
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.1.1)
+> **Servicing hotfix** · Released August 17, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.1.1)
 
 > **API changes** · [SkiaSharp API diff](1.53.1.1/index.md)
 
 ## Highlights
 
-Maintenance release for the 1.53 line. No tracked pull requests for this version.
+SkiaSharp 1.53.1.1 is a hotfix on top of 1.53.1.
 
 ## Breaking Changes
 
-*None*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.53.1...release/1.53.1.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.53.1.1)
+*None in this release.*

--- a/documentation/docfx/releases/1.53.1.2.md
+++ b/documentation/docfx/releases/1.53.1.2.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:48Z by generate-release-notes.py
-  version:   1.53.1.2
-  status:    stable
-  branch:    release/1.53.1.2
-  diff:      release/1.53.1.1..release/1.53.1.2
-  prs:       0
-  api:       self=1.53.1.2/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.53.1.2 -->
 # Version 1.53.1.2
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.1.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.1.2)
+> **Servicing hotfix** · Released August 24, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.1.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.1.2)
 
 > **API changes** · [SkiaSharp API diff](1.53.1.2/index.md)
 
 ## Highlights
 
-Maintenance release for the 1.53 line. No tracked pull requests for this version.
+SkiaSharp 1.53.1.2 is a further hotfix on the 1.53.1 line.
 
 ## Breaking Changes
 
-*None*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.53.1.1...release/1.53.1.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.53.1.2)
+*None in this release.*

--- a/documentation/docfx/releases/1.53.1.md
+++ b/documentation/docfx/releases/1.53.1.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:48Z by generate-release-notes.py
-  version:   1.53.1
-  status:    stable
-  branch:    release/1.53.1
-  diff:      release/1.53.0..release/1.53.1
-  prs:       0
-  api:       self=1.53.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.53.1 -->
 # Version 1.53.1
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.1)
+> **Servicing update** · Released August 15, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.1)
 
 > **API changes** · [SkiaSharp API diff](1.53.1/index.md)
 
 ## Highlights
 
-Maintenance release for the 1.53 line. No tracked pull requests for this version.
+SkiaSharp 1.53.1 is a servicing update on the 1.53 line.
 
 ## Breaking Changes
 
-*None*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.53.0...release/1.53.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.53.1)
+*None in this release.*

--- a/documentation/docfx/releases/1.53.2.md
+++ b/documentation/docfx/releases/1.53.2.md
@@ -1,30 +1,29 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:20Z by generate-release-notes.py
-  version:   1.53.2
-  status:    stable
-  branch:    release/1.53.2-gpu2
-  diff:      release/1.53.1..release/1.53.2-gpu2
-  prs:       0
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-16T18:45:00Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.53.2 -->
 # Version 1.53.2
-
-> **Servicing release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.2)
+> **GPU and SVG previews** · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.53.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.53.2)
 
 ## Highlights
 
-A servicing release. No pull requests were recorded in this version's diff range (`release/1.53.1..release/1.53.2-gpu2`), so there are no itemised changes to report.
+SkiaSharp 1.53.2 ships preview builds of the GPU backend and the SVG module alongside the 1.53 servicing line.
 
-## Links
+## Breaking Changes
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.53.1...v1.53.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.53.2)
-- [API Diff](1.53.2/)
+*None in this release.*
+
+## Gpu 2 (August 24, 2016)
+
+A second GPU preview build refining the earlier 1.53.2 GPU preview.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.53.2-svg1...v1.53.2-gpu2)
+
+## Svg 1 (August 25, 2016)
+
+The first GPU and SVG preview builds on the 1.53.2 line.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.53.2-gpu1...v1.53.2-svg1)
+
+## Gpu 1 (August 19, 2016)
+
+The first GPU and SVG preview builds on the 1.53.2 line.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.53.1.2...v1.53.2-gpu1)

--- a/documentation/docfx/releases/1.54.0.md
+++ b/documentation/docfx/releases/1.54.0.md
@@ -1,36 +1,35 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:49Z by generate-release-notes.py
-  version:   1.54.0
-  status:    stable
-  branch:    release/1.54.0
-  diff:      release/1.53.1.2..release/1.54.0
-  prs:       0
-  api:       self=1.54.0/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.54.0 -->
 # Version 1.54.0
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.54.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.54.0)
+> **First public release** · Released September 5, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.54.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.54.0)
 
 > **API changes** · [SkiaSharp API diff](1.54.0/index.md)
 
 ## Highlights
 
-Initial release of SkiaSharp 1.54.0. No tracked pull requests for this version.
+SkiaSharp 1.54.0 is the first public NuGet release, wrapping Skia with GPU and SVG support. This debut ships the SkiaSharp binding for Skia together with initial GPU and SVG previews. Expect API churn as the surface is still being shaped — SKImageInfo, SKRect, SKRectI and SKCodecOptions all had their public fields turned into properties.
 
 ## Breaking Changes
 
-*None*
+- **Value-type fields converted to properties** — SKImageInfo, SKRect, SKRectI and SKCodecOptions replaced their public fields (Width/Height, Left/Top/Right/Bottom, HasSubset/Subset/ZeroInitialized, and the AlphaType/ColorType fields) with properties, and SKImageInfo.Size now returns SKSizeI instead of SKPointI. Rebuild against the new signatures.
 
-## Links
+## API Surface
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.53.1.2...release/1.54.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.54.0)
+- **Initial SkiaSharp API surface** — Ships the first public SkiaSharp binding covering canvases, paints, paths, codecs and image info, alongside early GPU and SVG previews.
+
+## Gpu 2 (August 24, 2016)
+
+The second GPU preview iterated on the GPU-backed rendering pipeline ahead of the stable cut.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.53.2-svg1...v1.53.2-gpu2)
+
+## Svg 1 (August 25, 2016)
+
+The first SVG preview introduced the SVG surface used to author SVG documents from SkiaSharp.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.53.2-gpu1...v1.53.2-svg1)
+
+## Gpu 1 (August 19, 2016)
+
+The first SVG preview introduced the SVG surface used to author SVG documents from SkiaSharp.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.53.1.2...v1.53.2-gpu1)

--- a/documentation/docfx/releases/1.54.1.1.md
+++ b/documentation/docfx/releases/1.54.1.1.md
@@ -1,30 +1,11 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-16T19:32:21Z by generate-release-notes.py
-  version:   1.54.1.1
-  status:    stable
-  branch:    release/1.54.1.1
-  diff:      release/1.54.1..release/1.54.1.1
-  prs:       0
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-16T18:40:06Z by claude-opus-4.8 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.54.1.1 -->
 # Version 1.54.1.1
-
-> **Servicing release** · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.54.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.54.1.1)
+> **Metadata refresh** · Released September 7, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.54.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.54.1.1)
 
 ## Highlights
 
-A servicing release with no tracked code changes over the previous version. Update to pick up the latest packaged binaries.
+SkiaSharp 1.54.1.1 is a package-only refresh of the 1.54.1 release — no code changes.
 
-## Links
+## Breaking Changes
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.54.1...v1.54.1.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.54.1.1)
-- [API Diff](1.54.1.1/)
+*None in this release.*

--- a/documentation/docfx/releases/1.54.1.md
+++ b/documentation/docfx/releases/1.54.1.md
@@ -1,36 +1,18 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:49Z by generate-release-notes.py
-  version:   1.54.1
-  status:    stable
-  branch:    release/1.54.1
-  diff:      release/1.54.0..release/1.54.1
-  prs:       0
-  api:       self=1.54.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.54.1 -->
 # Version 1.54.1
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.54.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.54.1)
+> **Servicing release** · Released October 11, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.54.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.54.1)
 
 > **API changes** · [SkiaSharp API diff](1.54.1/index.md)
 
 ## Highlights
 
-Maintenance release for the 1.54 line. No tracked pull requests for this version.
+SkiaSharp 1.54.1 is a servicing release that tightens SKMatrix and the disposable object hierarchy.
 
 ## Breaking Changes
 
-*None*
+- **SKMatrix fields removed** — SKMatrix no longer exposes its ScaleX/ScaleY, SkewX/SkewY, TransX/TransY and Persp0/Persp1/Persp2 fields directly — use the matrix constructors and helper APIs instead.
+- **Dispose overrides removed on SKObject and path iterators** — The explicit Dispose() overrides and finalizers on SKObject, SKPath.Iterator and SKPath.RawIterator were removed. Disposal now flows through the standard IDisposable pattern inherited from the base type.
 
-## Links
+## Lifecycle & Internals
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.54.0...release/1.54.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.54.1)
+- **Cleaned up SKObject disposal** — Removes duplicate Dispose overrides and finalizers on SKObject and the SKPath iterators so lifecycle flows through a single base implementation.

--- a/documentation/docfx/releases/1.55.0.md
+++ b/documentation/docfx/releases/1.55.0.md
@@ -1,36 +1,20 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:50Z by generate-release-notes.py
-  version:   1.55.0
-  status:    stable
-  branch:    release/1.55.0
-  diff:      release/1.54.1.1..release/1.55.0
-  prs:       0
-  api:       self=1.55.0/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.55.0 -->
 # Version 1.55.0
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.55.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.55.0)
+> **API cleanup** · Released November 10, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.55.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.55.0)
 
 > **API changes** · [SkiaSharp API diff](1.55.0/index.md)
 
 ## Highlights
 
-Initial release of SkiaSharp 1.55.0. No tracked pull requests for this version.
+SkiaSharp 1.55.0 trims optional parameters off public APIs and makes SKCodecOptions.Subset nullable. Several methods on SKCanvas, GRContext and SKPath drop their default parameter values so overload resolution is unambiguous. SKCodecOptions.Subset becomes a nullable SKRectI, and a handful of legacy helpers on SKCodec, SKDocument and SKMatrix are removed.
 
 ## Breaking Changes
 
-*None*
+- **Default parameter values removed from public APIs** — Methods such as SKCanvas.ClipRect/ClipPath/DrawColor, GRContext.Flush and several SKPath overloads no longer supply default argument values — callers must pass the argument explicitly or use the matching overload. This is an ABI change; recompile against the new signatures.
+- **SKCodecOptions.Subset is now nullable** — SKCodecOptions.Subset changed from SKRectI to SKRectI? and HasSubset lost its setter. Assign null (or leave unset) to opt out of subsetting.
+- **Legacy methods removed** — SKCodec.GetValidSubset and SKDocument.Close were removed; use the replacement APIs on those types.
 
-## Links
+## API Surface
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.54.1.1...release/1.55.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.55.0)
+- **Optional parameters replaced with explicit overloads** — Trims defaults off SKCanvas, GRContext and SKPath methods so the ABI is stable across future changes and overload resolution is deterministic.
+- **SKCodecOptions.Subset is nullable** — Subset now surfaces as SKRectI? and pairs with a read-only HasSubset, better reflecting that a subset is optional.

--- a/documentation/docfx/releases/1.55.1.md
+++ b/documentation/docfx/releases/1.55.1.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:50Z by generate-release-notes.py
-  version:   1.55.1
-  status:    stable
-  branch:    release/1.55.1
-  diff:      release/1.55.0..release/1.55.1
-  prs:       0
-  api:       self=1.55.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.55.1 -->
 # Version 1.55.1
-
-> **Maintenance release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.55.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.55.1)
+> **Servicing release** · Released November 20, 2016 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.55.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.55.1)
 
 > **API changes** · [SkiaSharp API diff](1.55.1/index.md)
 
 ## Highlights
 
-Maintenance release for the 1.55 line. No tracked pull requests for this version.
+SkiaSharp 1.55.1 is a servicing release with bundling and packaging fixes on top of 1.55.0.
 
 ## Breaking Changes
 
-*None*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.55.0...release/1.55.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.55.1)
+*None in this release.*

--- a/documentation/docfx/releases/1.56.0.md
+++ b/documentation/docfx/releases/1.56.0.md
@@ -1,35 +1,22 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:50Z by generate-release-notes.py
-  version:   1.56.0
-  status:    stable
-  branch:    release/1.56.0
-  diff:      release/1.55.1..release/1.56.0
-  prs:       0
-  api:       self=1.56.0/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.56.0 -->
 # Version 1.56.0
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.56.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.56.0)
+> **Views assemblies land** · Released January 14, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.56.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.56.0)
 
 > **API changes** · [SkiaSharp API diff](1.56.0/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.56.0. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.56.0 adds the SkiaSharp.Views assemblies for macOS, iOS and tvOS and trims a few obsolete APIs. New SkiaSharp.Views.Mac, SkiaSharp.Views.iOS and SkiaSharp.Views.tvOS packages provide native view integrations. SKPictureRecorder.BeginRecording renames its argument and the multi-mode SKImageFilter.CreateMerge overload is removed.
 
 ## Breaking Changes
 
-*None in this release.*
+- **Obsolete SKImageFilter.CreateMerge overload removed** — The overload that took a parallel SKXferMode[] alongside the filter array is gone. Use the remaining CreateMerge overload that takes just the filters (and optional crop rect).
+- **SKPictureRecorder.BeginRecording parameter renamed** — The parameter on SKPictureRecorder.BeginRecording is now called cullRect (was rect). Named-argument callers must update the name.
 
-## Links
+## Platform
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.55.1...release/1.56.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.56.0)
+- **SkiaSharp.Views ships for Apple platforms** — Adds the SkiaSharp.Views.Mac, SkiaSharp.Views.iOS and SkiaSharp.Views.tvOS assemblies, giving native view hosts for SKSurface rendering on Apple platforms.
+
+## API Surface
+
+- **SKPictureRecorder argument clarified** — BeginRecording now names its bounds argument cullRect, matching Skia's own terminology.

--- a/documentation/docfx/releases/1.56.1.md
+++ b/documentation/docfx/releases/1.56.1.md
@@ -1,35 +1,19 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:50Z by generate-release-notes.py
-  version:   1.56.1
-  status:    stable
-  branch:    release/1.56.1
-  diff:      release/1.56.0..release/1.56.1
-  prs:       0
-  api:       self=1.56.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.56.1 -->
 # Version 1.56.1
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.56.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.56.1)
+> **Servicing release** · Released February 7, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.56.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.56.1)
 
 > **API changes** · [SkiaSharp API diff](1.56.1/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.56.1. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.56.1 is a servicing release with fixes on top of 1.56.0.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## Links
+## Beta 0 (February 2, 2017)
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.56.0...release/1.56.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.56.1)
+The 1.56.1 beta cut the servicing candidate ahead of the 1.56.1 stable release.
+
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.56.0...v1.56.1-beta)

--- a/documentation/docfx/releases/1.56.2.md
+++ b/documentation/docfx/releases/1.56.2.md
@@ -1,35 +1,22 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:51Z by generate-release-notes.py
-  version:   1.56.2
-  status:    stable
-  branch:    release/1.56.2
-  diff:      release/1.56.1..release/1.56.2
-  prs:       0
-  api:       self=1.56.2/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.56.2 -->
 # Version 1.56.2
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.56.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.56.2)
+> **Index8 rework** · Released March 7, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.56.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.56.2)
 
 > **API changes** · [SkiaSharp API diff](1.56.2/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.56.2. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.56.2 reworks the indexed-colour APIs and trims a handful of SKPath and SKBitmap helpers. SKColorTable now speaks premultiplied colours (SKPMColor) to match how Skia stores its palette, and SKBitmap.GetIndex8Color is gone. Several SKPath overloads drop optional add-mode defaults so their overload set is explicit.
 
 ## Breaking Changes
 
-*None in this release.*
+- **SKColorTable exposes SKPMColor** — SKColorTable.Colors and the indexer now return SKPMColor[] / SKPMColor rather than SKColor. Convert to and from premultiplied colours when interacting with palette data.
+- **SKBitmap.GetIndex8Color removed** — GetIndex8Color(x, y) is gone. Read the palette index and look it up through the bitmap's SKColorTable instead.
+- **SKPath.AddPath defaults removed** — The AddMode = 0 default was removed from the SKPath.AddPath overloads. Pass the AddMode explicitly.
+- **SKPath.Iterator.Next overload removed** — The Next(SKPoint[], bool doConsumeDegenerates, bool exact) overload was removed from SKPath.Iterator; use the remaining overload.
+- **SKImageInfo fields no longer readonly** — SKImageInfo.Empty and SKImageInfo.PlatformColorType are no longer readonly, so referencing code that expected compile-time constness needs to adjust.
 
-## Links
+## API Surface
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.56.1...release/1.56.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.56.2)
+- **Indexed-colour APIs use premultiplied colours** — SKColorTable now surfaces SKPMColor, matching Skia's internal storage and avoiding a hidden conversion on every palette read.
+- **SKPath overloads made explicit** — Removes optional AddMode defaults from SKPath.AddPath so overloads resolve unambiguously and the ABI is stable.

--- a/documentation/docfx/releases/1.57.0.md
+++ b/documentation/docfx/releases/1.57.0.md
@@ -1,35 +1,21 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:51Z by generate-release-notes.py
-  version:   1.57.0
-  status:    stable
-  branch:    release/1.57.0
-  diff:      release/1.56.2..release/1.57.0
-  prs:       0
-  api:       self=1.57.0/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.57.0 -->
 # Version 1.57.0
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.57.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.57.0)
+> **Encoded-format alignment** · Released April 4, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.57.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.57.0)
 
 > **API changes** · [SkiaSharp API diff](1.57.0/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.57.0. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.57.0 unifies the encoded-image format enums and drops a few obsolete GPU and image helpers. SKCodec.EncodedFormat now returns the shared SKEncodedImageFormat, SKImageEncodeFormat is renumbered to match, and the deprecated GRPixelConfig.Index8 value plus SKImage.ToTextureImage are removed.
 
 ## Breaking Changes
 
-*None in this release.*
+- **SKCodec.EncodedFormat returns SKEncodedImageFormat** — The property no longer returns SKEncodedFormat — callers should switch to the shared SKEncodedImageFormat enum used across the API.
+- **SKImageEncodeFormat values renumbered** — The Unknown = 0 value was removed and the remaining values shifted down by one (Bmp = 0, Gif = 1, …). Recompile against the new enum values — persisted integer values are not compatible.
+- **GRPixelConfig.Index8 removed** — The Index8 pixel config was removed from GRPixelConfig, matching Skia's removal of GPU support for indexed colour.
+- **SKImage.ToTextureImage removed** — SKImage.ToTextureImage(GRContext) is gone. Create a GPU-backed image with the GRContext-based SKImage factories instead.
 
-## Links
+## API Surface
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.56.2...release/1.57.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.57.0)
+- **Encoded-image format enums unified** — SKCodec and the encoders now speak the same SKEncodedImageFormat enum, removing the parallel SKEncodedFormat / SKImageEncodeFormat duplication.
+- **Deprecated GPU helpers removed** — Drops GRPixelConfig.Index8 and SKImage.ToTextureImage, matching what Skia itself supports on the GPU.

--- a/documentation/docfx/releases/1.57.1.md
+++ b/documentation/docfx/releases/1.57.1.md
@@ -1,35 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:51Z by generate-release-notes.py
-  version:   1.57.1
-  status:    stable
-  branch:    release/1.57.1
-  diff:      release/1.57.0..release/1.57.1
-  prs:       0
-  api:       self=1.57.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.57.1 -->
 # Version 1.57.1
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.57.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.57.1)
+> **Servicing release** · Released May 5, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.57.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.57.1)
 
 > **API changes** · [SkiaSharp API diff](1.57.1/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.57.1. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.57.1 is a servicing release with fixes on top of 1.57.0.
 
 ## Breaking Changes
 
 *None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.57.0...release/1.57.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.57.1)

--- a/documentation/docfx/releases/1.58.0.md
+++ b/documentation/docfx/releases/1.58.0.md
@@ -1,35 +1,14 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:52Z by generate-release-notes.py
-  version:   1.58.0
-  status:    stable
-  branch:    release/1.58.0
-  diff:      release/1.57.1..release/1.58.0
-  prs:       0
-  api:       self=1.58.0/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.58.0 -->
 # Version 1.58.0
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.58.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.58.0)
+> **Initial 1.58 release** · Released May 17, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.58.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.58.0)
 
 > **API changes** · [SkiaSharp API diff](1.58.0/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.58.0. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.58.0 is the first release on the 1.58 line, tracking the underlying Skia bump.
 
 ## Breaking Changes
 
-*None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.57.1...release/1.58.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.58.0)
+- **GRContextOptions batch and path-mask tuning knobs removed** — `GRContextOptions` drops the batch-tuning surface (`ClipBatchToBounds`, `DrawBatchBounds`, `MaxBatchLookahead`, `MaxBatchLookback`) and `ForceSWPathMasks`, matching the upstream Skia rename from "batch" to "op". Callers that were tweaking these knobs should remove the assignments — the equivalent behaviour is now controlled by newer op-list settings.
+- **GRPixelConfig loses the ASTC 12x12, LATC and R11 EAC values** — The `Astc12x12`, `Latc` and `R11Eac` members of `GRPixelConfig` were removed upstream. Switch to a supported compressed format (for example `Etc1`) or fall back to an uncompressed configuration.

--- a/documentation/docfx/releases/1.58.1.1.md
+++ b/documentation/docfx/releases/1.58.1.1.md
@@ -1,35 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:52Z by generate-release-notes.py
-  version:   1.58.1.1
-  status:    stable
-  branch:    release/1.58.1.1
-  diff:      release/1.58.1..release/1.58.1.1
-  prs:       0
-  api:       self=1.58.1.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.58.1.1 -->
 # Version 1.58.1.1
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.58.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.58.1.1)
+> **1.58 servicing refresh** · Released September 12, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.58.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.58.1.1)
 
 > **API changes** · [SkiaSharp API diff](1.58.1.1/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.58.1.1. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.58.1.1 is a packaging servicing update on the 1.58 line with no public API changes.
 
 ## Breaking Changes
 
 *None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.58.1...release/1.58.1.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.58.1.1)

--- a/documentation/docfx/releases/1.58.1.md
+++ b/documentation/docfx/releases/1.58.1.md
@@ -1,35 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:52Z by generate-release-notes.py
-  version:   1.58.1
-  status:    stable
-  branch:    release/1.58.1
-  diff:      release/1.58.0..release/1.58.1
-  prs:       0
-  api:       self=1.58.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.58.1 -->
 # Version 1.58.1
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.58.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.58.1)
+> **1.58 servicing release** · Released June 30, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.58.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.58.1)
 
 > **API changes** · [SkiaSharp API diff](1.58.1/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.58.1. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.58.1 is a servicing update on the 1.58 line with a small Skia refresh.
 
 ## Breaking Changes
 
-*None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.58.0...release/1.58.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.58.1)
+- **GRContextOptions loses DisableDistanceFieldPaths and ForceSoftwarePathMasks** — The `DisableDistanceFieldPaths` and `ForceSoftwarePathMasks` properties on `GRContextOptions` were removed upstream. Callers should drop the assignments — path rendering picks the right strategy automatically.

--- a/documentation/docfx/releases/1.59.0.md
+++ b/documentation/docfx/releases/1.59.0.md
@@ -1,35 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:53Z by generate-release-notes.py
-  version:   1.59.0
-  status:    stable
-  branch:    release/1.59.0
-  diff:      release/1.58.1.1..release/1.59.0
-  prs:       0
-  api:       self=1.59.0/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.59.0 -->
 # Version 1.59.0
-
-> **Initial release** · Released · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.0)
+> **1.59 line opens** · Released July 15, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.0)
 
 > **API changes** · [SkiaSharp API diff](1.59.0/index.md)
 
 ## Highlights
 
-This release publishes SkiaSharp 1.59.0. No user-facing pull requests were recorded in the release data for this version.
+SkiaSharp 1.59.0 opens the 1.59 line with an assembly version bump and a small GR options trim.
 
 ## Breaking Changes
 
-*None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.58.1.1...release/1.59.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.59.0)
+- **GRContextOptions.ClipDrawOpsToBounds removed** — The `ClipDrawOpsToBounds` property on `GRContextOptions` was removed upstream. Drop the assignment — the equivalent behaviour is now on by default.

--- a/documentation/docfx/releases/1.59.1.1.md
+++ b/documentation/docfx/releases/1.59.1.1.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:53Z by generate-release-notes.py
-  version:   1.59.1.1
-  status:    stable
-  branch:    release/1.59.1.1
-  diff:      release/1.59.1..release/1.59.1.1
-  prs:       0
-  api:       self=1.59.1.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.59.1.1 -->
 # Version 1.59.1.1
-
-> **Servicing release** · Released September 12, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.1.1)
+> **1.59 packaging refresh** · Released September 12, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.1.1)
 
 > **API changes** · [SkiaSharp API diff](1.59.1.1/index.md)
 
 ## Highlights
 
-A servicing update for the 1.59 line. No pull requests were recorded in this version's diff range, so there are no user-facing changes to itemize.
+SkiaSharp 1.59.1.1 is a packaging servicing update on the 1.59 line with no public API changes.
 
 ## Breaking Changes
 
 *None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.59.1...v1.59.1.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.59.1.1)

--- a/documentation/docfx/releases/1.59.1.md
+++ b/documentation/docfx/releases/1.59.1.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:53Z by generate-release-notes.py
-  version:   1.59.1
-  status:    stable
-  branch:    release/1.59.1
-  diff:      release/1.59.0..release/1.59.1
-  prs:       0
-  api:       self=1.59.1/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.59.1 -->
 # Version 1.59.1
-
-> **Maintenance release** · Released July 18, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.1)
+> **1.59 servicing release** · Released July 17, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.1)
 
 > **API changes** · [SkiaSharp API diff](1.59.1/index.md)
 
 ## Highlights
 
-A maintenance release for the 1.59 line. No pull requests were recorded in this version's diff range, so there are no user-facing changes to call out.
+SkiaSharp 1.59.1 is a servicing update on the 1.59 line with no public API changes.
 
 ## Breaking Changes
 
 *None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.59.0...v1.59.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.59.1)

--- a/documentation/docfx/releases/1.59.2.md
+++ b/documentation/docfx/releases/1.59.2.md
@@ -1,30 +1,12 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:53Z by generate-release-notes.py
-  version:   1.59.2
-  status:    stable
-  branch:    release/1.59.2
-  diff:      release/1.59.1..release/1.59.2
-  prs:       1
-  api:       self=1.59.2/index.md
-
-  - SKManagedStream Memory Fixes by @mattleibow in https://github.com/mono/SkiaSharp/pull/386
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.59.2 -->
 # Version 1.59.2
-
-> **Managed stream reliability release** · Released October 26, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.2)
+> **SKManagedStream memory fixes** · Released October 26, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.2)
 
 > **API changes** · [SkiaSharp API diff](1.59.2/index.md)
 
 ## Highlights
 
-This release focuses on improving `SKManagedStream` memory handling, reducing the risk of leaks and lifetime issues when managed streams are passed into native Skia code.
+SkiaSharp 1.59.2 fixes memory handling in SKManagedStream on the 1.59 line.
 
 ## Breaking Changes
 
@@ -32,11 +14,4 @@ This release focuses on improving `SKManagedStream` memory handling, reducing th
 
 ## Bug Fixes
 
-### Core API
-
-- **`SKManagedStream` memory fixes** — Tightens managed stream lifetime handling to make stream-backed interop more reliable. ([#386](https://github.com/mono/SkiaSharp/pull/386))
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.59.1...v1.59.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.59.2)
+- **SKManagedStream memory handling corrected** — Fixes lifetime and buffer-handling issues in SKManagedStream so managed streams flowing through native Skia no longer leak or corrupt memory. ([#386](https://github.com/mono/SkiaSharp/pull/386))

--- a/documentation/docfx/releases/1.59.3.md
+++ b/documentation/docfx/releases/1.59.3.md
@@ -1,36 +1,13 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:53Z by generate-release-notes.py
-  version:   1.59.3
-  status:    stable
-  branch:    release/1.59.3
-  diff:      release/1.59.2..release/1.59.3
-  prs:       0
-  api:       self=1.59.3/index.md
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.59.3 -->
 # Version 1.59.3
-
-> **Maintenance release** · Released December 19, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.3)
+> **1.59 servicing update** · Released December 19, 2017 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.59.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.59.3)
 
 > **API changes** · [SkiaSharp API diff](1.59.3/index.md)
 
 ## Highlights
 
-A maintenance release for the 1.59 line. No pull requests were recorded in this version's diff range, so there are no user-facing changes to highlight.
+SkiaSharp 1.59.3 is a servicing update on the 1.59 line with no public API changes.
 
 ## Breaking Changes
 
 *None in this release.*
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.59.2...v1.59.3)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.59.3)

--- a/documentation/docfx/releases/1.60.0.md
+++ b/documentation/docfx/releases/1.60.0.md
@@ -1,36 +1,17 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:54Z by generate-release-notes.py
-  version:   1.60.0
-  status:    stable
-  branch:    release/1.60.0
-  diff:      release/1.59.3..release/1.60.0
-  prs:       0
-  api:       self=1.60.0/index.md;hb=1.4.6
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.60.0 -->
 # Version 1.60.0
+> **First public 1.60 release** · Released February 22, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.0)
 
-> **Initial 1.60 release** · Released February 23, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.0)
-
-> **API changes** · [SkiaSharp API diff](1.60.0/index.md) · [HarfBuzzSharp 1.4.6](harfbuzzsharp/1.4.6.md)
+> **API changes** · [SkiaSharp API diff](1.60.0/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/1.4.6/index.md)
 
 ## Highlights
 
-This release starts the 1.60 line and ships alongside HarfBuzzSharp 1.4.6; see the linked HarfBuzzSharp release page above for the binding details. No pull requests were recorded in this version's diff range, so there are no additional user-facing changes to itemize here.
+SkiaSharp 1.60.0 was the first public 1.60 release, published alongside HarfBuzzSharp 1.4.6.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## Links
+## HarfBuzzSharp 1.4.6
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.59.3...v1.60.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.60.0)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/1.60.1.md
+++ b/documentation/docfx/releases/1.60.1.md
@@ -1,42 +1,21 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:54Z by generate-release-notes.py
-  version:   1.60.1
-  status:    stable
-  branch:    release/1.60.1
-  diff:      release/1.60.0..release/1.60.1
-  prs:       1
-  api:       self=1.60.1/index.md;hb=1.4.6.1
-
-  - Made some types public for 3rd-party Xamarin.Forms platforms by @mattleibow in https://github.com/mono/SkiaSharp/pull/522
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.60.1 -->
 # Version 1.60.1
+> **Public types for Xamarin.Forms** · Released May 21, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.1)
 
-> **Platform extensibility update** · Released May 22, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.1)
-
-> **API changes** · [SkiaSharp API diff](1.60.1/index.md) · [HarfBuzzSharp 1.4.6.1](harfbuzzsharp/1.4.6.1.md)
+> **API changes** · [SkiaSharp API diff](1.60.1/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/1.4.6.1/index.md)
 
 ## Highlights
 
-This release makes additional types public so third-party Xamarin.Forms platform implementations can integrate more cleanly with SkiaSharp. It also ships alongside HarfBuzzSharp 1.4.6.1; see the linked HarfBuzzSharp release page above for the binding details.
+SkiaSharp 1.60.1 opens up types needed by third-party Xamarin.Forms platform backends.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## API Surface
 
-### API Surface
+- **Types exposed for third-party Xamarin.Forms backends** — Makes previously-internal renderer helpers public so third parties can build their own Xamarin.Forms platform integrations on top of SkiaSharp. ([#522](https://github.com/mono/SkiaSharp/pull/522))
 
-- **More public types for custom Xamarin.Forms platforms** — Exposes the types needed by third-party platform backends without requiring internal access workarounds. ([#522](https://github.com/mono/SkiaSharp/pull/522))
+## HarfBuzzSharp 1.4.6.1
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.60.0...v1.60.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.60.1)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/1.60.2.md
+++ b/documentation/docfx/releases/1.60.2.md
@@ -1,36 +1,17 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:55Z by generate-release-notes.py
-  version:   1.60.2
-  status:    stable
-  branch:    release/1.60.2
-  diff:      release/1.60.1..release/1.60.2
-  prs:       0
-  api:       self=1.60.2/index.md;hb=1.4.6.1
-
-  *No changes found.*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.60.2 -->
 # Version 1.60.2
+> **Servicing refresh** · Released June 28, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.2)
 
-> **Maintenance release** · Released June 28, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.2)
-
-> **API changes** · [SkiaSharp API diff](1.60.2/index.md) · [HarfBuzzSharp 1.4.6.1](harfbuzzsharp/1.4.6.1.md)
+> **API changes** · [SkiaSharp API diff](1.60.2/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/1.4.6.1/index.md)
 
 ## Highlights
 
-A maintenance release for the 1.60 line. It ships alongside HarfBuzzSharp 1.4.6.1; see the linked HarfBuzzSharp release page above for the binding details. No pull requests were recorded in this version's diff range, so there are no user-facing changes to call out.
+SkiaSharp 1.60.2 is a servicing refresh of the 1.60 line with no consumer-visible changes.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## Links
+## HarfBuzzSharp 1.4.6.1
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.60.1...v1.60.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.60.2)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/1.60.3.md
+++ b/documentation/docfx/releases/1.60.3.md
@@ -1,37 +1,17 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:55Z by generate-release-notes.py
-  version:   1.60.3
-  status:    stable
-  branch:    release/1.60.3
-  diff:      release/1.60.2..release/1.60.3
-  prs:       2
-  api:       self=1.60.3/index.md;hb=1.4.6.1
-
-  - Fixed some more docs by @mattleibow in https://github.com/mono/SkiaSharp/pull/565
-  - Fixing Docs by @mattleibow in https://github.com/mono/SkiaSharp/pull/562
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.60.3 -->
 # Version 1.60.3
+> **Documentation servicing** · Released August 13, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.3)
 
-> **Servicing release** · Released August 13, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.60.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.60.3)
-
-> **API changes** · [SkiaSharp API diff](1.60.3/index.md) · [HarfBuzzSharp 1.4.6.1](harfbuzzsharp/1.4.6.1.md)
+> **API changes** · [SkiaSharp API diff](1.60.3/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/1.4.6.1/index.md)
 
 ## Highlights
 
-A servicing update for the 1.60 line with no user-facing code changes to call out from the recorded pull requests. It also ships alongside HarfBuzzSharp 1.4.6.1; see the linked HarfBuzzSharp release page above for the binding details.
+SkiaSharp 1.60.3 is a servicing release covering documentation fixes only.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## Links
+## HarfBuzzSharp 1.4.6.1
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.60.2...v1.60.3)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.60.3)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/1.68.0.md
+++ b/documentation/docfx/releases/1.68.0.md
@@ -1,64 +1,27 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:54:56Z by generate-release-notes.py
-  version:   1.68.0
-  status:    stable
-  branch:    release/1.68.0
-  diff:      release/1.60.3..release/1.68.0
-  prs:       5
-  api:       self=1.68.0/index.md;hb=1.4.6.2
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Preview 28 · 1.68.0 · 2018-11-06 · https://github.com/mono/SkiaSharp/compare/v1.60.3...v1.68.0-preview28  (5 PRs)
-    - Statically Link Windows Binaries by @mattleibow in https://github.com/mono/SkiaSharp/pull/662
-    - Merged in a few improvements to the CI by @mattleibow in https://github.com/mono/SkiaSharp/pull/638
-    - Improve the Linux CI by @mattleibow in https://github.com/mono/SkiaSharp/pull/635
-    - Testing PR Builder by @mattleibow in https://github.com/mono/SkiaSharp/pull/616
-    - Added a Groovy script for CI by @mattleibow in https://github.com/mono/SkiaSharp/pull/615
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.68.0 -->
 # Version 1.68.0
+> **1.68 line opens** · Released December 2, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.0)
 
-> **Windows packaging update** · Released December 4, 2018 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.0)
-
-> **API changes** · [SkiaSharp API diff](1.68.0/index.md) · [HarfBuzzSharp 1.4.6.2](harfbuzzsharp/1.4.6.2.md)
+> **API changes** · [SkiaSharp API diff](1.68.0/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/1.4.6.2/index.md)
 
 ## Highlights
 
-The 1.68 release improves Windows deployment by statically linking the Windows native binaries, reducing external dependency friction when shipping SkiaSharp apps. It also ships alongside HarfBuzzSharp 1.4.6.2; see the linked HarfBuzzSharp release page above for the binding details.
+SkiaSharp 1.68.0 opens the 1.68 line with build and CI improvements landing across Linux and Windows.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## Platform
 
-### Platform
+- **Linux and cross-platform CI hardened** — Improves the Linux build pipeline and folds in a batch of CI reliability fixes that keep the multi-platform native builds green. ([#635](https://github.com/mono/SkiaSharp/pull/635), [#638](https://github.com/mono/SkiaSharp/pull/638))
 
-- **Statically linked Windows binaries** — Updates the Windows native packages to link their dependencies statically, simplifying deployment for Windows apps. ([#662](https://github.com/mono/SkiaSharp/pull/662))
+## HarfBuzzSharp 1.4.6.2
 
-## Platform Support
-
-| Platform | What's New |
-|----------|-----------|
-| 🪟 Windows | Native binaries are now statically linked |
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.60.3...v1.68.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.68.0)
-
----
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.
 
 ## Preview 28 (November 6, 2018)
 
-This preview introduced statically linked Windows native binaries.
+Preview 28 cut the first 1.68 preview, bundling the Windows static-linking work and the Linux CI improvements.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.60.3...v1.68.0-preview28)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.60.3...v1.68.0-preview28)

--- a/documentation/docfx/releases/1.68.1.1.md
+++ b/documentation/docfx/releases/1.68.1.1.md
@@ -1,51 +1,12 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:10Z by generate-release-notes.py
-  version:   1.68.1.1
-  status:    stable
-  branch:    release/1.68.1.1
-  diff:      release/1.68.1..release/1.68.1.1
-  prs:       16
-  api:       self=1.68.1.1/index.md;hb=2.6.1.1
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (4 PRs)
-    - Remove an unused argument of type TaskScheduler from AnimatedSampleBase by @bender2k14 in https://github.com/mono/SkiaSharp/pull/1063 [community ✨]
-    - suffices to start the rotation matrix as the identity matrix by @bender2k14 in https://github.com/mono/SkiaSharp/pull/1062 [community ✨]
-    - Don't go straight for the max samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1060
-    - Add the .targets file to buildTransitive by @mattleibow in https://github.com/mono/SkiaSharp/pull/1057
-
-  ## Preview 9 · 1.68.1.1 · 2019-12-10 · https://github.com/mono/SkiaSharp/compare/v1.68.1...v1.68.1.1-preview.9  (12 PRs)
-    - Correctly decode images by @mattleibow in https://github.com/mono/SkiaSharp/pull/1055
-    - Improve the Docker samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1051
-    - Pulling in some changes from other places by @mattleibow in https://github.com/mono/SkiaSharp/pull/1054
-    - Improve native build process + add Nano Server by @mattleibow in https://github.com/mono/SkiaSharp/pull/1040
-    - Assemblies are required in platform ref folders by @mattleibow in https://github.com/mono/SkiaSharp/pull/1044
-    - Use a patch update for now as this is just fixes by @mattleibow in https://github.com/mono/SkiaSharp/pull/1045
-    - Update README.md by @mattleibow in https://github.com/mono/SkiaSharp/pull/1043
-    - TryRemove instances WeakReferences by @daltonks in https://github.com/mono/SkiaSharp/pull/1039 [community ✨]
-    - Add Code Checks by @mattleibow in https://github.com/mono/SkiaSharp/pull/1038
-    - Fix issues with harfbuzz strings by @mattleibow in https://github.com/mono/SkiaSharp/pull/1034
-    - Cherry pick some fixes for buffer overflow bugs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1037
-    - Use Docker to Build Linux & Update Versions to v1.68.2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1036
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.68.1.1 -->
 # Version 1.68.1.1
+> **1.68.1 servicing** · Released December 14, 2019 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.1.1)
 
-> **Servicing and packaging fixes** · Released December 19, 2019 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.1.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.1.1)
-
-> **API changes** · [SkiaSharp API diff](1.68.1.1/index.md) · [HarfBuzzSharp 2.6.1.1](harfbuzzsharp/2.6.1.1.md)
+> **API changes** · [SkiaSharp API diff](1.68.1.1/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.1/index.md)
 
 ## Highlights
 
-This patch release focuses on correctness: image decoding fixes, safer lifetime handling, cleaner transitive build assets, and a handful of native and string-processing fixes. It also ships with HarfBuzzSharp 2.6.1.1 for the corresponding text-binding updates.
+SkiaSharp 1.68.1.1 is a servicing patch on 1.68.1 with image decoding, HarfBuzz string and native build fixes.
 
 ## Breaking Changes
 
@@ -53,37 +14,33 @@ This patch release focuses on correctness: image decoding fixes, safer lifetime 
 
 ## Bug Fixes
 
-- **Image and text correctness** — Fixes image decoding issues and resolves problems with HarfBuzz string handling. ([#1055](https://github.com/mono/SkiaSharp/pull/1055), [#1034](https://github.com/mono/SkiaSharp/pull/1034))
-- **Packaging and references** — Ensures `.targets` flow transitively and that reference assemblies land in the expected platform ref folders. ([#1057](https://github.com/mono/SkiaSharp/pull/1057), [#1044](https://github.com/mono/SkiaSharp/pull/1044))
-- **Object lifetime cleanup** — Improves weak-reference removal and avoids over-aggressive sample count selection. ❤️ [@daltonks](https://github.com/daltonks) ([#1039](https://github.com/mono/SkiaSharp/pull/1039), [#1060](https://github.com/mono/SkiaSharp/pull/1060))
+- **Image decoding corrected** — Fixes cases where images were decoded with the wrong colour or pixel handling, restoring correct output for common formats. ([#1055](https://github.com/mono/SkiaSharp/pull/1055))
+- **HarfBuzz string handling and buffer overflows** — Corrects string marshalling in the HarfBuzz binding and cherry-picks upstream fixes for buffer-overflow bugs. ([#1034](https://github.com/mono/SkiaSharp/pull/1034), [#1037](https://github.com/mono/SkiaSharp/pull/1037))
+- **Sample renderer picks a supported sample count** — Stops the sample surfaces asking for the maximum MSAA sample count, which some drivers refused. ([#1060](https://github.com/mono/SkiaSharp/pull/1060))
 
-## Security
+## Lifecycle & Internals
 
-- **Cherry-picked buffer overflow fixes** — Pulls in native fixes aimed at closing known overflow issues in the 1.68 servicing line. ([#1037](https://github.com/mono/SkiaSharp/pull/1037))
+- **Weak-reference tracking cleaned up on removal** — TryRemove now clears the tracked WeakReference so long-lived object caches do not keep stale entries around. — ❤️ [@daltonks](https://github.com/daltonks) ([#1039](https://github.com/mono/SkiaSharp/pull/1039))
+
+## Platform
+
+- **Native build modernised; Nano Server added** — Reworks the native build process and adds a Nano Server target so SkiaSharp runs in stripped-down Windows containers. ([#1040](https://github.com/mono/SkiaSharp/pull/1040))
+
+## HarfBuzzSharp 2.6.1.1
+
+Rolls the bundled HarfBuzz build forward to 2.6.1.1 with the native build-process modernisation.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@daltonks](https://github.com/daltonks) | Improved weak-reference cleanup |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.68.1...release/1.68.1.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.68.1.1)
-
----
-
-## Unreleased
-
-Post-preview cleanup added a few final packaging and servicing refinements before release.
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1.1-preview.9...release/1.68.1.1)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@bender2k14](https://github.com/bender2k14) | Sample cleanups — dropped an unused TaskScheduler argument and simplified the rotation matrix initialisation ([#1062](https://github.com/mono/SkiaSharp/pull/1062), [#1063](https://github.com/mono/SkiaSharp/pull/1063)) |
+| [@daltonks](https://github.com/daltonks) | Cleaned up WeakReference tracking so TryRemove clears the stored reference ([#1039](https://github.com/mono/SkiaSharp/pull/1039)) |
 
 ## Preview 9 (December 10, 2019)
 
-This preview concentrated on decode fixes, native build and packaging cleanup, and a round of servicing updates.
+Preview 9 was the only preview cut for 1.68.1.1, bundling the image-decoding correction, HarfBuzz string fixes, buffer-overflow cherry-picks and the Nano Server build work.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1...v1.68.1.1-preview.9)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1...v1.68.1.1-preview.9)

--- a/documentation/docfx/releases/1.68.1.md
+++ b/documentation/docfx/releases/1.68.1.md
@@ -1,204 +1,83 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:09Z by generate-release-notes.py
-  version:   1.68.1
-  status:    stable
-  branch:    release/1.68.1
-  diff:      release/1.68.0..release/1.68.1
-  prs:       66
-  api:       self=1.68.1/index.md;hb=2.6.1
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (7 PRs)
-    - Updated all the samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1021
-    - Improve stability of UWP GPU View by @mattleibow in https://github.com/mono/SkiaSharp/pull/1024
-    - Use better PR labels for build artifacts by @mattleibow in https://github.com/mono/SkiaSharp/pull/1025
-    - Fix bad colors by @mattleibow in https://github.com/mono/SkiaSharp/pull/1023
-    - Correction of #879 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1022
-    - Add binding for SKTypeface.IsFixedPitch by @mattleibow in https://github.com/mono/SkiaSharp/pull/1019
-    - Env.Is64BitOperatingSystem isn't in dotnet build by @mattleibow in https://github.com/mono/SkiaSharp/pull/1020
-
-  ## Release Candidate 172 · 1.68.1 · 2019-11-17 · https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.170...v1.68.1-rc.172  (1 PRs)
-    - Final tweaks to prepare for release by @mattleibow in https://github.com/mono/SkiaSharp/pull/1013
-
-  ## Release Candidate 170 · 1.68.1 · 2019-11-16 · https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.169...v1.68.1-rc.170  (1 PRs)
-    - netstandard SkiaSharp.Views.Forms.dll should be ref-only by @mattleibow in https://github.com/mono/SkiaSharp/pull/1012
-
-  ## Release Candidate 169 · 1.68.1 · 2019-11-12 · https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.165...v1.68.1-rc.169  (2 PRs)
-    - Free memory when the view is detached. Fixes #1004 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1005
-    - Use Clang for Windows (m68) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1007
-
-  ## Release Candidate 165 · 1.68.1 · 2019-11-06 · https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.153...v1.68.1-rc.165  (6 PRs)
-    - Fix #994 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1000
-    - Bind SkPictureShader by @alexandrvslv in https://github.com/mono/SkiaSharp/pull/973 [community ✨]
-    - Add some task to generate docs by @mattleibow in https://github.com/mono/SkiaSharp/pull/997 (skia: mono/skia#68)
-    - Created a P/Invoke Generator by @mattleibow in https://github.com/mono/SkiaSharp/pull/992
-    - Fix a memory leak in SKRoundRect by @mattleibow in https://github.com/mono/SkiaSharp/pull/995
-    - Add int unicode overloads to be more consistent by @Gillibald in https://github.com/mono/SkiaSharp/pull/972 [community ✨]
-
-  ## Release Candidate 153 · 1.68.1 · 2019-10-19 · https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.147...v1.68.1-rc.153  (9 PRs)
-    - Updating the submodules by @mattleibow in https://github.com/mono/SkiaSharp/pull/985 (skia: mono/skia#66)
-    - Linux build version script to hide exports of dependencies by @Gillibald in https://github.com/mono/SkiaSharp/pull/984 [community ✨]
-    - Update the docs and reduce diff by @mattleibow in https://github.com/mono/SkiaSharp/pull/979
-    - HarfBuzzSharp 2.6.1 by @Gillibald in https://github.com/mono/SkiaSharp/pull/929 [community ✨]
-    - Enable bitcode for watchOS and tvOS by @mattleibow in https://github.com/mono/SkiaSharp/pull/971 (skia: mono/skia#63)
-    - Build arm64_32 architecture for watchOS by @mattleibow in https://github.com/mono/SkiaSharp/pull/967 (skia: mono/skia#62)
-    - Reset the counter for the master branch by @mattleibow in https://github.com/mono/SkiaSharp/pull/966
-    - Trying to get master back on track by @mattleibow in https://github.com/mono/SkiaSharp/pull/962
-    - Some of the colorspaces created are just references by @mattleibow in https://github.com/mono/SkiaSharp/pull/922
-
-  ## Release Candidate 147 · 1.68.1 · 2019-07-30 · https://github.com/mono/SkiaSharp/compare/v1.68.0...v1.68.1-rc.147  (40 PRs)
-    - Re-work the managed-native types by @mattleibow in https://github.com/mono/SkiaSharp/pull/900 (skia: mono/skia#61)
-    - Add *.dylib to the app bundle when using the full fx by @mattleibow in https://github.com/mono/SkiaSharp/pull/919
-    - Add the WPF backend for Xamarin.Forms by @mattleibow in https://github.com/mono/SkiaSharp/pull/917
-    - Update Xamarin.Forms by @mattleibow in https://github.com/mono/SkiaSharp/pull/916
-    - Split the desktop projects and packages by @mattleibow in https://github.com/mono/SkiaSharp/pull/899
-    - A few tweaks to harfbuzz by @mattleibow in https://github.com/mono/SkiaSharp/pull/915
-    - Update HarfBuzz to v2.5.3 by @Gillibald in https://github.com/mono/SkiaSharp/pull/904 [community ✨]
-    - Improve the test runners by @mattleibow in https://github.com/mono/SkiaSharp/pull/903
-    - Make sure everything is fine in Debug builds by @mattleibow in https://github.com/mono/SkiaSharp/pull/891
-    - [HarfBuzzSharp] font funcs by @Gillibald in https://github.com/mono/SkiaSharp/pull/881 [community ✨]
-    - Change native artifact name to match Azure Build. by @danien in https://github.com/mono/SkiaSharp/pull/892 [community ✨]
-    - Use Span<T> for data, bitmap data and text blobs by @mattleibow in https://github.com/mono/SkiaSharp/pull/865
-    - Add a method to reduce verbosity for multi-delegates by @mattleibow in https://github.com/mono/SkiaSharp/pull/882
-    - Upgrade the macOS bots and software by @mattleibow in https://github.com/mono/SkiaSharp/pull/884
-    - Publicly publish all the native artifacts by @mattleibow in https://github.com/mono/SkiaSharp/pull/889
-    - Make sure to use the correct .targets name on Linux by @mattleibow in https://github.com/mono/SkiaSharp/pull/886
-    - Use better variables and scripts by @mattleibow in https://github.com/mono/SkiaSharp/pull/885
-    - Improve the delegate proxies by @mattleibow in https://github.com/mono/SkiaSharp/pull/878
-    - Fix implementation of the iOS canvas by @mattleibow in https://github.com/mono/SkiaSharp/pull/879
-    - Fix #849 : function ToSKPixmap create display artifacts with transparent bitmaps by @Odirb in https://github.com/mono/SkiaSharp/pull/863 [community ✨]
-    - Update HarfBuzz to v2.5.2 by @Gillibald in https://github.com/mono/SkiaSharp/pull/872 [community ✨]
-    - Make sure to build Debug samples in PRs by @mattleibow in https://github.com/mono/SkiaSharp/pull/875
-    - Update some versions and fix the sample builds by @mattleibow in https://github.com/mono/SkiaSharp/pull/869
-    - Update skia to fix a typo by @mattleibow in https://github.com/mono/SkiaSharp/pull/868
-    - Raster views shouldn't allocate 0 bytes. Fixes #759 by @mattleibow in https://github.com/mono/SkiaSharp/pull/761
-    - [harfbuzz] Allow loading face by table data by @mattleibow in https://github.com/mono/SkiaSharp/pull/862
-    - Make sure to remove the correct packages by @mattleibow in https://github.com/mono/SkiaSharp/pull/859
-    - Add support for a custom preview label by @mattleibow in https://github.com/mono/SkiaSharp/pull/857
-    - Few changes for release by @mattleibow in https://github.com/mono/SkiaSharp/pull/850
-    - Support building SkiaSharp without fontconfig by @mattleibow in https://github.com/mono/SkiaSharp/pull/821
-    - Moving Documentation to SkiaSharp-API-docs by @mattleibow in https://github.com/mono/SkiaSharp/pull/843
-    - Use the correct combination of OpenJDK and Tizen by @mattleibow in https://github.com/mono/SkiaSharp/pull/817
-    - Switched badge and templates by @mattleibow in https://github.com/mono/SkiaSharp/pull/779
-    - Skip Signing on Public Builds by @mattleibow in https://github.com/mono/SkiaSharp/pull/790
-    - [build] Added NuGet Signing by @mattleibow in https://github.com/mono/SkiaSharp/pull/786
-    - Refactor the pipeline to reuse most of the functionality by @mattleibow in https://github.com/mono/SkiaSharp/pull/785
-    - Adding iOS/macOS Certificates by @mattleibow in https://github.com/mono/SkiaSharp/pull/777
-    - Added Azure DevOps Pipeline by @mattleibow in https://github.com/mono/SkiaSharp/pull/776
-    - Update issue templates by @mattleibow in https://github.com/mono/SkiaSharp/pull/737
-    - Update to include nuget-validation build.cake by @newky2k in https://github.com/mono/SkiaSharp/pull/724 [community ✨]
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.68.1 -->
 # Version 1.68.1
+> **1.68.1 stable** · Released November 22, 2019 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.1)
 
-> **Desktop expansion and API polish** · Released November 22, 2019 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.1)
-
-> **API changes** · [SkiaSharp API diff](1.68.1/index.md) · [HarfBuzzSharp 2.6.1](harfbuzzsharp/2.6.1.md)
+> **API changes** · [SkiaSharp API diff](1.68.1/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1/index.md)
 
 ## Highlights
 
-This release significantly broadens the 1.68 line with new desktop and Xamarin.Forms capabilities, wider Apple platform coverage, and a larger managed API surface. Highlights include the new WPF backend for Xamarin.Forms, `Span<T>`-based data APIs, additional text and shader bindings, and a bundled HarfBuzzSharp 2.6.1 update.
+SkiaSharp 1.68.1 ships the long-running 1.68.1 line as stable with a broad wave of API, view and HarfBuzz work. This is a large servicing release built from six release candidates over four months. It expands the managed API with Span-based buffers, an SKPictureShader binding and new SKTypeface members, reworks the managed/native type layer for stability, splits the desktop view packages, and refreshes HarfBuzzSharp to 2.6.1.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## API Surface
 
-### Platform
-
-- **WPF backend for Xamarin.Forms** — Adds WPF support to the Xamarin.Forms views stack, expanding desktop UI options. ([#917](https://github.com/mono/SkiaSharp/pull/917))
-- **Apple platform packaging updates** — Enables bitcode for watchOS and tvOS and adds `arm64_32` support for watchOS. ([#971](https://github.com/mono/SkiaSharp/pull/971), [#967](https://github.com/mono/SkiaSharp/pull/967))
-- **Desktop package refinements** — Splits desktop projects and packages to better match platform-specific deployment needs. ([#899](https://github.com/mono/SkiaSharp/pull/899))
-
-### API Surface
-
-- **New graphics APIs** — Adds bindings for `SKPictureShader`, `SKTypeface.IsFixedPitch`, and additional Unicode overloads to round out the core API surface. ❤️ [@alexandrvslv](https://github.com/alexandrvslv), [@Gillibald](https://github.com/Gillibald) ([#973](https://github.com/mono/SkiaSharp/pull/973), [#1019](https://github.com/mono/SkiaSharp/pull/1019), [#972](https://github.com/mono/SkiaSharp/pull/972))
-- **Span-based data access** — Introduces `Span<T>`-focused APIs for data buffers, bitmap access, and text blobs to reduce copying and improve ergonomics. ([#865](https://github.com/mono/SkiaSharp/pull/865))
-
-### Text & Fonts
-
-- **HarfBuzzSharp 2.6.1** — This release ships with HarfBuzzSharp 2.6.1 for updated text shaping support; see the linked HarfBuzz release page for binding-specific details. ([#929](https://github.com/mono/SkiaSharp/pull/929), [#904](https://github.com/mono/SkiaSharp/pull/904), [#881](https://github.com/mono/SkiaSharp/pull/881))
+- **Span-based data, bitmap and text APIs** — Adds Span<T> overloads for data buffers, bitmap pixels and text blobs so callers can hand SkiaSharp existing memory without copying through byte arrays. ([#865](https://github.com/mono/SkiaSharp/pull/865))
+- **SKPictureShader and typeface additions** — Binds SkPictureShader for tiling and transforming recorded pictures, adds SKTypeface.IsFixedPitch, and lands int-unicode overloads for consistency across the text APIs. — ❤️ [@alexandrvslv](https://github.com/alexandrvslv), [@Gillibald](https://github.com/Gillibald) ([#973](https://github.com/mono/SkiaSharp/pull/973), [#1019](https://github.com/mono/SkiaSharp/pull/1019), [#972](https://github.com/mono/SkiaSharp/pull/972))
+- **Managed/native type layer reworked** — Reworks how managed wrappers own and reference native objects so shared instances such as colour spaces stop being disposed out from under callers. ([#900](https://github.com/mono/SkiaSharp/pull/900), [#922](https://github.com/mono/SkiaSharp/pull/922))
+- **HarfBuzzSharp font funcs and table loading** — Adds font-funcs bindings on the HarfBuzzSharp side and lets faces be loaded directly from table data, alongside general HarfBuzz binding polish. — ❤️ [@Gillibald](https://github.com/Gillibald) ([#881](https://github.com/mono/SkiaSharp/pull/881), [#862](https://github.com/mono/SkiaSharp/pull/862), [#915](https://github.com/mono/SkiaSharp/pull/915))
 
 ## Bug Fixes
 
-- **View and lifecycle stability** — Improves UWP GPU view stability and frees native resources when views are detached. ([#1024](https://github.com/mono/SkiaSharp/pull/1024), [#1005](https://github.com/mono/SkiaSharp/pull/1005))
-- **Rendering correctness** — Fixes transparent pixmap artifacts, color issues, and incorrect color-space ownership behavior. ❤️ [@Odirb](https://github.com/Odirb) ([#863](https://github.com/mono/SkiaSharp/pull/863), [#1023](https://github.com/mono/SkiaSharp/pull/1023), [#922](https://github.com/mono/SkiaSharp/pull/922))
-- **Memory management** — Fixes a memory leak in `SKRoundRect` and avoids zero-byte raster allocations. ([#995](https://github.com/mono/SkiaSharp/pull/995), [#761](https://github.com/mono/SkiaSharp/pull/761))
+- **iOS canvas and raster view corrections** — Fixes the iOS canvas implementation and stops raster views allocating zero-byte buffers when the surface has no size yet. — ❤️ [@Odirb](https://github.com/Odirb) ([#879](https://github.com/mono/SkiaSharp/pull/879), [#761](https://github.com/mono/SkiaSharp/pull/761), [#863](https://github.com/mono/SkiaSharp/pull/863))
+- **Memory and stability fixes** — Frees native memory when a view is detached, plugs an SKRoundRect leak, and improves UWP GPU view stability under teardown. ([#1005](https://github.com/mono/SkiaSharp/pull/1005), [#995](https://github.com/mono/SkiaSharp/pull/995), [#1024](https://github.com/mono/SkiaSharp/pull/1024), [#1023](https://github.com/mono/SkiaSharp/pull/1023), [#1000](https://github.com/mono/SkiaSharp/pull/1000))
+
+## Platform
+
+- **Desktop view packages split; WPF Forms backend added** — Splits the desktop view projects and NuGet packages so consumers can pull only the framework they need, and adds a WPF backend for Xamarin.Forms. ([#899](https://github.com/mono/SkiaSharp/pull/899), [#917](https://github.com/mono/SkiaSharp/pull/917))
+- **watchOS and tvOS bitcode, arm64_32 for watchOS** — Enables bitcode for watchOS and tvOS and adds the watchOS arm64_32 slice so SkiaSharp keeps working on modern Apple wearables. ([#971](https://github.com/mono/SkiaSharp/pull/971), [#967](https://github.com/mono/SkiaSharp/pull/967))
+- **Optional fontconfig on Linux** — Lets SkiaSharp be built without fontconfig for stripped-down Linux containers and images that do not ship the library. ([#821](https://github.com/mono/SkiaSharp/pull/821))
+
+## HarfBuzzSharp 2.6.1
+
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@alexandrvslv](https://github.com/alexandrvslv) | Added the `SKPictureShader` binding |
-| [@Gillibald](https://github.com/Gillibald) | Added Unicode overloads, improved Linux native packaging, and updated HarfBuzz |
-| [@Odirb](https://github.com/Odirb) | Fixed transparent bitmap artifacts in `ToSKPixmap` |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.68.0...release/1.68.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.68.1)
-
----
-
-## Unreleased
-
-Final release prep added last-minute GPU stability, color, and API cleanups before the 1.68.1 tag landed.
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.172...release/1.68.1)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@Gillibald](https://github.com/Gillibald) | HarfBuzzSharp 2.6.1 bump, HarfBuzz font funcs, int-unicode overloads, and additional HarfBuzz updates ([#872](https://github.com/mono/SkiaSharp/pull/872), [#881](https://github.com/mono/SkiaSharp/pull/881), [#904](https://github.com/mono/SkiaSharp/pull/904), [#929](https://github.com/mono/SkiaSharp/pull/929), [#972](https://github.com/mono/SkiaSharp/pull/972), [#984](https://github.com/mono/SkiaSharp/pull/984)) |
+| [@alexandrvslv](https://github.com/alexandrvslv) | SKPictureShader binding ([#973](https://github.com/mono/SkiaSharp/pull/973)) |
+| [@danien](https://github.com/danien) | Contributed a fix landing in this release ([#892](https://github.com/mono/SkiaSharp/pull/892)) |
+| [@newky2k](https://github.com/newky2k) | Contributed a fix landing in this release ([#724](https://github.com/mono/SkiaSharp/pull/724)) |
+| [@Odirb](https://github.com/Odirb) | Fixed ToSKPixmap display artifacts with transparent bitmaps (#849) ([#863](https://github.com/mono/SkiaSharp/pull/863)) |
 
 ## Release Candidate 172 (November 17, 2019)
 
-This candidate focused on final packaging and release-readiness tweaks.
+Release Candidate 172 was the final RC before stable, folding in the last UWP GPU view stability fixes and colour corrections.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.170...v1.68.1-rc.172)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.170...v1.68.1-rc.172)
 
 ## Release Candidate 170 (November 16, 2019)
 
-This candidate corrected the `netstandard` packaging shape for `SkiaSharp.Views.Forms`.
+Release Candidate 170 added the SKTypeface.IsFixedPitch binding and prepared for the stable cut.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.169...v1.68.1-rc.170)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.169...v1.68.1-rc.170)
 
 ## Release Candidate 169 (November 12, 2019)
 
-This candidate fixed view-detach memory leaks and moved the Windows milestone build to Clang.
+Release Candidate 169 landed the SKRoundRect leak fix and view teardown corrections.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.165...v1.68.1-rc.169)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.165...v1.68.1-rc.169)
 
 ## Release Candidate 165 (November 6, 2019)
 
-This candidate added `SKPictureShader`, more Unicode overloads, and several memory-management fixes.
+Release Candidate 165 brought in the SKPictureShader binding and further HarfBuzz updates.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.153...v1.68.1-rc.165)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.153...v1.68.1-rc.165)
 
 ## Release Candidate 153 (October 19, 2019)
 
-This candidate brought in HarfBuzzSharp 2.6.1, improved Apple platform packaging, and tightened Linux native exports.
+Release Candidate 153 shipped the managed/native type rework and bitcode support for watchOS/tvOS.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.147...v1.68.1-rc.153)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1-rc.147...v1.68.1-rc.153)
 
 ## Release Candidate 147 (July 30, 2019)
 
-This first candidate delivered the managed/native type rework, new desktop capabilities, `Span<T>` APIs, and multiple rendering fixes.
+Release Candidate 147 opened the 1.68.1 line with the Span<T> APIs, the desktop package split, and the WPF Xamarin.Forms backend.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.0...v1.68.1-rc.147)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.0...v1.68.1-rc.147)

--- a/documentation/docfx/releases/1.68.2.1.md
+++ b/documentation/docfx/releases/1.68.2.1.md
@@ -1,40 +1,17 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:25Z by generate-release-notes.py
-  version:   1.68.2.1
-  status:    stable
-  branch:    release/1.68.2.1
-  diff:      release/1.68.2..release/1.68.2.1
-  prs:       1
-  api:       self=1.68.2.1/index.md;hb=2.6.1.3
-
-  - Ensure that the assemblies are in fact signed by @mattleibow in https://github.com/mono/SkiaSharp/pull/1268
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.68.2.1 -->
 # Version 1.68.2.1
+> **Signing servicing** · Released May 2, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.2.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.2.1)
 
-> **Package signing hotfix** · Released May 2, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.2.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.2.1)
-
-> **API changes** · [SkiaSharp API diff](1.68.2.1/index.md) · [HarfBuzzSharp 2.6.1.3](harfbuzzsharp/2.6.1.3.md)
+> **API changes** · [SkiaSharp API diff](1.68.2.1/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.3/index.md)
 
 ## Highlights
 
-This is a focused maintenance release that ensures the distributed assemblies are correctly signed. It also ships with HarfBuzzSharp 2.6.1.3 for the aligned text-binding package version.
+SkiaSharp 1.68.2.1 is a servicing patch that ensures the shipped assemblies are correctly signed.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## Bug Fixes
+## HarfBuzzSharp 2.6.1.3
 
-- **Assembly signing validation** — Ensures the packaged assemblies are in fact signed as expected. ([#1268](https://github.com/mono/SkiaSharp/pull/1268))
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.68.2...release/1.68.2.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.68.2.1)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/1.68.2.md
+++ b/documentation/docfx/releases/1.68.2.md
@@ -1,238 +1,118 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:25Z by generate-release-notes.py
-  version:   1.68.2
-  status:    stable
-  branch:    release/1.68.2
-  diff:      release/1.68.1..release/1.68.2
-  prs:       71
-  api:       self=1.68.2/index.md;hb=2.6.1.2
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (10 PRs)
-    - Update docs for release by @mattleibow in https://github.com/mono/SkiaSharp/pull/1263
-    - Prevent the GC from collecting "this" and "pixels" by @mattleibow in https://github.com/mono/SkiaSharp/pull/1258
-    - Rename some methods to be more .NET by @mattleibow in https://github.com/mono/SkiaSharp/pull/1255
-    - Null out the field when disposing. Fixes #960 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1256
-    - No need to allocate on disposal by @mattleibow in https://github.com/mono/SkiaSharp/pull/1257
-    - Always reference netstandard by @mattleibow in https://github.com/mono/SkiaSharp/pull/1250
-    - Expose a generic, writable span for the pixels by @mattleibow in https://github.com/mono/SkiaSharp/pull/1242
-    - Use the correct URL for OpenJDK on Linux by @mattleibow in https://github.com/mono/SkiaSharp/pull/1245
-    - Fixed unit tests crashes and a WGL deadlock (#1228 for master) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1237
-    - [Android.Views] Refresh the surface when recreated by @mattleibow in https://github.com/mono/SkiaSharp/pull/1234
-
-  ## Preview 60 · 1.68.2 · 2020-04-13 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.50...v1.68.2-preview.60  (9 PRs)
-    - Remove the [Preserve] attribute by @mattleibow in https://github.com/mono/SkiaSharp/pull/1229
-    - Make sure to not dispose system fonts by @mattleibow in https://github.com/mono/SkiaSharp/pull/1224
-    - Remove reflection usage for SKObject creation by @Gillibald in https://github.com/mono/SkiaSharp/pull/1209 [community ✨]
-    - Link Code of Conduct by @terrajobst in https://github.com/mono/SkiaSharp/pull/1216 [community ✨]
-    - Update cake to 0.37 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1215
-    - Update expat native library to 2.2.9 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1214
-    - Update SKTouchHandler.cs to fix crash bug caused by passing incorrect parameter, added pressure and eraser handling by @mscherotter in https://github.com/mono/SkiaSharp/pull/1212 [community ✨]
-    - Release the skia objects when the view is unloaded by @mattleibow in https://github.com/mono/SkiaSharp/pull/1213
-    - Add a test for text align by @mattleibow in https://github.com/mono/SkiaSharp/pull/1207
-
-  ## Preview 50 · 1.68.2 · 2020-04-03 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.45...v1.68.2-preview.50  (4 PRs)
-    - Resolve some concurrency issues by @mattleibow in https://github.com/mono/SkiaSharp/pull/1200
-    - Fixing issue #1187 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1206
-    - Added device type to touch events (touch, mouse, pen) by @mscherotter in https://github.com/mono/SkiaSharp/pull/1191 [community ✨]
-    - The lang parameter is not used, so remove it. by @mattleibow in https://github.com/mono/SkiaSharp/pull/1190
-
-  ## Preview 45 · 1.68.2 · 2020-03-24 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.43...v1.68.2-preview.45  (2 PRs)
-    - Re-work views to avoid incorrect disposal by @mattleibow in https://github.com/mono/SkiaSharp/pull/1180
-    - Merge filter factory overloads now accept null arguments by @ziriax in https://github.com/mono/SkiaSharp/pull/1185 [community ✨]
-
-  ## Preview 43 · 1.68.2 · 2020-03-15 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.39...v1.68.2-preview.43  (3 PRs)
-    - Add the expected overload for newer versions XF.Tizen by @mattleibow in https://github.com/mono/SkiaSharp/pull/1117
-    - Update all the build tools by @mattleibow in https://github.com/mono/SkiaSharp/pull/1175
-    - Use vcpkg to build ANGLE by @mattleibow in https://github.com/mono/SkiaSharp/pull/1158
-
-  ## Preview 39 · 1.68.2 · 2020-02-27 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.29...v1.68.2-preview.39  (7 PRs)
-    - A few changes and improvements by @mattleibow in https://github.com/mono/SkiaSharp/pull/1153
-    - Change paint encoding instead of throwing #1151 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1152
-    - Make sure the view is still in the hierarchy by @mattleibow in https://github.com/mono/SkiaSharp/pull/1143
-    - Before drawing, MakeCurrent by @mattleibow in https://github.com/mono/SkiaSharp/pull/1141
-    - Add a WPF for .NET Core sample by @mattleibow in https://github.com/mono/SkiaSharp/pull/1140
-    - Queue the redraw. Fixes #1074 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1135
-    - Prevent double load issue. Fixes #1118 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1133
-
-  ## Preview 29 · 1.68.2 · 2020-02-06 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.21...v1.68.2-preview.29  (6 PRs)
-    - Added more from SKImage by @mattleibow in https://github.com/mono/SkiaSharp/pull/1126
-    - Added the rest of SKRegion members by @mattleibow in https://github.com/mono/SkiaSharp/pull/1125
-    - More Improvements by @mattleibow in https://github.com/mono/SkiaSharp/pull/1123
-    - Improve Generator & Structs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1122
-    - Adding the SKColorF (with SKColorSpace) overloads by @mattleibow in https://github.com/mono/SkiaSharp/pull/1116 (skia: mono/skia#74)
-    - Update the build for the new team by @mattleibow in https://github.com/mono/SkiaSharp/pull/1120
-
-  ## Preview 21 · 1.68.2 · 2020-01-19 · https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.17...v1.68.2-preview.21  (3 PRs)
-    - Update Xamarin.Forms to v4.2.0.910310 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1109
-    - Make sure all things are listed in cgmanifest.json by @mattleibow in https://github.com/mono/SkiaSharp/pull/1103
-    - Fix issues with buffer samples #1087 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1098
-
-  ## Preview 17 · 1.68.2 · 2020-01-10 · https://github.com/mono/SkiaSharp/compare/v1.68.1.1-preview.9...v1.68.2-preview.17  (15 PRs)
-    - SKGLViewRenderer dispose corrections by @zbyszekpy in https://github.com/mono/SkiaSharp/pull/1095 [community ✨]
-    - Add a few more members for SKCanvas by @mattleibow in https://github.com/mono/SkiaSharp/pull/1090
-    - [WIP] Add GTK views for Xamarin.Forms by @mattleibow in https://github.com/mono/SkiaSharp/pull/1089 (skia: mono/skia#72)
-    - Fix broken antialiasing with UWP SKSwapChainPanel by @validvoid in https://github.com/mono/SkiaSharp/pull/1086 [community ✨]
-    - Fix some issues with macOS SKGLView by @mattleibow in https://github.com/mono/SkiaSharp/pull/1083
-    - Multi-target SkiaSharp.Views.Windows.Forms by @mattleibow in https://github.com/mono/SkiaSharp/pull/1082
-    - WPF Mouse Wheel on Touch Event by @alexandrvslv in https://github.com/mono/SkiaSharp/pull/1079 [community ✨]
-    - Update the OpenJDK and Tizen bits by @mattleibow in https://github.com/mono/SkiaSharp/pull/1015
-    - Add SKShader binding to create Improved Perlin noise by @mattleibow in https://github.com/mono/SkiaSharp/pull/1056
-    - Update to v1.68.2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1077
-    - Upgrade to VS2019 and .NET Core 3.0 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1030
-    - Remove an unused argument of type TaskScheduler from AnimatedSampleBase by @bender2k14 in https://github.com/mono/SkiaSharp/pull/1063 [community ✨]
-    - suffices to start the rotation matrix as the identity matrix by @bender2k14 in https://github.com/mono/SkiaSharp/pull/1062 [community ✨]
-    - Don't go straight for the max samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1060
-    - Add the .targets file to buildTransitive by @mattleibow in https://github.com/mono/SkiaSharp/pull/1057
-
-  ## Preview 9 · 1.68.1.1 · 2019-12-10 · https://github.com/mono/SkiaSharp/compare/v1.68.1...v1.68.1.1-preview.9  (12 PRs)
-    - Correctly decode images by @mattleibow in https://github.com/mono/SkiaSharp/pull/1055
-    - Improve the Docker samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1051
-    - Pulling in some changes from other places by @mattleibow in https://github.com/mono/SkiaSharp/pull/1054
-    - Improve native build process + add Nano Server by @mattleibow in https://github.com/mono/SkiaSharp/pull/1040
-    - Assemblies are required in platform ref folders by @mattleibow in https://github.com/mono/SkiaSharp/pull/1044
-    - Use a patch update for now as this is just fixes by @mattleibow in https://github.com/mono/SkiaSharp/pull/1045
-    - Update README.md by @mattleibow in https://github.com/mono/SkiaSharp/pull/1043
-    - TryRemove instances WeakReferences by @daltonks in https://github.com/mono/SkiaSharp/pull/1039 [community ✨]
-    - Add Code Checks by @mattleibow in https://github.com/mono/SkiaSharp/pull/1038
-    - Fix issues with harfbuzz strings by @mattleibow in https://github.com/mono/SkiaSharp/pull/1034
-    - Cherry pick some fixes for buffer overflow bugs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1037
-    - Use Docker to Build Linux & Update Versions to v1.68.2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1036
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.68.2 -->
 # Version 1.68.2
+> **1.68.2 stable** · Released April 30, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.2)
 
-> **Stability, views, and touch improvements** · Released April 30, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.2)
-
-> **API changes** · [SkiaSharp API diff](1.68.2/index.md) · [HarfBuzzSharp 2.6.1.2](harfbuzzsharp/2.6.1.2.md)
+> **API changes** · [SkiaSharp API diff](1.68.2/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.2/index.md)
 
 ## Highlights
 
-Version 1.68.2 is a broad quality release for the 1.x line, bringing new APIs, better pixel access, improved touch input, and a long list of lifecycle and platform fixes across Android, macOS, UWP, Windows Forms, and Xamarin.Forms. It also ships with HarfBuzzSharp 2.6.1.2 for the matching text-binding updates.
+SkiaSharp 1.68.2 lands after nine previews with view lifecycle fixes, new APIs and platform work across the board. This release tightens view lifetime and disposal on every UI backend, adds writable pixel spans, SKColorF/SKColorSpace overloads, more SKImage/SKRegion members and improved Perlin noise shaders, and brings in community fixes for WPF, UWP, macOS and Android views. HarfBuzzSharp is refreshed to 2.6.1.2.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## API Surface
 
-### API Surface
-
-- **Core graphics expansion** — Adds more `SKImage`, `SKRegion`, and `SKCanvas` members, plus `SKColorF` overloads with color-space support and improved Perlin noise shader creation. ([#1126](https://github.com/mono/SkiaSharp/pull/1126), [#1125](https://github.com/mono/SkiaSharp/pull/1125), [#1090](https://github.com/mono/SkiaSharp/pull/1090), [#1116](https://github.com/mono/SkiaSharp/pull/1116), [#1056](https://github.com/mono/SkiaSharp/pull/1056))
-- **Writable pixel spans** — Exposes a generic writable span over pixel memory to make low-level image manipulation easier and safer. ([#1242](https://github.com/mono/SkiaSharp/pull/1242))
-
-### Platform
-
-- **View platform coverage** — Adds GTK views for Xamarin.Forms, multi-targets Windows Forms views, and fills in expected Xamarin.Forms Tizen overloads. ([#1089](https://github.com/mono/SkiaSharp/pull/1089), [#1082](https://github.com/mono/SkiaSharp/pull/1082), [#1117](https://github.com/mono/SkiaSharp/pull/1117))
-- **Touch input improvements** — Adds device-type reporting for touch events along with pressure and eraser handling. ❤️ [@mscherotter](https://github.com/mscherotter) ([#1191](https://github.com/mono/SkiaSharp/pull/1191), [#1212](https://github.com/mono/SkiaSharp/pull/1212))
+- **Writable pixel spans and SKColorF overloads** — Exposes a generic, writable Span<T> over pixel memory and adds SKColorF variants (with SKColorSpace) across the paint and canvas APIs for wide-gamut work. ([#1242](https://github.com/mono/SkiaSharp/pull/1242), [#1116](https://github.com/mono/SkiaSharp/pull/1116))
+- **More SKImage, SKRegion and SKCanvas members bound** — Rounds out SKImage, SKRegion and SKCanvas by binding members that were previously missing from the managed surface. ([#1126](https://github.com/mono/SkiaSharp/pull/1126), [#1125](https://github.com/mono/SkiaSharp/pull/1125), [#1090](https://github.com/mono/SkiaSharp/pull/1090))
+- **Improved Perlin noise shader** — Adds an SKShader factory for the improved Perlin noise variant, matching Skia's newer noise generator. ([#1056](https://github.com/mono/SkiaSharp/pull/1056))
+- **.NET-style method renames** — Renames a handful of methods to follow .NET conventions so the managed surface reads more naturally. ([#1255](https://github.com/mono/SkiaSharp/pull/1255))
+- **Merge-filter factories accept nulls** — The merge image-filter factory overloads now accept null arguments, matching the semantics of the underlying Skia API. — ❤️ [@ziriax](https://github.com/ziriax) ([#1185](https://github.com/mono/SkiaSharp/pull/1185))
 
 ## Bug Fixes
 
-- **View lifecycle and disposal** — Reworks disposal to avoid incorrect ownership transitions, releases Skia objects when views unload, and fixes Android surface recreation behavior. ([#1180](https://github.com/mono/SkiaSharp/pull/1180), [#1213](https://github.com/mono/SkiaSharp/pull/1213), [#1234](https://github.com/mono/SkiaSharp/pull/1234))
-- **Platform-specific rendering fixes** — Fixes UWP antialiasing, macOS `SKGLView` issues, redraw timing problems, and double-load scenarios. ❤️ [@validvoid](https://github.com/validvoid), [@zbyszekpy](https://github.com/zbyszekpy), [@alexandrvslv](https://github.com/alexandrvslv) ([#1086](https://github.com/mono/SkiaSharp/pull/1086), [#1095](https://github.com/mono/SkiaSharp/pull/1095), [#1083](https://github.com/mono/SkiaSharp/pull/1083), [#1135](https://github.com/mono/SkiaSharp/pull/1135), [#1133](https://github.com/mono/SkiaSharp/pull/1133))
-- **Memory and threading stability** — Resolves concurrency issues, WGL deadlocks, unit test crashes, system-font disposal problems, and GC lifetime hazards around pixel buffers. ❤️ [@Gillibald](https://github.com/Gillibald) ([#1200](https://github.com/mono/SkiaSharp/pull/1200), [#1237](https://github.com/mono/SkiaSharp/pull/1237), [#1224](https://github.com/mono/SkiaSharp/pull/1224), [#1258](https://github.com/mono/SkiaSharp/pull/1258), [#1209](https://github.com/mono/SkiaSharp/pull/1209))
-- **API correctness** — Allows null merge-filter factory arguments, changes paint encoding behavior to avoid throwing, and removes unnecessary allocations during disposal. ❤️ [@ziriax](https://github.com/ziriax) ([#1185](https://github.com/mono/SkiaSharp/pull/1185), [#1152](https://github.com/mono/SkiaSharp/pull/1152), [#1257](https://github.com/mono/SkiaSharp/pull/1257))
+- **View lifecycle and disposal reworked** — Reworks the view classes across UI stacks to avoid incorrect disposal, releases Skia objects when views unload, and fixes queued-redraw and double-load issues. ([#1180](https://github.com/mono/SkiaSharp/pull/1180), [#1213](https://github.com/mono/SkiaSharp/pull/1213), [#1135](https://github.com/mono/SkiaSharp/pull/1135), [#1133](https://github.com/mono/SkiaSharp/pull/1133))
+- **UWP, Android, macOS and WPF fixes** — Fixes broken antialiasing on the UWP SKSwapChainPanel, refreshes the Android surface when recreated, corrects macOS SKGLView issues, and adds mouse-wheel touch events to WPF. — ❤️ [@validvoid](https://github.com/validvoid), [@alexandrvslv](https://github.com/alexandrvslv) ([#1086](https://github.com/mono/SkiaSharp/pull/1086), [#1234](https://github.com/mono/SkiaSharp/pull/1234), [#1083](https://github.com/mono/SkiaSharp/pull/1083), [#1079](https://github.com/mono/SkiaSharp/pull/1079))
+- **SKTouchHandler crash and disposal fixes** — Fixes a touch-handler crash caused by an incorrect parameter (also adding pressure and eraser handling) and corrects SKGLViewRenderer disposal. — ❤️ [@mscherotter](https://github.com/mscherotter), [@zbyszekpy](https://github.com/zbyszekpy) ([#1212](https://github.com/mono/SkiaSharp/pull/1212), [#1095](https://github.com/mono/SkiaSharp/pull/1095))
+- **Concurrency and system-font handling** — Resolves several concurrency issues in shared object caches and stops system fonts from being disposed by the managed layer. ([#1200](https://github.com/mono/SkiaSharp/pull/1200), [#1224](https://github.com/mono/SkiaSharp/pull/1224))
+- **GL and rendering corrections** — Makes sure GL contexts are made current before drawing, fixes text-encoding handling in paint, and adds a text-alignment regression test. ([#1141](https://github.com/mono/SkiaSharp/pull/1141), [#1152](https://github.com/mono/SkiaSharp/pull/1152), [#1207](https://github.com/mono/SkiaSharp/pull/1207), [#1143](https://github.com/mono/SkiaSharp/pull/1143))
+
+## Lifecycle & Internals
+
+- **Reflection removed from SKObject creation** — Replaces reflection-based construction of SKObject wrappers with direct instantiation, reducing startup cost and helping AOT scenarios. — ❤️ [@Gillibald](https://github.com/Gillibald) ([#1209](https://github.com/mono/SkiaSharp/pull/1209))
+- **Preserve attribute dropped; GC-safety hardened** — Removes the linker-only [Preserve] attribute and pins 'this' and pixel buffers during native calls so the GC cannot move them mid-draw. ([#1229](https://github.com/mono/SkiaSharp/pull/1229), [#1258](https://github.com/mono/SkiaSharp/pull/1258), [#1256](https://github.com/mono/SkiaSharp/pull/1256), [#1257](https://github.com/mono/SkiaSharp/pull/1257))
+
+## Platform
+
+- **GTK views for Xamarin.Forms and Tizen overload** — Adds GTK view backends for Xamarin.Forms and the overload that newer versions of XF.Tizen expect. ([#1089](https://github.com/mono/SkiaSharp/pull/1089), [#1117](https://github.com/mono/SkiaSharp/pull/1117))
+- **Windows Forms multi-targeting and ANGLE via vcpkg** — Multi-targets SkiaSharp.Views.Windows.Forms and moves the ANGLE native build to vcpkg for a more reliable Windows toolchain. ([#1082](https://github.com/mono/SkiaSharp/pull/1082), [#1158](https://github.com/mono/SkiaSharp/pull/1158))
+- **Xamarin.Forms 4.2 and always-referenced netstandard** — Updates the bundled Xamarin.Forms baseline to 4.2.0.910310 and always references netstandard so downstream targets resolve consistently. ([#1109](https://github.com/mono/SkiaSharp/pull/1109), [#1250](https://github.com/mono/SkiaSharp/pull/1250))
+
+## Security
+
+- **Bundled expat updated to 2.2.9** — Refreshes the bundled expat native library to 2.2.9, picking up the security fixes shipped by upstream. ([#1214](https://github.com/mono/SkiaSharp/pull/1214))
+
+## HarfBuzzSharp 2.6.1.2
+
+Refreshes HarfBuzzSharp to 2.6.1.2 with the native build modernisation, buffer-overflow cherry-picks and general binding polish carried into 1.68.2.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@Gillibald](https://github.com/Gillibald) | Removed reflection from `SKObject` creation and helped harden object lifetime behavior |
-| [@mscherotter](https://github.com/mscherotter) | Expanded touch input with device type, pressure, and eraser support |
-| [@ziriax](https://github.com/ziriax) | Improved merge filter factory null handling |
-| [@validvoid](https://github.com/validvoid) | Fixed UWP antialiasing for `SKSwapChainPanel` |
-| [@zbyszekpy](https://github.com/zbyszekpy) | Corrected `SKGLViewRenderer` disposal |
-| [@alexandrvslv](https://github.com/alexandrvslv) | Added WPF mouse wheel touch-event support |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.68.1...release/1.68.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.68.2)
-
----
-
-## Unreleased
-
-Final release prep focused on pixel-lifetime safety, .NET-friendly naming cleanup, and a last round of Android and WGL fixes.
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.60...release/1.68.2)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@bender2k14](https://github.com/bender2k14) | Sample cleanups carried over from 1.68.1.1 — dropped an unused TaskScheduler argument and simplified the rotation matrix initialisation ([#1062](https://github.com/mono/SkiaSharp/pull/1062), [#1063](https://github.com/mono/SkiaSharp/pull/1063)) |
+| [@mscherotter](https://github.com/mscherotter) | Fixed an SKTouchHandler crash and added touch-device type (touch, mouse, pen) with pressure and eraser handling ([#1191](https://github.com/mono/SkiaSharp/pull/1191), [#1212](https://github.com/mono/SkiaSharp/pull/1212)) |
+| [@alexandrvslv](https://github.com/alexandrvslv) | Added mouse-wheel touch events on WPF ([#1079](https://github.com/mono/SkiaSharp/pull/1079)) |
+| [@daltonks](https://github.com/daltonks) | Cleaned up WeakReference tracking so TryRemove clears the stored reference ([#1039](https://github.com/mono/SkiaSharp/pull/1039)) |
+| [@Gillibald](https://github.com/Gillibald) | Removed reflection usage in SKObject creation ([#1209](https://github.com/mono/SkiaSharp/pull/1209)) |
+| [@terrajobst](https://github.com/terrajobst) | Contributed an improvement that landed in this release ([#1216](https://github.com/mono/SkiaSharp/pull/1216)) |
+| [@validvoid](https://github.com/validvoid) | Fixed broken antialiasing on the UWP SKSwapChainPanel ([#1086](https://github.com/mono/SkiaSharp/pull/1086)) |
+| [@zbyszekpy](https://github.com/zbyszekpy) | Corrected SKGLViewRenderer disposal ([#1095](https://github.com/mono/SkiaSharp/pull/1095)) |
+| [@ziriax](https://github.com/ziriax) | Made the merge image-filter factory overloads accept null arguments ([#1185](https://github.com/mono/SkiaSharp/pull/1185)) |
 
 ## Preview 60 (April 13, 2020)
 
-This preview tightened view and font lifetimes, improved touch pressure and eraser handling, and removed reflection from object creation.
+Preview 60 was the final preview before stable, folding in the GC-safety pinning fixes and last view lifecycle corrections.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.50...v1.68.2-preview.60)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.50...v1.68.2-preview.60)
 
 ## Preview 50 (April 3, 2020)
 
-This preview resolved concurrency issues and added touch device-type reporting.
+Preview 50 finished the view lifetime rework and added the writable pixel Span and .NET-style renames.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.45...v1.68.2-preview.50)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.45...v1.68.2-preview.50)
 
 ## Preview 45 (March 24, 2020)
 
-This preview reworked view disposal and improved merge-filter factory null handling.
+Preview 45 landed the Android surface-recreate fix and further Xamarin.Forms/WPF corrections.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.43...v1.68.2-preview.45)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.43...v1.68.2-preview.45)
 
 ## Preview 43 (March 15, 2020)
 
-This preview added the expected Xamarin.Forms Tizen overload and continued the platform bring-up work for ANGLE-backed rendering.
+Preview 43 removed reflection from SKObject creation and dropped the [Preserve] attribute.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.39...v1.68.2-preview.43)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.39...v1.68.2-preview.43)
 
 ## Preview 39 (February 27, 2020)
 
-This preview fixed redraw, hierarchy, and GL context issues while improving paint encoding behavior.
+Preview 39 added the expat 2.2.9 refresh, touch-handler improvements and the WPF mouse-wheel touch event.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.29...v1.68.2-preview.39)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.29...v1.68.2-preview.39)
 
 ## Preview 29 (February 6, 2020)
 
-This preview expanded the core API surface with new `SKImage`, `SKRegion`, and `SKColorF` capabilities.
+Preview 29 brought the GTK Xamarin.Forms views, macOS SKGLView fixes and Windows Forms multi-targeting.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.21...v1.68.2-preview.29)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.21...v1.68.2-preview.29)
 
 ## Preview 21 (January 19, 2020)
 
-This preview stabilized buffer behavior and prepared the 1.68.2 line for the larger API wave that followed.
+Preview 21 added the SKColorF/SKColorSpace overloads and more SKImage, SKRegion and SKCanvas members.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.17...v1.68.2-preview.21)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.2-preview.17...v1.68.2-preview.21)
 
 ## Preview 17 (January 10, 2020)
 
-This first 1.68.2 preview introduced improved GPU and text APIs, broader view-platform support, and several platform-specific fixes.
+Preview 17 shipped the improved Perlin noise shader and moved ANGLE to vcpkg.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1.1-preview.9...v1.68.2-preview.17)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1.1-preview.9...v1.68.2-preview.17)
 
 ## Preview 9 (December 10, 2019)
 
-This carried forward the 1.68.1.1 servicing work around decoding, packaging, native builds, and HarfBuzz string fixes.
+Preview 9 opened the 1.68.2 line and also formed the basis of 1.68.1.1 with the image-decoding and HarfBuzz string fixes.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1...v1.68.1.1-preview.9)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.1...v1.68.1.1-preview.9)

--- a/documentation/docfx/releases/1.68.3.md
+++ b/documentation/docfx/releases/1.68.3.md
@@ -1,50 +1,22 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:25Z by generate-release-notes.py
-  version:   1.68.3
-  status:    stable
-  branch:    release/1.68.3
-  diff:      release/1.68.2..release/1.68.3
-  prs:       4
-  api:       self=1.68.3/index.md;hb=2.6.1.4
-
-  - Update the version to 1.68.3 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1292
-  - Performance Improvements by @mattleibow in https://github.com/mono/SkiaSharp/pull/1277
-  - Update to the new Tizen by @mattleibow in https://github.com/mono/SkiaSharp/pull/1280
-  - Ensure that the assemblies are in fact signed by @mattleibow in https://github.com/mono/SkiaSharp/pull/1268
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:1.68.3 -->
 # Version 1.68.3
+> **Performance and signing** · Released May 18, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.3)
 
-> **Performance and Tizen refresh** · Released May 18, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/1.68.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v1.68.3)
-
-> **API changes** · [SkiaSharp API diff](1.68.3/index.md) · [HarfBuzzSharp 2.6.1.4](harfbuzzsharp/2.6.1.4.md)
+> **API changes** · [SkiaSharp API diff](1.68.3/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.4/index.md)
 
 ## Highlights
 
-Version 1.68.3 is a small servicing release that focuses on runtime performance work, updated Tizen support, and package correctness. It also ships with HarfBuzzSharp 2.6.1.4 for the matching text-binding line.
+SkiaSharp 1.68.3 is a servicing release with performance improvements and correctly signed assemblies.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
-
-### Platform
-
-- **Updated Tizen support** — Refreshes the release line for the newer Tizen toolchain and platform expectations. ([#1280](https://github.com/mono/SkiaSharp/pull/1280))
-
 ## Bug Fixes
 
-- **Performance improvements** — Includes a focused round of core performance tuning in the 1.68 branch. ([#1277](https://github.com/mono/SkiaSharp/pull/1277))
-- **Package correctness** — Carries forward the assembly signing fix for the final 1.68 servicing release. ([#1268](https://github.com/mono/SkiaSharp/pull/1268))
+- **Performance improvements** — Folds in a round of performance improvements on the managed-native boundary. ([#1277](https://github.com/mono/SkiaSharp/pull/1277))
+- **Assemblies correctly signed** — Ensures the assemblies shipped in the NuGet packages are in fact signed. ([#1268](https://github.com/mono/SkiaSharp/pull/1268))
 
-## Links
+## HarfBuzzSharp 2.6.1.4
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.68.2...release/1.68.3)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/1.68.3)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/2.80.0.md
+++ b/documentation/docfx/releases/2.80.0.md
@@ -1,165 +1,82 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:42Z by generate-release-notes.py
-  version:   2.80.0
-  status:    stable
-  branch:    release/2.80.0
-  diff:      release/1.68.3..release/2.80.0
-  prs:       37
-  api:       self=2.80.0/index.md;hb=2.6.1.5
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (5 PRs)
-    - Create a WASM package by @mattleibow in https://github.com/mono/SkiaSharp/pull/1389
-    - Explicitly request GL ES 3.x in case we have it by @mattleibow in https://github.com/mono/SkiaSharp/pull/1388
-    - Update the version of Clang used to build for Tizen by @mattleibow in https://github.com/mono/SkiaSharp/pull/1386
-    - Clone a specific branch of WASM by @mattleibow in https://github.com/mono/SkiaSharp/pull/1387
-    - Build for Linux ARM32 (armhf) and ARM64 (aarch64) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1382
-
-  ## Preview 33 · 2.80.0 · 2020-06-30 · https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.24...v2.80.0-preview.33  (8 PRs)
-    - Fix Packaging by @mattleibow in https://github.com/mono/SkiaSharp/pull/1366 (skia: mono/skia#81)
-    - SkiaSharpSample project now default startup project in the WPF SkiaSharpSample solution by @bender2k14 in https://github.com/mono/SkiaSharp/pull/1369 [community ✨]
-    - Fix #1353 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1368
-    - Add & Run WASM Unit Tests by @mattleibow in https://github.com/mono/SkiaSharp/pull/1361
-    - Keep the text blob builder alive by @mattleibow in https://github.com/mono/SkiaSharp/pull/1365
-    - Keep the font set alive by @mattleibow in https://github.com/mono/SkiaSharp/pull/1362
-    - Build libSkiaSharp for WASM (only) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1359
-    - Retry a couple of times by @mattleibow in https://github.com/mono/SkiaSharp/pull/1360
-
-  ## Preview 24 · 2.80.0 · 2020-06-27 · https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.14...v2.80.0-preview.24  (5 PRs)
-    - Build SkiaSharp for Win32 ARM64 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1358
-    - Add snapshots with bounds by @mattleibow in https://github.com/mono/SkiaSharp/pull/1357
-    - Reduce the usage of deprecated native functions by @mattleibow in https://github.com/mono/SkiaSharp/pull/1356
-    - Load specific native libraries on desktop/netfx by @mattleibow in https://github.com/mono/SkiaSharp/pull/1342
-    - Correctly dispose (again) the managed/native object relationship by @mattleibow in https://github.com/mono/SkiaSharp/pull/1344
-
-  ## Preview 14 · 2.80.0 · 2020-06-17 · https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.12...v2.80.0-preview.14  (1 PRs)
-    - Add Alpine Native Libraries by @mattleibow in https://github.com/mono/SkiaSharp/pull/1339
-
-  ## Preview 12 · 2.80.0 · 2020-06-11 · https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.3...v2.80.0-preview.12  (5 PRs)
-    - Do not add the SkiaSharp prefix to dependencies by @mattleibow in https://github.com/mono/SkiaSharp/pull/1331
-    - Fix a crash when there is no GL context by @mattleibow in https://github.com/mono/SkiaSharp/pull/1328
-    - Don't embed libSkiaSharp in the assemblies by @mattleibow in https://github.com/mono/SkiaSharp/pull/1296
-    - Expose SKPath.ToWinding by @mattleibow in https://github.com/mono/SkiaSharp/pull/1326
-    - Expose SKPaint.ColorF by @mattleibow in https://github.com/mono/SkiaSharp/pull/1325
-
-  ## Preview 3 · 2.80.0 · 2020-06-07 · https://github.com/mono/SkiaSharp/compare/v1.68.3...v2.80.0-preview.3  (13 PRs)
-    - Use the correct shaders by @mattleibow in https://github.com/mono/SkiaSharp/pull/1323
-    - Improve the CI build label by @mattleibow in https://github.com/mono/SkiaSharp/pull/1322
-    - Update Samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1313
-    - Allow the path to gn and ninja to be specified by @mattleibow in https://github.com/mono/SkiaSharp/pull/1300
-    - Make the SKFont's public API glyph-only and the others types use it under the hood by @mattleibow in https://github.com/mono/SkiaSharp/pull/1299
-    - Improve the GPU APIs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1294
-    - Build for Vulkan on all supported platforms by @mattleibow in https://github.com/mono/SkiaSharp/pull/1287
-    - Use Clang 10 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1286
-    - Implemented SKCanvas.DrawTextOnPath by @ziriax in https://github.com/mono/SkiaSharp/pull/1198 [community ✨]
-    - New Images / Icons by @mattleibow in https://github.com/mono/SkiaSharp/pull/1281
-    - Vulkan Support for Win32 (and APIs for everyone as well) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1010
-    - Adding back the removed enum members by @mattleibow in https://github.com/mono/SkiaSharp/pull/1285
-    - Update to a much later version of skia (m80) by @mattleibow in https://github.com/mono/SkiaSharp/pull/986 (skia: mono/skia#64)
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.80.0 -->
 # Version 2.80.0
+> **Skia m80 and Vulkan everywhere** · Released July 8, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.0)
 
-> **Skia m80, Vulkan, and WebAssembly** · Released July 9, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.0)
-
-> **API changes** · [SkiaSharp API diff](2.80.0/index.md) · [HarfBuzzSharp 2.6.1.5](harfbuzzsharp/2.6.1.5.md)
+> **API changes** · [SkiaSharp API diff](2.80.0/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.5/index.md)
 
 ## Highlights
 
-Version 2.80.0 is a major platform release built on Skia milestone 80, with broad GPU work, first-class Vulkan support, and the first official WebAssembly and new ARM native packages in this line. It also expands the managed API surface with new text, color, path, and snapshot APIs, while shipping with HarfBuzzSharp 2.6.1.5 for the aligned shaping bindings.
+SkiaSharp 2.80.0 rebases on Skia m80, brings Vulkan everywhere, and adds Linux ARM, Alpine, ARM64, and WebAssembly natives. Vulkan is now available on every platform that supports it, alongside a cleaned-up GPU API. Native coverage grows to Linux ARM32/ARM64, Alpine, and Win32 ARM64, plus a first WebAssembly build. SKFont becomes the canonical text/glyph type, and several disposal and GL crashes are fixed.
 
 ## Breaking Changes
 
-*None called out for this release.*
+*None in this release.*
 
-## New Features
+## Engine
 
-### Engine
+- **Rebased on Skia m80** — The bundled engine is refreshed from a much older Skia to milestone 80, bringing years of upstream rendering and text fixes into SkiaSharp. ([#986](https://github.com/mono/SkiaSharp/pull/986))
 
-- **Skia milestone 80** — Updates the underlying engine to a much newer Skia milestone and carries that work through the 2.80 release family. ([#986](https://github.com/mono/SkiaSharp/pull/986))
+## API Surface
 
-### GPU & Rendering
-
-- **Vulkan support across supported platforms** — Brings Vulkan support to Win32 and broadens the GPU stack across the supported native targets. ([#1010](https://github.com/mono/SkiaSharp/pull/1010), [#1287](https://github.com/mono/SkiaSharp/pull/1287))
-- **Expanded GPU APIs** — Improves the GPU-facing managed APIs and adds snapshot support with bounds for easier diagnostics and capture. ([#1294](https://github.com/mono/SkiaSharp/pull/1294), [#1357](https://github.com/mono/SkiaSharp/pull/1357))
-
-### Platform
-
-- **WebAssembly support** — Adds `libSkiaSharp` for WebAssembly, the corresponding package work, and initial WASM unit-test coverage. ([#1359](https://github.com/mono/SkiaSharp/pull/1359), [#1361](https://github.com/mono/SkiaSharp/pull/1361), [#1387](https://github.com/mono/SkiaSharp/pull/1387), [#1389](https://github.com/mono/SkiaSharp/pull/1389))
-- **Broader native package coverage** — Adds Linux ARM32/ARM64, Win32 ARM64, and Alpine native libraries while improving desktop native library loading. ([#1382](https://github.com/mono/SkiaSharp/pull/1382), [#1358](https://github.com/mono/SkiaSharp/pull/1358), [#1339](https://github.com/mono/SkiaSharp/pull/1339), [#1342](https://github.com/mono/SkiaSharp/pull/1342))
-
-### API Surface
-
-- **New drawing and color APIs** — Adds `SKCanvas.DrawTextOnPath`, `SKPaint.ColorF`, and `SKPath.ToWinding`, plus text API work that aligns `SKFont` more closely with glyph-based operations. ❤️ [@ziriax](https://github.com/ziriax) ([#1198](https://github.com/mono/SkiaSharp/pull/1198), [#1325](https://github.com/mono/SkiaSharp/pull/1325), [#1326](https://github.com/mono/SkiaSharp/pull/1326), [#1299](https://github.com/mono/SkiaSharp/pull/1299))
+- **Vulkan on every supported platform** — Vulkan support is built for Win32 alongside the existing platforms, with a shared managed API so consumers can target Vulkan the same way everywhere. ([#1010](https://github.com/mono/SkiaSharp/pull/1010), [#1287](https://github.com/mono/SkiaSharp/pull/1287))
+- **GPU APIs cleaned up** — The GPU surface is reworked for consistency across backends and to expose the pieces callers previously had to reach around. ([#1294](https://github.com/mono/SkiaSharp/pull/1294))
+- **SKFont becomes the text/glyph type** — SKFont's public API is now glyph-only, and the other text types are built on top of it — the canonical shape for text work going forward. ([#1299](https://github.com/mono/SkiaSharp/pull/1299))
+- **New drawing and path helpers** — SKCanvas.DrawTextOnPath, SKPath.ToWinding, SKPaint.ColorF, and image snapshots with bounds fill in gaps that consumers previously had to work around. — ❤️ [@ziriax](https://github.com/ziriax) ([#1198](https://github.com/mono/SkiaSharp/pull/1198), [#1326](https://github.com/mono/SkiaSharp/pull/1326), [#1325](https://github.com/mono/SkiaSharp/pull/1325), [#1357](https://github.com/mono/SkiaSharp/pull/1357))
 
 ## Bug Fixes
 
-- **Lifetime and disposal fixes** — Keeps text blob builders and font sets alive when required and revisits managed/native ownership to prevent premature disposal. ([#1365](https://github.com/mono/SkiaSharp/pull/1365), [#1362](https://github.com/mono/SkiaSharp/pull/1362), [#1344](https://github.com/mono/SkiaSharp/pull/1344))
-- **Startup and packaging correctness** — Fixes package composition, avoids embedding `libSkiaSharp` into assemblies, and fixes startup failures when no GL context is available. ([#1366](https://github.com/mono/SkiaSharp/pull/1366), [#1296](https://github.com/mono/SkiaSharp/pull/1296), [#1328](https://github.com/mono/SkiaSharp/pull/1328))
+- **GL and shader crashes fixed** — A crash when no GL context is present is resolved, the correct shaders are used, and GL ES 3.x is explicitly requested when available. ([#1328](https://github.com/mono/SkiaSharp/pull/1328), [#1323](https://github.com/mono/SkiaSharp/pull/1323), [#1388](https://github.com/mono/SkiaSharp/pull/1388))
+- **Text and font lifetime corrected** — The text blob builder and font set are now kept alive while in use, fixing intermittent crashes during text rendering. ([#1365](https://github.com/mono/SkiaSharp/pull/1365), [#1362](https://github.com/mono/SkiaSharp/pull/1362))
+
+## Lifecycle & Internals
+
+- **Managed/native disposal reworked** — The relationship between managed wrappers and native objects is disposed correctly again, closing a class of finalizer and use-after-dispose issues. ([#1344](https://github.com/mono/SkiaSharp/pull/1344))
+- **Native library loading on desktop** — Desktop and .NET Framework hosts now load a specific native library rather than relying on ambient search order, and libSkiaSharp is no longer embedded inside the managed assemblies. ([#1342](https://github.com/mono/SkiaSharp/pull/1342), [#1296](https://github.com/mono/SkiaSharp/pull/1296))
+
+## Platform
+
+- **Linux ARM, Alpine, and Win32 ARM64 natives** — Ships native libraries for Linux ARM32 (armhf) and ARM64 (aarch64), Alpine, and Win32 ARM64 — SkiaSharp now runs out of the box on those targets. ([#1382](https://github.com/mono/SkiaSharp/pull/1382), [#1339](https://github.com/mono/SkiaSharp/pull/1339), [#1358](https://github.com/mono/SkiaSharp/pull/1358))
+- **WebAssembly build** — There is now a libSkiaSharp build for WebAssembly and a matching WASM package, laying the groundwork for browser-hosted rendering. ([#1359](https://github.com/mono/SkiaSharp/pull/1359), [#1389](https://github.com/mono/SkiaSharp/pull/1389))
+
+## HarfBuzzSharp 2.6.1.5
+
+HarfBuzzSharp 2.6.1.5 rides along with the SkiaSharp packaging, native library, and platform coverage work — the same builds now ship for Linux ARM, Alpine, and the other new targets.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@ziriax](https://github.com/ziriax) | Implemented `SKCanvas.DrawTextOnPath` |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/1.68.3...release/2.80.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.80.0)
-
----
-
-## Unreleased
-
-Final release prep added packaged WASM support, Linux ARM builds, and a refreshed Tizen toolchain before the 2.80.0 tag.
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.33...release/2.80.0)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@bender2k14](https://github.com/bender2k14) | Made SkiaSharpSample the default startup project in the WPF sample solution ([#1369](https://github.com/mono/SkiaSharp/pull/1369)) |
+| [@ziriax](https://github.com/ziriax) | Contributed the SKCanvas.DrawTextOnPath implementation ([#1198](https://github.com/mono/SkiaSharp/pull/1198)) |
 
 ## Preview 33 (June 30, 2020)
 
-This preview hardened WASM and native packaging, added WASM unit tests, and fixed object lifetime issues around text blobs and font sets.
+Preview 33 wrapped up packaging fixes and text/font lifetime fixes ahead of stable.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.24...v2.80.0-preview.33)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.24...v2.80.0-preview.33)
 
 ## Preview 24 (June 27, 2020)
 
-This preview added Win32 ARM64 support, snapshot bounds APIs, and improved desktop native loading and disposal behavior.
+Preview 24 added Win32 ARM64 natives, image snapshots with bounds, and disposal fixes.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.14...v2.80.0-preview.24)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.14...v2.80.0-preview.24)
 
 ## Preview 14 (June 17, 2020)
 
-This preview introduced Alpine native libraries.
+Preview 14 introduced the Alpine native libraries.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.12...v2.80.0-preview.14)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.12...v2.80.0-preview.14)
 
 ## Preview 12 (June 11, 2020)
 
-This preview exposed `SKPath.ToWinding` and `SKPaint.ColorF`, adjusted packaging, and fixed GL-context startup crashes.
+Preview 12 added SKPath.ToWinding, SKPaint.ColorF, and fixed a crash when no GL context is present.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.3...v2.80.0-preview.12)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.0-preview.3...v2.80.0-preview.12)
 
 ## Preview 3 (June 7, 2020)
 
-This first preview delivered the Skia m80 upgrade, Vulkan support, `DrawTextOnPath`, and the first wave of GPU API improvements.
+Preview 3 was the initial v2 preview: Skia m80, Vulkan for Win32, GPU API cleanup, the SKFont refactor, and SKCanvas.DrawTextOnPath.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v1.68.3...v2.80.0-preview.3)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v1.68.3...v2.80.0-preview.3)

--- a/documentation/docfx/releases/2.80.1.md
+++ b/documentation/docfx/releases/2.80.1.md
@@ -1,48 +1,25 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:42Z by generate-release-notes.py
-  version:   2.80.1
-  status:    stable
-  branch:    release/2.80.1
-  diff:      release/2.80.0..release/2.80.1
-  prs:       3
-  api:       self=2.80.1/index.md;hb=2.6.1.6
-
-  - SKTypeface does not count bytes but glyphs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1399
-  - Added Uno Platform support by @mattleibow in https://github.com/mono/SkiaSharp/pull/1396
-  - Set the version to 2.80.1 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1400
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.80.1 -->
 # Version 2.80.1
+> **Uno Platform support** · Released July 14, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.1)
 
-> **Uno support and text corrections** · Released July 14, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.1)
-
-> **API changes** · [SkiaSharp API diff](2.80.1/index.md) · [HarfBuzzSharp 2.6.1.6](harfbuzzsharp/2.6.1.6.md)
+> **API changes** · [SkiaSharp API diff](2.80.1/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.6/index.md)
 
 ## Highlights
 
-This small servicing release adds initial Uno Platform support and corrects `SKTypeface` text metrics behavior so glyph counts are handled consistently. It also ships with HarfBuzzSharp 2.6.1.6 for the aligned text-binding package.
+SkiaSharp 2.80.1 adds Uno Platform support and corrects SKTypeface glyph accounting.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## API Surface
 
-### Platform
-
-- **Uno Platform support** — Adds official Uno Platform support to the 2.80 line. ([#1396](https://github.com/mono/SkiaSharp/pull/1396))
+- **Uno Platform support** — SkiaSharp now ships views and integration for Uno Platform applications. ([#1396](https://github.com/mono/SkiaSharp/pull/1396))
 
 ## Bug Fixes
 
-- **Correct glyph counting in `SKTypeface`** — Fixes the API to count glyphs rather than bytes. ([#1399](https://github.com/mono/SkiaSharp/pull/1399))
+- **SKTypeface counts glyphs, not bytes** — SKTypeface's character/glyph counts are now correct for multi-byte text. ([#1399](https://github.com/mono/SkiaSharp/pull/1399))
 
-## Links
+## HarfBuzzSharp 2.6.1.6
 
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.80.0...release/2.80.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.80.1)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/2.80.2.md
+++ b/documentation/docfx/releases/2.80.2.md
@@ -1,157 +1,75 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:55:44Z by generate-release-notes.py
-  version:   2.80.2
-  status:    stable
-  branch:    release/2.80.2
-  diff:      release/2.80.1..release/2.80.2
-  prs:       33
-  api:       self=2.80.2/index.md;hb=2.6.1.7
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (1 PRs)
-    - Update Docs for v2.80.2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1493
-
-  ## Preview 36 · 2.80.2 · 2020-09-02 · https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.33...v2.80.2-preview.36  (3 PRs)
-    - Update Chromium Web Driver by @mattleibow in https://github.com/mono/SkiaSharp/pull/1488
-    - Check the correct directory for native libraries with ASP.NET by @mattleibow in https://github.com/mono/SkiaSharp/pull/1483
-    - [macOS] Use NeedsDisplay instead of Display by @mattleibow in https://github.com/mono/SkiaSharp/pull/1475
-
-  ## Preview 33 · 2.80.2 · 2020-08-25 · https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.19...v2.80.2-preview.33  (10 PRs)
-    - Add a few more GPU debugging members by @mattleibow in https://github.com/mono/SkiaSharp/pull/1478
-    - Use the version of OpenTK that is correctly sn by @mattleibow in https://github.com/mono/SkiaSharp/pull/1480
-    - Update the HarfBuzz package version by @mattleibow in https://github.com/mono/SkiaSharp/pull/1476
-    - Expose SKGraphics for Debugging by @mattleibow in https://github.com/mono/SkiaSharp/pull/1473
-    - [UWP] Don't block the UI thread when invalidating by @mattleibow in https://github.com/mono/SkiaSharp/pull/1468
-    - Add an extensions for SKColorF by @mattleibow in https://github.com/mono/SkiaSharp/pull/1469
-    - Make sure to overwrite the underlying pixel by @mattleibow in https://github.com/mono/SkiaSharp/pull/1457
-    - Revert the code for SetScaleTranslate by @mattleibow in https://github.com/mono/SkiaSharp/pull/1452
-    - Sometimes we can't return float, for some reason by @mattleibow in https://github.com/mono/SkiaSharp/pull/1453
-    - Create a NuGet containing just the native/nugets by @mattleibow in https://github.com/mono/SkiaSharp/pull/1456
-
-  ## Preview 19 · 2.80.2 · 2020-08-04 · https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.18...v2.80.2-preview.19  (1 PRs)
-    - Use the correct native code for WASM + GL by @mattleibow in https://github.com/mono/SkiaSharp/pull/1445
-
-  ## Preview 18 · 2.80.2 · 2020-08-02 · https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.9...v2.80.2-preview.18  (6 PRs)
-    - Use buildTransitive as well as build by @mattleibow in https://github.com/mono/SkiaSharp/pull/1440
-    - Fix the shaky unit test by @mattleibow in https://github.com/mono/SkiaSharp/pull/1441
-    - Use linear metrics for backwards compat by @mattleibow in https://github.com/mono/SkiaSharp/pull/1439
-    - Handle invalid text correctly by @mattleibow in https://github.com/mono/SkiaSharp/pull/1438
-    - Update skia to fix #465 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1436
-    - Add a replacement method by @mattleibow in https://github.com/mono/SkiaSharp/pull/1431
-
-  ## Preview 9 · 2.80.2 · 2020-07-27 · https://github.com/mono/SkiaSharp/compare/v2.80.1...v2.80.2-preview.9  (12 PRs)
-    - Add the GPU views for Uno Platform by @mattleibow in https://github.com/mono/SkiaSharp/pull/1429
-    - Update the Uno package versions by @mattleibow in https://github.com/mono/SkiaSharp/pull/1426
-    - Update GitHub Templates by @mattleibow in https://github.com/mono/SkiaSharp/pull/1427
-    - Some performance improvements for Forms by @mattleibow in https://github.com/mono/SkiaSharp/pull/1424
-    - Add WASM Support for Uno Platform by @mattleibow in https://github.com/mono/SkiaSharp/pull/1333
-    - Add more Uno things by @mattleibow in https://github.com/mono/SkiaSharp/pull/1420
-    - Passing `--configuration=debug` to the bootstrapper now generates a debug library by @mattleibow in https://github.com/mono/SkiaSharp/pull/1418
-    - Update Docker samples to .NET Core 3.1 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1417
-    - Alpine appears to not be ignoring the request to build without fontconfig by @mattleibow in https://github.com/mono/SkiaSharp/pull/1416
-    - SKCanvas.DrawTextOnPath v2.80.1 iOS NullReferenceException (#1408) by @ziriax in https://github.com/mono/SkiaSharp/pull/1410 [community ✨]
-    - Fix issue when creating SKData from a non-seekable stream by @mattleibow in https://github.com/mono/SkiaSharp/pull/1411
-    - Fixed origin parameter is ignored in SKSurface.Create by @ziriax in https://github.com/mono/SkiaSharp/pull/1404 [community ✨]
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
-
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.80.2 -->
 # Version 2.80.2
+> **Uno, WASM, and platform polish** · Released September 11, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.2)
 
-> **Uno, WebAssembly, and GPU diagnostics** · Released September 12, 2020 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.2)
-
-> **API changes** · [SkiaSharp API diff](2.80.2/index.md) · [HarfBuzzSharp 2.6.1.7](harfbuzzsharp/2.6.1.7.md)
+> **API changes** · [SkiaSharp API diff](2.80.2/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.7/index.md)
 
 ## Highlights
 
-Version 2.80.2 extends the 2.80 line with broader Uno Platform coverage, better WebAssembly support, and new GPU diagnostics APIs, while also landing important fixes for text, invalidation, native library probing, and pixel handling. It ships with HarfBuzzSharp 2.6.1.7 for the aligned shaping bindings.
+SkiaSharp 2.80.2 finishes Uno Platform support, wires WASM + GL for Uno, and fixes stream, text, and platform bugs. Uno Platform gets GPU views, WASM support, and refreshed package versions. Alongside that, the release fixes non-seekable stream handling for SKData, several text-rendering regressions, and platform-specific issues on macOS, UWP, and ASP.NET.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## API Surface
 
-### Platform
-
-- **Broader Uno Platform support** — Adds Uno GPU views, additional Uno-specific work, and WebAssembly support for Uno applications. ([#1429](https://github.com/mono/SkiaSharp/pull/1429), [#1420](https://github.com/mono/SkiaSharp/pull/1420), [#1333](https://github.com/mono/SkiaSharp/pull/1333))
-- **Native-only packaging** — Introduces a NuGet package that carries only the native assets for scenarios that need a slimmer distribution model. ([#1456](https://github.com/mono/SkiaSharp/pull/1456))
-
-### GPU & Rendering
-
-- **GPU diagnostics APIs** — Exposes `SKGraphics` debugging hooks and adds several more GPU debugging members. ([#1473](https://github.com/mono/SkiaSharp/pull/1473), [#1478](https://github.com/mono/SkiaSharp/pull/1478))
-
-### API Surface
-
-- **Additional color helpers** — Adds extensions for `SKColorF` and a replacement helper API in the 2.80 line. ([#1469](https://github.com/mono/SkiaSharp/pull/1469), [#1431](https://github.com/mono/SkiaSharp/pull/1431))
+- **Uno Platform coverage expanded** — Adds GPU views for Uno, WASM support for Uno, and refreshes the Uno package versions and samples. ([#1429](https://github.com/mono/SkiaSharp/pull/1429), [#1333](https://github.com/mono/SkiaSharp/pull/1333), [#1426](https://github.com/mono/SkiaSharp/pull/1426), [#1420](https://github.com/mono/SkiaSharp/pull/1420))
+- **SKGraphics exposed for debugging** — The SKGraphics diagnostics surface (font cache limits, purge, memory dump) is now available from managed code, alongside a few additional GPU debugging members. ([#1473](https://github.com/mono/SkiaSharp/pull/1473), [#1478](https://github.com/mono/SkiaSharp/pull/1478))
+- **SKColorF extensions** — New extension methods make it easier to convert to and work with SKColorF values. ([#1469](https://github.com/mono/SkiaSharp/pull/1469))
 
 ## Bug Fixes
 
-- **Text and drawing correctness** — Fixes invalid-text handling, restores compatible linear metrics behavior, corrects `SKCanvas.DrawTextOnPath` on iOS, and honors the `origin` parameter in `SKSurface.Create`. ❤️ [@ziriax](https://github.com/ziriax) ([#1438](https://github.com/mono/SkiaSharp/pull/1438), [#1439](https://github.com/mono/SkiaSharp/pull/1439), [#1410](https://github.com/mono/SkiaSharp/pull/1410), [#1404](https://github.com/mono/SkiaSharp/pull/1404))
-- **Platform invalidation and probing** — Improves UWP invalidation, switches macOS refreshes to `NeedsDisplay`, and checks the correct native-library directory for ASP.NET deployments. ([#1468](https://github.com/mono/SkiaSharp/pull/1468), [#1475](https://github.com/mono/SkiaSharp/pull/1475), [#1483](https://github.com/mono/SkiaSharp/pull/1483))
-- **Native and pixel fixes** — Corrects the WebAssembly + GL native path, ensures pixel writes update the backing store, and reverts problematic `SetScaleTranslate` behavior. ([#1445](https://github.com/mono/SkiaSharp/pull/1445), [#1457](https://github.com/mono/SkiaSharp/pull/1457), [#1452](https://github.com/mono/SkiaSharp/pull/1452))
+- **SKData from non-seekable streams** — Creating SKData from a stream that can't seek no longer fails, and SKSurface.Create honours the origin parameter that was previously ignored. — ❤️ [@ziriax](https://github.com/ziriax) ([#1411](https://github.com/mono/SkiaSharp/pull/1411), [#1404](https://github.com/mono/SkiaSharp/pull/1404))
+- **Text rendering fixes** — Uses linear metrics for backwards compatibility, handles invalid text without crashing, and fixes an iOS NullReferenceException in SKCanvas.DrawTextOnPath. — ❤️ [@ziriax](https://github.com/ziriax) ([#1439](https://github.com/mono/SkiaSharp/pull/1439), [#1438](https://github.com/mono/SkiaSharp/pull/1438), [#1410](https://github.com/mono/SkiaSharp/pull/1410))
+- **WASM + GL uses the correct natives** — The WASM build now picks up the correct native code for GL rendering. ([#1445](https://github.com/mono/SkiaSharp/pull/1445))
+- **Pixel and matrix correctness** — Overwrites the underlying pixel where it should, reverts a bad SetScaleTranslate path, and adjusts a float-return signature that couldn't be used everywhere. ([#1457](https://github.com/mono/SkiaSharp/pull/1457), [#1452](https://github.com/mono/SkiaSharp/pull/1452), [#1453](https://github.com/mono/SkiaSharp/pull/1453))
+- **Native library discovery under ASP.NET** — SkiaSharp now checks the correct directory for its native libraries when hosted under ASP.NET. ([#1483](https://github.com/mono/SkiaSharp/pull/1483))
+
+## Platform
+
+- **macOS uses NeedsDisplay** — The macOS view now invalidates via NeedsDisplay instead of the eager Display call, matching platform expectations. ([#1475](https://github.com/mono/SkiaSharp/pull/1475))
+- **UWP no longer blocks the UI thread on invalidate** — UWP invalidation is now non-blocking, removing a source of hangs when redrawing frequently. ([#1468](https://github.com/mono/SkiaSharp/pull/1468))
+- **Skia updated** — Bundled Skia is updated to pick up an upstream fix for issue #465. ([#1436](https://github.com/mono/SkiaSharp/pull/1436))
+
+## HarfBuzzSharp 2.6.1.7
+
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@ziriax](https://github.com/ziriax) | Fixed `SKCanvas.DrawTextOnPath` on iOS and corrected `SKSurface.Create` origin handling |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.80.1...release/2.80.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.80.2)
-
----
-
-## Unreleased
-
-The final release prep for 2.80.2 was limited to documentation refresh work.
-
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.36...release/2.80.2)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@ziriax](https://github.com/ziriax) | Fixed the iOS NullReferenceException in SKCanvas.DrawTextOnPath and the ignored origin parameter in SKSurface.Create ([#1404](https://github.com/mono/SkiaSharp/pull/1404), [#1410](https://github.com/mono/SkiaSharp/pull/1410)) |
 
 ## Preview 36 (September 2, 2020)
 
-This preview improved ASP.NET native probing and switched macOS invalidation to `NeedsDisplay`.
+Preview 36 fixed ASP.NET native library discovery, macOS NeedsDisplay behaviour, and added GPU debugging APIs.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.33...v2.80.2-preview.36)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.33...v2.80.2-preview.36)
 
 ## Preview 33 (August 25, 2020)
 
-This preview added GPU debugging APIs, `SKColorF` extensions, native-only packaging, and several rendering and invalidation fixes.
+Preview 33 exposed SKGraphics, unblocked the UWP UI thread on invalidate, and added SKColorF extensions.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.19...v2.80.2-preview.33)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.19...v2.80.2-preview.33)
 
 ## Preview 19 (August 4, 2020)
 
-This preview corrected the native WebAssembly + GL implementation.
+Preview 19 reverted a bad SetScaleTranslate and corrected pixel writes.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.18...v2.80.2-preview.19)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.18...v2.80.2-preview.19)
 
 ## Preview 18 (August 2, 2020)
 
-This preview improved build-transitive packaging, text handling, linear-metrics compatibility, and replacement APIs while pulling in a Skia fix.
+Preview 18 fixed WASM + GL native selection and shipped text-rendering fixes (linear metrics, invalid text).
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.9...v2.80.2-preview.18)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2-preview.9...v2.80.2-preview.18)
 
 ## Preview 9 (July 27, 2020)
 
-This first preview brought Uno GPU and WASM support, Forms performance work, and important fixes for streams, iOS text-on-path, and `SKSurface.Create`.
+Preview 9 landed the Uno Platform expansion — GPU views, WASM support, and refreshed package versions.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.1...v2.80.2-preview.9)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.1...v2.80.2-preview.9)

--- a/documentation/docfx/releases/2.80.3.md
+++ b/documentation/docfx/releases/2.80.3.md
@@ -1,189 +1,85 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:01Z by generate-release-notes.py
-  version:   2.80.3
-  status:    stable
-  branch:    release/2.80.3
-  diff:      release/2.80.2..release/2.80.3
-  prs:       55
-  api:       self=2.80.3/index.md;hb=2.6.1.8
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (1 PRs)
-    - Update WinUI to 0.8.0 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1741
-
-  ## Preview 93 · 2.80.3 · 2021-06-11 · https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.90...v2.80.3-preview.93  (1 PRs)
-    - Add support for SKXamlCanvas on Uno Platform SkiaSharp backends v2.0 (#1634) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1704
-
-  ## Preview 90 · 2.80.3 · 2021-05-30 · https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.40...v2.80.3-preview.90  (25 PRs)
-    - Add .NET Interactive Support by @mattleibow in https://github.com/mono/SkiaSharp/pull/1710
-    - Update Uno by @mattleibow in https://github.com/mono/SkiaSharp/pull/1708
-    - Properly Detect & Handle Musl Systems by @mattleibow in https://github.com/mono/SkiaSharp/pull/1657
-    - Roll back to a specific version of Xamarin.iOS that works with XCode 12.4 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1703
-    - Add support for WinUI for Desktop by @mattleibow in https://github.com/mono/SkiaSharp/pull/1696
-    - Improve build props/targets by @mattleibow in https://github.com/mono/SkiaSharp/pull/1698
-    - Update to .NET 5.0 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1697
-    - Pack things correctly and pin the xharness version by @mattleibow in https://github.com/mono/SkiaSharp/pull/1685
-    - avoid issues with failure to create gl surface by @gmurray81 in https://github.com/mono/SkiaSharp/pull/1642 [community ✨]
-    - Swap the buffers after a resize by @mattleibow in https://github.com/mono/SkiaSharp/pull/1668
-    - Fix Android Test Runner by @mattleibow in https://github.com/mono/SkiaSharp/pull/1665
-    - Fix The Bad Things by @mattleibow in https://github.com/mono/SkiaSharp/pull/1662
-    - Split the packages up for better downloads by @mattleibow in https://github.com/mono/SkiaSharp/pull/1660
-    - Expose IsAbandoned in the C# API by @mattleibow in https://github.com/mono/SkiaSharp/pull/1659
-    - Make sure to properly read image pixels by @mattleibow in https://github.com/mono/SkiaSharp/pull/1636
-    - Add the arm64 build target by @mattleibow in https://github.com/mono/SkiaSharp/pull/1627
-    - Run nightly builds to ensure always green by @mattleibow in https://github.com/mono/SkiaSharp/pull/1651
-    - Attempt to use the local ChromeDriver first by @mattleibow in https://github.com/mono/SkiaSharp/pull/1653
-    - Add iOS device tests by @mattleibow in https://github.com/mono/SkiaSharp/pull/1638
-    - Add Tests for Mobile (Android and iOS) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1630
-    - Be a bit more defensive in the display links by @mattleibow in https://github.com/mono/SkiaSharp/pull/1620
-    - Refactor the Android surface factory by @mattleibow in https://github.com/mono/SkiaSharp/pull/1617
-    - Introduce some metal consistency by @mattleibow in https://github.com/mono/SkiaSharp/pull/1615
-    - Add the SKRuntimeEffect API by @mattleibow in https://github.com/mono/SkiaSharp/pull/1604
-    - Merge Metal APIs from main branch by @mattleibow in https://github.com/mono/SkiaSharp/pull/1598
-
-  ## Preview 40 · 2.80.3 · 2021-02-05 · https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.24...v2.80.3-preview.40  (10 PRs)
-    - Expose GRContextOptions by @mattleibow in https://github.com/mono/SkiaSharp/pull/1529
-    - Make SKElement.OnRender do nothing if there is no PresentationSource by @HarlanHugh in https://github.com/mono/SkiaSharp/pull/1606 [community ✨]
-    - Add a few APIs that make things better later by @mattleibow in https://github.com/mono/SkiaSharp/pull/1603
-    - docs: Add unoplatform references by @jeromelaban in https://github.com/mono/SkiaSharp/pull/1602 [community ✨]
-    - Add Metal APIs for macOS and iOS by @mattleibow in https://github.com/mono/SkiaSharp/pull/1394
-    - Remove the externals/harfbuzz submodule by @mattleibow in https://github.com/mono/SkiaSharp/pull/1599
-    - Improve the local builds by @mattleibow in https://github.com/mono/SkiaSharp/pull/1597
-    - Make things consistent by @mattleibow in https://github.com/mono/SkiaSharp/pull/1595
-    - Update Xcode & .NET Core 3.1 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1594
-    - Improve the local builds by @mattleibow in https://github.com/mono/SkiaSharp/pull/1593
-
-  ## Preview 24 · 2.80.3 · 2021-01-27 · https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.18...v2.80.3-preview.24  (5 PRs)
-    - Build and include all the emscripten version for WASM by @mattleibow in https://github.com/mono/SkiaSharp/pull/1590
-    - Add a picture test to the WASM tests by @mattleibow in https://github.com/mono/SkiaSharp/pull/1592
-    - Update externals for new gn and add helper script by @mattleibow in https://github.com/mono/SkiaSharp/pull/1591
-    - Use v2 Signing by @mattleibow in https://github.com/mono/SkiaSharp/pull/1568
-    - Update to a later Tizen Studio by @mattleibow in https://github.com/mono/SkiaSharp/pull/1566
-
-  ## Preview 18 · 2.80.3 · 2020-10-28 · https://github.com/mono/SkiaSharp/compare/v2.80.2...v2.80.3-preview.18  (13 PRs)
-    - Support VS 2013 because it is easy to do so by @mattleibow in https://github.com/mono/SkiaSharp/pull/1536
-    - Load the fonts on iOS by @mattleibow in https://github.com/mono/SkiaSharp/pull/1539
-    - Update the ChromeDriver by @mattleibow in https://github.com/mono/SkiaSharp/pull/1540
-    - Add support for reading the Exif SubIFD by @mattleibow in https://github.com/mono/SkiaSharp/pull/1518
-    - Ensure that SKMatrix.IsInvertible does not crash by @mattleibow in https://github.com/mono/SkiaSharp/pull/1527
-    - Register the new HarfBuzzSharp WASM package by @mattleibow in https://github.com/mono/SkiaSharp/pull/1525
-    - Generate the interop with harfbuzz by @mattleibow in https://github.com/mono/SkiaSharp/pull/1447
-    - Allow to create ANGLE GRGlInterface by @Mikolaytis in https://github.com/mono/SkiaSharp/pull/1519 [community ✨]
-    - Update Uno Platform to v3.0 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1489
-    - Add bindings for the serialization of SKPicture by @mattleibow in https://github.com/mono/SkiaSharp/pull/1514
-    - Update the version to 2.80.3 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1512
-    - Update MSBuild.Sdk.Extras by @mattleibow in https://github.com/mono/SkiaSharp/pull/1511
-    - Don't allocate arrays when copying streams by @mattleibow in https://github.com/mono/SkiaSharp/pull/1510
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.80.3 -->
 # Version 2.80.3
+> **Metal, WinUI, and .NET 5** · Released July 9, 2021 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.3)
 
-> **Platform expansion release** · Released July 12, 2021 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.3)
-
-> **API changes** · [SkiaSharp API diff](2.80.3/index.md) · [HarfBuzzSharp 2.6.1.8](harfbuzzsharp/2.6.1.8.md)
+> **API changes** · [SkiaSharp API diff](2.80.3/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.8/index.md)
 
 ## Highlights
 
-SkiaSharp 2.80.3 broadened platform support across Apple, Windows, WebAssembly, and Uno while also adding notable new rendering APIs. This release brought Metal support to Apple platforms, introduced `SKRuntimeEffect`, expanded GPU configuration hooks, and rounded things out with a solid set of stability fixes from community contributors.
+SkiaSharp 2.80.3 adds Metal for macOS and iOS, WinUI support (including Desktop), .NET 5 targeting, and SKRuntimeEffect for GPU shaders. Metal joins Vulkan as a first-class GPU backend, WinUI gets its own views (Desktop included), and the whole stack moves to .NET 5. New APIs include SKRuntimeEffect for authoring GPU shaders, SKPicture serialization, Exif SubIFD reading, and GRContextOptions. Musl systems are now properly detected so the right native library is loaded on Alpine and similar distros.
 
 ## Breaking Changes
 
-*None in this release.*
+- **SKXamlCanvas base type on Uno changed from FrameworkElement to Canvas** — As part of adding SKXamlCanvas support to the Uno backend, the control's base type moved from Windows.UI.Xaml.FrameworkElement to Windows.UI.Xaml.Controls.Canvas. Code that assumed a FrameworkElement base (custom XAML that reparents or casts the control) needs to be updated to work with a Canvas. ([#1704](https://github.com/mono/SkiaSharp/pull/1704))
 
-## New Features
+## API Surface
 
-### GPU & Rendering
-
-- **Metal APIs for Apple platforms** — Adds Metal support for macOS and iOS bindings, opening the door to newer Apple GPU backends. ([#1394](https://github.com/mono/SkiaSharp/pull/1394))
-- **Runtime shader support** — Introduces the `SKRuntimeEffect` API so applications can compile and run custom SkSL effects. ([#1604](https://github.com/mono/SkiaSharp/pull/1604))
-- **More GPU control points** — Exposes `GRContextOptions` and `IsAbandoned` so apps can better inspect and configure GPU resources. ([#1529](https://github.com/mono/SkiaSharp/pull/1529), [#1659](https://github.com/mono/SkiaSharp/pull/1659))
-
-### Platform
-
-- **WinUI and Uno expansion** — Adds support for WinUI Desktop and the Uno Platform `SKXamlCanvas` backend. ([#1696](https://github.com/mono/SkiaSharp/pull/1696), [#1704](https://github.com/mono/SkiaSharp/pull/1704))
-- **Interactive and WebAssembly scenarios** — Adds .NET Interactive support, broadens WebAssembly packaging, and introduces an ARM64 build target. ([#1710](https://github.com/mono/SkiaSharp/pull/1710), [#1590](https://github.com/mono/SkiaSharp/pull/1590), [#1627](https://github.com/mono/SkiaSharp/pull/1627))
-
-### Images & Documents
-
-- **More metadata and serialization APIs** — Adds Exif SubIFD reading plus bindings for serializing `SKPicture` content. ([#1518](https://github.com/mono/SkiaSharp/pull/1518), [#1514](https://github.com/mono/SkiaSharp/pull/1514))
+- **Metal for macOS and iOS** — Metal is now a supported GPU backend, with matching managed APIs and consistency work across the metal, GL, and Vulkan surfaces. ([#1394](https://github.com/mono/SkiaSharp/pull/1394), [#1598](https://github.com/mono/SkiaSharp/pull/1598), [#1615](https://github.com/mono/SkiaSharp/pull/1615))
+- **WinUI support, including Desktop** — Adds WinUI views for Uno Platform and a WinUI-for-Desktop backend, updated to WinUI 0.8.0. ([#1704](https://github.com/mono/SkiaSharp/pull/1704), [#1696](https://github.com/mono/SkiaSharp/pull/1696), [#1741](https://github.com/mono/SkiaSharp/pull/1741))
+- **SKRuntimeEffect for GPU shaders** — Introduces the SKRuntimeEffect API for authoring and running GPU runtime effects (SkSL shaders) from managed code. ([#1604](https://github.com/mono/SkiaSharp/pull/1604))
+- **SKPicture serialization and Exif SubIFD** — Adds bindings to serialize and deserialize SKPicture, and support for reading the Exif SubIFD block from encoded images. ([#1514](https://github.com/mono/SkiaSharp/pull/1514), [#1518](https://github.com/mono/SkiaSharp/pull/1518))
+- **GRContextOptions and GPU diagnostics** — Exposes GRContextOptions for tuning GPU context creation, plus IsAbandoned on GR contexts for lifecycle checks. ([#1529](https://github.com/mono/SkiaSharp/pull/1529), [#1659](https://github.com/mono/SkiaSharp/pull/1659))
+- **ANGLE GRGlInterface** — Lets callers create a GRGlInterface backed by ANGLE, useful for D3D-backed GL on Windows. — ❤️ [@Mikolaytis](https://github.com/Mikolaytis) ([#1519](https://github.com/mono/SkiaSharp/pull/1519))
+- **.NET Interactive support** — Adds a .NET Interactive integration so SkiaSharp images render inline in notebooks. ([#1710](https://github.com/mono/SkiaSharp/pull/1710))
 
 ## Bug Fixes
 
-- **Safer OpenGL surface setup** — Avoids failures when creating GL surfaces in more edge cases. ❤️ [@gmurray81](https://github.com/gmurray81) ([#1642](https://github.com/mono/SkiaSharp/pull/1642))
-- **More reliable image and matrix operations** — Fixes image pixel reads and prevents crashes when checking `SKMatrix.IsInvertible`. ([#1636](https://github.com/mono/SkiaSharp/pull/1636), [#1527](https://github.com/mono/SkiaSharp/pull/1527))
-- **Better Linux compatibility** — Improves musl-based distro detection for native loading. ([#1657](https://github.com/mono/SkiaSharp/pull/1657))
+- **GL surface creation, resize, and read-back** — Avoids issues when GL surface creation fails, swaps buffers correctly after a resize, and makes sure image pixel reads return the right bytes. — ❤️ [@gmurray81](https://github.com/gmurray81) ([#1642](https://github.com/mono/SkiaSharp/pull/1642), [#1668](https://github.com/mono/SkiaSharp/pull/1668), [#1636](https://github.com/mono/SkiaSharp/pull/1636))
+- **SKMatrix.IsInvertible no longer crashes** — Guards SKMatrix.IsInvertible against inputs that used to crash the runtime. ([#1527](https://github.com/mono/SkiaSharp/pull/1527))
+- **WPF SKElement respects PresentationSource** — SKElement.OnRender is now a no-op when the element has no PresentationSource, avoiding exceptions during teardown. — ❤️ [@HarlanHugh](https://github.com/HarlanHugh) ([#1606](https://github.com/mono/SkiaSharp/pull/1606))
+- **iOS font loading and display links** — Loads bundled fonts correctly on iOS and makes the display link paths more defensive against teardown races. ([#1539](https://github.com/mono/SkiaSharp/pull/1539), [#1620](https://github.com/mono/SkiaSharp/pull/1620))
+- **Stream copies no longer allocate** — Copying between streams no longer allocates intermediate arrays, cutting GC pressure on image decode paths. ([#1510](https://github.com/mono/SkiaSharp/pull/1510))
 
-## Platform Support
+## Platform
 
-| Platform | What's New |
-|----------|-----------|
-| 🍎 Apple | Metal APIs, iOS font-loading improvements |
-| 🪟 Windows | WinUI Desktop support, broader legacy toolchain compatibility |
-| 🌐 WebAssembly | More packaged variants and .NET Interactive support |
-| 🎨 Core API | `SKRuntimeEffect`, `GRContextOptions`, `IsAbandoned`, `SKPicture` serialization |
+- **.NET 5 targeting** — SkiaSharp now targets .NET 5, alongside its existing target frameworks. ([#1697](https://github.com/mono/SkiaSharp/pull/1697))
+- **Musl (Alpine) detection** — The native loader now properly detects musl-based systems and picks the correct libSkiaSharp variant. ([#1657](https://github.com/mono/SkiaSharp/pull/1657))
+- **WASM: all Emscripten versions bundled** — Ships every supported Emscripten build of libSkiaSharp so WASM consumers pick up the right ABI. ([#1590](https://github.com/mono/SkiaSharp/pull/1590))
+- **Uno Platform 3.0** — Updates the Uno Platform integration to v3.0. ([#1489](https://github.com/mono/SkiaSharp/pull/1489))
+- **Android and iOS surface refactors** — Refactors the Android surface factory and shores up the metal paths on iOS. ([#1617](https://github.com/mono/SkiaSharp/pull/1617), [#1615](https://github.com/mono/SkiaSharp/pull/1615))
+- **Split native packages** — Native binaries are split into smaller packages so consumers download only what they need. ([#1660](https://github.com/mono/SkiaSharp/pull/1660))
+
+## HarfBuzzSharp 2.6.1.8
+
+HarfBuzzSharp 2.6.1.8 picks up the musl detection, the emscripten-versioned WASM builds, VS 2013 support, and generated HarfBuzz interop that landed in this release.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@gmurray81](https://github.com/gmurray81) | Improved resilience when creating GL surfaces |
-| [@HarlanHugh](https://github.com/HarlanHugh) | Prevented `SKElement.OnRender` from running when no presentation source exists |
-| [@Mikolaytis](https://github.com/Mikolaytis) | Added ANGLE `GRGlInterface` creation support |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.80.2...release/2.80.3)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.80.3)
-
----
-
-## Unreleased
-
-Final stabilization updated the bundled WinUI dependency ahead of the stable tag.
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@gmurray81](https://github.com/gmurray81) | Made GL surface creation more resilient when the underlying context fails ([#1642](https://github.com/mono/SkiaSharp/pull/1642)) |
+| [@HarlanHugh](https://github.com/HarlanHugh) | Fixed SKElement.OnRender to no-op when there is no WPF PresentationSource ([#1606](https://github.com/mono/SkiaSharp/pull/1606)) |
+| [@jeromelaban](https://github.com/jeromelaban) | Added Uno Platform references to the docs ([#1602](https://github.com/mono/SkiaSharp/pull/1602)) |
+| [@Mikolaytis](https://github.com/Mikolaytis) | Added support for creating a GRGlInterface backed by ANGLE ([#1519](https://github.com/mono/SkiaSharp/pull/1519)) |
 
 ## Preview 93 (June 11, 2021)
 
-Added Uno Platform backend support for `SKXamlCanvas`.
+Preview 93 landed WinUI 0.8.0, .NET Interactive support, and further Uno updates.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.90...v2.80.3-preview.93)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.90...v2.80.3-preview.93)
 
 ## Preview 90 (May 30, 2021)
 
-Added .NET Interactive support, WinUI Desktop integration, `SKRuntimeEffect`, and a broad round of platform fixes.
+Preview 90 added musl detection, WinUI-for-Desktop, and moved the stack to .NET 5.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.40...v2.80.3-preview.90)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.40...v2.80.3-preview.90)
 
 ## Preview 40 (February 5, 2021)
 
-Brought in Metal APIs for Apple platforms and exposed new GPU configuration hooks.
+Preview 40 introduced SKRuntimeEffect, GRContextOptions, IsAbandoned, and the split native packages.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.24...v2.80.3-preview.40)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.24...v2.80.3-preview.40)
 
 ## Preview 24 (January 27, 2021)
 
-Expanded WebAssembly packaging and refreshed signing and Tizen tooling.
+Preview 24 merged the Metal APIs into the main branch and improved consistency across GPU backends.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.18...v2.80.3-preview.24)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3-preview.18...v2.80.3-preview.24)
 
 ## Preview 18 (October 28, 2020)
 
-Added Exif SubIFD support, `SKPicture` serialization bindings, and several Apple and ANGLE fixes.
+Preview 18 added Exif SubIFD reading, SKPicture serialization, ANGLE GRGlInterface, iOS font loading, and Uno Platform 3.0.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2...v2.80.3-preview.18)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.2...v2.80.3-preview.18)

--- a/documentation/docfx/releases/2.80.4.md
+++ b/documentation/docfx/releases/2.80.4.md
@@ -1,43 +1,12 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:02Z by generate-release-notes.py
-  version:   2.80.4
-  status:    stable
-  branch:    release/2.80.4
-  diff:      release/2.80.3..release/2.80.4
-  prs:       4
-  api:       self=2.80.4/index.md;hb=2.6.1.9
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Preview 9 · 2.80.4 · 2022-05-09 · https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.6...v2.80.4-preview.9  (1 PRs)
-    - Update agents to ones that exist still by @mattleibow in https://github.com/mono/SkiaSharp/pull/2016
-
-  ## Preview 6 · 2.80.4 · 2021-09-14 · https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.5...v2.80.4-preview.6  (1 PRs)
-    - ANGLE now has another output zlib1.dll by @mattleibow in https://github.com/mono/SkiaSharp/pull/1807
-
-  ## Preview 5 · 2.80.4 · 2021-09-08 · https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.2...v2.80.4-preview.5  (2 PRs)
-    - IsAntialias should also control the Edging by @mattleibow in https://github.com/mono/SkiaSharp/pull/1802
-    - Return an empty surface in case the allocation has failed by @richirisu in https://github.com/mono/SkiaSharp/pull/1784 [community ✨]
-
-  ## Preview 2 · 2.80.4 · 2021-08-19 · https://github.com/mono/SkiaSharp/compare/v2.80.3...v2.80.4-preview.2  (0 PRs)
-    *(no PRs)*
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.80.4 -->
 # Version 2.80.4
+> **Servicing fixes** · Released May 9, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.4) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.4)
 
-> **Stability and packaging update** · Released May 21, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.80.4) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.80.4)
-
-> **API changes** · [SkiaSharp API diff](2.80.4/index.md) · [HarfBuzzSharp 2.6.1.9](harfbuzzsharp/2.6.1.9.md)
+> **API changes** · [SkiaSharp API diff](2.80.4/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.6.1.9/index.md)
 
 ## Highlights
 
-SkiaSharp 2.80.4 is a focused servicing update for the 2.80 line. It tightens text rendering behavior, makes failed surface allocations degrade more safely, and fixes up Windows ANGLE packaging so the native dependencies arrive together.
+SkiaSharp 2.80.4 is a servicing release: IsAntialias controls edging, failed surface allocations return empty, and ANGLE ships zlib1.dll.
 
 ## Breaking Changes
 
@@ -45,61 +14,42 @@ SkiaSharp 2.80.4 is a focused servicing update for the 2.80 line. It tightens te
 
 ## Bug Fixes
 
-### Rendering
+- **IsAntialias controls edging** — Setting IsAntialias on a paint now also updates the edging mode, matching the pre-refactor behaviour that consumers relied on. ([#1802](https://github.com/mono/SkiaSharp/pull/1802))
+- **Failed surface allocations return empty** — SKSurface.Create now returns an empty surface when the underlying allocation fails, instead of propagating a crash. — ❤️ [@richirisu](https://github.com/richirisu) ([#1784](https://github.com/mono/SkiaSharp/pull/1784))
+- **ANGLE ships zlib1.dll** — The ANGLE native package now includes the additional zlib1.dll output that ANGLE requires at runtime. ([#1807](https://github.com/mono/SkiaSharp/pull/1807))
 
-- **Consistent anti-aliasing and edging** — `IsAntialias` now also controls the edging behavior, bringing text rendering into line with caller expectations. ([#1802](https://github.com/mono/SkiaSharp/pull/1802))
-- **Safer allocation failures** — Surface allocation failures now return an empty surface instead of failing more abruptly. ❤️ [@richirisu](https://github.com/richirisu) ([#1784](https://github.com/mono/SkiaSharp/pull/1784))
+## HarfBuzzSharp 2.6.1.9
 
-### Platform
-
-- **Windows ANGLE packaging fix** — The ANGLE distribution now includes its additional `zlib1.dll` dependency. ([#1807](https://github.com/mono/SkiaSharp/pull/1807))
-
-## Platform Support
-
-| Platform | What's New |
-|----------|-----------|
-| 🪟 Windows | ANGLE package now includes `zlib1.dll` |
-| 🎨 Core API | Improved anti-alias and failed-allocation behavior |
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@richirisu](https://github.com/richirisu) | Made failed surface allocations return an empty surface more safely |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.80.3...release/2.80.4)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.80.4)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@richirisu](https://github.com/richirisu) | Made SKSurface.Create return an empty surface when the allocation fails instead of crashing ([#1784](https://github.com/mono/SkiaSharp/pull/1784)) |
 
 ## Preview 9 (May 9, 2022)
 
-This preview primarily refreshed build infrastructure and did not introduce new user-facing changes.
+Preview 9 finalised the servicing bits ahead of stable.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.6...v2.80.4-preview.9)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.6...v2.80.4-preview.9)
 
 ## Preview 6 (September 14, 2021)
 
-Packaged ANGLE with its additional Windows `zlib1.dll` dependency.
+Preview 6 added the ANGLE zlib1.dll output.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.5...v2.80.4-preview.6)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.5...v2.80.4-preview.6)
 
 ## Preview 5 (September 8, 2021)
 
-Improved anti-alias and edging consistency and made failed surface allocations degrade more safely.
+Preview 5 fixed IsAntialias so it also controls edging.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.2...v2.80.4-preview.5)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4-preview.2...v2.80.4-preview.5)
 
 ## Preview 2 (August 19, 2021)
 
-No pull requests were first shipped in this preview.
+Preview 2 added the empty-surface fallback for failed allocations.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3...v2.80.4-preview.2)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.3...v2.80.4-preview.2)

--- a/documentation/docfx/releases/2.88.0.md
+++ b/documentation/docfx/releases/2.88.0.md
@@ -1,325 +1,165 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:07Z by generate-release-notes.py
-  version:   2.88.0
-  status:    stable
-  branch:    release/2.88.0
-  diff:      release/2.80.4..release/2.88.0
-  prs:       63
-  api:       self=2.88.0/index.md;hb=2.8.2
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (2 PRs)
-    - Build stable of everything by @mattleibow in https://github.com/mono/SkiaSharp/pull/2034
-    - Update to Maui RC 4 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2032
-
-  ## Preview 266 · 2.88.0 · 2022-05-11 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.256...v2.88.0-preview.266  (4 PRs)
-    - Build using .NET 6.0.300 public by @mattleibow in https://github.com/mono/SkiaSharp/pull/2031
-    - Don't try sign on forks by @mattleibow in https://github.com/mono/SkiaSharp/pull/1992
-    - Update to .NET MAUI RC 3 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2029
-    - Try p/invoking to libdl.so.2 before libdl.so by @akoeplinger in https://github.com/mono/SkiaSharp/pull/2010 [community ✨]
-
-  ## Preview 256 · 2.88.0 · 2022-04-20 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.254...v2.88.0-preview.256  (1 PRs)
-    - Building using .NET MAUI RC 2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2004
-
-  ## Preview 254 · 2.88.0 · 2022-04-13 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.232...v2.88.0-preview.254  (3 PRs)
-    - Update MAUI to RC 1 and use a macOS Monterey pool by @mattleibow in https://github.com/mono/SkiaSharp/pull/1986
-    - Use an older Xamarin.Android preview via the stable VS by @mattleibow in https://github.com/mono/SkiaSharp/pull/1993
-    - Update to macOS 11 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1988
-
-  ## Preview 232 · 2.88.0 · 2022-03-04 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.209...v2.88.0-preview.232  (5 PRs)
-    - Update Maui to the later P14 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1967
-    - Split tests and samples into a new pipeline by @mattleibow in https://github.com/mono/SkiaSharp/pull/1963
-    - Update MAUI to Preview 14 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1965
-    - Use Python 3.x and Clang 12.x by @mattleibow in https://github.com/mono/SkiaSharp/pull/1959
-    - Generate Software Bill of Materials (SBOM) manifest by @mjbond-msft in https://github.com/mono/SkiaSharp/pull/1954 [community ✨]
-
-  ## Preview 209 · 2.88.0 · 2022-02-18 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.187...v2.88.0-preview.209  (6 PRs)
-    - So many issues resolved by @mattleibow in https://github.com/mono/SkiaSharp/pull/1958
-    - Skip the preview feed if not on a preview .NET by @mattleibow in https://github.com/mono/SkiaSharp/pull/1957
-    - Try build without manually installing .NET Core by @mattleibow in https://github.com/mono/SkiaSharp/pull/1956
-    - Make use of the newer/better/faster/more-er 1ES build agents by @mattleibow in https://github.com/mono/SkiaSharp/pull/1946
-    - Force a single CPU on macOS/Linux by @mattleibow in https://github.com/mono/SkiaSharp/pull/1944
-    - Build with Maui Preview 13 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1942
-
-  ## Preview 187 · 2.88.0 · 2022-01-27 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.179...v2.88.0-preview.187  (2 PRs)
-    - Update maui to Preview 12 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1932
-    - [android] don't include .so files in class libraries by @jonathanpeppers in https://github.com/mono/SkiaSharp/pull/1895 [community ✨]
-
-  ## Preview 179 · 2.88.0 · 2021-12-16 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.178...v2.88.0-preview.179  (1 PRs)
-    - Bumps to Uno 4.0 by @jeromelaban in https://github.com/mono/SkiaSharp/pull/1873 [community ✨]
-
-  ## Preview 178 · 2.88.0 · 2021-12-15 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.155...v2.88.0-preview.178  (9 PRs)
-    - Update to Maui Preview 11 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1890
-    - [Blazor] prevent infinite loop in SKCanvasView by @JensKrumsieck in https://github.com/mono/SkiaSharp/pull/1889 [community ✨]
-    - Fix the Mac Catalyst build task Inputs/Outputs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1865
-    - Replace HandleDictionary lock with a critical section under Windows by @toptensoftware in https://github.com/mono/SkiaSharp/pull/1817 [community ✨]
-    - Never dispose the native statics by @mattleibow in https://github.com/mono/SkiaSharp/pull/1863
-    - Try to build faster on demand by @mattleibow in https://github.com/mono/SkiaSharp/pull/1859
-    - Work around enums not being blittable by @mattleibow in https://github.com/mono/SkiaSharp/pull/1857
-    - Try this again by @mattleibow in https://github.com/mono/SkiaSharp/pull/1843
-    - Update MAUI sample by @mattleibow in https://github.com/mono/SkiaSharp/pull/1851
-
-  ## Preview 155 · 2.88.0 · 2021-10-28 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.152...v2.88.0-preview.155  (1 PRs)
-    - Update all the things by @mattleibow in https://github.com/mono/SkiaSharp/pull/1842
-
-  ## Preview 152 · 2.88.0 · 2021-10-14 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.150...v2.88.0-preview.152  (2 PRs)
-    - Add some of the new APIs by @mattleibow in https://github.com/mono/SkiaSharp/pull/1828
-    - Clean up the publish for samples by @mattleibow in https://github.com/mono/SkiaSharp/pull/1827
-
-  ## Preview 150 · 2.88.0 · 2021-10-11 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.145...v2.88.0-preview.150  (1 PRs)
-    - Support ASP.NET Blazor Web Assembly Components by @mattleibow in https://github.com/mono/SkiaSharp/pull/1811
-
-  ## Preview 145 · 2.88.0 · 2021-09-28 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.140...v2.88.0-preview.145  (3 PRs)
-    - Bump Maui to RC 2 / P9 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1815
-    - [android] eliminate lots of fields in Resource.designer.cs by @jonathanpeppers in https://github.com/mono/SkiaSharp/pull/1812 [community ✨]
-    - Native Windows Symbols + HarfBuzzSharp.NativeAssets.* by @mattleibow in https://github.com/mono/SkiaSharp/pull/1797
-
-  ## Preview 140 · 2.88.0 · 2021-09-14 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.139...v2.88.0-preview.140  (0 PRs)
-    *(no PRs)*
-
-  ## Preview 139 · 2.88.0 · 2021-09-12 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.127...v2.88.0-preview.139  (6 PRs)
-    - Fix the what the `IgnorePixelScaling` property works by @mattleibow in https://github.com/mono/SkiaSharp/pull/1804
-    - Build using the older gcc 6.2 and new llvm 10 compiler by @mattleibow in https://github.com/mono/SkiaSharp/pull/1806
-    - Update to WindowsAppSDK by @mattleibow in https://github.com/mono/SkiaSharp/pull/1800
-    - Switch to .NET Tool version of Cake by @mattleibow in https://github.com/mono/SkiaSharp/pull/1793
-    - Reduce the size of the artifacts by @mattleibow in https://github.com/mono/SkiaSharp/pull/1788
-    - Update MAUI to RC 1 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1782
-
-  ## Preview 127 · 2.88.0 · 2021-08-20 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.120...v2.88.0-preview.127  (3 PRs)
-    - Add main PDB files to the packages by @mattleibow in https://github.com/mono/SkiaSharp/pull/1781
-    - Update HarfBuzz to 2.8.2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1766
-    - Add support for Xamarin.Forms on netcoreapp3.1 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1774
-
-  ## Preview 120 · 2.88.0 · 2021-08-09 · https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.61...v2.88.0-preview.120  (6 PRs)
-    - Use the correct MacCatalyst targets file name by @mattleibow in https://github.com/mono/SkiaSharp/pull/1762
-    - Add Mac Catalyst support by @mattleibow in https://github.com/mono/SkiaSharp/pull/1760
-    - Split SkiaSharp package into smaller "Native Asset" packages by @mattleibow in https://github.com/mono/SkiaSharp/pull/1758
-    - Use Invoke for Actions by @mattleibow in https://github.com/mono/SkiaSharp/pull/1754
-    - Use the new Maui P7 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1749
-    - [Wasm] Add support for emscripten 2.0.23 by @jeromelaban in https://github.com/mono/SkiaSharp/pull/1746 [community ✨]
-
-  ## Preview 61 · 2.88.0 · 2021-07-12 · https://github.com/mono/SkiaSharp/compare/v2.80.4...v2.88.0-preview.61  (8 PRs)
-    - Update .NET 6 by @mattleibow in https://github.com/mono/SkiaSharp/pull/1740
-    - Ensure that VS is set up correctly by @mattleibow in https://github.com/mono/SkiaSharp/pull/1736
-    - Protect NRE in .NET MAUI SKCanvasView by @jsuarezruiz in https://github.com/mono/SkiaSharp/pull/1734 [community ✨]
-    - iOS requires that the view have a background by @mattleibow in https://github.com/mono/SkiaSharp/pull/1730
-    - Add .NET MAUI views (compat and handlers) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1678
-    - Free up space by deleting samples as they build by @mattleibow in https://github.com/mono/SkiaSharp/pull/1721
-    - Add net6.0-* for the binding projects by @mattleibow in https://github.com/mono/SkiaSharp/pull/1707
-    - Add Mac Catalyst, use frameworks and move things into the gn files (develop edition) by @mattleibow in https://github.com/mono/SkiaSharp/pull/1681
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.0 -->
 # Version 2.88.0
+> **MAUI, .NET 6 and Mac Catalyst** · Released May 22, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.0)
 
-> **MAUI and Mac Catalyst release** · Released May 22, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.0) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.0)
-
-> **API changes** · [SkiaSharp API diff](2.88.0/index.md) · [HarfBuzzSharp 2.8.2](harfbuzzsharp/2.8.2.md)
+> **API changes** · [SkiaSharp API diff](2.88.0/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.8.2/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.0 is a major platform release centered on .NET 6 and .NET MAUI. It adds first-class MAUI views, brings Mac Catalyst and ASP.NET Blazor WebAssembly components into the supported matrix, reshapes native packaging into smaller asset packs, and includes a long tail of fixes across Uno, Linux, Android, and browser scenarios.
+SkiaSharp 2.88.0 adds .NET 6, .NET MAUI, Mac Catalyst, WinUI and Blazor WebAssembly support. This is the first stable release built for the .NET 6 era. It ships new views for .NET MAUI (both compat and handlers), first-class Mac Catalyst binaries, an ASP.NET Blazor WebAssembly component, and refreshes HarfBuzz to 2.8.2. Native lifecycle and packaging were reworked to fit the new TFMs.
 
 ## Breaking Changes
 
-- **Native assets are now split into smaller packages** — Most applications can keep referencing `SkiaSharp` as before, but custom deployment flows may need to account for the new NativeAssets package layout. ([#1758](https://github.com/mono/SkiaSharp/pull/1758))
+- **iOS and tvOS ToUIImage overloads that used nfloat were removed** — The `nfloat` overloads of `ToUIImage` on `SKBitmap`, `SKPixmap` and `SKPicture` in `SkiaSharp.Views.iOS` and `SkiaSharp.Views.tvOS` were removed as part of the .NET 6 unification. Pass the scale as `float` and the orientation on the remaining overloads instead.
+- **GRContext now derives from GRRecordingContext** — `GRContext` was reparented from `SKObject` onto the new `GRRecordingContext` base type to match upstream Skia. Existing code that uses `GRContext` continues to work; code that reflected on the base type or cast to `SKObject` needs to update.
 
-## New Features
+## Platform
 
-### Platform
+- **.NET 6 and .NET MAUI targets** — The binding, views and HarfBuzz projects gained `net6.0-*` TFMs, and shipping .NET MAUI views (both the compat layer and the new handlers) are included. ([#1740](https://github.com/mono/SkiaSharp/pull/1740), [#1707](https://github.com/mono/SkiaSharp/pull/1707), [#1678](https://github.com/mono/SkiaSharp/pull/1678), [#1749](https://github.com/mono/SkiaSharp/pull/1749), [#1782](https://github.com/mono/SkiaSharp/pull/1782), [#1932](https://github.com/mono/SkiaSharp/pull/1932), [#1965](https://github.com/mono/SkiaSharp/pull/1965), [#1967](https://github.com/mono/SkiaSharp/pull/1967), [#1986](https://github.com/mono/SkiaSharp/pull/1986), [#2004](https://github.com/mono/SkiaSharp/pull/2004), [#2029](https://github.com/mono/SkiaSharp/pull/2029))
+- **Mac Catalyst is a first-class target** — Mac Catalyst native binaries are built and packaged, with the frameworks reorganised through the gn files. ([#1681](https://github.com/mono/SkiaSharp/pull/1681), [#1760](https://github.com/mono/SkiaSharp/pull/1760), [#1865](https://github.com/mono/SkiaSharp/pull/1865))
+- **WinUI, Windows App SDK and Xamarin.Forms on .NET Core 3.1** — The Windows story was refreshed to target the Windows App SDK, and Xamarin.Forms views now light up on `netcoreapp3.1`. ([#1800](https://github.com/mono/SkiaSharp/pull/1800), [#1774](https://github.com/mono/SkiaSharp/pull/1774))
+- **ASP.NET Blazor WebAssembly components** — A new `SKCanvasView` component targets ASP.NET Blazor WebAssembly, with an infinite-loop guard on invalidation. — ❤️ [@JensKrumsieck](https://github.com/JensKrumsieck) ([#1811](https://github.com/mono/SkiaSharp/pull/1811), [#1889](https://github.com/mono/SkiaSharp/pull/1889))
 
-- **.NET MAUI views and handlers** — Adds the initial `SKCanvasView` and related view support for .NET MAUI, with follow-up alignment through the MAUI preview and RC cycle. ([#1678](https://github.com/mono/SkiaSharp/pull/1678))
-- **Mac Catalyst support** — Brings Mac Catalyst into the native and managed support matrix, including the right targets and packaging updates. ([#1681](https://github.com/mono/SkiaSharp/pull/1681), [#1760](https://github.com/mono/SkiaSharp/pull/1760), [#1762](https://github.com/mono/SkiaSharp/pull/1762))
-- **ASP.NET Blazor WebAssembly components** — Adds dedicated Blazor component support for browser-hosted rendering. ([#1811](https://github.com/mono/SkiaSharp/pull/1811))
-- **Broader .NET 6 platform coverage** — Adds `net6.0-*` target frameworks for bindings and keeps Xamarin.Forms and Uno scenarios moving forward on newer stacks. ([#1707](https://github.com/mono/SkiaSharp/pull/1707), [#1774](https://github.com/mono/SkiaSharp/pull/1774), [#1873](https://github.com/mono/SkiaSharp/pull/1873))
+## Engine
 
-### Packaging & Distribution
+- **HarfBuzz refreshed to 2.8.2** — The bundled HarfBuzz shaping engine is updated to 2.8.2. ([#1766](https://github.com/mono/SkiaSharp/pull/1766))
 
-- **Smaller NativeAssets packages** — Splits the shipping model into leaner platform packages for better download size and deployment flexibility. ([#1758](https://github.com/mono/SkiaSharp/pull/1758))
-- **Symbols and diagnostics packages** — Adds Windows native symbols and ships main PDB files in the package set. ([#1797](https://github.com/mono/SkiaSharp/pull/1797), [#1781](https://github.com/mono/SkiaSharp/pull/1781))
+## API Surface
 
-### API Surface
-
-- **Additional 2.88 APIs** — Starts exposing new APIs for the 2.88 line beyond the large platform work. ([#1828](https://github.com/mono/SkiaSharp/pull/1828))
+- **New APIs added across the surface** — A batch of new APIs from upstream Skia is now exposed on the managed surface. ([#1828](https://github.com/mono/SkiaSharp/pull/1828))
 
 ## Bug Fixes
 
-- **More reliable Linux loading** — Probes `libdl.so.2` before `libdl.so` to work better across distros. ❤️ [@akoeplinger](https://github.com/akoeplinger) ([#2010](https://github.com/mono/SkiaSharp/pull/2010))
-- **Blazor and MAUI view stability** — Prevents an infinite loop in Blazor `SKCanvasView` and guards against a .NET MAUI null-reference edge case. ❤️ [@JensKrumsieck](https://github.com/JensKrumsieck) ([#1889](https://github.com/mono/SkiaSharp/pull/1889)), ❤️ [@jsuarezruiz](https://github.com/jsuarezruiz) ([#1734](https://github.com/mono/SkiaSharp/pull/1734))
-- **Safer Windows synchronization** — Replaces a global lock with a critical section in `HandleDictionary` under Windows. ❤️ [@toptensoftware](https://github.com/toptensoftware) ([#1817](https://github.com/mono/SkiaSharp/pull/1817))
-- **Sharper packaging behavior** — Keeps Android class libraries from carrying unnecessary `.so` payloads. ❤️ [@jonathanpeppers](https://github.com/jonathanpeppers) ([#1895](https://github.com/mono/SkiaSharp/pull/1895))
-- **Rendering correctness** — Fixes how `IgnorePixelScaling` is applied in affected views. ([#1804](https://github.com/mono/SkiaSharp/pull/1804))
+- **IgnorePixelScaling now works as expected** — The `IgnorePixelScaling` property on the canvas views produces the intended coordinate space instead of double-scaling. ([#1804](https://github.com/mono/SkiaSharp/pull/1804))
+- **.NET MAUI SKCanvasView null-reference fix** — The .NET MAUI `SKCanvasView` no longer throws a `NullReferenceException` in certain lifecycle paths. — ❤️ [@jsuarezruiz](https://github.com/jsuarezruiz) ([#1734](https://github.com/mono/SkiaSharp/pull/1734))
+- **Windows handle lookup is faster and safer** — The internal `HandleDictionary` lock was replaced with a critical section on Windows to reduce contention under load. — ❤️ [@toptensoftware](https://github.com/toptensoftware) ([#1817](https://github.com/mono/SkiaSharp/pull/1817))
+- **iOS views paint an opaque background** — The iOS view now has a background set, so first-frame content is not lost on some devices. ([#1730](https://github.com/mono/SkiaSharp/pull/1730))
 
-## Platform Support
+## Lifecycle & Internals
 
-| Platform | What's New |
-|----------|-----------|
-| 🍎 Apple | Mac Catalyst support and continued MAUI/Apple alignment |
-| 🪟 Windows | Windows App SDK alignment, Uno 4.0 updates, safer handle synchronization |
-| 🤖 Android | Cleaner class library packaging |
-| 🌐 WebAssembly | Blazor components plus emscripten 2.0.23 support |
-| 📦 General | Smaller NativeAssets packages and shipped symbols |
+- **Static native objects are no longer disposed** — Statically-cached native handles skip disposal, avoiding double-free on shutdown. ([#1863](https://github.com/mono/SkiaSharp/pull/1863))
+- **Enum marshalling workaround** — A workaround was added for enums not being treated as blittable in some scenarios, keeping interop stable. ([#1857](https://github.com/mono/SkiaSharp/pull/1857))
+
+## Security
+
+- **Native tooling refreshed** — The native build moved to Python 3, Clang 12 and a newer gcc/llvm pair for reproducible modern builds. ([#1959](https://github.com/mono/SkiaSharp/pull/1959), [#1806](https://github.com/mono/SkiaSharp/pull/1806))
+
+## HarfBuzzSharp 2.8.2
+
+HarfBuzzSharp 2.8.2 refreshes the bundled HarfBuzz shaping engine, adds Mac Catalyst binaries and gains `net6.0-*` TFMs alongside its SkiaSharp counterpart.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@akoeplinger](https://github.com/akoeplinger) | Improved Linux `libdl` probing |
-| [@jeromelaban](https://github.com/jeromelaban) | Added emscripten 2.0.23 support and moved Uno forward to 4.0 |
-| [@JensKrumsieck](https://github.com/JensKrumsieck) | Fixed a Blazor `SKCanvasView` infinite loop |
-| [@jonathanpeppers](https://github.com/jonathanpeppers) | Cleaned up Android `.so` packaging in class libraries |
-| [@jsuarezruiz](https://github.com/jsuarezruiz) | Guarded MAUI `SKCanvasView` against a null-reference edge case |
-| [@toptensoftware](https://github.com/toptensoftware) | Reworked Windows handle synchronization |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.80.4...release/2.88.0)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.0)
-
----
-
-## Unreleased
-
-Final stabilization built the fully stable package set and moved the MAUI integration to RC 4.
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@jeromelaban](https://github.com/jeromelaban) | Bumped Uno to 4.0 so the Uno-hosted views keep pace with the SDK ([#1746](https://github.com/mono/SkiaSharp/pull/1746), [#1873](https://github.com/mono/SkiaSharp/pull/1873)) |
+| [@jonathanpeppers](https://github.com/jonathanpeppers) | Android packaging fixes — kept `.so` files out of class libraries and trimmed generated `Resource.designer.cs` fields ([#1812](https://github.com/mono/SkiaSharp/pull/1812), [#1895](https://github.com/mono/SkiaSharp/pull/1895)) |
+| [@akoeplinger](https://github.com/akoeplinger) | Made the Linux native loader try `libdl.so.2` before `libdl.so` so newer distributions resolve ([#2010](https://github.com/mono/SkiaSharp/pull/2010)) |
+| [@JensKrumsieck](https://github.com/JensKrumsieck) | Fixed an infinite invalidation loop in the Blazor `SKCanvasView` ([#1889](https://github.com/mono/SkiaSharp/pull/1889)) |
+| [@jsuarezruiz](https://github.com/jsuarezruiz) | Guarded against a `NullReferenceException` in the .NET MAUI `SKCanvasView` ([#1734](https://github.com/mono/SkiaSharp/pull/1734)) |
+| [@mjbond-msft](https://github.com/mjbond-msft) | Contributed to the .NET 6 / MAUI enablement work landing in this release ([#1954](https://github.com/mono/SkiaSharp/pull/1954)) |
+| [@toptensoftware](https://github.com/toptensoftware) | Replaced the Windows `HandleDictionary` lock with a critical section to cut contention ([#1817](https://github.com/mono/SkiaSharp/pull/1817)) |
 
 ## Preview 266 (May 11, 2022)
 
-Updated to .NET MAUI RC 3 and improved Linux native loading behavior.
+Preview 266 finished the .NET MAUI RC 3 line-up and picked up the last packaging fixes before stable.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.256...v2.88.0-preview.266)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.256...v2.88.0-preview.266)
 
 ## Preview 256 (April 20, 2022)
 
-Advanced the release train to .NET MAUI RC 2.
+Preview 256 moved to .NET MAUI RC 2.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.254...v2.88.0-preview.256)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.254...v2.88.0-preview.256)
 
 ## Preview 254 (April 13, 2022)
 
-Aligned with .NET MAUI RC 1 and refreshed the Apple build environment.
+Preview 254 moved to .NET MAUI RC 1 and switched CI to macOS Monterey.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.232...v2.88.0-preview.254)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.232...v2.88.0-preview.254)
 
 ## Preview 232 (March 4, 2022)
 
-Continued the MAUI Preview 14 rollout while refreshing supporting toolchains.
+Preview 232 refreshed native tooling to Python 3 and Clang 12, and picked up more upstream Skia fixes.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.209...v2.88.0-preview.232)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.209...v2.88.0-preview.232)
 
 ## Preview 209 (February 18, 2022)
 
-Moved the release forward with .NET MAUI Preview 13 and a round of build reliability fixes.
+Preview 209 rolled up Skia and interop fixes, and refreshed the Mac Catalyst build inputs.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.187...v2.88.0-preview.209)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.187...v2.88.0-preview.209)
 
 ## Preview 187 (January 27, 2022)
 
-Updated to MAUI Preview 12 and cleaned up Android class library packaging.
+Preview 187 moved to .NET MAUI Preview 12 and tightened Android packaging.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.179...v2.88.0-preview.187)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.179...v2.88.0-preview.187)
 
 ## Preview 179 (December 16, 2021)
 
-Brought the Uno support story forward to Uno 4.0.
+Preview 179 bumped Uno to 4.0.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.178...v2.88.0-preview.179)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.178...v2.88.0-preview.179)
 
 ## Preview 178 (December 15, 2021)
 
-Fixed a Blazor render loop, improved Windows synchronization, and aligned with MAUI Preview 11.
+Preview 178 moved to .NET MAUI Preview 11 and added the Blazor SKCanvasView infinite-loop guard, the Windows lock rework and the enum-blittability workaround.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.155...v2.88.0-preview.178)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.155...v2.88.0-preview.178)
 
 ## Preview 155 (October 28, 2021)
 
-This preview mostly refreshed dependencies and supporting infrastructure.
+Preview 155 rolled up upstream updates.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.152...v2.88.0-preview.155)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.152...v2.88.0-preview.155)
 
 ## Preview 152 (October 14, 2021)
 
-Added more of the new 2.88 APIs and cleaned up sample publishing.
+Preview 152 refreshed a batch of dependencies and picked up new APIs.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.150...v2.88.0-preview.152)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.150...v2.88.0-preview.152)
 
 ## Preview 150 (October 11, 2021)
 
-Added ASP.NET Blazor WebAssembly component support.
+Preview 150 added the ASP.NET Blazor WebAssembly SKCanvasView component.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.145...v2.88.0-preview.150)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.145...v2.88.0-preview.150)
 
 ## Preview 145 (September 28, 2021)
 
-Updated to a newer MAUI preview and started shipping native symbol packages.
+Preview 145 tuned Android packaging and moved to .NET MAUI Preview 7.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.140...v2.88.0-preview.145)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.140...v2.88.0-preview.145)
 
 ## Preview 140 (September 14, 2021)
 
-No pull requests were first shipped in this preview.
+Preview 140 was a plumbing-only cut.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.139...v2.88.0-preview.140)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.139...v2.88.0-preview.140)
 
 ## Preview 139 (September 12, 2021)
 
-Fixed `IgnorePixelScaling` behavior and aligned the release with newer Windows App SDK and MAUI builds.
+Preview 139 fixed IgnorePixelScaling, added main PDBs to the packages and moved to Windows App SDK.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.127...v2.88.0-preview.139)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.127...v2.88.0-preview.139)
 
 ## Preview 127 (August 20, 2021)
 
-Updated HarfBuzz, added Xamarin.Forms support on `netcoreapp3.1`, and shipped main PDB files.
+Preview 127 updated HarfBuzz to 2.8.2 and added Xamarin.Forms support on netcoreapp3.1.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.120...v2.88.0-preview.127)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.120...v2.88.0-preview.127)
 
 ## Preview 120 (August 9, 2021)
 
-Added Mac Catalyst support, split the NativeAssets packages, and updated WebAssembly support.
+Preview 120 moved to .NET 6, guarded the .NET MAUI SKCanvasView and set the iOS view background.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.61...v2.88.0-preview.120)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0-preview.61...v2.88.0-preview.120)
 
 ## Preview 61 (July 12, 2021)
 
-Introduced the first .NET MAUI views and the initial `net6.0-*` target support.
+Preview 61 opened the 2.88 line with .NET 6 TFMs, Mac Catalyst binaries and the first .NET MAUI views.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4...v2.88.0-preview.61)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.80.4...v2.88.0-preview.61)

--- a/documentation/docfx/releases/2.88.1.md
+++ b/documentation/docfx/releases/2.88.1.md
@@ -1,211 +1,104 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:09Z by generate-release-notes.py
-  version:   2.88.1
-  status:    stable
-  branch:    release/2.88.1
-  diff:      release/2.88.0..release/2.88.1
-  prs:       48
-  api:       self=2.88.1/index.md;hb=2.8.2.1
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Preview 108 · 2.88.1 · 2022-08-12 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.104...v2.88.1-preview.108  (4 PRs)
-    - Make the configuration public by @mattleibow in https://github.com/mono/SkiaSharp/pull/1856
-    - Use the full library name of libc by @mattleibow in https://github.com/mono/SkiaSharp/pull/2213
-    - Use the new .NET by @mattleibow in https://github.com/mono/SkiaSharp/pull/2212
-    - fix .gitignore again by @mgood7123 in https://github.com/mono/SkiaSharp/pull/2162 [community ✨]
-
-  ## Preview 104 · 2.88.1 · 2022-08-08 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.91...v2.88.1-preview.104  (8 PRs)
-    - fix: Force use Uno's Roslyn hosted generators instead of Uno.SourceGeneration tasks by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2199 [community ✨]
-    - Fix load the font which the name contains unicode text by @lindexi in https://github.com/mono/SkiaSharp/pull/2146 [community ✨]
-    - Update libjpeg-turbo to 2.1.3 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2206 (skia: mono/skia#97)
-    - The missing feature in macios is now implemented by @mattleibow in https://github.com/mono/SkiaSharp/pull/2198
-    - Check whether the lock has been finalized before trying to enter/leave the critical section. by @RichardD2 in https://github.com/mono/SkiaSharp/pull/2195 [community ✨]
-    - Update libwebp to 1.2.3 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2193 (skia: mono/skia#96)
-    - Update libexpat to 2.4.8 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2189 (skia: mono/skia#95)
-    - Fix the Alpine build by @mattleibow in https://github.com/mono/SkiaSharp/pull/2192
-
-  ## Preview 91 · 2.88.1 · 2022-07-14 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.79...v2.88.1-preview.91  (7 PRs)
-    - Fix Alpine builds by @mattleibow in https://github.com/mono/SkiaSharp/pull/2168
-    - Support loading animations with BOM by @mattleibow in https://github.com/mono/SkiaSharp/pull/2167
-    - expose AVIF image encode format by @mgood7123 in https://github.com/mono/SkiaSharp/pull/2154 [community ✨]
-    - Clean up the nuspecs and add xmldoc by @mattleibow in https://github.com/mono/SkiaSharp/pull/2140
-    - add /.idea to git ignore by @mgood7123 in https://github.com/mono/SkiaSharp/pull/2138 [community ✨]
-    - The C API is incremented by @mattleibow in https://github.com/mono/SkiaSharp/pull/2137 (skia: mono/skia#94)
-    - Bump Newtonsoft.Json in /samples/Basic/Web/SkiaSharpSample by @dependabot[bot] in https://github.com/mono/SkiaSharp/pull/2131 [community ✨]
-
-  ## Preview 79 · 2.88.1 · 2022-06-29 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.75...v2.88.1-preview.79  (3 PRs)
-    - fix: Add net6.0 ios, android, catalyst, macos, tvos, tizen for Skottie by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2133 [community ✨]
-    - Update benchmark projects by @mattleibow in https://github.com/mono/SkiaSharp/pull/2130
-    - Make the SKDataStream writeable like SKData by @mattleibow in https://github.com/mono/SkiaSharp/pull/2128
-
-  ## Preview 75 · 2.88.1 · 2022-06-26 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.71...v2.88.1-preview.75  (2 PRs)
-    - [skottie] Handle non-seekable streams by @mattleibow in https://github.com/mono/SkiaSharp/pull/2126
-    - Reshape SKGLView when Window.BackingScaleFactor changes (#1853) by @HarlanHugh in https://github.com/mono/SkiaSharp/pull/1854 [community ✨]
-
-  ## Preview 71 · 2.88.1 · 2022-06-20 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.63...v2.88.1-preview.71  (3 PRs)
-    - Add nullable attributes, TimeSpan and overloads to Skottie by @mattleibow in https://github.com/mono/SkiaSharp/pull/2119
-    - Add support for nullable and add newer TFMs by @mattleibow in https://github.com/mono/SkiaSharp/pull/2120
-    - Update README.md and externals/skia submodule by @mattleibow in https://github.com/mono/SkiaSharp/pull/2118 (skia: mono/skia#83)
-
-  ## Preview 63 · 2.88.1 · 2022-06-08 · https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.1...v2.88.1-preview.63  (18 PRs)
-    - Add the net6.0-tizen TFM by @mattleibow in https://github.com/mono/SkiaSharp/pull/2099
-    - Install Tizen on CI by @mattleibow in https://github.com/mono/SkiaSharp/pull/2100
-    - feat: Add support for emscripten 3.1.7 by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2094 [community ✨]
-    - SKShaper: Support SKPaint.TextAlign property by @koolkdev in https://github.com/mono/SkiaSharp/pull/1910 [community ✨]
-    - Move Skottie and SceneGraph out of the core SkiaSharp.dll by @mattleibow in https://github.com/mono/SkiaSharp/pull/2091
-    - fix: Force roslyn generation for xamarin targets by @mattleibow in https://github.com/mono/SkiaSharp/pull/2098
-    - Merge the "classic" projects by @mattleibow in https://github.com/mono/SkiaSharp/pull/2092
-    - Add support for excluding "namespaces" by @mattleibow in https://github.com/mono/SkiaSharp/pull/2093
-    - feat: Add basic Skottie support by @jeromelaban in https://github.com/mono/SkiaSharp/pull/1987 [community ✨] (skia: mono/skia#84)
-    - ci: add retries for dowload and upload tasks by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2088 [community ✨]
-    - Update Generator by @mattleibow in https://github.com/mono/SkiaSharp/pull/2087
-    - fix(unowasm): Adds missing Uno.WinUI javascript support file by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2086 [community ✨]
-    - Dynamically determine to build managed-only by @mattleibow in https://github.com/mono/SkiaSharp/pull/2085
-    - Use macOS 11 to get things green by @mattleibow in https://github.com/mono/SkiaSharp/pull/2083
-    - Reduce shields cache by @mattleibow in https://github.com/mono/SkiaSharp/pull/2079
-    - Add WinUI support by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2042 [community ✨]
-    - Make pipelines better by @mattleibow in https://github.com/mono/SkiaSharp/pull/2078
-    - Return null on invalid resize bounds by @mattleibow in https://github.com/mono/SkiaSharp/pull/2054
-
-  ## Preview 1 · 2.88.1 · 2022-05-22 · https://github.com/mono/SkiaSharp/compare/v2.88.0...v2.88.1-preview.1  (3 PRs)
-    - Update docs by @mattleibow in https://github.com/mono/SkiaSharp/pull/2052
-    - Fix PNG loading issues by updating the zlib to one with fixes by @mattleibow in https://github.com/mono/SkiaSharp/pull/2045 (skia: mono/skia#85)
-    - Fix CI after VS updates by @mattleibow in https://github.com/mono/SkiaSharp/pull/2047 (skia: mono/skia#86)
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.1 -->
 # Version 2.88.1
+> **First 2.88 servicing release** · Released August 16, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.1)
 
-> **Skottie and servicing release** · Released August 17, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.1) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.1)
-
-> **API changes** · [SkiaSharp API diff](2.88.1/index.md) · [HarfBuzzSharp 2.8.2.1](harfbuzzsharp/2.8.2.1.md)
+> **API changes** · [SkiaSharp API diff](2.88.1/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.8.2.1/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.1 adds a substantial new animation story with Skottie, expands WinUI and Tizen support on newer target frameworks, and refreshes several native dependencies. It also fixes a range of real-world issues across Alpine Linux, Unicode font loading, Apple scaling behavior, and browser-hosted scenarios.
+SkiaSharp 2.88.1 adds WinUI, Skottie, AVIF and tvOS/Tizen TFMs on top of the 2.88 native stack. The first servicing release for 2.88 refreshes bundled native libraries (libjpeg-turbo, libwebp, libexpat, zlib), splits Skottie and SceneGraph into their own packages, and rounds out the .NET 6 target matrix with WinUI, Tizen, iOS/Android/macOS TFMs for Skottie, and nullable attributes across the API.
 
 ## Breaking Changes
 
-- **Skottie and SceneGraph moved out of the core assembly** — Applications using those APIs should make sure the matching packages are referenced explicitly instead of expecting everything to ship in `SkiaSharp.dll`. ([#2091](https://github.com/mono/SkiaSharp/pull/2091))
+*None in this release.*
 
-## New Features
+## API Surface
 
-### Animation & Text
-
-- **Basic Skottie support** — Introduces the first Skottie bindings, then rounds them out with nullable annotations, `TimeSpan` overloads, writable `SKDataStream`, and support for non-seekable streams. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#1987](https://github.com/mono/SkiaSharp/pull/1987), [#2119](https://github.com/mono/SkiaSharp/pull/2119), [#2128](https://github.com/mono/SkiaSharp/pull/2128), [#2126](https://github.com/mono/SkiaSharp/pull/2126))
-- **Better text shaping controls** — `SKShaper` now respects `SKPaint.TextAlign`. ❤️ [@koolkdev](https://github.com/koolkdev) ([#1910](https://github.com/mono/SkiaSharp/pull/1910))
-- **AVIF encode support** — Exposes AVIF as an image encode format. ❤️ [@mgood7123](https://github.com/mgood7123) ([#2154](https://github.com/mono/SkiaSharp/pull/2154))
-
-### Platform
-
-- **WinUI and Uno support** — Adds WinUI support and keeps Uno generation aligned on supported targets, with follow-up generation fixes for Xamarin targets. ([#2042](https://github.com/mono/SkiaSharp/pull/2042), [#2098](https://github.com/mono/SkiaSharp/pull/2098), [#2199](https://github.com/mono/SkiaSharp/pull/2199))
-- **More modern target frameworks** — Adds `net6.0-tizen` and expands Skottie package TFMs across Apple, Android, tvOS, Mac Catalyst, and Tizen. ([#2099](https://github.com/mono/SkiaSharp/pull/2099), [#2133](https://github.com/mono/SkiaSharp/pull/2133))
-- **Updated WebAssembly toolchain** — Adds emscripten 3.1.7 support. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2094](https://github.com/mono/SkiaSharp/pull/2094))
+- **Skottie graduates from experimental** — Skottie and SceneGraph move out of the core `SkiaSharp.dll` into their own packages, gain `net6.0` TFMs for iOS/Android/Catalyst/macOS/tvOS/Tizen, and pick up `TimeSpan` overloads, nullable attributes and non-seekable stream support. — ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2091](https://github.com/mono/SkiaSharp/pull/2091), [#2119](https://github.com/mono/SkiaSharp/pull/2119), [#1987](https://github.com/mono/SkiaSharp/pull/1987), [#2126](https://github.com/mono/SkiaSharp/pull/2126))
+- **AVIF encoding** — The `SKEncodedImageFormat` surface now exposes AVIF so images can be encoded to AVIF where the underlying decoder supports it. — ❤️ [@mgood7123](https://github.com/mgood7123) ([#2154](https://github.com/mono/SkiaSharp/pull/2154))
+- **WinUI support** — SkiaSharp views now light up on WinUI, and the Uno WinUI target ships the missing JavaScript support file. — ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2042](https://github.com/mono/SkiaSharp/pull/2042), [#2086](https://github.com/mono/SkiaSharp/pull/2086))
+- **Writable SKDataStream and animations with a BOM** — `SKDataStream` is now writable like `SKData`, and animation loaders tolerate a leading byte-order mark. ([#2128](https://github.com/mono/SkiaSharp/pull/2128), [#2167](https://github.com/mono/SkiaSharp/pull/2167))
+- **Nullable attributes and new TFMs on the binding** — The binding project adds nullable annotations plus newer TFMs, and the `net6.0-tizen` TFM is added. ([#2120](https://github.com/mono/SkiaSharp/pull/2120), [#2099](https://github.com/mono/SkiaSharp/pull/2099))
 
 ## Bug Fixes
 
-- **Unicode font names load correctly** — Fixes font loading when the font name contains Unicode characters. ❤️ [@lindexi](https://github.com/lindexi) ([#2146](https://github.com/mono/SkiaSharp/pull/2146))
-- **Apple view scaling updates** — Reshapes `SKGLView` correctly when `Window.BackingScaleFactor` changes. ❤️ [@HarlanHugh](https://github.com/HarlanHugh) ([#1854](https://github.com/mono/SkiaSharp/pull/1854))
-- **Alpine and libc loading reliability** — Fixes Alpine builds and prefers the full libc library name where required. ([#2168](https://github.com/mono/SkiaSharp/pull/2168), [#2192](https://github.com/mono/SkiaSharp/pull/2192), [#2213](https://github.com/mono/SkiaSharp/pull/2213))
-- **Safer native lock cleanup** — Checks whether the lock has already been finalized before entering or leaving the critical section. ❤️ [@RichardD2](https://github.com/RichardD2) ([#2195](https://github.com/mono/SkiaSharp/pull/2195))
-- **Animation and imaging fixes** — Adds BOM handling for animation loading and fixes PNG loading by updating zlib. ([#2167](https://github.com/mono/SkiaSharp/pull/2167), [#2045](https://github.com/mono/SkiaSharp/pull/2045))
+- **PNG decoding regressions fixed** — The bundled zlib was updated to pick up upstream decode fixes that resolved PNG loading failures. ([#2045](https://github.com/mono/SkiaSharp/pull/2045))
+- **Fonts with Unicode filenames load correctly** — Font loaders no longer fail when the font's file name contains Unicode characters. — ❤️ [@lindexi](https://github.com/lindexi) ([#2146](https://github.com/mono/SkiaSharp/pull/2146))
+- **GLView reshapes on scale change** — `SKGLView` on macOS now reshapes when the window's backing scale factor changes so content stays crisp on scale transitions. — ❤️ [@HarlanHugh](https://github.com/HarlanHugh) ([#1854](https://github.com/mono/SkiaSharp/pull/1854))
+- **Finalized locks no longer throw** — Internal critical sections now check whether the lock has been finalized before entering, avoiding rare shutdown exceptions. — ❤️ [@RichardD2](https://github.com/RichardD2) ([#2195](https://github.com/mono/SkiaSharp/pull/2195))
+- **SKShaper honours SKPaint.TextAlign** — `SKShaper` now respects the `TextAlign` on the supplied `SKPaint` when laying out shaped text. — ❤️ [@koolkdev](https://github.com/koolkdev) ([#1910](https://github.com/mono/SkiaSharp/pull/1910))
+- **Resize returns null on invalid bounds** — `Resize` now returns `null` instead of asserting when called with a zero or negative dimension. ([#2054](https://github.com/mono/SkiaSharp/pull/2054))
+- **Linux libc resolution** — The Linux native loader uses the full library name of libc so it resolves on more distributions. ([#2213](https://github.com/mono/SkiaSharp/pull/2213))
 
-## Native Dependencies
+## Security
 
-- **Refreshed native libraries** — Updates zlib, libjpeg-turbo, libwebp, and libexpat to newer servicing releases. ([#2045](https://github.com/mono/SkiaSharp/pull/2045), [#2206](https://github.com/mono/SkiaSharp/pull/2206), [#2193](https://github.com/mono/SkiaSharp/pull/2193), [#2189](https://github.com/mono/SkiaSharp/pull/2189))
+- **Bundled native libraries refreshed** — libjpeg-turbo bumped to 2.1.3, libwebp to 1.2.3, and libexpat to 2.4.8 — all pull in upstream security and correctness fixes. ([#2206](https://github.com/mono/SkiaSharp/pull/2206), [#2193](https://github.com/mono/SkiaSharp/pull/2193), [#2189](https://github.com/mono/SkiaSharp/pull/2189))
 
-## Platform Support
+## Lifecycle & Internals
 
-| Platform | What's New |
-|----------|-----------|
-| 🍎 Apple | Better scaling updates and broader Skottie TFMs |
-| 🪟 Windows | WinUI support and safer native critical-section cleanup |
-| 🐧 Linux | Alpine and libc loading fixes |
-| 🌐 WebAssembly | emscripten 3.1.7 support |
-| 🤖 Android / 📺 Tizen | Expanded target framework coverage for Skottie and core packages |
+- **C API version incremented** — The C API version was incremented to mark the surface changes in this release for downstream consumers of the native library. ([#2137](https://github.com/mono/SkiaSharp/pull/2137))
+
+## HarfBuzzSharp 2.8.2.1
+
+HarfBuzzSharp 2.8.2.1 picks up the merged "classic" project layout, refreshed generator and the missing macOS/iOS feature implementation alongside the SkiaSharp packaging changes.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@jeromelaban](https://github.com/jeromelaban) | Added core Skottie support, WinUI work, broader TFMs, and emscripten 3.1.7 support |
-| [@koolkdev](https://github.com/koolkdev) | Made `SKShaper` respect `SKPaint.TextAlign` |
-| [@lindexi](https://github.com/lindexi) | Fixed Unicode font loading |
-| [@RichardD2](https://github.com/RichardD2) | Hardened critical-section finalization handling |
-| [@HarlanHugh](https://github.com/HarlanHugh) | Fixed `SKGLView` backing-scale reshape behavior |
-| [@mgood7123](https://github.com/mgood7123) | Exposed AVIF encoding support |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.0...release/2.88.1)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.1)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@jeromelaban](https://github.com/jeromelaban) | Landed the initial Skottie support, the WinUI target, and the missing Uno WinUI JavaScript support file ([#1987](https://github.com/mono/SkiaSharp/pull/1987), [#2042](https://github.com/mono/SkiaSharp/pull/2042), [#2086](https://github.com/mono/SkiaSharp/pull/2086), [#2088](https://github.com/mono/SkiaSharp/pull/2088), [#2094](https://github.com/mono/SkiaSharp/pull/2094), [#2133](https://github.com/mono/SkiaSharp/pull/2133), [#2199](https://github.com/mono/SkiaSharp/pull/2199)) |
+| [@mgood7123](https://github.com/mgood7123) | Exposed the AVIF image encode format ([#2138](https://github.com/mono/SkiaSharp/pull/2138), [#2154](https://github.com/mono/SkiaSharp/pull/2154), [#2162](https://github.com/mono/SkiaSharp/pull/2162)) |
+| [@HarlanHugh](https://github.com/HarlanHugh) | Fixed `SKGLView` reshape when the macOS window's backing scale factor changes ([#1854](https://github.com/mono/SkiaSharp/pull/1854)) |
+| [@koolkdev](https://github.com/koolkdev) | Made `SKShaper` honour `SKPaint.TextAlign` when shaping text ([#1910](https://github.com/mono/SkiaSharp/pull/1910)) |
+| [@lindexi](https://github.com/lindexi) | Fixed font loading for fonts whose file names contain Unicode text ([#2146](https://github.com/mono/SkiaSharp/pull/2146)) |
+| [@RichardD2](https://github.com/RichardD2) | Guarded the internal critical section against being entered after finalization ([#2195](https://github.com/mono/SkiaSharp/pull/2195)) |
 
 ## Preview 108 (August 12, 2022)
 
-Made configuration APIs public and refined libc probing on affected platforms.
+Preview 108 finished the .NET 6 TFM matrix and picked up the last fixes before stable.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.104...v2.88.1-preview.108)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.104...v2.88.1-preview.108)
 
 ## Preview 104 (August 8, 2022)
 
-Fixed Unicode font loading, completed a missing macios feature, refreshed native dependencies, and improved Alpine builds.
+Preview 104 rolled up the native-library refreshes — libjpeg-turbo, libwebp, libexpat — and the finalized-lock guard.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.91...v2.88.1-preview.104)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.91...v2.88.1-preview.104)
 
 ## Preview 91 (July 14, 2022)
 
-Added BOM handling for animations, exposed AVIF encoding, and continued Alpine servicing.
+Preview 91 added Unicode font-file support, non-seekable Skottie streams and BOM-tolerant animations, and incremented the C API.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.79...v2.88.1-preview.91)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.79...v2.88.1-preview.91)
 
 ## Preview 79 (June 29, 2022)
 
-Expanded Skottie TFMs and made `SKDataStream` writable like `SKData`.
+Preview 79 rounded out the Skottie API with nullable attributes and `TimeSpan` overloads and the writable `SKDataStream`.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.75...v2.88.1-preview.79)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.75...v2.88.1-preview.79)
 
 ## Preview 75 (June 26, 2022)
 
-Improved Skottie handling for non-seekable streams and fixed `SKGLView` backing-scale updates.
+Preview 75 landed the `SKGLView` macOS reshape fix.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.71...v2.88.1-preview.75)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.71...v2.88.1-preview.75)
 
 ## Preview 71 (June 20, 2022)
 
-Added nullable annotations and `TimeSpan` overloads for Skottie while broadening target framework support.
+Preview 71 added the `net6.0-tizen` TFM and the Skottie/SceneGraph package split.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.63...v2.88.1-preview.71)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.63...v2.88.1-preview.71)
 
 ## Preview 63 (June 8, 2022)
 
-Introduced Skottie, WinUI, `net6.0-tizen`, emscripten 3.1.7 support, and several package-structure improvements.
+Preview 63 was the big cut — WinUI support, Skottie, `SKShaper` text alignment, and the initial nullable/TFM refresh.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.1...v2.88.1-preview.63)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.1-preview.1...v2.88.1-preview.63)
 
 ## Preview 1 (May 22, 2022)
 
-Started the 2.88.1 servicing train with a PNG-loading fix via an updated zlib.
+Preview 1 opened the 2.88.1 line with documentation and CI fixes and the zlib update that resolved PNG loading.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0...v2.88.1-preview.1)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.0...v2.88.1-preview.1)

--- a/documentation/docfx/releases/2.88.2.md
+++ b/documentation/docfx/releases/2.88.2.md
@@ -1,58 +1,34 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:09Z by generate-release-notes.py
-  version:   2.88.2
-  status:    stable
-  branch:    release/2.88.2
-  diff:      release/2.88.1..release/2.88.2
-  prs:       3
-  api:       self=2.88.2/index.md;hb=2.8.2.2
-
-  - Convert SKRect to CGRect correctly by @mattleibow in https://github.com/mono/SkiaSharp/pull/2243
-  - fix: Remove unused native library block from SkiaSharp.Views.Uno.WinUI by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2231 [community ✨]
-  - [Tizen] Change tizen graphics backend engine by @myroot in https://github.com/mono/SkiaSharp/pull/2225 [community ✨]
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.2 -->
 # Version 2.88.2
+> **Tizen backend and Uno cleanup** · Released September 8, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.2)
 
-> **Targeted platform fixes** · Released September 8, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.2) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.2)
-
-> **API changes** · [SkiaSharp API diff](2.88.2/index.md) · [HarfBuzzSharp 2.8.2.2](harfbuzzsharp/2.8.2.2.md)
+> **API changes** · [SkiaSharp API diff](2.88.2/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.8.2.2/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.2 is a small servicing release with three focused fixes: better Apple rectangle interop, a cleanup for Uno WinUI packaging, and an updated Tizen graphics backend.
+SkiaSharp 2.88.2 switches the Tizen graphics backend and removes an unused native block from Uno WinUI.
 
 ## Breaking Changes
 
 *None in this release.*
 
+## Platform
+
+- **New Tizen graphics backend** — The Tizen views were switched onto a different graphics backend engine, giving Tizen consumers a more current rendering stack. — ❤️ [@myroot](https://github.com/myroot) ([#2225](https://github.com/mono/SkiaSharp/pull/2225))
+
 ## Bug Fixes
 
-- **Correct `SKRect` to `CGRect` conversion** — Fixes an Apple interop issue when converting managed rectangles to CoreGraphics rectangles. ([#2243](https://github.com/mono/SkiaSharp/pull/2243))
-- **Cleaner Uno WinUI package contents** — Removes an unused native library block from `SkiaSharp.Views.Uno.WinUI`. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2231](https://github.com/mono/SkiaSharp/pull/2231))
-- **Updated Tizen graphics backend** — Switches the Tizen graphics backend engine used by the views package. ❤️ [@myroot](https://github.com/myroot) ([#2225](https://github.com/mono/SkiaSharp/pull/2225))
+- **Uno WinUI no longer references a missing native library** — An unused native-library block was removed from `SkiaSharp.Views.Uno.WinUI` so the package no longer references a native asset it does not need. — ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2231](https://github.com/mono/SkiaSharp/pull/2231))
 
-## Platform Support
+## HarfBuzzSharp 2.8.2.2
 
-| Platform | What's New |
-|----------|-----------|
-| 🍎 Apple | Fixed `SKRect`/`CGRect` interop |
-| 🪟 Windows | Cleaned up Uno WinUI package metadata |
-| 📺 Tizen | Updated graphics backend engine |
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@jeromelaban](https://github.com/jeromelaban) | Removed an unused native library block from the Uno WinUI package |
-| [@myroot](https://github.com/myroot) | Updated the Tizen graphics backend engine |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.1...release/2.88.2)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.2)
+| Contributor | Contributions |
+|-------------|---------------|
+| [@jeromelaban](https://github.com/jeromelaban) | Removed the unused native-library block from `SkiaSharp.Views.Uno.WinUI` ([#2231](https://github.com/mono/SkiaSharp/pull/2231)) |
+| [@myroot](https://github.com/myroot) | Switched the Tizen views onto a new graphics backend engine ([#2225](https://github.com/mono/SkiaSharp/pull/2225)) |

--- a/documentation/docfx/releases/2.88.3.md
+++ b/documentation/docfx/releases/2.88.3.md
@@ -1,76 +1,39 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:09Z by generate-release-notes.py
-  version:   2.88.3
-  status:    stable
-  branch:    release/2.88.3
-  diff:      release/2.88.2..release/2.88.3
-  prs:       10
-  api:       self=2.88.3/index.md;hb=2.8.2.3
-
-  - fix(wasm): Adjust for invalid globbing for 3.1.12 archive lookup by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2269 [community ✨]
-  - Intercept and capture GL for .NET by @mattleibow in https://github.com/mono/SkiaSharp/pull/2268
-  - Add .NET 7 Support for Blazor views by @mattleibow in https://github.com/mono/SkiaSharp/pull/2254
-  - Update to ubuntu-20.04 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2256
-  - Add build infrastructure for .NET 7 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2255
-  - feat: Generate for Emscripten 3.1.12 and SIMD features by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2259 [community ✨]
-  - A skip is basically a read to a null buffer by @mattleibow in https://github.com/mono/SkiaSharp/pull/2265
-  - Use new .NET things by @mattleibow in https://github.com/mono/SkiaSharp/pull/2264
-  - Fix the use of vcpkg by @mattleibow in https://github.com/mono/SkiaSharp/pull/2257
-  - Add RTLD_DEEPBIND flag to dlopen mode by @snnz in https://github.com/mono/SkiaSharp/pull/2247 [community ✨]
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.3 -->
 # Version 2.88.3
+> **.NET 7 and Blazor** · Released October 4, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.3)
 
-> **WebAssembly and .NET 7 update** · Released October 4, 2022 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.3) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.3)
-
-> **API changes** · [SkiaSharp API diff](2.88.3/index.md) · [HarfBuzzSharp 2.8.2.3](harfbuzzsharp/2.8.2.3.md)
+> **API changes** · [SkiaSharp API diff](2.88.3/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.8.2.3/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.3 keeps the release line current with .NET 7, adds newer WebAssembly outputs for emscripten 3.1.12 with SIMD, and ships a handful of targeted fixes for native loading and stream behavior.
+SkiaSharp 2.88.3 adds .NET 7 support for the Blazor views and picks up build fixes.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## Platform
 
-### Platform
+- **.NET 7 support** — Build infrastructure and the Blazor views now target .NET 7, and Emscripten builds regenerate against 3.1.12 with SIMD features enabled. — ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2255](https://github.com/mono/SkiaSharp/pull/2255), [#2254](https://github.com/mono/SkiaSharp/pull/2254), [#2259](https://github.com/mono/SkiaSharp/pull/2259))
 
-- **.NET 7 support for Blazor views** — Adds .NET 7 compatibility for the Blazor view packages and the surrounding build infrastructure. ([#2254](https://github.com/mono/SkiaSharp/pull/2254), [#2255](https://github.com/mono/SkiaSharp/pull/2255))
-- **New GL interception hooks** — Adds support for intercepting and capturing OpenGL activity from .NET. ([#2268](https://github.com/mono/SkiaSharp/pull/2268))
+## API Surface
 
-### Web & WASM
-
-- **emscripten 3.1.12 + SIMD outputs** — Generates updated WebAssembly assets for emscripten 3.1.12 and SIMD-enabled scenarios. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2259](https://github.com/mono/SkiaSharp/pull/2259))
+- **GL interception hook** — A hook lets .NET consumers intercept and capture GL calls, which is useful for diagnostics and custom render pipelines. ([#2268](https://github.com/mono/SkiaSharp/pull/2268))
 
 ## Bug Fixes
 
-- **WebAssembly archive discovery** — Fixes invalid globbing when locating the emscripten 3.1.12 archive. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2269](https://github.com/mono/SkiaSharp/pull/2269))
-- **Safer Linux native loading** — Adds `RTLD_DEEPBIND` to the `dlopen` flags to improve native loading behavior on affected systems. ❤️ [@snnz](https://github.com/snnz) ([#2247](https://github.com/mono/SkiaSharp/pull/2247))
-- **More consistent stream skipping** — Treats skip operations as reads to a null buffer in the underlying stream implementation. ([#2265](https://github.com/mono/SkiaSharp/pull/2265))
+- **Skipping past data no longer allocates** — A stream skip is now implemented as a read into a null buffer, avoiding a spurious allocation on the fast path. ([#2265](https://github.com/mono/SkiaSharp/pull/2265))
+- **Deep-binding dlopen flag on Linux** — The native loader now passes `RTLD_DEEPBIND` when opening the library, so symbols resolve within SkiaSharp's own module first on Linux hosts that mix incompatible native libraries. — ❤️ [@snnz](https://github.com/snnz) ([#2247](https://github.com/mono/SkiaSharp/pull/2247))
 
-## Platform Support
+## HarfBuzzSharp 2.8.2.3
 
-| Platform | What's New |
-|----------|-----------|
-| 🌐 WebAssembly | emscripten 3.1.12 outputs, SIMD builds, archive lookup fix |
-| 🐧 Linux | `RTLD_DEEPBIND` native loading improvement |
-| 📦 General | .NET 7 support for Blazor views |
+HarfBuzzSharp 2.8.2.3 picks up the .NET 7 build infrastructure alongside the SkiaSharp bindings.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@jeromelaban](https://github.com/jeromelaban) | Added emscripten 3.1.12 and SIMD support and fixed archive lookup |
-| [@snnz](https://github.com/snnz) | Improved native loading with `RTLD_DEEPBIND` |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.2...release/2.88.3)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.3)
+| Contributor | Contributions |
+|-------------|---------------|
+| [@jeromelaban](https://github.com/jeromelaban) | Regenerated the Emscripten bindings against 3.1.12 and enabled SIMD features ([#2259](https://github.com/mono/SkiaSharp/pull/2259), [#2269](https://github.com/mono/SkiaSharp/pull/2269)) |
+| [@snnz](https://github.com/snnz) | Added the `RTLD_DEEPBIND` flag to the Linux native loader ([#2247](https://github.com/mono/SkiaSharp/pull/2247)) |

--- a/documentation/docfx/releases/2.88.4.md
+++ b/documentation/docfx/releases/2.88.4.md
@@ -1,181 +1,96 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:11Z by generate-release-notes.py
-  version:   2.88.4
-  status:    stable
-  branch:    release/2.88.4
-  diff:      release/2.88.3..release/2.88.4
-  prs:       48
-  api:       self=2.88.4/index.md;hb=2.8.2.4
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Preview 96 · 2.88.4 · 2023-08-17 · https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.95...v2.88.4-preview.96  (1 PRs)
-    - Try and follow more dotnet versions (#2556) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2557 [community ✨]
-
-  ## Preview 95 · 2.88.4 · 2023-08-16 · https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.82...v2.88.4-preview.95  (5 PRs)
-    - Include the NativeReference for Hot Restart by @mattleibow in https://github.com/mono/SkiaSharp/pull/2553
-    - Skip the .NET 7.0.4xx installs by @mattleibow in https://github.com/mono/SkiaSharp/pull/2554
-    - Removing nesting levels through block-scoped `using` statement by @Lehonti in https://github.com/mono/SkiaSharp/pull/2528 [community ✨]
-    - fix: Disambiguate SKGLView for uno and maui targets by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2529 [community ✨]
-    - Update libpng to v1.6.40 and libexpat to 2.5.0+more by @mattleibow in https://github.com/mono/SkiaSharp/pull/2510 (skia: mono/skia#101)
-
-  ## Preview 82 · 2.88.4 · 2023-06-22 · https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.76...v2.88.4-preview.82  (6 PRs)
-    - fix: Adjust net7.0-* resolution for Uno.WinUI targets by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2503 [community ✨]
-    - feat: Move to JSImport for WinUI Target on net7.0 by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2428 [community ✨]
-    - Fixed ToRect extension method extension by @niza93 in https://github.com/mono/SkiaSharp/pull/2392 [community ✨]
-    - Pack the iossimulator RID artifacts by @mattleibow in https://github.com/mono/SkiaSharp/pull/2498
-    - Update Cake to the latest 2.x version by @mattleibow in https://github.com/mono/SkiaSharp/pull/2500
-    - Include the new WASM assets in Blazor for .NET 8 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2497
-
-  ## Preview 76 · 2.88.4 · 2023-06-19 · https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.70...v2.88.4-preview.76  (5 PRs)
-    - fix(wasm): Enable Wasm EH and SIMD in all configurations for net8+ by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2495 [community ✨]
-    - Improve performance of hex string parsing in SKColor by @jwikberg in https://github.com/mono/SkiaSharp/pull/2467 [community ✨]
-    - Support for ARM64 macOS Machines by @mattleibow in https://github.com/mono/SkiaSharp/pull/2468 (skia: mono/skia#100)
-    - Add a .NET iOS & Mac Catalyst sample and .NET "Core" sample support by @mattleibow in https://github.com/mono/SkiaSharp/pull/2491
-    - Update macOS and Xcode by @mattleibow in https://github.com/mono/SkiaSharp/pull/2425
-
-  ## Preview 70 · 2.88.4 · 2023-06-14 · https://github.com/mono/SkiaSharp/compare/v2.88.3...v2.88.4-preview.70  (31 PRs)
-    - Run cve-bin-tool by @mattleibow in https://github.com/mono/SkiaSharp/pull/2490
-    - Update a few dependencies by @mattleibow in https://github.com/mono/SkiaSharp/pull/2487
-    - Use the new DownloadBuildArtifacts task by @mattleibow in https://github.com/mono/SkiaSharp/pull/2489
-    - Update bitmap SKAlphaType in SKXamlCanvas.Wasm.cs by @roubachof in https://github.com/mono/SkiaSharp/pull/2443 [community ✨]
-    - Fix SKCanvasView dispose exception when the view is disposed before it's rendered by @jjzhang12 in https://github.com/mono/SkiaSharp/pull/2472 [community ✨]
-    - additional check to avoid exception by @FoggyFinder in https://github.com/mono/SkiaSharp/pull/2313 [community ✨]
-    - chore: Add support for .NET 8 Preview 4 by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2457 [community ✨]
-    - Install .NET 7 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2485
-    - Install a specific Tizen version by @mattleibow in https://github.com/mono/SkiaSharp/pull/2486
-    - Update zlib to 1.2.13 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2484 (skia: mono/skia#99)
-    - Update Cake files to override deployment targets by @mattleibow in https://github.com/mono/SkiaSharp/pull/2482
-    - Ship the .aar with the NuGet for android by @dellis1972 in https://github.com/mono/SkiaSharp/pull/2465 [community ✨]
-    - Add a manual, full-run pipeline by @mattleibow in https://github.com/mono/SkiaSharp/pull/2480
-    - Skip updating GitHub status when no token by @mattleibow in https://github.com/mono/SkiaSharp/pull/2479
-    - Add `$schema` to `cgmanifest.json` by @JamieMagee in https://github.com/mono/SkiaSharp/pull/2232 [community ✨]
-    - Use the new XHarness .NET tool and latest .NET 6 MAUI by @mattleibow in https://github.com/mono/SkiaSharp/pull/2478
-    - Switch to Debian archives by @mattleibow in https://github.com/mono/SkiaSharp/pull/2476
-    - Use the correct method for setting Opaque on macOS by @mattleibow in https://github.com/mono/SkiaSharp/pull/2477
-    - [Uno] Default Opaque to false for SKXamlCanvas on MacOS and iOS by @roubachof in https://github.com/mono/SkiaSharp/pull/2398 [community ✨]
-    - Update SKSwapChainPanel.Android.cs by @roubachof in https://github.com/mono/SkiaSharp/pull/2400 [community ✨]
-    - Update SKSwapChainPanel.iOS.cs by @roubachof in https://github.com/mono/SkiaSharp/pull/2401 [community ✨]
-    - [ci] Use default feed to install the .NET SDK by @pjcollins in https://github.com/mono/SkiaSharp/pull/2393 [community ✨]
-    - [ci] Add exclusions for PoliCheck and CredScan by @pjcollins in https://github.com/mono/SkiaSharp/pull/2389 [community ✨]
-    - [Tizen] Fixes Canvas Size calculation by @myroot in https://github.com/mono/SkiaSharp/pull/2322 [community ✨]
-    - Update some more NuGets by @mattleibow in https://github.com/mono/SkiaSharp/pull/2304
-    - Enable CodeQL by @Redth in https://github.com/mono/SkiaSharp/pull/2303 [community ✨]
-    - Use the latest versions of some NuGets and SDKs by @mattleibow in https://github.com/mono/SkiaSharp/pull/2301
-    - feat(wasm): Add mt and mt+simd, fix harfbuzz for emsdk 3.1.12 by @jeromelaban in https://github.com/mono/SkiaSharp/pull/2286 [community ✨]
-    - Update Windows App SDK by @mattleibow in https://github.com/mono/SkiaSharp/pull/2276
-    - Force an older version of Windows SDK by @mattleibow in https://github.com/mono/SkiaSharp/pull/2273
-    - Removing all .NET 5 SDK requirements by @mattleibow in https://github.com/mono/SkiaSharp/pull/2266
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.4 -->
 # Version 2.88.4
+> **.NET 8, Apple Silicon and WASM refresh** · Released August 22, 2023 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.4) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.4)
 
-> **Platform servicing release** · Released August 22, 2023 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.4) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.4)
-
-> **API changes** · [SkiaSharp API diff](2.88.4/index.md) · [HarfBuzzSharp 2.8.2.4](harfbuzzsharp/2.8.2.4.md)
+> **API changes** · [SkiaSharp API diff](2.88.4/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.8.2.4/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.4 is a broad servicing release focused on keeping the 2.x line healthy on modern platforms. It improves .NET 8, Uno, and WebAssembly readiness, updates several native dependencies, expands Apple and Android packaging, and lands a deep set of fixes across view controls and platform integrations.
+SkiaSharp 2.88.4 adds .NET 8 and Apple Silicon macOS support and refreshes bundled native libraries. This release adds native ARM64 macOS binaries, .NET 8 WASM assets for Blazor, and moves the WinUI target onto `JSImport` on `net7.0`. It refreshes libpng, libexpat and zlib, ships the Android `.aar` inside the NuGet, and picks up Uno WASM improvements including EH+SIMD.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## Platform
 
-### Platform
+- **Apple Silicon macOS** — Native binaries are now produced for ARM64 macOS machines, so `.NET on macOS-arm64` no longer runs SkiaSharp under Rosetta. ([#2468](https://github.com/mono/SkiaSharp/pull/2468))
+- **.NET 8 WASM assets for Blazor** — The new WebAssembly assets shipped with .NET 8 are now included so Blazor apps on .NET 8 pick up the right native. ([#2497](https://github.com/mono/SkiaSharp/pull/2497))
+- **.NET iOS and Mac Catalyst samples** — New .NET iOS and Mac Catalyst samples plus a .NET "Core" sample host demonstrate the modern-platform bindings. ([#2491](https://github.com/mono/SkiaSharp/pull/2491))
+- **Android .aar shipped in the NuGet** — The Android `.aar` is now included in the NuGet package so consumers no longer have to source it separately. — ❤️ [@dellis1972](https://github.com/dellis1972) ([#2465](https://github.com/mono/SkiaSharp/pull/2465))
+- **.NET 5 SDK requirement dropped** — All build-time requirements on the .NET 5 SDK have been removed. ([#2266](https://github.com/mono/SkiaSharp/pull/2266))
 
-- **.NET 8 readiness** — Adds support for .NET 8 Preview 4, ships the new WebAssembly assets needed by Blazor on .NET 8, and keeps the release aligned with newer SDKs. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2457](https://github.com/mono/SkiaSharp/pull/2457), [#2497](https://github.com/mono/SkiaSharp/pull/2497))
-- **WinUI JSImport path on .NET 7** — Moves the WinUI target over to JSImport and adjusts target resolution for newer Uno stacks. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2428](https://github.com/mono/SkiaSharp/pull/2428), [#2503](https://github.com/mono/SkiaSharp/pull/2503), [#2529](https://github.com/mono/SkiaSharp/pull/2529))
-- **Broader Apple support** — Adds .NET iOS and Mac Catalyst samples, packages iOS simulator RID artifacts, and supports ARM64 macOS build machines. ([#2491](https://github.com/mono/SkiaSharp/pull/2491), [#2498](https://github.com/mono/SkiaSharp/pull/2498), [#2468](https://github.com/mono/SkiaSharp/pull/2468))
-- **Android AAR shipping** — Includes the `.aar` payload directly in the Android NuGet package. ❤️ [@dellis1972](https://github.com/dellis1972) ([#2465](https://github.com/mono/SkiaSharp/pull/2465))
+## API Surface
 
-### Web & WASM
-
-- **More capable WebAssembly builds** — Adds multithreaded and multithreaded+SIMD variants, then enables exception handling and SIMD across all net8+ configurations. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2286](https://github.com/mono/SkiaSharp/pull/2286), [#2495](https://github.com/mono/SkiaSharp/pull/2495))
+- **WinUI moves to JSImport on net7.0** — The WinUI target now uses `JSImport` on `net7.0`, aligning with the modern WinUI/Uno interop model. — ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#2428](https://github.com/mono/SkiaSharp/pull/2428))
+- **Faster hex-string parsing on SKColor** — `SKColor` hex-string parsing was rewritten to avoid the per-character allocations and lookups it used to do. — ❤️ [@jwikberg](https://github.com/jwikberg) ([#2467](https://github.com/mono/SkiaSharp/pull/2467))
 
 ## Bug Fixes
 
-- **View disposal and guard fixes** — Fixes `SKCanvasView` dispose-time exceptions and adds extra guard checks to avoid view lifecycle crashes. ❤️ [@jjzhang12](https://github.com/jjzhang12) ([#2472](https://github.com/mono/SkiaSharp/pull/2472)), ❤️ [@FoggyFinder](https://github.com/FoggyFinder) ([#2313](https://github.com/mono/SkiaSharp/pull/2313))
-- **Uno rendering correctness** — Corrects `SKXamlCanvas` alpha handling on WebAssembly, defaults `Opaque` more safely on Apple-backed Uno targets, and refreshes swap-chain panel implementations. ❤️ [@roubachof](https://github.com/roubachof) ([#2443](https://github.com/mono/SkiaSharp/pull/2443), [#2398](https://github.com/mono/SkiaSharp/pull/2398), [#2400](https://github.com/mono/SkiaSharp/pull/2400), [#2401](https://github.com/mono/SkiaSharp/pull/2401))
-- **Tizen layout fix** — Corrects canvas size calculation on Tizen. ❤️ [@myroot](https://github.com/myroot) ([#2322](https://github.com/mono/SkiaSharp/pull/2322))
-- **Core API cleanup** — Improves `SKColor` hex parsing performance and fixes the `ToRect` extension helper. ❤️ [@jwikberg](https://github.com/jwikberg) ([#2467](https://github.com/mono/SkiaSharp/pull/2467)), ❤️ [@niza93](https://github.com/niza93) ([#2392](https://github.com/mono/SkiaSharp/pull/2392))
+- **SKCanvasView dispose race fixed** — `SKCanvasView` no longer throws when the view is disposed before it has been rendered for the first time. — ❤️ [@jjzhang12](https://github.com/jjzhang12) ([#2472](https://github.com/mono/SkiaSharp/pull/2472))
+- **WASM canvas resilience** — `SKXamlCanvas` on WASM tolerates a missing canvas element, updates the bitmap `SKAlphaType` correctly, and disambiguates `SKGLView` between Uno and MAUI targets. — ❤️ [@roubachof](https://github.com/roubachof), [@jeromelaban](https://github.com/jeromelaban) ([#2443](https://github.com/mono/SkiaSharp/pull/2443), [#2529](https://github.com/mono/SkiaSharp/pull/2529))
+- **Uno Opaque defaults on Apple platforms** — `SKXamlCanvas` on Uno now defaults `Opaque` to `false` on macOS and iOS to match the platform expectation, and `SKSwapChainPanel` was updated for Android and iOS. — ❤️ [@roubachof](https://github.com/roubachof) ([#2398](https://github.com/mono/SkiaSharp/pull/2398), [#2400](https://github.com/mono/SkiaSharp/pull/2400), [#2401](https://github.com/mono/SkiaSharp/pull/2401), [#2477](https://github.com/mono/SkiaSharp/pull/2477))
+- **Tizen canvas sizing corrected** — The Tizen views now compute canvas size correctly on high-DPI displays. — ❤️ [@myroot](https://github.com/myroot) ([#2322](https://github.com/mono/SkiaSharp/pull/2322))
+- **ToRect extension fixed** — The `ToRect` extension no longer returns wrong bounds in an edge case. — ❤️ [@niza93](https://github.com/niza93) ([#2392](https://github.com/mono/SkiaSharp/pull/2392))
+- **Guard against a race in the view lifecycle** — An additional check avoids an exception in a lifecycle race path. — ❤️ [@FoggyFinder](https://github.com/FoggyFinder) ([#2313](https://github.com/mono/SkiaSharp/pull/2313))
 
-## Native Dependencies
+## Security
 
-- **Servicing refresh for bundled libraries** — Updates zlib, libpng, and libexpat to newer releases in the native layer. ([#2484](https://github.com/mono/SkiaSharp/pull/2484), [#2510](https://github.com/mono/SkiaSharp/pull/2510))
+- **Bundled native libraries refreshed** — libpng bumped to 1.6.40, libexpat to 2.5.0, and zlib to 1.2.13 — pulling in the latest upstream security and correctness fixes. ([#2510](https://github.com/mono/SkiaSharp/pull/2510), [#2484](https://github.com/mono/SkiaSharp/pull/2484))
 
-## Platform Support
+## Lifecycle & Internals
 
-| Platform | What's New |
-|----------|-----------|
-| 🍎 Apple | ARM64 macOS build support, iOS/Mac Catalyst samples, iOS simulator artifacts |
-| 🤖 Android | `.aar` packaged directly in the NuGet |
-| 🌐 WebAssembly | MT + SIMD variants and net8-ready assets |
-| 🪟 Windows / Uno | JSImport transition and newer target-resolution fixes |
-| 📺 Tizen | Canvas size calculation fix |
+- **Cleaner using scopes** — Several internal blocks were rewritten with C# 8 block-scoped `using` statements to reduce nesting. — ❤️ [@Lehonti](https://github.com/Lehonti) ([#2528](https://github.com/mono/SkiaSharp/pull/2528))
+
+## HarfBuzzSharp 2.8.2.4
+
+HarfBuzzSharp 2.8.2.4 adds native binaries for Apple Silicon macOS, ships the Hot Restart native reference, and enables WASM multi-threading and SIMD alongside SkiaSharp.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@jeromelaban](https://github.com/jeromelaban) | Advanced Uno/.NET 8 readiness and expanded WebAssembly build variants |
-| [@roubachof](https://github.com/roubachof) | Improved Uno rendering behavior across WebAssembly, iOS, macOS, and Android |
-| [@dellis1972](https://github.com/dellis1972) | Added Android `.aar` packaging to the NuGet |
-| [@jjzhang12](https://github.com/jjzhang12) | Fixed `SKCanvasView` dispose exceptions |
-| [@FoggyFinder](https://github.com/FoggyFinder) | Added extra guard checks to avoid exceptions |
-| [@myroot](https://github.com/myroot) | Fixed Tizen canvas size calculations |
-| [@jwikberg](https://github.com/jwikberg) | Improved `SKColor` hex parsing performance |
-| [@niza93](https://github.com/niza93) | Fixed the `ToRect` extension helper |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.3...release/2.88.4)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.4)
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@jeromelaban](https://github.com/jeromelaban) | Moved WinUI to `JSImport` on net7.0, disambiguated `SKGLView`, and enabled WASM EH+SIMD in all configurations for net8+ ([#2286](https://github.com/mono/SkiaSharp/pull/2286), [#2428](https://github.com/mono/SkiaSharp/pull/2428), [#2457](https://github.com/mono/SkiaSharp/pull/2457), [#2495](https://github.com/mono/SkiaSharp/pull/2495), [#2503](https://github.com/mono/SkiaSharp/pull/2503), [#2529](https://github.com/mono/SkiaSharp/pull/2529)) |
+| [@roubachof](https://github.com/roubachof) | Fixed the Uno `SKXamlCanvas` Alpha type on WASM, defaulted `Opaque` on Apple platforms, and updated the Android and iOS `SKSwapChainPanel` ([#2398](https://github.com/mono/SkiaSharp/pull/2398), [#2400](https://github.com/mono/SkiaSharp/pull/2400), [#2401](https://github.com/mono/SkiaSharp/pull/2401), [#2443](https://github.com/mono/SkiaSharp/pull/2443)) |
+| [@pjcollins](https://github.com/pjcollins) | Contributed to the modern-platform enablement work landing in this release ([#2389](https://github.com/mono/SkiaSharp/pull/2389), [#2393](https://github.com/mono/SkiaSharp/pull/2393)) |
+| [@dellis1972](https://github.com/dellis1972) | Made the Android `.aar` ship inside the NuGet package ([#2465](https://github.com/mono/SkiaSharp/pull/2465)) |
+| [@FoggyFinder](https://github.com/FoggyFinder) | Added a defensive check to avoid an exception in a lifecycle race path ([#2313](https://github.com/mono/SkiaSharp/pull/2313)) |
+| [@JamieMagee](https://github.com/JamieMagee) | Contributed dependency and infrastructure improvements ([#2232](https://github.com/mono/SkiaSharp/pull/2232)) |
+| [@jjzhang12](https://github.com/jjzhang12) | Fixed the `SKCanvasView` dispose exception when the view is disposed before it has been rendered ([#2472](https://github.com/mono/SkiaSharp/pull/2472)) |
+| [@jwikberg](https://github.com/jwikberg) | Rewrote hex-string parsing in `SKColor` for a large performance win ([#2467](https://github.com/mono/SkiaSharp/pull/2467)) |
+| [@Lehonti](https://github.com/Lehonti) | Removed nesting by adopting block-scoped `using` statements ([#2528](https://github.com/mono/SkiaSharp/pull/2528)) |
+| [@myroot](https://github.com/myroot) | Fixed Tizen canvas-size calculation on high-DPI displays ([#2322](https://github.com/mono/SkiaSharp/pull/2322)) |
+| [@niza93](https://github.com/niza93) | Fixed the `ToRect` extension method ([#2392](https://github.com/mono/SkiaSharp/pull/2392)) |
+| [@Redth](https://github.com/Redth) | Contributed to the modern-platform enablement work landing in this release ([#2303](https://github.com/mono/SkiaSharp/pull/2303)) |
 
 ## Preview 96 (August 17, 2023)
 
-This preview primarily carried follow-up automation and versioning work rather than new user-facing changes.
+Preview 96 shipped the final Hot Restart native reference.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.95...v2.88.4-preview.96)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.95...v2.88.4-preview.96)
 
 ## Preview 95 (August 16, 2023)
 
-Added Hot Restart packaging support, tightened Uno target selection, and refreshed libpng and libexpat.
+Preview 95 landed the libpng/libexpat refresh, WinUI JSImport move, the SKCanvasView disambiguation and the `using`-scope cleanup.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.82...v2.88.4-preview.95)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.82...v2.88.4-preview.95)
 
 ## Preview 82 (June 22, 2023)
 
-Advanced Uno net7 targeting, shipped iOS simulator artifacts, and added .NET 8 Blazor assets.
+Preview 82 added the .NET 8 WASM assets and the ToRect fix.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.76...v2.88.4-preview.82)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.76...v2.88.4-preview.82)
 
 ## Preview 76 (June 19, 2023)
 
-Enabled broader WASM EH/SIMD coverage, improved `SKColor` parsing, and expanded Apple build and sample support.
+Preview 76 added the .NET iOS/Catalyst samples, faster SKColor hex parsing and ARM64 macOS binaries.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.70...v2.88.4-preview.76)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.4-preview.70...v2.88.4-preview.76)
 
 ## Preview 70 (June 14, 2023)
 
-Started the release with .NET 8 preview support, Android NuGet AAR packaging, new WASM variants, and several Uno and Tizen fixes.
+Preview 70 opened the line with zlib 1.2.13, Uno Opaque and swap-chain fixes, and the drop of the .NET 5 SDK requirement.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.3...v2.88.4-preview.70)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.3...v2.88.4-preview.70)

--- a/documentation/docfx/releases/2.88.5.md
+++ b/documentation/docfx/releases/2.88.5.md
@@ -1,31 +1,12 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:11Z by generate-release-notes.py
-  version:   2.88.5
-  status:    stable
-  branch:    release/2.88.5
-  diff:      release/2.88.4..release/2.88.5
-  prs:       3
-  api:       self=2.88.5/index.md;hb=2.8.2.5
-
-  - Floor outwards when converting to SKRectI (#2568) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2574 [community ✨]
-  - fix(skxamlcanvas): [Wasm] Don't fail when the canvas can't be found (#2563) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2564 [community ✨]
-  - fix(uno): Ensure that the canvas' context is active when rendering (#2559) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2560 [community ✨]
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.5 -->
 # Version 2.88.5
+> **WASM and coordinate fixes** · Released August 22, 2023 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.5) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.5)
 
-> **Uno WebAssembly hotfix** · Released August 23, 2023 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.5) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.5)
-
-> **API changes** · [SkiaSharp API diff](2.88.5/index.md) · [HarfBuzzSharp 2.8.2.5](harfbuzzsharp/2.8.2.5.md)
+> **API changes** · [SkiaSharp API diff](2.88.5/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/2.8.2.5/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.5 is a quick follow-up to 2.88.4 that focuses squarely on Uno and WebAssembly rendering correctness. All three changes are targeted fixes aimed at keeping canvas discovery, context activation, and rectangle conversion behaving predictably.
+SkiaSharp 2.88.5 fixes SKXamlCanvas on WASM and rounds SKRectI conversions the right way.
 
 ## Breaking Changes
 
@@ -33,19 +14,10 @@ SkiaSharp 2.88.5 is a quick follow-up to 2.88.4 that focuses squarely on Uno and
 
 ## Bug Fixes
 
-- **More reliable Uno render contexts** — Ensures the canvas context is active before rendering in Uno targets. ([#2560](https://github.com/mono/SkiaSharp/pull/2560))
-- **Graceful missing-canvas handling on WASM** — Prevents `SKXamlCanvas` from failing when the expected canvas element cannot be found. ([#2564](https://github.com/mono/SkiaSharp/pull/2564))
-- **Correct outward flooring for `SKRectI` conversion** — Fixes rectangle conversion so integer bounds expand outward as expected. ([#2574](https://github.com/mono/SkiaSharp/pull/2574))
+- **SKRectI conversion floors outwards** — Converting a `SKRect` to `SKRectI` now floors outwards so the integer rectangle fully contains the source instead of clipping fractional pixels. ([#2574](https://github.com/mono/SkiaSharp/pull/2574))
+- **SKXamlCanvas tolerates a missing canvas on WASM** — The WASM `SKXamlCanvas` no longer fails when the target canvas element can't be found, matching the behaviour on other platforms. ([#2564](https://github.com/mono/SkiaSharp/pull/2564))
+- **Uno canvas context is active on render** — On Uno, the canvas' GL context is ensured active before rendering, avoiding intermittent blank frames. ([#2560](https://github.com/mono/SkiaSharp/pull/2560))
 
-## Platform Support
+## HarfBuzzSharp 2.8.2.5
 
-| Platform | What's New |
-|----------|-----------|
-| 🌐 WebAssembly | Better missing-canvas handling |
-| 🪟 Windows / Uno | Active render-context fix |
-| 🎨 Core API | Correct outward flooring for `SKRectI` conversions |
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.4...release/2.88.5)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.5)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/2.88.6.md
+++ b/documentation/docfx/releases/2.88.6.md
@@ -1,88 +1,39 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:27Z by generate-release-notes.py
-  version:   2.88.6
-  status:    stable
-  branch:    release/2.88.6
-  diff:      release/2.88.5..release/2.88.6
-  prs:       7
-  api:       self=2.88.6/index.md;hb=7.3.0
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (3 PRs)
-    - [release/2.x] Update webp to 1.3.2 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2623 (skia: mono/skia#113)
-    - fix: Restore nosimd builds for edge enhanced security and safari (#2612) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2618 [community ✨]
-    - Re-generate all the changelogs (#2592) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2593 [community ✨]
-
-  ## Preview 1 · 2.88.6 · 2023-08-30 · https://github.com/mono/SkiaSharp/compare/v2.88.5...v2.88.6-preview.1.2  (4 PRs)
-    - [release/2.x] Update harfbuzz to 7.3.0 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2577 (skia: mono/skia#102)
-    - Remove the unused arm64e architecture (#2587) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2590 [community ✨]
-    - libjpeg is not used (#2588) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2589 [community ✨]
-    - [release/2.x] Update libjpeg-turbo to 3.0.0 by @mattleibow in https://github.com/mono/SkiaSharp/pull/2581 (skia: mono/skia#103)
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.6 -->
 # Version 2.88.6
+> **HarfBuzz 7 and native refresh** · Released September 20, 2023 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.6) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.6)
 
-> **Compatibility and native dependency refresh** · Released September 21, 2023 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.6) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.6)
-
-> **API changes** · [SkiaSharp API diff](2.88.6/index.md) · [HarfBuzzSharp 7.3.0](harfbuzzsharp/7.3.0.md)
+> **API changes** · [SkiaSharp API diff](2.88.6/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/7.3.0/index.md)
 
 ## Highlights
 
-This 2.88 servicing release refreshes the bundled native dependencies and restores the no-SIMD browser builds needed by stricter environments. It keeps the line compatible across Safari, Edge Enhanced Security, and existing image and text workloads without introducing breaking changes.
+SkiaSharp 2.88.6 refreshes HarfBuzz to 7.3.0, libwebp to 1.3.2 and libjpeg-turbo to 3.0.0.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
+## Engine
 
-### Images & Documents
+- **HarfBuzz shaping engine bumped to 7.3.0** — The bundled HarfBuzz jumps from the 2.x line to 7.3.0, picking up years of shaping fixes and new script coverage. ([#2577](https://github.com/mono/SkiaSharp/pull/2577))
 
-- **Updated native image codecs** — Refreshes libjpeg-turbo to 3.0.0 and WebP to 1.3.2 for the 2.88 line. ([#2581](https://github.com/mono/SkiaSharp/pull/2581), [#2623](https://github.com/mono/SkiaSharp/pull/2623))
+## Security
 
-### Text & Fonts
-
-- **Updated HarfBuzz runtime** — Moves the bundled text shaping stack to HarfBuzz 7.3.0. ([#2577](https://github.com/mono/SkiaSharp/pull/2577))
+- **libwebp and libjpeg-turbo refreshed** — libwebp is bumped to 1.3.2 and libjpeg-turbo to 3.0.0, pulling in the current upstream security fixes. ([#2623](https://github.com/mono/SkiaSharp/pull/2623), [#2581](https://github.com/mono/SkiaSharp/pull/2581))
 
 ## Bug Fixes
 
-- **Restored no-SIMD browser builds** — Brings back the builds needed for Edge Enhanced Security and Safari scenarios. ([#2618](https://github.com/mono/SkiaSharp/pull/2618))
+- **SIMD-less WASM builds restored for Safari and hardened Edge** — Restored a no-SIMD WASM build for browsers that still refuse SIMD — Safari and Edge with Enhanced Security enabled. ([#2618](https://github.com/mono/SkiaSharp/pull/2618))
 
-## Platform Support
+## Platform
 
-| Platform | What's New |
-|----------|-----------|
-| 🌐 WebAssembly | Restored no-SIMD builds for stricter browser environments |
-| 📦 General | Updated libjpeg-turbo, WebP, and HarfBuzz dependencies |
+- **Unused arm64e architecture removed** — The unused `arm64e` architecture was dropped from Apple builds to keep binaries lean. ([#2590](https://github.com/mono/SkiaSharp/pull/2590))
 
-## Community Contributors ❤️
+## HarfBuzzSharp 7.3.0
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@jeromelaban](https://github.com/jeromelaban) | Restored the no-SIMD browser builds used by Edge Enhanced Security and Safari |
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.5...release/2.88.6)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.6)
-
----
-
-## Unreleased
-
-Updated WebP and restored the no-SIMD browser build variants before the stable tag was cut.
-
----
+HarfBuzzSharp 7.3.0 pulls the bundled HarfBuzz forward from the 2.x line to 7.3.0, picking up years of shaping fixes and new script coverage.
 
 ## Preview 1 (August 30, 2023)
 
-Introduced the HarfBuzz 7.3.0 and libjpeg-turbo 3.0.0 refresh for the 2.88.6 line.
+Preview 1 landed the HarfBuzz 7.3.0 bump, libjpeg-turbo 3.0.0 and libwebp 1.3.2, and the arm64e cleanup.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.5...v2.88.6-preview.1.2)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.5...v2.88.6-preview.1.2)

--- a/documentation/docfx/releases/2.88.7.md
+++ b/documentation/docfx/releases/2.88.7.md
@@ -1,32 +1,12 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:43Z by generate-release-notes.py
-  version:   2.88.7
-  status:    stable
-  branch:    release/2.88.7
-  diff:      release/2.88.6..release/2.88.7
-  prs:       4
-  api:       self=2.88.7/index.md;hb=7.3.0.1
-
-  - Revert "[release/2.x] Update libjpeg-turbo to 3.0.0 (#2581)" by @mattleibow in https://github.com/mono/SkiaSharp/pull/2702 (skia: mono/skia#116)
-  - Only run the full compliance nightly by @mattleibow in https://github.com/mono/SkiaSharp/pull/2701
-  - Add the new APIScan to the pipeline by @mattleibow in https://github.com/mono/SkiaSharp/pull/2694
-  - Install missing Tizen packages after image update by @mattleibow in https://github.com/mono/SkiaSharp/pull/2693
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.7 -->
 # Version 2.88.7
+> **libjpeg-turbo revert** · Released January 10, 2024 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.7) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.7)
 
-> **Dependency rollback hotfix** · Released January 11, 2024 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.7) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.7)
-
-> **API changes** · [SkiaSharp API diff](2.88.7/index.md) · [HarfBuzzSharp 7.3.0.1](harfbuzzsharp/7.3.0.1.md)
+> **API changes** · [SkiaSharp API diff](2.88.7/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/7.3.0.1/index.md)
 
 ## Highlights
 
-This small servicing release restores the previous libjpeg-turbo baseline on the 2.88 line. It is focused on compatibility and stability rather than new functionality.
+SkiaSharp 2.88.7 reverts the libjpeg-turbo 3.0.0 bump to restore JPEG decoding compatibility.
 
 ## Breaking Changes
 
@@ -34,15 +14,8 @@ This small servicing release restores the previous libjpeg-turbo baseline on the
 
 ## Bug Fixes
 
-- **Rolled back libjpeg-turbo 3.0.0** — Reverts the earlier codec update and returns the 2.88 line to the prior known-good native dependency set. ([#2702](https://github.com/mono/SkiaSharp/pull/2702))
+- **libjpeg-turbo reverted to the pre-3.0 version** — The libjpeg-turbo 3.0.0 bump from 2.88.6 caused regressions for some JPEGs and is reverted in this release. ([#2702](https://github.com/mono/SkiaSharp/pull/2702))
 
-## Platform Support
+## HarfBuzzSharp 7.3.0.1
 
-| Platform | What's New |
-|----------|-----------|
-| 📦 General | Reverted libjpeg-turbo to the previous stable baseline |
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.6...release/2.88.7)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.7)
+No HarfBuzzSharp binding changes shipped in this release — it rebuilds the same HarfBuzz as the previous line.

--- a/documentation/docfx/releases/2.88.8.md
+++ b/documentation/docfx/releases/2.88.8.md
@@ -1,86 +1,33 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:43Z by generate-release-notes.py
-  version:   2.88.8
-  status:    stable
-  branch:    release/2.88.8
-  diff:      release/2.88.7..release/2.88.8
-  prs:       9
-  api:       self=2.88.8/index.md;hb=7.3.0.2
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Preview 1 · 2.88.8 · 2024-04-04 · https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8-preview.1.1  (9 PRs)
-    - [release/2.x] Add some new overloads for better compat by @mattleibow in https://github.com/mono/SkiaSharp/pull/2810
-    - [release/2.x] Clean up APIScan and other compliance yaml by @mattleibow in https://github.com/mono/SkiaSharp/pull/2805
-    - Fix yaml by @mattleibow in https://github.com/mono/SkiaSharp/pull/2792
-    - Clean up YAML a bit by @mattleibow in https://github.com/mono/SkiaSharp/pull/2791
-    - Fix the script for mac (#2749) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2783 [community ✨]
-    - Make PlatformConfiguration properties trimmable (#2717) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2734 [community ✨]
-    - Avoid async void in SKXamlCanvas. (#2720) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2731 [community ✨]
-    - Do not provide invalid externs by @mattleibow in https://github.com/mono/SkiaSharp/pull/2710
-    - Use the version of gn that works on old Apline (#2711) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2712 [community ✨]
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.8 -->
 # Version 2.88.8
+> **Trimming and compatibility overloads** · Released April 9, 2024 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.8) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.8)
 
-> **Compatibility and trimming improvements** · Released April 10, 2024 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.8) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.8)
-
-> **API changes** · [SkiaSharp API diff](2.88.8/index.md) · [HarfBuzzSharp 7.3.0.2](harfbuzzsharp/7.3.0.2.md)
+> **API changes** · [SkiaSharp API diff](2.88.8/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/7.3.0.2/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.8 adds compatibility overloads, improves trimming friendliness, and tightens up several cross-platform view and interop behaviors. It is a practical maintenance release aimed at keeping the 2.88 line easy to adopt on modern .NET workloads.
+SkiaSharp 2.88.8 adds compat overloads for SKImageFilter and makes SKXamlCanvas trim-friendly.
 
 ## Breaking Changes
 
-*None in this release.*
+- **Default arguments removed from SKImageFilter.Create* methods** — Optional trailing arguments on `SKImageFilter.CreateAlphaThreshold`, `CreateArithmetic`, `CreateBlendMode`, `CreateBlur`, `CreateColorFilter`, `CreateDilate`, `CreateDisplacementMapEffect`, `CreateDistantLitDiffuse/Specular`, `CreateDropShadow`, `CreateDropShadowOnly`, `CreateErode`, `CreateMagnifier`, `CreateMatrixConvolution`, `CreateMerge`, `CreateOffset`, `CreatePaint`, `CreatePointLitDiffuse/Specular` and `CreateSpotLitDiffuse/Specular` no longer have C# default values. Companion overloads without those optional parameters were added (#2810) so calls made through the compiler continue to work, but any code that reflected on the signature or dispatched dynamically may need to be updated. ([#2810](https://github.com/mono/SkiaSharp/pull/2810))
 
-## New Features
+## API Surface
 
-### API Surface
+- **New SKImageFilter compatibility overloads** — New overloads on the `SKImageFilter.Create*` factory methods keep existing source-level callers working now that the default arguments have been removed. ([#2810](https://github.com/mono/SkiaSharp/pull/2810))
 
-- **Added compatibility overloads** — Adds several overloads to improve source compatibility across the 2.88 line. ([#2810](https://github.com/mono/SkiaSharp/pull/2810))
+## Lifecycle & Internals
 
-### Platform
+- **Trim-friendly PlatformConfiguration** — The `PlatformConfiguration` properties are now annotated so the trimmer can preserve them, avoiding runtime failures in trimmed apps. ([#2734](https://github.com/mono/SkiaSharp/pull/2734))
+- **SKXamlCanvas removes async void** — `SKXamlCanvas` no longer uses `async void`, so exceptions surface where callers can observe them. ([#2731](https://github.com/mono/SkiaSharp/pull/2731))
+- **Invalid externs no longer emitted** — The native binding no longer declares extern functions for entry points that don't exist, so the DLL loads cleanly on tighter loaders. ([#2710](https://github.com/mono/SkiaSharp/pull/2710))
 
-- **Improved trimming friendliness** — Makes `PlatformConfiguration` properties trimmable in linker-sensitive apps. ❤️ [@maxkatz6](https://github.com/maxkatz6) ([#2734](https://github.com/mono/SkiaSharp/pull/2734))
-- **Improved support for older Alpine environments** — Uses a `gn` version that still runs on older Alpine systems. ([#2712](https://github.com/mono/SkiaSharp/pull/2712))
+## HarfBuzzSharp 7.3.0.2
 
-## Bug Fixes
-
-- **Safer `SKXamlCanvas` callbacks** — Avoids `async void` in `SKXamlCanvas`, reducing hard-to-diagnose UI failures. ❤️ [@lindexi](https://github.com/lindexi) ([#2731](https://github.com/mono/SkiaSharp/pull/2731))
-- **Cleaner extern declarations** — Stops emitting invalid externs in generated interop. ([#2710](https://github.com/mono/SkiaSharp/pull/2710))
-
-## Platform Support
-
-| Platform | What's New |
-|----------|-----------|
-| 🎨 Core API | Added compatibility overloads |
-| 🐧 Linux | Improved support for older Alpine environments |
-| 🌐 XAML Views | Safer `SKXamlCanvas` behavior and trimmable configuration properties |
-
-## Community Contributors ❤️
-
-| Contributor | What They Did |
-|-------------|--------------|
-| [@maxkatz6](https://github.com/maxkatz6) | Made `PlatformConfiguration` properties trimmable |
-| [@lindexi](https://github.com/lindexi) | Removed `async void` from `SKXamlCanvas` |
-
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.7...release/2.88.8)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.8)
-
----
+HarfBuzzSharp 7.3.0.2 picks up the APIScan and compliance YAML clean-up alongside the SkiaSharp maintenance.
 
 ## Preview 1 (April 4, 2024)
 
-Introduced the compatibility overloads, trimming improvements, and `SKXamlCanvas` reliability fixes that make up 2.88.8.
+Preview 1 landed the SKImageFilter compatibility overloads, the trim annotations on `PlatformConfiguration`, the SKXamlCanvas async void fix and the invalid-extern cleanup.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8-preview.1.1)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8-preview.1.1)

--- a/documentation/docfx/releases/2.88.9.md
+++ b/documentation/docfx/releases/2.88.9.md
@@ -1,110 +1,44 @@
-<!--
-  RAW PR DATA — Do not remove this comment block.
-  AI uses this data to generate the polished release notes below.
-  Re-run the script to refresh this data from git history.
-
-  Generated: 2026-06-17T23:56:44Z by generate-release-notes.py
-  version:   2.88.9
-  status:    stable
-  branch:    release/2.88.9
-  diff:      release/2.88.8..release/2.88.9
-  prs:       14
-  api:       self=2.88.9/index.md;hb=7.3.0.3
-
-  PRs grouped by the preview they first shipped in (newest first). Render each milestone as a trailing
-  "## <label> (<date>)" section per TEMPLATE.md, and merge them all for the top-level Highlights:
-
-  ## Unreleased — not yet in a tagged preview  (2 PRs)
-    - Use a snapshot now that 4.0 has been removed by @mattleibow in https://github.com/mono/SkiaSharp/pull/3054
-    - Add symbols to the packages by @mattleibow in https://github.com/mono/SkiaSharp/pull/3046
-
-  ## Preview 2 · 2.88.9 · 2024-10-24 · https://github.com/mono/SkiaSharp/compare/v2.88.9-preview.1.1...v2.88.9-preview.2.2  (5 PRs)
-    - fix: Add WinUI native helper for GetByteBuffer by @jeromelaban in https://github.com/mono/SkiaSharp/pull/3039 [community ✨]
-    - The fancy logic stopped working long ago by @mattleibow in https://github.com/mono/SkiaSharp/pull/3043
-    - Fix CI again using the new rollback locations by @mattleibow in https://github.com/mono/SkiaSharp/pull/3041
-    - Ignore some files to aid switching branches by @mattleibow in https://github.com/mono/SkiaSharp/pull/3021
-    - feat: Add support for .NET 9 (#3010) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/3012 [community ✨]
-
-  ## Preview 1 · 2.88.9 · 2024-07-18 · https://github.com/mono/SkiaSharp/compare/v2.88.8...v2.88.9-preview.1.1  (7 PRs)
-    - Update the signing template by @mattleibow in https://github.com/mono/SkiaSharp/pull/2932
-    - Authenticate Docker by @mattleibow in https://github.com/mono/SkiaSharp/pull/2929
-    - Fix SKXamlCanvas on Uno Skia to use Bgra8888 (#2918) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2919 [community ✨]
-    - Fix the GetKerningPairAdjustments API. (#2858) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2886 [community ✨]
-    - fix: XamlRoot may be null when the SKXamlCanvas is unloaded (#2854) by @github-actions[bot] in https://github.com/mono/SkiaSharp/pull/2884 [community ✨]
-    - Use new license expressions by @mattleibow in https://github.com/mono/SkiaSharp/pull/2877
-    - Work around annoying fake warning in the IDE by @mattleibow in https://github.com/mono/SkiaSharp/pull/2844
--->
-
-<!-- Generated: 2026-06-18T00:00:00Z by claude-sonnet-4.5 -->
+<!-- RELEASE-NOTES DATA (generated, do not edit) format:3 version:2.88.9 -->
 # Version 2.88.9
+> **Uno Skia and API fixes** · Released November 7, 2024 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.9) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.9)
 
-> **Platform compatibility and .NET 9 servicing release** · Released November 7, 2024 · [NuGet](https://www.nuget.org/packages/SkiaSharp/2.88.9) · [GitHub Release](https://github.com/mono/SkiaSharp/releases/tag/v2.88.9)
-
-> **API changes** · [SkiaSharp API diff](2.88.9/index.md) · [HarfBuzzSharp 7.3.0.3](harfbuzzsharp/7.3.0.3.md)
+> **API changes** · [SkiaSharp API diff](2.88.9/index.md) · [HarfBuzzSharp API diff](harfbuzzsharp/7.3.0.3/index.md)
 
 ## Highlights
 
-SkiaSharp 2.88.9 keeps the long-lived 2.x line current with .NET 9, improves WinUI and Uno/XAML behavior, and adds symbol packages for easier diagnostics. It is a focused compatibility update for applications that are staying on 2.88 while newer 3.x work continues elsewhere.
+SkiaSharp 2.88.9 fixes Uno Skia XamlCanvas, WinUI byte-buffer marshalling and SKTypeface kerning.
 
 ## Breaking Changes
 
 *None in this release.*
 
-## New Features
-
-### Platform
-
-- **Added .NET 9 support** — Keeps the 2.88 line usable on the .NET 9 wave. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#3012](https://github.com/mono/SkiaSharp/pull/3012))
-- **Added WinUI native helper for `GetByteBuffer`** — Improves WinUI interop for native buffer access. ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#3039](https://github.com/mono/SkiaSharp/pull/3039))
-
-### Packaging
-
-- **Published symbol packages** — Adds symbols to the packages to improve debugging and crash analysis. ([#3046](https://github.com/mono/SkiaSharp/pull/3046))
-
 ## Bug Fixes
 
-- **Fixed `GetKerningPairAdjustments`** — Corrects the kerning adjustment API behavior. ❤️ [@pdjonov](https://github.com/pdjonov) ([#2886](https://github.com/mono/SkiaSharp/pull/2886))
-- **Improved XAML canvas reliability** — Fixes null `XamlRoot` unload paths and corrects Uno Skia to use `Bgra8888`. ❤️ [@jeromelaban](https://github.com/jeromelaban) [@Youssef1313](https://github.com/Youssef1313) ([#2884](https://github.com/mono/SkiaSharp/pull/2884), [#2919](https://github.com/mono/SkiaSharp/pull/2919))
+- **SKXamlCanvas on Uno Skia uses Bgra8888** — `SKXamlCanvas` on Uno Skia now uses `Bgra8888` colours so the on-screen surface matches what the Skia backend produces. ([#2919](https://github.com/mono/SkiaSharp/pull/2919))
+- **WinUI native helper for GetByteBuffer** — A WinUI-specific native helper was added so `GetByteBuffer` works reliably on the WinUI target. — ❤️ [@jeromelaban](https://github.com/jeromelaban) ([#3039](https://github.com/mono/SkiaSharp/pull/3039))
+- **GetKerningPairAdjustments returns the right values** — `SKTypeface.GetKerningPairAdjustments` no longer returns wrong values for kerning pairs. ([#2886](https://github.com/mono/SkiaSharp/pull/2886))
+- **SKXamlCanvas tolerates null XamlRoot on unload** — `SKXamlCanvas` no longer throws when its `XamlRoot` is null during unload. ([#2884](https://github.com/mono/SkiaSharp/pull/2884))
 
-## Platform Support
+## HarfBuzzSharp 7.3.0.3
 
-| Platform | What's New |
-|----------|-----------|
-| 🪟 Windows | .NET 9 support and a new WinUI native helper for `GetByteBuffer` |
-| 🌐 XAML / Uno | Fixed `XamlRoot` unload handling and `Bgra8888` rendering |
-| 📦 General | Symbol packages for easier debugging |
+HarfBuzzSharp 7.3.0.3 works around a spurious IDE warning alongside the SkiaSharp maintenance.
 
 ## Community Contributors ❤️
 
-| Contributor | What They Did |
-|-------------|--------------|
-| [@jeromelaban](https://github.com/jeromelaban) | Added .NET 9 support, the WinUI native helper, and XAML unload fixes |
-| [@pdjonov](https://github.com/pdjonov) | Fixed `GetKerningPairAdjustments` |
-| [@Youssef1313](https://github.com/Youssef1313) | Fixed Uno Skia `SKXamlCanvas` to use `Bgra8888` |
+Thank you to everyone who contributed to this release!
 
-## Links
-
-- [Full Changelog](https://github.com/mono/SkiaSharp/compare/release/2.88.8...release/2.88.9)
-- [NuGet Package](https://www.nuget.org/packages/SkiaSharp/2.88.9)
-
----
-
-## Unreleased
-
-Added symbol packages and moved the 2.88 line to snapshot-based versioning ahead of the final release.
-
----
+| Contributor | Contributions |
+|-------------|---------------|
+| [@jeromelaban](https://github.com/jeromelaban) | Added the WinUI native helper so `GetByteBuffer` works on the WinUI target ([#3039](https://github.com/mono/SkiaSharp/pull/3039)) |
 
 ## Preview 2 (October 24, 2024)
 
-Added .NET 9 support and a WinUI native helper while continuing the 2.88 compatibility fixes.
+Preview 2 finished the 2.88.9 fixes.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.9-preview.1.1...v2.88.9-preview.2.2)
-
----
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.9-preview.1.1...v2.88.9-preview.2.2)
 
 ## Preview 1 (July 18, 2024)
 
-Fixed XAML and Uno rendering issues and corrected the `GetKerningPairAdjustments` API.
+Preview 1 opened the line with the Uno Skia `SKXamlCanvas` Bgra8888 fix, the kerning-adjustments fix and the XamlRoot null-tolerance fix.
 
-[Full Changelog](https://github.com/mono/SkiaSharp/compare/v2.88.8...v2.88.9-preview.1.1)
+[Full changelog](https://github.com/mono/SkiaSharp/compare/v2.88.8...v2.88.9-preview.1.1)


### PR DESCRIPTION
## Regenerate historical 1.x / 2.x release notes (v2 format)

Regenerates **all 54 historical SkiaSharp release-notes pages** (`1.49.0` → `2.88.9`) from the old v1 raw-data-block format to the v2/v3 pipeline format, so the whole back-catalogue matches the live-version pages. Base: `dev/release-notes-v2`.

### Why these weren't already covered
`versions.json` sets a **`history_floor` of `3.0.0`** — a performance guard so daily `--all` runs skip the obsolete back-catalogue instead of rebuilding ~54 old pages from the NuGet feed every time. That floor was silently skipping all 1.x/2.x regeneration.

### How it was produced
Six chunked `notes_only` + `force` runs (≤11 pages/turn, to keep prose synthesis sharp) against a **throwaway branch with the floor temporarily lowered to 1.0.0**:

| Chunk | Range | Pages |
|-------|-------|-------|
| h1 | 1.49–1.53 | 11 |
| h2 | 1.54–1.57 | 10 |
| h3 | 1.58–1.59 | 8 |
| h4 | 1.60–1.68 | 10 |
| h5 | 2.80 | 5 |
| h6 | 2.88 | 10 |

The floor on `dev/release-notes-v2` stays at **3.0.0** — these pages are regenerated **once** and then re-frozen by the floor, so daily runs stay fast. The throwaway branch has been deleted.

### What changed
- **0 boilerplate** across all 54 pages — every bullet freshly synthesised.
- v3 banner (stacked blockquote rows), **dual SkiaSharp + HarfBuzzSharp API-diff links** where diff folders exist, a folded summary-only `## HarfBuzzSharp` section, plus Highlights / Breaking Changes / categorised bullets.
- `1.49.0` (first public preview) correctly carries **no** API-diff link (nothing to diff against).
- **Page set is unchanged** (same 54 filenames) → `TOC.yml`/`index.md` membership untouched. HarfBuzz hub-page retirement is left to the live-version PR (#4399), keeping this PR purely the 54 page bodies.

### Relationship to #4399
#4399 regenerates the **live** versions (3.x/4.x). This PR completes the set with the **historical** 1.x/2.x pages. They touch disjoint files and can merge independently.
