### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "35783c4e03feb56349e25607240946374561ff50"
+          "commitHash": "15fb073bf63e1aaa3a9c3e88db511a2f10cfd969"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "cd6e9269149b4d242445b2ac36ae7f68e851d083"
+          "commitHash": "35783c4e03feb56349e25607240946374561ff50"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "0208108c7aed5f4e0faa525cbba52c238005a1ef"
+      "upstream_merge_commit": "87424bcdba68e14ff3b40524ed09ad150ce3c92e"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/285

# [skia-sync] Merge upstream chrome/m151 bug fixes

Companion to the mono/skia PR on the `skia-sync/m151` branch. Bug-fix-only sync on the current
milestone (m151 → m151) — **not** a version bump.

## Changes

- `cgmanifest.json` — updated `commitHash` and `upstream_merge_commit` to the new submodule tip
- `externals/skia` submodule pointer — bumped to the merge commit on `skia-sync/m151`

No version files, soname, NuGet versions, or `SK_C_INCREMENT` changed (release-line policy).

## Breaking change analysis

None. Upstream delta is a single internal Ganesh GPU fix ("stencil clear rect in native coords");
no public Skia API, no C API, no binding surface affected.

## Binding / C# changes

None. `regenerate-bindings.ps1` reports **"No changes to bindings (C API signatures unchanged)"**
and **"No new functions found"**.

## Build & test results (Linux x64)

- ✅ `dotnet cake --target=externals-linux --arch=x64` — native build succeeded
- ✅ `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — 0 errors
- ✅ `dotnet test tests/SkiaSharp.Tests.Console` — **5711 passed, 0 failed, 182 skipped**

## Items needing human attention

None. Standard bug-fix sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).