### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "5952f46c4d4c61658783ac2383897252ed8b7fc3"
+          "commitHash": "0478cbcd1b843abb599e7573c99cdd83e5a4e0b3"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "c3226a9bcd777ce15adb61e7181aac2aa57cf6da"
+      "upstream_merge_commit": "b4204f7ff931ec662a690d00b2d1c19afeb3a4fe"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/291

## Skia sync — chrome/m151 (bug-fix, same milestone)

Same-milestone (m151 → m151) bug-fix sync. No version bump; only the submodule
pointer and `cgmanifest.json` change.

### Upstream change

Merged 1 new upstream commit from `google/skia` `chrome/m151`:

- `b4204f7ff9` — [M151] [ganesh] prevent stale readbacks

Files: `src/gpu/ganesh/GrDrawingManager.cpp`, `src/gpu/ganesh/SurfaceContext.cpp`,
`tests/ReadWritePixelsGpuTest.cpp`. All internal Ganesh (GPU) — no public
headers, no C API, no `include/**`.

### Breaking change analysis

- **Public C++ headers changed**: none.
- **C API changed** (`include/c/`, `src/c/`): none.
- **New `SK_API` symbols**: none.
- **Binding regeneration required**: no.
- **ABI / soname change**: no (soname stays `151.0.0`).

Risk: **low**. Runtime behaviour change is limited to Ganesh's `readPixels`
now propagating a failed-flush signal instead of silently reading stale data.

### Version / binding updates

| File | Change |
|------|--------|
| `externals/skia` submodule pointer | `5952f46c4d` → `0478cbcd1b` |
| `cgmanifest.json` `commitHash` | updated to `0478cbcd1b843abb599e7573c99cdd83e5a4e0b3` |
| `cgmanifest.json` `upstream_merge_commit` | updated to `b4204f7ff931ec662a690d00b2d1c19afeb3a4fe` |
| `scripts/VERSIONS.txt` | **unchanged** (same milestone) |
| `scripts/azure-templates-variables.yml` | **unchanged** |
| `externals/skia/include/c/sk_types.h` | `SK_C_INCREMENT` verified `0` |

### C# changes

None required — no new C API, so no new P/Invokes to wrap.

### Build & test (Linux x64)

| Step | Result |
|------|--------|
| `dotnet cake --target=externals-linux --arch=x64` | ✅ succeeded (13m 52s) |
| `dotnet build binding/SkiaSharp/SkiaSharp.csproj -c Release` | ✅ succeeded (0 errors) |
| `dotnet test tests/SkiaSharp.Tests.Console` (net10.0/x64) | ✅ **5720 passed, 0 failed, 182 skipped** |

Native artifacts produced: `libSkiaSharp.so.151.0.0`, `libHarfBuzzSharp.so.0.61421.0`.

### Items needing human attention

None.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).