### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "0aa2d542e833ffd1d4d1b68a5152375e7f65ce11"
+          "commitHash": "8f1657daedd02cac85334501081e255824c754a1"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "bee4c917220040e147f14964635ff92ce6c5a3f6"
+      "upstream_merge_commit": "587c5b0f5a7b0260826a0c19094c2d952195066e"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "8f1657daedd02cac85334501081e255824c754a1"
+          "commitHash": "80c7b8fdf0cf932e08230922a6b38b82d91e004c"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/290

## SkiaSharp — pick up upstream `chrome/m150` bug fixes

Release-line bug-fix sync for `release/4.150.x`. **No version bump** (milestone stays at m150; increment stays 0).

### Companion PR
- `mono/skia`: `skia-sync/release-4.150.x` → `release/4.150.x`
- Submodule bump: `0aa2d542e8` → `8f1657daed`

### Upstream changes
2 Ganesh cherry-picks on `chrome/m150` — details in the mono/skia PR summary.
Both are internal GPU dirty-tracking / readback fixes; **no public API surface changes**.

### Breaking change analysis
- **C API diff**: 0 additions / 0 removals / 0 signature changes
- **Managed binding regen**: not required (no C API changes)
- **ABI**: unchanged

### Files changed in this repo
| File | Change |
|---|---|
| `externals/skia` | Submodule pointer bumped to `8f1657daed` |
| `cgmanifest.json` | Skia `commitHash` + `upstream_merge_commit` refreshed |

No changes to `VERSIONS.txt`, `sk_types.h` (`SK_C_INCREMENT` stays 0), `scripts/azure-templates-variables.yml`, or any C# source.

### Build & test results (Linux x64)
- `dotnet cake --target=externals-linux --arch=x64`: ✅ (13m 37s)
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj`: ✅ (0 errors, 4 pre-existing SDK warnings)
- `dotnet test tests/SkiaSharp.Tests.Console`: ✅ **Passed: 5584 / Failed: 0 / Skipped: 172 / Total: 5756** (2m 47s)

### Items needing human attention
None. Only Linux x64 was built in this workflow — other platforms (Windows/macOS/iOS/Android/WASM) will be exercised by CI on this PR.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).