### PR TITLE
Automate Skia submodule and cgmanifest sync

### DIFF
--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -71,6 +71,7 @@ GITHUB_WORKFLOWS = [
     {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Pages - PR Staging - Cleanup", "scope": "global", "trigger": "event"},
     {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Pages - PR Staging - Sweep Stale", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Sync - Docs Submodule", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-submodule-sync.yml", "name": "Sync - Skia Submodule", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Sync - Skia Upstream", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Sync - Issue Triage", "scope": "global", "trigger": "schedule"},

--- a/.github/workflows/auto-skia-submodule-sync.yml
+++ b/.github/workflows/auto-skia-submodule-sync.yml
@@ -1,0 +1,120 @@
+name: Sync - Skia Submodule
+
+on:
+  schedule:
+    - cron: "30 10 * * *"  # Daily at 10:30 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-skia-submodule-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout SkiaSharp
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Update Skia submodule and cgmanifest
+        id: update
+        run: |
+          git submodule update --init --remote --depth 1 -- externals/skia
+
+          SKIA_SHA=$(git -C externals/skia rev-parse HEAD)
+          MANIFEST_MATCHES=$(jq '[.registrations[] | select(
+            .component.type == "git"
+            and .component.git.repositoryUrl == "https://github.com/mono/skia.git"
+          )] | length' cgmanifest.json)
+
+          if [ "$MANIFEST_MATCHES" -ne 1 ]; then
+            echo "Expected exactly one mono/skia git registration in cgmanifest.json, found $MANIFEST_MATCHES"
+            exit 1
+          fi
+
+          TMP=$(mktemp)
+          jq --arg sha "$SKIA_SHA" '
+            (.registrations[]
+              | select(
+                .component.type == "git"
+                and .component.git.repositoryUrl == "https://github.com/mono/skia.git"
+              )
+              | .component.git.commitHash) = $sha
+          ' cgmanifest.json > "$TMP"
+          mv "$TMP" cgmanifest.json
+
+          echo "skia_sha=$SKIA_SHA" >> "$GITHUB_OUTPUT"
+          echo "latest_msg=$(git -C externals/skia log -1 --format=%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet -- externals/skia; then
+            echo "submodule_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skia submodule has changed"
+            echo "submodule_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --quiet -- cgmanifest.json; then
+            echo "manifest_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "cgmanifest.json has changed"
+            echo "manifest_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --quiet -- externals/skia cgmanifest.json; then
+            echo "Skia submodule and cgmanifest.json are up to date"
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update PR
+        if: steps.check.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LATEST_MSG: ${{ steps.update.outputs.latest_msg }}
+          SKIA_SHA: ${{ steps.update.outputs.skia_sha }}
+        run: |
+          BRANCH="automation/update-skia-submodule"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Always start fresh from main to avoid stale commit accumulation.
+          git checkout -B "$BRANCH" origin/main
+
+          git add externals/skia cgmanifest.json
+          if git diff --cached --quiet; then
+            echo "No changes after staging"
+            exit 0
+          fi
+
+          git commit -m "Sync Skia submodule and cgmanifest
+
+          Latest: $LATEST_MSG
+          Commit: $SKIA_SHA"
+
+          git push origin "$BRANCH" --force
+
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already exists, force-pushed update"
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "Sync Skia submodule and cgmanifest" \
+              --body "Automated update of the \`externals/skia/\` submodule to track \`mono/skia\`'s \`skiasharp\` branch.
+
+          The \`mono/skia\` git registration in \`cgmanifest.json\` is derived from the checked-out submodule SHA. The workflow opens a PR when either the submodule pointer or manifest hash changes, so it also repairs manifest drift.
+
+          Created by [auto-skia-submodule-sync](https://github.com/${{ github.repository }}/actions/workflows/auto-skia-submodule-sync.yml)."
+          fi

--- a/documentation/dev/dependencies.md
+++ b/documentation/dev/dependencies.md
@@ -135,6 +135,13 @@ The Skia entry in cgmanifest.json includes custom fields for version tracking:
 | `chrome_milestone` | Integer milestone number — used to filter NVD results |
 | `upstream_merge_commit` | SHA of the upstream `chrome/mNNN` branch tip that was merged into the fork |
 
+The [`auto-skia-submodule-sync`](../../.github/workflows/auto-skia-submodule-sync.yml)
+workflow runs daily to advance `externals/skia` to the `mono/skia` `skiasharp`
+branch and derive the Component Governance git registration's `commitHash` from
+the checked-out submodule. It opens a PR when either value changes, which also
+repairs manifest drift. The milestone fields above remain owned by the full Skia
+upstream update workflow.
+
 ### When to Update
 
 Update these fields whenever merging new upstream Skia code:


### PR DESCRIPTION
## Description

The Skia submodule pointer and its Component Governance git registration can drift apart, leaving `cgmanifest.json` stale even when no submodule bump is needed. Add a daily and manually dispatchable workflow that tracks `mono/skia`'s `skiasharp` branch, derives the manifest hash from the checked-out submodule, and opens or refreshes one PR whenever either value changes.

The workflow intentionally updates only the Component Governance git registration hash. Skia milestone and upstream merge metadata remain owned by the full Skia upstream update workflow.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, ...)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, ...)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None. CI-only automation; no public API or product behavior changes.

## Testing

Validated the workflow YAML and shell syntax, compiled the CI status script, and exercised the `jq` manifest rewrite against the current Skia gitlink. No product tests were added because this only changes automation and documentation.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later (N/A)
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated (N/A)