### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "409aad73a2579c2306607b40fcbd3166bc8aea13"
+          "commitHash": "44e88b31ada8ec2105112fe0146db3e9959df810"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a7fb0b3c2e109e4e68f50bf823cf6b8d524c4a0c"
+      "upstream_merge_commit": "4452d2cbf43fe0c09d513faeb95a560456f7be0c"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "44e88b31ada8ec2105112fe0146db3e9959df810"
+          "commitHash": "686ce0cf1571ed234c1d59958909cd0b3e8ef2f4"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "4452d2cbf43fe0c09d513faeb95a560456f7be0c"
+      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/312

# [skia-sync] Bump externals/skia to chrome/m150 tip (release/4.150.x)

Companion to the mono/skia PR on `skia-sync/release-4.150.x`.

## Scope

Release-line bug-fix sync for **m150** — milestone unchanged, no version bump. The only expected
parent-repo changes are the submodule pointer and `cgmanifest.json`'s hash fields.

## Upstream delta

One upstream commit merged from `google/skia` `chrome/m150`:

- `4452d2cbf4` — "Roll infra dep to 055b7587…" (b/535581863). **Infra-only** (Skia build/CI
  infrastructure; `DEPS infra_revision`, `go.*`, `infra/bots/**`). No C/C++, no C API, no headers,
  no third-party deps, no `BUILD.gn` changes.

See the mono/skia PR summary for the full merge + conflict analysis.

## Files changed in this repo

| File | Change |
|------|--------|
| `externals/skia` | `409aad73a2…` → `44e88b31ad…` (submodule pointer to the merge commit on `skia-sync/release-4.150.x`) |
| `cgmanifest.json` | `commitHash` → `44e88b31ada8ec2105112fe0146db3e9959df810`; `upstream_merge_commit` → `4452d2cbf43fe0c09d513faeb95a560456f7be0c` |

## Version files

**No changes** — this is a release-line sync (`current == target == 150`, `is_release=true`).
`scripts/VERSIONS.txt`, `scripts/azure-templates-variables.yml`, and
`externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT`) are intentionally untouched.

## Breaking change analysis

- **Public C API surface:** unchanged (no `include/c/**` or `src/c/**` touched upstream).
- **Managed bindings:** no regeneration required — no upstream C API changes.
- **ABI:** stable.
- **Binary output:** identical modulo build metadata (upstream change touches only Skia's Go infra
  tooling, not any file compiled into `libSkiaSharp`).

## Build & test results

- **Native (Linux x64) rebuild:** attempted, failed at the expat compile step with a pre-existing
  mismatch between the vendored expat 2.8.1 sources and our fork's `third_party/expat/BUILD.gn`
  (references `random_dev_urandom.c`, which the 2.8.1 pin no longer ships). The same failure
  reproduces on the base `release/4.150.x` HEAD before this merge, so it is **not** a regression
  from this sync. Because the upstream commit merged here is infra-only and cannot alter
  `libSkiaSharp`'s bytes, this sync does not depend on a green native rebuild.
- **Managed C# build / tests:** not run (native rebuild is the prerequisite; blocked by the
  pre-existing expat issue above). No managed changes were made in this sync.

## Items needing human attention

1. **Pre-existing expat build break (not caused by this sync).** `third_party/expat/BUILD.gn` in
   the mono/skia fork references `expat/lib/random_dev_urandom.c` / `random_dev_urandom.h`, but the
   currently-pinned expat 2.8.1 (`6154446fcc…`, from mono/skia PR #245) has removed those files.
   Any source rebuild of the native library on `release/4.150.x` will hit
   `ninja: error: '…expat/lib/random_dev_urandom.c' … missing`. This needs a follow-up in mono/skia
   to either update `third_party/expat/BUILD.gn` to match expat 2.8.1's source layout
   (`random.c` / `random_getrandom.c` only), or repin expat. Flagged here so the reviewer can open a
   separate issue; it is orthogonal to this infra roll.
2. Otherwise, no reviewer action required for this merge itself.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).