### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "0aa2d542e833ffd1d4d1b68a5152375e7f65ce11"
+          "commitHash": "9280c2de358fa47f6b4f18b798522a865abe3004"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "bee4c917220040e147f14964635ff92ce6c5a3f6"
+      "upstream_merge_commit": "587c5b0f5a7b0260826a0c19094c2d952195066e"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/288

# [skia-sync] Merge upstream chrome/m150 bug fixes

Release-line bug-fix sync into `release/4.150.x`. Companion to mono/skia PR on branch
`skia-sync/release-4.150.x`.

## Breaking change analysis

None. Both upstream commits are internal Ganesh (GPU) bug fixes:
- Prevent stale readbacks (m150 backport).
- Unwind dirty tracking when a resolve task fails.

No public API, C API, or ABI changes.

## Version / binding updates

Same-milestone sync (m150 → m150): **no version bumps**. Only `cgmanifest.json` changed:
- `commitHash`: `0aa2d542e8…` → `9280c2de35…`
- `upstream_merge_commit`: `bee4c91722…` → `587c5b0f5a…`

`VERSIONS.txt` and `azure-templates-variables.yml` intentionally kept at their existing
`release/4.150.x` values (`4.150.2` / file `4.150.2.0`). The `update-versions.ps1` script defaults
these back to `4.150.0` on a same-milestone run — reverted manually because the release line has
already published `4.150.1`.

Bindings regenerated (`regenerate-bindings.ps1`): **no changes** (C API signatures unchanged).

## C# changes

None.

## Build & test results

- Native build (Linux x64): ✅ 16m 08s, clean.
- C# build (`binding/SkiaSharp/SkiaSharp.csproj`): ✅ 0 errors.
- Full test suite: ✅ **Passed 5584, Failed 0, Skipped 172, Total 5756** (2m 40s).

Test log: `test-output.txt` (workflow artifact).

## Items needing human attention

- Confirm the `update-versions.ps1` behavior of resetting nuget versions to `<major>.<milestone>.0`
  on same-milestone syncs is expected for release-line bug-fix syncs. It was reverted here so the
  release-line keeps its published `4.150.2` version.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).