### PR TITLE
[Windows] Stop pinning a Windows SDK version by default

### DIFF
--- a/native/windows/build.cake
+++ b/native/windows/build.cake
@@ -4,7 +4,8 @@ DirectoryPath OUTPUT_PATH = MakeAbsolute(ROOT_PATH.Combine("output/native"));
 var llvmHomeArg = Argument("llvm", EnvironmentVariable("LLVM_HOME") ?? "C:/Program Files/LLVM");
 DirectoryPath LLVM_HOME = string.IsNullOrEmpty(llvmHomeArg) || llvmHomeArg.ToLower() == "msvc" ? "" : llvmHomeArg;
 string VC_TOOLSET_VERSION = Argument("vcToolsetVersion", "14.2");
-string WINDOWS_SDK_VERSION = Argument("windowsSdkVersion", "10.0.22621.0");
+// empty lets gn detect an installed SDK
+string WINDOWS_SDK_VERSION = Argument("windowsSdkVersion", "");
 
 // GPU features can be disabled for NanoServer builds
 string SUPPORT_VULKAN_VAR = Argument ("supportVulkan", EnvironmentVariable ("SUPPORT_VULKAN") ?? "true");
@@ -45,6 +46,7 @@ Task("libSkiaSharp")
 
         var clang = string.IsNullOrEmpty(LLVM_HOME.FullPath) ? "" : $"clang_win='{LLVM_HOME}' ";
         var win_vcvars_version = string.IsNullOrEmpty(VC_TOOLSET_VERSION) ? "" : $"win_vcvars_version='{VC_TOOLSET_VERSION}' ";
+        var win_sdk_version = string.IsNullOrEmpty(WINDOWS_SDK_VERSION) ? "" : $"win_sdk_version='{WINDOWS_SDK_VERSION}' ";
         var vcVarsArchitecture = skiaArch == "x64" ? "amd64" : $"amd64_{skiaArch}";
         var d = CONFIGURATION.ToLower() == "release" ? "" : "d";
         var spectreLibPath = GetSpectreLibPath(arch);
@@ -74,7 +76,7 @@ Task("libSkiaSharp")
             $"skia_enable_graphite=true " +
             clang +
             win_vcvars_version +
-            $"win_sdk_version='{WINDOWS_SDK_VERSION}' " +
+            win_sdk_version +
             $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DSK_ENABLE_LEGACY_SHADERCONTEXT', '/MT{d}', '/EHsc', '/Z7', '/guard:cf', '-D_HAS_AUTO_PTR_ETC=1' ] " +
             $"extra_ldflags=[ '/DEBUG:FULL', '/DEBUGTYPE:CV,FIXUP', '/guard:cf', '/LIBPATH:{spectreLibPath}', '/DELAYLOAD:d3d12.dll', '/DELAYLOAD:dxgi.dll', '/DELAYLOAD:D3DCOMPILER_47.dll', '/DEFAULTLIB:delayimp' ] " +
             ADDITIONAL_GN_ARGS);

--- a/scripts/infra/native/windows/windows-shared.cake
+++ b/scripts/infra/native/windows/windows-shared.cake
@@ -11,12 +11,16 @@ void RunNinjaWithVcVars(
     var vcVarsAll = ((DirectoryPath)VS_INSTALL)
         .CombineWithFilePath("VC/Auxiliary/Build/vcvarsall.bat");
     var ninjaScript = DEPOT_PATH.CombineWithFilePath("ninja.py");
+    // omitted rather than empty, as vcvarsall fails on an SDK that is not installed
+    var windowsSdkVersionArg = string.IsNullOrEmpty(windowsSdkVersion)
+        ? ""
+        : $" {windowsSdkVersion}";
     var vcVarsVersionArg = string.IsNullOrEmpty(vcVarsVersion)
         ? ""
         : $" -vcvars_ver={vcVarsVersion}";
     var ninjaTarget = string.IsNullOrEmpty(target) ? "" : $" {target}";
     var command =
-        $"call \"{vcVarsAll.FullPath}\" {architecture} {windowsSdkVersion}{vcVarsVersionArg} >nul" +
+        $"call \"{vcVarsAll.FullPath}\" {architecture}{windowsSdkVersionArg}{vcVarsVersionArg}" +
         $" && \"{PYTHON_EXE}\" \"{ninjaScript.FullPath}\" -C \"{outDir.FullPath}\"{ninjaTarget}";
 
     Information($"Initializing the Visual C++ environment once for {architecture}.");


### PR DESCRIPTION
## Description

The `benchmark-source (windows-latest, Windows, native/windows)` leg of **Track - Benchmarks** dies the instant it starts the native build ([failing run](https://github.com/mono/SkiaSharp/actions/runs/30504103191/job/90750147904)):

```
Done. Made 114 targets from 63 files in 358ms
Initializing the Visual C++ environment once for amd64.
An error occurred when executing task 'libSkiaSharp'.
Error: Process 'cmd.exe' failed with error: 1
```

**Root cause.** `RunNinjaWithVcVars` (added in #4570) runs:

```
call "<VS>/VC/Auxiliary/Build/vcvarsall.bat" amd64 10.0.22621.0 -vcvars_ver=14.2 >nul && <ninja>
```

`10.0.22621.0` was the default of the `--windowsSdkVersion` argument, also new in #4570, and it matches what the AzDO agents ship. The GitHub-hosted runner is **`windows-2025-vs2026`**, which ships **only** Windows SDK `10.0.26100.0`. vcvarsall hard-fails on an SDK version that isn't installed and returns 1 — and `>nul` swallowed the reason, which is why the log says nothing at all.

Reproduced locally (VS 18, SDKs 22621 + 26100 installed) with the exact generated command line:

| SDK argument | exit | output with `>nul` |
| --- | --- | --- |
| `10.0.22621.0` (installed) | 0 | — |
| `10.0.20348.0` (not installed) | **1** | *(nothing)* |

Dropping `>nul` reveals it: `[ERROR:winsdk.bat] Windows SDK 10.0.20348.0 : '…\include\10.0.20348.0\um' not found or was incomplete`.

**Nothing needed that default.** Before #4570 there was no such argument: gn resolved `win_sdk_version` itself (`BUILDCONFIG.gn` → `lowest_version_dir.py`) and the toolchain interpolated that same resolved value into the vcvarsall command it generated — so the version was always one that exists on the machine, and the two could never disagree. The same runner image built libSkiaSharp from source successfully an hour before the failure ([run 30492110303, job 90712480452](https://github.com/mono/SkiaSharp/actions/runs/30492110303) — 33 min of ninja, green). Hardcoding a version just meant the build broke on any machine that didn't happen to have that exact SDK — CI here, and equally a developer box with only a newer one.

**The fix:** default the argument to empty and omit it from *both* gn and vcvarsall when unset, so each detects an SDK that actually exists. Setting it still pins both — so `--windowsSdkVersion 10.0.26100.0` remains available to build against a specific SDK locally, and gn and vcvarsall stay in agreement when you do. Dropping `>nul` restores visibility. It was hiding the vcvarsall banner, but `>nul` redirects only stdout — and VsDevCmd writes its errors there too, so it discarded the diagnosis along with the banner (verified: with `2>nul` the `[ERROR:winsdk.bat]` lines still appear, with `>nul` nothing does). The banner is five lines per architecture and is worth having in the log; the next failure in here will say *why* instead of just surfacing an exit code.

**Why it wasn't caught.** `benchmark-source` is `if: github.event_name == 'pull_request'` — it is *skipped on main* (verified on run 30503500442). #4570 merged green without this path ever being exercised, and the failure surfaced on an unrelated PR (#4575, which touches no native files). Worth considering separately whether the native source-build legs should also run on main.

<details>
<summary>Alternatives considered</summary>

- **Override the SDK only in `track-benchmarks.yml`.** Fixes CI but leaves the same landmine for every other consumer, including local builds on a machine without `10.0.22621.0`.
- **Detect the SDK in cake** via skia's `find_winsdk.py` + `lowest_version_dir.py` and pass that one value to both. Works, but it reimplements in cake what gn already does for itself, for no gain over simply not passing a version.
- **Install the missing SDK on the runner.** `install-winsdk.ps1` exists, but it needs a per-SDK fwlink `LinkId` and adds minutes to every run for an SDK the job has no reason to care about.
- **Drop the vcvarsall call entirely.** Every tool in `gn/toolchain/BUILD.gn` is invoked by absolute path and every search path is an explicit flag (`-imsvc`, `/LIBPATH:`), so it may well be redundant for our LLVM-based config — but proving that needs a real Windows build and is a different change with a different blast radius. Filed as #4589.

</details>

**Related issues**

Regression from #4570 ("[Windows] Initialize the MSVC environment once per native build"). #4589 follows up on whether the vcvarsall call is needed at all.

Fixes #

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — build-infrastructure only, no public API or managed behavior change.

One build-side behaviour change worth naming: `--windowsSdkVersion` no longer defaults to `10.0.22621.0`. Unset, gn detects the SDK as it did before #4570; set, it pins gn and vcvarsall exactly as before. On the AzDO agents gn's detection returns `10.0.22621.0` — the same version that was hardcoded — so the compiler flags are expected to be identical; the CI run on this PR is what confirms it.

## Testing

No unit tests — cake/CI build plumbing with no managed surface. Verified empirically instead:

- **Reproduced the failure locally** with the exact command shape the helper generates, against VS 18 with SDKs 22621 + 26100: installed SDK → exit 0; missing SDK → exit 1 with *zero* output, matching CI byte for byte. Removing `>nul` surfaced `[ERROR:winsdk.bat] Windows SDK … not found or was incomplete`.
- **Confirmed why `>nul` hid the error**: rerunning the failing command with `2>nul` (discarding stderr) still printed `[ERROR:winsdk.bat] Windows SDK … not found or was incomplete`, proving VsDevCmd writes errors to stdout; with `>nul` the same command captured zero lines and exit 1 — exactly the CI symptom.
- **Verified both generated command shapes** — with the SDK argument omitted and with it present (`amd64 10.0.26100.0 -vcvars_ver=14.2`): both initialize for `x64` and exit 0, and the chained ninja command runs. Also checked the `ProcessArgumentBuilder` rendering through `System.Diagnostics.Process` so the nested quotes survive `cmd /s`.
- **Confirmed against live CI**: on this branch the Windows leg reached ~18 minutes of ninja compilation, versus dying in ~40 seconds before the fix.
- **Confirmed gn still detects** when `win_sdk_version` is unset: `BUILDCONFIG.gn` declares it empty and calls `lowest_version_dir.py`. Ran that script against a real `Windows Kits\10\Include` — returns `10.0.22621.0` with 22621 + 26100 installed, i.e. the value that was previously hardcoded.
- **Checked what actually consumes the SDK version** in `gn/skia/BUILD.gn`: includes are emitted as `-imsvc` flags (or gn `include_dirs`) and libs as `lib_dirs` → `/LIBPATH:`, all interpolated from gn's `$win_sdk_version`.
- **Cake script compilation** validated with `--dryrun`, both with no argument and with `--windowsSdkVersion=10.0.26100.0`, confirming the override still plumbs through.

Not tested locally: a full libSkiaSharp compile (no depot_tools/skia checkout on this machine) and the macOS/Linux legs (untouched). The two things CI must confirm are the `benchmark-source (windows-latest, …)` job — which only runs on pull requests, so this PR *is* the test — and the AzDO Windows native job proving gn's detection resolves to the SDK that was previously hardcoded.

## Checklist

- [x] Tests added or updated (if omitted, explain why above) — n/a, CI/build script change; verified empirically as described above
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later — n/a, no public API change
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated — n/a, no C API or submodule change



