### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "c3d5aa0dbb97f08740d4baee173526eb03807e19"
+          "commitHash": "79d0730c37995511727b6b9bcd8acc94e9a00b3e"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "ce0793e98bca1d560c853fe98258bab9c351d883"
+      "upstream_merge_commit": "bddc2ea153cb99995396017713752890ed34de1d"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "50140bf90b385231f5b4c66050c54e3f936472dc"
+          "commitHash": "05c00dea0aeef7a211468d17c2f5022821ce9261"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "583a75ea28674c7edc9cb91fc2847b83c8d9f3f1"
+      "upstream_merge_commit": "ab2410bc857c1ff6ad8d6d2f0db9c33cb49aeb37"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "99efa9cc18d5be5e3b496b0a09af12eca6f96e07"
+          "commitHash": "c3d5aa0dbb97f08740d4baee173526eb03807e19"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "ba90f98535defcadbd4f3f753d42c48a187c41de"
+      "upstream_merge_commit": "ce0793e98bca1d560c853fe98258bab9c351d883"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "05c00dea0aeef7a211468d17c2f5022821ce9261"
+          "commitHash": "d3f721327f2fc35e7f51c5991d9f4c951f9a6887"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "ab2410bc857c1ff6ad8d6d2f0db9c33cb49aeb37"
+      "upstream_merge_commit": "37c5e6b26aee27e8e9ba5dc2b0afb854ff8ef411"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "70a3ea2181a30c04e4784132b9b79840f22d73df"
+          "commitHash": "99efa9cc18d5be5e3b496b0a09af12eca6f96e07"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "1a70f537d1b3c0223089f21cff34633984fffa62"
+      "upstream_merge_commit": "ba90f98535defcadbd4f3f753d42c48a187c41de"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "d3f721327f2fc35e7f51c5991d9f4c951f9a6887"
+          "commitHash": "70a3ea2181a30c04e4784132b9b79840f22d73df"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "37c5e6b26aee27e8e9ba5dc2b0afb854ff8ef411"
+      "upstream_merge_commit": "1a70f537d1b3c0223089f21cff34633984fffa62"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "cd6e9269149b4d242445b2ac36ae7f68e851d083"
+          "commitHash": "50140bf90b385231f5b4c66050c54e3f936472dc"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "0208108c7aed5f4e0faa525cbba52c238005a1ef"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "583a75ea28674c7edc9cb91fc2847b83c8d9f3f1"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -65,19 +65,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -85,36 +85,36 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/284

## Update skia to milestone 152 (main-tip sync)

Bumps the SkiaSharp fork of Skia to `upstream/main` (google/skia HEAD). This sync was launched targeting `m151` in `main`-tip mode, but the upstream tip has moved on to **m152**, so this is effectively a milestone bump (151 → 152) plus the merged bug fixes.

Companion PR: mono/skia `[skia-sync] Merge upstream chrome/m152` on `skia-sync/main`.

### Version / binding updates

| File | Change |
|------|--------|
| `externals/skia` (submodule) | → `50140bf90b3852…` (merge commit on `skia-sync/main` in mono/skia) |
| `cgmanifest.json` | `commitHash` → new submodule SHA; `chrome_milestone` `151 → 152`; `version` `chrome/m151 → chrome/m152`; `upstream_merge_commit` → `583a75ea28674c7edc9cb91fc2847b83c8d9f3f1` (upstream/main tip) |
| `scripts/VERSIONS.txt` | `skia release m151 → m152`; `libSkiaSharp milestone 151 → 152`; `soname 151.0.0 → 152.0.0`; `SkiaSharp assembly/file 4.151.0.0 → 4.152.0.0`; ALL ~30 nuget lines `4.151.0 → 4.152.0` |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION: 4.151.0 → 4.152.0` |
| `externals/skia/include/c/sk_types.h` | `SK_C_INCREMENT` remains `0` (no new C API functions in this sync) |

### Breaking change analysis

`main`-tip syncs skip the full milestone-pair breaking-change analysis (the tip is not a milestone branch), but the empirical results are:

- **Regenerated bindings produced zero diff** — `git diff --stat binding/` after re-running the generator on all four SkiaSharp configs was empty. No `+internal static` lines in `SkiaApi.generated.cs`.
- **No changes to `binding/SkiaSharp/*.cs`** required — the C# wrapper layer is untouched.
- **Native build succeeded on first attempt** after the version bump — no C API shim fixes needed.
- **No new required upstream `gn` args** — `native/linux/libSkiaSharp/build.cake` unchanged.

Conclusion: this sync is API-additive-or-neutral at the C API / P/Invoke boundary. Any behavior changes are internal to Skia's C++ implementation.

### C# changes

None. C# builds with 0 warnings, 0 errors.

### Build & test results (Linux x64)

- `dotnet cake --target=externals-linux --arch=x64` → **succeeded** in ~16 min. Produced `libSkiaSharp.so.152.0.0` and `libHarfBuzzSharp.so.0.61421.0`.
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` → **succeeded** (0 warnings, 0 errors).
- `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` (full suite) → **Passed! Failed: 0, Passed: 5707, Skipped: 182, Total: 5889, Duration: 2m 47s** (net10.0/x64).

Full test log: `test-output.txt` in the workflow artifacts.

### Items needing human attention

- **Milestone advanced 151 → 152** — the workflow was launched for `m151` but the upstream tip is now `m152`. Reviewers should confirm this is the intended time to move to m152; the version bump is unavoidable because SkiaSharp's build-time verifier compares `SK_MILESTONE` from the header to `libSkiaSharp milestone` in `VERSIONS.txt` and refuses to build on mismatch.
- **Only Linux x64 native was built here.** Windows / macOS / iOS / Android / WASM / MacCatalyst / Tizen must be validated in CI before merging. The dependency graph changes for `main`-tip merges are large (upstream is well ahead of the fork base), so cross-platform is a real risk.
- **`pwsh` in the workflow sandbox is broken** — module autoloading fails (`Get-Content`, `Write-Host`, `Select-Object` all unresolvable), so `.agents/skills/update-skia/scripts/update-versions.ps1` and `regenerate-bindings.ps1` could not be used. Version updates, generator invocation, and HarfBuzz revert were done manually. The workflow's `Install native build dependencies` (or equivalent) step should be fixed to provide a working pwsh module layout.
- **Companion mono/skia PR must be merged first** and the submodule pointer updated on this branch before merging here (see skill Phase 11 merge sequence).

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).