### PR TITLE
Restore import argparse dropped in #4410 (fixes release-notes workflow on main)

### DIFF
--- a/scripts/infra/docs/release-notes-data.py
+++ b/scripts/infra/docs/release-notes-data.py
@@ -94,6 +94,7 @@ Requirements: git, Python 3.7+
 
 from __future__ import annotations
 
+import argparse
 import fnmatch
 import hashlib
 import json


### PR DESCRIPTION
## Regression

#4410 broke the **Sync - Release Notes & API Diffs** workflow on `main`. The `Prepare` step fails immediately:

```
Traceback (most recent call last):
  File ".../scripts/infra/docs/release-notes-data.py", line 2360, in <module>
    main()
  File ".../scripts/infra/docs/release-notes-data.py", line 2316, in main
    parser = argparse.ArgumentParser(
NameError: name 'argparse' is not defined. Did you forget to import 'argparse'?
```

(run [29204563881](https://github.com/mono/SkiaSharp/actions/runs/29204563881), Prepare step exit 1.)

## Cause

#4410 added `import fnmatch` to `release-notes-data.py`, but the edit **replaced** `import argparse` rather than adding `fnmatch` alongside it. The script is only ever run as a program (via `prepare.sh`), so `py_compile` and any import-time smoke check still pass — the `NameError` only fires at runtime when `main()` constructs its `ArgumentParser`, which is why it wasn't caught pre-merge.

## Fix

Re-add `import argparse` (alphabetical order, before `fnmatch`). One line.

Verified locally:

```
$ python3 scripts/infra/docs/release-notes-data.py --help   # exit 0 (was NameError)
$ # classifier still works: externals/skia -> product, docs -> mixed, externals/depot_tools -> internal
```

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>