### PR TITLE
Invoke vcvarsall only once before windows compilation

### DIFF
--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -4,6 +4,7 @@ DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native"));
 var llvmHomeArg = Argument("llvm", EnvironmentVariable("LLVM_HOME") ?? "C:/Program Files/LLVM");
 DirectoryPath LLVM_HOME = string.IsNullOrEmpty(llvmHomeArg) || llvmHomeArg.ToLower() == "msvc" ? "" : llvmHomeArg;
 string VC_TOOLSET_VERSION = Argument("vcToolsetVersion", "14.2");
+string WINDOWS_SDK_VERSION = Argument("windowsSdkVersion", "10.0.22621.0");
 
 // GPU features can be disabled for NanoServer builds
 string SUPPORT_VULKAN_VAR = Argument ("supportVulkan", EnvironmentVariable ("SUPPORT_VULKAN") ?? "true");
@@ -44,10 +45,12 @@ Task("libSkiaSharp")
 
         var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
         var win_vcvars_version = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"win_vcvars_version='{VC_TOOLSET_VERSION}' ";
+        var vcVarsArchitecture = skiaArch == "x64" ? "amd64" : $"amd64_{skiaArch}";
         var d = CONFIGURATION.ToLower() == "release" ? "" : "d";
         var spectreLibPath = GetSpectreLibPath(arch);
+        var nativeOutDir = $"{VARIANT}/{arch}";
 
-        GnNinja($"{VARIANT}/{arch}", "SkiaSharp",
+        GenerateGnBuild(nativeOutDir,
             $"target_os='win'" +
             $"target_cpu='{skiaArch}' " +
             $"skia_enable_fontmgr_win_gdi=false " +
@@ -71,9 +74,18 @@ Task("libSkiaSharp")
             $"skia_enable_graphite=true " +
             clang +
             win_vcvars_version +
+            $"win_sdk_version='{WINDOWS_SDK_VERSION}' " +
             $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DSK_ENABLE_LEGACY_SHADERCONTEXT', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +
             $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP', '/guard:cf', '/LIBPATH:{spectreLibPath}', '/DELAYLOAD:d3d12.dll', '/DELAYLOAD:dxgi.dll', '/DELAYLOAD:D3DCOMPILER_47.dll', '/DEFAULTLIB:delayimp' ] " +
             ADDITIONAL_GN_ARGS);
+
+        RunNinjaWithVcVars(
+            SKIA_PATH,
+            $"out/{nativeOutDir}",
+            "SkiaSharp",
+            vcVarsArchitecture,
+            WINDOWS_SDK_VERSION,
+            VC_TOOLSET_VERSION);
 
         var outDir = OUTPUT_PATH.Combine($"{VARIANT}/{dir}");
         EnsureDirectoryExists(outDir);

--- a/scripts/infra/native/shared/native-shared.cake
+++ b/scripts/infra/native/shared/native-shared.cake
@@ -199,7 +199,7 @@ void RunNinja(DirectoryPath working, DirectoryPath outDir, string target = "")
     RunPython(working, script, $"-C {outDir} {target}");
 }
 
-void GnNinja(DirectoryPath outDir, string target, string skiaArgs)
+void GenerateGnBuild(DirectoryPath outDir, string skiaArgs)
 {
     // override win_vc with the command line args
     if (!string.IsNullOrEmpty(VS_INSTALL)) {
@@ -214,6 +214,11 @@ void GnNinja(DirectoryPath outDir, string target, string skiaArgs)
 
     // generate native skia build files
     RunGn(SKIA_PATH, $"out/{outDir}", skiaArgs);
+}
+
+void GnNinja(DirectoryPath outDir, string target, string skiaArgs)
+{
+    GenerateGnBuild(outDir, skiaArgs);
 
     // build native skia
     RunNinja(SKIA_PATH, $"out/{outDir}", target);

--- a/scripts/infra/native/windows/windows-shared.cake
+++ b/scripts/infra/native/windows/windows-shared.cake
@@ -1,5 +1,35 @@
 var VERIFY_EXCLUDED = new[] { "VCRUNTIME", "MSVCP" };
 
+void RunNinjaWithVcVars(
+    DirectoryPath working,
+    DirectoryPath outDir,
+    string target,
+    string architecture,
+    string windowsSdkVersion,
+    string vcVarsVersion)
+{
+    var vcVarsAll = ((DirectoryPath)VS_INSTALL)
+        .CombineWithFilePath("VC/Auxiliary/Build/vcvarsall.bat");
+    var ninjaScript = DEPOT_PATH.CombineWithFilePath("ninja.py");
+    var vcVarsVersionArg = string.IsNullOrEmpty(vcVarsVersion)
+        ? ""
+        : $" -vcvars_ver={vcVarsVersion}";
+    var ninjaTarget = string.IsNullOrEmpty(target) ? "" : $" {target}";
+    var command =
+        $"call \"{vcVarsAll.FullPath}\" {architecture} {windowsSdkVersion}{vcVarsVersionArg} >nul" +
+        $" && \"{PYTHON_EXE}\" \"{ninjaScript.FullPath}\" -C \"{outDir.FullPath}\"{ninjaTarget}";
+
+    Information($"Initializing the Visual C++ environment once for {architecture}.");
+    RunProcess("cmd.exe", new ProcessSettings {
+        Arguments = new ProcessArgumentBuilder()
+            .Append("/d")
+            .Append("/s")
+            .Append("/c")
+            .AppendQuoted(command),
+        WorkingDirectory = working.FullPath,
+    });
+}
+
 string GetSpectreLibPath(string arch)
 {
     var spectreArch = arch.ToLower() switch {


### PR DESCRIPTION
## Summary

Initialize the architecture-specific Visual C++ environment once before invoking Ninja for Windows SkiaSharp native builds.

The corresponding Skia change has merged as [mono/skia#306](https://github.com/mono/skia/pull/306). It removes the redundant `vcvarsall.bat` prefix from every Windows GN compile, archive, and link edge. This PR updates SkiaSharp to that merged commit and invokes one direct command per architecture:

```cmd
call vcvarsall.bat <architecture> <windows-sdk> -vcvars_ver=<toolset> && ninja ...
```

Architecture mappings:

- x86: `amd64_x86`
- x64: `amd64`
- ARM64: `amd64_arm64`

The build remains on the original `Azure Pipelines / windows-2022` pool with Ninja's default parallelism.

## Results

Validated in Azure build [1532137](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1532137):

| Architecture | Original `libSkiaSharp` | One-time vcvars | Improvement |
|---|---:|---:|---:|
| x86 | 49:52 | 21:33.863 | **56.8% faster** |
| x64 | 46:33 | 20:17.847 | **56.4% faster** |
| ARM64 | 45:06 | 20:38.700 | **54.2% faster** |

For each architecture:

- the clean build completed every Ninja edge and linked successfully;
- dependency validation passed;
- the Visual C++ environment was initialized exactly once;
- no Ninja edge invoked `vcvarsall.bat`.

## Additional validation

Skia remains independently buildable on Windows without running `vcvarsall`: GN emits absolute compiler/linker paths and explicit MSVC and Windows SDK include/library paths. Standalone clang-cl and MSVC compile/relink tests succeeded with `INCLUDE`, `LIB`, and `VCINSTALLDIR` unset.

The final merged-submodule integration is being validated in Azure build [1532412](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1532412).