### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "4998e69e2ed8fbdc46d4d0602393d24b62d36295"
+          "commitHash": "e235d7efdbbadf137921737245cb8a80ca41620f"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "c3226a9bcd777ce15adb61e7181aac2aa57cf6da"
+      "upstream_merge_commit": "6e283b083ace7a6db4414e33ac3f49baf7aedcc2"
     }
   ]
 }


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/287

# mono/SkiaSharp — Sync submodule to upstream Skia `main` (m151 tip)

Pairs with the mono/skia PR on branch `skia-sync/main`.

This is a **main-tip sync**, not a milestone bump. `CURRENT == TARGET == 151`,
so SkiaSharp's public version numbers, soname, and NuGet package versions are
**unchanged**. Only the submodule pointer + cgmanifest metadata move.

## Parent-repo changes

| File | Change |
|------|--------|
| `externals/skia` | Submodule pointer advanced to the mono/skia `skia-sync/main` tip (upstream `main` merged, VMA bumped, milestone pinned to 151). |
| `cgmanifest.json` | `commitHash` → new mono/skia SHA; `upstream_merge_commit` → `6e283b083ace7a6db4414e33ac3f49baf7aedcc2` (google/skia `main` HEAD). `chrome_milestone` stays at **151**. |
| `scripts/VERSIONS.txt` | **No change** — same-milestone sync. |
| `scripts/azure-templates-variables.yml` | **No change** — `SKIASHARP_VERSION` stays `4.151.0`. |
| Bindings (`binding/SkiaSharp/SkiaApi.generated.cs`) | Regenerator ran, produced **zero diff** (no C API surface change from upstream). |

## Breaking-change analysis

Upstream `main` diff since our previous merge base touches ~10 public headers:

| Header | Change | Impact on SkiaSharp |
|--------|--------|---------------------|
| `include/core/SkMilestone.h` | Bumped to 152 | **Reverted** in fork — stays 151 |
| `include/core/SkSpan.h` | Added `SkPreIncrementSpan` / `SkPostIncrementSpan` transitional helpers | 🟢 Additive, no C API impact |
| `include/gpu/ganesh/GrRecordingContext.h` | Reordered `fProxyProvider` / `fDrawingManager` (destruction order fix) | 🟢 Private members, no ABI impact |
| `include/android/SkAndroidFrameworkUtils.h` | Removed `getSurfaceFromCanvas` | ⚪ Android framework helper — not used by our C API |
| `include/gpu/graphite/*.h` | Various Graphite additions | ⚪ SkiaSharp uses Ganesh, not Graphite |
| `include/config/copts.bzl`, `include/gpu/ganesh/d3d/BUILD.bazel`, `include/private/gpu/ganesh/BUILD.bazel` | Bazel/build-config only | ⚪ Not compiled into SkiaSharp |

No upstream removals landed in any header referenced by `externals/skia/src/c/`
or `externals/skia/include/c/`. `SkiaApi.generated.cs` regeneration confirms
zero C API drift.

## Binding regeneration

- `pwsh ./utils/generate.ps1` ran cleanly (per `regenerate-bindings.ps1`).
- `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` reverted (HarfBuzz updates are
  always separate — no `hb_language_impl_t` delegate fallout to hand-fix here).
- `binding/SkiaSharp/SkiaApi.generated.cs`: no changes.
- No new C API functions ⇒ no new C# wrappers required (Phase 9 skipped).

## C# changes

None. This is submodule metadata only.

## Build & test results

| Step | Result |
|------|--------|
| Native build (Linux x64, `dotnet cake --target=externals-linux --arch=x64`) | ✅ Green after VMA bump |
| Managed build (`dotnet build binding/SkiaSharp/SkiaSharp.csproj`) | ✅ 0 errors |
| Full test suite (`tests/SkiaSharp.Tests.Console`, net10.0 x64) | ✅ **5720 passed / 0 failed / 182 skipped** (2m 45s) |

Test log: `/tmp/gh-aw/agent/test-output.txt` (uploaded as workflow artifact).

## Items needing human attention

- **Vulkanmemoryallocator was bumped in mono/skia** to keep upstream's
  `VulkanAMDMemoryAllocator.cpp` compiling. Confirm the new revision is
  acceptable for the release line. See paired mono/skia PR.
- **Only Linux x64 was built here.** The other platforms (Windows x64,
  macOS x64/arm64, iOS, Android, WASM) will be exercised by CI on this PR.
  Watch specifically for Vulkan build differences resulting from the VMA bump.
- **Upstream deliberately dropped `SkAndroidFrameworkUtils::getSurfaceFromCanvas`.**
  Not referenced anywhere in our C API, but flagging in case a downstream
  Android consumer was reaching into that private header.
- Upstream bumped many active dependencies (brotli, expat, freetype, harfbuzz,
  libpng, libwebp, vulkan-headers) that we left at our current pins. Consider
  running the `native-dependency-update` skill on any of these that carry CVE
  or bug-fix motivation, in a follow-up PR.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).