### PR TITLE
Fix support-tier drift: drop stale 4.148 from support.stable

### DIFF
--- a/scripts/infra/docs/versions.json
+++ b/scripts/infra/docs/versions.json
@@ -3,7 +3,6 @@
   "support": {
     "$comment": "SkiaSharp's SUPPORTED release paths, used only by the release-notes TOC/index grouping. SkiaSharp ships NuGet packages on two paths (it is NOT a multi-tier channel product), so this is two lists of 'major.minor' lines (the SkiaSharp MINOR number IS the Chrome/Skia milestone). 'stable' = the supported stable line(s): normally the current Chrome Stable milestone, or the Chrome Extended-stable milestone during the promotion gap (when a preview is about to go stable). 'preview' = the in-flight preview/RC line(s): normally the Chrome Beta milestone, or newer when we are previewing ahead in Dev/Canary. Every other 3.x+ line is OUT OF SUPPORT; 1.x/2.x lines are OBSOLETE. MAINTAINED BY HAND on each release (we do not ship every Chrome milestone, so this must not be auto-derived from Chromium Dash). The security audit's heads-up check (.agents/skills/security-audit/scripts/query-milestone-schedule.py) compares these lists to the live Chrome channels and reports drift; the fix is always a manual edit here. Empty/absent block => every 3.x+ line is treated as supported (legacy behavior).",
     "stable": [
-      "4.148",
       "4.150"
     ],
     "preview": [


### PR DESCRIPTION
## Summary

`scripts/infra/docs/versions.json` `support.stable` listed `["4.148", "4.150"]`, but the current Chrome **Stable** milestone is **m150**. The `4.148` entry was stale drift left over from a prior milestone. This PR drops it so `support.stable` is `["4.150"]` only.

The `support` block drives the release-notes TOC/index grouping (supported stable + preview paths) and is maintained by hand on each release.

## Verification against live Chrome channels (2026-07-21)

| Channel | Milestone |
|---|---|
| Extended stable | m150 |
| Stable | m150 |
| Beta | m151 |
| Dev / Canary | m152 |

- **Extended stable = m150** (synced with Stable today, 8-week cadence), so there is no older extended-stable line to keep supported — `4.148` was pure drift, not an intentional extended-stable entry.
- **preview = `["4.151"]`** already matches Beta (m151) and is left unchanged. `main` is still on m151, so Dev/Canary's m152 is not yet a preview line.

The repo's own drift-check now reports OK for both paths:

```
Support tiers (versions.json):  🟢 OK
  stable=['4.150']  preview=['4.151']   (Chrome Extended m150 / Stable m150 / Beta m151)
  🟢 [OK] support.stable/preview match the Chrome channels
```

## Notes

- Docs-only/config-only change (release-notes support grouping). No code, native, or generated-file impact.
- Forward-looking heads-up (no action here): m152 branches ~2026-07-27; the next milestone bump will move `preview` to `4.152` and promote `4.151` toward stable.