### PR TITLE
Track benchmarks every 6h with per-run datetime data points

### DIFF
--- a/.github/workflows/track-benchmarks.yml
+++ b/.github/workflows/track-benchmarks.yml
@@ -1,8 +1,8 @@
 name: Track - Benchmarks
 
-# Daily BenchmarkDotNet run on Linux/Windows/macOS, per version role. Roles split into
+# Periodic BenchmarkDotNet run on Linux/Windows/macOS, per version role. Roles split into
 # RELEASED (on nuget.org, must not regress) and UNRELEASED (CI-only):
-#   * nightly       -> newest -nightly.* from the EAP/CI feed (unreleased; daily trend)
+#   * nightly       -> newest -nightly.* from the EAP/CI feed (unreleased; trend)
 #   * latest        -> newest on nuget.org incl. preview/rc (released; less vital, still shipped)
 #   * curr-stable    \
 #   * prev-stable     >  released stable baselines, resolved from nuget.org
@@ -11,14 +11,14 @@ name: Track - Benchmarks
 #
 # History is PERSISTED to the `aw-data` branch (not the Actions cache), so it survives
 # indefinitely — years of trend, no cache eviction or size limits. Each (OS, role) leg
-# reads its existing history from that branch, appends today's point, and uploads it as
+# reads its existing history from that branch, appends this run's point, and uploads it as
 # an artifact; the `report` job aggregates everything, and — only for runs on main (the
-# nightly schedule) — the `persist-aw-data.yml` workflow commits the updated JSON back.
+# scheduled runs) — the `persist-aw-data.yml` workflow commits the updated JSON back.
 #
-# A leg is SKIPPED when its "fingerprint" (pinned version + hash of the benchmark
-# source) matches the last recorded one — released baselines don't change unless a new
-# release bumps the role or the benchmark code changes. The nightly role runs whenever a
-# new nightly publishes (its version changes).
+# Every run records a point (there is no skip): a run is cheap and we WANT to capture
+# runner/environment variation over time. Each point is keyed by a full datetime, so the
+# schedule can be sped up or slowed down freely — the dashboard's time axis just gets
+# denser or sparser. Retention is age-based (see track.py), independent of cadence.
 #
 # Outputs of the report job:
 #   * a Markdown dashboard in the run summary (time + allocations, per OS);
@@ -35,7 +35,7 @@ name: Track - Benchmarks
 
 on:
   schedule:
-    - cron: "0 8 * * *"  # Daily at 08:00 UTC (offset from the 07:00 size tracker)
+    - cron: "0 2,8,14,20 * * *"  # Every 6h (offset from the 07:00 size tracker); tune freely
   workflow_dispatch:
   pull_request:
 
@@ -147,20 +147,11 @@ jobs:
         run: |
           python3 scripts/infra/perf/benchmarks/write_version_props.py "$VERSION" "$PROJECT/version.props"
 
-      - name: Check freshness (skip unchanged baselines)
-        id: check
-        run: |
-          decision=$(python3 scripts/infra/perf/benchmarks/track.py --history "$HISTORY" --version "$VERSION" --check)
-          echo "skip=$([ "$decision" = skip ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "$decision: ${{ runner.os }}/${{ matrix.role }} ($VERSION)"
-
       - name: Run benchmarks
-        if: steps.check.outputs.skip != 'true'
         working-directory: ${{ env.PROJECT }}
         run: dotnet run -c Release -- --filter '*'
 
       - name: Record results
-        if: steps.check.outputs.skip != 'true'
         run: |
           python3 scripts/infra/perf/benchmarks/track.py \
             --history "$HISTORY" \
@@ -177,11 +168,11 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload raw BDN reports
-        # The full BenchmarkDotNet report(s) for this leg — archived per day by the
+        # The full BenchmarkDotNet report(s) for this leg — archived per run by the
         # report job (raw/<date>/<OS>-<role>/) so we can re-summarise later. The raw
         # archive is a persistence concern, so keep it main-only; PR `agent` artifacts
         # carry just the summary index.json (the raw loop simply finds nothing).
-        if: steps.check.outputs.skip != 'true' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: rawbench-${{ runner.os }}-${{ matrix.role }}

--- a/.github/workflows/track-benchmarks.yml
+++ b/.github/workflows/track-benchmarks.yml
@@ -35,7 +35,7 @@ name: Track - Benchmarks
 
 on:
   schedule:
-    - cron: "0 2,8,14,20 * * *"  # Every 6h (offset from the 07:00 size tracker); tune freely
+    - cron: "0 */6 * * *"  # Every 6h (00/06/12/18 UTC); tune freely
   workflow_dispatch:
   pull_request:
 

--- a/scripts/infra/perf/benchmarks/render_md.py
+++ b/scripts/infra/perf/benchmarks/render_md.py
@@ -5,10 +5,12 @@ Consumes ``benchmarks-<OS>-<role>.json`` documents produced by track-benchmarks.
 (one per operating system AND version role) and renders, per OS, a table whose
 columns run newest -> oldest, left -> right:
 
-    [ nightly today ... nightly 10 days ago ] [ curr-stable ] [ prev-stable ] [ prev-major ]
+    [ latest nightly ... 10 runs ago ] [ curr-stable ] [ prev-stable ] [ prev-major ]
 
-so a regression (today slower than an older build/release) shows as a red dot on
-the left. This mirrors track-artifact-sizes' layout (nightly days + released roles).
+so a regression (a recent run slower than an older build/release) shows as a red dot
+on the left. This mirrors track-artifact-sizes' layout (nightly points + released
+roles). Nightly points are now recorded per run (keyed by a full datetime), so a busy
+day contributes several columns.
 
 A small cross-OS snapshot of the latest nightly is included too, but note it is NOT
 hardware-normalized yet, so cross-OS numbers are placeholders for now.
@@ -60,6 +62,18 @@ def human_bytes(value):
 
 def short_name(full):
     return full[len(NAME_PREFIX):] if full.startswith(NAME_PREFIX) else full
+
+
+def _short_when(date_str):
+    """Compact column label from a point's ``date``: ``MM-DD`` for a legacy date-only
+    point, ``MM-DD HH:MM`` for a full datetime (several runs a day are distinguishable)."""
+    if not isinstance(date_str, str):
+        return str(date_str)
+    day, sep, time = date_str.partition("T")
+    label = day[5:] if len(day) >= 10 else day  # strip the 'YYYY-' prefix
+    if sep and len(time) >= 5:
+        return f"{label} {time[:5]}"  # append HH:MM
+    return label
 
 
 def _trend(curr, older):
@@ -134,7 +148,7 @@ def build_columns(roles):
         cols.append(Column(("pr", None), f"⭐ this PR<br>`{label}`", "role"))
     nightly = roles.get("nightly")
     for day in reversed((nightly or {}).get("days", [])[-DISPLAY_DAYS:]):
-        cols.append(Column(("nightly", day["date"]), f"🌙 {day['date'][5:]}", "nightly"))
+        cols.append(Column(("nightly", day["date"]), f"🌙 {_short_when(day['date'])}", "nightly"))
     for role in ROLE_ORDER:
         rh = roles.get(role)
         ver = (latest_day(rh) or {}).get("version", "?") if rh else None

--- a/scripts/infra/perf/benchmarks/track.py
+++ b/scripts/infra/perf/benchmarks/track.py
@@ -17,6 +17,11 @@ Design notes
   ``date`` field). This is a loosening of the earlier day granularity: the workflow
   now runs several times a day, so intra-day points accumulate and the dashboard's
   time axis shows hours. Re-running at the exact same timestamp replaces in place.
+* Every point also records two descriptors (metadata only -- neither is used to skip):
+  a ``fingerprint`` (``version | hash(benchmark source)``) so a perf change with an
+  unchanged fingerprint points at the environment rather than the code; and an ``env``
+  block (runner CPU, physical/logical cores, arch, OS, runtime -- straight from the
+  BenchmarkDotNet report's HostEnvironmentInfo) so a hardware/runtime change is visible.
 * History is retained for ``MAX_AGE_DAYS`` days, so changing the run cadence only
   changes point density -- never the length of the retained window.
 
@@ -30,6 +35,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import glob
+import hashlib
 import json
 import os
 import pathlib
@@ -73,6 +79,50 @@ def _point_time(entry: dict) -> dt.datetime | None:
     return parsed
 
 
+def _source_hash() -> str:
+    """Short hash of the benchmark source (.cs + .csproj). Combined with the pinned
+    version it forms a point's ``fingerprint`` -- recorded so the dashboard can tell a
+    same-code/same-version perf shift (environment) from a real code/version change."""
+    root = PROJECT_DIR
+    files = sorted(p for p in root.rglob("*")
+                   if p.suffix in (".cs", ".csproj")
+                   and "bin" not in p.parts and "obj" not in p.parts)
+    h = hashlib.sha256()
+    for p in files:
+        h.update(p.relative_to(root).as_posix().encode())
+        h.update(b"\0")
+        h.update(p.read_bytes())
+    return h.hexdigest()[:16]
+
+
+def fingerprint(version: str) -> str:
+    """Identifies the benchmarked code state: pinned version + benchmark source hash.
+    Recorded on every point (never used to skip a run)."""
+    return f"{version}|{_source_hash()}"
+
+
+def _extract_env(doc: dict) -> dict:
+    """Compact host/environment descriptor from a BDN report's ``HostEnvironmentInfo``.
+
+    Recorded per point so the dashboard can attribute a perf shift to a changed runner
+    (different CPU model, core count, arch, OS or runtime) rather than a code regression.
+    Keys BDN did not provide are dropped so the record stays clean.
+    """
+    h = doc.get("HostEnvironmentInfo") or {}
+    env = {
+        "cpu": h.get("ProcessorName"),
+        "physicalCpus": h.get("PhysicalProcessorCount"),
+        "physicalCores": h.get("PhysicalCoreCount"),
+        "logicalCores": h.get("LogicalCoreCount"),
+        "arch": h.get("Architecture"),
+        "os": h.get("OsVersion"),
+        "runtime": h.get("RuntimeVersion"),
+        "dotnetSdk": h.get("DotNetCliVersion"),
+        "bdnVersion": h.get("BenchmarkDotNetVersion"),
+    }
+    return {k: v for k, v in env.items() if v is not None}
+
+
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -96,8 +146,12 @@ def _num(value) -> float | None:
 # BenchmarkDotNet result parsing
 # --------------------------------------------------------------------------- #
 
-def parse_results(results_dir: str) -> dict[str, dict]:
+def parse_results(results_dir: str) -> tuple[dict[str, dict], dict]:
     """Merge every ``*-report-full.json`` in ``results_dir`` into one map.
+
+    Returns ``(benchmarks, env)`` where ``env`` is the host descriptor (see
+    ``_extract_env``) taken from the first report -- every report in a run shares the
+    same host, so one is representative.
 
     Records a superset of BenchmarkDotNet statistics so future dashboard work stays
     HTML-only (no re-collection): mean/median/min/max/p95/stdDev nanoseconds, allocated
@@ -113,6 +167,7 @@ def parse_results(results_dir: str) -> dict[str, dict]:
         )
 
     merged: dict[str, dict] = {}
+    env: dict = {}
     for path in files:
         try:
             with open(path, "r", encoding="utf-8") as fh:
@@ -120,6 +175,9 @@ def parse_results(results_dir: str) -> dict[str, dict]:
         except (json.JSONDecodeError, OSError) as err:
             _log(f"  ! skipping unreadable report {path}: {err}")
             continue
+
+        if not env:
+            env = _extract_env(doc)
 
         for bench in doc.get("Benchmarks", []):
             name = bench.get("FullName")
@@ -142,7 +200,7 @@ def parse_results(results_dir: str) -> dict[str, dict]:
             }
 
     _log(f"  parsed {len(merged)} benchmark(s) from {len(files)} report file(s)")
-    return merged
+    return merged, env
 
 
 # --------------------------------------------------------------------------- #
@@ -214,18 +272,22 @@ def main(argv: list[str]) -> int:
     args = parse_args(argv)
 
     _log(f"Collecting benchmark results for {args.os}...")
-    benchmarks = parse_results(str(_results_dir(args.role)))
+    benchmarks, env = parse_results(str(_results_dir(args.role)))
     if not benchmarks:
         _log("  no benchmarks parsed; leaving history unchanged")
         return 1
 
     history = load_history(args.history, args.os, args.role)
     now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    upsert_day(history, {
+    point = {
         "date": now,
         "version": args.version,
+        "fingerprint": fingerprint(args.version),
         "benchmarks": benchmarks,
-    }, MAX_AGE_DAYS)
+    }
+    if env:
+        point["env"] = env
+    upsert_day(history, point, MAX_AGE_DAYS)
     save_history(args.history, history)
     return 0
 

--- a/scripts/infra/perf/benchmarks/track.py
+++ b/scripts/infra/perf/benchmarks/track.py
@@ -9,18 +9,19 @@ nanoseconds) and the allocated bytes per operation.
 Design notes
 ------------
 * One history file **per operating system** (Linux / Windows / macOS). Each CI
-  matrix leg owns its own file and its own Actions cache, so the OSes never mix.
+  matrix leg owns its own file, so the OSes never mix.
 * A benchmark is keyed by its BenchmarkDotNet ``FullName``
   (``Namespace.Type.Method(Param: value)``). That name is the primary key of the
   time series -- renaming a benchmark starts a new series (by design).
-* History is retained for ``MAX_DAYS`` days even though the dashboard only shows
-  the most recent 10. Keeping more lets us look back further without re-running.
-* A leg is skipped (``--check`` prints ``skip``) when its fingerprint -- the pinned
-  version plus a hash of the benchmark source -- matches the last recorded one, so
-  unchanged baselines aren't re-run every day.
+* Each run records its own point, keyed by a full ISO-8601 UTC **datetime** (the
+  ``date`` field). This is a loosening of the earlier day granularity: the workflow
+  now runs several times a day, so intra-day points accumulate and the dashboard's
+  time axis shows hours. Re-running at the exact same timestamp replaces in place.
+* History is retained for ``MAX_AGE_DAYS`` days, so changing the run cadence only
+  changes point density -- never the length of the retained window.
 
 Only the Python standard library is used so the script runs on a clean runner.
-The history document is persisted between runs via the GitHub Actions cache; see
+The history document is persisted between runs on the ``aw-data`` branch; see
 ``.github/workflows/track-benchmarks.yml``.
 """
 
@@ -29,14 +30,13 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import glob
-import hashlib
 import json
 import os
 import pathlib
 import sys
 
 SCHEMA_VERSION = 1
-MAX_DAYS = 365  # days of history retained on disk (dashboard zooms across all of it)
+MAX_AGE_DAYS = 365  # age of history retained on disk (dashboard zooms across all of it)
 
 # This tracker is specific to the tracking projects, so its locations are constants.
 # From scripts/infra/perf/benchmarks/track.py, the repo root is parents[4].
@@ -51,24 +51,26 @@ def _results_dir(role: str) -> pathlib.Path:
     return base / "BenchmarkDotNet.Artifacts" / "results"
 
 
-def _source_hash() -> str:
-    """Short hash of the benchmark source (.cs + .csproj) — changes when a
-    benchmark is edited, so an unchanged baseline can be detected and skipped."""
-    root = PROJECT_DIR
-    files = sorted(p for p in root.rglob("*")
-                   if p.suffix in (".cs", ".csproj")
-                   and "bin" not in p.parts and "obj" not in p.parts)
-    h = hashlib.sha256()
-    for p in files:
-        h.update(p.relative_to(root).as_posix().encode())
-        h.update(b"\0")
-        h.update(p.read_bytes())
-    return h.hexdigest()[:16]
+def _point_time(entry: dict) -> dt.datetime | None:
+    """Parse a point's ``date`` into an aware UTC datetime.
 
-
-def fingerprint(version: str) -> str:
-    """A leg is unchanged when its pinned version and benchmark source are unchanged."""
-    return f"{version}|{_source_hash()}"
+    Tolerates both the legacy day granularity (``YYYY-MM-DD``) and the current full
+    ISO-8601 UTC datetime (``YYYY-MM-DDTHH:MM:SSZ``), so old and new points coexist.
+    Returns ``None`` when the value is missing or unparseable.
+    """
+    raw = (entry or {}).get("date")
+    if not isinstance(raw, str) or not raw:
+        return None
+    s = raw.strip()
+    if s.endswith("Z"):  # fromisoformat only learned 'Z' in 3.11
+        s = s[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed
 
 
 
@@ -171,15 +173,25 @@ def save_history(path: str, history: dict) -> None:
         json.dump(history, fh, indent=2, sort_keys=True)
     os.replace(tmp, path)
     _log(f"  wrote history -> {path} ({os.path.getsize(path) / 1024:.0f} KB, "
-         f"{len(history['days'])} day(s))")
+         f"{len(history['days'])} point(s))")
 
 
-def upsert_day(history: dict, entry: dict, max_days: int) -> None:
-    """Insert/replace the entry for its date, keep chronological, retain N days."""
-    days = [d for d in history.get("days", []) if d.get("date") != entry["date"]]
-    days.append(entry)
-    days.sort(key=lambda d: d["date"])
-    history["days"] = days[-max_days:]
+def upsert_day(history: dict, entry: dict, max_age_days: int) -> None:
+    """Insert/replace the point for its exact ``date`` key, keep chronological, and
+    retain points within ``max_age_days``.
+
+    ``date`` is now a full datetime, so each run is its own point; an idempotent
+    re-run at the same timestamp replaces in place. Retention is age-based (not a
+    fixed count), so changing the run cadence never shrinks the retained window.
+    """
+    _epoch = dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+    points = [d for d in history.get("days", []) if d.get("date") != entry["date"]]
+    points.append(entry)
+    points.sort(key=lambda d: _point_time(d) or _epoch)
+    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=max_age_days)
+    # Keep points newer than the cutoff; unparseable dates are kept (never silently dropped).
+    history["days"] = [d for d in points
+                       if (t := _point_time(d)) is None or t >= cutoff]
 
 
 # --------------------------------------------------------------------------- #
@@ -195,31 +207,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                    help="SkiaSharp package version being benchmarked.")
     p.add_argument("--os", default="?", help="OS label (stored for the dashboard).")
     p.add_argument("--role", default="nightly", help="Version role (stored for the dashboard).")
-    p.add_argument("--check", action="store_true",
-                   help="Print 'skip' if this leg's fingerprint matches the last recorded "
-                        "one (unchanged version + benchmark source), else 'run'. Records nothing.")
     return p.parse_args(argv)
-
-
-def _last_fingerprint(history_path: str) -> str:
-    if not os.path.exists(history_path):
-        return ""
-    try:
-        with open(history_path, "r", encoding="utf-8") as fh:
-            days = (json.load(fh) or {}).get("days") or []
-        return days[-1].get("fingerprint", "") if days else ""
-    except (json.JSONDecodeError, OSError):
-        return ""
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    fp = fingerprint(args.version)
-
-    if args.check:
-        last = _last_fingerprint(args.history)
-        print("skip" if (last and fp == last) else "run")
-        return 0
 
     _log(f"Collecting benchmark results for {args.os}...")
     benchmarks = parse_results(str(_results_dir(args.role)))
@@ -228,13 +220,12 @@ def main(argv: list[str]) -> int:
         return 1
 
     history = load_history(args.history, args.os, args.role)
-    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     upsert_day(history, {
-        "date": today,
+        "date": now,
         "version": args.version,
-        "fingerprint": fp,
         "benchmarks": benchmarks,
-    }, MAX_DAYS)
+    }, MAX_AGE_DAYS)
     save_history(args.history, history)
     return 0
 

--- a/scripts/infra/perf/templates/dashboard.html
+++ b/scripts/infra/perf/templates/dashboard.html
@@ -194,7 +194,7 @@
   const fmtTime = ns => ns==null?"·": ns<1e3?ns.toFixed(1)+" ns": ns<1e6?(ns/1e3).toFixed(2)+" µs": ns<1e9?(ns/1e6).toFixed(2)+" ms":(ns/1e9).toFixed(2)+" s";
   const fmtBytes = b => { if(b==null)return"·"; if(b<1024)return Math.round(b)+" B"; const k=b/1024; return k<1024?k.toFixed(1)+" KB":(k/1024).toFixed(2)+" MB"; };
   const fmtVal = (v,unit) => unit==="ns"?fmtTime(v):fmtBytes(v);
-  const dateMs = d => new Date(d+"T00:00:00Z").getTime();
+  const dateMs = d => new Date(/[T ]/.test(d) ? d : d+"T00:00:00Z").getTime();
   const esc = s => String(s==null?"":s).replace(/[&<>"]/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
   const getCss = n => getComputedStyle(document.documentElement).getPropertyValue(n).trim() || "#888";
 


### PR DESCRIPTION
## What & why

The benchmark tracker ran once a day and stored at most **one point per day** (keyed by `YYYY-MM-DD`, overwritten on re-run). This moves it to a **periodic 6-hour** schedule and records a **fresh data point on every run**, so we capture more of the trend (and runner/environment variation) and can freely speed up or slow down the cadence later.

## Changes

**Schedule + data model**
- `.github/workflows/track-benchmarks.yml` — `cron: "0 8 * * *"` → `cron: "0 */6 * * *"`; **removed** the per-leg `Check freshness` skip step and its guards so every leg runs and records each time (a run is only ~13–15 min, and we *want* the env variation).
- `scripts/infra/perf/benchmarks/track.py` — the point key `date` is now a full ISO-8601 UTC **datetime**, so each run is its own point (idempotent re-run at the same timestamp replaces in place). Retention is now **age-based** (`MAX_AGE_DAYS = 365`) so changing the cadence never shrinks the retained window.
- `scripts/infra/perf/benchmarks/render_md.py` — nightly columns labelled `MM-DD HH:MM` (legacy date-only points still `MM-DD`).
- `scripts/infra/perf/templates/dashboard.html` — one-line `dateMs` loosening so the already-`type:"time"` x-axis renders **hours**; the sizes trend keeps working via the date-only fallback.

**Recorded metadata (env-vs-code disambiguation)**
- Each point now records a **`fingerprint`** (`version | hash(benchmark source)`) — stored, **never used to skip**. Same fingerprint + different perf ⇒ environment; different fingerprint ⇒ code/version changed.
- Each point records an **`env`** block from the BenchmarkDotNet report's `HostEnvironmentInfo` (CPU, physical/logical cores, arch, OS, runtime, .NET SDK, BDN version). Both fields flow through `merge_summaries` into `index.json` and the dashboard's embedded data; renderers ignore them for now (surfacing in the UI is a follow-up). No RAM probe (BDN doesn't report it).

## Compatibility

Legacy date-only points already on the `aw-data` branch coexist and render with **no migration**. `merge_summaries.py`, `persist-aw-data.yml`, and the artifact-size tracker are untouched.

## Validation (real CI)

Verified on two full `Track - Benchmarks` runs against this PR:
- `resolve` ✓, all **15** benchmark legs ✓, all **3** PR source-build legs ✓, `report` ✓.
- A downloaded Linux nightly artifact confirmed a point with datetime `date`, `fingerprint`, and a full `env` block (`Intel Xeon 6973P-C`, 2 physical / 4 logical cores, X64, .NET 10.0.10). The runner CPU varied across runs (Intel Xeon 8370C / AMD EPYC 9V74 / Intel Xeon 6973P-C) — exactly the infra variation the `env` block now captures.
- One `report` run hit a transient `download-artifact@v4` 403 (GitHub infra, unrelated to this change); a re-run passed, and the next full run's `report` passed first try.