### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "15fb073bf63e1aaa3a9c3e88db511a2f10cfd969"
+          "commitHash": "80ba1418a67efa434107877d3d090d889f9a6286"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "87424bcdba68e14ff3b40524ed09ad150ce3c92e"
+      "upstream_merge_commit": "c3226a9bcd777ce15adb61e7181aac2aa57cf6da"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "80ba1418a67efa434107877d3d090d889f9a6286"
+          "commitHash": "4998e69e2ed8fbdc46d4d0602393d24b62d36295"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/286

# [skia-sync] Merge upstream chrome/m151 bug fixes

Same-milestone (m151 → m151) bug-fix sync. **Not a version bump** — only the submodule
pointer and `cgmanifest.json`'s tracking fields change.

## Companion mono/skia PR

Merge that PR first, then re-point the submodule to the squashed `skiasharp` SHA before
merging this one.

## Upstream changes

Two Ganesh runtime bug fixes (see companion PR for detail):

1. Unwind dirty tracking when a resolve task fails.
2. Ensure stencil is cleared on `kPreserve`.

Both changes are internal Ganesh implementation. No public headers, C API, `BUILD.gn`,
or `DEPS` touched upstream in this range, so:

## Breaking change analysis

**No breaking changes.** Zero changes to `include/`, zero changes to `externals/skia/src/c/`,
zero changes to `externals/skia/include/c/`. Binding regeneration produced **no diff** in
`binding/**` — the P/Invoke surface is byte-for-byte identical.

## Version/binding updates

- `cgmanifest.json`:
  - Skia `commitHash`: `15fb073bf6…` → `80ba1418a6…` (new merge commit)
  - `upstream_merge_commit`: `87424bcdba…` → `c3226a9bcd…` (upstream `chrome/m151` tip)
- `scripts/VERSIONS.txt`: **unchanged** (bug-fix sync, milestone stays 151, increment stays 0)
- `scripts/azure-templates-variables.yml`: **unchanged**
- `externals/skia/include/c/sk_types.h` `SK_C_INCREMENT`: **unchanged** (0)
- Submodule pointer: bumped to `80ba1418a6…` on `skia-sync/m151` branch.

## C# changes

None. `binding/SkiaSharp/SkiaApi.generated.cs` and the other generated bindings regenerate
byte-identically. No wrapper changes needed.

## Build & test results

- **Native (Linux x64):** clean build via `dotnet cake --target=externals-linux --arch=x64`.
  Produces `libSkiaSharp.so.151.0.0` (11.3 MB).
- **C# build:** `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — 0 errors, 4 warnings
  (pre-existing NETSDK1202 / xUnit analyzer warnings).
- **Full test suite:** `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj`
  - **Passed: 5711, Failed: 0, Skipped: 182, Total: 5893** (2m 43s)
  - Full log: `test-output.txt` workflow artifact.

## Items needing human attention

- The workflow's host-provisioned PowerShell 7.6 install is broken: the utility/management/security
  module `.psd1` files exist under `/opt/microsoft/powershell/7/Modules/` but their nested
  `.dll` implementations are not resolved (read-only fs prevents adding them side-by-side).
  As a result `.agents/skills/update-skia/scripts/update-versions.ps1` and
  `regenerate-bindings.ps1` cannot run in this environment. This sync performed the
  equivalent work by hand (edit `cgmanifest.json`, run the generator via
  `dotnet run --project utils/SkiaSharpGenerator`, revert `HarfBuzzApi.generated.cs`).
  The `Install native build dependencies` step in the workflow should also ensure a working
  PowerShell so future automated syncs can execute the skill scripts unmodified.

## Verification checklist

- [x] Submodule points to mono/skia PR branch (`80ba1418a6…` on `skia-sync/m151`)
- [x] `cgmanifest.json` `commitHash` and `upstream_merge_commit` updated
- [x] `SkiaApi.generated.cs` regenerated (no diff — API-identical merge)
- [x] Native build passes (Linux x64)
- [x] C# build passes (0 errors)
- [x] Full test suite passes (5711/5711)

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).