### PR TITLE
Add LargeImageScaleBenchmark to track the #4421 CPU image-sampling slowdown

### DIFF
--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/LargeImageScaleBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/LargeImageScaleBenchmark.cs
@@ -1,0 +1,126 @@
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks.Tracking;
+
+// Isolates the CPU raster-pipeline image-sampling slowdown from
+// https://github.com/mono/SkiaSharp/issues/4421 (PR #4428 re-enables the fix).
+//
+// Since Skia milestone 146 removed the default SK_ENABLE_LEGACY_SHADERCONTEXT define,
+// SkShaderBase::makeContext() returns nullptr for every shader, so SkBlitter::Choose,
+// for an N32 + SrcOver draw that carries a shader (a *scaled* image draw builds a
+// sampling shader), falls back from the fast hand-tuned SkARGB32_Shader_Blitter to the
+// generic raster-pipeline blitter. The per-pixel sampler stage chain (matrix -> tile ->
+// gather -> premul -> srcover) is 5x-10x slower than the legacy SIMD kernel.
+//
+// The sibling BitmapDrawBenchmark issues many TINY (37px) scaled draws, so its
+// scaled/unscaled ratio is diluted: the per-draw fixed cost (Choose + clip + the
+// once-per-draw raster-pipeline compile in SkRasterPipelineBlitter::blitRect) is a
+// common addend paid by BOTH the legacy and raster-pipeline paths, compressing the
+// ratio toward 1. This benchmark instead issues a SMALL number of LARGE full-surface
+// upscaled draws, so the per-pixel steady state dominates and the true per-pixel ratio
+// shows through (matching the reporter's full-screen 60fps cross-fade repro).
+//
+// Two methods on purpose (never rename — the full name is the history key):
+//   * UpscaleOpaque    — one full-surface upscaled opaque image draw. Isolates pure
+//                        sampling. No Clear: an opaque full-surface draw overwrites.
+//   * UpscaleCrossfade — an opaque base draw plus a second image at alpha 128, both
+//                        timed (no Clear). This is the reporter's real cross-fade frame;
+//                        (UpscaleCrossfade - UpscaleOpaque) isolates the extra sampling
+//                        and alpha blend of the second layer.
+// Larger Size makes each dst pixel more of the total work, so a platform hit by #4421
+// should show the ratio climb with Size.
+public class LargeImageScaleBenchmark
+{
+	// Surface/destination edge length. At least one LARGE size so per-pixel cost
+	// dominates the per-draw setup that dilutes the tiny-tile benchmark.
+	[Params(1024, 2048)]
+	public int Size { get; set; }
+
+	// Small source, upscaled to fill the surface. 300 does not divide 1024/2048, so the
+	// scale is non-integer (nearest gather per dst pixel), matching the reporter who
+	// upscales smaller bitmaps to a large, differently-sized canvas.
+	private const int SourceSize = 300;
+
+	// Paint alpha for the cross-fade's second (fading-in) layer: ~50%.
+	private const byte CrossfadeAlpha = 128;
+
+	private SKSurface _surface = null!;
+	private SKCanvas _canvas = null!;
+	private SKImage _imageA = null!;
+	private SKImage _imageB = null!;
+	private SKPaint _opaquePaint = null!;
+	private SKPaint _alphaPaint = null!;
+	private SKRect _source;
+	private SKRect _dest;
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		// Platform-default (N32) surface — the colour type the regression affects.
+		_surface = SKSurface.Create(new SKImageInfo(Size, Size));
+		_canvas = _surface.Canvas;
+
+		// Two deterministic, non-uniform source images so sampling reads varied texels
+		// and the cross-fade blends genuinely different content.
+		_imageA = CreateSource(SKColors.CornflowerBlue, SKColors.OrangeRed);
+		_imageB = CreateSource(SKColors.SeaGreen, SKColors.Gold);
+
+		_opaquePaint = new SKPaint(); // default: SrcOver, opaque
+		_alphaPaint = new SKPaint { Color = SKColors.Black.WithAlpha(CrossfadeAlpha) };
+
+		_source = new SKRect(0, 0, SourceSize, SourceSize);
+		_dest = new SKRect(0, 0, Size, Size);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup()
+	{
+		_alphaPaint.Dispose();
+		_opaquePaint.Dispose();
+		_imageB.Dispose();
+		_imageA.Dispose();
+		_surface.Dispose();
+	}
+
+	// A busy, non-uniform texture (no flat regions that could shortcut sampling).
+	private static SKImage CreateSource(SKColor a, SKColor b)
+	{
+		using var surface = SKSurface.Create(new SKImageInfo(SourceSize, SourceSize));
+		var canvas = surface.Canvas;
+		canvas.Clear(SKColors.White);
+		using var fill = new SKPaint { IsAntialias = false };
+		for (var y = 0; y < SourceSize; y += 20)
+		{
+			for (var x = 0; x < SourceSize; x += 20)
+			{
+				fill.Color = ((x + y) / 20 % 2 == 0) ? a : b;
+				canvas.DrawRect(new SKRect(x, y, x + 14, y + 14), fill);
+			}
+		}
+		using var line = new SKPaint { Color = SKColors.Black, IsAntialias = false, Style = SKPaintStyle.Stroke, StrokeWidth = 1 };
+		for (var i = 0; i < SourceSize; i += 37)
+			canvas.DrawLine(0, i, SourceSize, SourceSize - i, line);
+		return surface.Snapshot();
+	}
+
+	// #4421 path: a single large upscaled N32 SrcOver image draw => sampling shader =>
+	// raster-pipeline blitter fallback. Opaque + full surface, so no Clear is needed.
+	[Benchmark]
+	public int UpscaleOpaque()
+	{
+		_canvas.DrawImage(_imageA, _source, _dest, SKSamplingOptions.Default, _opaquePaint);
+		_canvas.Flush();
+		return Size;
+	}
+
+	// The reporter's real frame: an opaque base image plus a fading-in image at alpha
+	// 128. Two large upscaled draws; both timed, no Clear (the opaque base overwrites).
+	[Benchmark]
+	public int UpscaleCrossfade()
+	{
+		_canvas.DrawImage(_imageA, _source, _dest, SKSamplingOptions.Default, _opaquePaint);
+		_canvas.DrawImage(_imageB, _source, _dest, SKSamplingOptions.Default, _alphaPaint);
+		_canvas.Flush();
+		return Size;
+	}
+}


### PR DESCRIPTION
## What

Adds a single new tracking benchmark file, `benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/LargeImageScaleBenchmark.cs`. **Benchmark-only** — no changes to `BitmapDrawBenchmark.cs`, the workflow, or native build files.

## Why — the path this isolates

Since Skia milestone 146 removed the default `SK_ENABLE_LEGACY_SHADERCONTEXT` define (#4421; re-enabled by #4428), a **scaled N32 + SrcOver image draw** on the CPU regresses:

- A scaled `DrawImage` builds a **sampling shader**. In `SkBlitter::Choose`, for N32 + SrcOver + a shader it tries `shader->makeContext()`.
- With the define **off**, `SkShaderBase::makeContext` is `return nullptr` for *every* shader, so `Choose` falls back to `CreateSkRPBlitter()` — the generic raster‑pipeline blitter — instead of the fast hand‑tuned `SkARGB32_Shader_Blitter`.
- The RP blitter's **per‑pixel** sampler stage chain (matrix → tile/clamp → gather → premul → srcover) is ~5–10× slower than the legacy single SIMD kernel. `UseLegacyBlitter` never inspects paint alpha, so the trigger is simply "scaled N32 SrcOver image draw", not opacity.

This matches the reporter (janne‑hmp): a 60fps full‑screen cross‑fade between two upscaled bitmaps on a large (~3200×2000) `SKCanvasView`, using `SKSamplingOptions.Default` (nearest).

## Why a *few large* draws instead of many tiny ones

The existing `BitmapDrawBenchmark` issues 64/256 **tiny (37px)** scaled draws. The per‑draw fixed cost — `Choose` + clip + the once‑per‑draw raster‑pipeline compile (`SkRasterPipelineBlitter::blitRect` lazily compiles the pipeline once, then runs the whole rect) — is a **common addend paid by both the legacy and RP paths**, compressing the ratio toward 1. So it shows only ~2–4× and dilutes the true per‑pixel cost.

This benchmark instead issues a **small number of large full‑surface upscaled draws**, so the per‑pixel steady state dominates and the true per‑pixel ratio shows through — the regime the reporter actually hits.

## Design

- Class `LargeImageScaleBenchmark`, `[Params(1024, 2048)] int Size` (surface/dest edge). Larger dst ⇒ per‑pixel dominates ⇒ the OFF/ON ratio should climb.
- Source: two deterministic, non‑uniform 300×300 procedurally‑drawn `SKImage`s, upscaled to `Size×Size`. 300 doesn't divide 1024/2048, so the scale is non‑integer (a genuine per‑pixel nearest gather).
- `UpscaleOpaque` — one full‑surface upscaled opaque draw. Isolates **pure sampling**. No `Clear` (an opaque full‑surface draw overwrites).
- `UpscaleCrossfade` — opaque base + a second image at paint alpha 128, both timed. This is the reporter's real cross‑fade frame; `(Crossfade − Opaque)` isolates the extra **sampling + alpha blend** of the second layer.
- Public API only; N32 platform‑default surface; `SKSamplingOptions.Default` (nearest); SrcOver. Pre‑built paints/images/rects → zero managed allocation in the timed methods. `MemoryDiagnoser` is central in `Program.cs` (not re‑added).

The `.Source` sibling globs `..\SkiaSharp.Benchmarks.Tracking\Benchmarks\**\*.cs`, so this file flows into **both** the package (nightly / define‑OFF) and source (pr / define‑ON) columns automatically — no project edits.

## Local validation (define‑OFF nightly native, macOS arm64, `--job short`)

Only the define‑OFF (m146, RP‑blitter) side is available locally; a true OFF‑vs‑ON A/B needs two from‑source Skia builds (submodule isn't initialized and `gn` isn't present here), so the **definitive A/B comes from CI** now that #4463 fixed the `-pr` vs `-nightly` native cache key (once #4428 is rebased on this).

| Method | Size | Mean | Alloc |
|---|---|---|---|
| UpscaleOpaque | 1024 | 1.772 ms | 0 |
| UpscaleCrossfade | 1024 | 3.812 ms | 0 |
| UpscaleOpaque | 2048 | 7.069 ms | 0 |
| UpscaleCrossfade | 2048 | 15.209 ms | 0 |

- **Perfect 4× area scaling** (2048/1024 = 3.99× for both methods): time scales linearly with pixel count → per‑pixel steady state dominates and per‑draw setup is negligible. That is exactly the design goal, and the property that lets the CI OFF‑vs‑ON ratio show through **undiluted** (unlike the tiny‑tile benchmark).
- **Dilution demonstrated** on the same native: in `BitmapDrawBenchmark`, a scaled tiny draw is only **1.27×** an unscaled one (486.9/382.6 µs and 1839.9/1452.7 µs) — the marginal sampling cost is swamped by per‑draw fixed cost. This benchmark removes that dilution.
- Crossfade ≈ **2.15×** Opaque at both sizes — the second sampled layer + alpha blend, isolated.

Refs #4421, #4428.