### PR TITLE
perf(site): publish the perf dashboard at a hidden /perf/ page

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -282,6 +282,15 @@ jobs:
           # Docs → /docs/
           cp -r output/site/docs site/docs
 
+          # Perf dashboard → /perf/ (unlinked; there is intentionally no nav entry).
+          # Copied verbatim, NOT rendered through render_html.py: with no embedded
+          # window.__PERF_DATA__ the page live-fetches benchmarks/index.json +
+          # sizes/index.json from the aw-data branch (raw.githubusercontent.com sends
+          # Access-Control-Allow-Origin: *), so /perf/ always shows the latest nightly
+          # data without needing a site rebuild. A ?data=<base-url> override still works.
+          mkdir -p site/perf
+          cp scripts/infra/perf/templates/dashboard.html site/perf/index.html
+
           # Gallery (Blazor) → /gallery/
           cp -r output/gallery-publish/wwwroot site/gallery
 


### PR DESCRIPTION
Gives the perf dashboard a permanent home on the Pages site at **https://mono.github.io/SkiaSharp/perf/** — a hidden, always-fresh view of the nightly benchmark + size trends.

## Why

The perf tracker (#4438) writes its histories to the `aw-data` branch, but until now the only way to *see* the dashboard was to render it locally or hand it a `?data=` URL. This wires it into the existing site build so it can be checked any time.

## What

One step added to the **Assemble site** phase of `build-site.yml`:

```bash
mkdir -p site/perf
cp scripts/infra/perf/templates/dashboard.html site/perf/index.html
```

Key design choice — it is copied **verbatim**, *not* run through `render_html.py`:

- With no embedded `window.__PERF_DATA__`, the page **live-fetches** `benchmarks/index.json` + `sizes/index.json` straight from the `aw-data` branch via `raw.githubusercontent.com` (which returns `Access-Control-Allow-Origin: *`).
- So `/perf/` **always reflects the latest nightly data without a site rebuild** — the HTML only changes when the template itself does.
- A `?data=<base-url>` override still works (e.g. to point at a scratch/backfill branch).

**Deliberately unlinked** — there is no nav entry on the landing page or in the docs. It is a maintainer tool reachable by URL, not a public feature (as requested).

## Verification

Copied the template and loaded it locally with no query string: it fetches the live **48-day, 3-OS** `aw-data` history and renders (chart + grid) with **no console errors**. Confirmed `raw.githubusercontent.com` serves the JSON with `access-control-allow-origin: *`.

## Notes

- Independent of #4448 (the dashboard UI overhaul). This step copies whatever `dashboard.html` is on `main` at build time, so `/perf/` works today with the current UI and automatically upgrades to the grid-first UI once #4448 merges.
- CI/site-tooling only; no library changes.

Co-authored-by: Matthew Leibowitz <mattleibow@live.com>
Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
