### PR TITLE
perf: add nightly benchmark backfill mechanism

### DIFF
--- a/.github/workflows/backfill-benchmarks.yml
+++ b/.github/workflows/backfill-benchmarks.yml
@@ -27,6 +27,16 @@ on:
         required: false
         default: "19"
         type: string
+      since:
+        description: "Only include nightlies published on/after this date (YYYY-MM-DD)."
+        required: false
+        default: ""
+        type: string
+      until:
+        description: "Only include nightlies published on/before this date (YYYY-MM-DD)."
+        required: false
+        default: ""
+        type: string
   # On-demand escape hatch: also run on a PR that carries the 'run-backfill' label.
   # workflow_dispatch requires the workflow to already exist on the default branch, so
   # this lets the backfill be exercised from a PR before it lands on main. Normal PRs are
@@ -61,8 +71,22 @@ jobs:
           python-version: "3.12"
       - name: Resolve nightlies to backfill
         id: plan
+        env:
+          IN_COUNT: ${{ inputs.count }}
+          IN_SINCE: ${{ inputs.since }}
+          IN_UNTIL: ${{ inputs.until }}
         run: |
-          points=$(python3 scripts/infra/perf/benchmarks/backfill_dates.py --count "${{ inputs.count || '19' }}")
+          # workflow_dispatch drives the selection via inputs. On the label-triggered PR
+          # path inputs are empty, so fall back to the newest 19 (one per calendar day).
+          # TEMP (early-v4 one-off): PR-path fallback targets the older 4.133..4.150 stretch.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ARGS="--count ${IN_COUNT:-19}"
+            [ -n "$IN_SINCE" ] && ARGS="$ARGS --since $IN_SINCE"
+            [ -n "$IN_UNTIL" ] && ARGS="$ARGS --until $IN_UNTIL"
+          else
+            ARGS="--count 0 --since 2026-04-27 --until 2026-06-22"
+          fi
+          points=$(python3 scripts/infra/perf/benchmarks/backfill_dates.py $ARGS)
           echo "points=$points" >> "$GITHUB_OUTPUT"
           echo "$points" | python3 -m json.tool
 

--- a/.github/workflows/backfill-benchmarks.yml
+++ b/.github/workflows/backfill-benchmarks.yml
@@ -27,6 +27,12 @@ on:
         required: false
         default: "19"
         type: string
+  # On-demand escape hatch: also run on a PR that carries the 'run-backfill' label.
+  # workflow_dispatch requires the workflow to already exist on the default branch, so
+  # this lets the backfill be exercised from a PR before it lands on main. Normal PRs are
+  # unaffected — both jobs are gated on the label below, so nothing runs unless labelled.
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: read
@@ -41,7 +47,10 @@ defaults:
 
 jobs:
   plan:
-    if: github.repository_owner == 'mono'
+    if: >
+      github.repository_owner == 'mono' &&
+      (github.event_name == 'workflow_dispatch' ||
+       contains(github.event.pull_request.labels.*.name, 'run-backfill'))
     runs-on: ubuntu-latest
     outputs:
       points: ${{ steps.plan.outputs.points }}
@@ -53,13 +62,16 @@ jobs:
       - name: Resolve nightlies to backfill
         id: plan
         run: |
-          points=$(python3 scripts/infra/perf/benchmarks/backfill_dates.py --count "${{ inputs.count }}")
+          points=$(python3 scripts/infra/perf/benchmarks/backfill_dates.py --count "${{ inputs.count || '19' }}")
           echo "points=$points" >> "$GITHUB_OUTPUT"
           echo "$points" | python3 -m json.tool
 
   benchmark:
     needs: plan
-    if: github.repository_owner == 'mono'
+    if: >
+      github.repository_owner == 'mono' &&
+      (github.event_name == 'workflow_dispatch' ||
+       contains(github.event.pull_request.labels.*.name, 'run-backfill'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/backfill-benchmarks.yml
+++ b/.github/workflows/backfill-benchmarks.yml
@@ -1,0 +1,119 @@
+name: Backfill - Benchmarks
+
+# ONE-OFF, manually-dispatched backfill of historical `nightly` benchmark points, to seed
+# the perf dashboard's trend line with ~2-3 weeks of data before enough daily runs accrue.
+#
+# It mirrors the `nightly` leg of `track-benchmarks.yml` (the daily tracker), but instead of
+# one point for today it fans out over the newest N nightlies (one per calendar day, resolved
+# by `backfill_dates.py`) x Linux/Windows/macOS, benchmarking each OLD nightly and dating the
+# point by that nightly's real PUBLISH DATE (`track.py --date`). Each leg uploads its own
+# single-day history artifact; the workflow deliberately does NOT commit anything. A maintainer
+# then downloads the artifacts, merges them with `combine_histories.py` (seeded from the current
+# aw-data index.json so nothing is lost), and pushes a SCRATCH data branch for review via the
+# dashboard's `?data=<raw-base>` before any promotion to `aw-data`.
+#
+# Caveat: every backfilled point is measured on TODAY's runners. That makes the whole nightly
+# line internally consistent version-over-version, but a different hardware baseline than the
+# pre-existing/going-forward daily points — expected for a visual trend seed.
+#
+# This workflow is NOT mapped in persist-aw-data.yml and holds only `contents: read`, so it can
+# never write to `aw-data` — the daily green workflows are untouched.
+
+on:
+  workflow_dispatch:
+    inputs:
+      count:
+        description: "How many recent nightlies (one per calendar day) to backfill."
+        required: false
+        default: "19"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  plan:
+    if: github.repository_owner == 'mono'
+    runs-on: ubuntu-latest
+    outputs:
+      points: ${{ steps.plan.outputs.points }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Resolve nightlies to backfill
+        id: plan
+        run: |
+          points=$(python3 scripts/infra/perf/benchmarks/backfill_dates.py --count "${{ inputs.count }}")
+          echo "points=$points" >> "$GITHUB_OUTPUT"
+          echo "$points" | python3 -m json.tool
+
+  benchmark:
+    needs: plan
+    if: github.repository_owner == 'mono'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        point: ${{ fromJSON(needs.plan.outputs.points) }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    # Best-effort per leg: a single flaky (version, OS) must not fail the others or the run.
+    continue-on-error: true
+    env:
+      PROJECT: benchmarks/SkiaSharp.Benchmarks.Tracking
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set leg variables
+        run: |
+          echo "LABEL=${{ runner.os }}" >> "$GITHUB_ENV"
+          echo "VERSION=${{ matrix.point.version }}" >> "$GITHUB_ENV"
+          echo "DATE=${{ matrix.point.date }}" >> "$GITHUB_ENV"
+          echo "HISTORY=benchmarks-${{ runner.os }}-nightly-${{ matrix.point.version }}.json" >> "$GITHUB_ENV"
+
+      - name: Install Linux native dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1
+
+      - name: Pin version
+        # The nightly role restores from the committed nuget.config (EAP feed hosts every
+        # -nightly.*), so no runtime nuget.org injection is needed here.
+        run: |
+          python3 scripts/infra/perf/benchmarks/write_version_props.py "$VERSION" "$PROJECT/version.props"
+
+      - name: Run benchmarks
+        working-directory: ${{ env.PROJECT }}
+        run: dotnet run -c Release -- --filter '*'
+
+      - name: Record results (dated by publish date)
+        run: |
+          python3 scripts/infra/perf/benchmarks/track.py \
+            --history "$HISTORY" \
+            --os "$LABEL" \
+            --role nightly \
+            --version "$VERSION" \
+            --date "$DATE"
+
+      - name: Upload history artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks-${{ runner.os }}-nightly-${{ matrix.point.version }}
+          path: ${{ env.HISTORY }}
+          if-no-files-found: warn

--- a/.github/workflows/backfill-benchmarks.yml
+++ b/.github/workflows/backfill-benchmarks.yml
@@ -76,16 +76,12 @@ jobs:
           IN_SINCE: ${{ inputs.since }}
           IN_UNTIL: ${{ inputs.until }}
         run: |
-          # workflow_dispatch drives the selection via inputs. On the label-triggered PR
-          # path inputs are empty, so fall back to the newest 19 (one per calendar day).
-          # TEMP (early-v4 one-off): PR-path fallback targets the older 4.133..4.150 stretch.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ARGS="--count ${IN_COUNT:-19}"
-            [ -n "$IN_SINCE" ] && ARGS="$ARGS --since $IN_SINCE"
-            [ -n "$IN_UNTIL" ] && ARGS="$ARGS --until $IN_UNTIL"
-          else
-            ARGS="--count 0 --since 2026-04-27 --until 2026-06-22"
-          fi
+          # workflow_dispatch drives the selection via inputs (count + optional since/until).
+          # On the label-triggered PR path inputs are empty, so fall back to the newest 19
+          # nightlies (one per calendar day).
+          ARGS="--count ${IN_COUNT:-19}"
+          [ -n "$IN_SINCE" ] && ARGS="$ARGS --since $IN_SINCE"
+          [ -n "$IN_UNTIL" ] && ARGS="$ARGS --until $IN_UNTIL"
           points=$(python3 scripts/infra/perf/benchmarks/backfill_dates.py $ARGS)
           echo "points=$points" >> "$GITHUB_OUTPUT"
           echo "$points" | python3 -m json.tool

--- a/scripts/infra/perf/_common.py
+++ b/scripts/infra/perf/_common.py
@@ -125,6 +125,35 @@ def nuget_versions(package: str = "SkiaSharp") -> list[str]:
     return feed_versions(NUGET_FLATCONTAINER, package)
 
 
+def published_dates(package: str = "SkiaSharp") -> dict[str, str]:
+    """Map ``version -> published ISO-8601 timestamp`` for ``package`` on the EAP feed.
+
+    Reads the feed's ``RegistrationsBaseUrl/3.6.0`` (SemVer2) registration index, which
+    carries a ``published`` timestamp per version — the authoritative publish date used to
+    place a *backfilled* data point on the timeline (the flat container exposes no dates).
+    A single registration index fetch (the EAP feed returns every version inline), with each
+    registration *page* fetched by ``@id`` only if the feed paginated it. Versions without a
+    catalog entry/timestamp are omitted. Returns ``{}`` if the feed lacks a registration
+    resource.
+    """
+    resources = http_get_json(EAP_INDEX_URL).get("resources", [])
+    reg_base = pick_resource(resources, "RegistrationsBaseUrl/3.6.0")
+    if not reg_base:
+        return {}
+    index = http_get_json(f"{reg_base.rstrip('/')}/{package.lower()}/index.json")
+    dates: dict[str, str] = {}
+    for page in index.get("items", []):
+        items = page.get("items")
+        if items is None:  # paginated: the page body lives at its @id
+            items = http_get_json(page["@id"]).get("items", [])
+        for item in items:
+            entry = item.get("catalogEntry") or {}
+            version, published = entry.get("version"), entry.get("published")
+            if version and published:
+                dates[version] = published
+    return dates
+
+
 # --------------------------------------------------------------------------- #
 # Version-role resolution
 #

--- a/scripts/infra/perf/benchmarks/backfill_dates.py
+++ b/scripts/infra/perf/benchmarks/backfill_dates.py
@@ -23,8 +23,14 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))  # perf/
 from _common import eap_versions, log, published_dates, semver_key  # noqa: E402
 
 
-def select(count: int, package: str = "SkiaSharp") -> list[dict[str, str]]:
-    """Newest ``count`` nightlies, one per calendar day, with their publish dates."""
+def select(count: int, package: str = "SkiaSharp",
+           since: str | None = None, until: str | None = None) -> list[dict[str, str]]:
+    """Newest ``count`` nightlies, one per calendar day, with their publish dates.
+
+    ``since`` / ``until`` (inclusive ``YYYY-MM-DD``) restrict the calendar-day window before
+    the ``count`` cap is applied — e.g. ``until=2026-06-22`` backfills an older stretch without
+    re-measuring days already recorded. ``count <= 0`` means "all days in the window".
+    """
     dates = published_dates(package)
     nightlies = [v for v in eap_versions(package) if "-nightly." in v.lower() and v in dates]
 
@@ -33,7 +39,9 @@ def select(count: int, package: str = "SkiaSharp") -> list[dict[str, str]]:
     for v in sorted(nightlies, key=semver_key):  # ascending -> last write per day wins
         by_day[dates[v][:10]] = v
 
-    chosen_days = sorted(by_day)[-count:] if count > 0 else sorted(by_day)
+    days = sorted(d for d in by_day
+                  if (since is None or d >= since) and (until is None or d <= until))
+    chosen_days = days[-count:] if count > 0 else days
     return [{"version": by_day[d], "date": d} for d in chosen_days]
 
 
@@ -41,11 +49,14 @@ def main(argv: list[str]) -> int:
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--count", type=int, default=19,
-                   help="How many recent nightlies (one per calendar day) to backfill. Default 19.")
+                   help="How many recent nightlies (one per calendar day) to backfill. "
+                        "Default 19; <=0 means all days in the window.")
+    p.add_argument("--since", default=None, help="Only include days on/after this YYYY-MM-DD.")
+    p.add_argument("--until", default=None, help="Only include days on/before this YYYY-MM-DD.")
     p.add_argument("--package", default="SkiaSharp", help="Package to resolve (default SkiaSharp).")
     args = p.parse_args(argv)
 
-    points = select(args.count, args.package)
+    points = select(args.count, args.package, args.since, args.until)
     if not points:
         log("  no nightly versions with publish dates resolved")
         return 1

--- a/scripts/infra/perf/benchmarks/backfill_dates.py
+++ b/scripts/infra/perf/benchmarks/backfill_dates.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Select the historical ``-nightly.*`` versions to BACKFILL, dated by publish date.
+
+The daily tracker records one ``nightly`` point per day going forward. To seed the
+dashboard's trend with history, this picks the newest ``--count`` nightlies — **one per
+calendar day** (the newest nightly published that day) — and stamps each with its real
+publish date from the EAP feed's registration index. Output (stdout, single line) is
+consumed as a GitHub Actions matrix by ``backfill-benchmarks.yml``:
+
+    [{"version": "4.151.0-nightly.55", "date": "2026-07-15"}, ...]   # oldest -> newest
+
+All feed access reuses ``_common`` (no duplicated feed/SemVer logic); logs go to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))  # perf/
+from _common import eap_versions, log, published_dates, semver_key  # noqa: E402
+
+
+def select(count: int, package: str = "SkiaSharp") -> list[dict[str, str]]:
+    """Newest ``count`` nightlies, one per calendar day, with their publish dates."""
+    dates = published_dates(package)
+    nightlies = [v for v in eap_versions(package) if "-nightly." in v.lower() and v in dates]
+
+    # Collapse to one version per calendar day: the newest nightly published that day.
+    by_day: dict[str, str] = {}
+    for v in sorted(nightlies, key=semver_key):  # ascending -> last write per day wins
+        by_day[dates[v][:10]] = v
+
+    chosen_days = sorted(by_day)[-count:] if count > 0 else sorted(by_day)
+    return [{"version": by_day[d], "date": d} for d in chosen_days]
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--count", type=int, default=19,
+                   help="How many recent nightlies (one per calendar day) to backfill. Default 19.")
+    p.add_argument("--package", default="SkiaSharp", help="Package to resolve (default SkiaSharp).")
+    args = p.parse_args(argv)
+
+    points = select(args.count, args.package)
+    if not points:
+        log("  no nightly versions with publish dates resolved")
+        return 1
+    log(f"  selected {len(points)} nightly point(s): {points[0]['date']} .. {points[-1]['date']}")
+    print(json.dumps(points))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/infra/perf/benchmarks/combine_histories.py
+++ b/scripts/infra/perf/benchmarks/combine_histories.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Combine many single-day benchmark history files into one merged summary, by unioning days.
+
+The backfill workflow runs one matrix leg per (OS, version) and uploads one
+``benchmarks-<OS>-nightly-<version>.json`` artifact each — every file the usual
+``{schema, os, role, days:[...]}`` shape, but carrying just the one backfilled day. This
+merges them into the schema-2 ``benchmarks/index.json`` the dashboard reads:
+
+    {"schema": 2, "generatedUtc": "...", "legs": {"<OS>|<role>": {os, role, days:[...]}, ...}}
+
+Unlike ``merge_summaries.py`` (which keys legs by ``OS|role`` and OVERWRITES on collision, so
+it can't fold many one-day files for the same leg together), this **unions** each leg's days
+(dedup by date, incoming wins, chronological). ``--seed`` loads an existing merged index first
+so pre-existing legs/days — e.g. the current ``aw-data`` curr-stable/latest/prev-* and the
+already-recorded nightly day — are preserved and extended, not lost. Only the standard library.
+
+Usage: combine_histories.py <histories-dir> <out-json> [--seed <existing-index.json>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import glob
+import json
+import os
+import sys
+
+
+def _upsert_days(leg: dict, incoming: list[dict]) -> None:
+    """Merge ``incoming`` day entries into ``leg['days']`` (dedup by date, incoming wins)."""
+    by_date = {d["date"]: d for d in leg.get("days", []) if d.get("date")}
+    for day in incoming:
+        if day.get("date"):
+            by_date[day["date"]] = day
+    leg["days"] = [by_date[k] for k in sorted(by_date)]
+
+
+def _load(path: str) -> dict | None:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (json.JSONDecodeError, OSError) as err:
+        print(f"  ! skipping {path}: {err}", file=sys.stderr)
+        return None
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("histories_dir")
+    p.add_argument("out_json")
+    p.add_argument("--seed", default=None,
+                   help="Existing merged index.json whose legs/days seed the result.")
+    args = p.parse_args(argv)
+
+    legs: dict[str, dict] = {}
+    if args.seed:
+        seed = _load(args.seed) or {}
+        for key, doc in (seed.get("legs") or {}).items():
+            legs[key] = {
+                "schema": doc.get("schema", 1),
+                "os": doc.get("os", key.split("|")[0]),
+                "role": doc.get("role", key.split("|")[-1]),
+                "days": list(doc.get("days", [])),
+            }
+        print(f"  seeded {len(legs)} leg(s) from {args.seed}", file=sys.stderr)
+
+    files = sorted(glob.glob(os.path.join(args.histories_dir, "benchmarks-*.json")))
+    for path in files:
+        doc = _load(path)
+        if not isinstance(doc, dict):
+            continue
+        os_name, role = doc.get("os", "?"), doc.get("role", "nightly")
+        key = f"{os_name}|{role}"
+        leg = legs.setdefault(key, {"schema": doc.get("schema", 1),
+                                    "os": os_name, "role": role, "days": []})
+        _upsert_days(leg, doc.get("days", []))
+
+    merged = {
+        "schema": 2,
+        "generatedUtc": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "legs": legs,
+    }
+    with open(args.out_json, "w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2, sort_keys=True)
+    total_days = sum(len(l.get("days", [])) for l in legs.values())
+    print(f"  combined {len(files)} file(s) -> {len(legs)} leg(s), {total_days} day(s) "
+          f"-> {args.out_json}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/infra/perf/benchmarks/track.py
+++ b/scripts/infra/perf/benchmarks/track.py
@@ -195,6 +195,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                    help="SkiaSharp package version being benchmarked.")
     p.add_argument("--os", default="?", help="OS label (stored for the dashboard).")
     p.add_argument("--role", default="nightly", help="Version role (stored for the dashboard).")
+    p.add_argument("--date", default=None,
+                   help="Override the data point's date (YYYY-MM-DD, UTC). Defaults to today. "
+                        "Used to BACKFILL a historical point dated by the version's publish date; "
+                        "the normal daily path omits it and gets today.")
     p.add_argument("--check", action="store_true",
                    help="Print 'skip' if this leg's fingerprint matches the last recorded "
                         "one (unchanged version + benchmark source), else 'run'. Records nothing.")
@@ -228,9 +232,16 @@ def main(argv: list[str]) -> int:
         return 1
 
     history = load_history(args.history, args.os, args.role)
-    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    if args.date is not None:
+        try:
+            day = dt.datetime.strptime(args.date, "%Y-%m-%d").strftime("%Y-%m-%d")
+        except ValueError:
+            _log(f"  invalid --date {args.date!r}; expected YYYY-MM-DD")
+            return 2
+    else:
+        day = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     upsert_day(history, {
-        "date": today,
+        "date": day,
         "version": args.version,
         "fingerprint": fp,
         "benchmarks": benchmarks,


### PR DESCRIPTION
## Why

The cross-platform perf tracker (#4438) persists benchmark history to the `aw-data` branch and renders an interactive dashboard, but `aw-data` currently holds only **one day** per leg — so the dashboard's `nightly` trend line is a single point. This adds a mechanism to **backfill ~2–3 weeks of historical nightly data** so the trend chart shows a real multi-week line, landed on a **scratch branch** for review before any promotion to `aw-data`.

## Approach

CI **measures** (runs BenchmarkDotNet against each old nightly on Linux/Windows/macOS and uploads one history artifact per leg); a maintainer then **downloads the artifacts, assembles locally, and pushes a scratch data branch**. The workflow therefore needs no write permission and never touches `aw-data`.

Each backfilled point measures an **old nightly** but is dated by that nightly's **real publish date** (from the EAP feed's registration endpoint), so the points land on the correct timeline.

## Changes (all additive; reuse `_common` + `track.py`)

- **`track.py`** — new optional `--date YYYY-MM-DD`. Defaults to today, so the daily path is unchanged; validated when provided.
- **`_common.py`** — new `published_dates()` reads the EAP `RegistrationsBaseUrl/3.6.0` registration index (one inline fetch) → `{version: publishedISO}`.
- **`backfill_dates.py`** — selects the newest N nightlies, **one per calendar day**, and prints `[{version, date}]` for the workflow matrix.
- **`combine_histories.py`** — **unions** per-`(OS, role)` days across the many single-day artifact files, **seeded from the current `aw-data` `index.json`** so existing legs/days (curr-stable/latest/prev-*, the existing nightly day) are preserved and extended. (`merge_summaries.py` overwrites on collision, so a union helper is needed.)
- **`.github/workflows/backfill-benchmarks.yml`** — `workflow_dispatch`-only (input `count`, default 19). `plan` → points JSON; `benchmark` → matrix `(version × 3 OS)`, mirrors the daily nightly leg (`write_version_props` → BDN → `track.py --date`), uploads one uniquely-named history artifact per leg. **No commit in CI** (`permissions: contents: read`), and it is **not mapped in `persist-aw-data.yml`**, so the daily green workflows are untouched.

## Baseline caveat

Every backfilled point is measured on **today's runners**. That makes the whole nightly line internally consistent version-over-version, but a different hardware baseline than the pre-existing/going-forward daily points — expected and acceptable for a visual trend seed.

## Not in scope

- `scripts/infra/perf/templates/dashboard.html` (owned by another session) is untouched.
- Promotion to `aw-data` is a documented, optional follow-up; this PR only provides the mechanism + scratch-branch workflow.