### PR TITLE
[WASM] Fix net11 exception-handling mismatch in emsdk 5.0.6 native libs

### DIFF
--- a/native/wasm/build.cake
+++ b/native/wasm/build.cake
@@ -23,6 +23,7 @@ Task("libSkiaSharp")
     bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd") || EMSCRIPTEN_FEATURES.Contains("_simd");
     bool hasThreadingEnabled = EMSCRIPTEN_FEATURES.Contains("mt");
     bool hasWasmEH = EMSCRIPTEN_FEATURES.Contains("_wasmeh");
+    bool hasNewExc = EMSCRIPTEN_FEATURES.Contains("_newexc");
 
     var emscriptenFeaturesModifiers = 
         EMSCRIPTEN_FEATURES
@@ -66,9 +67,10 @@ Task("libSkiaSharp")
         $"  { (hasSimdEnabled ? ", '-msimd128'" : "") } " +
         $"  { (hasThreadingEnabled ? ", '-pthread'" : "") } " +
         $"  { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } " +
+        $"  { (hasNewExc ? ", '-s', 'WASM_LEGACY_EXCEPTIONS=0'" : "") } " +
         $"] " +
         // SIMD support is based on https://github.com/google/skia/blob/1f193df9b393d50da39570dab77a0bb5d28ec8ef/modules/canvaskit/compile.sh#L57
-        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
+        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } { (hasNewExc ? ", '-s', 'WASM_LEGACY_EXCEPTIONS=0'" : "") } ] " +
         $"skia_emsdk_dir='{EMSCRIPTEN_ROOT}'" +
         COMPILERS +
         ADDITIONAL_GN_ARGS);
@@ -116,6 +118,7 @@ Task("libHarfBuzzSharp")
     bool hasSimdEnabled = EMSCRIPTEN_FEATURES.Contains("simd") || EMSCRIPTEN_FEATURES.Contains("_simd");
     bool hasThreadingEnabled = EMSCRIPTEN_FEATURES.Contains("mt");
     bool hasWasmEH = EMSCRIPTEN_FEATURES.Contains("_wasmeh");
+    bool hasNewExc = EMSCRIPTEN_FEATURES.Contains("_newexc");
 
     var emscriptenFeaturesModifiers = 
         EMSCRIPTEN_FEATURES
@@ -127,8 +130,8 @@ Task("libHarfBuzzSharp")
         $"target_cpu='wasm' " +
         $"is_static_skiasharp=true " +
         $"skia_use_partition_alloc=false " +
-        $"extra_cflags=[ '-s', 'WARN_UNALIGNED=1' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
-        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } ] " +
+        $"extra_cflags=[ '-s', 'WARN_UNALIGNED=1' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } { (hasNewExc ? ", '-s', 'WASM_LEGACY_EXCEPTIONS=0'" : "") } ] " +
+        $"extra_cflags_cc=[ '-frtti' { (hasSimdEnabled ? ", '-msimd128'" : "") } { (hasThreadingEnabled ? ", '-pthread'" : "") } { (hasWasmEH ? ", '-fwasm-exceptions'" : "") } { (hasNewExc ? ", '-s', 'WASM_LEGACY_EXCEPTIONS=0'" : "") } ] " +
         $"skia_emsdk_dir='{EMSCRIPTEN_ROOT}'" +
         COMPILERS +
         ADDITIONAL_GN_ARGS);

--- a/scripts/azure-templates-stages-native-wasm.yml
+++ b/scripts/azure-templates-stages-native-wasm.yml
@@ -59,16 +59,16 @@ stages:
             - 5.0.6:
               displayName: 5.0.6
               version: 5.0.6
-              features: _wasmeh,st
+              features: _wasmeh,_newexc,st
             - 5.0.6:
               displayName: '5.0.6_Threading'
               version: 5.0.6
-              features: _wasmeh,mt
+              features: _wasmeh,_newexc,mt
             - 5.0.6:
               displayName: '5.0.6_SIMD'
               version: 5.0.6
-              features: _wasmeh,st,simd
+              features: _wasmeh,_newexc,st,simd
             - 5.0.6:
               displayName: '5.0.6_SIMD_Threading'
               version: 5.0.6
-              features: _wasmeh,mt,simd
+              features: _wasmeh,_newexc,mt,simd


### PR DESCRIPTION
## Problem

A .NET 11 Blazor WebAssembly app referencing SkiaSharp links fine (PR #4459 routes net11.0+ to the emsdk 5.0.6 static lib) but **fails at runtime** in a modern browser:

```
CompileError: WebAssembly.compileStreaming(): module uses a mix of legacy and
new exception handling instructions (function #19801)
```

.NET 11 (preview 6+) links WASM apps with the **new** exnref exception-handling model (`WASM_LEGACY_EXCEPTIONS=0` → `try_table`/`throw_ref`). SkiaSharp's emsdk 5.0.6 `libSkiaSharp.a`/`libHarfBuzzSharp.a` are compiled with `-fwasm-exceptions` but **without pinning the instruction variant**, so they emit the **legacy** wasm-EH instructions (`try`/`catch`). V8 refuses to compile a module that mixes both schemes → the error.

## Fix

Compile the **5.0.6 (net11) variant only** with the new EH instruction set so it matches .NET 11:

- `native/wasm/build.cake`: add a `_newexc` emscripten feature that appends `-s WASM_LEGACY_EXCEPTIONS=0` to `extra_cflags` **and** `extra_cflags_cc` (a compile-time codegen flag — required both for C++ exceptions and for the wasm setjmp/longjmp in the C deps like libjpeg-turbo/libpng). Emscripten's `settings.js` documents that codegen-affecting settings must be passed at compile time when wasm object files are produced, which the `.a` build does.
- `scripts/azure-templates-stages-native-wasm.yml`: add `_newexc` to the four **5.0.6** matrix entries only.

**net8 (3.1.34) and net9/net10 (3.1.56) stay on legacy EH** to match their runtimes — those emsdks predate the exnref proposal. No packaging/targets changes are needed (`_`-prefixed feature tokens are excluded from the artifact path, and the net11.0+ → 5.0.6 selection already exists from #4459).

## Verification

Rebuilt the emsdk 5.0.6 `st` and `st,simd` libraries from source with this change and confirmed on a net11.0 Blazor WASM app in a modern browser:

| TFM | libSkiaSharp | Result |
|---|---|---|
| net11 | shipped `4.151.0-preview.3.2` (legacy EH) | ❌ `CompileError … mix of legacy and new exception handling instructions` |
| net11 | rebuilt `5.0.6/st` + `st,simd` (new EH) | ✅ SkiaSharp draws + encodes a valid PNG (`native OK`) |
| net10 | shipped `3.1.56` (legacy EH) | ✅ unaffected by this change |

Link flags confirm the split: net11 links `-mllvm -wasm-use-legacy-eh=0` + `-lc++-wasmexcept`; net10 links `-lc++-except` with no `-wasm-use-legacy-eh=0`. The rebuilt `.a` disassembles to the new `try_table`/`throw_ref` instructions with no legacy `try`-block/`delegate`/`rethrow`. CI (build 1517651) is green: the four native `WASM (5.0.6*)` jobs build with the flag and all net8/9/10 stages are unchanged.

## Follow-up

Automated net11 WASM regression coverage (running the real WASM test suite on net11) is tracked as a separate stacked PR to keep this change focused on the build fix.