### PR TITLE
Add regression-tracking benchmarks for common colour/interop paths

### DIFF
--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/ColorMathBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/ColorMathBenchmark.cs
@@ -1,0 +1,83 @@
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks.Tracking;
+
+// Per-item colour conversions that live (mostly) in the managed wrapper — the kind of
+// hot maths that per-frame / per-pixel loops hit through the public API:
+//   * SKColor -> SKColorF   (ported to managed C# in #4370; hit by animated shader uniforms)
+//   * SKPMColor.PreMultiply / UnPreMultiply (ported to managed int maths in #4385)
+// All deterministic and allocation-free, so the Allocated column is a clean machine-
+// independent signal, and the ToColorF/ToColor time ratio (reverse is still native, #4370
+// left it so) flags a managed regression even on noisy shared CI runners.
+public class ColorMathBenchmark
+{
+	[Params(4096)]
+	public int Colors { get; set; }
+
+	private SKColor[] _colors = null!;
+	private SKColorF[] _colorFs = null!;
+	private SKPMColor[] _pmColors = null!;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		// Deterministic inputs (fixed seed) so the workload is identical everywhere. Alpha
+		// is varied across the full 0..255 range so the premultiply maths is exercised.
+		var rnd = new Random (42);
+		_colors = new SKColor[Colors];
+		_colorFs = new SKColorF[Colors];
+		_pmColors = new SKPMColor[Colors];
+		for (var i = 0; i < Colors; i++) {
+			var c = new SKColor (
+				(byte)rnd.Next (256), (byte)rnd.Next (256),
+				(byte)rnd.Next (256), (byte)rnd.Next (256));
+			_colors[i] = c;
+			_colorFs[i] = c;                       // native reverse input, precomputed
+			_pmColors[i] = SKPMColor.PreMultiply (c);
+		}
+	}
+
+	// #4370: managed SKColor -> SKColorF. XOR into an int sink so the JIT cannot elide the
+	// conversion; the returned sink keeps the result live.
+	[Benchmark]
+	public int ToColorF ()
+	{
+		var sink = 0;
+		foreach (var c in _colors) {
+			SKColorF f = c;
+			sink ^= (int)(f.Red * 255f) ^ (int)(f.Green * 255f) ^ (int)(f.Blue * 255f);
+		}
+		return sink;
+	}
+
+	// Contrast sentinel: SKColorF -> SKColor is still native (#4370 deliberately left it),
+	// so a managed regression in ToColorF surfaces as a diverging ToColorF/ToColor ratio.
+	[Benchmark]
+	public int ToColor ()
+	{
+		var sink = 0;
+		foreach (var f in _colorFs)
+			sink ^= (int)(uint)(SKColor)f;
+		return sink;
+	}
+
+	// #4385: managed SKColor -> premultiplied SKPMColor.
+	[Benchmark]
+	public int PreMultiply ()
+	{
+		var sink = 0;
+		foreach (var c in _colors)
+			sink ^= (int)(uint)SKPMColor.PreMultiply (c);
+		return sink;
+	}
+
+	// #4385: managed premultiplied -> straight SKColor (the 256-entry scale-table path).
+	[Benchmark]
+	public int UnPreMultiply ()
+	{
+		var sink = 0;
+		foreach (var pm in _pmColors)
+			sink ^= (int)(uint)SKPMColor.UnPreMultiply (pm);
+		return sink;
+	}
+}

--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/RasterImageLifecycleBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/RasterImageLifecycleBenchmark.cs
@@ -1,0 +1,65 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks.Tracking;
+
+// Short-lived native-backed object churn: allocate + dispose many small objects per op.
+// This is the exact create/dispose lifecycle the recent leak fixes touch — #4455 (the
+// CoTaskMem raster buffer inside SKImage.Create) and #4453 (the GCHandle for a managed
+// release delegate in SKData.Create). MemoryDiagnoser's Allocated bytes + GC counts are the
+// tracked signal here: a future per-object managed-alloc regression (an added closure,
+// boxing, or an un-freed handle) would show as a step in this benchmark's allocation line.
+public class RasterImageLifecycleBenchmark
+{
+	[Params(256)]
+	public int Count { get; set; }
+
+	private const int Width = 64;
+	private const int Height = 64;
+	private const int BufferBytes = 256;
+
+	private SKImageInfo _info;
+	private SKDataReleaseDelegate _release = null!;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		_info = new SKImageInfo (Width, Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+		// A single reused delegate, so the only per-iteration managed allocation attributable
+		// to the create path is what it does internally (a native GCHandle), not a fresh
+		// closure per call.
+		_release = static (address, _) => Marshal.FreeCoTaskMem (address);
+	}
+
+	// #4455: SKImage.Create(info) allocates a CoTaskMem raster buffer, wraps it, and frees it
+	// on Dispose via a built-in release proc. Create + Dispose, Count times.
+	[Benchmark]
+	public int CreateRasterImage ()
+	{
+		var alive = 0;
+		for (var i = 0; i < Count; i++) {
+			using var image = SKImage.Create (_info);
+			if (image is not null)
+				alive++;
+		}
+		return alive;
+	}
+
+	// #4453: SKData.Create(ptr, len, releaseProc) pins the managed delegate via a GCHandle for
+	// native; Dispose invokes the proc, which frees the buffer. Each op owns a fresh CoTaskMem
+	// buffer that the SKData takes ownership of through the release proc.
+	[Benchmark]
+	public int CreateDataWithReleaseProc ()
+	{
+		var alive = 0;
+		for (var i = 0; i < Count; i++) {
+			var buffer = Marshal.AllocCoTaskMem (BufferBytes);
+			using var data = SKData.Create (buffer, BufferBytes, _release);
+			if (data is not null)
+				alive++;
+			else
+				Marshal.FreeCoTaskMem (buffer); // create failed => proc never runs; free here
+		}
+		return alive;
+	}
+}

--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/RuntimeEffectShaderBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/RuntimeEffectShaderBenchmark.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks.Tracking;
+
+// A per-frame animated-shader workload against the public runtime-effect API: one compiled
+// SKRuntimeEffect is reused, and each op rebuilds the uniforms (a float time + an SKColor
+// tint), turns them into a shader, and paints a full-surface rect. This is the common path
+// an app with an animated SkSL shader pays every frame, and it stitches together several of
+// the areas the recent PRs touched:
+//   * SKRuntimeEffectUniforms build + ToData lifecycle — where #4442 fixed an SKData leak;
+//   * the managed SKColor -> SKColorF convert (#4370) is paid when setting the colour uniform;
+//   * shader creation + a real draw.
+// Per-frame allocations are the headline signal (a leak or extra managed alloc here is paid
+// at frame rate), alongside the wall-clock time.
+public class RuntimeEffectShaderBenchmark
+{
+	private const int Size = 256;
+
+	// Deterministic, self-contained SkSL (no external content). Uses only the two uniforms
+	// the benchmark sets each frame so the compile is stable across every SkiaSharp version.
+	private const string Sksl =
+		"uniform float time;" +
+		"uniform float4 tint;" +
+		"half4 main(float2 p) {" +
+		"  float2 uv = p / float2(256.0, 256.0);" +
+		"  float w = 0.5 + 0.5 * sin(time + uv.x * 6.2831853);" +
+		"  return half4(half3(tint.rgb) * half(w), half(tint.a));" +
+		"}";
+
+	private SKSurface _surface = null!;
+	private SKCanvas _canvas = null!;
+	private SKRuntimeEffect _effect = null!;
+	private SKPaint _paint = null!;
+	private SKRect _rect;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		_surface = SKSurface.Create (new SKImageInfo (Size, Size));
+		_canvas = _surface.Canvas;
+		_effect = SKRuntimeEffect.CreateShader (Sksl, out var errors)
+			?? throw new InvalidOperationException ("SkSL failed to compile: " + errors);
+		_paint = new SKPaint ();
+		_rect = new SKRect (0, 0, Size, Size);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		_paint.Dispose ();
+		_effect.Dispose ();
+		_surface.Dispose ();
+	}
+
+	// One animated frame: fresh uniforms (time + an SKColor tint that hits the #4370 convert),
+	// build the shader, paint it. The shader is disposed after the draw (the native paint holds
+	// its own ref for the duration of DrawRect).
+	[Benchmark]
+	public int DrawFrame ()
+	{
+		using var uniforms = new SKRuntimeEffectUniforms (_effect) {
+			{ "time", 1.5f },
+			{ "tint", new SKColor (90, 160, 220, 255) }, // SKColor -> SKColorF convert (#4370)
+		};
+		using var shader = _effect.ToShader (uniforms);
+		_paint.Shader = shader;
+		_canvas.DrawRect (_rect, _paint);
+		_canvas.Flush ();
+		return Size;
+	}
+}

--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/SceneRenderBenchmark.cs
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/Benchmarks/SceneRenderBenchmark.cs
@@ -1,0 +1,165 @@
+using BenchmarkDotNet.Attributes;
+
+namespace SkiaSharp.Benchmarks.Tracking;
+
+// The "touch many things" tracker: one representative composite frame rendered onto a reused
+// CPU surface, deliberately broad so that many unrelated future optimizations each nudge it a
+// little (the opposite of a micro-benchmark that only moves for one change). It walks the
+// common draw path end to end — transforms, linear + radial gradient shaders, filled and
+// stroked primitives, a built path, a scaled image draw (the CPU image-sampling path from
+// #4421), a colour-filter layer, and clipping — then a managed colour-maths step (premultiply
+// + SKColor->SKColorF over a small palette, weaving in #4370 / #4385). No fonts or external
+// content (machine-dependent); `Complexity` scales how many times the scene is layered.
+public class SceneRenderBenchmark
+{
+	[Params(1, 4)]
+	public int Complexity { get; set; }
+
+	private const int Size = 512;
+	private const int SourceSize = 128;
+
+	private SKSurface _surface = null!;
+	private SKCanvas _canvas = null!;
+	private SKImage _image = null!;
+	private SKPaint _fill = null!;
+	private SKPaint _stroke = null!;
+	private SKPaint _linear = null!;
+	private SKPaint _radial = null!;
+	private SKPaint _filtered = null!;
+	private SKPath _path = null!;
+	private SKColor[] _palette = null!;
+	private SKRect _srcRect;
+	private SKRect _dstRect;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		_surface = SKSurface.Create (new SKImageInfo (Size, Size));
+		_canvas = _surface.Canvas;
+		_image = CreateSource ();
+
+		_fill = new SKPaint { Color = SKColors.CornflowerBlue, IsAntialias = true, Style = SKPaintStyle.Fill };
+		_stroke = new SKPaint { Color = SKColors.OrangeRed, IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 3 };
+
+		_linear = new SKPaint { IsAntialias = true };
+		_linear.Shader = SKShader.CreateLinearGradient (
+			new SKPoint (0, 0), new SKPoint (Size, Size),
+			new[] { SKColors.MidnightBlue, SKColors.Teal, SKColors.Gold },
+			SKShaderTileMode.Clamp);
+
+		_radial = new SKPaint { IsAntialias = true };
+		_radial.Shader = SKShader.CreateRadialGradient (
+			new SKPoint (Size / 2f, Size / 2f), Size / 2f,
+			new[] { SKColors.White, SKColors.DarkSlateGray },
+			SKShaderTileMode.Clamp);
+
+		_filtered = new SKPaint { IsAntialias = true, Color = SKColors.White };
+		_filtered.ColorFilter = SKColorFilter.CreateBlendMode (SKColors.MediumPurple, SKBlendMode.Multiply);
+
+		// A representative palette for the managed colour-maths step. Deterministic + varied alpha.
+		var rnd = new Random (42);
+		_palette = new SKColor[64];
+		for (var i = 0; i < _palette.Length; i++)
+			_palette[i] = new SKColor ((byte)rnd.Next (256), (byte)rnd.Next (256), (byte)rnd.Next (256), (byte)rnd.Next (256));
+
+		// Version-appropriate path construction: SKPathBuilder on 4.x+, classic SKPath below.
+#if SKIASHARP_4_OR_GREATER
+		using (var builder = new SKPathBuilder ()) {
+			builder.MoveTo (40, 40);
+			builder.LineTo (300, 90);
+			builder.CubicTo (360, 200, 120, 260, 200, 380);
+			builder.LineTo (60, 300);
+			builder.Close ();
+			_path = builder.Snapshot ();
+		}
+#else
+		_path = new SKPath ();
+		_path.MoveTo (40, 40);
+		_path.LineTo (300, 90);
+		_path.CubicTo (360, 200, 120, 260, 200, 380);
+		_path.LineTo (60, 300);
+		_path.Close ();
+#endif
+
+		_srcRect = new SKRect (0, 0, SourceSize, SourceSize);
+		_dstRect = new SKRect (0, 0, Size * 0.7f, Size * 0.7f); // non-integer scale => sampling
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		_path.Dispose ();
+		_filtered.Dispose ();
+		_radial.Dispose ();
+		_linear.Dispose ();
+		_stroke.Dispose ();
+		_fill.Dispose ();
+		_image.Dispose ();
+		_surface.Dispose ();
+	}
+
+	// A busy, non-uniform source image so the scaled draw genuinely samples texels.
+	private static SKImage CreateSource ()
+	{
+		using var surface = SKSurface.Create (new SKImageInfo (SourceSize, SourceSize));
+		var canvas = surface.Canvas;
+		canvas.Clear (SKColors.White);
+		using var fill = new SKPaint { IsAntialias = false };
+		for (var y = 0; y < SourceSize; y += 16) {
+			for (var x = 0; x < SourceSize; x += 16) {
+				fill.Color = ((x + y) / 16 % 2 == 0) ? SKColors.SeaGreen : SKColors.Goldenrod;
+				canvas.DrawRect (new SKRect (x, y, x + 12, y + 12), fill);
+			}
+		}
+		return surface.Snapshot ();
+	}
+
+	[Benchmark]
+	public int RenderFrame ()
+	{
+		_canvas.Clear (SKColors.White);
+
+		for (var r = 0; r < Complexity; r++) {
+			_canvas.Save ();
+			_canvas.Translate (r * 8f, r * 8f);
+			_canvas.RotateDegrees (r * 5f, Size / 2f, Size / 2f);
+			_canvas.Scale (1f - r * 0.05f);
+
+			// Gradient shader fills (linear + radial).
+			_canvas.DrawRect (new SKRect (0, 0, Size, Size), _linear);
+			_canvas.DrawCircle (Size / 2f, Size / 2f, Size / 3f, _radial);
+
+			// Filled + stroked primitives.
+			_canvas.DrawRect (new SKRect (40, 40, 220, 180), _fill);
+			_canvas.DrawRoundRect (new SKRect (60, 220, 260, 360), 18, 18, _stroke);
+			_canvas.DrawOval (new SKRect (280, 60, 460, 200), _fill);
+			_canvas.DrawCircle (360, 300, 70, _stroke);
+
+			// A built path.
+			_canvas.DrawPath (_path, _stroke);
+
+			// Scaled image draw (the #4421 CPU sampling path).
+			_canvas.DrawImage (_image, _srcRect, _dstRect, SKSamplingOptions.Default, _fill);
+
+			// A colour-filter layer.
+			_canvas.DrawRect (new SKRect (150, 150, 380, 320), _filtered);
+
+			// Clipping + a clipped path draw.
+			_canvas.ClipRect (new SKRect (80, 80, 420, 420));
+			_canvas.DrawPath (_path, _fill);
+
+			_canvas.Restore ();
+		}
+
+		// Managed colour maths over the palette (weaves in #4385 + #4370) with a live sink.
+		var sink = 0;
+		foreach (var c in _palette) {
+			sink ^= (int)(uint)SKPMColor.PreMultiply (c);
+			SKColorF f = c;
+			sink ^= (int)(f.Red * 255f);
+		}
+
+		_canvas.Flush ();
+		return sink;
+	}
+}


### PR DESCRIPTION
## What

Expand `benchmarks/SkiaSharp.Benchmarks.Tracking` with a small, curated set of **permanent** regression benchmarks, derived from the areas the recent perf/agentic PRs touch. Each new benchmark is one `.cs` file in `Tracking/Benchmarks/`, so it's automatically picked up by both the package-mode project and the source-mode `…Tracking.Source` project (the ⭐ `pr` column).

Following the project's philosophy (and how `dotnet/performance` / `aspnetcore` structure their suites), this is a **scaled pyramid** — a few small common-path trackers + one large "touch many things" indicator — *not* a micro-benchmark per PR.

### Tier 1 — small common-path trackers

- **`ColorMathBenchmark`** — managed `SKColor → SKColorF` (#4370) + `SKPMColor.PreMultiply` / `UnPreMultiply` (#4385). Pure managed, zero-alloc; the `ToColorF`/`ToColor` ratio (the reverse operator stays native) is a clean managed-regression signal even on noisy shared runners.
- **`RasterImageLifecycleBenchmark`** — create+dispose churn of `SKImage.Create` raster (#4455) and `SKData.Create` with a managed release proc (#4453). `MemoryDiagnoser`'s **Allocated** bytes are the tracked signal for the leak-fix area.
- **`RuntimeEffectShaderBenchmark`** — a per-frame animated SkSL shader: build uniforms (an `SKColor` uniform hits the #4370 convert), `ToShader`, draw. Exercises the uniforms lifecycle whose `SKData` leak #4442 fixed; per-frame allocation is the headline.

### Tier 2 — large composite

- **`SceneRenderBenchmark`** — one broad frame (transforms, linear + radial gradients, filled/stroked primitives, a built path, a scaled image draw = the #4421 CPU sampling path, a colour-filter layer, clipping, managed colour maths). Deliberately broad so many unrelated future optimizations each nudge it — a **merge indicator**.

**Not added:** #4372 (niche `SKNWayCanvas`/`SKOverdrawCanvas` debug wrappers) and #4468 (HarfBuzz — a separate assembly the tracking project doesn't reference).

## Constraints honoured

- **Public API only** (project references the nightly NuGet, no internal `SkiaApi`).
- **Deterministic + machine-independent**: fixed seeds, no fonts/external content.
- **Never-rename** names chosen for permanent history keys.
- Compile against both the **3.119 baseline** and **4.x nightly** (only `SKPath`/`SKPathBuilder` needs the existing `#if`).

## Validation

### Local (short job)

Built against SkiaSharp **4.151.0-preview.2.1** and **3.119.4**; a `--job short` run emits time + allocation data for every case:

| Benchmark | Mean | Allocated |
|---|---:|---:|
| `ColorMathBenchmark.ToColorF` (managed, #4370) | 9,986 ns | 0 B |
| `ColorMathBenchmark.ToColor` (native reverse, sentinel) | 15,930 ns | 0 B |
| `ColorMathBenchmark.PreMultiply` (#4385) | 10,239 ns | 0 B |
| `ColorMathBenchmark.UnPreMultiply` (#4385) | 6,986 ns | 0 B |
| `RasterImageLifecycleBenchmark.CreateRasterImage` (#4455) | 235 µs | 55,296 B |
| `RasterImageLifecycleBenchmark.CreateDataWithReleaseProc` (#4453) | 57.7 µs | 34,816 B |
| `RuntimeEffectShaderBenchmark.DrawFrame` (#4442) | 328 µs | 680 B |
| `SceneRenderBenchmark.RenderFrame` (Complexity 1 / 4) | 1.05 ms / 4.53 ms | 0 B |

(The managed `ToColorF` already measuring faster than the still-native `ToColor` is the #4370 win showing through.)

### CI baseline — `pr` column, run [29608575980](https://github.com/mono/SkiaSharp/actions/runs/29608575980) (2026-07-17)

Full source build of this branch (the ⭐ `pr` role) on the GitHub-hosted runners — one point per OS, the **baseline** each future run diffs against. Managed allocation is OS-independent (single column). On `pr`/HEAD `ToColorF` is still native, so expect its line to drop once #4370 merges.

| Benchmark (params) | Linux | Windows | macOS | Allocated |
|---|---:|---:|---:|---:|
| `ColorMathBenchmark.ToColorF` (4096) | 21.5 µs | 32.6 µs | 14.5 µs | 0 B |
| `ColorMathBenchmark.ToColor` (4096) | 14.1 µs | 15.8 µs | 21.4 µs | 0 B |
| `ColorMathBenchmark.PreMultiply` (4096) | 15.9 µs | 23.1 µs | 11.1 µs | 0 B |
| `ColorMathBenchmark.UnPreMultiply` (4096) | 14.6 µs | 19.2 µs | 9.0 µs | 0 B |
| `RasterImageLifecycleBenchmark.CreateRasterImage` (256) | 263.5 µs | 283.7 µs | 166.3 µs | 54.0 KB |
| `RasterImageLifecycleBenchmark.CreateDataWithReleaseProc` (256) | 117.2 µs | 131.1 µs | 84.6 µs | 34.0 KB |
| `RuntimeEffectShaderBenchmark.DrawFrame` | 2.83 ms | 1.12 ms | 558 µs | ~0.7 KB |
| `SceneRenderBenchmark.RenderFrame` (Complexity 1) | 4.90 ms | 2.56 ms | 1.46 ms | 0 B |
| `SceneRenderBenchmark.RenderFrame` (Complexity 4) | 19.18 ms | 10.76 ms | 6.04 ms | 0 B |

All 21 legs green (3 OSes × source `pr` + 5 package roles incl. `prev-major` 3.119.4); the `perf-dashboard` artifact renders all four benchmarks.

Absolute ns are environment-dependent; the tracked signals are per-OS version-role ratios + allocations.
