### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -158,7 +158,7 @@
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "7342b9bdb46e2ae791f68cc3c97266db71b88fd0"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2c424f6b9068cc28d3c7c92f47b2f4c0d8641917"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
## Description

Automated Skia milestone bump from m151 to m152.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/315

**Areas affected**

- [ ] Managed API (`binding/`)
- [x] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Update the `externals/skia` submodule from Chrome milestone **m151** to **m152**.

- Bump the `externals/skia` gitlink to the mono/skia `skia-sync/m152` tip
  (`7342b9bdb46e2ae791f68cc3c97266db71b88fd0`), which merges upstream
  `chrome/m152` (`2c424f6b9068cc28d3c7c92f47b2f4c0d8641917`).
- Update version/manifest files m151 → m152: `scripts/VERSIONS.txt`,
  `cgmanifest.json`, `scripts/azure-templates-variables.yml`.

No SkiaSharp C#/binding source changes were required: binding regeneration
produced no C API diff and no new generated functions. The only native-side
behavior change (Ganesh Vulkan default memory allocator) is contained in the
fork-owned C shim inside the submodule and preserves the existing ABI, so
`GRContext.CreateVulkan` continues to work without any public API change.

See the companion mono/skia PR for the submodule-level merge, dependency roll,
and C shim details.

## Testing

- Native build from source (`dotnet cake --target=externals-linux --arch=x64`):
  green.
- Managed build (`binding/SkiaSharp/SkiaSharp.csproj`): 0 errors.
- Full unfiltered test gate (`tests/SkiaSharp.Tests.Console.slnx`, net10.0):
  - Core: Passed 5915, Skipped 202, Failed 0
  - Vulkan: Passed 23, Skipped 2, Failed 0
  - Direct3D: Passed 2, Skipped 3, Failed 0
- Vulkan executed on a real lavapipe device for both Ganesh and Graphite backends.

## Human review

- Confirm milestone bump to m152 for this base branch
  (`mattleibow-dev-vulkan-sync-validation`).
- Review the paired mono/skia PR for the VMA roll and Ganesh allocator fix.
- Not executed locally: macOS/Metal, Windows/Direct3D on hardware, Ganesh GL
  (agent opted out `ganesh-gl`).


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-07-31T06:10:50Z_
