### PR TITLE
release-notes: delete prose on data change to force a full re-author (no stale pages)

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -38,11 +38,17 @@ prepare.sh   →   (you write prose.json per page)   →   render.sh
 
 1. **`.agents/skills/release-notes/scripts/prepare.sh`** — regenerates the API diffs
    (Cake), the per-page `_sources/<version>.data.json` facts, and `_sources/index.json`,
-   and writes the list of pages needing prose to `output/files-to-polish.txt`.
-2. **You** read each listed page's `data.json` and write its `prose.json` (below).
+   and writes the list of pages needing prose to `output/files-to-polish.txt`. **When a
+   page's facts changed, Prepare DELETES that page's `prose.json`** so there is nothing
+   stale to keep — every page on the list starts from a blank prose slate.
+2. **You** read each listed page's `data.json` and write its `prose.json` from scratch
+   (below). Each page in the list has **no `prose.json`** — do not go looking for an old
+   one to "check if it still matches"; the facts moved (new/removed PRs, re-tags), so you
+   author fresh. Cover every `product` PR you'd expect a consumer to notice — a page that
+   silently drops a real change is the failure this design prevents.
 3. **`.agents/skills/release-notes/scripts/render.sh`** — renders every page from
-   `data.json` + `prose.json` and rebuilds `TOC.yml` + `index.md`. It fails loudly on
-   invalid prose.
+   `data.json` + `prose.json` and rebuilds `TOC.yml` + `index.md`. It **fails loudly** if
+   any page on the list still lacks a `prose.json` (you missed one) or if prose is invalid.
 
 Both scripts take the **same three flags** — `--force`, `--min-version`, `--max-version`
 — and nothing else. Choose them from what was asked:

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -1176,6 +1176,11 @@ Always the same incremental Prepare + offline Polish sequence:
    index data. `release-notes-data.py` fetches `main` + every `release/*`, regenerates each
    selected SkiaSharp line's data JSON (§4.3), folds in the HarfBuzz block for released
    pages (§4.5), and writes only pages whose **whole `data.json` dict** changed.
+   **When a page's `data.json` changes, `release-notes-data.py` also DELETES that page's
+   `_sources/<stem>.prose.json`** (the human-owned `<stem>.notes.md` sidecar is left in
+   place): the facts moved, so the committed prose is stale by definition and there must
+   be nothing for Polish to keep or judge as "still matching" (§4.6 point 4). This is
+   scoped to a genuine data change — a bare `--force` re-render does not discard prose.
    `release-notes-index.py` writes timestamp-free `_sources/index.json` (the Chrome schedule +
    the `live_unreleased` set that `release-notes-render.py --all` prunes against, §4.2).
 2. **`data.json` is the release-notes change-detection key.** It has no timestamp, so
@@ -1194,12 +1199,17 @@ Always the same incremental Prepare + offline Polish sequence:
    data JSON shape or its Polish contract changes materially; a forced run rewrites the
    pages to the new format, then the pipeline settles back to idempotent.
 4. **Polish writes prose and renders offline.** The Files-to-polish list names only
-   genuinely changed pages, so the AI never rewrites an up-to-date page. After the AI
-   writes each `_sources/<stem>.prose.json` and validates the page with
+   genuinely changed pages, and each of them has had its `prose.json` **deleted** by
+   Prepare (point 1), so the AI **re-authors that page from scratch** against the fresh
+   `data.json` — it never inspects an old prose file to decide whether it "still matches"
+   (that soft judgment silently dropped brand-new product PRs). After the AI writes each
+   `_sources/<stem>.prose.json` and validates the page with
    `release-notes-render.py <data.json> <prose.json> [out.md]`, it runs `render.sh` (or the
    equivalent `release-notes-render.py --all`) once to regenerate every SkiaSharp page, retire
-   old HarfBuzz hub pages, `TOC.yml`, and `index.md` from committed JSON. When Prepare's
-   patch is empty, the workflow skips Polish and opens no PR (§2.3).
+   old HarfBuzz hub pages, `TOC.yml`, and `index.md` from committed JSON. **`--all`
+   hard-fails** if any `data.json` has no matching `prose.json` — i.e. a changed/new page
+   the AI forgot to author — so a changed page can never ship with stale (or missing)
+   prose. When Prepare's patch is empty, the workflow skips Polish and opens no PR (§2.3).
 
 A ranged run (`--min-version` / `--max-version`) is scoped by SkiaSharp version core
 and therefore includes HarfBuzz automatically through the selected pages' `harfbuzz`

--- a/scripts/infra/docs/release-notes-data.py
+++ b/scripts/infra/docs/release-notes-data.py
@@ -2215,13 +2215,29 @@ def _write_page(branch, all_branches, verbose=False, force=False,
     # data.json + prose.json during Polish.
     data = build_data_json(prs, metadata)
     data_path = _data_json_path(output_path)
-    if not force and _data_json_unchanged(data_path, data):
+    changed = not _data_json_unchanged(data_path, data)
+    if not force and not changed:
         log("  Skipping {} (unchanged)".format(output_path))
         return None
 
     data_path.parent.mkdir(parents=True, exist_ok=True)
     data_path.write_text(json.dumps(data, indent=2) + "\n")
     log("  Wrote {} ({} PRs)".format(data_path, len(prs)))
+    if changed:
+        # The facts moved (new/removed PRs, re-tags, roster shifts), so the committed
+        # prose is stale by definition. DELETE it to FORCE the Polish agent to
+        # re-author the page from the fresh data.json — instead of letting it judge
+        # whether the old prose still "matches", which silently dropped brand-new
+        # product PRs (§4.6). The human-owned <version>.notes.md sidecar is left in
+        # place. render --all then hard-fails until fresh prose exists, so a changed
+        # page can never ship with stale prose. Scoped to a genuine change (not a bare
+        # --force re-render) so re-rendering after a format/skill tweak does not throw
+        # away good prose. The .md itself is not deleted — render overwrites it wholesale
+        # from the new prose.
+        prose_path = _prose_json_path(output_path)
+        if prose_path.exists():
+            prose_path.unlink()
+            log("  Discarded {} (data changed — forcing full re-author)".format(prose_path))
     return str(output_path)
 
 

--- a/scripts/infra/docs/release-notes-render.py
+++ b/scripts/infra/docs/release-notes-render.py
@@ -924,11 +924,17 @@ def render_all():
             page = _page_for_data(dp)
             pp = dp.with_name(dp.name[:-len(".data.json")] + ".prose.json")
             if not pp.is_file():
-                # Missing prose is tolerated (warn + keep the committed .md): a
-                # scoped/partial run legitimately renders the whole set while only
-                # polishing a subset, so pages outside this run's scope have no
-                # fresh prose. Invalid prose, below, is NOT tolerated.
-                log("  WARNING: no prose.json for {} - keeping committed page".format(page))
+                # Missing prose.json is now a HARD ERROR (§4.6). After Prepare every
+                # data.json has a matching prose.json: unchanged pages keep their
+                # committed prose, and changed pages have theirs DELETED so the agent
+                # must re-author from the fresh facts. So a data.json with no prose.json
+                # means the agent failed to (re)author a changed/new page — we fail the
+                # --all pass rather than silently keep a now-stale committed page.
+                invalid.append((page, [
+                    "no prose.json — the page's data.json changed (or is new) but the "
+                    "Polish agent did not author prose for it; re-author "
+                    + pp.name]))
+                log("  ERROR: no prose.json for {} (data changed but prose missing)".format(page))
                 continue
             prose = json.loads(pp.read_text())
             errs = validate(data, prose)


### PR DESCRIPTION
## Problem

The release-notes Polish agent decides *per page* whether the prose needs updating. When a page's `data.json` changed, the agent read the existing `prose.json`, judged it *"compatible / no changes needed,"* and skipped it — **silently dropping brand-new product PRs**.

Concretely: scheduled run → PR #4413 added three performance PRs (#4408, #4388, #4396) to `4.151.0-unreleased.data.json`, but left the prose untouched. The rendered page never mentioned them, and the PR shipped **updated `data.json` with a stale `.md`** (only JSON files, no MD). An *earlier* run on the same facts (#4412) *did* update the prose — so the behaviour is non-deterministic, and the soft "does the old prose still match?" judgment is the root cause.

Rendering proves it: checking out the bot branch and running `render.py --all` produces **0 changed files**, because the page body is prose-driven and the prose was never updated. There was no `.md` to commit — nothing was "lost in commit"; it was never generated.

## Fix — force a full re-author when the facts move

Remove the soft judgment entirely: if the data changed, there is nothing to be "compatible" with.

- **`release-notes-data.py`** — when a page's `data.json` genuinely changes, **delete its `_sources/<v>.prose.json`**, so the agent must re-author the page from scratch against the fresh facts. Scoped to a real change (a bare `--force` re-render does **not** discard prose). The human-owned `<v>.notes.md` sidecar is preserved. The `.md` is **not** deleted — `render` overwrites it wholesale from the new prose (deleting it would only risk the TOC/index page-discovery + prune logic).
- **`release-notes-render.py`** — a `data.json` with **no** matching `prose.json` is now a **hard error** in `--all` (was: *warn and keep the stale committed page*). After Prepare, unchanged pages keep their prose and changed pages have theirs deleted — so a missing `prose.json` can only mean the agent failed to author a changed/new page. The run fails instead of shipping stale.

## Why not a coverage gate

I first considered "every product PR must appear on the page," but **185 of 632 product PRs (29%)** across the committed corpus are intentionally omitted — that's the SKILL's own *"curate, don't enumerate"* rule. A coverage gate would fail `render --all` on 39 historical pages. Deleting prose on change is both simpler and correct: it forces reconsideration of the *whole* page from current facts without hard-coding what must be mentioned.

## Verification

- All **71** committed pages have a `prose.json` → making missing-prose a hard error is safe.
- `render --all` with all prose present → **exit 0**, "Rendered 71 pages", idempotent (no `.md` churn).
- Remove one page's `prose.json` → **exit 1**, `ERROR: no prose.json for …4.150.0.md (data changed but prose missing)` / `PROSE VALIDATION FAILED for 1 page(s)`.
- Both scripts compile; only 4 files changed.

`SKILL.md` and the spec (§4.6) updated: changed pages have **no** prose and are authored fresh; `--all` fails loudly if a listed page lacks prose.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>