### PR TITLE
Add daily artifact size tracker workflow

### DIFF
--- a/.github/scripts/render-artifact-sizes.py
+++ b/.github/scripts/render-artifact-sizes.py
@@ -99,7 +99,7 @@ class Column:
 def build_columns(history: dict) -> list[Column]:
     columns: list[Column] = []
     for entry in history.get("nightly", []):
-        # Header: MM-DD over the short build number.
+        # Header: MM-DD observation date.
         date = entry.get("date", "")
         short_date = date[5:] if len(date) >= 10 else date
         columns.append(Column(date, f"{short_date}", "nightly"))
@@ -290,7 +290,7 @@ def render_header(history: dict, nights: dict[str, dict]) -> list[str]:
     newest = nightly[-1]
     lines += [
         f"**Latest nightly:** `{newest.get('version', '?')}` "
-        f"(build {newest.get('buildId', '?')}, {newest.get('date', '?')}) &middot; "
+        f"(observed {newest.get('date', '?')}) &middot; "
         f"{len(newest.get('packages', {}))} packages &middot; "
         f"tracking {len(nightly)} day(s) + {len(ROLES)} released refs",
         f"_Updated {history.get('updatedUtc', 'unknown')}._",

--- a/.github/scripts/render-artifact-sizes.py
+++ b/.github/scripts/render-artifact-sizes.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Render the artifact-size history JSON as a Markdown dashboard.
+
+Output is written to ``$GITHUB_STEP_SUMMARY`` when that variable is set (so the
+tables show up on the workflow run summary) and always echoed to stdout.
+
+Two tables are produced across the same 14 columns
+(``--max-nightly`` daily nightly builds + 4 released reference roles):
+
+  1. **All packages** -- top-level ``.nupkg`` size for every package.
+  2. **Native packages** -- per os/arch size of each native binary. Packages
+     whose binaries did not change across the window are collapsed.
+
+The history document is produced by ``track-artifact-sizes.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+ROLES = ("prev-major", "prev-stable", "curr-stable", "latest")
+ROLE_LABELS = {
+    "prev-major": "prev&#8209;major",
+    "prev-stable": "prev&#8209;stable",
+    "curr-stable": "curr&#8209;stable",
+    "latest": "latest",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Formatting helpers
+# --------------------------------------------------------------------------- #
+
+def human(size: int | None) -> str:
+    """Format a byte count as a compact human-readable string."""
+    if size is None:
+        return "&middot;"
+    if size < 1024:
+        return f"{size} B"
+    units = ["KB", "MB", "GB"]
+    value = float(size)
+    for unit in units:
+        value /= 1024.0
+        if value < 1024.0 or unit == units[-1]:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} GB"
+
+
+def delta_marker(curr: int | None, prev: int | None) -> str:
+    """Return a small ▲/▼ marker (with signed human delta) or empty string."""
+    if curr is None or prev is None or curr == prev:
+        return ""
+    diff = curr - prev
+    arrow = "🔺" if diff > 0 else "🔻"
+    return f" {arrow}{'+' if diff > 0 else '-'}{human(abs(diff))}"
+
+
+def friendly_native_label(path: str) -> str:
+    """Turn a native archive path into a compact os/arch label.
+
+    ``runtimes/win-x64/native/libSkiaSharp.dll``                 -> ``win-x64``
+    ``runtimes/ios/native/libSkiaSharp.framework/libSkiaSharp``  -> ``ios (framework)``
+    ``runtimes/maccatalyst/native/libSkiaSharp.framework.zip``   -> ``maccatalyst (framework)``
+    ``buildTransitive/.../libSkiaSharp.a/3.1.56/mt,simd/libSkiaSharp.a`` -> ``wasm 3.1.56/mt,simd``
+    """
+    m = re.match(r"runtimes/([^/]+)/native/(.+)", path)
+    if m:
+        rid, rest = m.group(1), m.group(2)
+        if ".framework" in rest:
+            return f"{rid} (framework)"
+        return rid
+    # WebAssembly static libs: ``.../lib<X>.a/<emver>/<variant>/<leaf>``. The
+    # leaf is kept because some packages ship two files per variant.
+    m = re.search(r"lib\w+\.a/([^/]+)/([^/]+)/([^/]+)$", path)
+    if m:
+        emver, variant, leaf = m.groups()
+        return f"wasm {emver}/{variant} · {leaf}"
+    # Fallback: last two path segments.
+    return "/".join(path.split("/")[-2:])
+
+
+# --------------------------------------------------------------------------- #
+# Column model
+# --------------------------------------------------------------------------- #
+
+class Column:
+    """One table column: a nightly day or a released reference role."""
+
+    def __init__(self, key: str, header: str, kind: str):
+        self.key = key          # date (nightly) or role name (released)
+        self.header = header    # markdown header text
+        self.kind = kind        # "nightly" | "released"
+
+
+def build_columns(history: dict) -> list[Column]:
+    columns: list[Column] = []
+    for entry in history.get("nightly", []):
+        # Header: MM-DD over the short build number.
+        date = entry.get("date", "")
+        short_date = date[5:] if len(date) >= 10 else date
+        columns.append(Column(date, f"{short_date}", "nightly"))
+    for role in ROLES:
+        columns.append(Column(role, ROLE_LABELS[role], "released"))
+    return columns
+
+
+def nightly_by_date(history: dict) -> dict[str, dict]:
+    return {e["date"]: e for e in history.get("nightly", [])}
+
+
+def package_nupkg(history: dict, column: Column, package_id: str,
+                  nights: dict[str, dict]) -> int | None:
+    if column.kind == "nightly":
+        entry = nights.get(column.key, {})
+        pkg = entry.get("packages", {}).get(package_id)
+        return pkg.get("nupkg") if pkg else None
+    version = history.get("roles", {}).get(column.key, {}).get(package_id)
+    if not version:
+        return None
+    cached = history.get("releasedCache", {}).get(f"{package_id}@{version}")
+    return cached.get("nupkg") if cached else None
+
+
+def package_natives(history: dict, column: Column, package_id: str,
+                    nights: dict[str, dict]) -> dict[str, int]:
+    if column.kind == "nightly":
+        entry = nights.get(column.key, {})
+        pkg = entry.get("packages", {}).get(package_id)
+        return pkg.get("natives", {}) if pkg else {}
+    version = history.get("roles", {}).get(column.key, {}).get(package_id)
+    if not version:
+        return {}
+    cached = history.get("releasedCache", {}).get(f"{package_id}@{version}")
+    return cached.get("natives", {}) if cached else {}
+
+
+# --------------------------------------------------------------------------- #
+# Universe discovery
+# --------------------------------------------------------------------------- #
+
+def all_package_ids(history: dict) -> list[str]:
+    ids: set[str] = set()
+    for entry in history.get("nightly", []):
+        ids.update(entry.get("packages", {}).keys())
+    for role_map in history.get("roles", {}).values():
+        ids.update(role_map.keys())
+    return sorted(ids)
+
+
+def is_native_package(history: dict, package_id: str) -> bool:
+    for entry in history.get("nightly", []):
+        pkg = entry.get("packages", {}).get(package_id)
+        if pkg and pkg.get("natives"):
+            return True
+    for role, role_map in history.get("roles", {}).items():
+        version = role_map.get(package_id)
+        if version:
+            cached = history.get("releasedCache", {}).get(f"{package_id}@{version}")
+            if cached and cached.get("natives"):
+                return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Table rendering
+# --------------------------------------------------------------------------- #
+
+def render_all_packages_table(history: dict, columns: list[Column],
+                              nights: dict[str, dict]) -> list[str]:
+    lines = ["### 📦 All packages — `.nupkg` size", ""]
+    header = "| Package | " + " | ".join(c.header for c in columns) + " |"
+    sep = "|:--|" + "|".join(["--:"] * len(columns)) + "|"
+    lines += [header, sep]
+
+    for pid in all_package_ids(history):
+        cells = []
+        prev_val: int | None = None
+        newest_nightly_idx = _last_nightly_index(columns)
+        for i, col in enumerate(columns):
+            val = package_nupkg(history, col, pid, nights)
+            text = human(val)
+            # Show a delta marker only on the newest nightly column to keep the
+            # wide table readable.
+            if i == newest_nightly_idx:
+                text += delta_marker(val, prev_val)
+            if col.kind == "nightly":
+                prev_val = val if val is not None else prev_val
+            cells.append(text)
+        lines.append(f"| `{pid}` | " + " | ".join(cells) + " |")
+    lines.append("")
+    return lines
+
+
+def render_native_tables(history: dict, columns: list[Column],
+                         nights: dict[str, dict]) -> list[str]:
+    lines = ["### 🧬 Native packages — per os/arch binary size", ""]
+    native_ids = [p for p in all_package_ids(history) if is_native_package(history, p)]
+    if not native_ids:
+        return lines + ["_No native packages recorded yet._", ""]
+
+    changed_blocks: list[list[str]] = []
+    unchanged_blocks: list[list[str]] = []
+    for pid in native_ids:
+        block, changed = _render_one_native_table(history, columns, pid, nights)
+        (changed_blocks if changed else unchanged_blocks).append(block)
+
+    for block in changed_blocks:
+        lines += block
+
+    if unchanged_blocks:
+        lines += [
+            "<details>",
+            f"<summary>Unchanged native packages ({len(unchanged_blocks)})</summary>",
+            "",
+        ]
+        for block in unchanged_blocks:
+            lines += block
+        lines += ["</details>", ""]
+    return lines
+
+
+def _render_one_native_table(history: dict, columns: list[Column], pid: str,
+                             nights: dict[str, dict]) -> tuple[list[str], bool]:
+    # Collect every native path ever seen for this package.
+    paths: set[str] = set()
+    for col in columns:
+        paths.update(package_natives(history, col, pid, nights).keys())
+    ordered_paths = sorted(paths)
+
+    header = "| os/arch | " + " | ".join(c.header for c in columns) + " |"
+    sep = "|:--|" + "|".join(["--:"] * len(columns)) + "|"
+    rows = [f"#### `{pid}`", "", header, sep]
+
+    changed = False
+    newest_nightly_idx = _last_nightly_index(columns)
+    for path in ordered_paths:
+        cells = []
+        prev_val: int | None = None
+        nightly_values: list[int | None] = []
+        for i, col in enumerate(columns):
+            val = package_natives(history, col, pid, nights).get(path)
+            text = human(val)
+            if i == newest_nightly_idx:
+                text += delta_marker(val, prev_val)
+            if col.kind == "nightly":
+                nightly_values.append(val)
+                prev_val = val if val is not None else prev_val
+            cells.append(text)
+        if _row_changed(nightly_values):
+            changed = True
+        rows.append(f"| {friendly_native_label(path)} | " + " | ".join(cells) + " |")
+    rows.append("")
+    return rows, changed
+
+
+def _row_changed(nightly_values: list[int | None]) -> bool:
+    """A row "changed" if, across the nightly window, its size varied or the
+    binary was added/removed (an arch appeared or disappeared). Released
+    reference columns are shown for comparison but do not drive this flag."""
+    present = [v for v in nightly_values if v is not None]
+    if len(set(present)) > 1:
+        return True
+    if present and any(v is None for v in nightly_values):
+        return True
+    return False
+
+
+def _last_nightly_index(columns: list[Column]) -> int:
+    idx = -1
+    for i, col in enumerate(columns):
+        if col.kind == "nightly":
+            idx = i
+    return idx
+
+
+# --------------------------------------------------------------------------- #
+# Header / highlights
+# --------------------------------------------------------------------------- #
+
+def render_header(history: dict, nights: dict[str, dict]) -> list[str]:
+    lines = ["## 📊 SkiaSharp artifact size tracker", ""]
+    nightly = history.get("nightly", [])
+    if not nightly:
+        return lines + ["_No data collected yet._", ""]
+
+    newest = nightly[-1]
+    lines += [
+        f"**Latest nightly:** `{newest.get('version', '?')}` "
+        f"(build {newest.get('buildId', '?')}, {newest.get('date', '?')}) &middot; "
+        f"{len(newest.get('packages', {}))} packages &middot; "
+        f"tracking {len(nightly)} day(s) + {len(ROLES)} released refs",
+        f"_Updated {history.get('updatedUtc', 'unknown')}._",
+        "",
+    ]
+
+    # Released reference versions legend (representative version lines).
+    roles = history.get("roles", {})
+    legend_pkgs = [("SkiaSharp", "SkiaSharp"), ("HarfBuzzSharp", "HarfBuzzSharp")]
+    legend_rows = []
+    for label, pid in legend_pkgs:
+        cols = [roles.get(role, {}).get(pid, "&middot;") for role in ROLES]
+        if any(c != "&middot;" for c in cols):
+            legend_rows.append(f"| {label} | " + " | ".join(f"`{c}`" for c in cols) + " |")
+    if legend_rows:
+        lines += [
+            "**Released reference versions**",
+            "",
+            "| line | " + " | ".join(ROLE_LABELS[r] for r in ROLES) + " |",
+            "|:--|" + "|".join([":--"] * len(ROLES)) + "|",
+            *legend_rows,
+            "",
+        ]
+
+    lines += _render_movers(history, nights)
+    return lines
+
+
+def _render_movers(history: dict, nights: dict[str, dict]) -> list[str]:
+    nightly = history.get("nightly", [])
+    if len(nightly) < 2:
+        return []
+    newest, prev = nightly[-1], nightly[-2]
+    movers = []
+    for pid in all_package_ids(history):
+        curr = (newest.get("packages", {}).get(pid) or {}).get("nupkg")
+        was = (prev.get("packages", {}).get(pid) or {}).get("nupkg")
+        if curr is not None and was is not None and curr != was:
+            movers.append((abs(curr - was), curr - was, pid))
+    if not movers:
+        return []
+    movers.sort(reverse=True)
+    lines = [
+        f"**Biggest day-over-day movers** ({prev.get('date')} → {newest.get('date')})",
+        "",
+    ]
+    for _mag, diff, pid in movers[:5]:
+        arrow = "🔺" if diff > 0 else "🔻"
+        lines.append(f"- {arrow} `{pid}` {'+' if diff > 0 else '-'}{human(abs(diff))}")
+    lines.append("")
+    return lines
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+def render(history: dict) -> str:
+    columns = build_columns(history)
+    nights = nightly_by_date(history)
+    lines: list[str] = []
+    lines += render_header(history, nights)
+    if history.get("nightly") or history.get("roles"):
+        lines += render_all_packages_table(history, columns, nights)
+        lines += render_native_tables(history, columns, nights)
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--history", default="artifact-sizes.json",
+                   help="Path to the JSON history document.")
+    p.add_argument("--output", default=None,
+                   help="Write the Markdown here (default: $GITHUB_STEP_SUMMARY, else stdout only).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if not os.path.exists(args.history):
+        print(f"History file not found: {args.history}", file=sys.stderr)
+        return 1
+    with open(args.history, "r", encoding="utf-8") as fh:
+        history = json.load(fh)
+
+    markdown = render(history)
+    print(markdown)
+
+    target = args.output or os.environ.get("GITHUB_STEP_SUMMARY")
+    if target:
+        with open(target, "a", encoding="utf-8") as fh:
+            fh.write(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/track-artifact-sizes.py
+++ b/.github/scripts/track-artifact-sizes.py
@@ -9,9 +9,11 @@ This script builds/updates a JSON "history" document that records:
 
 Two kinds of data points ("columns") are collected:
 
-  * ``nightly`` -- the latest *succeeded* ``main`` build of the Azure DevOps
-    ``xamarin/public`` pipeline (definitionId 4). Packages are read from the
-    ``nuget_preview`` build artifact. The newest ``--max-nightly`` days are kept.
+  * ``nightly`` -- the latest ``-nightly.*`` build from the official SkiaSharp
+    Early Access Preview feed (https://aka.ms/skiasharp-eap/index.json). Every
+    package is measured at its family's headline nightly version (SkiaSharp and
+    HarfBuzzSharp version independently), keyed by the observation date. The
+    newest ``--max-nightly`` days are kept.
   * ``released`` -- reference versions resolved from NuGet.org. For every package
     four roles are resolved from that package's *own* version line
     (SkiaSharp and HarfBuzzSharp version independently):
@@ -48,16 +50,13 @@ import zipfile
 
 SCHEMA_VERSION = 1
 
-AZDO_ORG = "xamarin"
-AZDO_PROJECT = "public"
-AZDO_PIPELINE_ID = 4
-AZDO_API = f"https://dev.azure.com/{AZDO_ORG}/{AZDO_PROJECT}/_apis"
+# The official SkiaSharp Early Access Preview (EAP) feed. This aka.ms link
+# redirects to a standard NuGet v3 feed on Azure DevOps Artifacts (anonymous)
+# and hosts the daily ``-nightly.*`` builds we sample.
+EAP_INDEX_URL = "https://aka.ms/skiasharp-eap/index.json"
 
+# NuGet.org flat container, used for the released reference versions.
 NUGET_FLATCONTAINER = "https://api.nuget.org/v3-flatcontainer"
-
-# The build artifact that contains the preview-versioned packages produced by
-# every main build.
-NIGHTLY_ARTIFACT = "nuget_preview"
 
 ROLES = ("prev-major", "prev-stable", "curr-stable", "latest")
 
@@ -117,24 +116,6 @@ def http_download(url: str, dest: str, *, retries: int = 4, timeout: int = 600) 
 # --------------------------------------------------------------------------- #
 # NuGet package measurement
 # --------------------------------------------------------------------------- #
-
-_NUPKG_RE = re.compile(r"^(?P<id>.+?)\.(?P<ver>\d+\.\d+.*?)\.nupkg$", re.IGNORECASE)
-
-
-def split_nupkg_name(filename: str) -> tuple[str, str] | None:
-    """Split ``SkiaSharp.NativeAssets.Win32.4.151.0-preview.1.1.nupkg`` into
-    ``("SkiaSharp.NativeAssets.Win32", "4.151.0-preview.1.1")``.
-
-    Symbol packages are ignored (returns ``None``).
-    """
-    low = filename.lower()
-    if low.endswith(".snupkg") or ".symbols." in low:
-        return None
-    m = _NUPKG_RE.match(filename)
-    if not m:
-        return None
-    return m.group("id"), m.group("ver")
-
 
 def _is_native_entry(name: str) -> bool:
     """Return True if a zip entry is an actual native binary payload.
@@ -203,120 +184,144 @@ def measure_nupkg(path: str) -> dict:
     return {"nupkg": file_size, "natives": natives}
 
 
-def measure_nupkg_dir(directory: str) -> dict:
-    """Measure every ``.nupkg`` found under ``directory`` (recursively).
+# --------------------------------------------------------------------------- #
+# NuGet feed helpers (flat container)
+# --------------------------------------------------------------------------- #
 
-    Returns ``{packageId: {"version": v, **measurement}}``. When the same
-    package id appears more than once the first occurrence wins.
+def resolve_eap_feed() -> dict:
+    """Resolve the EAP feed's service URLs from its v3 index.
+
+    Returns ``{"flat": <PackageBaseAddress>, "search": <SearchQueryService>}``.
     """
-    packages: dict[str, dict] = {}
-    for root, _dirs, files in os.walk(directory):
-        for fn in sorted(files):
-            if not fn.lower().endswith(".nupkg"):
-                continue
-            split = split_nupkg_name(fn)
-            if not split:
-                continue
-            pkg_id, version = split
-            if pkg_id in packages:
-                continue
-            measurement = measure_nupkg(os.path.join(root, fn))
-            measurement["version"] = version
-            packages[pkg_id] = measurement
-    return packages
+    index = http_get_json(EAP_INDEX_URL)
+    resources = index.get("resources", [])
+    flat = _find_resource(resources, "PackageBaseAddress/")
+    search = _find_resource(resources, "SearchQueryService")
+    if not flat:
+        raise RuntimeError("EAP feed index has no PackageBaseAddress resource.")
+    return {"flat": flat, "search": search}
 
 
-# --------------------------------------------------------------------------- #
-# Azure DevOps (nightly) helpers
-# --------------------------------------------------------------------------- #
+def _find_resource(resources: list[dict], type_prefix: str) -> str | None:
+    for res in resources:
+        if str(res.get("@type", "")).startswith(type_prefix):
+            return res["@id"]
+    return None
 
-def resolve_nightly_build(build_id: int | None) -> dict:
-    """Return metadata for the nightly build to sample.
 
-    When ``build_id`` is given it is used directly; otherwise the latest
-    succeeded ``main`` build of the pipeline is chosen.
+def get_versions(flat_base: str, package_id: str) -> list[str]:
+    """Return the versions of a package from a flat-container base URL.
+
+    The returned list is not guaranteed to be sorted (Azure DevOps feeds are
+    not), so callers must sort with ``_semver_key`` when order matters.
     """
-    if build_id is not None:
-        data = http_get_json(f"{AZDO_API}/build/builds/{build_id}?api-version=7.1")
-        return _build_meta(data)
-
-    url = (
-        f"{AZDO_API}/build/builds?api-version=7.1&definitions={AZDO_PIPELINE_ID}"
-        "&$top=25&queryOrder=finishTimeDescending"
-        "&reasonFilter=individualCI,batchedCI,schedule,manual"
-        "&statusFilter=completed&resultFilter=succeeded"
-    )
-    data = http_get_json(url)
-    for build in data.get("value", []):
-        if build.get("sourceBranch") == "refs/heads/main":
-            return _build_meta(build)
-    raise RuntimeError("No succeeded main build found for pipeline 4.")
-
-
-def _build_meta(build: dict) -> dict:
-    version = _clean_build_version(build.get("buildNumber", ""))
-    finish = build.get("finishTime") or build.get("queueTime") or ""
-    date = finish[:10] if finish else dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
-    return {
-        "buildId": int(build["id"]),
-        "version": version,
-        "date": date,
-        "buildNumber": build.get("buildNumber", ""),
-    }
-
-
-def _clean_build_version(build_number: str) -> str:
-    """``4.151.0-preview.0.38+main`` -> ``4.151.0-preview.0.38``."""
-    return build_number.split("+", 1)[0].strip()
-
-
-def get_artifact_download_url(build_id: int, artifact_name: str) -> str:
-    data = http_get_json(f"{AZDO_API}/build/builds/{build_id}/artifacts?api-version=7.1")
-    for artifact in data.get("value", []):
-        if artifact.get("name") == artifact_name:
-            url = artifact.get("resource", {}).get("downloadUrl")
-            if not url:
-                raise RuntimeError(f"Artifact '{artifact_name}' has no downloadUrl.")
-            return url
-    available = ", ".join(a.get("name", "?") for a in data.get("value", []))
-    raise RuntimeError(
-        f"Artifact '{artifact_name}' not found on build {build_id}. Available: {available}"
-    )
-
-
-def measure_nightly(build_meta: dict, work_dir: str) -> dict[str, dict]:
-    """Download + extract the nightly artifact and measure every package."""
-    build_id = build_meta["buildId"]
-    _log(f"  resolving artifact '{NIGHTLY_ARTIFACT}' on build {build_id} "
-         f"({build_meta['buildNumber']})")
-    url = get_artifact_download_url(build_id, NIGHTLY_ARTIFACT)
-
-    zip_path = os.path.join(work_dir, f"{NIGHTLY_ARTIFACT}.zip")
-    extract_dir = os.path.join(work_dir, NIGHTLY_ARTIFACT)
-    _log(f"  downloading artifact (this is ~0.5 GB)...")
-    http_download(url, zip_path)
-    _log(f"  extracting {os.path.getsize(zip_path) / 1e6:.0f} MB archive...")
-    with zipfile.ZipFile(zip_path) as zf:
-        zf.extractall(extract_dir)
-    os.remove(zip_path)
-
-    packages = measure_nupkg_dir(extract_dir)
-    shutil.rmtree(extract_dir, ignore_errors=True)
-    _log(f"  measured {len(packages)} packages "
-         f"({sum(1 for p in packages.values() if p['natives'])} native)")
-    return packages
-
-
-# --------------------------------------------------------------------------- #
-# NuGet.org (released reference) helpers
-# --------------------------------------------------------------------------- #
-
-def get_nuget_versions(package_id: str) -> list[str]:
-    url = f"{NUGET_FLATCONTAINER}/{package_id.lower()}/index.json"
+    url = f"{flat_base.rstrip('/')}/{package_id.lower()}/index.json"
     try:
         return list(http_get_json(url).get("versions", []))
     except RuntimeError:
         return []
+
+
+def download_nupkg(flat_base: str, package_id: str, version: str, work_dir: str) -> str | None:
+    """Download a single ``.nupkg`` from a flat-container feed to ``work_dir``."""
+    lower = package_id.lower()
+    url = f"{flat_base.rstrip('/')}/{lower}/{version}/{lower}.{version}.nupkg"
+    dest = os.path.join(work_dir, f"{lower}.{version}.nupkg")
+    try:
+        http_download(url, dest)
+    except RuntimeError:
+        return None
+    return dest
+
+
+def enumerate_feed_packages(search_base: str) -> list[str]:
+    """List SkiaSharp/HarfBuzzSharp package ids published to the feed.
+
+    Internal ``_``-prefixed packages (``_NuGets``, ``_NativeAssets*`` ...) are
+    excluded. Returns an empty list if the search service is unavailable.
+    """
+    if not search_base:
+        return []
+    url = f"{search_base.rstrip('/')}/?q=&prerelease=true&take=1000&semVerLevel=2.0.0"
+    try:
+        data = http_get_json(url)
+    except RuntimeError:
+        return []
+    ids = []
+    for item in data.get("data", []):
+        pid = item.get("id", "")
+        if pid.startswith("_"):
+            continue
+        if pid.startswith("SkiaSharp") or pid.startswith("HarfBuzzSharp"):
+            ids.append(pid)
+    return sorted(set(ids))
+
+
+# --------------------------------------------------------------------------- #
+# Nightly collection (EAP feed)
+# --------------------------------------------------------------------------- #
+
+def latest_nightly(versions: list[str]) -> str | None:
+    """Newest ``-nightly.*`` version (by SemVer) from a version list."""
+    nightlies = [v for v in versions if "-nightly." in v.lower()]
+    if not nightlies:
+        return None
+    return sorted(nightlies, key=_semver_key)[-1]
+
+
+def _nightly_family(package_id: str) -> str:
+    """The version-line a package belongs to."""
+    return "harfbuzz" if package_id.startswith("HarfBuzzSharp") else "skia"
+
+
+def collect_nightly(feed: dict, work_dir: str) -> tuple[dict[str, dict], str | None]:
+    """Measure every package at its family's headline nightly version.
+
+    All SkiaSharp-family packages share one nightly version and all
+    HarfBuzzSharp-family packages share another. Packages that do not publish
+    the headline nightly (e.g. deprecated ones) are skipped, keeping the
+    snapshot coherent. Returns ``(packages, skia_headline_version)``.
+    """
+    flat = feed["flat"]
+    package_ids = enumerate_feed_packages(feed["search"])
+    if not package_ids:
+        raise RuntimeError("Could not enumerate any packages from the EAP feed.")
+
+    headlines = {
+        "skia": latest_nightly(get_versions(flat, "SkiaSharp")),
+        "harfbuzz": latest_nightly(get_versions(flat, "HarfBuzzSharp")),
+    }
+    _log(f"  headline nightly: SkiaSharp={headlines['skia']} "
+         f"HarfBuzzSharp={headlines['harfbuzz']}")
+
+    packages: dict[str, dict] = {}
+    for pkg_id in package_ids:
+        target = headlines[_nightly_family(pkg_id)]
+        if not target:
+            continue
+        versions = get_versions(flat, pkg_id)
+        if target not in versions:
+            continue  # package does not ship this nightly (deprecated / not built)
+        dest = download_nupkg(flat, pkg_id, target, work_dir)
+        if dest is None:
+            _log(f"    ! could not download {pkg_id} {target}; skipping")
+            continue
+        measurement = measure_nupkg(dest)
+        measurement["version"] = target
+        os.remove(dest)
+        packages[pkg_id] = measurement
+
+    _log(f"  measured {len(packages)} packages "
+         f"({sum(1 for p in packages.values() if p['natives'])} native)")
+    return packages, headlines["skia"]
+
+
+# --------------------------------------------------------------------------- #
+# Released reference helpers (NuGet.org)
+# --------------------------------------------------------------------------- #
+
+def get_nuget_versions(package_id: str) -> list[str]:
+    return get_versions(NUGET_FLATCONTAINER, package_id)
 
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?$")
@@ -380,12 +385,8 @@ def resolve_roles(versions: list[str]) -> dict[str, str | None]:
 
 def measure_released_version(package_id: str, version: str, work_dir: str) -> dict | None:
     """Download a single released nupkg from NuGet.org and measure it."""
-    lower = package_id.lower()
-    url = f"{NUGET_FLATCONTAINER}/{lower}/{version}/{lower}.{version}.nupkg"
-    dest = os.path.join(work_dir, f"{lower}.{version}.nupkg")
-    try:
-        http_download(url, dest)
-    except RuntimeError:
+    dest = download_nupkg(NUGET_FLATCONTAINER, package_id, version, work_dir)
+    if dest is None:
         _log(f"    ! could not download {package_id} {version}; skipping")
         return None
     measurement = measure_nupkg(dest)
@@ -472,8 +473,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--history", default="artifact-sizes.json",
                    help="Path to the JSON history document (read + written).")
-    p.add_argument("--build-id", type=int, default=None,
-                   help="Sample a specific AzDO build id instead of the latest main build.")
+    p.add_argument("--date", default=None,
+                   help="Observation date for the nightly entry (YYYY-MM-DD; default: today UTC).")
     p.add_argument("--max-nightly", type=int, default=10,
                    help="Number of nightly days to retain (default: 10).")
     p.add_argument("--nightly-only", action="store_true",
@@ -498,22 +499,18 @@ def main(argv: list[str]) -> int:
     try:
         # ---- Nightly -----------------------------------------------------
         if not args.released_only:
-            _log("Collecting nightly build...")
-            build_meta = resolve_nightly_build(args.build_id)
-            existing = next((n for n in history.get("nightly", [])
-                             if n.get("date") == build_meta["date"]), None)
-            if existing and existing.get("buildId") == build_meta["buildId"] and not args.force:
-                _log(f"  already have build {build_meta['buildId']} "
-                     f"for {build_meta['date']}; skipping download")
+            _log("Collecting nightly from the EAP feed...")
+            today = args.date or dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+            feed = resolve_eap_feed()
+            packages, headline = collect_nightly(feed, work_dir)
+            if packages:
+                upsert_nightly(history, {
+                    "date": today,
+                    "version": headline,
+                    "packages": packages,
+                }, args.max_nightly)
             else:
-                packages = measure_nightly(build_meta, work_dir)
-                if packages:
-                    upsert_nightly(history, {
-                        "date": build_meta["date"],
-                        "buildId": build_meta["buildId"],
-                        "version": build_meta["version"],
-                        "packages": packages,
-                    }, args.max_nightly)
+                _log("  no nightly packages measured; leaving history unchanged")
 
         # ---- Released reference versions ---------------------------------
         if not args.nightly_only:

--- a/.github/scripts/track-artifact-sizes.py
+++ b/.github/scripts/track-artifact-sizes.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Collect SkiaSharp/HarfBuzzSharp NuGet package + native binary sizes.
+
+This script builds/updates a JSON "history" document that records:
+
+  * the top-level ``.nupkg`` size of every package produced by the build, and
+  * for packages that ship native binaries, the size of each individual native
+    payload (per os/arch), with symbol files (``.pdb``) excluded.
+
+Two kinds of data points ("columns") are collected:
+
+  * ``nightly`` -- the latest *succeeded* ``main`` build of the Azure DevOps
+    ``xamarin/public`` pipeline (definitionId 4). Packages are read from the
+    ``nuget_preview`` build artifact. The newest ``--max-nightly`` days are kept.
+  * ``released`` -- reference versions resolved from NuGet.org. For every package
+    four roles are resolved from that package's *own* version line
+    (SkiaSharp and HarfBuzzSharp version independently):
+        prev-major  -> newest stable of the previous major line
+        prev-stable -> second-newest stable in the current major
+        curr-stable -> newest stable
+        latest      -> newest overall (including preview / rc)
+    Released package sizes are immutable, so they are measured once and cached.
+
+Only the Python standard library is used so the script runs on a clean runner.
+
+The history document is persisted between runs via the GitHub Actions cache; see
+``.github/workflows/track-artifact-sizes.yml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+SCHEMA_VERSION = 1
+
+AZDO_ORG = "xamarin"
+AZDO_PROJECT = "public"
+AZDO_PIPELINE_ID = 4
+AZDO_API = f"https://dev.azure.com/{AZDO_ORG}/{AZDO_PROJECT}/_apis"
+
+NUGET_FLATCONTAINER = "https://api.nuget.org/v3-flatcontainer"
+
+# The build artifact that contains the preview-versioned packages produced by
+# every main build.
+NIGHTLY_ARTIFACT = "nuget_preview"
+
+ROLES = ("prev-major", "prev-stable", "curr-stable", "latest")
+
+USER_AGENT = "skiasharp-artifact-size-tracker/1.0 (+https://github.com/mono/SkiaSharp)"
+
+# Native binary file extensions (managed .dll are filtered out separately).
+_NATIVE_EXTS = (".so", ".dylib", ".dll", ".a")
+
+
+# --------------------------------------------------------------------------- #
+# Small HTTP helpers (stdlib only)
+# --------------------------------------------------------------------------- #
+
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def http_get(url: str, *, retries: int = 4, timeout: int = 120) -> bytes:
+    """GET a URL returning the raw bytes, with simple exponential backoff."""
+    last_err: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read()
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as err:
+            last_err = err
+            wait = min(30, 2 ** attempt)
+            _log(f"  ! request failed ({err}); retry {attempt}/{retries} in {wait}s")
+            time.sleep(wait)
+    raise RuntimeError(f"GET failed after {retries} attempts: {url}\n  {last_err}")
+
+
+def http_get_json(url: str, **kwargs) -> dict:
+    return json.loads(http_get(url, **kwargs).decode("utf-8"))
+
+
+def http_download(url: str, dest: str, *, retries: int = 4, timeout: int = 600) -> None:
+    """Download a URL to ``dest`` fully (streamed), with retries."""
+    last_err: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as fh:
+                shutil.copyfileobj(resp, fh, length=1024 * 1024)
+            return
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as err:
+            last_err = err
+            wait = min(30, 2 ** attempt)
+            _log(f"  ! download failed ({err}); retry {attempt}/{retries} in {wait}s")
+            time.sleep(wait)
+            if os.path.exists(dest):
+                os.remove(dest)
+    raise RuntimeError(f"Download failed after {retries} attempts: {url}\n  {last_err}")
+
+
+# --------------------------------------------------------------------------- #
+# NuGet package measurement
+# --------------------------------------------------------------------------- #
+
+_NUPKG_RE = re.compile(r"^(?P<id>.+?)\.(?P<ver>\d+\.\d+.*?)\.nupkg$", re.IGNORECASE)
+
+
+def split_nupkg_name(filename: str) -> tuple[str, str] | None:
+    """Split ``SkiaSharp.NativeAssets.Win32.4.151.0-preview.1.1.nupkg`` into
+    ``("SkiaSharp.NativeAssets.Win32", "4.151.0-preview.1.1")``.
+
+    Symbol packages are ignored (returns ``None``).
+    """
+    low = filename.lower()
+    if low.endswith(".snupkg") or ".symbols." in low:
+        return None
+    m = _NUPKG_RE.match(filename)
+    if not m:
+        return None
+    return m.group("id"), m.group("ver")
+
+
+def _is_native_entry(name: str) -> bool:
+    """Return True if a zip entry is an actual native binary payload.
+
+    Handles the layouts SkiaSharp ships:
+      * ``runtimes/<rid>/native/<lib>.so|.dylib|.dll``
+      * ``runtimes/<rid>/native/<lib>.framework/<lib>``      (Apple mach-o binary)
+      * ``runtimes/<rid>/native/<lib>.framework.zip``        (MacCatalyst)
+      * ``buildTransitive/.../libSkiaSharp.a/.../libSkiaSharp.a`` (WebAssembly)
+
+    Symbol files and framework metadata are excluded.
+    """
+    if name.endswith("/"):
+        return False
+    low = name.lower()
+    base = name.rsplit("/", 1)[-1]
+
+    # Never count symbols or framework metadata.
+    if low.endswith((".pdb", ".dwarf", ".plist")):
+        return False
+    if "/_codesignature/" in low or base == "Info.plist":
+        return False
+
+    # Compressed Apple frameworks are shipped as a single payload archive.
+    if low.endswith((".framework.zip", ".xcframework.zip")):
+        return True
+
+    # Mach-o binary inside an (uncompressed) *.framework directory: the file
+    # name matches the framework name and has no extension.
+    if ".framework/" in low:
+        parts = name.split("/")
+        if len(parts) >= 2 and parts[-2].endswith(".framework"):
+            framework_stem = parts[-2][: -len(".framework")]
+            if base == framework_stem:
+                return True
+        return False
+
+    ext = os.path.splitext(base)[1].lower()
+    if ext not in _NATIVE_EXTS:
+        return False
+
+    # Managed assemblies are ``.dll`` files under ``lib/``; native binaries only
+    # ever live in a ``.../native/...`` runtime folder, so gate ``.dll`` on that.
+    if ext == ".dll":
+        return "/native/" in low
+
+    return True
+
+
+def measure_nupkg(path: str) -> dict:
+    """Measure a single ``.nupkg``.
+
+    Returns ``{"nupkg": <compressed file size>, "natives": {<path>: <size>, ...}}``
+    where ``natives`` is empty for managed-only packages.
+    """
+    file_size = os.path.getsize(path)
+    natives: dict[str, int] = {}
+    try:
+        with zipfile.ZipFile(path) as zf:
+            for zi in zf.infolist():
+                if _is_native_entry(zi.filename):
+                    natives[zi.filename] = zi.file_size
+    except zipfile.BadZipFile:
+        _log(f"  ! not a valid zip, skipping: {path}")
+        return {"nupkg": file_size, "natives": {}}
+    return {"nupkg": file_size, "natives": natives}
+
+
+def measure_nupkg_dir(directory: str) -> dict:
+    """Measure every ``.nupkg`` found under ``directory`` (recursively).
+
+    Returns ``{packageId: {"version": v, **measurement}}``. When the same
+    package id appears more than once the first occurrence wins.
+    """
+    packages: dict[str, dict] = {}
+    for root, _dirs, files in os.walk(directory):
+        for fn in sorted(files):
+            if not fn.lower().endswith(".nupkg"):
+                continue
+            split = split_nupkg_name(fn)
+            if not split:
+                continue
+            pkg_id, version = split
+            if pkg_id in packages:
+                continue
+            measurement = measure_nupkg(os.path.join(root, fn))
+            measurement["version"] = version
+            packages[pkg_id] = measurement
+    return packages
+
+
+# --------------------------------------------------------------------------- #
+# Azure DevOps (nightly) helpers
+# --------------------------------------------------------------------------- #
+
+def resolve_nightly_build(build_id: int | None) -> dict:
+    """Return metadata for the nightly build to sample.
+
+    When ``build_id`` is given it is used directly; otherwise the latest
+    succeeded ``main`` build of the pipeline is chosen.
+    """
+    if build_id is not None:
+        data = http_get_json(f"{AZDO_API}/build/builds/{build_id}?api-version=7.1")
+        return _build_meta(data)
+
+    url = (
+        f"{AZDO_API}/build/builds?api-version=7.1&definitions={AZDO_PIPELINE_ID}"
+        "&$top=25&queryOrder=finishTimeDescending"
+        "&reasonFilter=individualCI,batchedCI,schedule,manual"
+        "&statusFilter=completed&resultFilter=succeeded"
+    )
+    data = http_get_json(url)
+    for build in data.get("value", []):
+        if build.get("sourceBranch") == "refs/heads/main":
+            return _build_meta(build)
+    raise RuntimeError("No succeeded main build found for pipeline 4.")
+
+
+def _build_meta(build: dict) -> dict:
+    version = _clean_build_version(build.get("buildNumber", ""))
+    finish = build.get("finishTime") or build.get("queueTime") or ""
+    date = finish[:10] if finish else dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    return {
+        "buildId": int(build["id"]),
+        "version": version,
+        "date": date,
+        "buildNumber": build.get("buildNumber", ""),
+    }
+
+
+def _clean_build_version(build_number: str) -> str:
+    """``4.151.0-preview.0.38+main`` -> ``4.151.0-preview.0.38``."""
+    return build_number.split("+", 1)[0].strip()
+
+
+def get_artifact_download_url(build_id: int, artifact_name: str) -> str:
+    data = http_get_json(f"{AZDO_API}/build/builds/{build_id}/artifacts?api-version=7.1")
+    for artifact in data.get("value", []):
+        if artifact.get("name") == artifact_name:
+            url = artifact.get("resource", {}).get("downloadUrl")
+            if not url:
+                raise RuntimeError(f"Artifact '{artifact_name}' has no downloadUrl.")
+            return url
+    available = ", ".join(a.get("name", "?") for a in data.get("value", []))
+    raise RuntimeError(
+        f"Artifact '{artifact_name}' not found on build {build_id}. Available: {available}"
+    )
+
+
+def measure_nightly(build_meta: dict, work_dir: str) -> dict[str, dict]:
+    """Download + extract the nightly artifact and measure every package."""
+    build_id = build_meta["buildId"]
+    _log(f"  resolving artifact '{NIGHTLY_ARTIFACT}' on build {build_id} "
+         f"({build_meta['buildNumber']})")
+    url = get_artifact_download_url(build_id, NIGHTLY_ARTIFACT)
+
+    zip_path = os.path.join(work_dir, f"{NIGHTLY_ARTIFACT}.zip")
+    extract_dir = os.path.join(work_dir, NIGHTLY_ARTIFACT)
+    _log(f"  downloading artifact (this is ~0.5 GB)...")
+    http_download(url, zip_path)
+    _log(f"  extracting {os.path.getsize(zip_path) / 1e6:.0f} MB archive...")
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract_dir)
+    os.remove(zip_path)
+
+    packages = measure_nupkg_dir(extract_dir)
+    shutil.rmtree(extract_dir, ignore_errors=True)
+    _log(f"  measured {len(packages)} packages "
+         f"({sum(1 for p in packages.values() if p['natives'])} native)")
+    return packages
+
+
+# --------------------------------------------------------------------------- #
+# NuGet.org (released reference) helpers
+# --------------------------------------------------------------------------- #
+
+def get_nuget_versions(package_id: str) -> list[str]:
+    url = f"{NUGET_FLATCONTAINER}/{package_id.lower()}/index.json"
+    try:
+        return list(http_get_json(url).get("versions", []))
+    except RuntimeError:
+        return []
+
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?$")
+
+
+def _semver_key(version: str) -> tuple:
+    """Return a sortable key for a NuGet SemVer2 version string.
+
+    Release versions sort after their pre-releases (per SemVer precedence).
+    """
+    m = _SEMVER_RE.match(version)
+    if not m:
+        return ((0, 0, 0, 0), (1,))
+    major, minor, patch, rev, pre = m.groups()
+    core = (int(major), int(minor), int(patch), int(rev or 0))
+    if pre is None:
+        # A release sorts after all of its pre-releases: flag 1 > flag 0.
+        return (core, (1,))
+    ids: list[tuple] = []
+    for part in pre.split("."):
+        if part.isdigit():
+            ids.append((0, int(part)))  # numeric identifiers compare numerically
+        else:
+            ids.append((1, part))       # ... and lower than alphanumeric ones
+    # flag 0 marks a pre-release; the nested tuple only ever compares within
+    # pre-releases, so its (int, int|str) items never clash across positions.
+    return (core, (0, tuple(ids)))
+
+
+def _is_stable(version: str) -> bool:
+    return "-" not in version
+
+
+def resolve_roles(versions: list[str]) -> dict[str, str | None]:
+    """Resolve the four reference roles from a package's version list."""
+    roles: dict[str, str | None] = {r: None for r in ROLES}
+    if not versions:
+        return roles
+
+    ordered = sorted(versions, key=_semver_key)
+    roles["latest"] = ordered[-1]
+
+    stables = [v for v in ordered if _is_stable(v)]
+    if not stables:
+        return roles
+
+    curr = stables[-1]
+    roles["curr-stable"] = curr
+    curr_major = _semver_key(curr)[0][0]
+
+    same_major = [v for v in stables if _semver_key(v)[0][0] == curr_major]
+    if len(same_major) >= 2:
+        roles["prev-stable"] = same_major[-2]
+
+    lower_major = [v for v in stables if _semver_key(v)[0][0] < curr_major]
+    if lower_major:
+        roles["prev-major"] = lower_major[-1]
+
+    return roles
+
+
+def measure_released_version(package_id: str, version: str, work_dir: str) -> dict | None:
+    """Download a single released nupkg from NuGet.org and measure it."""
+    lower = package_id.lower()
+    url = f"{NUGET_FLATCONTAINER}/{lower}/{version}/{lower}.{version}.nupkg"
+    dest = os.path.join(work_dir, f"{lower}.{version}.nupkg")
+    try:
+        http_download(url, dest)
+    except RuntimeError:
+        _log(f"    ! could not download {package_id} {version}; skipping")
+        return None
+    measurement = measure_nupkg(dest)
+    measurement["version"] = version
+    os.remove(dest)
+    return measurement
+
+
+def collect_released(
+    package_ids: list[str],
+    released_cache: dict,
+    work_dir: str,
+    *,
+    force: bool,
+) -> dict[str, dict[str, str | None]]:
+    """Resolve roles for every package and ensure the cache has their sizes.
+
+    Returns ``{role: {packageId: version}}`` describing the resolution used for
+    this run. ``released_cache`` is mutated in place, keyed by ``id@version``.
+    """
+    resolved: dict[str, dict[str, str | None]] = {r: {} for r in ROLES}
+    for pkg_id in sorted(package_ids):
+        versions = get_nuget_versions(pkg_id)
+        if not versions:
+            continue
+        roles = resolve_roles(versions)
+        wanted = {v for v in roles.values() if v}
+        for version in sorted(wanted):
+            cache_key = f"{pkg_id}@{version}"
+            if force or cache_key not in released_cache:
+                measurement = measure_released_version(pkg_id, version, work_dir)
+                if measurement is None:
+                    continue
+                released_cache[cache_key] = measurement
+        for role, version in roles.items():
+            if version and f"{pkg_id}@{version}" in released_cache:
+                resolved[role][pkg_id] = version
+    return resolved
+
+
+# --------------------------------------------------------------------------- #
+# History document
+# --------------------------------------------------------------------------- #
+
+def load_history(path: str) -> dict:
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict) and data.get("schema") == SCHEMA_VERSION:
+                data.setdefault("nightly", [])
+                data.setdefault("releasedCache", {})
+                data.setdefault("roles", {})
+                return data
+            _log(f"  history schema mismatch (found {data.get('schema')}); starting fresh")
+        except (json.JSONDecodeError, OSError) as err:
+            _log(f"  could not read history ({err}); starting fresh")
+    return {"schema": SCHEMA_VERSION, "nightly": [], "releasedCache": {}, "roles": {}}
+
+
+def save_history(path: str, history: dict) -> None:
+    history["schema"] = SCHEMA_VERSION
+    history["updatedUtc"] = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(history, fh, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+    _log(f"  wrote history -> {path} ({os.path.getsize(path) / 1024:.0f} KB)")
+
+
+def upsert_nightly(history: dict, entry: dict, max_nightly: int) -> None:
+    nightly = [n for n in history.get("nightly", []) if n.get("date") != entry["date"]]
+    nightly.append(entry)
+    nightly.sort(key=lambda n: n["date"])
+    history["nightly"] = nightly[-max_nightly:]
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--history", default="artifact-sizes.json",
+                   help="Path to the JSON history document (read + written).")
+    p.add_argument("--build-id", type=int, default=None,
+                   help="Sample a specific AzDO build id instead of the latest main build.")
+    p.add_argument("--max-nightly", type=int, default=10,
+                   help="Number of nightly days to retain (default: 10).")
+    p.add_argument("--nightly-only", action="store_true",
+                   help="Only collect the nightly data point.")
+    p.add_argument("--released-only", action="store_true",
+                   help="Only (re)collect released reference versions.")
+    p.add_argument("--force", action="store_true",
+                   help="Re-measure even when data is already cached.")
+    p.add_argument("--work-dir", default=None,
+                   help="Directory for temporary downloads (default: a temp dir).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    history = load_history(args.history)
+
+    owns_work_dir = args.work_dir is None
+    work_dir = args.work_dir or tempfile.mkdtemp(prefix="artifact-sizes-")
+    os.makedirs(work_dir, exist_ok=True)
+
+    try:
+        # ---- Nightly -----------------------------------------------------
+        if not args.released_only:
+            _log("Collecting nightly build...")
+            build_meta = resolve_nightly_build(args.build_id)
+            existing = next((n for n in history.get("nightly", [])
+                             if n.get("date") == build_meta["date"]), None)
+            if existing and existing.get("buildId") == build_meta["buildId"] and not args.force:
+                _log(f"  already have build {build_meta['buildId']} "
+                     f"for {build_meta['date']}; skipping download")
+            else:
+                packages = measure_nightly(build_meta, work_dir)
+                if packages:
+                    upsert_nightly(history, {
+                        "date": build_meta["date"],
+                        "buildId": build_meta["buildId"],
+                        "version": build_meta["version"],
+                        "packages": packages,
+                    }, args.max_nightly)
+
+        # ---- Released reference versions ---------------------------------
+        if not args.nightly_only:
+            _log("Collecting released reference versions...")
+            package_ids = _known_package_ids(history)
+            if not package_ids:
+                _log("  no known package ids yet; run nightly collection first")
+            else:
+                resolved = collect_released(
+                    package_ids, history["releasedCache"], work_dir, force=args.force)
+                history["roles"] = resolved
+                total = len(history["releasedCache"])
+                _log(f"  released cache now holds {total} package/version entries")
+
+        save_history(args.history, history)
+    finally:
+        if owns_work_dir:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    return 0
+
+
+def _known_package_ids(history: dict) -> list[str]:
+    """Package universe = every id ever seen in a nightly entry."""
+    ids: set[str] = set()
+    for entry in history.get("nightly", []):
+        ids.update(entry.get("packages", {}).keys())
+    return sorted(ids)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/track-artifact-sizes.yml
+++ b/.github/workflows/track-artifact-sizes.yml
@@ -4,8 +4,8 @@ name: Track - Artifact Sizes
 # its native binaries (per os/arch), and renders a dashboard to the run summary.
 #
 # Data is collected from:
-#   * the latest succeeded `main` nightly build (Azure DevOps pipeline 4), read
-#     from its `nuget_preview` artifact, and
+#   * the latest `-nightly.*` build on the official SkiaSharp EAP feed
+#     (https://aka.ms/skiasharp-eap/index.json), and
 #   * four released reference versions per package, resolved from NuGet.org.
 #
 # The rolling JSON history is persisted between runs via the Actions cache using
@@ -16,11 +16,6 @@ on:
   schedule:
     - cron: "0 7 * * *"  # Daily at 07:00 UTC
   workflow_dispatch:
-    inputs:
-      build_id:
-        description: "Azure DevOps build id to sample (default: latest main build)"
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -53,15 +48,10 @@ jobs:
             artifact-sizes-v1-
 
       - name: Collect artifact sizes
-        env:
-          # Passed via env (never interpolated into the shell) to avoid any
-          # template-injection from the free-form dispatch input.
-          BUILD_ID: ${{ github.event.inputs.build_id }}
         run: |
           python3 .github/scripts/track-artifact-sizes.py \
             --history artifact-sizes.json \
-            --max-nightly 10 \
-            ${BUILD_ID:+--build-id "$BUILD_ID"}
+            --max-nightly 10
 
       - name: Render dashboard
         run: |

--- a/.github/workflows/track-artifact-sizes.yml
+++ b/.github/workflows/track-artifact-sizes.yml
@@ -1,0 +1,84 @@
+name: Track - Artifact Sizes
+
+# Measures the on-disk size of every SkiaSharp / HarfBuzzSharp NuGet package and
+# its native binaries (per os/arch), and renders a dashboard to the run summary.
+#
+# Data is collected from:
+#   * the latest succeeded `main` nightly build (Azure DevOps pipeline 4), read
+#     from its `nuget_preview` artifact, and
+#   * four released reference versions per package, resolved from NuGet.org.
+#
+# The rolling JSON history is persisted between runs via the Actions cache using
+# the standard "unique key + restore-keys prefix" pattern, so each run restores
+# the most recent history and saves an updated copy.
+
+on:
+  schedule:
+    - cron: "0 7 * * *"  # Daily at 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: "Azure DevOps build id to sample (default: latest main build)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: track-artifact-sizes
+  cancel-in-progress: false
+
+jobs:
+  track:
+    if: github.repository_owner == 'mono'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Restore size history
+        uses: actions/cache/restore@v4
+        with:
+          path: artifact-sizes.json
+          key: artifact-sizes-v1-${{ github.run_id }}
+          restore-keys: |
+            artifact-sizes-v1-
+
+      - name: Collect artifact sizes
+        env:
+          # Passed via env (never interpolated into the shell) to avoid any
+          # template-injection from the free-form dispatch input.
+          BUILD_ID: ${{ github.event.inputs.build_id }}
+        run: |
+          python3 .github/scripts/track-artifact-sizes.py \
+            --history artifact-sizes.json \
+            --max-nightly 10 \
+            ${BUILD_ID:+--build-id "$BUILD_ID"}
+
+      - name: Render dashboard
+        run: |
+          python3 .github/scripts/render-artifact-sizes.py \
+            --history artifact-sizes.json
+
+      - name: Save size history
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: artifact-sizes.json
+          key: artifact-sizes-v1-${{ github.run_id }}
+
+      - name: Upload size history
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-sizes
+          path: artifact-sizes.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,6 @@ fastlane/screenshots
 .docs
 .playwright-mcp/
 .github/aw/logs/
+
+# Local output of the artifact size tracker (persisted via Actions cache in CI)
+artifact-sizes.json


### PR DESCRIPTION
## What

Adds a scheduled workflow that tracks the on-disk size of **every** SkiaSharp / HarfBuzzSharp NuGet package and its **native binaries per os/arch** over time, rendering a dashboard to the run summary.

## Data model — 14 columns

Both views span the same columns:

- **10 nightly** — the latest `*.*.*-nightly.*` build from the **official SkiaSharp EAP feed** (`https://aka.ms/skiasharp-eap/index.json`, which redirects to an anonymous Azure DevOps Artifacts v3 feed — **no secrets**). One observation per day. The two version lines are resolved independently: SkiaSharp (e.g. `4.151.0-nightly.48`) and HarfBuzzSharp (e.g. `14.2.1-nightly.64`); every package is measured at its family's headline nightly.
- **4 released reference versions** — resolved from NuGet.org, **per package** (SkiaSharp `4.x`, HarfBuzzSharp `14.x`):
  - `prev-major` — newest stable of the previous major line
  - `prev-stable` — second-newest stable in the current major
  - `curr-stable` — newest stable
  - `latest` — newest overall (incl. preview/rc)

## Two views

1. **All packages** — top-level `.nupkg` size for every produced package (auto-discovered from the feed's search service; internal `_*` packages excluded).
2. **Native packages** — per-os/arch size of each real native binary (`.so`/`.dll`/`.dylib`, Apple frameworks, wasm `.a`), **excluding `.pdb` symbols**. Native packages are auto-detected; packages unchanged over the nightly window are collapsed, and arch add/drop is surfaced.

## Files

| File | Purpose |
|---|---|
| `.github/scripts/track-artifact-sizes.py` | Collector (Python 3, stdlib only). Resolves the EAP feed's flat-container + search URLs dynamically, measures each package at its family's headline nightly, and resolves the 4 released refs from NuGet.org. Full per-package downloads; merges into a JSON history — nightly appended + trimmed to 10 days, released measured once and cached. |
| `.github/scripts/render-artifact-sizes.py` | Renders the history as Markdown to `$GITHUB_STEP_SUMMARY`. |
| `.github/workflows/track-artifact-sizes.yml` | Daily cron + `workflow_dispatch`. Persists the JSON via the Actions cache (rolling `run-id` key + `restore-keys` prefix) and uploads it as an artifact. |
| `.gitignore` | Ignore the local `artifact-sizes.json`. |

## Notes

- Persistence uses the GitHub Actions cache (per request), not a committed file.
- The nightly set (~40 packages, incl. large natives) is ~0.5–1 GB/day; released nupkgs are fetched only the first time a version is seen, then cached.

## Verification

Validated end-to-end against real data: EAP nightly resolution (SkiaSharp `4.151.0-nightly.48`, HarfBuzzSharp `14.2.1-nightly.64`, 40 packages measured incl. 21 native with per-arch sizes matching direct probes), NuGet.org released role resolution + downloads, native layout detection across all platforms (RID folders, Apple frameworks, wasm `.a`), day-over-day change detection with collapse, and the render step writing to `GITHUB_STEP_SUMMARY`. Scripts are `pyflakes`-clean and the YAML validates.