### PR TITLE
Modernize the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,19 +17,6 @@ Fixes #
 
 <!-- "Fixes #123" / "Closes #123" auto-closes the issue; use "Related to #123" for context only. -->
 
-**Areas affected**
-
-- [ ] Managed API (`binding/`)
-- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
-- [ ] Generated P/Invoke bindings
-- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
-- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
-- [ ] Rendering output / visual behavior
-- [ ] Performance
-- [ ] Tests
-- [ ] Build, packaging, or CI
-- [ ] Documentation or samples
-
 **Required skia PR**
 
 None.
@@ -42,6 +29,19 @@ Requires https://github.com/mono/skia/pull/<number>
 Native changes also require committing inside externals/skia (then `git add externals/skia`
 here) and re-running `pwsh ./utils/generate.ps1` to regenerate + commit SkiaApi.generated.cs.
 -->
+
+**Areas affected**
+
+- [ ] Managed API (`binding/`)
+- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
+- [ ] Generated P/Invoke bindings
+- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
+- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
+- [ ] Rendering output / visual behavior
+- [ ] Performance
+- [ ] Tests
+- [ ] Build, packaging, or CI
+- [ ] Documentation or samples
 
 ## Changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,27 +48,32 @@ here) and re-running `pwsh ./utils/generate.ps1` to regenerate + commit SkiaApi.
 None.
 
 <!--
-SkiaSharp keeps a STRICT stable ABI: additive only — no removals or signature /
-return-type changes; deprecate with [Obsolete] instead of removing.
+Scope: your PUBLIC API surface and any observable BEHAVIOR — NOT a file-by-file
+list. The diff already shows which files changed; the "what & why" narrative
+belongs in Description above. A CI-only or refactor PR that changes neither can
+just leave "None." (a short qualifier is fine, e.g.
+"None — CI-only, no public API or behavior change.").
 
-Changed public API or behavior? Copy the parts that apply over "None." above:
+Otherwise copy the parts that apply over "None." and delete the rest:
 
-**Added**
+**Public API**
+
+STRICT stable ABI — additive only: no removals, no signature or return-type
+changes; deprecate with [Obsolete] rather than removing. List the exact signatures:
 
 ```csharp
-void SKCanvas.DrawFoo(float x, float y, SKPaint paint);
+// added
+public bool SKPath.TryGetTightBounds(out SKRect bounds);
+
+// deprecated (kept for compatibility)
+[Obsolete("Use TryGetTightBounds instead.")]
+public SKRect SKPath.GetTightBounds();
 ```
 
-**Obsoleted**
+**Behavior**
 
-```csharp
-[Obsolete] void SKCanvas.OldMethod();  // use SKCanvas.NewMethod()
-```
-
-**Behavioral**
-
-A change to rendering output, defaults, exceptions, threading, or memory
-ownership that an app would notice after upgrading.
+What an app would notice after upgrading — rendering output, defaults, thrown
+exceptions, threading, or memory ownership — and the impact. Keep it to a line or two.
 -->
 
 ## Testing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,10 @@ Thanks for contributing to SkiaSharp!
 • Target the `main` branch — maintainers backport to release branches.
 • Adding or changing API? See documentation/dev/adding-apis.md and documentation/dev/api-design.md.
 • Replace each prompt below. Write "None." for sub-sections that don't apply —
-  but never delete the "API changes" or "Required skia PR" parts.
+  but always fill in "Changes" and "Required skia PR" rather than deleting them.
 -->
 
-### Description
+## Description
 
 <!-- What does this change do, and why? Reviewers need the *why* most. -->
 
@@ -42,15 +42,13 @@ None.
    • re-run `pwsh ./utils/generate.ps1` and commit SkiaApi.generated.cs
 -->
 
-### API changes
+## Changes
 
 <!--
   SkiaSharp keeps a STRICT stable ABI: additive only — no removals, no signature
   or return-type changes. Deprecate with [Obsolete] instead of removing.
-  Fill the fences below, or write "None." if there are no public API changes.
+  List the public API you touched below (or write "None."), and note any behavioral change.
 -->
-
-None.
 
 **Added**
 
@@ -66,16 +64,14 @@ None.
 // [Obsolete] void SKCanvas.OldMethod();  // use SKCanvas.NewMethod()
 ```
 
-<!-- Changing or removing an existing public signature is not allowed — deprecate instead. -->
-
-### Behavioral changes
+**Behavioral**
 
 None.
 
 <!-- Any change to rendering output, defaults, exceptions, threading, or memory
      ownership that an app would notice after upgrading. -->
 
-### Testing
+## Testing
 
 <!--
   • What tests did you add or update, and where?
@@ -96,9 +92,9 @@ None.
 
 </details>
 
-### Checklist
+## Checklist
 
 - [ ] Tests added or updated (if omitted, explain in Testing above)
-- [ ] `API changes` above is complete (or "None.")
+- [ ] `Changes` above lists all public API and behavioral changes (or "None.")
 - [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
 - [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Thanks for contributing to SkiaSharp!
 
 <!-- What does this change do, and why? Reviewers need the *why* most. -->
 
-**Fixes**
+**Related issues**
 
 Fixes #
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,48 +1,102 @@
-**Description of Change**
+<!--
+Thanks for contributing to SkiaSharp!
 
-<!-- Describe your changes here. -->
-
-**Bugs Fixed**
-
-- Fixes #
-
-<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->
-
-**API Changes**
-
-None.
-
-<!-- REPLACE THIS COMMENT
-
-List all API changes here (or just put None), example:
-
-Added: 
- 
-- `string Class.Property { get; set; }`
-- `void Class.Method();`
-
-Changed:
-
- - `object Cell.OldPropertyName => object Cell.NewPropertyName`
-
+• Target the `main` branch — maintainers backport to release branches.
+• Adding or changing API? See documentation/dev/adding-apis.md and documentation/dev/api-design.md.
+• Replace each prompt below. Write "None." for sections that don't apply —
+  but never delete "API Changes" or "Required skia PR".
 -->
 
-**Behavioral Changes**
+## Description
+
+<!-- What does this change do, and why? Reviewers need the *why* most. -->
+
+## Related Issues
+
+Fixes #
+
+<!-- "Fixes #123" / "Closes #123" to auto-close, or "Related to #123" for context. -->
+
+## Areas Affected
+
+- [ ] Managed API (`binding/`)
+- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
+- [ ] Generated P/Invoke bindings
+- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
+- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
+- [ ] Rendering output / visual behavior
+- [ ] Performance
+- [ ] Tests
+- [ ] Build, packaging, or CI
+- [ ] Documentation or samples
+
+## API Changes
+
+<!--
+  SkiaSharp keeps a STRICT stable ABI: additive only — no removals, no signature
+  or return-type changes. Deprecate with [Obsolete] instead of removing.
+  Fill the fences below, or write "None." if there are no public API changes.
+-->
 
 None.
 
-<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->
+**Added**
 
-**Required skia PR**
+```csharp
+// New public signatures, e.g.:
+// void SKCanvas.DrawFoo(float x, float y, SKPaint paint);
+```
+
+**Obsoleted**
+
+```csharp
+// Deprecated APIs + their replacement, e.g.:
+// [Obsolete] void SKCanvas.OldMethod();  // use SKCanvas.NewMethod()
+```
+
+<!-- Changing or removing an existing public signature is not allowed — deprecate instead. -->
+
+## Behavioral Changes
 
 None.
 
-<!-- Replace this with the full URL to the skia PR. -->
+<!-- Any change to rendering output, defaults, exceptions, threading, or memory
+     ownership that an app would notice after upgrading. -->
 
-**PR Checklist**
+## Required skia PR
 
-- [ ] Has tests (if omitted, state reason in description)
-- [ ] Rebased on top of main at time of PR
-- [ ] Merged related skia PRs
-- [ ] Changes adhere to coding standard
-- [ ] Updated documentation
+None.
+
+<!--
+  If this touches the C API or externals/skia submodule, paste the companion PR:
+    Requires https://github.com/mono/skia/pull/<number>
+  Native changes also require:
+   • commit inside externals/skia first, then `git add externals/skia` here
+   • re-run `pwsh ./utils/generate.ps1` and commit SkiaApi.generated.cs
+-->
+
+## Testing
+
+<!--
+  • What tests did you add or update, and where?
+  • How can a reviewer reproduce your verification?
+  • Which backends/platforms did you run on (CPU, GPU/Metal/Vulkan/ANGLE,
+    Windows/macOS/Linux/Android/iOS/tvOS/Tizen/WASM)? Note anything you could NOT test.
+  • Rendering change? Mention any golden-image updates (tests/Content/Goldens/).
+-->
+
+<details>
+<summary>Screenshots / rendering output (before &amp; after)</summary>
+
+| Before | After |
+| --- | --- |
+|  |  |
+
+</details>
+
+## Checklist
+
+- [ ] Tests added or updated (if omitted, explain in Testing above)
+- [ ] `API Changes` above is complete (or "None.")
+- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
+- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,17 +7,17 @@ Thanks for contributing to SkiaSharp!
   but never delete "API Changes" or "Required skia PR".
 -->
 
-## Description
+### Description
 
 <!-- What does this change do, and why? Reviewers need the *why* most. -->
 
-## Related Issues
+### Related Issues
 
 Fixes #
 
 <!-- "Fixes #123" / "Closes #123" to auto-close, or "Related to #123" for context. -->
 
-## Areas Affected
+### Areas Affected
 
 - [ ] Managed API (`binding/`)
 - [ ] Native / C API (`externals/skia/src/c`, `include/c`)
@@ -30,7 +30,7 @@ Fixes #
 - [ ] Build, packaging, or CI
 - [ ] Documentation or samples
 
-## API Changes
+### API Changes
 
 <!--
   SkiaSharp keeps a STRICT stable ABI: additive only — no removals, no signature
@@ -56,14 +56,14 @@ None.
 
 <!-- Changing or removing an existing public signature is not allowed — deprecate instead. -->
 
-## Behavioral Changes
+### Behavioral Changes
 
 None.
 
 <!-- Any change to rendering output, defaults, exceptions, threading, or memory
      ownership that an app would notice after upgrading. -->
 
-## Required skia PR
+### Required skia PR
 
 None.
 
@@ -75,7 +75,7 @@ None.
    • re-run `pwsh ./utils/generate.ps1` and commit SkiaApi.generated.cs
 -->
 
-## Testing
+### Testing
 
 <!--
   • What tests did you add or update, and where?
@@ -94,7 +94,7 @@ None.
 
 </details>
 
-## Checklist
+### Checklist
 
 - [ ] Tests added or updated (if omitted, explain in Testing above)
 - [ ] `API Changes` above is complete (or "None.")

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@ Thanks for contributing to SkiaSharp!
 
 • Target the `main` branch — maintainers backport to release branches.
 • Adding or changing API? See documentation/dev/adding-apis.md and documentation/dev/api-design.md.
-• Replace each prompt below. Write "None." for sub-sections that don't apply —
-  but always fill in "Changes" and "Required skia PR" rather than deleting them.
+• Just fill in the Description — the other sections have sensible defaults. Each
+  section's comment holds a copy-paste block; drop it in only when you have something.
 -->
 
 ## Description
@@ -15,7 +15,7 @@ Thanks for contributing to SkiaSharp!
 
 Fixes #
 
-<!-- "Fixes #123" / "Closes #123" to auto-close, or "Related to #123" for context. -->
+<!-- "Fixes #123" / "Closes #123" auto-closes the issue; use "Related to #123" for context only. -->
 
 **Areas affected**
 
@@ -35,66 +35,65 @@ Fixes #
 None.
 
 <!--
-  If this touches the C API or externals/skia submodule, paste the companion PR:
-    Requires https://github.com/mono/skia/pull/<number>
-  Native changes also require:
-   • commit inside externals/skia first, then `git add externals/skia` here
-   • re-run `pwsh ./utils/generate.ps1` and commit SkiaApi.generated.cs
+Touching the C API or the externals/skia submodule? Replace "None." above with:
+
+Requires https://github.com/mono/skia/pull/<number>
+
+Native changes also require committing inside externals/skia (then `git add externals/skia`
+here) and re-running `pwsh ./utils/generate.ps1` to regenerate + commit SkiaApi.generated.cs.
 -->
 
 ## Changes
 
+None.
+
 <!--
-  SkiaSharp keeps a STRICT stable ABI: additive only — no removals, no signature
-  or return-type changes. Deprecate with [Obsolete] instead of removing.
-  List the public API you touched below (or write "None."), and note any behavioral change.
--->
+SkiaSharp keeps a STRICT stable ABI: additive only — no removals or signature /
+return-type changes; deprecate with [Obsolete] instead of removing.
+
+Changed public API or behavior? Copy the parts that apply over "None." above:
 
 **Added**
 
 ```csharp
-// New public signatures, e.g.:
-// void SKCanvas.DrawFoo(float x, float y, SKPaint paint);
+void SKCanvas.DrawFoo(float x, float y, SKPaint paint);
 ```
 
 **Obsoleted**
 
 ```csharp
-// Deprecated APIs + their replacement, e.g.:
-// [Obsolete] void SKCanvas.OldMethod();  // use SKCanvas.NewMethod()
+[Obsolete] void SKCanvas.OldMethod();  // use SKCanvas.NewMethod()
 ```
 
 **Behavioral**
 
-None.
-
-<!-- Any change to rendering output, defaults, exceptions, threading, or memory
-     ownership that an app would notice after upgrading. -->
+A change to rendering output, defaults, exceptions, threading, or memory
+ownership that an app would notice after upgrading.
+-->
 
 ## Testing
 
 <!--
-  • What tests did you add or update, and where?
-  • How can a reviewer reproduce your verification?
-  • Which backends/platforms did you run on (CPU, GPU/Metal/Vulkan/ANGLE,
-    Windows/macOS/Linux/Android/iOS/tvOS/Tizen/WASM)? Note anything you could NOT test.
-  • Rendering change? Mention any golden-image updates (tests/Content/Goldens/).
--->
+How did you verify this? Add or update tests where relevant, and note which
+backends/platforms you ran on (CPU, GPU/Metal/Vulkan/ANGLE, Windows/macOS/Linux/
+Android/iOS/tvOS/Tizen/WASM) and anything you could NOT test.
 
-**Screenshots (before / after)**
+Rendering change? Mention golden-image updates (tests/Content/Goldens/) and copy
+this in to show the difference:
 
 <details>
-<summary>Show rendering output</summary>
+<summary>Screenshots (before / after)</summary>
 
 | Before | After |
 | --- | --- |
 |  |  |
 
 </details>
+-->
 
 ## Checklist
 
-- [ ] Tests added or updated (if omitted, explain in Testing above)
+- [ ] Tests added or updated (if omitted, explain why above)
 - [ ] `Changes` above lists all public API and behavioral changes (or "None.")
 - [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
 - [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,21 +3,21 @@ Thanks for contributing to SkiaSharp!
 
 • Target the `main` branch — maintainers backport to release branches.
 • Adding or changing API? See documentation/dev/adding-apis.md and documentation/dev/api-design.md.
-• Replace each prompt below. Write "None." for sections that don't apply —
-  but never delete "API Changes" or "Required skia PR".
+• Replace each prompt below. Write "None." for sub-sections that don't apply —
+  but never delete the "API changes" or "Required skia PR" parts.
 -->
 
 ### Description
 
 <!-- What does this change do, and why? Reviewers need the *why* most. -->
 
-### Related Issues
+**Fixes**
 
 Fixes #
 
 <!-- "Fixes #123" / "Closes #123" to auto-close, or "Related to #123" for context. -->
 
-### Areas Affected
+**Areas affected**
 
 - [ ] Managed API (`binding/`)
 - [ ] Native / C API (`externals/skia/src/c`, `include/c`)
@@ -30,7 +30,19 @@ Fixes #
 - [ ] Build, packaging, or CI
 - [ ] Documentation or samples
 
-### API Changes
+**Required skia PR**
+
+None.
+
+<!--
+  If this touches the C API or externals/skia submodule, paste the companion PR:
+    Requires https://github.com/mono/skia/pull/<number>
+  Native changes also require:
+   • commit inside externals/skia first, then `git add externals/skia` here
+   • re-run `pwsh ./utils/generate.ps1` and commit SkiaApi.generated.cs
+-->
+
+### API changes
 
 <!--
   SkiaSharp keeps a STRICT stable ABI: additive only — no removals, no signature
@@ -56,24 +68,12 @@ None.
 
 <!-- Changing or removing an existing public signature is not allowed — deprecate instead. -->
 
-### Behavioral Changes
+### Behavioral changes
 
 None.
 
 <!-- Any change to rendering output, defaults, exceptions, threading, or memory
      ownership that an app would notice after upgrading. -->
-
-### Required skia PR
-
-None.
-
-<!--
-  If this touches the C API or externals/skia submodule, paste the companion PR:
-    Requires https://github.com/mono/skia/pull/<number>
-  Native changes also require:
-   • commit inside externals/skia first, then `git add externals/skia` here
-   • re-run `pwsh ./utils/generate.ps1` and commit SkiaApi.generated.cs
--->
 
 ### Testing
 
@@ -85,8 +85,10 @@ None.
   • Rendering change? Mention any golden-image updates (tests/Content/Goldens/).
 -->
 
+**Screenshots (before / after)**
+
 <details>
-<summary>Screenshots / rendering output (before &amp; after)</summary>
+<summary>Show rendering output</summary>
 
 | Before | After |
 | --- | --- |
@@ -97,6 +99,6 @@ None.
 ### Checklist
 
 - [ ] Tests added or updated (if omitted, explain in Testing above)
-- [ ] `API Changes` above is complete (or "None.")
+- [ ] `API changes` above is complete (or "None.")
 - [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
 - [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ SkiaSharp maintains stable ABI. Breaking changes break downstream apps.
 
 1. **Create a feature branch FIRST** — Use naming convention: `dev/issue-NNNN-description`
 2. **Make all commits on the feature branch** — Never commit directly to protected branches
-3. **Submit a Pull Request** — Changes must be reviewed before merging
+3. **Submit a Pull Request** — Fill in the PR template (`.github/pull_request_template.md`) completely; changes must be reviewed before merging
 
 ```bash
 # CORRECT — Always create a feature branch first
@@ -83,6 +83,8 @@ git checkout skiasharp && git commit  # FORBIDDEN (in skia submodule)
 ```
 
 **This applies to BOTH repositories.** The skia submodule has its own protected branches that must be respected.
+
+**Always use the PR template.** When opening a pull request, populate every section of the repository's `.github/pull_request_template.md` — do **not** open a PR with an empty or default body. Keep the ABI-critical **API Changes** and **Required skia PR** sections (write `None.` instead of deleting them), tick the relevant **Areas Affected**, describe how you verified the change under **Testing**, and attach before/after screenshots for any rendering change. The `externals/skia` submodule ships its own matching template for C API PRs.
 
 ---
 


### PR DESCRIPTION
## Description

The PR template was an old plain-markdown form (bold pseudo-headings, hidden comment scaffolding, stale checklist items). This replaces it with a structured, graphics-library-focused template that matches the modern YAML **issue** forms in feel, and updates `AGENTS.md` to require using it.

The redesign was informed by surveying PR templates across well-run graphics/game engines and .NET / native-interop libraries — **Bevy, Godot, three.js, MonoGame, Avalonia, dotnet/WPF, dotnet/WinForms, Flutter, SixLabors/ImageSharp, Silk.NET**, and **mono/skia** itself. (Two independent research passes plus a manual scan all converged on the same recommendations.)

## What changed

**`.github/pull_request_template.md`**
- Real `##` headings instead of `**bold**` pseudo-headings.
- New **Areas Affected** checkboxes to route reviewers (managed API · native/C API · generated bindings · native-dep/Skia update · views & integrations · rendering · perf · tests · build/CI · docs).
- **API Changes** now uses fenced ` ```csharp ` blocks (**Added** / **Obsoleted**) so multi-line signatures are readable; keeps the strict-ABI, additive-only rule.
- **Testing** upgraded from a single checkbox to a narrative prompt covering the CPU/GPU/Metal/Vulkan/ANGLE + Windows/macOS/Linux/Android/iOS/tvOS/Tizen/WASM matrix and golden-image updates.
- Collapsible **before/after screenshots** section for rendering changes.
- Native-path reminders: companion `mono/skia` PR, submodule staging, and `pwsh ./utils/generate.ps1` regeneration.
- Reference docs live in **mono/SkiaSharp-API-docs**, so the checklist asks contributors to file a docs issue there rather than "add XML doc comments" here.
- Dropped stale/unverifiable items ("rebased on main", "changes adhere to coding standard") that CI / merge-queue already handle.

**`AGENTS.md`**
- Branch-protection workflow now says to fill in `.github/pull_request_template.md` completely when opening a PR (never an empty/default body), keep the ABI-critical sections, and attach before/after screenshots for rendering changes.

## Follow-up (separate repo)

A matching redesign for the **mono/skia** fork template (`externals/skia`, `skiasharp` branch) has been drafted and is ready to apply via a separate `mono/skia` PR — it mirrors this structure but is adapted for the C API (C exports, `DEPS`, upstream-merge areas, companion-PR pointing back to SkiaSharp).

## Testing

Docs/process change only — no code affected, nothing to build or test. The template renders as standard GitHub Markdown.