### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "f2affc1d5f4452377c3e9e914053c9dfea65f198"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2c424f6b9068cc28d3c7c92f47b2f4c0d8641917"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated Skia milestone bump from m151 to m152.

**Companion skia PR:** https://github.com/mono/skia/pull/303

## SkiaSharp — bump to Skia milestone 152

Companion to the mono/skia PR on branch `skia-sync/m152`. See that PR for the upstream merge
audit (326 commits, 4 conflicts resolved, VMA bumped) — this summary covers the SkiaSharp-side
version bumps, bindings, build, and test results.

### Version bumps

| File | Change |
|---|---|
| `scripts/VERSIONS.txt` | milestone `151` → `152`, nuget `4.151.0` → `4.152.0`, soname `151.0.0` → `152.0.0`, `SK_C_INCREMENT` reset to `0` |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION` → `4.152.0` |
| `cgmanifest.json` | `commitHash` → `f2affc1d5f...` (mono/skia HEAD after VMA bump), `chrome_milestone` → `152`, `upstream_merge_commit` → `2c424f6b90...` |
| `externals/skia` submodule pointer | → `f2affc1d5f4452377c3e9e914053c9dfea65f198` on `skia-sync/m152` |

`update-versions.ps1` was invoked with `-UpstreamRef "chrome/m152"` so the merge SHA resolves
correctly in `cgmanifest.json`. The gate check passed.

### Bindings & C# API

- Ran `pwsh ./utils/generate.ps1`. The generator reported **"No changes to bindings (C API
  signatures unchanged)"** and **"No new functions"** — no `.generated.cs` deltas, no new
  wrapper work required. (HarfBuzz reverted-in-place as usual.)
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` → **0 errors, 0 warnings**.

### Native build

- `dotnet cake --target=externals-linux --arch=x64` succeeded after the VMA bump described in
  the mono/skia summary. `libSkiaSharp.so` and `libHarfBuzzSharp.so` produced.
- No new `--gnArgs` were required.

### Test results (Linux x64, lavapipe)

Full test-output log uploaded as workflow artifact: `test-output.txt`.

| Test assembly | Passed | Failed | Skipped |
|---|---|---|---|
| `SkiaSharp.Tests.dll` | 5912 | 0 | 202 |
| `SkiaSharp.Tests.SingletonInit.dll` | 1 | 0 | 0 |
| `SkiaSharp.Direct3D.Tests.dll` | 2 | 0 | 3 |
| `SkiaSharp.Vulkan.Tests.dll` | **14** | **9** | 2 |

Vulkan host is **present and executing** tests (14 pass) — it is not "all-skipped" — but Ganesh
Vulkan context creation fails on the sandbox's lavapipe.

### Items needing human attention

1. **9 Vulkan test failures — Ganesh `GRContext.CreateVulkan` returns null on lavapipe.**
   All failures share the same shape: `Assert.NotNull(grContext)` after calling
   `GRContext.CreateVulkan(grVkBackendContext)` (`tests/VulkanTests/GRContextTest.cs`) — plus
   the SharpVk/SilkNet backend/surface tests that internally construct a Ganesh Vulkan context.
   The Skia log emits:

   > `VK_KHR_driver_properties is not enabled, driver workarounds cannot be correctly applied`

   Note that **Graphite-Vulkan visual tests pass** (5/5 `graphite-vulkan` `RenderMatchesGolden`
   scenes green), so the physical Vulkan device is functional; it is only the Ganesh
   `GrDirectContexts::MakeVulkan` path that fails, which strongly implicates the m152
   Ganesh-Vulkan changes (new `VulkanPreferredFeatures` reshuffle, VMA bump, and Ganesh-only
   FBO workaround entries) — not a lavapipe-wide capability gap.

   Failing tests:
   - `GRContextTest.CreateVkContextIsValid`
   - `GRContextTest.CreateVkContextWithOptionsIsValid`
   - `SharpVkBackendContextTest.VkGpuSurfaceIsCreatedSharpVkTypes`
   - `SharpVkBackendContextTest.PropertyIsSetAndUnset`
   - `SilkNetBackendContextTest.VkGpuSurfaceIsCreatedSilkNetTypes`
   - `SilkNetBackendContextTest.HandlesAreMappedToBase`
   - `SilkNetBackendContextTest.PhysicalDeviceFeaturesIsSetAndUnset`
   - `SKSurfaceTest.VkGpuSurfaceIsCreated`
   - `SKSurfaceTest.VkGpuSurfaceIsCreatedSharpVkTypes`

   Likely candidates to investigate:
   - Enable `VK_KHR_driver_properties` in the test-side `GRVkExtensions.Initialize` call and see
     if the warning goes away.
   - Compare `include/gpu/vk/VulkanBackendContext.h` and `VulkanPreferredFeatures` requirements
     between m151 and m152 — a newly-required feature bit in `fDeviceFeatures2` could explain
     why Ganesh (which validates features up front) fails while Graphite (which negotiates its
     own feature set internally) succeeds.
   - Re-run on a non-lavapipe Vulkan host to disambiguate a genuine m152 regression vs. a
     lavapipe-only limitation.

2. **VMA revision bump** (see mono/skia summary) — treat this like a native-dependency-update
   review even though it landed in the sync PR.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).