### PR TITLE
Enable .NET 11 WASM integration testing (Playwright 1.55 + TFM parameterization)

### DIFF
--- a/tests/SkiaSharp.Tests.Integration/SkiaSharp.Tests.Integration.csproj
+++ b/tests/SkiaSharp.Tests.Integration/SkiaSharp.Tests.Integration.csproj
@@ -19,6 +19,13 @@
          with no version fails fast via the ValidateVersions target below. -->
     <SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''"></SkiaSharpVersion>
     <HarfBuzzSharpVersion Condition="'$(HarfBuzzSharpVersion)' == ''"></HarfBuzzSharpVersion>
+
+    <!-- Framework band for the generated temp projects. Defaults to net10.0. To smoke-test the
+         packages on a newer band (e.g. a .NET 11 preview), override all three, e.g.:
+         dotnet test -p:BaseFramework=net11.0 -p:SdkVersion=11.0.100-preview.6 -p:SdkAllowPrerelease=true -->
+    <BaseFramework Condition="'$(BaseFramework)' == ''">net10.0</BaseFramework>
+    <SdkVersion Condition="'$(SdkVersion)' == ''">10.0.100</SdkVersion>
+    <SdkAllowPrerelease Condition="'$(SdkAllowPrerelease)' == ''">false</SdkAllowPrerelease>
     
     <!-- Device configuration - can be overridden via command line -->
     <!-- dotnet test -p:iOSDevice="iPad Pro 13-inch (M4)" -p:iOSVersion="18.5" -->
@@ -35,7 +42,11 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+    <!-- Playwright 1.55 bundles Chromium 140, which supports the WebAssembly exception-handling
+         (exnref) feature the .NET 11 WASM runtime requires. Older Chromium (e.g. 131, bundled by
+         Playwright 1.49) aborts Blazor WASM startup on net11 with a "doesn't support WASM exception
+         handling" CompileError, so it cannot boot net11 apps under test. -->
+    <PackageReference Include="Microsoft.Playwright" Version="1.55.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="1.9.1" />
@@ -57,6 +68,9 @@
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="SkiaSharpVersion" Value="$(SkiaSharpVersion)" />
     <RuntimeHostConfigurationOption Include="HarfBuzzSharpVersion" Value="$(HarfBuzzSharpVersion)" />
+    <RuntimeHostConfigurationOption Include="BaseFramework" Value="$(BaseFramework)" />
+    <RuntimeHostConfigurationOption Include="SdkVersion" Value="$(SdkVersion)" />
+    <RuntimeHostConfigurationOption Include="SdkAllowPrerelease" Value="$(SdkAllowPrerelease)" />
     <RuntimeHostConfigurationOption Include="iOSDevice" Value="$(iOSDevice)" />
     <RuntimeHostConfigurationOption Include="iOSVersion" Value="$(iOSVersion)" />
     <RuntimeHostConfigurationOption Include="AndroidDevice" Value="$(AndroidDevice)" />

--- a/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/PlatformTestBase.cs
@@ -11,11 +11,33 @@ public abstract class PlatformTestBase : IDisposable
 {
     /// <summary>
     /// Base target framework the generated temp projects build against. Passed to
-    /// <c>dotnet new … -f</c> so the template-generated TFMs stay pinned to the .NET 10 band even
+    /// <c>dotnet new … -f</c> so the template-generated TFMs stay pinned to a known band even
     /// when a newer SDK (e.g. a net11.0 preview) is installed on the machine. Platform-suffixed
     /// MAUI TFMs (e.g. net10.0-android) derive from this.
+    /// <para>
+    /// Defaults to <c>net10.0</c>. Override to exercise a different band, e.g. to smoke-test the
+    /// packages on a .NET 11 preview:
+    /// <c>dotnet test -p:BaseFramework=net11.0 -p:SdkVersion=11.0.100-preview.x -p:SdkAllowPrerelease=true</c>.
+    /// (See <see cref="SdkVersion"/> / <see cref="SdkAllowPrerelease"/> for the matching SDK pin.)
+    /// </para>
     /// </summary>
-    protected const string BaseFramework = "net10.0";
+    protected static readonly string BaseFramework =
+        AppContext.GetData("BaseFramework") as string is { Length: > 0 } bf ? bf : "net10.0";
+
+    /// <summary>
+    /// SDK version the generated temp projects resolve to (written into their <c>global.json</c>).
+    /// Defaults to the .NET 10 band; override with <c>-p:SdkVersion=</c> when targeting a newer
+    /// <see cref="BaseFramework"/>.
+    /// </summary>
+    protected static readonly string SdkVersion =
+        AppContext.GetData("SdkVersion") as string is { Length: > 0 } sv ? sv : "10.0.100";
+
+    /// <summary>
+    /// Whether the generated temp projects may resolve a prerelease SDK. Defaults to <c>false</c>;
+    /// set <c>-p:SdkAllowPrerelease=true</c> when <see cref="SdkVersion"/> is a preview.
+    /// </summary>
+    protected static readonly bool SdkAllowPrerelease =
+        string.Equals(AppContext.GetData("SdkAllowPrerelease") as string, "true", StringComparison.OrdinalIgnoreCase);
 
     protected readonly ITestOutputHelper Output;
     protected readonly string TestDir;
@@ -53,18 +75,18 @@ public abstract class PlatformTestBase : IDisposable
             </configuration>
             """);
         
-        // Write global.json to pin the temp projects to the .NET 10 SDK band. The MAUI/console
+        // Write global.json to pin the temp projects to a known SDK band. The MAUI/console/Blazor
         // temp projects are generated outside the repo (in TempPath), so without this they would
         // resolve to the highest installed SDK — including .NET 11 previews — which makes
-        // `dotnet new maui` emit net11.0-* TFMs that don't match the net10.0-* frameworks the
-        // harness builds (causing NETSDK1005 "doesn't have a target for net10.0-*"). Stay within
-        // 10.0.x and never roll forward to a prerelease major.
-        File.WriteAllText(Path.Combine(TestDir, "global.json"), """
+        // `dotnet new` emit net11.0-* TFMs that don't match the frameworks the harness builds
+        // (causing NETSDK1005 "doesn't have a target for net10.0-*"). Defaults to the .NET 10 band;
+        // pass -p:SdkVersion / -p:SdkAllowPrerelease (alongside -p:BaseFramework) to target a newer band.
+        File.WriteAllText(Path.Combine(TestDir, "global.json"), $$"""
             {
               "sdk": {
-                "version": "10.0.100",
+                "version": "{{SdkVersion}}",
                 "rollForward": "latestFeature",
-                "allowPrerelease": false
+                "allowPrerelease": {{(SdkAllowPrerelease ? "true" : "false")}}
               }
             }
             """);


### PR DESCRIPTION
## Problem

While smoke-testing the `4.151.0-rc.1` packages, the Blazor **WASM** integration tests could not be run against **.NET 11**. Two gaps:

1. The harness hard-pins the generated temp projects to `net10.0` (a `const` + a fixed `global.json`), so there was no way to point it at a newer band.
2. Even when forced to net11, the Blazor app **never boots** and the test times out at `WaitForSelectorAsync`.

Instrumenting the browser console revealed the real cause — **not a SkiaSharp defect**:

```
MONO_WASM: Assert failed: This browser/engine doesn't support WASM exception handling
CompileError: WebAssembly.compileStreaming(): invalid value type 'exn', enable with --experimental-wasm-exnref
```

The .NET 11 WASM runtime requires the newer WebAssembly **exception-handling (`exnref`)** feature. The pinned **Microsoft.Playwright 1.49.0** bundles **Chromium 131**, which predates that support, so `compileStreaming()` fails and Mono aborts before Blazor renders. net10 passes in the same browser because its runtime doesn't require `exnref`.

SkiaSharp itself renders correctly on net11 — verified independently in a modern Chromium (pixel-level: OrangeRed circle + CornflowerBlue clear). The failure was purely the stale test browser.

## Fixes

- **Bump `Microsoft.Playwright` 1.49.0 → 1.55.0** (Chromium 140, which supports the required WASM exception handling).
- **Parameterize the generated temp projects' TFM + SDK pin** via `-p:BaseFramework` / `-p:SdkVersion` / `-p:SdkAllowPrerelease`. Defaults remain `net10.0` / `10.0.100` / `false`, so existing behavior is unchanged. To exercise a newer band:

  ```bash
  dotnet test -p:SkiaSharpVersion=X -p:HarfBuzzSharpVersion=Y     -p:BaseFramework=net11.0 -p:SdkVersion=11.0.100-preview.6 -p:SdkAllowPrerelease=true     -- --filter-class "*BlazorTests"
  ```

## Verification

Locally, against `SkiaSharp 4.151.0-rc.1.1` / `HarfBuzzSharp 14.2.1-rc.1.1`:

| TFM | Before | After |
|-----|--------|-------|
| net10.0 BlazorTests (SKCanvasView + SKGLView) | ✅ pass | ✅ pass (no regression) |
| net11.0 BlazorTests (SKCanvasView + SKGLView) | ❌ timeout (WASM EH) | ✅ **pass** |

## Notes / follow-ups (out of scope)

- The Playwright bump is a **test-only** dependency; it does not affect shipped packages.
- Wiring net11 into the CI release-testing matrix is a separate change; this PR only makes it *possible*.
- Minor latent smell spotted while debugging: `#render-status:has-text('Rendered')` also matches the initial "Not rendered" text (case-insensitive substring), so the real gate is the screenshot compare. Left as-is to keep this PR focused.