### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/binding/SkiaSharp.Resources/ResourcesApi.generated.cs
+++ b/binding/SkiaSharp.Resources/ResourcesApi.generated.cs
@@ -41,6 +41,7 @@ using sk_font_t = System.IntPtr;
 using sk_fontmgr_t = System.IntPtr;
 using sk_fontstyle_t = System.IntPtr;
 using sk_fontstyleset_t = System.IntPtr;
+using sk_image_async_read_result_t = System.IntPtr;
 using sk_image_t = System.IntPtr;
 using sk_imagefilter_t = System.IntPtr;
 using sk_manageddrawable_t = System.IntPtr;

--- a/binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs
+++ b/binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs
@@ -41,6 +41,7 @@ using sk_font_t = System.IntPtr;
 using sk_fontmgr_t = System.IntPtr;
 using sk_fontstyle_t = System.IntPtr;
 using sk_fontstyleset_t = System.IntPtr;
+using sk_image_async_read_result_t = System.IntPtr;
 using sk_image_t = System.IntPtr;
 using sk_imagefilter_t = System.IntPtr;
 using sk_manageddrawable_t = System.IntPtr;

--- a/binding/SkiaSharp.Skottie/SkottieApi.generated.cs
+++ b/binding/SkiaSharp.Skottie/SkottieApi.generated.cs
@@ -41,6 +41,7 @@ using sk_font_t = System.IntPtr;
 using sk_fontmgr_t = System.IntPtr;
 using sk_fontstyle_t = System.IntPtr;
 using sk_fontstyleset_t = System.IntPtr;
+using sk_image_async_read_result_t = System.IntPtr;
 using sk_image_t = System.IntPtr;
 using sk_imagefilter_t = System.IntPtr;
 using sk_manageddrawable_t = System.IntPtr;

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "0d6ea6b0484a64677509f67f865daecd220912cc"
+          "commitHash": "0c272f7de9b25f62e5d35d2e66edfb670aacd753"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "b4204f7ff931ec662a690d00b2d1c19afeb3a4fe"
+      "upstream_merge_commit": "b2bdbe65704d9b208704fdffc7be024b9d231317"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/298

## Merge upstream chrome/m151 bug fixes

Same-milestone (m151 → m151) bug-fix sync. Pulls 3 upstream Ganesh GL bug-fix commits via the companion mono/skia PR and refreshes generated bindings.

### Breaking change analysis

**No breaking changes.** All three merged upstream commits are internal Ganesh GL fixes:

| Upstream commit | Category | Risk |
|---|---|---|
| Imagination FBO deletion workaround | Internal GPU workaround | 🟢 None |
| Check results of internal flushes for internalWritePixels | Internal error handling | 🟢 None |
| Skip resolve/mipmap step on flush failure | Internal error handling | 🟢 None |

No C API surface changes, no removed/renamed/moved public headers, no enum churn.

### Version / binding updates

- `cgmanifest.json`
  - `commitHash`: `0d6ea6b0484a64677509f67f865daecd220912cc` → `0c272f7de9b25f62e5d35d2e66edfb670aacd753`
  - `upstream_merge_commit`: → `b2bdbe65704d9b208704fdffc7be024b9d231317`
  - `chrome_milestone`: unchanged (`151`)
- `scripts/VERSIONS.txt` — unchanged (same-milestone sync, no version bumps)
- `scripts/azure-templates-variables.yml` — unchanged
- `externals/skia/include/c/sk_types.h` `SK_C_INCREMENT` — unchanged (`0`)

### C# changes

Generated-only. `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1` added a single new typedef in three generated files:

```
binding/SkiaSharp.Resources/ResourcesApi.generated.cs   | 1 +
binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs | 1 +
binding/SkiaSharp.Skottie/SkottieApi.generated.cs       | 1 +
```

The added line is `using sk_image_async_read_result_t = System.IntPtr;` — a typedef alias that was already present in `SkiaApi.generated.cs` (from the recent async rescale/read-pixels C API addition on `skiasharp`) and is now also emitted for the auxiliary bindings that share the header set. **No new P/Invoke functions** were added; no hand-written wrappers required.

HarfBuzz bindings were reverted per policy (updates are handled separately).

### Build / test results (Linux x64)

- `dotnet cake --target=externals-linux --arch=x64` — ✅ succeeded (≈15m 37s)
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — ✅ 0 errors
- `dotnet test tests/SkiaSharp.Tests.Console/…` — ✅ **Passed! Failed: 0, Passed: 5763, Skipped: 187, Total: 5950** (2m 47s)

Test log uploaded as `test-output.txt` workflow artifact.

### Items needing human attention

None. Other platforms (macOS, Windows, iOS, Android, WASM) will be exercised by CI on this PR.

### Companion PR

Depends on the matching mono/skia PR on `skia-sync/m151` → `skiasharp`; the submodule pointer bump in this PR points at that branch's head.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).