### PR TITLE
Update DeviceRunners to 0.1.0-preview.12 for dotnet test --filter support

### DIFF
--- a/tests/SkiaSharp.Tests.Devices/SkiaSharp.Tests.Devices.csproj
+++ b/tests/SkiaSharp.Tests.Devices/SkiaSharp.Tests.Devices.csproj
@@ -33,11 +33,11 @@
   <ItemGroup>
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageReference Include="xunit.v3.assert" Version="3.2.2" />
-    <PackageReference Include="DeviceRunners.VisualRunners.Maui" Version="0.1.0-preview.11" />
-    <PackageReference Include="DeviceRunners.VisualRunners.Xunit3" Version="0.1.0-preview.11" />
-    <PackageReference Include="DeviceRunners.UITesting.Maui" Version="0.1.0-preview.11" />
-    <PackageReference Include="DeviceRunners.UITesting.Xunit3" Version="0.1.0-preview.11" />
-    <PackageReference Include="DeviceRunners.Testing.Targets" Version="0.1.0-preview.11" />
+    <PackageReference Include="DeviceRunners.VisualRunners.Maui" Version="0.1.0-preview.12" />
+    <PackageReference Include="DeviceRunners.VisualRunners.Xunit3" Version="0.1.0-preview.12" />
+    <PackageReference Include="DeviceRunners.UITesting.Maui" Version="0.1.0-preview.12" />
+    <PackageReference Include="DeviceRunners.UITesting.Xunit3" Version="0.1.0-preview.12" />
+    <PackageReference Include="DeviceRunners.Testing.Targets" Version="0.1.0-preview.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Maui.Core" Version="$(MauiVersion)" />

--- a/tests/SkiaSharp.Tests.Wasm/SkiaSharp.Tests.Wasm.csproj
+++ b/tests/SkiaSharp.Tests.Wasm/SkiaSharp.Tests.Wasm.csproj
@@ -18,9 +18,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageReference Include="xunit.v3.assert" Version="3.2.2" />
-    <PackageReference Include="DeviceRunners.VisualRunners.Blazor" Version="0.1.0-preview.11" />
-    <PackageReference Include="DeviceRunners.VisualRunners.Xunit3" Version="0.1.0-preview.11" />
-    <PackageReference Include="DeviceRunners.Testing.Targets" Version="0.1.0-preview.11" />
+    <PackageReference Include="DeviceRunners.VisualRunners.Blazor" Version="0.1.0-preview.12" />
+    <PackageReference Include="DeviceRunners.VisualRunners.Xunit3" Version="0.1.0-preview.12" />
+    <PackageReference Include="DeviceRunners.Testing.Targets" Version="0.1.0-preview.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Bumps all DeviceRunners packages in the WASM and Devices test projects from `0.1.0-preview.11` → `0.1.0-preview.12`.

`dotnet test --filter …` support for device/WASM runs was added in DeviceRunners **preview.12** ([mattleibow/DeviceRunners#143](https://github.com/mattleibow/DeviceRunners/pull/143)). The `preview.11` packages we referenced contain **none** of that chain, so `--filter` was silently ignored on WASM.

## Why `--filter` doesn't work today

The whole chain is new in preview.12:

| Stage | Mechanism | In preview.11? |
|---|---|---|
| `Testing.Targets` | Forwards `$(VSTestTestCaseFilter)` (from `dotnet test --filter`) to the CLI | ❌ |
| CLI → WASM | Appends `?device-runners-filter=<expr>` to the browser URL | ❌ |
| CLI → Maui/Windows | Passes `--device-runners-filter <expr>` arg | ❌ |
| Blazor runner | `AddCliConfiguration(url)` reads `device-runners-filter` → `SetTestCaseFilter(...)` | ❌ (reads only `device-runners-autorun`) |

## No test code changes needed

The bump alone enables the filter:
- Blazor's `UseVisualTestRunner` auto-wires `AddCliConfiguration` (reads the WASM query param).
- `MauiProgram.cs` already calls `.AddCliConfiguration()`.

## Verification

- ✅ `preview.12` resolves cleanly and is API-compatible (clean `dotnet restore` of the WASM project).
- ⚠️ Not built/run end-to-end (WASM needs the `wasm-tools` workload + native assets; Devices needs MAUI workloads + a device/emulator).

## ⚠️ Mirror gap (blocks CI restore until resolved)

`NuGet.config` restricts to the dnceng `dotnet-public` mirror (no nuget.org). preview.12 is only **partially** upstreamed there. These IDs still need mirroring at `0.1.0-preview.12`:

- `DeviceRunners.VisualRunners.Blazor`
- `DeviceRunners.VisualRunners.Xunit3`
- `DeviceRunners.UITesting.Xunit3`

(`DeviceRunners.VisualRunners.Maui`, `DeviceRunners.UITesting.Maui`, and `DeviceRunners.Testing.Targets` are already present.)

CI restore will `NU1102` until the three above are mirrored.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>