### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "4998e69e2ed8fbdc46d4d0602393d24b62d36295"
+          "commitHash": "1308166c5f99aee238f1b1a62c975e98644f8300"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "c3226a9bcd777ce15adb61e7181aac2aa57cf6da"
+      "upstream_merge_commit": "b4204f7ff931ec662a690d00b2d1c19afeb3a4fe"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/289

# mono/SkiaSharp — Merge upstream chrome/m151 bug fixes

Same-milestone (m151 → m151) bug-fix sync. Bumps the `externals/skia` submodule to pick up one upstream Ganesh fix.

## Breaking change analysis

**None.** The only upstream commit is `b4204f7ff9 [M151] [ganesh] prevent stale readbacks`, an internal correctness fix in `GrDrawingManager` / `SurfaceContext` (Ganesh readback path). No C++ headers, no C API surface, no binding-generator input changed.

## Version / binding updates

- `scripts/VERSIONS.txt` — **unchanged** (release-line-style sync; milestone/soname/nuget versions stay at m151 / 151.0.0 / 4.151.0).
- `scripts/azure-templates-variables.yml` — **unchanged**.
- `externals/skia/include/c/sk_types.h` `SK_C_INCREMENT` — **unchanged** (still 0).
- `cgmanifest.json`:
  - `commitHash` → `1308166c5f99aee238f1b1a62c975e98644f8300` (new mono/skia `skia-sync/m151` tip)
  - `upstream_merge_commit` → `b4204f7ff931ec662a690d00b2d1c19afeb3a4fe`
- `binding/**/*.generated.cs` — regenerated; **zero diff vs `origin/main`** (no new/removed `internal static` P/Invokes).

## Build & test results (Linux x64)

- `dotnet cake --target=externals-linux --arch=x64`: ✅ built `libSkiaSharp.so` and `libHarfBuzzSharp.so` from source (~10 min).
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj`: ✅ 0 errors.
- Bindings regenerated via `utils/generate.ps1` (invoked directly per project — pwsh in this sandbox has a broken module auto-loader, so the wrapper scripts were bypassed); HarfBuzz binding reverted per skill Phase 8.
- `dotnet test tests/SkiaSharp.Tests.Console` full suite: **5720 passed / 182 skipped / 0 failed** on re-run.
  - First run reported 1 failure in `SKColorSpaceTest.ColorSpaceIsNotDisposedPrematurely` (`Assert.Equal(4, 3)` on a GC-timing check). Re-run of the full suite passed cleanly. The test is unrelated to this sync (Ganesh readback change cannot affect `SKColorSpace` reference counts) and is a known-flaky GC/finalizer timing test.

## C# changes

None. No wrappers to add or update.

## Items needing human attention

1. **Flaky test on first run.** `SKColorSpaceTest.ColorSpaceIsNotDisposedPrematurely` failed once with Expected=4 / Actual=3, passed on immediate re-run. Worth filing/checking an existing tracking issue — not caused by this PR.
2. **Sandbox-only workaround (not shipped).** The `.agents/skills/update-skia/scripts/update-versions.ps1` and `regenerate-bindings.ps1` scripts could not run in this container because `pwsh` here has a broken module auto-loader (`Get-Command New-Item` fails with `startIndex cannot be larger than length of string`; only manual `Import-Module <full-psd1-path>` works). This is an environment bug, not a repo bug — no source changes needed. If it recurs, the host `Install native build dependencies` step should reinstall/repair PowerShell (`Microsoft.PowerShell.Management` module auto-discovery). Manual equivalents of both scripts were executed instead.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).