### PR TITLE
Fix benchmark -pr column silently downloading nightly for cflags-only native PRs

### DIFF
--- a/.github/workflows/track-benchmarks.yml
+++ b/.github/workflows/track-benchmarks.yml
@@ -213,10 +213,13 @@ jobs:
         include:
           - os: ubuntu-latest
             label: Linux
+            nativeJob: native/linux
           - os: macos-latest
             label: macOS
+            nativeJob: native/macos
           - os: windows-latest
             label: Windows
+            nativeJob: native/windows
     runs-on: ${{ matrix.os }}
     timeout-minutes: 150
     continue-on-error: true
@@ -250,6 +253,18 @@ jobs:
         # native the download provides is byte-identical to what a source build would produce,
         # so we skip the (expensive) native build. Reads submodule SHAs from git — no submodule
         # checkout needed here.
+        #
+        # Use this leg's PER-PLATFORM child job (native/linux|macos|windows, from matrix.nativeJob)
+        # rather than the coarse parent `native`. The parent job's key only hashes
+        # scripts/infra/native/shared/** + the submodule SHAs; the per-platform build.cake files
+        # (native/<plat>/**, which hold extra_cflags) live in its CHILDREN and are invisible to
+        # the parent key. Using the parent key made a flag-only native change (e.g. adding a
+        # -D define to extra_cflags) look "unchanged", so the -pr column silently DOWNLOADED the
+        # define-OFF nightly instead of building this branch — a meaningless A/B. The child key is
+        # a strict superset of the parent (same shared files + submodules, plus native/<plat>/**),
+        # so flag-only native changes now correctly trigger the source build.
+        env:
+          NATIVE_JOB: ${{ matrix.nativeJob }}
         run: |
           mode="$PR_NATIVE_SOURCE_BUILD"
           build=false
@@ -257,10 +272,11 @@ jobs:
             build=true
           elif [ "$mode" = "auto" ]; then
             git fetch --no-tags --depth=1 origin main
-            keyhead=$(python3 scripts/infra/caching/repo-deps.py cache-key --job native --name k | sed -n 's/^Key:[[:space:]]*//p')
+            keyhead=$(python3 scripts/infra/caching/repo-deps.py cache-key --job "$NATIVE_JOB" --name k | sed -n 's/^Key:[[:space:]]*//p')
             git worktree add -q --detach "$RUNNER_TEMP/native-base" FETCH_HEAD
-            keybase=$(cd "$RUNNER_TEMP/native-base" && python3 scripts/infra/caching/repo-deps.py cache-key --job native --name k | sed -n 's/^Key:[[:space:]]*//p')
+            keybase=$(cd "$RUNNER_TEMP/native-base" && python3 scripts/infra/caching/repo-deps.py cache-key --job "$NATIVE_JOB" --name k | sed -n 's/^Key:[[:space:]]*//p')
             git worktree remove --force "$RUNNER_TEMP/native-base"
+            echo "native job: $NATIVE_JOB"
             echo "native key HEAD: $keyhead"
             echo "native key main: $keybase"
             [ -n "$keybase" ] && [ "$keyhead" != "$keybase" ] && build=true


### PR DESCRIPTION
## Problem

The `Track - Benchmarks` workflow's `-pr` (⭐ source) column is documented as "a FULL source build of THIS checkout" (`track-benchmarks.yml` line 10). For **cflags-only native PRs it silently downloaded the prebuilt define-OFF nightly instead**, producing a meaningless A/B (define-OFF vs define-OFF = noise).

This was found on PR #4428 (motivated by #4421), which changes **only** native compiler flags — it adds `-DSK_ENABLE_LEGACY_SHADERCONTEXT` to `extra_cflags` in `native/<platform>/build.cake`. Its benchmark run showed no difference in the `-pr` column vs `-nightly`, and the `benchmark-source` logs revealed all three legs printed `native source build: false (mode=auto)` → `dotnet cake --target=externals-download`.

## Root cause

The `benchmark-source` job's **"Decide native build mode"** step, in `auto` mode, decided whether to source-build by comparing the repo-deps cache-key at HEAD vs `main` using the **coarse parent** `--job native`.

In `scripts/infra/caching/repo-deps.json`, the `native` job's own include is only `scripts/infra/native/shared/**` (plus the global includes and the `externals/skia` + `externals/depot_tools` submodule SHAs). The per-platform `build.cake` files that hold `extra_cflags` live in the job's **children** (`native/linux`, `native/macos`, `native/windows`, …). In `repo-deps.py`, `resolve_job` accumulates a parent's includes *into* children but a parent key **never descends into its children** — so `--job native` never hashes `native/*/build.cake`. A cflags-only change is therefore invisible → `auto` says "native unchanged" → downloads the define-OFF nightly.

The real AzDO native build caching already uses the per-platform **child** keys (`cacheJob: native/windows|macos|linux` etc. in `scripts/azure-templates-stages-native-*.yml`), which is why the shipped `4.151.0-pr.4428.1` packages *did* rebuild with the define. Only this benchmark workflow used the coarse parent key.

## Fix

In `benchmark-source`, add an explicit **`nativeJob`** field per matrix leg (`native/linux` / `native/macos` / `native/windows`) and use it in **both** cache-key invocations (HEAD and the `main` worktree) instead of `--job native`. Everything else — the `--base` logic, the worktree comparison, and the `PR_NATIVE_SOURCE_BUILD` true/false/auto override — is unchanged.

The child key is a **strict superset** of the parent (same `scripts/infra/native/shared/**` + submodule SHAs, plus `native/<plat>/**` + `scripts/infra/native/<plat>/**`), so nothing is lost — it only *adds* the platform's native files, so flag-only native changes now correctly trigger the source build and each leg still rebuilds only when *its* platform inputs change.

Only `track-benchmarks.yml` consumed the coarse `--job native ` key (confirmed by `grep 'cache-key --job native '`). The other `cacheJob` consumers (`azure-templates-jobs-bootstrapper.yml`, the native stage templates) already pass explicit child jobs and are unaffected.

## Validation

Made a throwaway `-DSK_ENABLE_LEGACY_SHADERCONTEXT` edit to `native/macos/build.cake` and compared keys vs `main`:

| Job | Baseline | With cflags edit | Result |
|-----|----------|------------------|--------|
| `native` (buggy parent) | `…_1fff20565ae8f4cf602fd6ee` | `…_1fff20565ae8f4cf602fd6ee` | **IDENTICAL** — the bug |
| `native/macos` (fixed child) | `…_74bc6137ab905739666644ea` | `…_5c0df49b0f4ad50d2c63b8b2` | **DIFFERS** ✓ |
| `native/windows` | unchanged | unchanged | correct (macOS-only edit) |
| `native/linux` | unchanged | unchanged | correct |

`--base origin/main` output confirms the `native` node lists no `native/macos/` file (only `scripts/infra/native/shared/`), while `native/macos` lists `macos → native/macos/ (3 files)`.

## Follow-up

After this lands, **PR #4428's benchmark A/B should be re-run** so the `-pr` column actually builds the define-ON native and the tiled-bitmap benchmark (`BitmapDrawBenchmark.DrawScaledTiles` / `DrawUnscaledTiles`) produces a meaningful comparison.

Refs #4421, #4428.