### PR TITLE
Move public CI to dnceng agents and provision required tools

### DIFF
--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -37,6 +37,8 @@ parameters:
         name: NetCore-Public
         demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
+      parameters:
+        installWindowsSdk19041: true
   - name: buildAgentMac
     displayName: 'The macOS build agent configuration:'
     type: object

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -74,8 +74,8 @@ parameters:
     type: object
     default:
       pool:
-        name: NetCore-Public
-        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+        name: Azure Pipelines
+        vmImage: ubuntu-24.04
         os: linux
 
 variables:

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -18,24 +18,24 @@ parameters:
     type: object
     default:
       pool:
-        name: Azure Pipelines
-        vmImage: ubuntu-22.04
-        os: windows
+        name: NetCore-Public
+        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+        os: linux
   - name: buildAgentWindows
     displayName: 'The Windows build agent configuration:'
     type: object
     default:
       pool:
-        name: Azure Pipelines
-        vmImage: windows-2022
+        name: NetCore-Public
+        demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
   - name: buildAgentWindowsNative
     displayName: 'The Windows build agent configuration for building the native assets:'
     type: object
     default:
       pool:
-        name: Azure Pipelines
-        vmImage: windows-2022
+        name: NetCore-Public
+        demands: ImageOverride -equals windows.vs2026.amd64.open
         os: windows
   - name: buildAgentMac
     displayName: 'The macOS build agent configuration:'
@@ -51,31 +51,31 @@ parameters:
     default:
       pool:
         name: Azure Pipelines
-        vmImage: macos-14
+        vmImage: macos-15
         os: macos
   - name: buildAgentLinux
     displayName: 'The Linux build agent configuration:'
     type: object
     default:
       pool:
-        name: Azure Pipelines
-        vmImage: ubuntu-22.04
+        name: NetCore-Public
+        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         os: linux
   - name: buildAgentLinuxNative
     displayName: 'The Linux build agent configuration for building the native assets:'
     type: object
     default:
       pool:
-        name: Azure Pipelines
-        vmImage: ubuntu-22.04
+        name: NetCore-Public
+        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         os: linux
   - name: buildAgentAndroidTests
     displayName: 'The build agent configuration for building the Android tests:'
     type: object
     default:
       pool:
-        name: Azure Pipelines
-        vmImage: ubuntu-24.04
+        name: NetCore-Public
+        demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         os: linux
 
 variables:

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -35,10 +35,8 @@ parameters:
     default:
       pool:
         name: NetCore-Public
-        demands: ImageOverride -equals windows.vs2026.amd64.open
+        demands: ImageOverride -equals windows.vs2022.amd64.open
         os: windows
-      parameters:
-        installWindowsSdk19041: true
   - name: buildAgentMac
     displayName: 'The macOS build agent configuration:'
     type: object

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -35,7 +35,7 @@ parameters:
     default:
       pool:
         name: NetCore-Public
-        demands: ImageOverride -equals windows.vs2022.amd64.open
+        demands: ImageOverride -equals 1es-windows-2022-open
         os: windows
   - name: buildAgentMac
     displayName: 'The macOS build agent configuration:'

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -349,6 +349,9 @@ jobs:
                 dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}
 
               env:
+                ANDROID_HOME: $(ANDROID_HOME)
+                ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
+                AndroidSdkDirectory: $(AndroidSdkDirectory)
                 JavaSdkDirectory: $(JAVA_HOME)
                 LLVM_HOME: $(LLVM_HOME)
                 # There seems to be a bug in some verions of mspdbcmf.exe. This looks to be fixed in a VS preview.
@@ -363,6 +366,9 @@ jobs:
                 dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}
 
               env:
+                ANDROID_HOME: $(ANDROID_HOME)
+                ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
+                AndroidSdkDirectory: $(AndroidSdkDirectory)
                 JavaSdkDirectory: $(JAVA_HOME)
               displayName: Run the bootstrapper for ${{ parameters.target }}
               retryCountOnTaskFailure: ${{ parameters.retryCount }}

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -88,6 +88,12 @@ jobs:
         - checkout: self
           submodules: false
           fetchDepth: 1
+        - task: UsePythonVersion@0
+          displayName: Switch to the correct Python version
+          retryCountOnTaskFailure: 3
+          inputs:
+            versionSpec: '3.x'
+            architecture: 'x64'
         - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
           displayName: Configure build variables
         - pwsh: |

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -228,6 +228,10 @@ jobs:
             displayName: Install Android SDK
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          - pwsh: .\scripts\infra\managed\install-android-package.ps1 -Package "platform-tools"
+            displayName: Install Android platform tools
+            retryCountOnTaskFailure: 3
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           # install the required version of the Android Platforms
           - pwsh: .\scripts\infra\managed\install-android-platform.ps1 -API "$(ANDROID_PLATFORM_VERSIONS)"
             displayName: Install Android APIs

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -367,8 +367,6 @@ jobs:
                 dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}
 
               env:
-                ANDROID_HOME: $(ANDROID_HOME)
-                ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
                 AndroidSdkDirectory: $(AndroidSdkDirectory)
                 JavaSdkDirectory: $(JAVA_HOME)
                 LLVM_HOME: $(LLVM_HOME)
@@ -385,8 +383,6 @@ jobs:
                 dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}
 
               env:
-                ANDROID_HOME: $(ANDROID_HOME)
-                ANDROID_SDK_ROOT: $(ANDROID_SDK_ROOT)
                 AndroidSdkDirectory: $(AndroidSdkDirectory)
                 JavaSdkDirectory: $(JAVA_HOME)
               displayName: Run the bootstrapper for ${{ parameters.target }}

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -232,6 +232,14 @@ jobs:
             displayName: Install Android platform tools
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          - pwsh: .\scripts\infra\managed\install-android-package.ps1 -Package "build-tools;35.0.0"
+            displayName: Install Android 35 build tools
+            retryCountOnTaskFailure: 3
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          - pwsh: .\scripts\infra\managed\install-android-package.ps1 -Package "build-tools;36.0.0"
+            displayName: Install Android 36 build tools
+            retryCountOnTaskFailure: 3
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           # install the required version of the Android Platforms
           - pwsh: .\scripts\infra\managed\install-android-platform.ps1 -API "$(ANDROID_PLATFORM_VERSIONS)"
             displayName: Install Android APIs

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -300,6 +300,11 @@ jobs:
               displayName: Install the Windows 10 SDK 10.0.19041
               retryCountOnTaskFailure: 3
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          - ${{ if eq(parameters.buildAgent.parameters.installWindowsSdk19041, 'true') }}:
+            - pwsh: .\scripts\infra\native\windows\install-winsdk.ps1 -LinkId 2120843 -Version 10.0.19041.0
+              displayName: Install the Windows 10 SDK 10.0.19041
+              retryCountOnTaskFailure: 3
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
 
       # install any .NET global tools
       - ${{ if ne(parameters.skipInstall, 'true') }}:
@@ -354,6 +359,7 @@ jobs:
                 AndroidSdkDirectory: $(AndroidSdkDirectory)
                 JavaSdkDirectory: $(JAVA_HOME)
                 LLVM_HOME: $(LLVM_HOME)
+                VS_INSTALL: $(VS_INSTALL)
                 # There seems to be a bug in some verions of mspdbcmf.exe. This looks to be fixed in a VS preview.
                 AppxSymbolPackageEnabled: false
               displayName: Run the bootstrapper for ${{ parameters.target }}

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -300,12 +300,6 @@ jobs:
               displayName: Install the Windows 10 SDK 10.0.19041
               retryCountOnTaskFailure: 3
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-          - ${{ if eq(parameters.buildAgent.parameters.installWindowsSdk19041, 'true') }}:
-            - pwsh: .\scripts\infra\native\windows\install-winsdk.ps1 -LinkId 2120843 -Version 10.0.19041.0
-              displayName: Install the Windows 10 SDK 10.0.19041
-              retryCountOnTaskFailure: 3
-              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-
       # install any .NET global tools
       - ${{ if ne(parameters.skipInstall, 'true') }}:
         - ${{ each tool in parameters.tools }}:

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -83,17 +83,18 @@ jobs:
         displayName: Get the volume information before the run
         condition: always()
 
+      - task: UsePythonVersion@0
+        displayName: Switch to the correct Python version
+        retryCountOnTaskFailure: 3
+        inputs:
+          versionSpec: '3.x'
+          architecture: 'x64'
+
       # prepare - checkout strategy depends on caching
       - ${{ if and(ne(parameters.cacheJob, ''), eq(parameters.enableCaching, true)) }}:
         - checkout: self
           submodules: false
           fetchDepth: 1
-        - task: UsePythonVersion@0
-          displayName: Switch to the correct Python version
-          retryCountOnTaskFailure: 3
-          inputs:
-            versionSpec: '3.x'
-            architecture: 'x64'
         - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
           displayName: Configure build variables
         - pwsh: |
@@ -159,14 +160,6 @@ jobs:
 
       # install extra bits for the native builds
       - ${{ if and(startsWith(parameters.name, 'native_'), ne(parameters.skipInstall, 'true')) }}:
-        # switch to the correct Python version
-        - task: UsePythonVersion@0
-          displayName: Switch to the correct Python version
-          retryCountOnTaskFailure: 3
-          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-          inputs:
-            versionSpec: '3.x'
-            architecture: 'x64'
         # install ninja
         - pwsh: .\scripts\infra\native\shared\install-ninja.ps1
           displayName: Install Ninja
@@ -216,8 +209,8 @@ jobs:
             displayName: Install Ninja
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-        # install the bits needed for Android on macOS and Windows
-        - ${{ if and(eq(parameters.installAndroidSdk, 'true'), ne(parameters.buildAgent.pool.os, 'linux')) }}:
+        # install the bits needed for Android
+        - ${{ if eq(parameters.installAndroidSdk, 'true') }}:
           # install the correct version of the JDK
           - pwsh: .\scripts\infra\managed\install-openjdk.ps1
             displayName: Install OpenJDK

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -203,6 +203,13 @@ jobs:
 
       # install extra bits for the managed builds
       - ${{ if and(not(startsWith(parameters.name, 'native_')), ne(parameters.skipInstall, 'true')) }}:
+        - ${{ if eq(parameters.buildAgent.pool.os, 'windows') }}:
+          - task: UseNode@1
+            displayName: Install Node.js
+            retryCountOnTaskFailure: 3
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            inputs:
+              version: 20.x
         # install ninja
         - ${{ if eq(parameters.installNinja, 'true') }}:
           - pwsh: .\scripts\infra\native\shared\install-ninja.ps1

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -334,7 +334,7 @@ stages:
             installEmsdk: true
             initScript: source ~/emsdk/emsdk_env.sh
             preBuildSteps:
-              - bash: ./scripts/infra/managed/install-chrome.sh
+              - bash: bash ./scripts/infra/managed/install-chrome.sh
                 displayName: Install Chrome for WASM tests
             postBuildSteps:
               - pwsh: python3 scripts/infra/tests/extract-visual-goldens.py output/logs/testlogs --failures-out output/logs/testlogs/visual-failures
@@ -370,7 +370,7 @@ stages:
             requiredArtifacts:
               - name: native
             preBuildSteps:
-              - bash: ./scripts/infra/managed/install-chrome.sh
+              - bash: bash ./scripts/infra/managed/install-chrome.sh
                 displayName: Install Chrome for WASM tests
             postBuildSteps:
               - task: PublishTestResults@2

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -333,6 +333,9 @@ stages:
               - name: native
             installEmsdk: true
             initScript: source ~/emsdk/emsdk_env.sh
+            preBuildSteps:
+              - bash: ./scripts/infra/managed/install-chrome.sh
+                displayName: Install Chrome for WASM tests
             postBuildSteps:
               - pwsh: python3 scripts/infra/tests/extract-visual-goldens.py output/logs/testlogs --failures-out output/logs/testlogs/visual-failures
                 displayName: Extract visual-regression failure images for triage
@@ -366,6 +369,9 @@ stages:
             previewWorkloads: wasm-tools,android
             requiredArtifacts:
               - name: native
+            preBuildSteps:
+              - bash: ./scripts/infra/managed/install-chrome.sh
+                displayName: Install Chrome for WASM tests
             postBuildSteps:
               - task: PublishTestResults@2
                 displayName: Publish the WASM preview test results

--- a/scripts/infra/managed/install-chrome.sh
+++ b/scripts/infra/managed/install-chrome.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+CHROME_VERSION="150.0.7871.186-1"
+CHROME_SHA256="4193e00b6d5d5969ee63f7a69596868f546aa0e8cb077b3e0bf9cc1e2c719d00"
+CHROME_PACKAGE_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb"
+
 if command -v google-chrome >/dev/null 2>&1; then
     chrome_path="$(command -v google-chrome)"
 else
@@ -10,7 +14,23 @@ else
 
     curl --fail --location --retry 5 \
         --output "$package" \
-        https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        "$CHROME_PACKAGE_URL"
+
+    actual_sha256="$(sha256sum "$package" | cut -d' ' -f1)"
+    if [[ "$actual_sha256" != "$CHROME_SHA256" ]]; then
+        echo "Chrome SHA-256 mismatch: expected $CHROME_SHA256, got $actual_sha256" >&2
+        exit 1
+    fi
+
+    package_name="$(dpkg-deb --field "$package" Package)"
+    package_version="$(dpkg-deb --field "$package" Version)"
+    package_architecture="$(dpkg-deb --field "$package" Architecture)"
+    if [[ "$package_name" != "google-chrome-stable" ||
+          "$package_version" != "$CHROME_VERSION" ||
+          "$package_architecture" != "amd64" ]]; then
+        echo "Unexpected Chrome package: $package_name $package_version $package_architecture" >&2
+        exit 1
+    fi
 
     sudo apt-get update
     sudo apt-get install -y "$package"

--- a/scripts/infra/managed/install-chrome.sh
+++ b/scripts/infra/managed/install-chrome.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if command -v google-chrome >/dev/null 2>&1; then
+    chrome_path="$(command -v google-chrome)"
+else
+    package="$(mktemp --suffix=.deb)"
+    trap 'rm -f "$package"' EXIT
+
+    curl --fail --location --retry 5 \
+        --output "$package" \
+        https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+
+    sudo apt-get update
+    sudo apt-get install -y "$package"
+
+    chrome_path="$(command -v google-chrome)"
+fi
+
+"$chrome_path" --version
+echo "##vso[task.setvariable variable=CHROME_PATH]$chrome_path"

--- a/scripts/infra/native/shared/install-ninja.ps1
+++ b/scripts/infra/native/shared/install-ninja.ps1
@@ -1,6 +1,9 @@
 $ErrorActionPreference = 'Stop'
 
-if ($IsMacOS) {
+if (Get-Command ninja -ErrorAction SilentlyContinue) {
+    ninja --version
+    exit $LASTEXITCODE
+} elseif ($IsMacOS) {
     brew install ninja
 } elseif ($IsLinux) {
     sudo apt install -y ninja-build

--- a/scripts/infra/native/windows/install-7zip.ps1
+++ b/scripts/infra/native/windows/install-7zip.ps1
@@ -1,5 +1,6 @@
 Param(
-    [string] $Version = '26.02'
+    [string] $Version = '26.02',
+    [string] $Sha256 = 'db407a4f6d4999e5c7bc00ce8a882be94717b56e7fa68140fe3f12605d91643e'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -29,6 +30,11 @@ New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 
 Write-Host "Downloading 7-zip Installer: $uri..."
 .\scripts\infra\native\shared\download-file.ps1 -Uri $uri -OutFile $installer
+
+$actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $installer).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $Sha256.ToLowerInvariant()) {
+    throw "7-Zip $Version SHA-256 mismatch: expected $Sha256, got $actualSha256"
+}
 
 $p = "$env:BUILD_SOURCESDIRECTORY\output\logs\install-logs"
 New-Item -ItemType Directory -Force -Path $p | Out-Null

--- a/scripts/infra/native/windows/install-7zip.ps1
+++ b/scripts/infra/native/windows/install-7zip.ps1
@@ -5,7 +5,8 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 
-$sevenZipPath = (Get-Command 7z -ErrorAction SilentlyContinue).Source
+$sevenZipPath = (Get-Command 7z -CommandType Application -ErrorAction SilentlyContinue |
+    Select-Object -First 1).Source
 if (-not $sevenZipPath) {
     $installedPath = Join-Path $env:ProgramFiles '7-Zip\7z.exe'
     if (Test-Path $installedPath) {

--- a/scripts/infra/native/windows/install-7zip.ps1
+++ b/scripts/infra/native/windows/install-7zip.ps1
@@ -1,18 +1,26 @@
 Param(
-    [string] $Version = '21.07'
+    [string] $Version = '26.02'
 )
 
 $ErrorActionPreference = 'Stop'
 
-try {
-    7z --help
-    Write-Host "7-zip already installed."
-    exit 0
-} catch {
-    # no op
+$sevenZipPath = (Get-Command 7z -ErrorAction SilentlyContinue).Source
+if (-not $sevenZipPath) {
+    $installedPath = Join-Path $env:ProgramFiles '7-Zip\7z.exe'
+    if (Test-Path $installedPath) {
+        $sevenZipPath = $installedPath
+    }
 }
 
-$uri = "https://www.7-zip.org/a/7z$($Version.Replace('.', ''))-x64.msi"
+if ($sevenZipPath) {
+    & $sevenZipPath --help
+    Write-Host "7-zip already installed."
+    $sevenZipDirectory = Split-Path $sevenZipPath
+    Write-Host "##vso[task.setvariable variable=PATH;]$sevenZipDirectory;$env:PATH"
+    exit 0
+}
+
+$uri = "https://github.com/ip7z/7zip/releases/download/$Version/7z$($Version.Replace('.', ''))-x64.msi"
 
 $HOME_DIR = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
 $tempDir = Join-Path "$HOME_DIR" "7zip-temp"

--- a/scripts/infra/shared/shared.cake
+++ b/scripts/infra/shared/shared.cake
@@ -60,6 +60,11 @@ var MSBUILD_VERSION_PROPERTIES = new Dictionary<string, string> {
     { "PREVIEW_LABEL", PREVIEW_LABEL },
 };
 
+var ANDROID_SDK_ROOT = EnvironmentVariable("ANDROID_SDK_ROOT");
+if (!string.IsNullOrEmpty(ANDROID_SDK_ROOT)) {
+    MSBUILD_VERSION_PROPERTIES["AndroidSdkDirectory"] = ANDROID_SDK_ROOT;
+}
+
 var DATE_TIME_NOW = DateTime.Now;
 var DATE_TIME_STR = DATE_TIME_NOW.ToString ("yyyyMMdd_HHmmss");
 

--- a/scripts/infra/tests/tests-apple.cake
+++ b/scripts/infra/tests/tests-apple.cake
@@ -27,9 +27,8 @@ Task ("tests-ios")
         var udid = System.Text.Json.JsonDocument.Parse(createJson).RootElement.GetProperty("udid").GetString();
         Information("  Created simulator with UDID: {0}", udid);
 
-        // Boot by UDID and verify that CoreSimulator reached the booted state.
-        RunProcess("xcrun", $"simctl boot \"{udid}\"");
-        RunProcess("xcrun", $"simctl bootstatus \"{udid}\" -b");
+        // Boot by UDID
+        DotNetTool($"apple simulator boot \"{udid}\" --wait");
         Information("  Simulator booted");
 
         FilePath csproj = $"{ROOT_PATH}/tests/SkiaSharp.Tests.Devices/SkiaSharp.Tests.Devices.csproj";

--- a/scripts/infra/tests/tests-apple.cake
+++ b/scripts/infra/tests/tests-apple.cake
@@ -27,8 +27,9 @@ Task ("tests-ios")
         var udid = System.Text.Json.JsonDocument.Parse(createJson).RootElement.GetProperty("udid").GetString();
         Information("  Created simulator with UDID: {0}", udid);
 
-        // Boot by UDID
-        DotNetTool($"apple simulator boot \"{udid}\" --wait");
+        // Boot by UDID and verify that CoreSimulator reached the booted state.
+        RunProcess("xcrun", $"simctl boot \"{udid}\"");
+        RunProcess("xcrun", $"simctl bootstatus \"{udid}\" -b");
         Information("  Simulator booted");
 
         FilePath csproj = $"{ROOT_PATH}/tests/SkiaSharp.Tests.Devices/SkiaSharp.Tests.Devices.csproj";


### PR DESCRIPTION
## Description

Move eligible public CI jobs from Microsoft-hosted agents to the dnceng `NetCore-Public` pool and explicitly provision the tools that lean public images do not include.

Linux jobs now use `build.ubuntu.2204.amd64.open`, while managed Windows jobs use `windows.vs2026.amd64.open`. Jobs that require capabilities unavailable on those images remain on approved hosted agents: Android emulator tests need `/dev/kvm`, native Windows builds need the complete Visual Studio 2022 toolchain with Spectre-mitigated libraries, and native macOS moves to macOS 15 because dnceng has no macOS build-agent image. The generic Linux host metadata is also corrected from `windows` to `linux`.

Validation of the new images exposed several implicit hosted-agent dependencies. The shared bootstrapper now provisions Python, Node 20, Android platform/build tools, and Chrome where required; forwards the Android SDK path to MSBuild with the correct property casing; and reuses existing Ninja and 7-Zip installations before installing fallbacks. Direct Chrome and 7-Zip downloads are pinned and SHA-256 verified, with Chrome package identity, version, and architecture checked before installation.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — CI-only, with no public API or application behavior change.

## Testing

- Parsed the updated Azure Pipelines YAML and verified the resulting pool/host matrix.
- Syntax-checked the touched Bash and PowerShell provisioning scripts.
- Independently downloaded and verified the pinned Chrome and 7-Zip artifacts and package metadata.
- Exercised the migrated native, managed, test, sample, and packaging jobs through successive dnceng validations; build [1531914](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1531914) completed all stages successfully.

No product tests were added because this changes only CI infrastructure and provisioning.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later — not applicable
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated — not applicable