### PR TITLE
[WASM] Add preview-.NET WASM test job to catch exception-handling regressions

### DIFF
--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -28,6 +28,8 @@ parameters:
   installLlvm: true                             # whether or not to install the LLVM compiler
   installEmsdk: false                           # whether or not to install the Emscripten SDK
   installNinja: false                           # whether or not to install the ninja build system
+  installPreviewSdk: false                      # whether to install the preview .NET SDK ($(DOTNET_VERSION_PREVIEW)) and pin global.json to it
+  previewWorkloads: ''                           # workloads to install under the preview .NET SDK (comma-separated, e.g. 'wasm-tools,android')
   installXcode: true                            # whether or not to install Xcode
   publishArtifacts: []                          # the additional artifacts to publish
   tools: []                                     # any additional .net global tools
@@ -231,6 +233,30 @@ jobs:
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             retryCountOnTaskFailure: 3
             displayName: Install the .NET workloads
+        # install and select the preview .NET SDK (opt-in; for jobs that run against a preview runtime)
+        - ${{ if eq(parameters.installPreviewSdk, 'true') }}:
+          - task: UseDotNet@2
+            displayName: Install .NET $(DOTNET_VERSION_PREVIEW) (preview)
+            retryCountOnTaskFailure: 3
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            inputs:
+              packageType: sdk
+              version: $(DOTNET_VERSION_PREVIEW)
+          - pwsh: |
+              $globalJson = @{ sdk = @{ version = "$(DOTNET_VERSION_PREVIEW)"; allowPrerelease = $true; rollForward = "latestFeature" } } | ConvertTo-Json
+              Set-Content -Path global.json -Value $globalJson
+              Get-Content global.json
+              dotnet --version
+            displayName: Pin global.json to the preview .NET SDK
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          - ${{ if ne(parameters.previewWorkloads, '') }}:
+            # Reuse the shared workload install script, pinned to the exact preview workload set.
+            # WASM tests still restore the platform TFMs (e.g. -android) of referenced projects, so
+            # those workloads must be installed too — same as the non-preview test jobs.
+            - pwsh: .\scripts\infra\managed\install-dotnet-workloads.ps1 -Workloads "${{ parameters.previewWorkloads }}" -WorkloadSetVersion "$(DOTNET_WORKLOAD_VERSION_PREVIEW)" -Tizen ""
+              displayName: Install the preview .NET workloads (${{ parameters.previewWorkloads }})
+              retryCountOnTaskFailure: 3
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
 
       # install the mac tools
       - ${{ if and(eq(parameters.installXcode, 'true'), ne(parameters.buildAgent.parameters.installXcode, 'false'), eq(parameters.buildAgent.pool.os, 'macos'), ne(parameters.skipInstall, 'true')) }}:

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -340,6 +340,36 @@ stages:
               - name: testlogs_wasm
                 always: true
                 path: 'output/logs/testlogs'
+        - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Tests [WASM Preview] (Linux)
+          parameters:
+            # Runs the SkiaSharp.Tests.Wasm suite as the preview .NET (tests only — the rest of CI
+            # stays on net10) so WASM regressions on the newer runtime, such as an exception-handling
+            # mismatch in the native lib, fail CI. installPreviewSdk provisions the preview SDK +
+            # wasm-tools workload (which bundles the matching emscripten) and pins global.json to it.
+            name: tests_wasm_preview_linux
+            displayName: WASM Preview (Linux)
+            buildAgent: ${{ parameters.buildAgentLinux }}
+            packages: $(MANAGED_LINUX_PACKAGES) ninja-build
+            target: tests-wasm
+            additionalArgs: --skipExternals="all" --coverage=false --previewtfm=true
+            installAndroidSdk: false
+            shouldPublish: false
+            installPreviewSdk: true
+            previewWorkloads: wasm-tools,android
+            requiredArtifacts:
+              - name: native
+            postBuildSteps:
+              - task: PublishTestResults@2
+                displayName: Publish the WASM preview test results
+                condition: always()
+                inputs:
+                  testResultsFormat: VSTest
+                  testResultsFiles: 'output/logs/testlogs/**/*.trx'
+                  testRunTitle: 'Linux WASM Preview Tests'
+            publishArtifacts:
+              - name: testlogs_wasm_preview
+                always: true
+                path: 'output/logs/testlogs'
         # TODO: add tests for linux alpine
         # TODO: add tests for linux no dependencies
         # TODO: add tests for windows nano server

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -18,6 +18,10 @@ variables:
   XCODE_VERSION_NATIVE: '16.2'
   VISUAL_STUDIO_VERSION: ''
   DOTNET_VERSION: '10.0.108'
+  # Preview .NET SDK version + its workload set, used by jobs that run tests against a preview
+  # runtime. Bump both to the next preview .NET as it moves forward.
+  DOTNET_VERSION_PREVIEW: '11.0.100-preview.6.26359.118'
+  DOTNET_WORKLOAD_VERSION_PREVIEW: '11.0.100-preview.6.26364.2'
   DOTNET_WORKLOAD_TIZEN: '10.0.100/10.0.123'
   DOTNET_WORKLOAD_VERSION: '10.0.108'
   CONFIGURATION: 'Release'

--- a/scripts/infra/tests/tests-wasm.cake
+++ b/scripts/infra/tests/tests-wasm.cake
@@ -5,16 +5,28 @@ DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../../.."));
 #load "test-shared.cake"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// WASM TESTS — build and run browser-based tests via dotnet test
+// WASM TESTS — build and run the browser-based SkiaSharp.Tests.Wasm suite via dotnet test.
+//
+// Pass --previewtfm=true to build and run the suite as the preview .NET (-p:UsePreviewTFM=true).
+// The preview SDK and its wasm-tools workload must already be installed and selected (global.json)
+// by the caller.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Task ("Default")
     .Does (() =>
 {
     FilePath csproj = $"{ROOT_PATH}/tests/SkiaSharp.Tests.Wasm/SkiaSharp.Tests.Wasm.csproj";
-    DirectoryPath results = $"{ROOT_PATH}/output/logs/testlogs/SkiaSharp.Tests.Wasm/{DATE_TIME_STR}";
 
-    RunDeviceRunnersTest(csproj, results, noBuild: SKIP_BUILD);
+    var previewTfm = Argument("previewtfm", false);
+
+    var subdir = previewTfm ? "SkiaSharp.Tests.Wasm.Preview" : "SkiaSharp.Tests.Wasm";
+    DirectoryPath results = $"{ROOT_PATH}/output/logs/testlogs/{subdir}/{DATE_TIME_STR}";
+
+    var properties = previewTfm
+        ? new Dictionary<string, string> { ["UsePreviewTFM"] = "true" }
+        : null;
+
+    RunDeviceRunnersTest(csproj, results, noBuild: SKIP_BUILD, properties: properties);
 });
 
 RunTarget(TARGET);

--- a/source/SkiaSharp.Build.props
+++ b/source/SkiaSharp.Build.props
@@ -68,6 +68,17 @@
     <TFMMinimum>net6.0</TFMMinimum>
   </PropertyGroup>
 
+  <!--
+    Opt-in (off by default): shift the .NET version window forward one release, so projects target
+    the preview .NET and its predecessor instead of the current/previous shipping versions. Dropping
+    the now-EOL oldest version lets everything build cleanly under a preview .NET SDK. Enabled by the
+    preview WASM test job.
+  -->
+  <PropertyGroup Condition="'$(UsePreviewTFM)' == 'true'">
+    <TFMPrevious>net10.0</TFMPrevious>
+    <TFMCurrent>net11.0</TFMCurrent>
+  </PropertyGroup>
+
   <!-- Target Platform Versions -->
   <PropertyGroup>
     <!-- Previous (net9.0) -->


### PR DESCRIPTION
## What

Adds **automated preview-.NET WebAssembly regression coverage** by running the **existing** `tests/SkiaSharp.Tests.Wasm` suite as the preview .NET (currently net11) in CI. It is off by default; only this one test job opts in, so the rest of CI stays on net10 and the shipping TFMs are unchanged.

## Why

The emsdk 5.0.6 WASM `libSkiaSharp` can emit **legacy** wasm exception-handling instructions while the preview .NET links WASM apps with the **new** exnref model (`WASM_LEGACY_EXCEPTIONS=0`). Mixing them makes the WASM app fail **at runtime in the browser** with:

> `CompileError: WebAssembly.compileStreaming(): module uses a mix of legacy and new exception handling instructions`

There was **no CI test** that would have caught this. This PR is that guard: it runs the real WASM suite on the preview runtime, so an EH mismatch — or any preview-runtime WASM breakage — turns the build red.

## How

- **`source/SkiaSharp.Build.props`** — opt-in `UsePreviewTFM` toggle (default off): shifts the .NET version window forward one release (dropping the now-EOL oldest version) so projects build cleanly under a preview .NET SDK.
- **`scripts/infra/tests/tests-wasm.cake`** — `--previewtfm=true` runs the suite with `-p:UsePreviewTFM=true`. The cake is the run; it does not provision.
- **`scripts/azure-templates-jobs-bootstrapper.yml`** — reusable `installPreviewSdk` + `previewWorkloads` params (install the preview SDK, pin global.json to it, install the requested preview workloads) so other jobs can opt into a preview-runtime run.
- **`scripts/azure-templates-variables.yml`** — `DOTNET_VERSION_PREVIEW` + `DOTNET_WORKLOAD_VERSION_PREVIEW` (default `DOTNET_VERSION` stays net10).
- **`scripts/azure-templates-stages-test.yml`** — `tests_wasm_preview_linux` job (consumes the `native` artifact, `installPreviewSdk: true`, `previewWorkloads: wasm-tools`, runs `tests-wasm --previewtfm=true`). The net10 `tests_wasm_linux` job is unchanged.

## Validation

Locally verified end-to-end **both paths** (preview SDK, DeviceRunners headless browser, real 5.0.6 `st,simd` natives from CI artifacts):
- **Pass path** (new-EH `_wasmeh,_newexc,st,simd` lib): the module compiles and the suite runs (1180 total / 1081 passed / 0 failed / 99 skipped).
- **Fail path** (legacy-EH `_wasmeh,st,simd` lib, i.e. main today): the browser fails with the exact `module uses a mix of legacy and new exception handling instructions` CompileError and the job goes red.

## Note on branching

This is currently based on `main`, which has the 5.0.6 native builds but **not** the EH fix (PR #4487), so the `tests_wasm_preview_linux` job is **expected to be red here** — that red is the negative control proving the guard works. Once #4487 lands on main (5.0.6 built with `_newexc`) and this branch is rebased, it goes green.