### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "80c7b8fdf0cf932e08230922a6b38b82d91e004c"
+          "commitHash": "79528134cf18c73b9247116611d2f8bf4c13a226"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "587c5b0f5a7b0260826a0c19094c2d952195066e"
+      "upstream_merge_commit": "a7fb0b3c2e109e4e68f50bf823cf6b8d524c4a0c"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "79528134cf18c73b9247116611d2f8bf4c13a226"
+          "commitHash": "409aad73a2579c2306607b40fcbd3166bc8aea13"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/299

# Merge upstream chrome/m150 bug fixes

Release-line bug-fix sync onto `release/4.150.x`. `CURRENT == TARGET == 150`,
so this is **NOT a version bump** — only `cgmanifest.json` changes in the parent.

Paired mono/skia PR: `skia-sync/release-4.150.x` targeting `release/4.150.x`
(see `skia-sync-skia-summary.md`).

## Parent-repo changes

Only `cgmanifest.json`:

- `commitHash` → `409aad73a2579c2306607b40fcbd3166bc8aea13` (new mono/skia merge commit)
- `upstream_merge_commit` → `a7fb0b3c2e109e4e68f50bf823cf6b8d524c4a0c` (upstream m150 tip)
- `chrome_milestone` remains `150`

`scripts/VERSIONS.txt` and `scripts/azure-templates-variables.yml` were left
unchanged (the update-versions.ps1 script would have regressed the nuget
versions from `4.150.2` back to `4.150.0` on this release line — reverted, as
required by the release-line bug-fix sync policy).

## Breaking change analysis

None. All three upstream commits are internal Ganesh GL backend fixes:

- Imagination GPU FBO deletion workaround (driver bug workaround)
- Internal write-pixels flush-result checks (returns false on internal flush failure)
- Skip resolve/mipmap step on flush failure (safety in error paths)

No public C++ API surface change, no C API impact, no C# wrapper impact.

## Version / binding updates

- Milestone: unchanged (150 → 150)
- soname / assembly / nuget versions: unchanged
- `SK_C_INCREMENT`: unchanged (0)
- Generated bindings: **no diff** — Phase 8 script reported
  "No changes to bindings (C API signatures unchanged)" and
  "No new functions found"
- HarfBuzz bindings: reverted (as always) — no actual regeneration diff

## Build & test results

- Native build (Linux x64): ✅ succeeded (`dotnet cake --target=externals-linux --arch=x64`)
- C# build (`binding/SkiaSharp/SkiaSharp.csproj`): ✅ 0 errors
- Full test suite (`tests/SkiaSharp.Tests.Console`, `net10.0|x64`):
  `Passed! - Failed: 0, Passed: 5584, Skipped: 172, Total: 5756`

Test output archived to `test-output.txt`.

## Items needing human attention

- Only Linux x64 native was built in this automated sync. macOS / Windows /
  iOS / Android / WASM binaries will be built by CI on the PR.
- No release-notes update was performed for this bug-fix sync; the changes
  are internal Ganesh GL fixes with no user-visible API surface.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).