### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "06c4c54db86a29515d1699553d954fd5e291643e"
+          "commitHash": "0aa2d542e833ffd1d4d1b68a5152375e7f65ce11"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "ef2ebb78c8e230bb870d424583c4f871d2161c2e"
+          "commitHash": "06c4c54db86a29515d1699553d954fd5e291643e"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "3273c66a688fc8b9d72f739242e4050dd108df50"
+      "upstream_merge_commit": "bee4c917220040e147f14964635ff92ce6c5a3f6"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/283

## Sync: Skia `chrome/m150` bug fixes → `release/4.150.x`

Release-line bug-fix sync (m150 → m150, `IS_RELEASE=true`). Pairs with the
mono/skia PR on `skia-sync/release-4.150.x`.

### Breaking change analysis

None. The only new upstream commit is a Ganesh renderpass bounds check
(`bee4c91722 — Check clipped renderpass bounds against cleared stencil area`)
that touches internal GPU code (`src/gpu/ganesh/{GrAttachment,GrCaps,gl/GrGLCaps,
ops/OpsTask,vk/GrVkCaps}`). It changes no public headers, no C API, and no
binding surface.

### Version / binding updates

Same-milestone sync, so **no version bump** on either the parent repo or the
submodule:
- `scripts/VERSIONS.txt` — unchanged (stays at `4.150.1`).
- `scripts/azure-templates-variables.yml` — unchanged.
- `externals/skia/include/c/sk_types.h` `SK_C_INCREMENT` — stays `0`.
- `cgmanifest.json` — **only file changed in the parent repo**:
  - `commitHash`: `ef2ebb78c8…` → `06c4c54db8…` (new mono/skia merge commit)
  - `upstream_merge_commit`: `3273c66a68…` → `bee4c91722…` (new upstream tip)

> Note: `.agents/skills/update-skia/scripts/update-versions.ps1 -Current 150
> -Target 150` also downgraded the nuget/file versions from `4.150.1` back to
> `4.150.0`. Those edits were reverted before commit — the release line stays
> at `4.150.1`. The script's same-milestone path likely needs a fix so it
> touches only `cgmanifest.json`.

### C# / binding changes

None. `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` reported
`No changes to bindings (C API signatures unchanged)` and `No new functions
found`. `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` was reverted as usual.

### Build & test results (Linux x64)

- `dotnet cake --target=externals-linux --arch=x64` — ✅ (libSkiaSharp + libHarfBuzzSharp linked cleanly, 16m 09s).
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — ✅ 0 warnings, 0 errors.
- `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` —
  ✅ **Passed! Failed: 0, Passed: 5584, Skipped: 172, Total: 5756** (2m 41s, net10.0|x64).

Full test log: `test-output.txt` (workflow artifact).

### Items needing human attention

1. **`update-versions.ps1` same-milestone path bug.** When invoked with
   `-Current 150 -Target 150` on `release/4.150.x`, the script rewrites every
   nuget line and `SkiaSharp file` from `4.150.1` → `4.150.0`. For a bug-fix
   sync it should touch **only** `cgmanifest.json`. Reverted here manually; worth
   a follow-up fix so the release-line path is safe by default.
2. **Cross-platform review.** Only Linux x64 was built and tested in this
   workflow. Windows / macOS / iOS / Android / WASM builds are exercised by the
   normal PR CI matrix.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).