### PR TITLE
Add backend-neutral async RequestReadPixels to SKImage and SKSurface

### DIFF
--- a/binding/SkiaSharp/DelegateProxies.cs
+++ b/binding/SkiaSharp/DelegateProxies.cs
@@ -104,5 +104,19 @@ namespace SkiaSharp
 			var path = SKPath.GetObject (pathOrNull, false);
 			del.Invoke (path, *matrix);
 		}
+
+		private static partial void SKImageAsyncReadPixelsProxyImplementation (void* context, IntPtr result)
+		{
+			// The captured Action<IntPtr> is the closure built by SKImage/SKSurface.RequestReadPixels.
+			// `result` is non-owning and only valid for the duration of this invocation (it is IntPtr.Zero
+			// on failure); the closure must read all data before returning. This fires at most once, so the
+			// pinning handle is freed here.
+			var del = Get<Action<IntPtr>> ((IntPtr)context, out var gch);
+			try {
+				del.Invoke (result);
+			} finally {
+				gch.Free ();
+			}
+		}
 	}
 }

--- a/binding/SkiaSharp/GRContext.cs
+++ b/binding/SkiaSharp/GRContext.cs
@@ -176,6 +176,12 @@ namespace SkiaSharp
 			GC.KeepAlive (this);
 		}
 
+		public void CheckAsyncWorkCompletion ()
+		{
+			SkiaApi.gr_direct_context_check_async_work_completion (Handle);
+			GC.KeepAlive (this);
+		}
+
 		public void Flush (SKImage image)
 		{
 			if (image == null) {

--- a/binding/SkiaSharp/SKImage.cs
+++ b/binding/SkiaSharp/SKImage.cs
@@ -615,16 +615,19 @@ namespace SkiaSharp
 
 		// RequestReadPixels
 
-		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageAsyncReadResult> callback) =>
-			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.RepeatedLinear, callback);
+		public void RequestReadPixels (SKImageInfo info, Action<SKImageReadPixelsResult> callback) =>
+			RequestReadPixels (info, SKRectI.Create (info.Width, info.Height), SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
 
-		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageAsyncReadResult> callback)
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageReadPixelsResult> callback) =>
+			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
+
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageReadPixelsResult> callback)
 		{
 			if (callback == null)
 				throw new ArgumentNullException (nameof (callback));
 
 			Action<IntPtr> handler = raw => {
-				using var result = raw == IntPtr.Zero ? null : new SKImageAsyncReadResult (raw);
+				using var result = raw == IntPtr.Zero ? null : new SKImageReadPixelsResult (raw);
 				callback (result);
 			};
 			DelegateProxies.Create (handler, out _, out var ctx);

--- a/binding/SkiaSharp/SKImage.cs
+++ b/binding/SkiaSharp/SKImage.cs
@@ -613,6 +613,27 @@ namespace SkiaSharp
 			return result;
 		}
 
+		// RequestReadPixels
+
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageAsyncReadResult> callback) =>
+			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.RepeatedLinear, callback);
+
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageAsyncReadResult> callback)
+		{
+			if (callback == null)
+				throw new ArgumentNullException (nameof (callback));
+
+			Action<IntPtr> handler = raw => {
+				using var result = raw == IntPtr.Zero ? null : new SKImageAsyncReadResult (raw);
+				callback (result);
+			};
+			DelegateProxies.Create (handler, out _, out var ctx);
+
+			var cinfo = SKImageInfoNative.FromManaged (ref info);
+			SkiaApi.sk_image_async_rescale_and_read_pixels (Handle, &cinfo, &srcRect, rescaleGamma, rescaleMode, DelegateProxies.SKImageAsyncReadPixelsProxy, (void*)ctx);
+			GC.KeepAlive (this);
+		}
+
 		// ScalePixels
 
 		[Obsolete("Use ScalePixels(SKPixmap dst, SKSamplingOptions sampling) instead.", error: true)]

--- a/binding/SkiaSharp/SKImage.cs
+++ b/binding/SkiaSharp/SKImage.cs
@@ -615,9 +615,6 @@ namespace SkiaSharp
 
 		// RequestReadPixels
 
-		public void RequestReadPixels (SKImageInfo info, Action<SKImageReadPixelsResult> callback) =>
-			RequestReadPixels (info, SKRectI.Create (info.Width, info.Height), SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
-
 		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageReadPixelsResult> callback) =>
 			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
 
@@ -627,8 +624,10 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (callback));
 
 			Action<IntPtr> handler = raw => {
-				using var result = raw == IntPtr.Zero ? null : new SKImageReadPixelsResult (raw);
+				using var result = raw == IntPtr.Zero ? null : new SKImageReadPixelsResult (raw, info);
 				callback (result);
+				// Keep this image alive until the (possibly deferred) callback fires.
+				GC.KeepAlive (this);
 			};
 			DelegateProxies.Create (handler, out _, out var ctx);
 

--- a/binding/SkiaSharp/SKImageAsyncReadResult.cs
+++ b/binding/SkiaSharp/SKImageAsyncReadResult.cs
@@ -1,0 +1,99 @@
+#nullable disable
+
+using System;
+
+namespace SkiaSharp
+{
+	/// <summary>
+	/// The pixel data produced by <see cref="SKImage.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageAsyncReadResult})" />
+	/// or <see cref="SKSurface.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageAsyncReadResult})" />.
+	/// </summary>
+	/// <remarks>
+	/// This is a non-owning view over the native result. It is only valid for the duration of the
+	/// callback it is delivered to; the underlying pixels are released as soon as the callback returns.
+	/// Accessing any member after the callback has returned throws <see cref="ObjectDisposedException" />.
+	/// </remarks>
+	public sealed unsafe class SKImageAsyncReadResult : IDisposable
+	{
+		private IntPtr handle;
+
+		internal SKImageAsyncReadResult (IntPtr handle)
+		{
+			this.handle = handle;
+		}
+
+		/// <summary>
+		/// Gets the number of planes in the result. This is 1 for the standard (RGBA) read.
+		/// </summary>
+		public int PlaneCount {
+			get {
+				ThrowIfDisposed ();
+				return SkiaApi.sk_image_async_read_result_get_count (handle);
+			}
+		}
+
+		/// <summary>
+		/// Gets a pointer to the pixel data for the specified plane. The pointer is only valid for the
+		/// duration of the callback.
+		/// </summary>
+		/// <param name="planeIndex">The zero-based index of the plane.</param>
+		public IntPtr GetPlaneData (int planeIndex)
+		{
+			ThrowIfDisposed ();
+			if (planeIndex < 0 || planeIndex >= PlaneCount)
+				throw new ArgumentOutOfRangeException (nameof (planeIndex));
+			return (IntPtr)SkiaApi.sk_image_async_read_result_get_data (handle, planeIndex);
+		}
+
+		/// <summary>
+		/// Gets the number of bytes in a row of the specified plane.
+		/// </summary>
+		/// <param name="planeIndex">The zero-based index of the plane.</param>
+		public int GetPlaneRowBytes (int planeIndex)
+		{
+			ThrowIfDisposed ();
+			if (planeIndex < 0 || planeIndex >= PlaneCount)
+				throw new ArgumentOutOfRangeException (nameof (planeIndex));
+			return (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
+		}
+
+		/// <summary>
+		/// Copies <paramref name="rowCount" /> rows of the specified plane into <paramref name="destination" />.
+		/// </summary>
+		/// <param name="planeIndex">The zero-based index of the plane.</param>
+		/// <param name="destination">The buffer to copy the pixel data into.</param>
+		/// <param name="rowCount">The number of rows to copy (typically the destination image height).</param>
+		public void CopyPlaneTo (int planeIndex, Span<byte> destination, int rowCount)
+		{
+			ThrowIfDisposed ();
+			if (planeIndex < 0 || planeIndex >= PlaneCount)
+				throw new ArgumentOutOfRangeException (nameof (planeIndex));
+			if (rowCount < 0)
+				throw new ArgumentOutOfRangeException (nameof (rowCount));
+
+			var srcRowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
+			var required = checked (srcRowBytes * rowCount);
+			if (destination.Length < required)
+				throw new ArgumentException (
+					$"Destination must be at least {required} bytes (rowCount={rowCount} × rowBytes={srcRowBytes}); got {destination.Length}.",
+					nameof (destination));
+
+			var src = SkiaApi.sk_image_async_read_result_get_data (handle, planeIndex);
+			if (src == null)
+				throw new InvalidOperationException ("Plane data is null.");
+			new ReadOnlySpan<byte> (src, required).CopyTo (destination);
+		}
+
+		/// <summary>
+		/// Invalidates this view. This is called automatically when the callback returns.
+		/// </summary>
+		public void Dispose () => handle = IntPtr.Zero;
+
+		private void ThrowIfDisposed ()
+		{
+			if (handle == IntPtr.Zero)
+				throw new ObjectDisposedException (nameof (SKImageAsyncReadResult),
+					"The async read result is only valid for the duration of the callback.");
+		}
+	}
+}

--- a/binding/SkiaSharp/SKImageReadPixelsResult.cs
+++ b/binding/SkiaSharp/SKImageReadPixelsResult.cs
@@ -68,9 +68,18 @@ namespace SkiaSharp
 					nameof (destination));
 
 			var srcRowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
-			var copy = Math.Min (srcRowBytes, packedRowBytes);
+			var srcLength = checked (srcRowBytes * height);
+			CopyRows (new ReadOnlySpan<byte> (src, srcLength), srcRowBytes, destination, packedRowBytes, height);
+		}
+
+		// Copies `height` rows from a strided source into a strided destination, taking the smaller of
+		// the two strides per row (so source row padding is dropped when destination is tighter).
+		// Internal + span-based so the padding-stripping path is unit-testable without a real GPU read.
+		internal static void CopyRows (ReadOnlySpan<byte> source, int srcRowBytes, Span<byte> destination, int dstRowBytes, int height)
+		{
+			var copy = Math.Min (srcRowBytes, dstRowBytes);
 			for (var y = 0; y < height; y++)
-				new ReadOnlySpan<byte> (src + (y * srcRowBytes), copy).CopyTo (destination.Slice (y * packedRowBytes));
+				source.Slice (y * srcRowBytes, copy).CopyTo (destination.Slice (y * dstRowBytes));
 		}
 
 		// Returns a tightly-packed copy of the plane that outlives the callback.

--- a/binding/SkiaSharp/SKImageReadPixelsResult.cs
+++ b/binding/SkiaSharp/SKImageReadPixelsResult.cs
@@ -5,19 +5,19 @@ using System;
 namespace SkiaSharp
 {
 	/// <summary>
-	/// The pixel data produced by <see cref="SKImage.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageAsyncReadResult})" />
-	/// or <see cref="SKSurface.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageAsyncReadResult})" />.
+	/// The pixel data produced by <see cref="SKImage.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageReadPixelsResult})" />
+	/// or <see cref="SKSurface.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageReadPixelsResult})" />.
 	/// </summary>
 	/// <remarks>
 	/// This is a non-owning view over the native result. It is only valid for the duration of the
 	/// callback it is delivered to; the underlying pixels are released as soon as the callback returns.
 	/// Accessing any member after the callback has returned throws <see cref="ObjectDisposedException" />.
 	/// </remarks>
-	public sealed unsafe class SKImageAsyncReadResult : IDisposable
+	public sealed unsafe class SKImageReadPixelsResult : IDisposable
 	{
 		private IntPtr handle;
 
-		internal SKImageAsyncReadResult (IntPtr handle)
+		internal SKImageReadPixelsResult (IntPtr handle)
 		{
 			this.handle = handle;
 		}
@@ -92,7 +92,7 @@ namespace SkiaSharp
 		private void ThrowIfDisposed ()
 		{
 			if (handle == IntPtr.Zero)
-				throw new ObjectDisposedException (nameof (SKImageAsyncReadResult),
+				throw new ObjectDisposedException (nameof (SKImageReadPixelsResult),
 					"The async read result is only valid for the duration of the callback.");
 		}
 	}

--- a/binding/SkiaSharp/SKImageReadPixelsResult.cs
+++ b/binding/SkiaSharp/SKImageReadPixelsResult.cs
@@ -4,27 +4,17 @@ using System;
 
 namespace SkiaSharp
 {
-	/// <summary>
-	/// The pixel data produced by <see cref="SKImage.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageReadPixelsResult})" />
-	/// or <see cref="SKSurface.RequestReadPixels(SKImageInfo, SKRectI, Action{SKImageReadPixelsResult})" />.
-	/// </summary>
-	/// <remarks>
-	/// This is a non-owning view over the native result. It is only valid for the duration of the
-	/// callback it is delivered to; the underlying pixels are released as soon as the callback returns.
-	/// Accessing any member after the callback has returned throws <see cref="ObjectDisposedException" />.
-	/// </remarks>
 	public sealed unsafe class SKImageReadPixelsResult : IDisposable
 	{
 		private IntPtr handle;
+		private readonly SKImageInfo info;
 
-		internal SKImageReadPixelsResult (IntPtr handle)
+		internal SKImageReadPixelsResult (IntPtr handle, SKImageInfo info)
 		{
 			this.handle = handle;
+			this.info = info;
 		}
 
-		/// <summary>
-		/// Gets the number of planes in the result. This is 1 for the standard (RGBA) read.
-		/// </summary>
 		public int PlaneCount {
 			get {
 				ThrowIfDisposed ();
@@ -32,23 +22,6 @@ namespace SkiaSharp
 			}
 		}
 
-		/// <summary>
-		/// Gets a pointer to the pixel data for the specified plane. The pointer is only valid for the
-		/// duration of the callback.
-		/// </summary>
-		/// <param name="planeIndex">The zero-based index of the plane.</param>
-		public IntPtr GetPlaneData (int planeIndex)
-		{
-			ThrowIfDisposed ();
-			if (planeIndex < 0 || planeIndex >= PlaneCount)
-				throw new ArgumentOutOfRangeException (nameof (planeIndex));
-			return (IntPtr)SkiaApi.sk_image_async_read_result_get_data (handle, planeIndex);
-		}
-
-		/// <summary>
-		/// Gets the number of bytes in a row of the specified plane.
-		/// </summary>
-		/// <param name="planeIndex">The zero-based index of the plane.</param>
 		public int GetPlaneRowBytes (int planeIndex)
 		{
 			ThrowIfDisposed ();
@@ -57,36 +30,22 @@ namespace SkiaSharp
 			return (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
 		}
 
-		/// <summary>
-		/// Copies <paramref name="rowCount" /> rows of the specified plane into <paramref name="destination" />.
-		/// </summary>
-		/// <param name="planeIndex">The zero-based index of the plane.</param>
-		/// <param name="destination">The buffer to copy the pixel data into.</param>
-		/// <param name="rowCount">The number of rows to copy (typically the destination image height).</param>
-		public void CopyPlaneTo (int planeIndex, Span<byte> destination, int rowCount)
+		public ReadOnlySpan<byte> GetPlaneData (int planeIndex)
 		{
 			ThrowIfDisposed ();
 			if (planeIndex < 0 || planeIndex >= PlaneCount)
 				throw new ArgumentOutOfRangeException (nameof (planeIndex));
-			if (rowCount < 0)
-				throw new ArgumentOutOfRangeException (nameof (rowCount));
-
-			var srcRowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
-			var required = checked (srcRowBytes * rowCount);
-			if (destination.Length < required)
-				throw new ArgumentException (
-					$"Destination must be at least {required} bytes (rowCount={rowCount} × rowBytes={srcRowBytes}); got {destination.Length}.",
-					nameof (destination));
 
 			var src = SkiaApi.sk_image_async_read_result_get_data (handle, planeIndex);
 			if (src == null)
-				throw new InvalidOperationException ("Plane data is null.");
-			new ReadOnlySpan<byte> (src, required).CopyTo (destination);
+				return default;
+
+			// The (non-YUV) read produces a single plane whose height matches the requested info.
+			var rowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
+			var length = checked (rowBytes * info.Height);
+			return new ReadOnlySpan<byte> (src, length);
 		}
 
-		/// <summary>
-		/// Invalidates this view. This is called automatically when the callback returns.
-		/// </summary>
 		public void Dispose () => handle = IntPtr.Zero;
 
 		private void ThrowIfDisposed ()

--- a/binding/SkiaSharp/SKImageReadPixelsResult.cs
+++ b/binding/SkiaSharp/SKImageReadPixelsResult.cs
@@ -40,10 +40,73 @@ namespace SkiaSharp
 			if (src == null)
 				return default;
 
-			// The (non-YUV) read produces a single plane whose height matches the requested info.
+			// The raw plane exactly as Skia laid it out, including any per-row padding
+			// (rowBytes >= width * bytesPerPixel). Use GetPlaneRowBytes as the stride.
 			var rowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
 			var length = checked (rowBytes * info.Height);
 			return new ReadOnlySpan<byte> (src, length);
+		}
+
+		// Copies the plane into destination as tightly-packed pixels (any transfer-buffer row
+		// padding is stripped, so the destination stride is info.RowBytes).
+		public void CopyPlaneTo (int planeIndex, Span<byte> destination)
+		{
+			ThrowIfDisposed ();
+			if (planeIndex < 0 || planeIndex >= PlaneCount)
+				throw new ArgumentOutOfRangeException (nameof (planeIndex));
+
+			var src = (byte*)SkiaApi.sk_image_async_read_result_get_data (handle, planeIndex);
+			if (src == null)
+				throw new InvalidOperationException ("Plane data is null.");
+
+			var packedRowBytes = info.RowBytes;
+			var height = info.Height;
+			var required = checked (packedRowBytes * height);
+			if (destination.Length < required)
+				throw new ArgumentException (
+					$"Destination must be at least {required} bytes ({height} rows × {packedRowBytes}); got {destination.Length}.",
+					nameof (destination));
+
+			var srcRowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, planeIndex);
+			var copy = Math.Min (srcRowBytes, packedRowBytes);
+			for (var y = 0; y < height; y++)
+				new ReadOnlySpan<byte> (src + (y * srcRowBytes), copy).CopyTo (destination.Slice (y * packedRowBytes));
+		}
+
+		// Returns a tightly-packed copy of the plane that outlives the callback.
+		public byte[] ToArray (int planeIndex = 0)
+		{
+			ThrowIfDisposed ();
+			var pixels = new byte[info.BytesSize];
+			CopyPlaneTo (planeIndex, pixels);
+			return pixels;
+		}
+
+		// Materializes the whole (single-plane) result into an owned SKImage that outlives the callback.
+		public SKImage ToImage ()
+		{
+			ThrowIfDisposed ();
+			if (PlaneCount != 1)
+				throw new InvalidOperationException ("ToImage is only supported for single-plane (interleaved) results.");
+
+			var src = SkiaApi.sk_image_async_read_result_get_data (handle, 0);
+			if (src == null)
+				throw new InvalidOperationException ("Plane data is null.");
+
+			var rowBytes = (int)SkiaApi.sk_image_async_read_result_get_row_bytes (handle, 0);
+			return SKImage.FromPixelCopy (info, (IntPtr)src, rowBytes);
+		}
+
+		// Materializes the whole (single-plane) result into an owned SKBitmap that outlives the callback.
+		public SKBitmap ToBitmap ()
+		{
+			ThrowIfDisposed ();
+			if (PlaneCount != 1)
+				throw new InvalidOperationException ("ToBitmap is only supported for single-plane (interleaved) results.");
+
+			var bitmap = new SKBitmap (info);
+			CopyPlaneTo (0, new Span<byte> ((void*)bitmap.GetPixels (), bitmap.ByteCount));
+			return bitmap;
 		}
 
 		public void Dispose () => handle = IntPtr.Zero;

--- a/binding/SkiaSharp/SKSurface.cs
+++ b/binding/SkiaSharp/SKSurface.cs
@@ -408,9 +408,6 @@ namespace SkiaSharp
 
 		// RequestReadPixels
 
-		public void RequestReadPixels (SKImageInfo info, Action<SKImageReadPixelsResult> callback) =>
-			RequestReadPixels (info, SKRectI.Create (info.Width, info.Height), SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
-
 		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageReadPixelsResult> callback) =>
 			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
 
@@ -420,8 +417,10 @@ namespace SkiaSharp
 				throw new ArgumentNullException (nameof (callback));
 
 			Action<IntPtr> handler = raw => {
-				using var result = raw == IntPtr.Zero ? null : new SKImageReadPixelsResult (raw);
+				using var result = raw == IntPtr.Zero ? null : new SKImageReadPixelsResult (raw, info);
 				callback (result);
+				// Keep this surface alive until the (possibly deferred) callback fires.
+				GC.KeepAlive (this);
 			};
 			DelegateProxies.Create (handler, out _, out var ctx);
 

--- a/binding/SkiaSharp/SKSurface.cs
+++ b/binding/SkiaSharp/SKSurface.cs
@@ -406,6 +406,27 @@ namespace SkiaSharp
 			return result;
 		}
 
+		// RequestReadPixels
+
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageAsyncReadResult> callback) =>
+			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.RepeatedLinear, callback);
+
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageAsyncReadResult> callback)
+		{
+			if (callback == null)
+				throw new ArgumentNullException (nameof (callback));
+
+			Action<IntPtr> handler = raw => {
+				using var result = raw == IntPtr.Zero ? null : new SKImageAsyncReadResult (raw);
+				callback (result);
+			};
+			DelegateProxies.Create (handler, out _, out var ctx);
+
+			var cinfo = SKImageInfoNative.FromManaged (ref info);
+			SkiaApi.sk_surface_async_rescale_and_read_pixels (Handle, &cinfo, &srcRect, rescaleGamma, rescaleMode, DelegateProxies.SKImageAsyncReadPixelsProxy, (void*)ctx);
+			GC.KeepAlive (this);
+		}
+
 		public void Flush () => Flush (true);
 
 		public void Flush (bool submit, bool synchronous = false)

--- a/binding/SkiaSharp/SKSurface.cs
+++ b/binding/SkiaSharp/SKSurface.cs
@@ -408,16 +408,19 @@ namespace SkiaSharp
 
 		// RequestReadPixels
 
-		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageAsyncReadResult> callback) =>
-			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.RepeatedLinear, callback);
+		public void RequestReadPixels (SKImageInfo info, Action<SKImageReadPixelsResult> callback) =>
+			RequestReadPixels (info, SKRectI.Create (info.Width, info.Height), SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
 
-		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageAsyncReadResult> callback)
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageReadPixelsResult> callback) =>
+			RequestReadPixels (info, srcRect, SKImageRescaleGamma.Src, SKImageRescaleMode.Nearest, callback);
+
+		public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageReadPixelsResult> callback)
 		{
 			if (callback == null)
 				throw new ArgumentNullException (nameof (callback));
 
 			Action<IntPtr> handler = raw => {
-				using var result = raw == IntPtr.Zero ? null : new SKImageAsyncReadResult (raw);
+				using var result = raw == IntPtr.Zero ? null : new SKImageReadPixelsResult (raw);
 				callback (result);
 			};
 			DelegateProxies.Create (handler, out _, out var ctx);

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -40,6 +40,7 @@ using sk_font_t = System.IntPtr;
 using sk_fontmgr_t = System.IntPtr;
 using sk_fontstyle_t = System.IntPtr;
 using sk_fontstyleset_t = System.IntPtr;
+using sk_image_async_read_result_t = System.IntPtr;
 using sk_image_t = System.IntPtr;
 using sk_imagefilter_t = System.IntPtr;
 using sk_manageddrawable_t = System.IntPtr;
@@ -586,6 +587,25 @@ namespace SkiaSharp
 		private static Delegates.gr_direct_context_abandon_context gr_direct_context_abandon_context_delegate;
 		internal static void gr_direct_context_abandon_context (gr_direct_context_t context) =>
 			(gr_direct_context_abandon_context_delegate ??= GetSymbol<Delegates.gr_direct_context_abandon_context> ("gr_direct_context_abandon_context")).Invoke (context);
+		#endif
+
+		// void gr_direct_context_check_async_work_completion(gr_direct_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void gr_direct_context_check_async_work_completion (gr_direct_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void gr_direct_context_check_async_work_completion (gr_direct_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void gr_direct_context_check_async_work_completion (gr_direct_context_t context);
+		}
+		private static Delegates.gr_direct_context_check_async_work_completion gr_direct_context_check_async_work_completion_delegate;
+		internal static void gr_direct_context_check_async_work_completion (gr_direct_context_t context) =>
+			(gr_direct_context_check_async_work_completion_delegate ??= GetSymbol<Delegates.gr_direct_context_check_async_work_completion> ("gr_direct_context_check_async_work_completion")).Invoke (context);
 		#endif
 
 		// void gr_direct_context_dump_memory_statistics(const gr_direct_context_t* context, sk_tracememorydump_t* dump)
@@ -6832,6 +6852,82 @@ namespace SkiaSharp
 		#endregion
 
 		#region sk_image.h
+
+		// int32_t sk_image_async_read_result_get_count(const sk_image_async_read_result_t* result)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial Int32 sk_image_async_read_result_get_count (sk_image_async_read_result_t result);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_image_async_read_result_get_count (sk_image_async_read_result_t result);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int32 sk_image_async_read_result_get_count (sk_image_async_read_result_t result);
+		}
+		private static Delegates.sk_image_async_read_result_get_count sk_image_async_read_result_get_count_delegate;
+		internal static Int32 sk_image_async_read_result_get_count (sk_image_async_read_result_t result) =>
+			(sk_image_async_read_result_get_count_delegate ??= GetSymbol<Delegates.sk_image_async_read_result_get_count> ("sk_image_async_read_result_get_count")).Invoke (result);
+		#endif
+
+		// const void* sk_image_async_read_result_get_data(const sk_image_async_read_result_t* result, int32_t planeIndex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void* sk_image_async_read_result_get_data (sk_image_async_read_result_t result, Int32 planeIndex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void* sk_image_async_read_result_get_data (sk_image_async_read_result_t result, Int32 planeIndex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void* sk_image_async_read_result_get_data (sk_image_async_read_result_t result, Int32 planeIndex);
+		}
+		private static Delegates.sk_image_async_read_result_get_data sk_image_async_read_result_get_data_delegate;
+		internal static void* sk_image_async_read_result_get_data (sk_image_async_read_result_t result, Int32 planeIndex) =>
+			(sk_image_async_read_result_get_data_delegate ??= GetSymbol<Delegates.sk_image_async_read_result_get_data> ("sk_image_async_read_result_get_data")).Invoke (result, planeIndex);
+		#endif
+
+		// size_t sk_image_async_read_result_get_row_bytes(const sk_image_async_read_result_t* result, int32_t planeIndex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial /* size_t */ IntPtr sk_image_async_read_result_get_row_bytes (sk_image_async_read_result_t result, Int32 planeIndex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern /* size_t */ IntPtr sk_image_async_read_result_get_row_bytes (sk_image_async_read_result_t result, Int32 planeIndex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate /* size_t */ IntPtr sk_image_async_read_result_get_row_bytes (sk_image_async_read_result_t result, Int32 planeIndex);
+		}
+		private static Delegates.sk_image_async_read_result_get_row_bytes sk_image_async_read_result_get_row_bytes_delegate;
+		internal static /* size_t */ IntPtr sk_image_async_read_result_get_row_bytes (sk_image_async_read_result_t result, Int32 planeIndex) =>
+			(sk_image_async_read_result_get_row_bytes_delegate ??= GetSymbol<Delegates.sk_image_async_read_result_get_row_bytes> ("sk_image_async_read_result_get_row_bytes")).Invoke (result, planeIndex);
+		#endif
+
+		// void sk_image_async_rescale_and_read_pixels(const sk_image_t* image, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_image_async_rescale_and_read_pixels (sk_image_t image, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, void* callback, void* context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_image_async_rescale_and_read_pixels (sk_image_t image, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_image_async_rescale_and_read_pixels (sk_image_t image, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* context);
+		}
+		private static Delegates.sk_image_async_rescale_and_read_pixels sk_image_async_rescale_and_read_pixels_delegate;
+		internal static void sk_image_async_rescale_and_read_pixels (sk_image_t image, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* context) =>
+			(sk_image_async_rescale_and_read_pixels_delegate ??= GetSymbol<Delegates.sk_image_async_rescale_and_read_pixels> ("sk_image_async_rescale_and_read_pixels")).Invoke (image, dstInfo, srcRect, rescaleGamma, rescaleMode, callback, context);
+		#endif
 
 		// sk_alphatype_t sk_image_get_alpha_type(const sk_image_t* image)
 		#if !USE_DELEGATES
@@ -15438,6 +15534,25 @@ namespace SkiaSharp
 
 		#region sk_surface.h
 
+		// void sk_surface_async_rescale_and_read_pixels(sk_surface_t* surface, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_surface_async_rescale_and_read_pixels (sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, void* callback, void* context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_surface_async_rescale_and_read_pixels (sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_surface_async_rescale_and_read_pixels (sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* context);
+		}
+		private static Delegates.sk_surface_async_rescale_and_read_pixels sk_surface_async_rescale_and_read_pixels_delegate;
+		internal static void sk_surface_async_rescale_and_read_pixels (sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* context) =>
+			(sk_surface_async_rescale_and_read_pixels_delegate ??= GetSymbol<Delegates.sk_surface_async_rescale_and_read_pixels> ("sk_surface_async_rescale_and_read_pixels")).Invoke (surface, dstInfo, srcRect, rescaleGamma, rescaleMode, callback, context);
+		#endif
+
 		// void sk_surface_draw(sk_surface_t* surface, sk_canvas_t* canvas, float x, float y, const sk_paint_t* paint)
 		#if !USE_DELEGATES
 		#if USE_LIBRARY_IMPORT
@@ -17708,6 +17823,10 @@ namespace SkiaSharp {
 	// typedef void (*)(const sk_path_t* pathOrNull, const sk_matrix_t* matrix, void* context)* sk_glyph_path_proc
 	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 	internal unsafe delegate void SKGlyphPathProxyDelegate(sk_path_t pathOrNull, SKMatrix* matrix, void* context);
+
+	// typedef void (*)(void* context, const sk_image_async_read_result_t* result)* sk_image_async_read_pixels_proc
+	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+	internal unsafe delegate void SKImageAsyncReadPixelsProxyDelegate(void* context, sk_image_async_read_result_t result);
 
 	// typedef void (*)(const void* addr, void* context)* sk_image_raster_release_proc
 	[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
@@ -21311,6 +21430,26 @@ namespace SkiaSharp {
 		Disallow = 1,
 	}
 
+	// sk_image_rescale_gamma_t
+	public enum SKImageRescaleGamma {
+		// SRC_SK_IMAGE_RESCALE_GAMMA = 0
+		Src = 0,
+		// LINEAR_SK_IMAGE_RESCALE_GAMMA = 1
+		Linear = 1,
+	}
+
+	// sk_image_rescale_mode_t
+	public enum SKImageRescaleMode {
+		// NEAREST_SK_IMAGE_RESCALE_MODE = 0
+		Nearest = 0,
+		// LINEAR_SK_IMAGE_RESCALE_MODE = 1
+		Linear = 1,
+		// REPEATED_LINEAR_SK_IMAGE_RESCALE_MODE = 2
+		RepeatedLinear = 2,
+		// REPEATED_CUBIC_SK_IMAGE_RESCALE_MODE = 3
+		RepeatedCubic = 3,
+	}
+
 	// sk_jpegencoder_alphaoption_t
 	public enum SKJpegEncoderAlphaOption {
 		// IGNORE_SK_JPEGENCODER_ALPHA_OPTION = 0
@@ -21746,6 +21885,16 @@ internal static unsafe partial class DelegateProxies {
 	[MonoPInvokeCallback (typeof (SKGlyphPathProxyDelegate))]
 #endif
 	private static partial void SKGlyphPathProxyImplementation(sk_path_t pathOrNull,SKMatrix* matrix,void* context);
+
+	/// Proxy for sk_image_async_read_pixels_proc native function.
+#if USE_LIBRARY_IMPORT
+	public static readonly delegate* unmanaged[Cdecl] <void*, sk_image_async_read_result_t, void> SKImageAsyncReadPixelsProxy = &SKImageAsyncReadPixelsProxyImplementation;
+	[UnmanagedCallersOnly(CallConvs = new [] {typeof(CallConvCdecl)})]
+#else
+	public static readonly SKImageAsyncReadPixelsProxyDelegate SKImageAsyncReadPixelsProxy = SKImageAsyncReadPixelsProxyImplementation;
+	[MonoPInvokeCallback (typeof (SKImageAsyncReadPixelsProxyDelegate))]
+#endif
+	private static partial void SKImageAsyncReadPixelsProxyImplementation(void* context,sk_image_async_read_result_t result);
 
 	/// Proxy for sk_image_raster_release_proc native function.
 #if USE_LIBRARY_IMPORT

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1af4051dbaaa38b6016d4fc34a52acf9c639063d"
+          "commitHash": "0d6ea6b0484a64677509f67f865daecd220912cc"
         }
       }
     },

--- a/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
+++ b/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
@@ -6,24 +6,35 @@ namespace SkiaSharp.Tests
 {
 	public class SKAsyncReadPixelsTest : SKTest
 	{
-		private static readonly SKColor FillColor = SKColors.Red; // (255, 0, 0, 255)
+		private static readonly SKColor FillColor = SKColors.Red; // rgba 255,0,0,255
 
-		private static void AssertIsFillColor(byte[] pixels)
-		{
-			Assert.Equal(255, pixels[0]); // R
-			Assert.Equal(0, pixels[1]);   // G
-			Assert.Equal(0, pixels[2]);   // B
-			Assert.Equal(255, pixels[3]); // A
-		}
-
-		private static byte[] CopyFirstPlane(SKImageReadPixelsResult result, int rowCount)
+		private static byte[] GetPixels(SKImageReadPixelsResult result)
 		{
 			Assert.NotNull(result);
 			Assert.Equal(1, result.PlaneCount);
-			var rowBytes = result.GetPlaneRowBytes(0);
-			var pixels = new byte[rowBytes * rowCount];
-			result.CopyPlaneTo(0, pixels, rowCount);
-			return pixels;
+			return result.GetPlaneData(0).ToArray();
+		}
+
+		private static void AssertPixel(byte[] pixels, int height, int x, int y, byte r, byte g, byte b, byte a)
+		{
+			// GetPlaneData returns exactly rowBytes*height bytes, so rowBytes = length/height.
+			var rowBytes = pixels.Length / height;
+			var o = (y * rowBytes) + (x * 4);
+			Assert.Equal(r, pixels[o + 0]);
+			Assert.Equal(g, pixels[o + 1]);
+			Assert.Equal(b, pixels[o + 2]);
+			Assert.Equal(a, pixels[o + 3]);
+		}
+
+		// Left half red, right half blue — a pattern a broken rescale/row-traversal cannot fake.
+		private static SKSurface CreateSplitSurface(int size)
+		{
+			var surface = SKSurface.Create(new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul));
+			surface.Canvas.Clear(SKColors.Red);
+			using (var paint = new SKPaint { Color = SKColors.Blue })
+				surface.Canvas.DrawRect(new SKRect(size / 2, 0, size, size), paint);
+			surface.Flush();
+			return surface;
 		}
 
 		// Per Skia (SkImage.h/SkSurface.h): async reads are Ganesh-only; "in all other cases this
@@ -42,12 +53,12 @@ namespace SkiaSharp.Tests
 			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
 			{
 				done = true;
-				pixels = CopyFirstPlane(result, info.Height);
+				pixels = GetPixels(result);
 			});
 
-			// No Submit / CheckAsyncWorkCompletion pump: it must already have fired.
-			Assert.True(done);
-			AssertIsFillColor(pixels);
+			Assert.True(done); // no Submit / pump: it must already have fired
+			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255);
+			AssertPixel(pixels, info.Height, 3, 3, 255, 0, 0, 255);
 		}
 
 		[Fact]
@@ -65,22 +76,42 @@ namespace SkiaSharp.Tests
 			image.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
 			{
 				done = true;
-				pixels = CopyFirstPlane(result, info.Height);
+				pixels = GetPixels(result);
 			});
 
 			Assert.True(done);
-			AssertIsFillColor(pixels);
+			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255);
 		}
 
-		// Reading a smaller destination than the source rectangle exercises the rescale path.
+		// Same-size read of a two-colour pattern: verifies full readback + correct row traversal/stride.
+		[Fact]
+		public void RasterSurfaceRequestReadPixelsSameSizeReadsWholePattern()
+		{
+			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(8);
+
+			var done = false;
+			byte[] pixels = null;
+
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result =>
+			{
+				done = true;
+				pixels = GetPixels(result);
+			});
+
+			Assert.True(done);
+			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255); // left = red
+			AssertPixel(pixels, info.Height, 3, 3, 255, 0, 0, 255); // still left of the split
+			AssertPixel(pixels, info.Height, 4, 4, 0, 0, 255, 255); // right = blue
+			AssertPixel(pixels, info.Height, 7, 7, 0, 0, 255, 255);
+		}
+
+		// Downscale a two-colour pattern 8x8 -> 4x4; a no-op or broken rescale cannot reproduce it.
 		[Fact]
 		public void RasterSurfaceRequestReadPixelsDownscaleWorks()
 		{
-			var srcInfo = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
 			var dstInfo = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(srcInfo);
-			surface.Canvas.Clear(FillColor);
-			surface.Flush();
+			using var surface = CreateSplitSurface(8);
 
 			var done = false;
 			byte[] pixels = null;
@@ -88,12 +119,12 @@ namespace SkiaSharp.Tests
 			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), result =>
 			{
 				done = true;
-				pixels = CopyFirstPlane(result, dstInfo.Height);
+				pixels = GetPixels(result);
 			});
 
 			Assert.True(done);
-			// A solid fill downscales to the same solid color.
-			AssertIsFillColor(pixels);
+			AssertPixel(pixels, dstInfo.Height, 0, 0, 255, 0, 0, 255); // left column stays red
+			AssertPixel(pixels, dstInfo.Height, 3, 0, 0, 0, 255, 255); // right column stays blue
 		}
 
 		// The result view is only valid during the callback; using it afterwards must throw.
@@ -118,28 +149,6 @@ namespace SkiaSharp.Tests
 		}
 
 		[Fact]
-		public void RasterSurfaceRequestReadPixelsWholeImageOverloadWorks()
-		{
-			// The (info, callback) overload reads at 1:1 (srcRect == info size), so no rescale happens.
-			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(info);
-			surface.Canvas.Clear(FillColor);
-			surface.Flush();
-
-			var done = false;
-			byte[] pixels = null;
-
-			surface.RequestReadPixels(info, result =>
-			{
-				done = true;
-				pixels = CopyFirstPlane(result, info.Height);
-			});
-
-			Assert.True(done);
-			AssertIsFillColor(pixels);
-		}
-
-		[Fact]
 		public void RequestReadPixelsThrowsForNullCallback()
 		{
 			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
@@ -147,12 +156,34 @@ namespace SkiaSharp.Tests
 			Assert.Throws<ArgumentNullException>(() => surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), null));
 		}
 
-		// On Ganesh the read is genuinely asynchronous: the callback must NOT fire during the Request
-		// call. It only fires once work is submitted and CheckAsyncWorkCompletion is pumped. That
-		// false -> (pump) -> true transition is the proof of asynchrony.
+		// A srcRect not contained by the source causes failure: the callback is invoked with null.
+		[Fact]
+		public void RequestReadPixelsInvokesCallbackWithNullOnFailure()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			var called = false;
+			SKImageReadPixelsResult captured = null;
+
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 1000, 1000), result =>
+			{
+				called = true;
+				captured = result;
+			});
+
+			Assert.True(called);      // raster failure is delivered synchronously
+			Assert.Null(captured);
+		}
+
+		// On Ganesh the read is deferred when the backend supports transfer buffers; otherwise Skia
+		// falls back to a synchronous read. Assert the deferred transition only when it did not fire
+		// inline, and always assert it eventually completes with correct pixels.
 		[Fact]
 		[Trait(Traits.Category.Key, Traits.Category.Values.Gpu)]
-		public void GpuSurfaceRequestReadPixelsIsAsynchronousAndCorrect()
+		public void GpuSurfaceRequestReadPixelsCompletesWithCorrectPixels()
 		{
 			using var ctx = CreateGlContext();
 			ctx.MakeCurrent();
@@ -170,24 +201,26 @@ namespace SkiaSharp.Tests
 			{
 				done = true;
 				if (result != null)
-					pixels = CopyFirstPlane(result, info.Height);
+					pixels = GetPixels(result);
 			});
 
-			// PROVE ASYNC: the callback is deferred on the GPU backend.
-			Assert.False(done);
-
-			// Drive the work to completion.
-			grContext.Submit(synchronous: true);
-			for (var i = 0; i < 1000 && !done; i++)
+			var firedSynchronously = done;
+			if (!firedSynchronously)
 			{
-				grContext.CheckAsyncWorkCompletion();
-				if (!done)
-					Thread.Sleep(1);
+				// Proven deferred: it must not have fired before we pump.
+				Assert.False(done);
+				grContext.Submit(synchronous: true);
+				for (var i = 0; i < 1000 && !done; i++)
+				{
+					grContext.CheckAsyncWorkCompletion();
+					if (!done)
+						Thread.Sleep(1);
+				}
 			}
 
 			Assert.True(done);
 			Assert.NotNull(pixels);
-			AssertIsFillColor(pixels);
+			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255);
 		}
 
 		[Fact]
@@ -198,10 +231,12 @@ namespace SkiaSharp.Tests
 			ctx.MakeCurrent();
 			using var grContext = GRContext.CreateGl();
 
-			var srcInfo = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
 			var dstInfo = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			var srcInfo = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
 			using var surface = SKSurface.Create(grContext, true, srcInfo);
-			surface.Canvas.Clear(FillColor);
+			surface.Canvas.Clear(SKColors.Red);
+			using (var paint = new SKPaint { Color = SKColors.Blue })
+				surface.Canvas.DrawRect(new SKRect(4, 0, 8, 8), paint);
 			surface.Flush();
 
 			var done = false;
@@ -211,20 +246,24 @@ namespace SkiaSharp.Tests
 			{
 				done = true;
 				if (result != null)
-					pixels = CopyFirstPlane(result, dstInfo.Height);
+					pixels = GetPixels(result);
 			});
 
-			grContext.Submit(synchronous: true);
-			for (var i = 0; i < 1000 && !done; i++)
+			if (!done)
 			{
-				grContext.CheckAsyncWorkCompletion();
-				if (!done)
-					Thread.Sleep(1);
+				grContext.Submit(synchronous: true);
+				for (var i = 0; i < 1000 && !done; i++)
+				{
+					grContext.CheckAsyncWorkCompletion();
+					if (!done)
+						Thread.Sleep(1);
+				}
 			}
 
 			Assert.True(done);
 			Assert.NotNull(pixels);
-			AssertIsFillColor(pixels);
+			AssertPixel(pixels, dstInfo.Height, 0, 0, 255, 0, 0, 255); // left stays red
+			AssertPixel(pixels, dstInfo.Height, 3, 0, 0, 0, 255, 255); // right stays blue
 		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
+++ b/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
@@ -16,7 +16,7 @@ namespace SkiaSharp.Tests
 			Assert.Equal(255, pixels[3]); // A
 		}
 
-		private static byte[] CopyFirstPlane(SKImageAsyncReadResult result, int rowCount)
+		private static byte[] CopyFirstPlane(SKImageReadPixelsResult result, int rowCount)
 		{
 			Assert.NotNull(result);
 			Assert.Equal(1, result.PlaneCount);
@@ -105,7 +105,7 @@ namespace SkiaSharp.Tests
 			surface.Canvas.Clear(FillColor);
 			surface.Flush();
 
-			SKImageAsyncReadResult captured = null;
+			SKImageReadPixelsResult captured = null;
 
 			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
 			{
@@ -115,6 +115,28 @@ namespace SkiaSharp.Tests
 
 			Assert.NotNull(captured);
 			Assert.Throws<ObjectDisposedException>(() => _ = captured.PlaneCount);
+		}
+
+		[Fact]
+		public void RasterSurfaceRequestReadPixelsWholeImageOverloadWorks()
+		{
+			// The (info, callback) overload reads at 1:1 (srcRect == info size), so no rescale happens.
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			var done = false;
+			byte[] pixels = null;
+
+			surface.RequestReadPixels(info, result =>
+			{
+				done = true;
+				pixels = CopyFirstPlane(result, info.Height);
+			});
+
+			Assert.True(done);
+			AssertIsFillColor(pixels);
 		}
 
 		[Fact]

--- a/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
+++ b/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
@@ -6,30 +6,28 @@ namespace SkiaSharp.Tests
 {
 	public class SKAsyncReadPixelsTest : SKTest
 	{
-		private static readonly SKColor FillColor = SKColors.Red; // rgba 255,0,0,255
+		private const int SrcSize = 8;
+		private const int OffsetX = 2;
+		private const int OffsetY = 1;
+		private const int DstSize = 4; // srcRect = (2,1)..(6,5), read 1:1 (no rescale)
 
-		private static byte[] GetPixels(SKImageReadPixelsResult result)
+		// A distinct colour per pixel so any stride/offset/padding mistake is caught.
+		private static SKColor PatternColor(int x, int y) => new SKColor((byte)x, (byte)y, (byte)((x * 16) + y), 255);
+
+		private static SKBitmap CreatePatternBitmap(int size)
 		{
-			Assert.NotNull(result);
-			Assert.Equal(1, result.PlaneCount);
-			return result.GetPlaneData(0).ToArray();
+			var bmp = new SKBitmap(new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul));
+			for (var y = 0; y < size; y++)
+				for (var x = 0; x < size; x++)
+					bmp.SetPixel(x, y, PatternColor(x, y));
+			return bmp;
 		}
 
-		private static void AssertPixel(byte[] pixels, int height, int x, int y, byte r, byte g, byte b, byte a)
+		// Left half red, right half blue — a two-colour pattern for the rescale tests.
+		private static SKSurface CreateSplitSurface(int size, GRContext context = null)
 		{
-			// GetPlaneData returns exactly rowBytes*height bytes, so rowBytes = length/height.
-			var rowBytes = pixels.Length / height;
-			var o = (y * rowBytes) + (x * 4);
-			Assert.Equal(r, pixels[o + 0]);
-			Assert.Equal(g, pixels[o + 1]);
-			Assert.Equal(b, pixels[o + 2]);
-			Assert.Equal(a, pixels[o + 3]);
-		}
-
-		// Left half red, right half blue — a pattern a broken rescale/row-traversal cannot fake.
-		private static SKSurface CreateSplitSurface(int size)
-		{
-			var surface = SKSurface.Create(new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul));
+			var info = new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul);
+			var surface = context == null ? SKSurface.Create(info) : SKSurface.Create(context, true, info);
 			surface.Canvas.Clear(SKColors.Red);
 			using (var paint = new SKPaint { Color = SKColors.Blue })
 				surface.Canvas.DrawRect(new SKRect(size / 2, 0, size, size), paint);
@@ -37,76 +35,306 @@ namespace SkiaSharp.Tests
 			return surface;
 		}
 
-		// Per Skia (SkImage.h/SkSurface.h): async reads are Ganesh-only; "in all other cases this
-		// operates synchronously." So a raster surface must invoke the callback inline.
-		[Fact]
-		public void RasterSurfaceRequestReadPixelsIsSynchronousAndCorrect()
+		private static void AssertMatchesPattern(byte[] pixels, int rowBytes, int width, int height, int offsetX, int offsetY)
 		{
-			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(info);
-			surface.Canvas.Clear(FillColor);
-			surface.Flush();
-
-			var done = false;
-			byte[] pixels = null;
-
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			for (var oy = 0; oy < height; oy++)
 			{
-				done = true;
-				pixels = GetPixels(result);
-			});
+				for (var ox = 0; ox < width; ox++)
+				{
+					var expected = PatternColor(offsetX + ox, offsetY + oy);
+					var o = (oy * rowBytes) + (ox * 4);
+					Assert.Equal(expected.Red, pixels[o + 0]);
+					Assert.Equal(expected.Green, pixels[o + 1]);
+					Assert.Equal(expected.Blue, pixels[o + 2]);
+					Assert.Equal(expected.Alpha, pixels[o + 3]);
+				}
+			}
+		}
 
-			Assert.True(done); // no Submit / pump: it must already have fired
-			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255);
-			AssertPixel(pixels, info.Height, 3, 3, 255, 0, 0, 255);
+		private static void AssertBitmapMatchesPattern(SKBitmap bmp, int width, int height, int offsetX, int offsetY)
+		{
+			for (var oy = 0; oy < height; oy++)
+				for (var ox = 0; ox < width; ox++)
+					Assert.Equal(PatternColor(offsetX + ox, offsetY + oy), bmp.GetPixel(ox, oy));
+		}
+
+		private static SKImageInfo DstInfo => new SKImageInfo(DstSize, DstSize, SKColorType.Rgba8888, SKAlphaType.Premul);
+		private static SKRectI OffsetRect => new SKRectI(OffsetX, OffsetY, OffsetX + DstSize, OffsetY + DstSize);
+
+		// ---- Deterministic padding-strip unit test (real GPU/raster RGBA reads are never padded) ----
+
+		[Fact]
+		public void CopyRowsStripsSourcePadding()
+		{
+			const int width = 4, height = 3, bpp = 4;
+			const int packed = width * bpp;    // 16
+			const int srcStride = packed + 4;  // 20 -> 4 bytes of padding per row
+
+			var src = new byte[srcStride * height];
+			for (var y = 0; y < height; y++)
+			{
+				for (var x = 0; x < width; x++)
+				{
+					var o = (y * srcStride) + (x * bpp);
+					src[o + 0] = (byte)x;
+					src[o + 1] = (byte)y;
+					src[o + 2] = (byte)((x * 16) + y);
+					src[o + 3] = 255;
+				}
+				for (var p = packed; p < srcStride; p++)
+					src[(y * srcStride) + p] = 0xEE; // poison the padding
+			}
+
+			var dst = new byte[packed * height];
+			SKImageReadPixelsResult.CopyRows(src, srcStride, dst, packed, height);
+
+			for (var y = 0; y < height; y++)
+			{
+				for (var x = 0; x < width; x++)
+				{
+					var o = (y * packed) + (x * bpp);
+					Assert.Equal((byte)x, dst[o + 0]);
+					Assert.Equal((byte)y, dst[o + 1]);
+					Assert.Equal((byte)((x * 16) + y), dst[o + 2]);
+					Assert.Equal((byte)255, dst[o + 3]);
+				}
+			}
+			Assert.DoesNotContain((byte)0xEE, dst); // padding did not leak through
 		}
 
 		[Fact]
-		public void RasterImageRequestReadPixelsIsSynchronousAndCorrect()
+		public void CopyRowsWithoutPaddingIsExact()
 		{
-			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(info);
-			surface.Canvas.Clear(FillColor);
-			surface.Flush();
-			using var image = surface.Snapshot();
+			const int stride = 8, height = 3;
+			var src = new byte[stride * height];
+			for (var i = 0; i < src.Length; i++)
+				src[i] = (byte)(i + 1);
+
+			var dst = new byte[stride * height];
+			SKImageReadPixelsResult.CopyRows(src, stride, dst, stride, height);
+
+			Assert.Equal(src, dst);
+		}
+
+		// ---- Per-pixel correctness with an OFFSET srcRect (via a raster SKImage; read is synchronous) ----
+
+		[Fact]
+		public void GetPlaneDataMatchesPatternAtOffset()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
 
 			var done = false;
-			byte[] pixels = null;
-
-			image.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			byte[] raw = null;
+			var rowBytes = 0;
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
 			{
 				done = true;
-				pixels = GetPixels(result);
+				Assert.Equal(1, r.PlaneCount);
+				rowBytes = r.GetPlaneRowBytes(0);
+				Assert.True(rowBytes >= DstInfo.RowBytes); // stride is at least the packed width
+				raw = r.GetPlaneData(0).ToArray();         // raw view: length includes any padding
 			});
 
 			Assert.True(done);
-			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255);
+			AssertMatchesPattern(raw, rowBytes, DstSize, DstSize, OffsetX, OffsetY);
 		}
 
-		// Same-size read of a two-colour pattern: verifies full readback + correct row traversal/stride.
 		[Fact]
-		public void RasterSurfaceRequestReadPixelsSameSizeReadsWholePattern()
+		public void CopyPlaneToMatchesPatternAtOffset()
 		{
-			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = CreateSplitSurface(8);
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
 
 			var done = false;
-			byte[] pixels = null;
-
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result =>
+			byte[] packed = null;
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
 			{
 				done = true;
-				pixels = GetPixels(result);
+				packed = new byte[DstInfo.BytesSize];
+				r.CopyPlaneTo(0, packed);
 			});
 
 			Assert.True(done);
-			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255); // left = red
-			AssertPixel(pixels, info.Height, 3, 3, 255, 0, 0, 255); // still left of the split
-			AssertPixel(pixels, info.Height, 4, 4, 0, 0, 255, 255); // right = blue
-			AssertPixel(pixels, info.Height, 7, 7, 0, 0, 255, 255);
+			AssertMatchesPattern(packed, DstInfo.RowBytes, DstSize, DstSize, OffsetX, OffsetY);
 		}
 
-		// Downscale a two-colour pattern 8x8 -> 4x4; a no-op or broken rescale cannot reproduce it.
+		[Fact]
+		public void ToArrayMatchesPatternAtOffsetAndIsTightlyPacked()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			var done = false;
+			byte[] packed = null;
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
+			{
+				done = true;
+				packed = r.ToArray();
+			});
+
+			Assert.True(done);
+			Assert.Equal(DstInfo.BytesSize, packed.Length);
+			AssertMatchesPattern(packed, DstInfo.RowBytes, DstSize, DstSize, OffsetX, OffsetY);
+		}
+
+		[Fact]
+		public void ToImageMatchesPatternAtOffsetAndOutlivesCallback()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			SKImage result = null;
+			image.RequestReadPixels(DstInfo, OffsetRect, r => result = r.ToImage());
+
+			Assert.NotNull(result);
+			using (result)
+			{
+				Assert.Equal(DstSize, result.Width);
+				Assert.Equal(DstSize, result.Height);
+				using var outBmp = SKBitmap.FromImage(result);
+				AssertBitmapMatchesPattern(outBmp, DstSize, DstSize, OffsetX, OffsetY);
+			}
+		}
+
+		[Fact]
+		public void ToBitmapMatchesPatternAtOffsetAndOutlivesCallback()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			SKBitmap result = null;
+			image.RequestReadPixels(DstInfo, OffsetRect, r => result = r.ToBitmap());
+
+			Assert.NotNull(result);
+			using (result)
+				AssertBitmapMatchesPattern(result, DstSize, DstSize, OffsetX, OffsetY);
+		}
+
+		// ---- CopyPlaneTo destination-size edge cases ----
+
+		[Fact]
+		public void CopyPlaneToExactDestinationSucceeds()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
+			{
+				var exact = new byte[DstInfo.BytesSize];
+				r.CopyPlaneTo(0, exact);
+				AssertMatchesPattern(exact, DstInfo.RowBytes, DstSize, DstSize, OffsetX, OffsetY);
+			});
+		}
+
+		[Fact]
+		public void CopyPlaneToTooSmallDestinationThrows()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
+			{
+				Assert.Throws<ArgumentException>(() => r.CopyPlaneTo(0, new byte[DstInfo.BytesSize - 1]));
+				Assert.Throws<ArgumentException>(() => r.CopyPlaneTo(0, Span<byte>.Empty));
+			});
+		}
+
+		[Fact]
+		public void CopyPlaneToOversizedDestinationCopiesPrefixAndLeavesTail()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
+			{
+				const int tail = 8;
+				var big = new byte[DstInfo.BytesSize + tail];
+				for (var i = 0; i < big.Length; i++)
+					big[i] = 0xAB;
+
+				r.CopyPlaneTo(0, big);
+
+				AssertMatchesPattern(big, DstInfo.RowBytes, DstSize, DstSize, OffsetX, OffsetY);
+				for (var i = DstInfo.BytesSize; i < big.Length; i++)
+					Assert.Equal(0xAB, big[i]); // trailing bytes untouched
+			});
+		}
+
+		[Fact]
+		public void AccessorsThrowForInvalidPlaneIndex()
+		{
+			using var bmp = CreatePatternBitmap(SrcSize);
+			using var image = SKImage.FromBitmap(bmp);
+
+			image.RequestReadPixels(DstInfo, OffsetRect, r =>
+			{
+				foreach (var bad in new[] { -1, 1, 99 })
+				{
+					Assert.Throws<ArgumentOutOfRangeException>(() => r.GetPlaneRowBytes(bad));
+					Assert.Throws<ArgumentOutOfRangeException>(() => { r.GetPlaneData(bad); });
+					Assert.Throws<ArgumentOutOfRangeException>(() => r.CopyPlaneTo(bad, new byte[DstInfo.BytesSize]));
+					Assert.Throws<ArgumentOutOfRangeException>(() => r.ToArray(bad));
+				}
+			});
+		}
+
+		// ---- Behaviour: raster is synchronous; failure/null; argument validation ----
+
+		[Fact]
+		public void RasterSurfaceRequestReadPixelsIsSynchronous()
+		{
+			var info = new SKImageInfo(SrcSize, SrcSize, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(SrcSize);
+
+			var done = false;
+			byte[] pixels = null;
+			surface.RequestReadPixels(info, new SKRectI(0, 0, SrcSize, SrcSize), r =>
+			{
+				done = true;
+				pixels = r.ToArray();
+			});
+
+			Assert.True(done); // no pump: raster fires inline
+			// left half red, right half blue
+			Assert.Equal(255, pixels[0]);                    // (0,0).R
+			Assert.Equal(0, pixels[2]);                      // (0,0).B
+			var right = (0 * info.RowBytes) + (7 * 4);
+			Assert.Equal(0, pixels[right + 0]);              // (7,0).R
+			Assert.Equal(255, pixels[right + 2]);            // (7,0).B
+		}
+
+		[Fact]
+		public void RequestReadPixelsThrowsForNullCallback()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			using var image = SKImage.FromBitmap(CreatePatternBitmap(4));
+
+			Assert.Throws<ArgumentNullException>(() => surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), null));
+			Assert.Throws<ArgumentNullException>(() => image.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), null));
+		}
+
+		[Fact]
+		public void RequestReadPixelsInvokesCallbackWithNullOnFailure()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			surface.Canvas.Clear(SKColors.Red);
+			surface.Flush();
+
+			var called = false;
+			SKImageReadPixelsResult captured = null;
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 1000, 1000), r =>
+			{
+				called = true;
+				captured = r;
+			});
+
+			Assert.True(called);    // raster failure delivered synchronously
+			Assert.Null(captured);
+		}
+
 		[Fact]
 		public void RasterSurfaceRequestReadPixelsDownscaleWorks()
 		{
@@ -115,141 +343,47 @@ namespace SkiaSharp.Tests
 
 			var done = false;
 			byte[] pixels = null;
-
-			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), result =>
+			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), r =>
 			{
 				done = true;
-				pixels = GetPixels(result);
+				pixels = r.ToArray();
 			});
 
 			Assert.True(done);
-			AssertPixel(pixels, dstInfo.Height, 0, 0, 255, 0, 0, 255); // left column stays red
-			AssertPixel(pixels, dstInfo.Height, 3, 0, 0, 0, 255, 255); // right column stays blue
+			Assert.Equal(255, pixels[0]);                          // (0,0) red (left)
+			var right = (3 * 4);
+			Assert.Equal(255, pixels[right + 2]);                  // (3,0) blue (right)
 		}
 
-		// The result view is only valid during the callback; using it afterwards must throw.
+		// ---- Using the result after the callback returned must throw cleanly, never crash ----
+
 		[Fact]
-		public void RequestReadPixelsResultIsInvalidatedAfterCallback()
+		public void AllMembersThrowAfterCallbackReturns()
 		{
 			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
 			using var surface = SKSurface.Create(info);
-			surface.Canvas.Clear(FillColor);
+			surface.Canvas.Clear(SKColors.Red);
 			surface.Flush();
 
-			SKImageReadPixelsResult captured = null;
+			SKImageReadPixelsResult escaped = null;
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), r => escaped = r);
 
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
-			{
-				Assert.Equal(1, result.PlaneCount); // valid inside the callback
-				captured = result;
-			});
+			Assert.NotNull(escaped);
+			Assert.Throws<ObjectDisposedException>(() => { _ = escaped.PlaneCount; });
+			Assert.Throws<ObjectDisposedException>(() => escaped.GetPlaneRowBytes(0));
+			Assert.Throws<ObjectDisposedException>(() => { escaped.GetPlaneData(0); });
+			Assert.Throws<ObjectDisposedException>(() => escaped.CopyPlaneTo(0, new byte[info.BytesSize]));
+			Assert.Throws<ObjectDisposedException>(() => escaped.ToArray());
+			Assert.Throws<ObjectDisposedException>(() => escaped.ToImage());
+			Assert.Throws<ObjectDisposedException>(() => escaped.ToBitmap());
 
-			Assert.NotNull(captured);
-			Assert.Throws<ObjectDisposedException>(() => _ = captured.PlaneCount);
+			// Dispose is idempotent / safe to call again.
+			escaped.Dispose();
+			escaped.Dispose();
 		}
 
-		[Fact]
-		public void RequestReadPixelsThrowsForNullCallback()
-		{
-			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(info);
-			Assert.Throws<ArgumentNullException>(() => surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), null));
-		}
+		// ---- Ganesh GPU: genuinely deferred (when the backend supports it) + correct pixels ----
 
-		// A srcRect not contained by the source causes failure: the callback is invoked with null.
-		[Fact]
-		public void RequestReadPixelsInvokesCallbackWithNullOnFailure()
-		{
-			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(info);
-			surface.Canvas.Clear(FillColor);
-			surface.Flush();
-
-			var called = false;
-			SKImageReadPixelsResult captured = null;
-
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 1000, 1000), result =>
-			{
-				called = true;
-				captured = result;
-			});
-
-			Assert.True(called);      // raster failure is delivered synchronously
-			Assert.Null(captured);
-		}
-
-		[Fact]
-		public void ToArrayIsTightlyPackedAndCorrect()
-		{
-			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = CreateSplitSurface(8);
-
-			byte[] array = null;
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result => array = result.ToArray());
-
-			Assert.Equal(info.BytesSize, array.Length); // tightly packed (padding stripped)
-			AssertPixel(array, info.Height, 0, 0, 255, 0, 0, 255); // red
-			AssertPixel(array, info.Height, 7, 7, 0, 0, 255, 255); // blue
-		}
-
-		[Fact]
-		public void CopyPlaneToStripsPaddingAndValidatesSize()
-		{
-			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = CreateSplitSurface(8);
-
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result =>
-			{
-				var packed = new byte[info.BytesSize];
-				result.CopyPlaneTo(0, packed);
-				AssertPixel(packed, info.Height, 0, 0, 255, 0, 0, 255);
-				AssertPixel(packed, info.Height, 7, 7, 0, 0, 255, 255);
-
-				// A too-small destination throws rather than over-reading.
-				Assert.Throws<ArgumentException>(() => result.CopyPlaneTo(0, new byte[info.BytesSize - 1]));
-			});
-		}
-
-		[Fact]
-		public void ToImageOutlivesCallbackAndIsCorrect()
-		{
-			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = CreateSplitSurface(8);
-
-			SKImage image = null;
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result => image = result.ToImage());
-
-			Assert.NotNull(image); // owned copy, valid after the callback returned
-			using (image)
-			{
-				Assert.Equal(8, image.Width);
-				Assert.Equal(8, image.Height);
-				using var bmp = SKBitmap.FromImage(image);
-				Assert.Equal(SKColors.Red, bmp.GetPixel(0, 0));
-				Assert.Equal(SKColors.Blue, bmp.GetPixel(7, 7));
-			}
-		}
-
-		[Fact]
-		public void ToBitmapOutlivesCallbackAndIsCorrect()
-		{
-			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = CreateSplitSurface(8);
-
-			SKBitmap bitmap = null;
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result => bitmap = result.ToBitmap());
-
-			Assert.NotNull(bitmap);
-			using (bitmap)
-			{
-				Assert.Equal(SKColors.Red, bitmap.GetPixel(0, 0));
-				Assert.Equal(SKColors.Blue, bitmap.GetPixel(7, 7));
-			}
-		}
-
-		// On Ganesh the read is deferred when the backend supports transfer buffers; otherwise Skia
-		// falls back to a synchronous read. Assert the deferred transition only when it did not fire
-		// inline, and always assert it eventually completes with correct pixels.
 		[Fact]
 		[Trait(Traits.Category.Key, Traits.Category.Values.Gpu)]
 		public void GpuSurfaceRequestReadPixelsCompletesWithCorrectPixels()
@@ -258,26 +392,22 @@ namespace SkiaSharp.Tests
 			ctx.MakeCurrent();
 			using var grContext = GRContext.CreateGl();
 
-			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(grContext, true, info);
-			surface.Canvas.Clear(FillColor);
-			surface.Flush();
+			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(8, grContext);
 
 			var done = false;
 			byte[] pixels = null;
-
-			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), r =>
 			{
 				done = true;
-				if (result != null)
-					pixels = GetPixels(result);
+				if (r != null)
+					pixels = r.ToArray();
 			});
 
 			var firedSynchronously = done;
 			if (!firedSynchronously)
 			{
-				// Proven deferred: it must not have fired before we pump.
-				Assert.False(done);
+				Assert.False(done); // proven deferred: must not fire before we pump
 				grContext.Submit(synchronous: true);
 				for (var i = 0; i < 1000 && !done; i++)
 				{
@@ -289,7 +419,9 @@ namespace SkiaSharp.Tests
 
 			Assert.True(done);
 			Assert.NotNull(pixels);
-			AssertPixel(pixels, info.Height, 0, 0, 255, 0, 0, 255);
+			Assert.Equal(255, pixels[0]);              // (0,0) red
+			var right = (7 * 4);
+			Assert.Equal(255, pixels[right + 2]);      // (7,0) blue
 		}
 
 		[Fact]
@@ -301,21 +433,15 @@ namespace SkiaSharp.Tests
 			using var grContext = GRContext.CreateGl();
 
 			var dstInfo = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
-			var srcInfo = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
-			using var surface = SKSurface.Create(grContext, true, srcInfo);
-			surface.Canvas.Clear(SKColors.Red);
-			using (var paint = new SKPaint { Color = SKColors.Blue })
-				surface.Canvas.DrawRect(new SKRect(4, 0, 8, 8), paint);
-			surface.Flush();
+			using var surface = CreateSplitSurface(8, grContext);
 
 			var done = false;
 			byte[] pixels = null;
-
-			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), result =>
+			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), r =>
 			{
 				done = true;
-				if (result != null)
-					pixels = GetPixels(result);
+				if (r != null)
+					pixels = r.ToArray();
 			});
 
 			if (!done)
@@ -331,8 +457,8 @@ namespace SkiaSharp.Tests
 
 			Assert.True(done);
 			Assert.NotNull(pixels);
-			AssertPixel(pixels, dstInfo.Height, 0, 0, 255, 0, 0, 255); // left stays red
-			AssertPixel(pixels, dstInfo.Height, 3, 0, 0, 0, 255, 255); // right stays blue
+			Assert.Equal(255, pixels[0]);              // (0,0) red
+			Assert.Equal(255, pixels[(3 * 4) + 2]);    // (3,0) blue
 		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
+++ b/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Threading;
+using Xunit;
+
+namespace SkiaSharp.Tests
+{
+	public class SKAsyncReadPixelsTest : SKTest
+	{
+		private static readonly SKColor FillColor = SKColors.Red; // (255, 0, 0, 255)
+
+		private static void AssertIsFillColor(byte[] pixels)
+		{
+			Assert.Equal(255, pixels[0]); // R
+			Assert.Equal(0, pixels[1]);   // G
+			Assert.Equal(0, pixels[2]);   // B
+			Assert.Equal(255, pixels[3]); // A
+		}
+
+		private static byte[] CopyFirstPlane(SKImageAsyncReadResult result, int rowCount)
+		{
+			Assert.NotNull(result);
+			Assert.Equal(1, result.PlaneCount);
+			var rowBytes = result.GetPlaneRowBytes(0);
+			var pixels = new byte[rowBytes * rowCount];
+			result.CopyPlaneTo(0, pixels, rowCount);
+			return pixels;
+		}
+
+		// Per Skia (SkImage.h/SkSurface.h): async reads are Ganesh-only; "in all other cases this
+		// operates synchronously." So a raster surface must invoke the callback inline.
+		[Fact]
+		public void RasterSurfaceRequestReadPixelsIsSynchronousAndCorrect()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			var done = false;
+			byte[] pixels = null;
+
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			{
+				done = true;
+				pixels = CopyFirstPlane(result, info.Height);
+			});
+
+			// No Submit / CheckAsyncWorkCompletion pump: it must already have fired.
+			Assert.True(done);
+			AssertIsFillColor(pixels);
+		}
+
+		[Fact]
+		public void RasterImageRequestReadPixelsIsSynchronousAndCorrect()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+			using var image = surface.Snapshot();
+
+			var done = false;
+			byte[] pixels = null;
+
+			image.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			{
+				done = true;
+				pixels = CopyFirstPlane(result, info.Height);
+			});
+
+			Assert.True(done);
+			AssertIsFillColor(pixels);
+		}
+
+		// Reading a smaller destination than the source rectangle exercises the rescale path.
+		[Fact]
+		public void RasterSurfaceRequestReadPixelsDownscaleWorks()
+		{
+			var srcInfo = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			var dstInfo = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(srcInfo);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			var done = false;
+			byte[] pixels = null;
+
+			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), result =>
+			{
+				done = true;
+				pixels = CopyFirstPlane(result, dstInfo.Height);
+			});
+
+			Assert.True(done);
+			// A solid fill downscales to the same solid color.
+			AssertIsFillColor(pixels);
+		}
+
+		// The result view is only valid during the callback; using it afterwards must throw.
+		[Fact]
+		public void RequestReadPixelsResultIsInvalidatedAfterCallback()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			SKImageAsyncReadResult captured = null;
+
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			{
+				Assert.Equal(1, result.PlaneCount); // valid inside the callback
+				captured = result;
+			});
+
+			Assert.NotNull(captured);
+			Assert.Throws<ObjectDisposedException>(() => _ = captured.PlaneCount);
+		}
+
+		[Fact]
+		public void RequestReadPixelsThrowsForNullCallback()
+		{
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
+			Assert.Throws<ArgumentNullException>(() => surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), null));
+		}
+
+		// On Ganesh the read is genuinely asynchronous: the callback must NOT fire during the Request
+		// call. It only fires once work is submitted and CheckAsyncWorkCompletion is pumped. That
+		// false -> (pump) -> true transition is the proof of asynchrony.
+		[Fact]
+		[Trait(Traits.Category.Key, Traits.Category.Values.Gpu)]
+		public void GpuSurfaceRequestReadPixelsIsAsynchronousAndCorrect()
+		{
+			using var ctx = CreateGlContext();
+			ctx.MakeCurrent();
+			using var grContext = GRContext.CreateGl();
+
+			var info = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(grContext, true, info);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			var done = false;
+			byte[] pixels = null;
+
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 4, 4), result =>
+			{
+				done = true;
+				if (result != null)
+					pixels = CopyFirstPlane(result, info.Height);
+			});
+
+			// PROVE ASYNC: the callback is deferred on the GPU backend.
+			Assert.False(done);
+
+			// Drive the work to completion.
+			grContext.Submit(synchronous: true);
+			for (var i = 0; i < 1000 && !done; i++)
+			{
+				grContext.CheckAsyncWorkCompletion();
+				if (!done)
+					Thread.Sleep(1);
+			}
+
+			Assert.True(done);
+			Assert.NotNull(pixels);
+			AssertIsFillColor(pixels);
+		}
+
+		[Fact]
+		[Trait(Traits.Category.Key, Traits.Category.Values.Gpu)]
+		public void GpuSurfaceRequestReadPixelsDownscaleWorks()
+		{
+			using var ctx = CreateGlContext();
+			ctx.MakeCurrent();
+			using var grContext = GRContext.CreateGl();
+
+			var srcInfo = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			var dstInfo = new SKImageInfo(4, 4, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(grContext, true, srcInfo);
+			surface.Canvas.Clear(FillColor);
+			surface.Flush();
+
+			var done = false;
+			byte[] pixels = null;
+
+			surface.RequestReadPixels(dstInfo, new SKRectI(0, 0, 8, 8), result =>
+			{
+				done = true;
+				if (result != null)
+					pixels = CopyFirstPlane(result, dstInfo.Height);
+			});
+
+			grContext.Submit(synchronous: true);
+			for (var i = 0; i < 1000 && !done; i++)
+			{
+				grContext.CheckAsyncWorkCompletion();
+				if (!done)
+					Thread.Sleep(1);
+			}
+
+			Assert.True(done);
+			Assert.NotNull(pixels);
+			AssertIsFillColor(pixels);
+		}
+	}
+}

--- a/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
+++ b/tests/Tests/SkiaSharp/SKAsyncReadPixelsTest.cs
@@ -178,6 +178,75 @@ namespace SkiaSharp.Tests
 			Assert.Null(captured);
 		}
 
+		[Fact]
+		public void ToArrayIsTightlyPackedAndCorrect()
+		{
+			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(8);
+
+			byte[] array = null;
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result => array = result.ToArray());
+
+			Assert.Equal(info.BytesSize, array.Length); // tightly packed (padding stripped)
+			AssertPixel(array, info.Height, 0, 0, 255, 0, 0, 255); // red
+			AssertPixel(array, info.Height, 7, 7, 0, 0, 255, 255); // blue
+		}
+
+		[Fact]
+		public void CopyPlaneToStripsPaddingAndValidatesSize()
+		{
+			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(8);
+
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result =>
+			{
+				var packed = new byte[info.BytesSize];
+				result.CopyPlaneTo(0, packed);
+				AssertPixel(packed, info.Height, 0, 0, 255, 0, 0, 255);
+				AssertPixel(packed, info.Height, 7, 7, 0, 0, 255, 255);
+
+				// A too-small destination throws rather than over-reading.
+				Assert.Throws<ArgumentException>(() => result.CopyPlaneTo(0, new byte[info.BytesSize - 1]));
+			});
+		}
+
+		[Fact]
+		public void ToImageOutlivesCallbackAndIsCorrect()
+		{
+			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(8);
+
+			SKImage image = null;
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result => image = result.ToImage());
+
+			Assert.NotNull(image); // owned copy, valid after the callback returned
+			using (image)
+			{
+				Assert.Equal(8, image.Width);
+				Assert.Equal(8, image.Height);
+				using var bmp = SKBitmap.FromImage(image);
+				Assert.Equal(SKColors.Red, bmp.GetPixel(0, 0));
+				Assert.Equal(SKColors.Blue, bmp.GetPixel(7, 7));
+			}
+		}
+
+		[Fact]
+		public void ToBitmapOutlivesCallbackAndIsCorrect()
+		{
+			var info = new SKImageInfo(8, 8, SKColorType.Rgba8888, SKAlphaType.Premul);
+			using var surface = CreateSplitSurface(8);
+
+			SKBitmap bitmap = null;
+			surface.RequestReadPixels(info, new SKRectI(0, 0, 8, 8), result => bitmap = result.ToBitmap());
+
+			Assert.NotNull(bitmap);
+			using (bitmap)
+			{
+				Assert.Equal(SKColors.Red, bitmap.GetPixel(0, 0));
+				Assert.Equal(SKColors.Blue, bitmap.GetPixel(7, 7));
+			}
+		}
+
 		// On Ganesh the read is deferred when the backend supports transfer buffers; otherwise Skia
 		// falls back to a synchronous read. Assert the deferred transition only when it did not fire
 		// inline, and always assert it eventually completes with correct pixels.


### PR DESCRIPTION
## Description

Adds a **backend-neutral** async *rescale-and-read-pixels* feature to `SKImage` and `SKSurface`, wrapping the new core Skia C API (companion: mono/skia#295).

The underlying C++ types (`SkImage::AsyncReadResult`, `SkImage::RescaleGamma`, `SkImage::RescaleMode`) are core and shared by the raster, Ganesh and Graphite backends — `SkSurface` merely *aliases* the `SkImage` ones. So this lands as a generic feature on `main`. The in-flight Graphite PR (#3968) can then drop its Graphite-prefixed `SKGraphiteAsyncReadResult` / `SKGraphiteRescaleGamma` / `SKGraphiteRescaleMode` and consume these instead, keeping only its genuinely Graphite-specific `Context`-based entry point.

Raster surfaces/images invoke the callback **synchronously**; Ganesh defers it until `GRContext.Submit()` + `GRContext.CheckAsyncWorkCompletion()` are pumped (per Skia's docs, async read is Ganesh-only and the Graphite path is the context API).

**Related issues**

Related to #3968

**Required skia PR**

Requires https://github.com/mono/skia/pull/295

**Areas affected**

- [x] Managed API (`binding/`)
- [x] Native / C API (`externals/skia/src/c`, `include/c`)
- [x] Generated P/Invoke bindings
- [ ] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

**Public API** (additive only — no removals or signature changes):

```csharp
// SKImage / SKSurface (same shape on both)
public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, Action<SKImageReadPixelsResult> callback);            // default rescale: Src + Nearest
public void RequestReadPixels (SKImageInfo info, SKRectI srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, Action<SKImageReadPixelsResult> callback);

// GRContext
public void CheckAsyncWorkCompletion ();

// new types
public sealed class SKImageReadPixelsResult : IDisposable
{
    public int PlaneCount { get; }
    public int GetPlaneRowBytes (int planeIndex);
    public ReadOnlySpan<byte> GetPlaneData (int planeIndex);         // raw, zero-copy view (may include row padding)
    public void CopyPlaneTo (int planeIndex, Span<byte> destination); // tightly-packed copy into your buffer (padding stripped, bounded)
    public byte[] ToArray (int planeIndex = 0);                       // tightly-packed byte[] that outlives the callback
    public SKImage ToImage ();                                       // owned SKImage (single-plane result)
    public SKBitmap ToBitmap ();                                     // owned SKBitmap (single-plane result)
}
public enum SKImageRescaleGamma { Src, Linear }
public enum SKImageRescaleMode  { Nearest, Linear, RepeatedLinear, RepeatedCubic }
```

**Behavior**

`SKImageReadPixelsResult` is a non-owning, callback-scoped view (it is *not* an `SKObject` — the native pointer is non-ref-counted and reused). It is invalidated when the callback returns and throws `ObjectDisposedException` from every member afterwards. `GetPlaneData` is the raw, zero-copy span; the `CopyPlaneTo` / `ToArray` / `ToImage` / `ToBitmap` helpers produce owned, tightly-packed copies that survive past the callback (and cannot over-read the native transfer buffer). On failure (e.g. an out-of-bounds `srcRect`) the callback is invoked with `null`. There is no user `context`/state argument — capture it in the closure.

Defaults are `RescaleGamma.Src` + `RescaleMode.Nearest` (the least-transform "as-is" choice); use `RepeatedLinear`/`RepeatedCubic` explicitly for higher-quality downscales.

## Testing

`dotnet test tests/SkiaSharp.Tests.Console` — 18 `SKAsyncReadPixelsTest` cases pass locally (macOS arm64):

- **Correctness** with a per-pixel colour pattern read from an **offset** `srcRect` (not `0,0..WxH`), validating every destination pixel for `GetPlaneData` / `CopyPlaneTo` / `ToArray` / `ToImage` / `ToBitmap`.
- **Padding** — the strided row copy is factored into an `internal CopyRows` and unit-tested with a fabricated padded source (real GL/raster RGBA reads are never row-padded), asserting the packed output drops the padding.
- **Edge cases** — exact / too-small / empty / oversized destinations; invalid plane indices; `ToImage`/`ToBitmap` outlive the callback.
- **Behavior** — raster fires synchronously; out-of-bounds `srcRect` → `callback(null)`; null callback → `ArgumentNullException`; every member throws `ObjectDisposedException` (never crashes) when used after the callback; `Dispose` is idempotent.
- **Ganesh** (`[GPU]`): completes with correct pixels after `Submit(sync)` + a `CheckAsyncWorkCompletion` pump, plus a GPU downscale. The async-proof (`done==false` before the pump) is asserted only when the backend actually defers, tolerating Skia's documented synchronous transfer-buffer fallback. Auto-skips when no GL context is available.

The full suite is green apart from one pre-existing, unrelated visual-golden delta (`ganesh-gl/DiagonalLines`); this change touches no rendering path.

## Future work — YUV (not blocked by this PR)

This ships the RGBA (`count() == 1`) read only, but the design is deliberately YUV-ready: the C API result type + accessors are multi-plane (`count()` can be 3/4), and the enums/proc are shared. `asyncRescaleAndReadPixelsYUV420` / `YUVA420` can be added purely additively later — see the follow-up note in the comments for the proposed C# surface.
