### PR TITLE
docs: note the Vulkan 1.1 Ganesh requirement in the 4.148.0 notes sidecar

### DIFF
--- a/documentation/docfx/releases/_sources/4.148.0.notes.md
+++ b/documentation/docfx/releases/_sources/4.148.0.notes.md
@@ -14,7 +14,7 @@
 ## Behavioral breaking changes (same signature, different runtime behavior)
 
 These compile unchanged but behave differently at runtime, so they never appear in a signature
-diff. Test text layout and stream seeking after upgrading from 3.x.
+diff. Test text layout, stream seeking and Vulkan context creation after upgrading from 3.x.
 
 ### `new SKFont()` now has an empty typeface (#3735)
 
@@ -97,6 +97,54 @@ unchecked `(int)` cast, silently truncating large offsets — a latent data-corr
 - **Migration:** call `Move(int)` with an in-range offset (validate/clamp large values
   yourself first). Most callers already pass int-range values and only need to change the call
   to silence the obsolete warning.
+
+### `GRContext.CreateVulkan` aborts the process instead of returning null on Vulkan 1.0 (#4600)
+
+Upstream `0a3150b03b` (m139) made Ganesh acquire the Vulkan 1.1 core entry points unconditionally —
+its release note read *"The Vulkan implementation of Ganesh now requires Vulkan 1.1 as the minimum
+Vulkan version."* — and `dfea59a30f` (m140) then promoted the minimum-version check from a debug
+check to a fatal `SK_ABORT("Vulkan 1.1 is required but not available. …")`. Both commits are
+ancestors of the Skia pinned by 4.147.0/4.148.0 and of neither 3.119.x pin, so the v4 engine jump is
+where consumers first meet this.
+
+- **Before (3.x):** a Vulkan 1.0 instance or device made `GRContext.CreateVulkan` return `null`, and
+  the caller could fall back to raster.
+- **After (4.x):** Skia calls `SK_ABORT` and the **process terminates**. It is not an exception —
+  managed code can neither catch it nor pre-empt it.
+- **Who is affected:** anyone whose `VkInstance` was created with `VkApplicationInfo.apiVersion`
+  below `VK_API_VERSION_1_1` (including leaving it at `0`, which the Vulkan spec treats as 1.0), and
+  anyone leaving `GRVkBackendContext.MaxAPIVersion` at its default `0`. That default makes Skia fall
+  back to `vkEnumerateInstanceVersion` — the *loader's* version, not the version the instance was
+  actually created with — so it can over-declare and ask for entry points the instance cannot serve.
+- **Migration:** declare 1.1 in **both** places. Neither alone is sufficient:
+
+  ```csharp
+  // VK_MAKE_API_VERSION(0, 1, 1, 0) — 0x00401000
+  const uint VK_API_VERSION_1_1 = (1u << 22) | (1u << 12);
+
+  // 1. Create the instance as Vulkan 1.1 or later...
+  var appInfo = new VkApplicationInfo {
+      apiVersion = VK_API_VERSION_1_1, // was 0 (treated as 1.0) or VK_API_VERSION_1_0
+  };
+
+  // 2. ...and declare the same version on the backend context
+  var backendContext = new GRVkBackendContext {
+      VkInstance = instance,
+      VkPhysicalDevice = physicalDevice,
+      VkDevice = device,
+      VkQueue = queue,
+      GraphicsQueueIndex = queueIndex,
+      MaxAPIVersion = VK_API_VERSION_1_1, // was 0 — do not leave this unset
+      GetProcedureAddress = getProc,
+  };
+  ```
+
+  Genuinely 1.0-only hardware can no longer run Ganesh Vulkan at all. Those callers must pick raster
+  (or another GPU backend) up front rather than relying on `CreateVulkan` failing gracefully.
+
+  Distinct from the `GRVkBackendContextNative` entry below: that one covers interop fields that
+  *disappeared* (including `fMinAPIVersion`), this one covers the surviving `fMaxAPIVersion` —
+  `GRVkBackendContext.MaxAPIVersion` — whose default `0` is now unsafe to leave alone.
 
 ## Interop / native-struct breaking changes (not in any API diff)
 


### PR DESCRIPTION
## Description

Skia made Vulkan 1.1 the Ganesh minimum in **m139** (`0a3150b03b`, *"[vulkan] Require Vulkan 1.1 in Ganesh"*) and then promoted the minimum-version check from a debug check to **fatal** in **m140** (`dfea59a30f`, *"Promote Vulkan min version check from debug --> fatal"*).

The user-visible consequence is severe and was undocumented on our side: code that previously got a graceful `null` back from `GRContext.CreateVulkan` on a Vulkan 1.0 instance/device — and could fall back to raster — now **aborts the process**. It is not an exception, so managed code can neither catch nor pre-empt it. Anyone whose `VkInstance` was created with `VkApplicationInfo.apiVersion` below `VK_API_VERSION_1_1` (including leaving it at `0`, which the Vulkan spec treats as 1.0), or who leaves `GRVkBackendContext.MaxAPIVersion` at its default `0`, is exposed.

This adds one entry to the maintainer-authored manual-additions sidecar. **Sidecar only — CI does the rest.** Per spec §3.7 the file is maintainer-owned and never machine-written; editing it flips its `sha256` in `data.json` on the next Prepare run, which drops the stale `prose.json` and re-polishes exactly this page. So the rendered `4.148.0.md`, its `prose.json`, and the `data.json` hash are deliberately **not** hand-written here.

### Which release page — 4.148.0

The obvious guess is 4.151.0 (Skia m151). That is wrong, and rather than reasoning from milestone numbers I checked the `externals/skia` SHA each release tag actually pins, and whether the two upstream commits are in its history (`git ls-tree <tag> externals/skia`, then the GitHub compare API against `mono/skia`):

| SkiaSharp tag | pinned `externals/skia` | ancestry vs `0a3150b03b` / `dfea59a30f` | fatal `SK_ABORT` in tree |
|---|---|---|---|
| `v3.119.4` | `7dbfc07d` | **diverged** — neither commit is in its history | no (`VulkanUtilsPriv.cpp` doesn't even exist yet) |
| `v4.147.0-preview.1.1` | `6f8139ad` | **ahead** — both are ancestors | yes |
| `v4.148.0` | `1a155bae` | **ahead** — both are ancestors | yes |
| `v4.150.0`, `v4.151.0-rc.1.1`, current `main` | … | — | yes (inherited) |

So the abort first appears in the **4.147.0** preview line. But `git tag` shows 4.147.0 has `-preview.1.1`, `-preview.2.1` and `-preview.3.1` and **no `v4.147.0` tag** — matching its release data (`status: preview`, `superseded_by: 4.148.0`, "never released as stable"). `v4.148.0` is a real stable tag (`status: stable`, released June 22 2026, `supersedes: 4.147.0`).

**⇒ 4.148.0 is the first stable release shipping the abort**, and is where someone upgrading from 3.119.x meets it. It is also already the home for exactly this class of change: the sidecar scopes itself to *"the v4 breaking changes from the Skia m132/m147 upgrade ... the ones the API signature diff cannot show"*, and already documents the `GRVkBackendContextNative` field removals and the `GrVkYcbcrConversionInfo` retype. The new entry leads that Vulkan group and cross-references it — that entry covers fields that *disappeared* (incl. `fMinAPIVersion`), this one covers the surviving `fMaxAPIVersion`, whose default `0` is now unsafe.

4.150.x and 4.151.0 merely inherit the behaviour — nothing is new there — and `4.151.0-unreleased` is the unreleased head of the m151 line, so neither is the right page.

**Related issues**

Fixes #4600

<sub>Documentation only — #4600 also asks for XML docs on `MaxAPIVersion` and possibly a managed pre-check that restores the graceful `null`, so it stays open. #4601 (exposing Skia's device-lost callback) is an enhancement and deliberately gets no release note.</sub>

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — documentation only. No public API or behavioral change; this documents a behaviour change that already shipped with the Skia engine in 4.147.0/4.148.0.

One file changed: `documentation/docfx/releases/_sources/4.148.0.notes.md`. A new `### GRContext.CreateVulkan aborts the process instead of returning null on Vulkan 1.0 (#4600)` entry under the existing `## Behavioral breaking changes` heading, in the file's established shape (upstream cause → **Before (3.x)** / **After (4.x)** / **Who is affected** / **Migration** + a small C# snippet), plus that section's intro extended to mention Vulkan context creation.

## Testing

No code changed, so there is nothing to unit-test; verification was of the factual claims in the note and of how the page will pick it up.

**Claims in the note**

* Both upstream commits resolve in `mono/skia` with the exact titles cited (`0a3150b03b` 2025-06-09, `dfea59a30f` 2025-07-15).
* Read `src/gpu/vk/VulkanUtilsPriv.cpp` at the `v4.148.0` pin and confirmed the code the note describes: `uint32_t apiVersion = context.fMaxAPIVersion ? context.fMaxAPIVersion : instanceVersion;`, `instanceVersion` sourced from `vkEnumerateInstanceVersion` (i.e. the loader — which is why leaving `MaxAPIVersion` at `0` is the footgun), and `if (instanceVersion < VK_API_VERSION_1_1 || physDevVersion < VK_API_VERSION_1_1) { SK_ABORT(...) }`.
* Confirmed the `v3.119.4` skia pin is reachable and genuinely lacks the check — the file doesn't exist there, and the m119-era `GrVkCaps.cpp` / `VulkanInterface.cpp` / `GrVkUtil.cpp` don't contain it either.
* API names checked against `binding/SkiaSharp/GRVkBackendContext.cs` and `GRContext.cs`; the migration snippet matches what `tests/VulkanTests/VkContexts/SilkVkContext.cs` already does (`ApiVersion = Vk.Version11`, `MaxAPIVersion = SilkVkContext.ApiVersion` = `(1u << 22) | (1u << 12)`).
* **One early draft claim was wrong and was removed:** I had cited upstream's `relnotes/ganesh-vulkan11.md` by path. Skia clears `relnotes/` at each milestone roll-up, so that file exists at the m139 commit but is *not* in the tree 4.148.0 pins — the path would send a reader hunting for a file that isn't in `externals/skia`. The filename is gone; the quote (verified verbatim at `0a3150b03b`) stays.

**Pipeline**

* Sidecar integrity: valid UTF-8, no BOM, no mojibake, and it is the only file in the diff.
* I did run the render locally while drafting, purely to confirm the entry lands where expected: `render.sh --min-version 4.148.0 --max-version 4.148.0` (with `PYTHONUTF8=1`, since `Path.read_text()`/`write_text()` otherwise default to cp1252 on Windows and would mangle em-dashes across every page). The authoritative `--all` pass re-rendered all 72 pages plus `TOC.yml` and `index.md` with **no** unrelated churn. Those generated outputs are not part of this PR.
* Worth noting for reviewers: `release-notes-render.py` reads `data.json` + `prose.json` only and never opens the sidecar, so this change reaches the published page via the Prepare → re-polish → render cycle, not directly.
* Did not run `prepare.sh` (needs Cake + network + `gh`) — that is the CI job's work here.

## Checklist

- [x] Tests added or updated (if omitted, explain why above) — n/a, documentation-only change
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later — n/a, no API change (#4600 tracks the `MaxAPIVersion` XML doc work)
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated — n/a, no native change
