### PR TITLE
Add compact PR benchmark comment to the benchmark tracking workflow

### DIFF
--- a/.github/workflows/track-benchmarks.yml
+++ b/.github/workflows/track-benchmarks.yml
@@ -368,6 +368,11 @@ jobs:
     needs: [benchmark, benchmark-source]
     if: always() && github.repository_owner == 'mono'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed only for the PR-only benchmark comment below. Informational, never blocks;
+      # on fork PRs the token is read-only, so the post step is best-effort (continue-on-error).
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -444,3 +449,53 @@ jobs:
           name: agent
           path: aw-upload
           if-no-files-found: warn
+
+      # ----------------------------------------------------------------------- #
+      # PR-only: a single, informational benchmark comment. render_pr_md.py reads the
+      # same per-(OS, role) histories downloaded above, compares the ⭐ source-built `pr`
+      # leg against the nightly baseline, and emits a COMPACT marker comment (highlights +
+      # collapsed per-OS details). It never blocks the PR.
+      # ----------------------------------------------------------------------- #
+      - name: Render PR benchmark comment
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 scripts/infra/perf/benchmarks/render_pr_md.py histories \
+            --output pr-benchmarks.md
+          echo "---- rendered PR benchmark comment ----"
+          cat pr-benchmarks.md
+
+      - name: Post or update PR benchmark comment
+        if: github.event_name == 'pull_request'
+        # Best-effort: on fork PRs the GITHUB_TOKEN is read-only and cannot comment. That must
+        # never fail the run — this is informational only.
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('pr-benchmarks.md', 'utf8');
+
+            // Unique marker so we find-update-or-create a single comment per PR (same
+            // pattern as pr-artifacts-comment.yml).
+            const marker = '<!-- skiasharp-pr-benchmarks -->';
+            const prNumber = context.payload.pull_request.number;
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+
+            // Find the existing marker comment (paginate in case of many comments).
+            let existing = null;
+            for await (const page of github.paginate.iterator(
+              github.rest.issues.listComments,
+              { ...repo, issue_number: prNumber, per_page: 100 }
+            )) {
+              existing = page.data.find(c => c.body.includes(marker));
+              if (existing) break;
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...repo, issue_number: prNumber, body });
+            }

--- a/scripts/infra/perf/benchmarks/render_pr_md.py
+++ b/scripts/infra/perf/benchmarks/render_pr_md.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Render a COMPACT Markdown PR comment summarising this PR's benchmark deltas.
+
+Reads the same per-(OS, role) ``benchmarks-<OS>-<role>.json`` histories the benchmark
+``report`` job already downloads, compares the ⭐ ``pr`` role (a full source build of the
+PR checkout) against a baseline role (``nightly`` by default -- the CI trend that tracks
+main one build behind), and emits a short, informational comment:
+
+  * a **Highlights** section with the biggest movers (time + allocations), and
+  * a collapsed ``<details>`` block with the full per-OS deltas.
+
+Only benchmarks that move beyond the shared 5% noise threshold are surfaced, so the
+comment stays a summary rather than a table dump. It carries an HTML marker
+(``<!-- skiasharp-pr-benchmarks -->``) so the workflow's github-script step can
+find-update-or-create a single comment per PR. Informational only -- it never blocks a PR.
+
+The time/byte formatters, the trend dots and the history loader are imported from
+``render_md`` (and the shared ``_common`` log helper) -- this script only adds the
+PR-vs-baseline comparison and the compact layout on top; it duplicates none of that logic.
+
+Only the Python standard library is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import namedtuple
+
+# Run by path from CI (not as a package): make the sibling perf modules importable.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PERF = os.path.dirname(_HERE)
+for _p in (_HERE, _PERF):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import _common  # noqa: E402  (shared stderr log helper)
+import render_md as rmd  # noqa: E402  (formatters, history loader, trend dots)
+
+MARKER = "<!-- skiasharp-pr-benchmarks -->"
+
+# Baseline preference: the first present role wins. ``nightly`` is the closest apples-to-
+# apples reference (the published CI build tracking main's source one build behind); the
+# released stables are fallbacks for when a nightly leg produced nothing this run.
+BASELINE_PREFERENCE = ("nightly", "curr-stable", "latest", "prev-stable", "prev-major")
+
+# Human labels for a chosen baseline role (plain hyphens for prose; the non-breaking
+# variants in render_md are for narrow table headers).
+BASELINE_LABELS = {
+    "nightly": "🌙 nightly",
+    "curr-stable": "curr-stable",
+    "latest": "latest",
+    "prev-stable": "prev-stable",
+    "prev-major": "prev-major",
+}
+
+# Metrics we diff: (json key, section title, formatter, worse-word, better-word). Lower is
+# better for both, so a positive delta (pr > baseline) is the "worse" direction.
+METRICS = (
+    ("meanNs", "⏱️ Time", rmd.human_time, "slower", "faster"),
+    ("allocatedBytes", "📦 Allocations", rmd.human_bytes, "more alloc", "less alloc"),
+)
+
+TOP_MOVERS = 5        # bullets per metric in the Highlights section
+MAX_DETAIL_ROWS = 25  # cap per OS/metric detail table so a broad move can't dump everything
+
+Mover = namedtuple("Mover", "os name pr base delta")
+
+
+# --------------------------------------------------------------------------- #
+# Comparison primitives
+# --------------------------------------------------------------------------- #
+
+def _pct(pr, base):
+    """Signed fractional change of ``pr`` vs ``base`` (>0 = slower/larger = worse)."""
+    if pr is None or base is None or base == 0:
+        return None
+    return (pr - base) / base
+
+
+def _dot(delta):
+    """Trend dot for a signed delta: 🔴 worse (slower/larger), 🟢 better (faster/smaller)."""
+    return rmd.TREND_SLOWER if delta > 0 else rmd.TREND_FASTER
+
+
+def pick_baseline(roles, forced=None):
+    """``(role, latest-day)`` of the baseline to compare against, or ``(None, None)``.
+
+    ``forced`` pins a specific role when present; otherwise the first role in
+    ``BASELINE_PREFERENCE`` that actually has data wins.
+    """
+    order = (forced,) if forced else BASELINE_PREFERENCE
+    for role in order:
+        day = rmd.latest_day(roles.get(role))
+        if day:
+            return role, day
+    return None, None
+
+
+def build_context(histories, forced=None):
+    """``(oses, ctx)`` where ``ctx[os] = {"pr", "baseRole", "base"}`` — the latest ⭐ pr
+    day and the resolved baseline day for each OS that has any data."""
+    oses = rmd.ordered_oses(histories)
+    ctx = {}
+    for o in oses:
+        roles = histories[o]
+        role, base = pick_baseline(roles, forced)
+        ctx[o] = {"pr": rmd.latest_day(roles.get("pr")), "baseRole": role, "base": base}
+    return oses, ctx
+
+
+def collect_movers(ctx, oses, key):
+    """Every benchmark (across ``oses``) whose ⭐ pr value moved beyond the shared noise
+    threshold vs its baseline, as ``Mover``s (unsorted)."""
+    movers = []
+    for o in oses:
+        c = ctx[o]
+        pr, base = c["pr"], c["base"]
+        if not pr or not base:
+            continue
+        names = set(pr.get("benchmarks", {})) | set(base.get("benchmarks", {}))
+        for name in names:
+            pv = rmd.metric(pr, name, key)
+            bv = rmd.metric(base, name, key)
+            delta = _pct(pv, bv)
+            if delta is None or abs(delta) < rmd.TREND_PCT:
+                continue
+            movers.append(Mover(o, name, pv, bv, delta))
+    return movers
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+def _title(pr_number, run_url):
+    head = "## 📊 SkiaSharp benchmarks"
+    if pr_number:
+        link = f"[PR #{pr_number}]({run_url})" if run_url else f"PR #{pr_number}"
+        head += f" — {link}"
+    return head
+
+
+def _no_pr_body(pr_number, run_url):
+    lines = [MARKER, "", _title(pr_number, run_url), "",
+             "_No ⭐ source-build (`pr`) benchmark results were produced for this run, so "
+             "there is nothing to compare yet._ The source-build legs are best-effort and "
+             "may be skipped (native unchanged) or may have failed — see the run for details.",
+             ""]
+    if run_url:
+        lines += [f"📈 [View the benchmark run &amp; `perf-dashboard` artifact →]({run_url})", ""]
+    return "\n".join(lines) + "\n"
+
+
+def _baseline_label_for(ctx, oses):
+    used = {ctx[o]["baseRole"] for o in oses if ctx[o]["pr"] and ctx[o]["base"]}
+    keyer = lambda r: BASELINE_PREFERENCE.index(r) if r in BASELINE_PREFERENCE else 99
+    return " / ".join(BASELINE_LABELS.get(r, r) for r in sorted(used, key=keyer)) or "baseline"
+
+
+def _highlights(ctx, oses):
+    """The visible summary: per-metric mover counts + the biggest movers as bullets.
+    Returns ``(lines, any_mover)``."""
+    lines = []
+    any_mover = False
+    for key, mtitle, fmt, worse, better in METRICS:
+        movers = sorted(collect_movers(ctx, oses, key), key=lambda m: abs(m.delta), reverse=True)
+        if not movers:
+            continue
+        any_mover = True
+        regr = sum(1 for m in movers if m.delta > 0)
+        impr = len(movers) - regr
+        lines.append(f"**{mtitle}** — {rmd.TREND_SLOWER} {regr} {worse} · "
+                     f"{rmd.TREND_FASTER} {impr} {better}")
+        for m in movers[:TOP_MOVERS]:
+            lines.append(f"- {_dot(m.delta)} `{rmd.short_name(m.name)}` · {m.os} · "
+                         f"{fmt(m.base)} → {fmt(m.pr)} ({m.delta:+.0%})")
+        extra = len(movers) - TOP_MOVERS
+        if extra > 0:
+            lines.append(f"- …and {extra} more (see details below)")
+        lines.append("")
+    return lines, any_mover
+
+
+def _details(ctx, oses):
+    """The collapsed full per-OS deltas (only moved rows)."""
+    lines = ["<details>", "<summary>Full per-OS benchmark deltas</summary>", ""]
+    for o in oses:
+        c = ctx[o]
+        if not c["pr"] or not c["base"]:
+            continue
+        os_blocks = []
+        for key, mtitle, fmt, *_ in METRICS:
+            rows = sorted(collect_movers(ctx, [o], key), key=lambda m: abs(m.delta), reverse=True)
+            if not rows:
+                continue
+            base_label = BASELINE_LABELS.get(c["baseRole"], c["baseRole"])
+            block = [f"**{mtitle}** (vs {base_label} `{c['base'].get('version', '?')}`)", "",
+                     "| Benchmark | baseline | this PR | Δ |", "|:--|--:|--:|--:|"]
+            for m in rows[:MAX_DETAIL_ROWS]:
+                block.append(f"| `{rmd.short_name(m.name)}` | {fmt(m.base)} | {fmt(m.pr)} | "
+                             f"{_dot(m.delta)} {m.delta:+.0%} |")
+            hidden = len(rows) - MAX_DETAIL_ROWS
+            if hidden > 0:
+                block.append(f"| _…and {hidden} more_ |  |  |  |")
+            block.append("")
+            os_blocks += block
+        if os_blocks:
+            lines += [f"#### {o}", ""] + os_blocks
+    lines += ["</details>", ""]
+    return lines
+
+
+def render(histories, pr_number=None, run_url=None, forced_baseline=None):
+    oses, ctx = build_context(histories, forced_baseline)
+    if not any(ctx[o]["pr"] for o in oses):
+        return _no_pr_body(pr_number, run_url)
+
+    compared = [o for o in oses if ctx[o]["pr"]]
+    lines = [MARKER, "", _title(pr_number, run_url), "",
+             f"⭐ **this PR** (full source build) vs **{_baseline_label_for(ctx, oses)}** · "
+             f"{' · '.join(compared)}", "",
+             f"> Informational only — this never blocks the PR. {rmd.TREND_FASTER} faster / "
+             f"less allocation · {rmd.TREND_SLOWER} slower / more allocation; moves under "
+             f"{rmd.TREND_PCT:.0%} are hidden as noise.", ""]
+
+    highlights, any_mover = _highlights(ctx, oses)
+    if any_mover:
+        lines += ["### Highlights", "", *highlights]
+        lines += _details(ctx, oses)
+    else:
+        lines += [f"✅ No benchmarks moved beyond the {rmd.TREND_PCT:.0%} noise threshold "
+                  f"vs the baseline — this PR is performance-neutral.", ""]
+
+    if run_url:
+        lines += [f"📈 [Full interactive `perf-dashboard` &amp; run details →]({run_url})", ""]
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("histories_dir", help="Directory of benchmarks-<OS>-<role>.json histories.")
+    p.add_argument("--pr-number", default=os.environ.get("PR_NUMBER"),
+                   help="PR number for the comment header (env: PR_NUMBER).")
+    p.add_argument("--run-url", default=os.environ.get("RUN_URL"),
+                   help="Workflow run URL for the header/footer links (env: RUN_URL).")
+    p.add_argument("--baseline", default=None,
+                   help="Force a baseline role (default: auto — nightly, then released stables).")
+    p.add_argument("--output", default=None,
+                   help="Write the Markdown here (it is always also printed to stdout).")
+    return p.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    histories = rmd.load_histories(args.histories_dir)
+    md = render(histories, pr_number=args.pr_number, run_url=args.run_url,
+                forced_baseline=args.baseline)
+    print(md)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(md)
+
+    oses, ctx = build_context(histories, args.baseline)
+    compared = [o for o in oses if ctx[o]["pr"]]
+    total = sum(len(collect_movers(ctx, oses, k)) for k, *_ in METRICS)
+    _common.log(f"  rendered PR benchmark comment: {len(compared)} OS compared, "
+                f"{total} mover(s) beyond {rmd.TREND_PCT:.0%}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/infra/perf/benchmarks/render_pr_md.py
+++ b/scripts/infra/perf/benchmarks/render_pr_md.py
@@ -57,6 +57,14 @@ BASELINE_LABELS = {
 
 # Metrics we diff: (json key, section title, formatter, worse-word, better-word). Lower is
 # better for both, so a positive delta (pr > baseline) is the "worse" direction.
+# Metrics we diff: (json key, section title, formatter, worse-word, better-word). Lower is
+# better for both, so a positive delta (pr > baseline) is the "worse" direction.
+#
+# NOTE: time is reported RAW (BenchmarkDotNet mean), deliberately un-smoothed. The ⭐ pr and
+# baseline legs run on separate CI runners, so wall-clock time carries cross-runner variance
+# and microbenchmarks can swing run-to-run; the comment says as much and points at the
+# interactive perf-dashboard (which smooths the trend). Allocations are deterministic and are
+# the reliable signal. Both use the shared 5% noise threshold (render_md.TREND_PCT).
 METRICS = (
     ("meanNs", "⏱️ Time", rmd.human_time, "slower", "faster"),
     ("allocatedBytes", "📦 Allocations", rmd.human_bytes, "more alloc", "less alloc"),
@@ -223,7 +231,13 @@ def render(histories, pr_number=None, run_url=None, forced_baseline=None):
              f"{' · '.join(compared)}", "",
              f"> Informational only — this never blocks the PR. {rmd.TREND_FASTER} faster / "
              f"less allocation · {rmd.TREND_SLOWER} slower / more allocation; moves under "
-             f"{rmd.TREND_PCT:.0%} are hidden as noise.", ""]
+             f"{rmd.TREND_PCT:.0%} are hidden as noise.",
+             ">",
+             "> ⏱️ Times are **raw** BenchmarkDotNet means, and the ⭐ PR and baseline legs run "
+             "on **separate CI runners**, so microbenchmarks can swing run-to-run — treat small "
+             "time deltas as noise. Allocations are deterministic and the reliable signal. The "
+             "interactive `perf-dashboard` (linked below) applies smoothing for the trend view.",
+             ""]
 
     highlights, any_mover = _highlights(ctx, oses)
     if any_mover:


### PR DESCRIPTION
## What

On `pull_request` runs of **Track - Benchmarks**, post (and update) a single **informational** comment summarising this PR's performance improvements 🟢 / regressions 🔴 vs the baseline. It never blocks the PR.

## How

- **New renderer** `scripts/infra/perf/benchmarks/render_pr_md.py`
  - Reads the same per-(OS, role) `benchmarks-<OS>-<role>.json` histories the `report` job already downloads.
  - Compares the ⭐ source-built `pr` leg against the **🌙 nightly** baseline (falls back to released stables if a nightly leg produced nothing), per OS, for both **time** (`meanNs`) and **allocations** (`allocatedBytes`).
  - Emits a **compact** marker comment — a short **Highlights** section (biggest movers + counts) and a collapsed `<details>` block with the full per-OS deltas. Only benchmarks that move beyond the shared **5% noise threshold** are surfaced, so it's a summary, not a table dump.
  - The header links the run: `## 📊 SkiaSharp benchmarks — [PR #NNNN](run_url)`, and there's a footer link to the `perf-dashboard` artifact / run.
  - Reuses the time/byte formatters, trend dots and history loader from `render_md.py` and the log helper from `_common.py` — duplicates none of that logic. Stdlib-only.

- **Workflow wiring** in the `report` job of `.github/workflows/track-benchmarks.yml`
  - PR-only render step + a `actions/github-script` step that paginates issue comments, matches the HTML marker `<!-- skiasharp-pr-benchmarks -->`, and updates-if-present-else-creates (same pattern as `pr-artifacts-comment.yml`).
  - Adds `permissions: pull-requests: write`. The post step is `continue-on-error: true` so it never fails the run and tolerates read-only fork tokens.

## Behaviour / edge cases

- **Movers present** → highlights (top 5 per metric) + collapsed per-OS tables (capped at 25 rows/metric).
- **Performance-neutral** → `✅ No benchmarks moved beyond the 5% noise threshold`.
- **No `pr` leg** (source build skipped/failed) → a short "nothing to compare yet" note, so the single comment still updates in place rather than proliferating.

## Validation

- Renderer validated locally against fixtures built from the real `aw-data/benchmarks/index.json` leg shape, with a synthesized `pr` leg containing known ±9%/±12% movers and sub-5% jitter. Verified all four cases (movers / neutral / no-pr / empty dir) and a forced `--baseline`.
- `python3 -m py_compile` on the renderer, YAML parses, and the embedded github-script JS passes `node --check`.

## Constraints honoured

- Consistent with existing perf infra conventions (stdlib-only, path-imported modules, marker-comment JS).
- No AzDO pipeline changes; does **not** persist PR data to `aw-data`.

Independent of the parallel artifact-**size** PR-comment effort (used only as a style/pattern reference).