### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "f5971cb54aaeb5190ee633329ec98ff23ca2f387"
+          "commitHash": "6150e400c112b6950e62ac819b434b5149b38dd4"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "c3b29df302dde59a6e0bc991430a784e0d399f9d"
+      "upstream_merge_commit": "8e300af3fdfe6b3808867a7262d7af29c89dcf15"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "64a0e76c579ed9fa626da30efb9022d4cff9e49d"
+          "commitHash": "f5971cb54aaeb5190ee633329ec98ff23ca2f387"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "62442d6cf0ec21e3e7f1c23b018c619374fa39c7"
+      "upstream_merge_commit": "c3b29df302dde59a6e0bc991430a784e0d399f9d"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "c7358d0e92a1797ca1eae5910798a110e5d692a2"
+          "commitHash": "64a0e76c579ed9fa626da30efb9022d4cff9e49d"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "2c014dc494f1d7f0063ab1fd849d9292a0875a65"
+      "upstream_merge_commit": "62442d6cf0ec21e3e7f1c23b018c619374fa39c7"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "6150e400c112b6950e62ac819b434b5149b38dd4"
+          "commitHash": "4e6b38bc16c8f2334573e109fd295a6ac210284b"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "8e300af3fdfe6b3808867a7262d7af29c89dcf15"
+      "upstream_merge_commit": "833f1993991332798c035dcaf41e333d9d15a15a"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "1af4051dbaaa38b6016d4fc34a52acf9c639063d"
+          "commitHash": "c7358d0e92a1797ca1eae5910798a110e5d692a2"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "b4204f7ff931ec662a690d00b2d1c19afeb3a4fe"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2c014dc494f1d7f0063ab1fd849d9292a0875a65"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

**Companion skia PR:** https://github.com/mono/skia/pull/296

## Skia upstream sync (mono/SkiaSharp)

Bumps the `externals/skia` submodule pointer to the mono/skia `skia-sync/main` PR head (upstream `google/skia` `main` merged in). See the companion mono/skia PR for merge/conflict details.

**Mode:** `main`/tip sync — the automated workflow's pre-computed values were `CURRENT=151 / TARGET=151`, but upstream `main` has advanced past m151: `externals/skia/include/core/SkMilestone.h` now reports **`SK_MILESTONE 152`**. The build's version-consistency check (`libskia C++ API version did not match the expected '151', instead was '152'`) forced a version bump, so this sync is **treated as an m151 → m152 milestone bump**.

### Version updates

| File | Change |
|---|---|
| `scripts/VERSIONS.txt` | `libSkiaSharp` milestone `151` → `152`; `SK_C_INCREMENT` reset to `0`; soname, assembly, file, and all `nuget` lines advanced from `4.151.0` → `4.152.0` |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION` `4.151.0` → `4.152.0` |
| `cgmanifest.json` | `chrome_milestone` `151` → `152`; `commitHash` and `upstream_merge_commit` refreshed to the merged upstream tip (`2c014dc494f1d7f0063ab1fd849d9292a0875a65`) |
| `externals/skia` submodule | pointer advanced to the mono/skia `skia-sync/main` PR head |

`SK_C_INCREMENT` reset was performed by `update-versions.ps1` inside the submodule and travels in the mono/skia PR.

### Breaking change analysis

**None observed for consumers.**

- `SkiaApi.generated.cs` — regenerated by `pwsh ./utils/generate.ps1` — has **no diff** vs. `origin/main`. The `regenerate-bindings.ps1` script's "New generated functions" report was empty.
- No new C API functions to wrap, no new enums, no signature changes.
- No changes required in `binding/SkiaSharp/*.cs` — all C# wrappers compile unchanged.
- HarfBuzz bindings were reverted per policy (HarfBuzz updates are always separate).

The C++ / GPU work upstream between m151-tip and current-main is largely internal (Ganesh resolve-task fixes, VMA update, graphite `StorageBufferManager`, `Rust BMP` codec integration, misc renderer refactoring). None of it changes the public C API surface we ship.

### Build & tests (Linux x64)

- `dotnet cake --target=externals-linux --arch=x64` — succeeded (libSkiaSharp + libHarfBuzzSharp built).
  - First attempt failed with VMA API mismatch — resolved by bumping the `vulkanmemoryallocator` and `vulkan-headers` DEPS pins in the mono/skia PR to the upstream m152 SHAs (see companion summary).
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — 0 errors.
- `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` — **5729 passed, 0 failed, 185 skipped** (2m 44s). Full log at `/tmp/gh-aw/agent/test-output.txt` (artifact).

### Items needing human attention

1. **CI cross-platform verification.** Only Linux x64 was built locally. Windows / macOS / iOS / Android / WASM native builds must go green in CI before merging — the VMA / Vulkan-Headers pin bumps in the mono/skia PR affect every platform that enables Vulkan.
2. **Milestone bump review.** The workflow was launched as a same-milestone bug-fix sync (m151 → m151) but the upstream tip is already m152 — please confirm the m152 milestone/nuget-version bump is intended before merging. If m152 is not yet ready to ship, pin `upstream/main` back to a chrome/m151 branch instead of tip.
3. **DEPS: unadopted upstream additions.** See the mono/skia PR summary — `infra_revision` bump, `checkout_agents_internal`, and the `agents/shared` + `agents/internal` hooks were not adopted.
4. **Merge order.** Standard: merge the mono/skia PR first, refresh the submodule pointer to the squashed SHA on `skiasharp`, then merge this PR.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).