### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "4db4d8eabe7c1300d343a1d7f5b67b9a3081a74c"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2c424f6b9068cc28d3c7c92f47b2f4c0d8641917"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated Skia milestone bump from m151 to m152.

**Companion skia PR:** https://github.com/mono/skia/pull/304

## SkiaSharp: bump Skia to m152

Bumps the `externals/skia` submodule to `mono/skia` `skia-sync/m152` (which merges `upstream/chrome/m152`) and rolls all version files.

### Breaking-change analysis (m151 → m152)

From upstream `RELEASE_NOTES.md`:

| Change | Risk | C API impact |
|--------|------|--------------|
| `skgpu::graphite::ContextOptions::fAvoidDepth` added | 🟢 LOW / SKIP | Graphite only — SkiaSharp uses Ganesh. |
| `SkRRect::contains(const SkPoint&)` added | 🟢 LOW | Additive; not exposed via C API. |
| `SkPath::updateBoundsCache()` removed | 🟡 MEDIUM | **No usage** in `src/c/` or `include/c/`. Bounds are now computed upfront. |
| `SkIcoRustDecoder` added | 🟢 LOW | Optional feature gated on `skia_use_rust_ico_decode` (off). Not exposed. |

No C API adjustments required. Bindings regeneration produced **no diff** — the C ABI is unchanged from m151.

### Version updates (via `update-versions.ps1`)

- `scripts/VERSIONS.txt`: `libSkiaSharp` milestone 151→152, soname 151.0.0→152.0.0, all ~30 nuget lines 4.151.0→4.152.0, `SK_C_INCREMENT` reset to 0.
- `cgmanifest.json`: `chrome_milestone` 151→152, `commitHash` → `e2171b0b58…` (mono/skia m152 tip), `upstream_merge_commit` → `2c424f6b9068cc28d3c7c92f47b2f4c0d8641917`.
- `scripts/azure-templates-variables.yml`: `SKIASHARP_VERSION` → 4.152.0.
- `externals/skia/include/c/sk_types.h`: `SK_C_INCREMENT` → 0.

Gate: verification greps report no stale m151 references.

### Bindings

- `pwsh utils/generate.ps1` produced no diff to `binding/SkiaSharp/SkiaApi.generated.cs`.
- HarfBuzz bindings reverted per policy (HarfBuzz updates are separate).

### Build

- `dotnet cake --target=externals-linux --arch=x64`: ✅ (~12 min) — after rolling VMA in `mono/skia`; see the mono/skia PR.
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj`: ✅ 0 errors (4 unrelated NETSDK1202 net9-android warnings).

### Tests (`dotnet test tests/SkiaSharp.Tests.Console.slnx`)

Full log: `/tmp/gh-aw/agent/test-output.txt`.

| Suite | Passed | Failed | Skipped | Total |
|-------|-------:|-------:|--------:|------:|
| SingletonInit | 1 | 0 | 0 | 1 |
| SkiaSharp.Tests | 5912 | 0 | 202 | 6114 |
| Direct3D | 2 | 0 | 3 | 5 |
| **Vulkan** | **14** | **9** | **2** | **25** |

### Items needing human attention

- **Vulkan test regressions (9 failures).** All fail with `Assert.NotNull` on `GRContext.CreateVulkan(...)` or `System.InvalidOperationException: GRContext.CreateVulkan returned null.` The Vulkan host still runs (14 tests pass) and 5912 non-Vulkan tests pass, so this is a Vulkan-context-creation regression, not an environment gap. Suspected causes:
  - The **VulkanMemoryAllocator roll** to `eb744ea7` (required by m152's Skia sources). New VMA may change requirements.
  - Skia m147+ made `VulkanBackendContext::fMemoryAllocator` non-optional; our bindings may not be supplying one on all code paths that used to leave it null.
  - A subtle Vulkan features/extensions change in m152's `VulkanPreferredFeatures` — `[skia] WARNING - VK_KHR_driver_properties is not enabled` appears in the log.
  - Failing tests: `CreateVkContextIsValid`, `CreateVkContextWithOptionsIsValid`, `VkGpuSurfaceIsCreatedSilkNetTypes`, and 6 `VulkanVisualTests.RenderMatchesGolden(ganesh-vulkan, …)` scenes (`GradientBlend`, `Text`, `FilledCircle`, `DiagonalLines`, `RedRoundedRectOnWhite`, and one more).
- **Cross-platform builds not exercised.** Only Linux x64 native binaries were built (per workflow). macOS/Windows/iOS/Android/WASM native builds should be verified in CI before merge. The VMA roll in particular could affect the VMA compile on Windows/macOS.
- **`externals/depot_tools`** floats one commit ahead locally from `git-sync-deps`; reverted to the base branch's SHA to keep the parent PR focused on version bumps.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).