### PR TITLE
perf(sizes): fix size-history persistence (single-point overwrite)

### DIFF
--- a/.github/workflows/track-artifact-sizes.yml
+++ b/.github/workflows/track-artifact-sizes.yml
@@ -40,13 +40,15 @@ jobs:
 
       - name: Restore size history from data branch
         # Read the existing history from the aw-data branch (public raw URL, no auth).
-        # Missing (first run) is fine — track.py then starts a fresh document.
+        # The file is persisted as sizes/index.json (see persist-aw-data.yml); it must be
+        # restored under that same name or every run starts fresh and overwrites history
+        # with a single day's data point. Missing (first run) is fine.
         run: |
-          url="https://raw.githubusercontent.com/${{ github.repository }}/${DATA_BRANCH}/sizes/artifact-sizes.json"
+          url="https://raw.githubusercontent.com/${{ github.repository }}/${DATA_BRANCH}/sizes/index.json"
           if curl -fsSL "$url" -o artifact-sizes.json; then
-            echo "restored artifact-sizes.json from $DATA_BRANCH"
+            echo "restored size history from $DATA_BRANCH/sizes/index.json"
           else
-            echo "no existing artifact-sizes.json on $DATA_BRANCH (fresh start)"
+            echo "no existing sizes/index.json on $DATA_BRANCH (fresh start)"
             rm -f artifact-sizes.json
           fi
 


### PR DESCRIPTION
## Problem

The **artifact-size tracker only ever showed a single data point**, even though it had been running for days.

Root cause is a filename mismatch in the persistence loop:

| Step | File |
|------|------|
| `track-artifact-sizes.yml` **restore** | `aw-data/sizes/artifact-sizes.json` |
| `persist-aw-data.yml` **write** | `aw-data/sizes/index.json` |

The restore `curl` 404'd on every run, so `track.py` started from a fresh document and each day's run overwrote the summary with just that day's nightly point. The additive per-date **raw** snapshots kept accumulating (they're keyed by filename), which is exactly why the branch had multiple `sizes/raw/*.json` files but a single point in `sizes/index.json`.

The benchmark tracker doesn't have this bug — it restores from `benchmarks/index.json` (the path it's persisted at), which is why the perf series has a full history.

## Fix

Restore the size history from `sizes/index.json` so the nightly series accumulates across runs, matching the benchmark tracker's model. One-line change to the workflow.

## Backfill (already applied to `aw-data`, not in this PR)

The missing history has been **backfilled directly to the `aw-data` branch** so the size series now lines up with the perf series: **49 nightly points, 2026-05-01 → 2026-07-17**, same dates and same nightly versions as the benchmark tracker.

How it works: nightly packages are never deleted from the EAP feed, and the feed's registration service exposes each version's `published` date, so the headline nightly for any past date is the SemVer-max nightly published on-or-before it (what `latest_nightly` would have returned that day; SkiaSharp and HarfBuzzSharp resolved independently). Each package's size is read with tiny HTTP **Range** requests — `.nupkg` size from `Content-Length`, native sizes from the ZIP central directory at the file tail — instead of downloading ~25 GB of packages. It was validated to reproduce the committed 2026-07-17 snapshot exactly (40/40 packages, nupkg + natives).

This is a one-time operation (we'll most likely never backfill again), so the script is **not** committed — it's preserved below for the record.

<details>
<summary>Backfill script (<code>scripts/infra/perf/sizes/backfill.py</code>) — one-time, kept here for reference</summary>

```python
#!/usr/bin/env python3
"""Backfill historical nightly NuGet sizes into the size-tracker history.

The daily tracker (``track.py``) only measures *today's* headline nightly, so a
freshly-seeded history has a single data point. This script reconstructs the
missing history so the size time-series lines up with the benchmark/perf
time-series (same dates, same nightly versions).

How it works
------------
Nightly packages are never deleted from the SkiaSharp EAP feed, so every past
build is still measurable. Two things make the backfill cheap:

* **Dates → versions.** The feed's ``RegistrationsBaseUrl`` service exposes a
  ``published`` timestamp for every version. For any target date the *headline*
  nightly is the SemVer-max ``-nightly.*`` published on-or-before that date -
  exactly what ``latest_nightly`` would have returned on that day. SkiaSharp and
  HarfBuzzSharp headlines are resolved independently (as the daily tracker does).

* **Sizes without downloading.** A package's ``.nupkg`` size is its HTTP
  ``Content-Length``; the per-file (native) uncompressed sizes live in the ZIP
  *central directory* at the tail of the file. Both are obtained with a couple of
  small HTTP *Range* requests instead of pulling the whole (often 100+ MB) package.
  Anything unexpected (ZIP64, parse error, no Range support) falls back to a full
  download via ``measure_nupkg``.

The reconstructed points are merged into the existing history with the same
``upsert_nightly`` the daily tracker uses (keyed by date), so re-running is
idempotent and never clobbers a real observation.

Only the Python standard library is used.
"""

from __future__ import annotations

import argparse
import concurrent.futures
import datetime as dt
import io
import json
import os
import struct
import sys
import urllib.error
import urllib.request
import zipfile

_HERE = os.path.dirname(os.path.abspath(__file__))
sys.path.insert(0, os.path.dirname(_HERE))  # perf/  (for _common)
sys.path.insert(0, _HERE)                   # sizes/ (for track)

from _common import (  # noqa: E402
    EAP_INDEX_URL,
    feed_versions,
    http_get_json,
    pick_resource,
    semver_key,
)
import track  # noqa: E402  (reuse classification + history helpers)

USER_AGENT = "skiasharp-artifact-size-backfill/1.0 (+https://github.com/mono/SkiaSharp)"

# End-of-central-directory / central-directory signatures.
_EOCD_SIG = b"PK\x05\x06"
_EOCD64_LOCATOR_SIG = b"PK\x06\x07"
_CEN_SIG = b"PK\x01\x02"


def _log(msg: str) -> None:
    print(msg, file=sys.stderr, flush=True)


# --------------------------------------------------------------------------- #
# Ranged HTTP + ZIP central-directory parsing
# --------------------------------------------------------------------------- #

def _range_get(url: str, start: int | None, end: int | None, *,
               retries: int = 4, timeout: int = 120) -> tuple[bytes, int | None]:
    """GET a byte range. ``start=None`` means a suffix range (last ``-end`` bytes).

    Returns ``(body, total_size)`` where ``total_size`` is parsed from the
    ``Content-Range`` header (``None`` if the server ignored the range).
    """
    if start is None:
        rng = f"bytes=-{end}"
    elif end is None:
        rng = f"bytes={start}-"
    else:
        rng = f"bytes={start}-{end}"
    last: Exception | None = None
    for attempt in range(1, retries + 1):
        try:
            req = urllib.request.Request(
                url, headers={"User-Agent": USER_AGENT, "Range": rng})
            with urllib.request.urlopen(req, timeout=timeout) as resp:
                body = resp.read()
                total = None
                cr = resp.headers.get("Content-Range")  # "bytes A-B/T"
                if cr and "/" in cr:
                    tail = cr.rsplit("/", 1)[-1].strip()
                    if tail.isdigit():
                        total = int(tail)
                return body, total
        except (urllib.error.URLError, TimeoutError, ConnectionError) as err:
            last = err
            import time
            time.sleep(min(20, 2 ** attempt))
    raise RuntimeError(f"range GET failed after {retries} attempts: {url}\n  {last}")


def _parse_central_directory(cd: bytes) -> dict[str, int]:
    """Parse ZIP central-directory bytes into ``{filename: uncompressed_size}``.

    Raises ``ValueError`` on any structure it does not understand (ZIP64 sizes,
    truncation) so the caller can fall back to a full download.
    """
    files: dict[str, int] = {}
    pos = 0
    n = len(cd)
    while pos + 4 <= n and cd[pos:pos + 4] == _CEN_SIG:
        if pos + 46 > n:
            raise ValueError("central directory record truncated")
        (uncomp,) = struct.unpack_from("<I", cd, pos + 24)
        name_len, extra_len, comment_len = struct.unpack_from("<HHH", cd, pos + 28)
        name_start = pos + 46
        name_end = name_start + name_len
        if name_end > n:
            raise ValueError("central directory filename truncated")
        name = cd[name_start:name_end].decode("utf-8", "replace")
        if uncomp == 0xFFFFFFFF:
            # ZIP64 real size lives in the extra field; punt to full download.
            raise ValueError("ZIP64 uncompressed size")
        files[name] = uncomp
        pos = name_end + extra_len + comment_len
    if not files:
        raise ValueError("no central-directory records found")
    return files


def remote_measure(flat_base: str, package_id: str, version: str) -> dict | None:
    """Measure a nupkg via HTTP Range only (no full download).

    Returns ``{"nupkg", "natives", "files"}`` (same shape as ``measure_nupkg``),
    or ``None`` if the package is absent. Falls back to a full download on any
    structural surprise.
    """
    lower = package_id.lower()
    url = f"{flat_base.rstrip('/')}/{lower}/{version}/{lower}.{version}.nupkg"

    # Grow the tail window until it holds the whole central directory.
    tail_len = 65536
    for _ in range(5):
        try:
            tail, total = _range_get(url, None, tail_len)
        except RuntimeError:
            return None
        if total is None:
            return _full_measure(url)  # server ignored Range
        if _EOCD64_LOCATOR_SIG in tail:
            return _full_measure(url)  # ZIP64
        eocd = tail.rfind(_EOCD_SIG)
        if eocd == -1:
            if tail_len >= total:
                break
            tail_len = min(total, tail_len * 4)
            continue
        try:
            cd_size, cd_offset = struct.unpack_from("<II", tail, eocd + 12)
        except struct.error:
            break
        if cd_size == 0xFFFFFFFF or cd_offset == 0xFFFFFFFF:
            return _full_measure(url)  # ZIP64
        tail_start = total - len(tail)
        if cd_offset >= tail_start:
            cd = tail[cd_offset - tail_start: cd_offset - tail_start + cd_size]
        else:
            try:
                cd, _ = _range_get(url, cd_offset, cd_offset + cd_size - 1)
            except RuntimeError:
                return _full_measure(url)
        try:
            files = _parse_central_directory(cd)
        except ValueError:
            return _full_measure(url)
        natives = {name: sz for name, sz in files.items()
                   if track._is_native_entry(name)}
        return {"nupkg": total, "natives": natives, "files": files}
    return _full_measure(url)


def _full_measure(url: str) -> dict | None:
    """Fallback: download the whole nupkg into memory and measure it."""
    try:
        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
        with urllib.request.urlopen(req, timeout=600) as resp:
            blob = resp.read()
    except (urllib.error.URLError, TimeoutError, ConnectionError):
        return None
    natives: dict[str, int] = {}
    files: dict[str, int] = {}
    try:
        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
            for zi in zf.infolist():
                if zi.is_dir():
                    continue
                files[zi.filename] = zi.file_size
                if track._is_native_entry(zi.filename):
                    natives[zi.filename] = zi.file_size
    except zipfile.BadZipFile:
        return {"nupkg": len(blob), "natives": {}, "files": {}}
    return {"nupkg": len(blob), "natives": natives, "files": files}


# --------------------------------------------------------------------------- #
# Registration (published dates) + headline resolution
# --------------------------------------------------------------------------- #

def resolve_registration_base() -> str:
    """The EAP feed's semver2 RegistrationsBaseUrl (carries ``published`` dates)."""
    resources = http_get_json(EAP_INDEX_URL).get("resources", [])
    base = (pick_resource(resources, "RegistrationsBaseUrl/Versioned")
            or pick_resource(resources, "RegistrationsBaseUrl/3.6.0")
            or pick_resource(resources, "RegistrationsBaseUrl"))
    if not base:
        raise RuntimeError("EAP feed index has no RegistrationsBaseUrl resource.")
    return base


def nightly_published(reg_base: str, package_id: str) -> dict[str, str]:
    """``{version: published_iso}`` for every ``-nightly.*`` version of a package."""
    url = f"{reg_base.rstrip('/')}/{package_id.lower()}/index.json"
    try:
        reg = http_get_json(url)
    except RuntimeError:
        return {}
    out: dict[str, str] = {}
    for page in reg.get("items", []):
        items = page.get("items")
        if items is None:
            page_url = page.get("@id")
            if not page_url:
                continue
            try:
                items = http_get_json(page_url).get("items", [])
            except RuntimeError:
                continue
        for it in items:
            ce = it.get("catalogEntry", {})
            ver = ce.get("version", "")
            pub = ce.get("published", "")
            if ver and pub and "-nightly." in ver.lower():
                out[ver] = pub
    return out


def headline_on_or_before(published: dict[str, str], date: str) -> str | None:
    """SemVer-max ``-nightly.*`` published on-or-before ``date`` (YYYY-MM-DD).

    Mirrors the daily tracker's ``latest_nightly`` (SemVer-max) restricted to the
    versions that existed by ``date`` — i.e. what the tracker would have recorded.
    """
    cutoff = f"{date}T23:59:59Z"
    eligible = [v for v, pub in published.items() if pub <= cutoff]
    if not eligible:
        return None
    return sorted(eligible, key=semver_key)[-1]


# --------------------------------------------------------------------------- #
# Date set
# --------------------------------------------------------------------------- #

def dates_from_benchmarks(path: str) -> list[str]:
    """Day-granularity dates present in a benchmark ``index.json`` (all nightly legs).

    Intraday datetime points (``...THH:MM:SSZ``) are collapsed to their date so the
    size series lands on the same calendar days as the perf series.
    """
    with open(path, "r", encoding="utf-8") as fh:
        idx = json.load(fh)
    dates: set[str] = set()
    for leg, doc in (idx.get("legs") or {}).items():
        if not leg.endswith("|nightly"):
            continue
        for point in doc.get("days", []):
            d = str(point.get("date", ""))[:10]
            if len(d) == 10:
                dates.add(d)
    return sorted(dates)


# --------------------------------------------------------------------------- #
# Backfill
# --------------------------------------------------------------------------- #

def _measure_one(flat: str, pkg_id: str, version: str,
                 cache: dict[str, dict]) -> dict | None:
    key = f"{pkg_id}@{version}"
    if key not in cache:
        cache[key] = remote_measure(flat, pkg_id, version)
    return cache[key]


def backfill(history: dict, dates: list[str], *, raw_dir: str | None,
             workers: int) -> int:
    feed = track.resolve_eap_feed()
    flat = feed["flat"]
    reg_base = resolve_registration_base()

    package_ids = track.enumerate_feed_packages(feed["search"])
    if not package_ids:
        raise RuntimeError("Could not enumerate any packages from the EAP feed.")

    _log(f"  {len(package_ids)} feed packages; resolving published dates...")
    published = {
        "skia": nightly_published(reg_base, "SkiaSharp"),
        "harfbuzz": nightly_published(reg_base, "HarfBuzzSharp"),
    }
    # Which versions each package actually shipped (so we skip absent ones).
    pkg_versions = {pid: set(feed_versions(flat, pid)) for pid in package_ids}

    measure_cache: dict[str, dict] = {}
    added = 0
    for date in dates:
        headlines = {
            "skia": headline_on_or_before(published["skia"], date),
            "harfbuzz": headline_on_or_before(published["harfbuzz"], date),
        }
        if not headlines["skia"]:
            _log(f"  {date}: no skia nightly published yet; skipping")
            continue

        # (package, version) pairs to measure for this date.
        jobs: list[tuple[str, str]] = []
        for pid in package_ids:
            target = headlines[track._nightly_family(pid)]
            if target and target in pkg_versions.get(pid, ()):
                jobs.append((pid, target))

        packages: dict[str, dict] = {}
        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
            futs = {pool.submit(_measure_one, flat, pid, ver, measure_cache): (pid, ver)
                    for pid, ver in jobs}
            for fut in concurrent.futures.as_completed(futs):
                pid, ver = futs[fut]
                m = fut.result()
                if m is not None:
                    packages[pid] = {"version": ver, **m}

        if not packages:
            _log(f"  {date}: nothing measured; skipping")
            continue

        if raw_dir:
            os.makedirs(raw_dir, exist_ok=True)
            raw_pkgs = {pid: {"version": m["version"], "nupkg": m["nupkg"],
                              "files": m.get("files", {})}
                        for pid, m in packages.items()}
            with open(os.path.join(raw_dir, f"{date}.json"), "w", encoding="utf-8") as fh:
                json.dump({"date": date, "version": headlines["skia"],
                           "packages": raw_pkgs}, fh)

        summary = {pid: {"version": m["version"], "nupkg": m["nupkg"],
                         "natives": m.get("natives", {})}
                   for pid, m in packages.items()}
        track.upsert_nightly(history, {
            "date": date,
            "version": headlines["skia"],
            "packages": summary,
        }, max_nightly=100000)  # retain everything; retention is a track.py concern
        added += 1
        _log(f"  {date}: skia={headlines['skia']} hb={headlines['harfbuzz']} "
             f"-> {len(summary)} packages")
    return added


# --------------------------------------------------------------------------- #
# Main
# --------------------------------------------------------------------------- #

def parse_args(argv: list[str]) -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__,
                                formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--history", default="artifact-sizes.json",
                   help="Size history document to read + write (index.json).")
    p.add_argument("--benchmarks", default=None,
                   help="Benchmark index.json whose nightly dates define the backfill "
                        "date set (aligns sizes to the perf time-series).")
    p.add_argument("--dates", default=None,
                   help="Comma-separated YYYY-MM-DD dates to backfill (alternative to "
                        "--benchmarks).")
    p.add_argument("--min-date", default=None,
                   help="Drop backfill dates earlier than this (YYYY-MM-DD).")
    p.add_argument("--raw-dir", default=None,
                   help="Also write per-date raw snapshots (full per-file breakdown) here.")
    p.add_argument("--workers", type=int, default=8,
                   help="Concurrent package measurements (default: 8).")
    return p.parse_args(argv)


def main(argv: list[str]) -> int:
    args = parse_args(argv)

    if args.dates:
        dates = sorted({d.strip() for d in args.dates.split(",") if d.strip()})
    elif args.benchmarks:
        dates = dates_from_benchmarks(args.benchmarks)
    else:
        _log("error: provide --benchmarks or --dates")
        return 2
    if args.min_date:
        dates = [d for d in dates if d >= args.min_date]
    if not dates:
        _log("no dates to backfill")
        return 1

    history = track.load_history(args.history)
    _log(f"Backfilling {len(dates)} date(s): {dates[0]} .. {dates[-1]}")
    added = backfill(history, dates, raw_dir=args.raw_dir, workers=args.workers)

    history["nightly"].sort(key=lambda n: n["date"])
    track.save_history(args.history, history)
    _log(f"  backfilled {added} nightly point(s); history now has "
         f"{len(history['nightly'])} point(s)")
    return 0


if __name__ == "__main__":
    sys.exit(main(sys.argv[1:]))
```

</details>
