### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "cc7ff3ad427e6df08fc36202bd564a82af8a81b6"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2c424f6b9068cc28d3c7c92f47b2f4c0d8641917"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
## Description

Automated Skia milestone bump from m151 to m152.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/316

**Areas affected**

- [ ] Managed API (`binding/`)
- [x] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance SkiaSharp to Chrome milestone 152 by bumping the `externals/skia` submodule and all
version surfaces. Parent commit `96c1d092b` on branch `skia-sync/m152`.

- **Submodule gitlink** → `cc7ff3ad427e6df08fc36202bd564a82af8a81b6` (the tested `skia-sync/m152`
  tip; see the companion mono/skia PR for merge and adaptation detail).
- **`scripts/VERSIONS.txt`** → skia `m152`, `libSkiaSharp` milestone/soname `152.0.0`, C API
  increment `0`, `SkiaSharp` assembly/file `4.152.0.0`, and all NuGet package versions `4.152.0`.
- **`cgmanifest.json`** → milestone `152`, upstream commit hash `cc7ff3ad42`.
- **`scripts/azure-templates-variables.yml`** → milestone bump.

No managed C# source changes and no `*.generated.cs` changes: binding regeneration reported no
binding changes and no new native functions, so the C API surface is unchanged (the Ganesh Vulkan
allocator fix is internal to the C shim).

## Testing

Native build (`dotnet cake --target=externals-linux --arch=x64`) from source PASSED, then the full
unfiltered test solution ran green across every maintained host and every `GpuPolicy`-required
backend available on this headless linux/x64 agent:

| Host | Result |
|---|---|
| SingletonInit | 1 passed, 0 failed |
| Core | 5915 passed, 0 failed |
| Direct3D | 2 passed, 0 failed |
| Vulkan | 23 passed, 0 failed |

Total: **0 failures.** The Vulkan host initially failed 9 tests (`GRContext.CreateVulkan returned
null`) due to the m152 removal of the internal VMA fallback; after the Ganesh shim fix all 23
Vulkan tests pass. Vulkan executes deterministically via the pinned lavapipe ICD.

## Human review

- Only the `linux/x64` native library was built and only this platform's test hosts were run.
  Windows, macOS, iOS, MacCatalyst, tvOS, Android, Tizen and WASM native assets and their tests
  were not built/run locally and require CI validation.
- `ganesh-gl` is explicitly opted out on this agent (no GL/X stack); Metal is macOS-only. These
  backends need CI coverage.
- Review the companion mono/skia `skia-sync/m152` PR for the upstream merge, dependency decisions,
  and the Ganesh Vulkan allocator C API adaptation.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-07-31T15:39:02Z_
