### PR TITLE
docs(release-testing): Test Properties + WASM workflow; harden milestone audit + wire into publish

### DIFF
--- a/.agents/skills/release-publish/SKILL.md
+++ b/.agents/skills/release-publish/SKILL.md
@@ -45,7 +45,7 @@ Publish packages to NuGet.org and finalize releases.
 │  5. Refresh Web Notes    → Dispatch docs workflow (tag→stable flip)│
 │  6. Create GitHub Release→ Generate notes, set prerelease flag     │
 │  7. Customer Teaser      → Extract key bits from the generated log │
-│  8. Close Milestone      → Close this version's milestone (all)    │
+│  8. Milestone Hygiene    → Audit/sync assignments, then close      │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -333,7 +333,36 @@ example. Process:
 
 ---
 
-## Step 8: Close Milestone (Every Release)
+## Step 8: Milestone Hygiene (Every Release)
+
+Because the tag now exists (Step 4), this release counts as **shipped** — so this is the
+moment to (8a) sync every milestone assignment for the line, then (8b) close this version's
+milestone. Do both, in order.
+
+### 8a. Sync milestone assignments (run the audit)
+
+[`audit-milestones.ps1`](../../../scripts/infra/milestones/audit-milestones.ps1) walks the
+release branches for the line and assigns every merged PR — and the issues it closed — to the
+milestone of the release it actually **shipped** in. It's idempotent and self-correcting, so
+running it at every publish keeps milestones clean incrementally (an unshipped preview's PRs
+roll forward to the next shipped release; commits not yet in any shipped release are left alone).
+
+Pass the **base line** version (`X.Y.Z`, no `-preview`/`-rc` suffix — the script audits the
+whole line). Dry-run first, review, then apply:
+
+```bash
+# Review what would change (read-only)
+pwsh scripts/infra/milestones/audit-milestones.ps1 -DryRun -Version {X.Y.Z}
+
+# Apply
+pwsh scripts/infra/milestones/audit-milestones.ps1 -Version {X.Y.Z}
+```
+
+> See [`scripts/infra/milestones/README.md`](../../../scripts/infra/milestones/README.md) for
+> the full algorithm. The header prints which cadence branches shipped (have a tag) vs. rolled
+> forward, so you can sanity-check before applying.
+
+### 8b. Close this version's milestone
 
 **Required for _every_ release — preview, rc, and stable.** SkiaSharp now creates a
 GitHub milestone for every version in the cadence, so each published version has its

--- a/.agents/skills/release-testing/SKILL.md
+++ b/.agents/skills/release-testing/SKILL.md
@@ -256,6 +256,26 @@ dotnet test ... \
   -- --filter-class "*MauiAndroidTests"
 ```
 
+### Test Properties
+
+MSBuild `-p:` properties the test project accepts (all go **before** the `--`):
+
+| Property | What it's for |
+|----------|---------------|
+| `SkiaSharpVersion` | SkiaSharp package version under test (**required**) |
+| `HarfBuzzSharpVersion` | HarfBuzzSharp package version under test (**required**) |
+| `BaseFramework` | TFM the generated temp apps target (`dotnet new … -f`) |
+| `SdkVersion` | SDK feature band pinned in the temp apps' `global.json` |
+| `SdkAllowPrerelease` | allow a prerelease SDK for that band (`true` for previews) |
+| `iOSDevice` / `iOSVersion` | simulator device name + iOS runtime for MAUI iOS tests |
+| `AndroidDevice` / `AndroidVersion` | device name + Android version (display metadata) |
+| `AndroidDeviceId` | target emulator/device UDID (e.g. `emulator-5554`) |
+| `AndroidApiLevel` | expected API level, validated at runtime |
+
+> **Testing a different .NET band (e.g. a preview):** change these two — `BaseFramework` to `netX.0`
+> and `SdkVersion` to the matching SDK feature band — and add `-p:SdkAllowPrerelease=true` for a
+> preview SDK. With no override they use the project defaults.
+
 ### Android Emulator Workflow
 
 ⚠️ **CRITICAL:** Run only ONE Android emulator at a time to avoid device confusion.
@@ -303,6 +323,44 @@ dotnet test ... \
    ```
 
 5. **Repeat for next API level** (start from step 1)
+
+### WASM (Blazor) Workflow
+
+`BlazorTests` builds a **real** WASM app (`-p:WasmBuildNative=true`, so it exercises the shipped
+native `.a` libs), boots it headless in Playwright/Chromium, and screenshot-diffs the canvas. Run it
+once per .NET band you're validating.
+
+1. **Install the Playwright browser (one-time):**
+   ```bash
+   cd tests/SkiaSharp.Tests.Integration
+   dotnet build -p:SkiaSharpVersion={version} -p:HarfBuzzSharpVersion={hb-version}
+   pwsh bin/Debug/*/playwright.ps1 install chromium
+   ```
+
+2. **Run on the default .NET band:**
+   ```bash
+   dotnet test \
+     -p:SkiaSharpVersion={version} \
+     -p:HarfBuzzSharpVersion={hb-version} \
+     -- --filter-class "*BlazorTests"
+   ```
+
+3. **Run on another band** (e.g. a preview) — change `BaseFramework` + `SdkVersion` (see [Test Properties](#test-properties)):
+   ```bash
+   dotnet test \
+     -p:SkiaSharpVersion={version} \
+     -p:HarfBuzzSharpVersion={hb-version} \
+     -p:BaseFramework=netX.0 \
+     -p:SdkVersion=X.0.100 \
+     -p:SdkAllowPrerelease=true \
+     -- --filter-class "*BlazorTests"
+   ```
+
+   ⚠️ **The target band needs its own `wasm-tools` workload**, and Playwright must be new enough to
+   boot that runtime (a too-old Chromium can't start preview-.NET WASM apps — they use the `exnref`
+   exception-handling feature). The required Playwright version is pinned in the test project.
+
+4. **Repeat step 3 for each additional band.**
 
 ### Test Execution Order
 

--- a/scripts/infra/milestones/audit-milestones.ps1
+++ b/scripts/infra/milestones/audit-milestones.ps1
@@ -12,7 +12,9 @@
     2. Sort them in release order (preview.1, preview.2, rc.1, stable)
     3. For consecutive branches, compute: merge-base(main, branchN) .. merge-base(main, branchN+1)
     4. Commits in that range shipped in branchN+1
-    5. For main HEAD after the last branch: those go into the next milestone (rc.1 or stable)
+    5. Only assign a range to a milestone that actually SHIPPED (has a git tag). An unshipped
+       preview rolls its commits forward to the next shipped release; commits on main past the
+       last branch belong to a not-yet-cut release and are skipped until it ships.
     6. Extract PR numbers from commit messages, resolve linked issues, fix milestones
 
 .PARAMETER DryRun
@@ -64,7 +66,47 @@ Write-Host ""
 
 # Fetch release branches, sorted in release order
 git fetch origin --quiet 2>/dev/null
-$rawBranches = git branch -r --list "origin/release/$Version*" | ForEach-Object { $_.Trim() }
+
+# Published tags for this version line — a release counts as "shipped" only if it was tagged.
+# Pre-releases are tagged v{title}.{build} (e.g. v4.151.0-preview.2.1); stable is v{title}.
+$allTags = @(git ls-remote --tags origin "v$Version*" 2>/dev/null |
+    ForEach-Object { ($_ -split '/')[-1] } |
+    Where-Object { $_ -and $_ -notmatch '\^\{\}$' } | Sort-Object)
+
+function Get-ShippedTag([string]$Title) {
+    if ($Title -match '-(preview|rc)\.\d+$') {
+        # pre-release: newest tagged build of it (v{title}.{build}), if any
+        return ($allTags | Where-Object { $_ -like "v$Title.*" } | Select-Object -Last 1)
+    }
+    # stable / hotfix: the exact tag (v{title}), if it exists
+    if ($allTags -contains "v$Title") { return "v$Title" }
+    return $null
+}
+function Test-Shipped([string]$Title) { return [bool](Get-ShippedTag $Title) }
+
+# Effective milestone for a range = the earliest SHIPPED release at or after this position.
+# An unshipped preview rolls forward to the next shipped release (its commits are contained in
+# that release); if nothing at/after this position has shipped yet, the range is provisional and
+# returns $null so the caller skips it (this also stops trailing main commits from being
+# speculatively parked in an unreleased "stable" milestone).
+function Get-EffectiveShippedTitle([int]$StartIdx, [string[]]$Titles) {
+    for ($j = $StartIdx; $j -lt $Titles.Count; $j++) {
+        if (Test-Shipped $Titles[$j]) { return $Titles[$j] }
+    }
+    return $null
+}
+
+if ($allTags.Count -gt 0) {
+    Write-Host "🏷️  Published tags for $Version : $($allTags -join ', ')"
+} else {
+    Write-Host "🏷️  No published tags for $Version yet"
+}
+Write-Host ""
+
+# @() forces an array even when a single branch matches; without it PowerShell
+# collapses a one-element result to a scalar string, and $allBranches[0] would
+# then return the first *character* ('o' from "origin/...") instead of the branch.
+$rawBranches = @(git branch -r --list "origin/release/$Version*" | ForEach-Object { $_.Trim() })
 
 if ($rawBranches.Count -eq 0) {
     throw "No release branches found matching origin/release/$Version*"
@@ -80,27 +122,44 @@ function Get-ReleaseRank([string]$BranchName) {
     return @(3, 0)  # unknown suffix, sort last
 }
 
-$allBranches = $rawBranches | Sort-Object { $r = Get-ReleaseRank $_; $r[0] * 1000 + $r[1] }
+$allBranches = @($rawBranches | Sort-Object { $r = Get-ReleaseRank $_; $r[0] * 1000 + $r[1] })
 
 Write-Host "🔍 Found $($allBranches.Count) release branches:"
-$allBranches | ForEach-Object { Write-Host "   $_" }
+foreach ($b in $allBranches) {
+    $tag = Get-ShippedTag ($b -replace 'origin/release/', '')
+    if ($tag) {
+        Write-Host "   $b   ✅ shipped ($tag)"
+    } else {
+        Write-Host "   $b   ❌ unshipped (no tag → rolls forward)"
+    }
+}
 Write-Host ""
 
 # Find the previous version's stable branch to use as the "from" boundary for preview.1
 # Look for release branches with lower version numbers (skip *.x maintenance branches)
 $prevBranch = $null
-$allReleaseBranches = git branch -r --list "origin/release/*" | ForEach-Object { $_.Trim() }
-$prevCandidates = $allReleaseBranches | Where-Object {
+$allReleaseBranches = @(git branch -r --list "origin/release/*" | ForEach-Object { $_.Trim() })
+$prevCandidates = @($allReleaseBranches | Where-Object {
     # Match versioned branches like origin/release/4.148.0 but skip *.x maintenance branches
     $_ -match 'origin/release/\d+\.\d+\.\d+' -and $_ -notmatch '\.x$' -and $_ -notlike "origin/release/$Version*"
-} | Sort-Object -Descending
+})
+# Pick the highest version strictly below the target, preferring the bare stable branch
+# over its prereleases (e.g. 4.148.0 over 4.148.0-rc.1) so the boundary is the previous
+# STABLE cut — otherwise commits from that version's rc→stable window leak into preview.1.
+$prevBest = $null
 foreach ($candidate in $prevCandidates) {
-    $candidateVersion = ($candidate -replace 'origin/release/', '') -replace '-.*', ''
+    $stripped = ($candidate -replace 'origin/release/', '')
+    $candidateVersion = $stripped -replace '-.*', ''
     if ([version]$candidateVersion -lt [version]$Version) {
-        $prevBranch = $candidate
-        break
+        $ver = [version]$candidateVersion
+        $isStable = ($stripped -eq $candidateVersion)  # no -preview/-rc suffix
+        if ($null -eq $prevBest -or $ver -gt $prevBest.Ver -or
+            ($ver -eq $prevBest.Ver -and $isStable -and -not $prevBest.Stable)) {
+            $prevBest = @{ Ver = $ver; Stable = $isStable; Branch = $candidate }
+        }
     }
 }
+if ($prevBest) { $prevBranch = $prevBest.Branch }
 
 # Get merge-bases for each branch (the point on main where the branch was cut)
 $mergeBases = @()
@@ -124,45 +183,33 @@ if ($LASTEXITCODE -ne 0) { throw "Failed to fetch milestones: $json" }
 $msMap = @{}
 ($json | ConvertFrom-Json) | ForEach-Object { $_ } | ForEach-Object { $msMap[$_.title] = $_.number }
 
-# Build ranges: each release branch contains commits between its merge-base and the previous one
+# Build ranges: each release branch contains commits between its merge-base and the previous one.
+# Title is the effective SHIPPED milestone for the range — unshipped previews roll forward to the
+# next shipped release; a range with no shipped release yet gets Title = $null (skipped below).
+$titles = @($allBranches | ForEach-Object { $_ -replace 'origin/release/', '' })
 $ranges = @()
 
 for ($i = 0; $i -lt $allBranches.Count; $i++) {
-    $branch = $allBranches[$i]
-    $msTitle = ($branch -replace 'origin/release/', '')
-
-    if ($i -eq 0) {
-        # First branch — use previous version's stable branch merge-base as the "from" boundary
-        $ranges += @{ Branch = $branch; Title = $msTitle; From = $prevMergeBase; To = $mergeBases[$i] }
-    } else {
-        $ranges += @{ Branch = $branch; Title = $msTitle; From = $mergeBases[$i - 1]; To = $mergeBases[$i] }
+    $from = if ($i -eq 0) { $prevMergeBase } else { $mergeBases[$i - 1] }
+    $ranges += @{
+        Branch   = $allBranches[$i]
+        OwnTitle = $titles[$i]
+        Title    = (Get-EffectiveShippedTitle $i $titles)
+        From     = $from
+        To       = $mergeBases[$i]
     }
 }
 
-# Also: commits on main after the last branch → next milestone
+# Commits on main after the last release branch belong to the NEXT release, which hasn't been
+# cut or shipped yet — never park them in a speculative milestone. They get picked up on a later
+# run once that release is cut and tagged.
 $lastMb = $mergeBases[$mergeBases.Count - 1]
 $headSha = git rev-parse origin/main
 if ($lastMb -ne $headSha) {
-    # Find the next open milestone for this version by checking what exists
-    $lastTitle = ($allBranches[$allBranches.Count - 1] -replace 'origin/release/', '')
-    $lastRank = Get-ReleaseRank "origin/release/$lastTitle"
-
-    # Look through all milestones for this version, find the next one in release order
-    $nextTitle = $null
-    $candidates = $msMap.Keys | Where-Object { $_ -like "$Version*" } | Sort-Object {
-        $r = Get-ReleaseRank "origin/release/$_"; $r[0] * 1000 + $r[1]
-    }
-    foreach ($candidate in $candidates) {
-        $candidateRank = Get-ReleaseRank "origin/release/$candidate"
-        if (($candidateRank[0] * 1000 + $candidateRank[1]) -gt ($lastRank[0] * 1000 + $lastRank[1])) {
-            $nextTitle = $candidate
-            break
-        }
-    }
-
-    if ($nextTitle) {
-        $ranges += @{ Branch = "origin/main (HEAD)"; Title = $nextTitle; From = $lastMb; To = $headSha }
-    }
+    $trailing = @(git log --oneline --first-parent "$lastMb..$headSha" 2>/dev/null |
+        Where-Object { $_ -match '\(#(\d+)\)' })
+    Write-Host "⏭️  $($trailing.Count) commit(s) on main after the last release branch are not in any shipped release yet — skipping until the next release is cut and tagged."
+    Write-Host ""
 }
 
 $fixed = 0
@@ -171,6 +218,13 @@ $errors = 0
 
 foreach ($range in $ranges) {
     $msTitle = $range.Title
+
+    if ($null -eq $msTitle) {
+        Write-Host "⏭️  $($range.OwnTitle) — not shipped yet and nothing later has shipped; skipping (provisional, will assign once a release ships)."
+        Write-Host ""
+        continue
+    }
+
     if (-not $msMap.ContainsKey($msTitle)) {
         Write-Host "⚠️  Milestone '$msTitle' not found on GitHub, skipping"
         Write-Host ""
@@ -193,7 +247,8 @@ foreach ($range in $ranges) {
         }
     }
 
-    Write-Host "📦 $msTitle ($($prs.Count) PRs) — $($range.Branch)"
+    $rollNote = if ($range.OwnTitle -ne $msTitle) { "  (rolled forward from unshipped $($range.OwnTitle))" } else { "" }
+    Write-Host "📦 $msTitle ($($prs.Count) PRs) — $($range.Branch)$rollNote"
 
     foreach ($pr in $prs) {
         # Check PR milestone

--- a/scripts/infra/milestones/audit-milestones.ps1
+++ b/scripts/infra/milestones/audit-milestones.ps1
@@ -167,6 +167,7 @@ if ($lastMb -ne $headSha) {
 
 $fixed = 0
 $correct = 0
+$errors = 0
 
 foreach ($range in $ranges) {
     $msTitle = $range.Title


### PR DESCRIPTION
## What

Three related changes, all surfaced while wrapping up the 4.151.0-rc.1 release.

### 1. `release-testing` skill docs (`.agents/skills/release-testing/SKILL.md`)
Styled to match the existing **Android Emulator Workflow**:
- **`### Test Properties`** — table of every `-p:` property the integration test project accepts and what each is for; note that to test a different .NET band you change **`BaseFramework` + `SdkVersion`** (→ `netX.0`), plus `SdkAllowPrerelease=true` for previews.
- **`### WASM (Blazor) Workflow`** — step-by-step path parallel to the Android one: one-time Playwright install → run on the default band → run on another band via the two overrides → repeat per band, with the ⚠️ gotchas (per-band `wasm-tools`; Playwright/Chromium `exnref` requirement). Uses `netX.0`/`X.0.100` placeholders so it doesn't go stale.

### 2. `audit-milestones.ps1` hardening (`scripts/infra/milestones/`)
Milestone assignments are now **gated on what actually shipped (has a git tag)**:
- **Roll unshipped previews forward** to the next shipped release (an untagged `preview.3` whose commits are contained in `rc.1` → `rc.1`), instead of parking issues/PRs in a milestone that never produced an installable package.
- **Stop speculatively assigning trailing-main commits** to an unreleased "stable" milestone — they're skipped until the next release is cut and tagged.
- **Log published tags** and annotate each branch as ✅ shipped / ❌ unshipped in the listing.
- Fix **`$errors`** never being initialized (summary rendered a blank count).
- Fix **array-collapse**: a single-branch match (e.g. `-Version 4.150.1`) made `$rawBranches` a scalar string, so `$allBranches[0]` returned the char `'o'` from `"origin/..."` → bogus `Milestone 'o' not found`. Wrapped git results in `@()`.
- Fix **previous-release boundary**: a descending *string* sort picked `4.148.0-rc.1` over the bare stable `4.148.0`, leaking that version's rc→stable commits into the next `preview.1`. Now prefers the bare stable when versions tie.

### 3. Wire the audit into `release-publish`
New **Step 8a (Sync milestone assignments)** runs the audit after tagging and before closing the milestone, so every publish keeps milestones clean incrementally.

## Verification
Dry-runs: **4.151.0** rolls `preview.3`'s 21 PRs into `rc.1` and skips the 5 trailing commits; **4.150.0** (fully shipped) is unchanged — `0 to fix, 53 correct, 0 errors`. Script parse-checked clean.

Docs + milestone tooling; no product build/test impact.