### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -158,7 +158,7 @@
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "cc97d1a8ada002b047592268f05a15f66e362539"
+          "commitHash": "3e62e8090c206038d07a7e6292a45adb5ddffc66"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "3424966b8a2b1e96427f3eab2bd069954ff745e7"
+      "upstream_merge_commit": "1229bad352c65da6d043b57e74cdb0bc63d192b1"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "3e62e8090c206038d07a7e6292a45adb5ddffc66"
+          "commitHash": "628ebf109469c1905ba8c55ddaba736760368ca4"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "1229bad352c65da6d043b57e74cdb0bc63d192b1"
+      "upstream_merge_commit": "834e9eb6313474b5a4a934d5fdd8d39c7736c7af"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "5952f46c4d4c61658783ac2383897252ed8b7fc3"
+          "commitHash": "cc97d1a8ada002b047592268f05a15f66e362539"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "c3226a9bcd777ce15adb61e7181aac2aa57cf6da"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "3424966b8a2b1e96427f3eab2bd069954ff745e7"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -65,19 +65,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -85,36 +85,36 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/292

# mono/SkiaSharp — skia-sync/main (m151 → m152)

Companion PR to mono/skia `skia-sync/main`. Advances the Skia submodule to the current
tip of `google/skia` `main`, which now declares milestone m152.

## ⚠️ Milestone advanced (m151 → m152)

The workflow was pre-computed as a same-milestone tip sync (`TARGET==CURRENT==151`),
but upstream `main` now declares `SK_MILESTONE 152`. This is therefore a **real
milestone bump**, and all version files were advanced:

| File | Old | New |
|---|---|---|
| `scripts/VERSIONS.txt` — `skia release` | m151 | m152 |
| `scripts/VERSIONS.txt` — `libSkiaSharp milestone` | 151 | 152 |
| `scripts/VERSIONS.txt` — `libSkiaSharp soname` | 151.0.0 | 152.0.0 |
| `scripts/VERSIONS.txt` — `SkiaSharp assembly` | 4.151.0.0 | 4.152.0.0 |
| `scripts/VERSIONS.txt` — all ~30 NuGet lines | 4.151.0 | 4.152.0 |
| `scripts/azure-templates-variables.yml` — `SKIASHARP_VERSION` | 4.151.0 | 4.152.0 |
| `cgmanifest.json` — `chrome_milestone` | 151 | 152 |
| `cgmanifest.json` — `commitHash` / `upstream_merge_commit` | (old) | new submodule / `3424966b8a…` |
| `externals/skia/include/c/sk_types.h` — `SK_C_INCREMENT` | 0 | 0 (reset) |

**Please confirm this milestone bump is intended.** If m151 was supposed to be pinned,
this PR should be re-based against a `chrome/m151` branch instead of `main` tip.

## Breaking-change analysis

Because the workflow was pre-computed as a same-milestone sync, no formal m151→m152
breaking-change analysis was performed. Phase 8's `regenerate-bindings.ps1` produced
**no diff** in any generated `SkiaApi*.cs` file, indicating the C API surface (the shim
in `externals/skia/src/c/` + `include/c/`) is unchanged. No new C API functions, no
signature changes, no new enums — no C# wrapper work required.

Upstream m151→m152 changes that landed cleanly (no conflict, no C API impact) include
routine Ganesh, SkSL, codec and Vulkan work; a full changelog is available in
`RELEASE_NOTES.md`. If a formal m152 breaking-change review is required before merge,
please request one.

## Binding / C# changes

- `binding/SkiaSharp/SkiaApi.generated.cs` — no diff.
- `binding/SkiaSharp.Skottie/…generated.cs`, `binding/SkiaSharp.SceneGraph/…generated.cs`,
  `binding/SkiaSharp.Resources/…generated.cs` — no diff.
- `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` — reverted per skill policy (HarfBuzz
  is out of scope; handle via `native-dependency-update` if needed).
- No hand-written C# wrapper changes.

## Build & test results

- **Native build**: `dotnet cake --target=externals-linux --arch=x64` — ✅ succeeded (7m 27s).
- **C# build**: `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — ✅ 0 errors.
- **Test suite**: `dotnet test tests/SkiaSharp.Tests.Console/…` —
  **Passed: 5731, Failed: 0, Skipped: 182, Total: 5913** (2m 12s). Full test log at
  `/tmp/gh-aw/agent/test-output.txt`.

## Items needing human attention

1. **Confirm the m151 → m152 milestone bump is intended.** The workflow was invoked
   with `TARGET=m151` but upstream `main` is now m152.
2. **Cross-platform native builds** — only Linux x64 was built here. macOS
   (arm64/x64), Windows (x64/arm64), iOS, Android, tvOS, MacCatalyst, and WASM must
   still be validated in CI. The submodule PR bumps VulkanMemoryAllocator (needed to
   compile upstream m152 Vulkan code) — please verify VMA build cleanly on every
   platform.
3. **Skia `main` (tip) sync policy** — the tip has moved ~269 commits past our
   previous merge base and now advertises the next milestone. Consider switching to
   the released `chrome/m152` branch once it exists if you want a stable base.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).