### PR TITLE
Make binding generation deterministic across platforms

### DIFF
--- a/.github/workflows/binding-generation-determinism.yml
+++ b/.github/workflows/binding-generation-determinism.yml
@@ -1,0 +1,139 @@
+name: Tests - Binding Generation Determinism
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/binding-generation-determinism.yml'
+      - '.gitmodules'
+      - '.config/dotnet-tools.json'
+      - 'binding/lib*.json'
+      - 'build.cake'
+      - 'externals/skia'
+      - 'global.json'
+      - 'scripts/VERSIONS.txt'
+      - 'scripts/infra/managed/interop.cake'
+      - 'scripts/infra/native/shared/native-shared.cake'
+      - 'scripts/infra/shared/shared.cake'
+      - 'utils/generate.ps1'
+      - 'utils/SkiaSharpGenerator/**'
+  pull_request:
+    paths:
+      - '.github/workflows/binding-generation-determinism.yml'
+      - '.gitmodules'
+      - '.config/dotnet-tools.json'
+      - 'binding/lib*.json'
+      - 'build.cake'
+      - 'externals/skia'
+      - 'global.json'
+      - 'scripts/VERSIONS.txt'
+      - 'scripts/infra/managed/interop.cake'
+      - 'scripts/infra/native/shared/native-shared.cake'
+      - 'scripts/infra/shared/shared.cake'
+      - 'utils/generate.ps1'
+      - 'utils/SkiaSharpGenerator/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    name: Generate (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      GIT_SYNC_DEPS_SKIP_EMSDK: '1'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            artifact: linux
+            os: ubuntu-latest
+          - name: macOS
+            artifact: macos
+            os: macos-latest
+          - name: Windows
+            artifact: windows
+            os: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable Windows long paths
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: git config --global core.longpaths true
+
+      - name: Initialize Skia submodule
+        run: git submodule update --init --recursive externals/skia
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Generate bindings
+        run: dotnet cake --target=externals-interop
+
+      - name: Upload generated bindings
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-${{ matrix.artifact }}
+          path: output/generated
+          if-no-files-found: error
+          retention-days: 7
+
+  compare:
+    name: Compare generated bindings
+    needs: generate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download generated bindings
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bindings-*
+          path: generated
+
+      - name: Compare outputs byte-for-byte
+        shell: bash
+        run: |
+          mkdir -p comparison
+          status=0
+          for candidate in macos windows; do
+            summary="comparison/linux-${candidate}.summary.txt"
+            detail="comparison/linux-${candidate}.diff"
+            if diff -qr "generated/bindings-linux" "generated/bindings-${candidate}" > "$summary"; then
+              rm "$summary"
+              echo "Linux and ${candidate} outputs are byte-for-byte identical."
+            else
+              status=1
+              echo "::error::Linux and ${candidate} binding outputs differ."
+              git diff --no-index --no-color --text \
+                "generated/bindings-linux" "generated/bindings-${candidate}" \
+                > "$detail" || true
+              cat "$summary"
+              cat "$detail"
+            fi
+          done
+          exit "$status"
+
+      - name: Upload determinism diff
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: binding-determinism-diff
+          path: comparison
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/binding-generation-determinism.yml
+++ b/.github/workflows/binding-generation-determinism.yml
@@ -4,33 +4,40 @@ on:
   push:
     branches:
       - main
+    # Keep this exact whitelist in sync with pull_request below. The generated
+    # files are inputs because generation preserves their XML documentation.
     paths:
       - '.github/workflows/binding-generation-determinism.yml'
-      - '.gitmodules'
-      - '.config/dotnet-tools.json'
-      - 'binding/lib*.json'
-      - 'build.cake'
+      - 'binding/HarfBuzzSharp/HarfBuzzApi.generated.cs'
+      - 'binding/SkiaSharp.Resources/ResourcesApi.generated.cs'
+      - 'binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs'
+      - 'binding/SkiaSharp.Skottie/SkottieApi.generated.cs'
+      - 'binding/SkiaSharp/SkiaApi.generated.cs'
+      - 'binding/libHarfBuzzSharp.json'
+      - 'binding/libSkiaSharp.Resources.json'
+      - 'binding/libSkiaSharp.SceneGraph.json'
+      - 'binding/libSkiaSharp.Skottie.json'
+      - 'binding/libSkiaSharp.json'
       - 'externals/skia'
       - 'global.json'
-      - 'scripts/VERSIONS.txt'
-      - 'scripts/infra/managed/interop.cake'
-      - 'scripts/infra/native/shared/native-shared.cake'
-      - 'scripts/infra/shared/shared.cake'
       - 'utils/generate.ps1'
       - 'utils/SkiaSharpGenerator/**'
   pull_request:
+    # Same automatic-trigger whitelist as push.
     paths:
       - '.github/workflows/binding-generation-determinism.yml'
-      - '.gitmodules'
-      - '.config/dotnet-tools.json'
-      - 'binding/lib*.json'
-      - 'build.cake'
+      - 'binding/HarfBuzzSharp/HarfBuzzApi.generated.cs'
+      - 'binding/SkiaSharp.Resources/ResourcesApi.generated.cs'
+      - 'binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs'
+      - 'binding/SkiaSharp.Skottie/SkottieApi.generated.cs'
+      - 'binding/SkiaSharp/SkiaApi.generated.cs'
+      - 'binding/libHarfBuzzSharp.json'
+      - 'binding/libSkiaSharp.Resources.json'
+      - 'binding/libSkiaSharp.SceneGraph.json'
+      - 'binding/libSkiaSharp.Skottie.json'
+      - 'binding/libSkiaSharp.json'
       - 'externals/skia'
       - 'global.json'
-      - 'scripts/VERSIONS.txt'
-      - 'scripts/infra/managed/interop.cake'
-      - 'scripts/infra/native/shared/native-shared.cake'
-      - 'scripts/infra/shared/shared.cake'
       - 'utils/generate.ps1'
       - 'utils/SkiaSharpGenerator/**'
   workflow_dispatch:
@@ -80,11 +87,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Restore tools
-        run: dotnet tool restore
+      - name: Sync Skia dependencies
+        working-directory: externals/skia
+        run: python tools/git-sync-deps
 
       - name: Generate bindings
-        run: dotnet cake --target=externals-interop
+        shell: pwsh
+        run: pwsh -NoLogo -NoProfile -File ./utils/generate.ps1
 
       - name: Upload generated bindings
         uses: actions/upload-artifact@v4

--- a/.github/workflows/binding-generation-determinism.yml
+++ b/.github/workflows/binding-generation-determinism.yml
@@ -109,6 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download generated bindings
         uses: actions/download-artifact@v4
         with:
@@ -138,11 +141,49 @@ jobs:
           done
           exit "$status"
 
-      - name: Upload determinism diff
+      - name: Compare checked-in Skia bindings
+        shell: bash
+        run: |
+          status=0
+          check_freshness() {
+            name="$1"
+            committed="$2"
+            generated="generated/bindings-linux/${name}"
+            detail="comparison/committed-${name}.diff"
+
+            if cmp -s "$committed" "$generated"; then
+              echo "${committed} is current."
+            else
+              status=1
+              echo "::error file=${committed}::Checked-in binding differs from deterministic generation."
+              git diff --no-index --no-color --text "$committed" "$generated" \
+                > "$detail" || true
+              cat "$detail"
+            fi
+          }
+
+          # HarfBuzz bindings are versioned separately from Skia's DEPS checkout,
+          # so freshness is enforced for the four Skia outputs only.
+          check_freshness \
+            "SkiaApi.generated.cs" \
+            "binding/SkiaSharp/SkiaApi.generated.cs"
+          check_freshness \
+            "SkottieApi.generated.cs" \
+            "binding/SkiaSharp.Skottie/SkottieApi.generated.cs"
+          check_freshness \
+            "SceneGraphApi.generated.cs" \
+            "binding/SkiaSharp.SceneGraph/SceneGraphApi.generated.cs"
+          check_freshness \
+            "ResourcesApi.generated.cs" \
+            "binding/SkiaSharp.Resources/ResourcesApi.generated.cs"
+
+          exit "$status"
+
+      - name: Upload binding comparison diff
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: binding-determinism-diff
+          name: binding-generation-diff
           path: comparison
           if-no-files-found: error
           retention-days: 7

--- a/binding/SkiaSharp/SkiaApi.generated.cs
+++ b/binding/SkiaSharp/SkiaApi.generated.cs
@@ -122,791 +122,6 @@ namespace SkiaSharp
 {
 	internal unsafe partial class SkiaApi
 	{
-		#region sk_graphite.h
-
-		// bool sk_graphite_backend_is_available(sk_graphite_backend_t backend)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_backend_is_available (SKGraphiteBackend backend);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_backend_is_available (SKGraphiteBackend backend);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_backend_is_available (SKGraphiteBackend backend);
-		}
-		private static Delegates.sk_graphite_backend_is_available sk_graphite_backend_is_available_delegate;
-		internal static bool sk_graphite_backend_is_available (SKGraphiteBackend backend) =>
-			(sk_graphite_backend_is_available_delegate ??= GetSymbol<Delegates.sk_graphite_backend_is_available> ("sk_graphite_backend_is_available")).Invoke (backend);
-		#endif
-
-		// void sk_graphite_backend_texture_delete(sk_graphite_backend_texture_t* tex)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex);
-		}
-		private static Delegates.sk_graphite_backend_texture_delete sk_graphite_backend_texture_delete_delegate;
-		internal static void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex) =>
-			(sk_graphite_backend_texture_delete_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_delete> ("sk_graphite_backend_texture_delete")).Invoke (tex);
-		#endif
-
-		// sk_graphite_backend_t sk_graphite_backend_texture_get_backend(const sk_graphite_backend_texture_t* tex)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex);
-		}
-		private static Delegates.sk_graphite_backend_texture_get_backend sk_graphite_backend_texture_get_backend_delegate;
-		internal static SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex) =>
-			(sk_graphite_backend_texture_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_get_backend> ("sk_graphite_backend_texture_get_backend")).Invoke (tex);
-		#endif
-
-		// void sk_graphite_backend_texture_get_dimensions(const sk_graphite_backend_texture_t* tex, int32_t* outWidth, int32_t* outHeight)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight);
-		}
-		private static Delegates.sk_graphite_backend_texture_get_dimensions sk_graphite_backend_texture_get_dimensions_delegate;
-		internal static void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight) =>
-			(sk_graphite_backend_texture_get_dimensions_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_get_dimensions> ("sk_graphite_backend_texture_get_dimensions")).Invoke (tex, outWidth, outHeight);
-		#endif
-
-		// bool sk_graphite_backend_texture_is_valid(const sk_graphite_backend_texture_t* tex)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex);
-		}
-		private static Delegates.sk_graphite_backend_texture_is_valid sk_graphite_backend_texture_is_valid_delegate;
-		internal static bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex) =>
-			(sk_graphite_backend_texture_is_valid_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_is_valid> ("sk_graphite_backend_texture_is_valid")).Invoke (tex);
-		#endif
-
-		// void sk_graphite_context_async_rescale_and_read_pixels_surface(sk_graphite_context_t* context, const sk_surface_t* surface, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* callbackContext)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, void* callback, void* callbackContext);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* callbackContext);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* callbackContext);
-		}
-		private static Delegates.sk_graphite_context_async_rescale_and_read_pixels_surface sk_graphite_context_async_rescale_and_read_pixels_surface_delegate;
-		internal static void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* callbackContext) =>
-			(sk_graphite_context_async_rescale_and_read_pixels_surface_delegate ??= GetSymbol<Delegates.sk_graphite_context_async_rescale_and_read_pixels_surface> ("sk_graphite_context_async_rescale_and_read_pixels_surface")).Invoke (context, surface, dstInfo, srcRect, rescaleGamma, rescaleMode, callback, callbackContext);
-		#endif
-
-		// void sk_graphite_context_check_async_work_completion(sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_check_async_work_completion sk_graphite_context_check_async_work_completion_delegate;
-		internal static void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context) =>
-			(sk_graphite_context_check_async_work_completion_delegate ??= GetSymbol<Delegates.sk_graphite_context_check_async_work_completion> ("sk_graphite_context_check_async_work_completion")).Invoke (context);
-		#endif
-
-		// void sk_graphite_context_delete(sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_delete (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_delete (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_delete (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_delete sk_graphite_context_delete_delegate;
-		internal static void sk_graphite_context_delete (sk_graphite_context_t context) =>
-			(sk_graphite_context_delete_delegate ??= GetSymbol<Delegates.sk_graphite_context_delete> ("sk_graphite_context_delete")).Invoke (context);
-		#endif
-
-		// void sk_graphite_context_delete_backend_texture(sk_graphite_context_t* context, const sk_graphite_backend_texture_t* tex)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex);
-		}
-		private static Delegates.sk_graphite_context_delete_backend_texture sk_graphite_context_delete_backend_texture_delegate;
-		internal static void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex) =>
-			(sk_graphite_context_delete_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_context_delete_backend_texture> ("sk_graphite_context_delete_backend_texture")).Invoke (context, tex);
-		#endif
-
-		// void sk_graphite_context_free_gpu_resources(sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_free_gpu_resources sk_graphite_context_free_gpu_resources_delegate;
-		internal static void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context) =>
-			(sk_graphite_context_free_gpu_resources_delegate ??= GetSymbol<Delegates.sk_graphite_context_free_gpu_resources> ("sk_graphite_context_free_gpu_resources")).Invoke (context);
-		#endif
-
-		// sk_graphite_backend_t sk_graphite_context_get_backend(const sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_get_backend sk_graphite_context_get_backend_delegate;
-		internal static SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context) =>
-			(sk_graphite_context_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_backend> ("sk_graphite_context_get_backend")).Invoke (context);
-		#endif
-
-		// int64_t sk_graphite_context_get_current_budgeted_bytes(const sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_get_current_budgeted_bytes sk_graphite_context_get_current_budgeted_bytes_delegate;
-		internal static Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context) =>
-			(sk_graphite_context_get_current_budgeted_bytes_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_current_budgeted_bytes> ("sk_graphite_context_get_current_budgeted_bytes")).Invoke (context);
-		#endif
-
-		// int64_t sk_graphite_context_get_max_budgeted_bytes(const sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_get_max_budgeted_bytes sk_graphite_context_get_max_budgeted_bytes_delegate;
-		internal static Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context) =>
-			(sk_graphite_context_get_max_budgeted_bytes_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_max_budgeted_bytes> ("sk_graphite_context_get_max_budgeted_bytes")).Invoke (context);
-		#endif
-
-		// int32_t sk_graphite_context_get_max_texture_size(const sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_get_max_texture_size sk_graphite_context_get_max_texture_size_delegate;
-		internal static Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context) =>
-			(sk_graphite_context_get_max_texture_size_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_max_texture_size> ("sk_graphite_context_get_max_texture_size")).Invoke (context);
-		#endif
-
-		// sk_graphite_insert_status_t sk_graphite_context_insert_recording(sk_graphite_context_t* context, const sk_graphite_insert_recording_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info);
-		}
-		private static Delegates.sk_graphite_context_insert_recording sk_graphite_context_insert_recording_delegate;
-		internal static SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info) =>
-			(sk_graphite_context_insert_recording_delegate ??= GetSymbol<Delegates.sk_graphite_context_insert_recording> ("sk_graphite_context_insert_recording")).Invoke (context, info);
-		#endif
-
-		// bool sk_graphite_context_is_device_lost(const sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_context_is_device_lost (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_context_is_device_lost (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_context_is_device_lost (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_is_device_lost sk_graphite_context_is_device_lost_delegate;
-		internal static bool sk_graphite_context_is_device_lost (sk_graphite_context_t context) =>
-			(sk_graphite_context_is_device_lost_delegate ??= GetSymbol<Delegates.sk_graphite_context_is_device_lost> ("sk_graphite_context_is_device_lost")).Invoke (context);
-		#endif
-
-		// sk_graphite_recorder_t* sk_graphite_context_make_recorder(sk_graphite_context_t* context, int64_t recorderBudgetBytes, sk_graphite_image_provider_t* imageProvider)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider);
-		}
-		private static Delegates.sk_graphite_context_make_recorder sk_graphite_context_make_recorder_delegate;
-		internal static sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider) =>
-			(sk_graphite_context_make_recorder_delegate ??= GetSymbol<Delegates.sk_graphite_context_make_recorder> ("sk_graphite_context_make_recorder")).Invoke (context, recorderBudgetBytes, imageProvider);
-		#endif
-
-		// void sk_graphite_context_options_init_defaults(sk_graphite_context_options_t* out)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out);
-		}
-		private static Delegates.sk_graphite_context_options_init_defaults sk_graphite_context_options_init_defaults_delegate;
-		internal static void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out) =>
-			(sk_graphite_context_options_init_defaults_delegate ??= GetSymbol<Delegates.sk_graphite_context_options_init_defaults> ("sk_graphite_context_options_init_defaults")).Invoke (@out);
-		#endif
-
-		// void sk_graphite_context_perform_deferred_cleanup(sk_graphite_context_t* context, int64_t milliseconds)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds);
-		}
-		private static Delegates.sk_graphite_context_perform_deferred_cleanup sk_graphite_context_perform_deferred_cleanup_delegate;
-		internal static void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds) =>
-			(sk_graphite_context_perform_deferred_cleanup_delegate ??= GetSymbol<Delegates.sk_graphite_context_perform_deferred_cleanup> ("sk_graphite_context_perform_deferred_cleanup")).Invoke (context, milliseconds);
-		#endif
-
-		// void sk_graphite_context_set_max_budgeted_bytes(sk_graphite_context_t* context, int64_t bytes)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes);
-		}
-		private static Delegates.sk_graphite_context_set_max_budgeted_bytes sk_graphite_context_set_max_budgeted_bytes_delegate;
-		internal static void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes) =>
-			(sk_graphite_context_set_max_budgeted_bytes_delegate ??= GetSymbol<Delegates.sk_graphite_context_set_max_budgeted_bytes> ("sk_graphite_context_set_max_budgeted_bytes")).Invoke (context, bytes);
-		#endif
-
-		// bool sk_graphite_context_submit(sk_graphite_context_t* context, const sk_graphite_submit_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info);
-		}
-		private static Delegates.sk_graphite_context_submit sk_graphite_context_submit_delegate;
-		internal static bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info) =>
-			(sk_graphite_context_submit_delegate ??= GetSymbol<Delegates.sk_graphite_context_submit> ("sk_graphite_context_submit")).Invoke (context, info);
-		#endif
-
-		// bool sk_graphite_context_supports_protected_content(const sk_graphite_context_t* context)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context);
-		}
-		private static Delegates.sk_graphite_context_supports_protected_content sk_graphite_context_supports_protected_content_delegate;
-		internal static bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context) =>
-			(sk_graphite_context_supports_protected_content_delegate ??= GetSymbol<Delegates.sk_graphite_context_supports_protected_content> ("sk_graphite_context_supports_protected_content")).Invoke (context);
-		#endif
-
-		// sk_image_t* sk_graphite_image_make_texture(sk_graphite_recorder_t* recorder, const sk_image_t* image, bool mipmapped)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped);
-		}
-		private static Delegates.sk_graphite_image_make_texture sk_graphite_image_make_texture_delegate;
-		internal static sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped) =>
-			(sk_graphite_image_make_texture_delegate ??= GetSymbol<Delegates.sk_graphite_image_make_texture> ("sk_graphite_image_make_texture")).Invoke (recorder, image, mipmapped);
-		#endif
-
-		// void sk_graphite_image_provider_delete(sk_graphite_image_provider_t* provider)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider);
-		}
-		private static Delegates.sk_graphite_image_provider_delete sk_graphite_image_provider_delete_delegate;
-		internal static void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider) =>
-			(sk_graphite_image_provider_delete_delegate ??= GetSymbol<Delegates.sk_graphite_image_provider_delete> ("sk_graphite_image_provider_delete")).Invoke (provider);
-		#endif
-
-		// sk_graphite_image_provider_t* sk_graphite_image_provider_new(sk_graphite_image_provider_proc proc, void* userData)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_graphite_image_provider_t sk_graphite_image_provider_new (void* proc, void* userData);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_graphite_image_provider_t sk_graphite_image_provider_new (SKGraphiteImageProviderProxyDelegate proc, void* userData);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_graphite_image_provider_t sk_graphite_image_provider_new (SKGraphiteImageProviderProxyDelegate proc, void* userData);
-		}
-		private static Delegates.sk_graphite_image_provider_new sk_graphite_image_provider_new_delegate;
-		internal static sk_graphite_image_provider_t sk_graphite_image_provider_new (SKGraphiteImageProviderProxyDelegate proc, void* userData) =>
-			(sk_graphite_image_provider_new_delegate ??= GetSymbol<Delegates.sk_graphite_image_provider_new> ("sk_graphite_image_provider_new")).Invoke (proc, userData);
-		#endif
-
-		// sk_image_t* sk_graphite_image_wrap_texture(sk_graphite_recorder_t* recorder, const sk_graphite_backend_texture_t* backendTexture, sk_colortype_t colorType, sk_alphatype_t alphaType, sk_colorspace_t* colorSpace, sk_graphite_release_proc releaseProc, void* releaseContext)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, void* releaseProc, void* releaseContext);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
-		}
-		private static Delegates.sk_graphite_image_wrap_texture sk_graphite_image_wrap_texture_delegate;
-		internal static sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext) =>
-			(sk_graphite_image_wrap_texture_delegate ??= GetSymbol<Delegates.sk_graphite_image_wrap_texture> ("sk_graphite_image_wrap_texture")).Invoke (recorder, backendTexture, colorType, alphaType, colorSpace, releaseProc, releaseContext);
-		#endif
-
-		// sk_graphite_backend_texture_t* sk_graphite_recorder_create_backend_texture(sk_graphite_recorder_t* recorder, int32_t width, int32_t height, const sk_graphite_texture_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info);
-		}
-		private static Delegates.sk_graphite_recorder_create_backend_texture sk_graphite_recorder_create_backend_texture_delegate;
-		internal static sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info) =>
-			(sk_graphite_recorder_create_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_create_backend_texture> ("sk_graphite_recorder_create_backend_texture")).Invoke (recorder, width, height, info);
-		#endif
-
-		// void sk_graphite_recorder_delete(sk_graphite_recorder_t* recorder)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder);
-		}
-		private static Delegates.sk_graphite_recorder_delete sk_graphite_recorder_delete_delegate;
-		internal static void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder) =>
-			(sk_graphite_recorder_delete_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_delete> ("sk_graphite_recorder_delete")).Invoke (recorder);
-		#endif
-
-		// void sk_graphite_recorder_delete_backend_texture(sk_graphite_recorder_t* recorder, const sk_graphite_backend_texture_t* tex)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex);
-		}
-		private static Delegates.sk_graphite_recorder_delete_backend_texture sk_graphite_recorder_delete_backend_texture_delegate;
-		internal static void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex) =>
-			(sk_graphite_recorder_delete_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_delete_backend_texture> ("sk_graphite_recorder_delete_backend_texture")).Invoke (recorder, tex);
-		#endif
-
-		// sk_graphite_backend_t sk_graphite_recorder_get_backend(const sk_graphite_recorder_t* recorder)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder);
-		}
-		private static Delegates.sk_graphite_recorder_get_backend sk_graphite_recorder_get_backend_delegate;
-		internal static SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder) =>
-			(sk_graphite_recorder_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_get_backend> ("sk_graphite_recorder_get_backend")).Invoke (recorder);
-		#endif
-
-		// int32_t sk_graphite_recorder_get_max_texture_size(const sk_graphite_recorder_t* recorder)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder);
-		}
-		private static Delegates.sk_graphite_recorder_get_max_texture_size sk_graphite_recorder_get_max_texture_size_delegate;
-		internal static Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder) =>
-			(sk_graphite_recorder_get_max_texture_size_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_get_max_texture_size> ("sk_graphite_recorder_get_max_texture_size")).Invoke (recorder);
-		#endif
-
-		// sk_graphite_recording_t* sk_graphite_recorder_snap(sk_graphite_recorder_t* recorder)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder);
-		}
-		private static Delegates.sk_graphite_recorder_snap sk_graphite_recorder_snap_delegate;
-		internal static sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder) =>
-			(sk_graphite_recorder_snap_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_snap> ("sk_graphite_recorder_snap")).Invoke (recorder);
-		#endif
-
-		// void sk_graphite_recording_delete(sk_graphite_recording_t* recording)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_recording_delete (sk_graphite_recording_t recording);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_recording_delete (sk_graphite_recording_t recording);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_recording_delete (sk_graphite_recording_t recording);
-		}
-		private static Delegates.sk_graphite_recording_delete sk_graphite_recording_delete_delegate;
-		internal static void sk_graphite_recording_delete (sk_graphite_recording_t recording) =>
-			(sk_graphite_recording_delete_delegate ??= GetSymbol<Delegates.sk_graphite_recording_delete> ("sk_graphite_recording_delete")).Invoke (recording);
-		#endif
-
-		// sk_surface_t* sk_graphite_surface_make_render_target(sk_graphite_recorder_t* recorder, const sk_imageinfo_t* info, bool mipmapped, const sk_surfaceprops_t* props)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props);
-		}
-		private static Delegates.sk_graphite_surface_make_render_target sk_graphite_surface_make_render_target_delegate;
-		internal static sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props) =>
-			(sk_graphite_surface_make_render_target_delegate ??= GetSymbol<Delegates.sk_graphite_surface_make_render_target> ("sk_graphite_surface_make_render_target")).Invoke (recorder, info, mipmapped, props);
-		#endif
-
-		// sk_surface_t* sk_graphite_surface_wrap_backend_texture(sk_graphite_recorder_t* recorder, const sk_graphite_backend_texture_t* backendTexture, sk_colortype_t colorType, sk_colorspace_t* colorSpace, const sk_surfaceprops_t* props, sk_graphite_release_proc releaseProc, void* releaseContext)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, void* releaseProc, void* releaseContext);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
-		}
-		private static Delegates.sk_graphite_surface_wrap_backend_texture sk_graphite_surface_wrap_backend_texture_delegate;
-		internal static sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext) =>
-			(sk_graphite_surface_wrap_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_surface_wrap_backend_texture> ("sk_graphite_surface_wrap_backend_texture")).Invoke (recorder, backendTexture, colorType, colorSpace, props, releaseProc, releaseContext);
-		#endif
-
-		// void sk_graphite_texture_info_delete(sk_graphite_texture_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info);
-		}
-		private static Delegates.sk_graphite_texture_info_delete sk_graphite_texture_info_delete_delegate;
-		internal static void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info) =>
-			(sk_graphite_texture_info_delete_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_delete> ("sk_graphite_texture_info_delete")).Invoke (info);
-		#endif
-
-		// sk_graphite_backend_t sk_graphite_texture_info_get_backend(const sk_graphite_texture_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info);
-		}
-		private static Delegates.sk_graphite_texture_info_get_backend sk_graphite_texture_info_get_backend_delegate;
-		internal static SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info) =>
-			(sk_graphite_texture_info_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_get_backend> ("sk_graphite_texture_info_get_backend")).Invoke (info);
-		#endif
-
-		// bool sk_graphite_texture_info_get_mipmapped(const sk_graphite_texture_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info);
-		}
-		private static Delegates.sk_graphite_texture_info_get_mipmapped sk_graphite_texture_info_get_mipmapped_delegate;
-		internal static bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info) =>
-			(sk_graphite_texture_info_get_mipmapped_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_get_mipmapped> ("sk_graphite_texture_info_get_mipmapped")).Invoke (info);
-		#endif
-
-		// int32_t sk_graphite_texture_info_get_sample_count(const sk_graphite_texture_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		internal static partial Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			internal delegate Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info);
-		}
-		private static Delegates.sk_graphite_texture_info_get_sample_count sk_graphite_texture_info_get_sample_count_delegate;
-		internal static Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info) =>
-			(sk_graphite_texture_info_get_sample_count_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_get_sample_count> ("sk_graphite_texture_info_get_sample_count")).Invoke (info);
-		#endif
-
-		// bool sk_graphite_texture_info_is_valid(const sk_graphite_texture_info_t* info)
-		#if !USE_DELEGATES
-		#if USE_LIBRARY_IMPORT
-		[LibraryImport (SKIA)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static partial bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info);
-		#else // !USE_LIBRARY_IMPORT
-		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
-		[return: MarshalAs (UnmanagedType.I1)]
-		internal static extern bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info);
-		#endif
-		#else
-		private partial class Delegates {
-			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-			[return: MarshalAs (UnmanagedType.I1)]
-			internal delegate bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info);
-		}
-		private static Delegates.sk_graphite_texture_info_is_valid sk_graphite_texture_info_is_valid_delegate;
-		internal static bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info) =>
-			(sk_graphite_texture_info_is_valid_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_is_valid> ("sk_graphite_texture_info_is_valid")).Invoke (info);
-		#endif
-
-		#endregion
-
 		#region gr_context.h
 
 		// void gr_backendrendertarget_delete(gr_backendrendertarget_t* rendertarget)
@@ -7638,6 +6853,791 @@ namespace SkiaSharp
 		private static Delegates.sk_graphics_set_resource_cache_total_byte_limit sk_graphics_set_resource_cache_total_byte_limit_delegate;
 		internal static /* size_t */ IntPtr sk_graphics_set_resource_cache_total_byte_limit (/* size_t */ IntPtr newLimit) =>
 			(sk_graphics_set_resource_cache_total_byte_limit_delegate ??= GetSymbol<Delegates.sk_graphics_set_resource_cache_total_byte_limit> ("sk_graphics_set_resource_cache_total_byte_limit")).Invoke (newLimit);
+		#endif
+
+		#endregion
+
+		#region sk_graphite.h
+
+		// bool sk_graphite_backend_is_available(sk_graphite_backend_t backend)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_backend_is_available (SKGraphiteBackend backend);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_backend_is_available (SKGraphiteBackend backend);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_backend_is_available (SKGraphiteBackend backend);
+		}
+		private static Delegates.sk_graphite_backend_is_available sk_graphite_backend_is_available_delegate;
+		internal static bool sk_graphite_backend_is_available (SKGraphiteBackend backend) =>
+			(sk_graphite_backend_is_available_delegate ??= GetSymbol<Delegates.sk_graphite_backend_is_available> ("sk_graphite_backend_is_available")).Invoke (backend);
+		#endif
+
+		// void sk_graphite_backend_texture_delete(sk_graphite_backend_texture_t* tex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex);
+		}
+		private static Delegates.sk_graphite_backend_texture_delete sk_graphite_backend_texture_delete_delegate;
+		internal static void sk_graphite_backend_texture_delete (sk_graphite_backend_texture_t tex) =>
+			(sk_graphite_backend_texture_delete_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_delete> ("sk_graphite_backend_texture_delete")).Invoke (tex);
+		#endif
+
+		// sk_graphite_backend_t sk_graphite_backend_texture_get_backend(const sk_graphite_backend_texture_t* tex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex);
+		}
+		private static Delegates.sk_graphite_backend_texture_get_backend sk_graphite_backend_texture_get_backend_delegate;
+		internal static SKGraphiteBackend sk_graphite_backend_texture_get_backend (sk_graphite_backend_texture_t tex) =>
+			(sk_graphite_backend_texture_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_get_backend> ("sk_graphite_backend_texture_get_backend")).Invoke (tex);
+		#endif
+
+		// void sk_graphite_backend_texture_get_dimensions(const sk_graphite_backend_texture_t* tex, int32_t* outWidth, int32_t* outHeight)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight);
+		}
+		private static Delegates.sk_graphite_backend_texture_get_dimensions sk_graphite_backend_texture_get_dimensions_delegate;
+		internal static void sk_graphite_backend_texture_get_dimensions (sk_graphite_backend_texture_t tex, Int32* outWidth, Int32* outHeight) =>
+			(sk_graphite_backend_texture_get_dimensions_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_get_dimensions> ("sk_graphite_backend_texture_get_dimensions")).Invoke (tex, outWidth, outHeight);
+		#endif
+
+		// bool sk_graphite_backend_texture_is_valid(const sk_graphite_backend_texture_t* tex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex);
+		}
+		private static Delegates.sk_graphite_backend_texture_is_valid sk_graphite_backend_texture_is_valid_delegate;
+		internal static bool sk_graphite_backend_texture_is_valid (sk_graphite_backend_texture_t tex) =>
+			(sk_graphite_backend_texture_is_valid_delegate ??= GetSymbol<Delegates.sk_graphite_backend_texture_is_valid> ("sk_graphite_backend_texture_is_valid")).Invoke (tex);
+		#endif
+
+		// void sk_graphite_context_async_rescale_and_read_pixels_surface(sk_graphite_context_t* context, const sk_surface_t* surface, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* callbackContext)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, void* callback, void* callbackContext);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* callbackContext);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* callbackContext);
+		}
+		private static Delegates.sk_graphite_context_async_rescale_and_read_pixels_surface sk_graphite_context_async_rescale_and_read_pixels_surface_delegate;
+		internal static void sk_graphite_context_async_rescale_and_read_pixels_surface (sk_graphite_context_t context, sk_surface_t surface, SKImageInfoNative* dstInfo, SKRectI* srcRect, SKImageRescaleGamma rescaleGamma, SKImageRescaleMode rescaleMode, SKImageAsyncReadPixelsProxyDelegate callback, void* callbackContext) =>
+			(sk_graphite_context_async_rescale_and_read_pixels_surface_delegate ??= GetSymbol<Delegates.sk_graphite_context_async_rescale_and_read_pixels_surface> ("sk_graphite_context_async_rescale_and_read_pixels_surface")).Invoke (context, surface, dstInfo, srcRect, rescaleGamma, rescaleMode, callback, callbackContext);
+		#endif
+
+		// void sk_graphite_context_check_async_work_completion(sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_check_async_work_completion sk_graphite_context_check_async_work_completion_delegate;
+		internal static void sk_graphite_context_check_async_work_completion (sk_graphite_context_t context) =>
+			(sk_graphite_context_check_async_work_completion_delegate ??= GetSymbol<Delegates.sk_graphite_context_check_async_work_completion> ("sk_graphite_context_check_async_work_completion")).Invoke (context);
+		#endif
+
+		// void sk_graphite_context_delete(sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_delete (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_delete (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_delete (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_delete sk_graphite_context_delete_delegate;
+		internal static void sk_graphite_context_delete (sk_graphite_context_t context) =>
+			(sk_graphite_context_delete_delegate ??= GetSymbol<Delegates.sk_graphite_context_delete> ("sk_graphite_context_delete")).Invoke (context);
+		#endif
+
+		// void sk_graphite_context_delete_backend_texture(sk_graphite_context_t* context, const sk_graphite_backend_texture_t* tex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex);
+		}
+		private static Delegates.sk_graphite_context_delete_backend_texture sk_graphite_context_delete_backend_texture_delegate;
+		internal static void sk_graphite_context_delete_backend_texture (sk_graphite_context_t context, sk_graphite_backend_texture_t tex) =>
+			(sk_graphite_context_delete_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_context_delete_backend_texture> ("sk_graphite_context_delete_backend_texture")).Invoke (context, tex);
+		#endif
+
+		// void sk_graphite_context_free_gpu_resources(sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_free_gpu_resources sk_graphite_context_free_gpu_resources_delegate;
+		internal static void sk_graphite_context_free_gpu_resources (sk_graphite_context_t context) =>
+			(sk_graphite_context_free_gpu_resources_delegate ??= GetSymbol<Delegates.sk_graphite_context_free_gpu_resources> ("sk_graphite_context_free_gpu_resources")).Invoke (context);
+		#endif
+
+		// sk_graphite_backend_t sk_graphite_context_get_backend(const sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_get_backend sk_graphite_context_get_backend_delegate;
+		internal static SKGraphiteBackend sk_graphite_context_get_backend (sk_graphite_context_t context) =>
+			(sk_graphite_context_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_backend> ("sk_graphite_context_get_backend")).Invoke (context);
+		#endif
+
+		// int64_t sk_graphite_context_get_current_budgeted_bytes(const sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_get_current_budgeted_bytes sk_graphite_context_get_current_budgeted_bytes_delegate;
+		internal static Int64 sk_graphite_context_get_current_budgeted_bytes (sk_graphite_context_t context) =>
+			(sk_graphite_context_get_current_budgeted_bytes_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_current_budgeted_bytes> ("sk_graphite_context_get_current_budgeted_bytes")).Invoke (context);
+		#endif
+
+		// int64_t sk_graphite_context_get_max_budgeted_bytes(const sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_get_max_budgeted_bytes sk_graphite_context_get_max_budgeted_bytes_delegate;
+		internal static Int64 sk_graphite_context_get_max_budgeted_bytes (sk_graphite_context_t context) =>
+			(sk_graphite_context_get_max_budgeted_bytes_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_max_budgeted_bytes> ("sk_graphite_context_get_max_budgeted_bytes")).Invoke (context);
+		#endif
+
+		// int32_t sk_graphite_context_get_max_texture_size(const sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_get_max_texture_size sk_graphite_context_get_max_texture_size_delegate;
+		internal static Int32 sk_graphite_context_get_max_texture_size (sk_graphite_context_t context) =>
+			(sk_graphite_context_get_max_texture_size_delegate ??= GetSymbol<Delegates.sk_graphite_context_get_max_texture_size> ("sk_graphite_context_get_max_texture_size")).Invoke (context);
+		#endif
+
+		// sk_graphite_insert_status_t sk_graphite_context_insert_recording(sk_graphite_context_t* context, const sk_graphite_insert_recording_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info);
+		}
+		private static Delegates.sk_graphite_context_insert_recording sk_graphite_context_insert_recording_delegate;
+		internal static SKGraphiteInsertStatus sk_graphite_context_insert_recording (sk_graphite_context_t context, SKGraphiteInsertRecordingInfo* info) =>
+			(sk_graphite_context_insert_recording_delegate ??= GetSymbol<Delegates.sk_graphite_context_insert_recording> ("sk_graphite_context_insert_recording")).Invoke (context, info);
+		#endif
+
+		// bool sk_graphite_context_is_device_lost(const sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_context_is_device_lost (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_context_is_device_lost (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_context_is_device_lost (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_is_device_lost sk_graphite_context_is_device_lost_delegate;
+		internal static bool sk_graphite_context_is_device_lost (sk_graphite_context_t context) =>
+			(sk_graphite_context_is_device_lost_delegate ??= GetSymbol<Delegates.sk_graphite_context_is_device_lost> ("sk_graphite_context_is_device_lost")).Invoke (context);
+		#endif
+
+		// sk_graphite_recorder_t* sk_graphite_context_make_recorder(sk_graphite_context_t* context, int64_t recorderBudgetBytes, sk_graphite_image_provider_t* imageProvider)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider);
+		}
+		private static Delegates.sk_graphite_context_make_recorder sk_graphite_context_make_recorder_delegate;
+		internal static sk_graphite_recorder_t sk_graphite_context_make_recorder (sk_graphite_context_t context, Int64 recorderBudgetBytes, sk_graphite_image_provider_t imageProvider) =>
+			(sk_graphite_context_make_recorder_delegate ??= GetSymbol<Delegates.sk_graphite_context_make_recorder> ("sk_graphite_context_make_recorder")).Invoke (context, recorderBudgetBytes, imageProvider);
+		#endif
+
+		// void sk_graphite_context_options_init_defaults(sk_graphite_context_options_t* out)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out);
+		}
+		private static Delegates.sk_graphite_context_options_init_defaults sk_graphite_context_options_init_defaults_delegate;
+		internal static void sk_graphite_context_options_init_defaults (SKGraphiteContextOptions* @out) =>
+			(sk_graphite_context_options_init_defaults_delegate ??= GetSymbol<Delegates.sk_graphite_context_options_init_defaults> ("sk_graphite_context_options_init_defaults")).Invoke (@out);
+		#endif
+
+		// void sk_graphite_context_perform_deferred_cleanup(sk_graphite_context_t* context, int64_t milliseconds)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds);
+		}
+		private static Delegates.sk_graphite_context_perform_deferred_cleanup sk_graphite_context_perform_deferred_cleanup_delegate;
+		internal static void sk_graphite_context_perform_deferred_cleanup (sk_graphite_context_t context, Int64 milliseconds) =>
+			(sk_graphite_context_perform_deferred_cleanup_delegate ??= GetSymbol<Delegates.sk_graphite_context_perform_deferred_cleanup> ("sk_graphite_context_perform_deferred_cleanup")).Invoke (context, milliseconds);
+		#endif
+
+		// void sk_graphite_context_set_max_budgeted_bytes(sk_graphite_context_t* context, int64_t bytes)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes);
+		}
+		private static Delegates.sk_graphite_context_set_max_budgeted_bytes sk_graphite_context_set_max_budgeted_bytes_delegate;
+		internal static void sk_graphite_context_set_max_budgeted_bytes (sk_graphite_context_t context, Int64 bytes) =>
+			(sk_graphite_context_set_max_budgeted_bytes_delegate ??= GetSymbol<Delegates.sk_graphite_context_set_max_budgeted_bytes> ("sk_graphite_context_set_max_budgeted_bytes")).Invoke (context, bytes);
+		#endif
+
+		// bool sk_graphite_context_submit(sk_graphite_context_t* context, const sk_graphite_submit_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info);
+		}
+		private static Delegates.sk_graphite_context_submit sk_graphite_context_submit_delegate;
+		internal static bool sk_graphite_context_submit (sk_graphite_context_t context, SKGraphiteSubmitInfo* info) =>
+			(sk_graphite_context_submit_delegate ??= GetSymbol<Delegates.sk_graphite_context_submit> ("sk_graphite_context_submit")).Invoke (context, info);
+		#endif
+
+		// bool sk_graphite_context_supports_protected_content(const sk_graphite_context_t* context)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context);
+		}
+		private static Delegates.sk_graphite_context_supports_protected_content sk_graphite_context_supports_protected_content_delegate;
+		internal static bool sk_graphite_context_supports_protected_content (sk_graphite_context_t context) =>
+			(sk_graphite_context_supports_protected_content_delegate ??= GetSymbol<Delegates.sk_graphite_context_supports_protected_content> ("sk_graphite_context_supports_protected_content")).Invoke (context);
+		#endif
+
+		// sk_image_t* sk_graphite_image_make_texture(sk_graphite_recorder_t* recorder, const sk_image_t* image, bool mipmapped)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped);
+		}
+		private static Delegates.sk_graphite_image_make_texture sk_graphite_image_make_texture_delegate;
+		internal static sk_image_t sk_graphite_image_make_texture (sk_graphite_recorder_t recorder, sk_image_t image, [MarshalAs (UnmanagedType.I1)] bool mipmapped) =>
+			(sk_graphite_image_make_texture_delegate ??= GetSymbol<Delegates.sk_graphite_image_make_texture> ("sk_graphite_image_make_texture")).Invoke (recorder, image, mipmapped);
+		#endif
+
+		// void sk_graphite_image_provider_delete(sk_graphite_image_provider_t* provider)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider);
+		}
+		private static Delegates.sk_graphite_image_provider_delete sk_graphite_image_provider_delete_delegate;
+		internal static void sk_graphite_image_provider_delete (sk_graphite_image_provider_t provider) =>
+			(sk_graphite_image_provider_delete_delegate ??= GetSymbol<Delegates.sk_graphite_image_provider_delete> ("sk_graphite_image_provider_delete")).Invoke (provider);
+		#endif
+
+		// sk_graphite_image_provider_t* sk_graphite_image_provider_new(sk_graphite_image_provider_proc proc, void* userData)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_graphite_image_provider_t sk_graphite_image_provider_new (void* proc, void* userData);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_graphite_image_provider_t sk_graphite_image_provider_new (SKGraphiteImageProviderProxyDelegate proc, void* userData);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_graphite_image_provider_t sk_graphite_image_provider_new (SKGraphiteImageProviderProxyDelegate proc, void* userData);
+		}
+		private static Delegates.sk_graphite_image_provider_new sk_graphite_image_provider_new_delegate;
+		internal static sk_graphite_image_provider_t sk_graphite_image_provider_new (SKGraphiteImageProviderProxyDelegate proc, void* userData) =>
+			(sk_graphite_image_provider_new_delegate ??= GetSymbol<Delegates.sk_graphite_image_provider_new> ("sk_graphite_image_provider_new")).Invoke (proc, userData);
+		#endif
+
+		// sk_image_t* sk_graphite_image_wrap_texture(sk_graphite_recorder_t* recorder, const sk_graphite_backend_texture_t* backendTexture, sk_colortype_t colorType, sk_alphatype_t alphaType, sk_colorspace_t* colorSpace, sk_graphite_release_proc releaseProc, void* releaseContext)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, void* releaseProc, void* releaseContext);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
+		}
+		private static Delegates.sk_graphite_image_wrap_texture sk_graphite_image_wrap_texture_delegate;
+		internal static sk_image_t sk_graphite_image_wrap_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, SKAlphaType alphaType, sk_colorspace_t colorSpace, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext) =>
+			(sk_graphite_image_wrap_texture_delegate ??= GetSymbol<Delegates.sk_graphite_image_wrap_texture> ("sk_graphite_image_wrap_texture")).Invoke (recorder, backendTexture, colorType, alphaType, colorSpace, releaseProc, releaseContext);
+		#endif
+
+		// sk_graphite_backend_texture_t* sk_graphite_recorder_create_backend_texture(sk_graphite_recorder_t* recorder, int32_t width, int32_t height, const sk_graphite_texture_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info);
+		}
+		private static Delegates.sk_graphite_recorder_create_backend_texture sk_graphite_recorder_create_backend_texture_delegate;
+		internal static sk_graphite_backend_texture_t sk_graphite_recorder_create_backend_texture (sk_graphite_recorder_t recorder, Int32 width, Int32 height, sk_graphite_texture_info_t info) =>
+			(sk_graphite_recorder_create_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_create_backend_texture> ("sk_graphite_recorder_create_backend_texture")).Invoke (recorder, width, height, info);
+		#endif
+
+		// void sk_graphite_recorder_delete(sk_graphite_recorder_t* recorder)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder);
+		}
+		private static Delegates.sk_graphite_recorder_delete sk_graphite_recorder_delete_delegate;
+		internal static void sk_graphite_recorder_delete (sk_graphite_recorder_t recorder) =>
+			(sk_graphite_recorder_delete_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_delete> ("sk_graphite_recorder_delete")).Invoke (recorder);
+		#endif
+
+		// void sk_graphite_recorder_delete_backend_texture(sk_graphite_recorder_t* recorder, const sk_graphite_backend_texture_t* tex)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex);
+		}
+		private static Delegates.sk_graphite_recorder_delete_backend_texture sk_graphite_recorder_delete_backend_texture_delegate;
+		internal static void sk_graphite_recorder_delete_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t tex) =>
+			(sk_graphite_recorder_delete_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_delete_backend_texture> ("sk_graphite_recorder_delete_backend_texture")).Invoke (recorder, tex);
+		#endif
+
+		// sk_graphite_backend_t sk_graphite_recorder_get_backend(const sk_graphite_recorder_t* recorder)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder);
+		}
+		private static Delegates.sk_graphite_recorder_get_backend sk_graphite_recorder_get_backend_delegate;
+		internal static SKGraphiteBackend sk_graphite_recorder_get_backend (sk_graphite_recorder_t recorder) =>
+			(sk_graphite_recorder_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_get_backend> ("sk_graphite_recorder_get_backend")).Invoke (recorder);
+		#endif
+
+		// int32_t sk_graphite_recorder_get_max_texture_size(const sk_graphite_recorder_t* recorder)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder);
+		}
+		private static Delegates.sk_graphite_recorder_get_max_texture_size sk_graphite_recorder_get_max_texture_size_delegate;
+		internal static Int32 sk_graphite_recorder_get_max_texture_size (sk_graphite_recorder_t recorder) =>
+			(sk_graphite_recorder_get_max_texture_size_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_get_max_texture_size> ("sk_graphite_recorder_get_max_texture_size")).Invoke (recorder);
+		#endif
+
+		// sk_graphite_recording_t* sk_graphite_recorder_snap(sk_graphite_recorder_t* recorder)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder);
+		}
+		private static Delegates.sk_graphite_recorder_snap sk_graphite_recorder_snap_delegate;
+		internal static sk_graphite_recording_t sk_graphite_recorder_snap (sk_graphite_recorder_t recorder) =>
+			(sk_graphite_recorder_snap_delegate ??= GetSymbol<Delegates.sk_graphite_recorder_snap> ("sk_graphite_recorder_snap")).Invoke (recorder);
+		#endif
+
+		// void sk_graphite_recording_delete(sk_graphite_recording_t* recording)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_recording_delete (sk_graphite_recording_t recording);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_recording_delete (sk_graphite_recording_t recording);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_recording_delete (sk_graphite_recording_t recording);
+		}
+		private static Delegates.sk_graphite_recording_delete sk_graphite_recording_delete_delegate;
+		internal static void sk_graphite_recording_delete (sk_graphite_recording_t recording) =>
+			(sk_graphite_recording_delete_delegate ??= GetSymbol<Delegates.sk_graphite_recording_delete> ("sk_graphite_recording_delete")).Invoke (recording);
+		#endif
+
+		// sk_surface_t* sk_graphite_surface_make_render_target(sk_graphite_recorder_t* recorder, const sk_imageinfo_t* info, bool mipmapped, const sk_surfaceprops_t* props)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props);
+		}
+		private static Delegates.sk_graphite_surface_make_render_target sk_graphite_surface_make_render_target_delegate;
+		internal static sk_surface_t sk_graphite_surface_make_render_target (sk_graphite_recorder_t recorder, SKImageInfoNative* info, [MarshalAs (UnmanagedType.I1)] bool mipmapped, sk_surfaceprops_t props) =>
+			(sk_graphite_surface_make_render_target_delegate ??= GetSymbol<Delegates.sk_graphite_surface_make_render_target> ("sk_graphite_surface_make_render_target")).Invoke (recorder, info, mipmapped, props);
+		#endif
+
+		// sk_surface_t* sk_graphite_surface_wrap_backend_texture(sk_graphite_recorder_t* recorder, const sk_graphite_backend_texture_t* backendTexture, sk_colortype_t colorType, sk_colorspace_t* colorSpace, const sk_surfaceprops_t* props, sk_graphite_release_proc releaseProc, void* releaseContext)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, void* releaseProc, void* releaseContext);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext);
+		}
+		private static Delegates.sk_graphite_surface_wrap_backend_texture sk_graphite_surface_wrap_backend_texture_delegate;
+		internal static sk_surface_t sk_graphite_surface_wrap_backend_texture (sk_graphite_recorder_t recorder, sk_graphite_backend_texture_t backendTexture, SKColorTypeNative colorType, sk_colorspace_t colorSpace, sk_surfaceprops_t props, SKGraphiteReleaseProxyDelegate releaseProc, void* releaseContext) =>
+			(sk_graphite_surface_wrap_backend_texture_delegate ??= GetSymbol<Delegates.sk_graphite_surface_wrap_backend_texture> ("sk_graphite_surface_wrap_backend_texture")).Invoke (recorder, backendTexture, colorType, colorSpace, props, releaseProc, releaseContext);
+		#endif
+
+		// void sk_graphite_texture_info_delete(sk_graphite_texture_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info);
+		}
+		private static Delegates.sk_graphite_texture_info_delete sk_graphite_texture_info_delete_delegate;
+		internal static void sk_graphite_texture_info_delete (sk_graphite_texture_info_t info) =>
+			(sk_graphite_texture_info_delete_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_delete> ("sk_graphite_texture_info_delete")).Invoke (info);
+		#endif
+
+		// sk_graphite_backend_t sk_graphite_texture_info_get_backend(const sk_graphite_texture_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info);
+		}
+		private static Delegates.sk_graphite_texture_info_get_backend sk_graphite_texture_info_get_backend_delegate;
+		internal static SKGraphiteBackend sk_graphite_texture_info_get_backend (sk_graphite_texture_info_t info) =>
+			(sk_graphite_texture_info_get_backend_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_get_backend> ("sk_graphite_texture_info_get_backend")).Invoke (info);
+		#endif
+
+		// bool sk_graphite_texture_info_get_mipmapped(const sk_graphite_texture_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info);
+		}
+		private static Delegates.sk_graphite_texture_info_get_mipmapped sk_graphite_texture_info_get_mipmapped_delegate;
+		internal static bool sk_graphite_texture_info_get_mipmapped (sk_graphite_texture_info_t info) =>
+			(sk_graphite_texture_info_get_mipmapped_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_get_mipmapped> ("sk_graphite_texture_info_get_mipmapped")).Invoke (info);
+		#endif
+
+		// int32_t sk_graphite_texture_info_get_sample_count(const sk_graphite_texture_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		internal static partial Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			internal delegate Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info);
+		}
+		private static Delegates.sk_graphite_texture_info_get_sample_count sk_graphite_texture_info_get_sample_count_delegate;
+		internal static Int32 sk_graphite_texture_info_get_sample_count (sk_graphite_texture_info_t info) =>
+			(sk_graphite_texture_info_get_sample_count_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_get_sample_count> ("sk_graphite_texture_info_get_sample_count")).Invoke (info);
+		#endif
+
+		// bool sk_graphite_texture_info_is_valid(const sk_graphite_texture_info_t* info)
+		#if !USE_DELEGATES
+		#if USE_LIBRARY_IMPORT
+		[LibraryImport (SKIA)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static partial bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info);
+		#else // !USE_LIBRARY_IMPORT
+		[DllImport (SKIA, CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs (UnmanagedType.I1)]
+		internal static extern bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info);
+		#endif
+		#else
+		private partial class Delegates {
+			[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+			[return: MarshalAs (UnmanagedType.I1)]
+			internal delegate bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info);
+		}
+		private static Delegates.sk_graphite_texture_info_is_valid sk_graphite_texture_info_is_valid_delegate;
+		internal static bool sk_graphite_texture_info_is_valid (sk_graphite_texture_info_t info) =>
+			(sk_graphite_texture_info_is_valid_delegate ??= GetSymbol<Delegates.sk_graphite_texture_info_is_valid> ("sk_graphite_texture_info_is_valid")).Invoke (info);
 		#endif
 
 		#endregion
@@ -21578,103 +21578,6 @@ namespace SkiaSharp {
 
 	}
 
-	// sk_matrix_t
-	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKMatrix : IEquatable<SKMatrix> {
-		// public float scaleX
-		private Single scaleX;
-		public Single ScaleX {
-			readonly get => scaleX;
-			set => scaleX = value;
-		}
-
-		// public float skewX
-		private Single skewX;
-		public Single SkewX {
-			readonly get => skewX;
-			set => skewX = value;
-		}
-
-		// public float transX
-		private Single transX;
-		public Single TransX {
-			readonly get => transX;
-			set => transX = value;
-		}
-
-		// public float skewY
-		private Single skewY;
-		public Single SkewY {
-			readonly get => skewY;
-			set => skewY = value;
-		}
-
-		// public float scaleY
-		private Single scaleY;
-		public Single ScaleY {
-			readonly get => scaleY;
-			set => scaleY = value;
-		}
-
-		// public float transY
-		private Single transY;
-		public Single TransY {
-			readonly get => transY;
-			set => transY = value;
-		}
-
-		// public float persp0
-		private Single persp0;
-		public Single Persp0 {
-			readonly get => persp0;
-			set => persp0 = value;
-		}
-
-		// public float persp1
-		private Single persp1;
-		public Single Persp1 {
-			readonly get => persp1;
-			set => persp1 = value;
-		}
-
-		// public float persp2
-		private Single persp2;
-		public Single Persp2 {
-			readonly get => persp2;
-			set => persp2 = value;
-		}
-
-		public readonly bool Equals (SKMatrix obj) =>
-#pragma warning disable CS8909
-			scaleX == obj.scaleX && skewX == obj.skewX && transX == obj.transX && skewY == obj.skewY && scaleY == obj.scaleY && transY == obj.transY && persp0 == obj.persp0 && persp1 == obj.persp1 && persp2 == obj.persp2;
-#pragma warning restore CS8909
-
-		public readonly override bool Equals (object obj) =>
-			obj is SKMatrix f && Equals (f);
-
-		public static bool operator == (SKMatrix left, SKMatrix right) =>
-			left.Equals (right);
-
-		public static bool operator != (SKMatrix left, SKMatrix right) =>
-			!left.Equals (right);
-
-		public readonly override int GetHashCode ()
-		{
-			var hash = new HashCode ();
-			hash.Add (scaleX);
-			hash.Add (skewX);
-			hash.Add (transX);
-			hash.Add (skewY);
-			hash.Add (scaleY);
-			hash.Add (transY);
-			hash.Add (persp0);
-			hash.Add (persp1);
-			hash.Add (persp2);
-			return hash.ToHashCode ();
-		}
-
-	}
-
 	// sk_matrix44_t
 	[StructLayout (LayoutKind.Sequential)]
 	public unsafe partial struct SKMatrix44 : IEquatable<SKMatrix44> {
@@ -21828,6 +21731,103 @@ namespace SkiaSharp {
 
 	}
 
+	// sk_matrix_t
+	[StructLayout (LayoutKind.Sequential)]
+	public unsafe partial struct SKMatrix : IEquatable<SKMatrix> {
+		// public float scaleX
+		private Single scaleX;
+		public Single ScaleX {
+			readonly get => scaleX;
+			set => scaleX = value;
+		}
+
+		// public float skewX
+		private Single skewX;
+		public Single SkewX {
+			readonly get => skewX;
+			set => skewX = value;
+		}
+
+		// public float transX
+		private Single transX;
+		public Single TransX {
+			readonly get => transX;
+			set => transX = value;
+		}
+
+		// public float skewY
+		private Single skewY;
+		public Single SkewY {
+			readonly get => skewY;
+			set => skewY = value;
+		}
+
+		// public float scaleY
+		private Single scaleY;
+		public Single ScaleY {
+			readonly get => scaleY;
+			set => scaleY = value;
+		}
+
+		// public float transY
+		private Single transY;
+		public Single TransY {
+			readonly get => transY;
+			set => transY = value;
+		}
+
+		// public float persp0
+		private Single persp0;
+		public Single Persp0 {
+			readonly get => persp0;
+			set => persp0 = value;
+		}
+
+		// public float persp1
+		private Single persp1;
+		public Single Persp1 {
+			readonly get => persp1;
+			set => persp1 = value;
+		}
+
+		// public float persp2
+		private Single persp2;
+		public Single Persp2 {
+			readonly get => persp2;
+			set => persp2 = value;
+		}
+
+		public readonly bool Equals (SKMatrix obj) =>
+#pragma warning disable CS8909
+			scaleX == obj.scaleX && skewX == obj.skewX && transX == obj.transX && skewY == obj.skewY && scaleY == obj.scaleY && transY == obj.transY && persp0 == obj.persp0 && persp1 == obj.persp1 && persp2 == obj.persp2;
+#pragma warning restore CS8909
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKMatrix f && Equals (f);
+
+		public static bool operator == (SKMatrix left, SKMatrix right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKMatrix left, SKMatrix right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (scaleX);
+			hash.Add (skewX);
+			hash.Add (transX);
+			hash.Add (skewY);
+			hash.Add (scaleY);
+			hash.Add (transY);
+			hash.Add (persp0);
+			hash.Add (persp1);
+			hash.Add (persp2);
+			return hash.ToHashCode ();
+		}
+
+	}
+
 	// sk_pngencoder_options_t
 	[StructLayout (LayoutKind.Sequential)]
 	public readonly unsafe partial struct SKPngEncoderOptions : IEquatable<SKPngEncoderOptions> {
@@ -21868,47 +21868,6 @@ namespace SkiaSharp {
 			hash.Add (fComments);
 			hash.Add (fGainmap);
 			hash.Add (fGainmapInfo);
-			return hash.ToHashCode ();
-		}
-
-	}
-
-	// sk_point_t
-	[StructLayout (LayoutKind.Sequential)]
-	public unsafe partial struct SKPoint : IEquatable<SKPoint> {
-		// public float x
-		private Single x;
-		public Single X {
-			readonly get => x;
-			set => x = value;
-		}
-
-		// public float y
-		private Single y;
-		public Single Y {
-			readonly get => y;
-			set => y = value;
-		}
-
-		public readonly bool Equals (SKPoint obj) =>
-#pragma warning disable CS8909
-			x == obj.x && y == obj.y;
-#pragma warning restore CS8909
-
-		public readonly override bool Equals (object obj) =>
-			obj is SKPoint f && Equals (f);
-
-		public static bool operator == (SKPoint left, SKPoint right) =>
-			left.Equals (right);
-
-		public static bool operator != (SKPoint left, SKPoint right) =>
-			!left.Equals (right);
-
-		public readonly override int GetHashCode ()
-		{
-			var hash = new HashCode ();
-			hash.Add (x);
-			hash.Add (y);
 			return hash.ToHashCode ();
 		}
 
@@ -21958,6 +21917,47 @@ namespace SkiaSharp {
 			hash.Add (x);
 			hash.Add (y);
 			hash.Add (z);
+			return hash.ToHashCode ();
+		}
+
+	}
+
+	// sk_point_t
+	[StructLayout (LayoutKind.Sequential)]
+	public unsafe partial struct SKPoint : IEquatable<SKPoint> {
+		// public float x
+		private Single x;
+		public Single X {
+			readonly get => x;
+			set => x = value;
+		}
+
+		// public float y
+		private Single y;
+		public Single Y {
+			readonly get => y;
+			set => y = value;
+		}
+
+		public readonly bool Equals (SKPoint obj) =>
+#pragma warning disable CS8909
+			x == obj.x && y == obj.y;
+#pragma warning restore CS8909
+
+		public readonly override bool Equals (object obj) =>
+			obj is SKPoint f && Equals (f);
+
+		public static bool operator == (SKPoint left, SKPoint right) =>
+			left.Equals (right);
+
+		public static bool operator != (SKPoint left, SKPoint right) =>
+			!left.Equals (right);
+
+		public readonly override int GetHashCode ()
+		{
+			var hash = new HashCode ();
+			hash.Add (x);
+			hash.Add (y);
 			return hash.ToHashCode ();
 		}
 

--- a/utils/SkiaSharpGenerator/BaseTool.cs
+++ b/utils/SkiaSharpGenerator/BaseTool.cs
@@ -20,7 +20,7 @@ namespace SkiaSharpGenerator
 		protected readonly Dictionary<string, FunctionMapping> functionMappings = new Dictionary<string, FunctionMapping>();
 		protected readonly Dictionary<string, bool> skiaTypes = new Dictionary<string, bool>();
 
-		protected readonly List<string> excludedFiles = new List<string>();
+		protected readonly HashSet<string> excludedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		protected readonly List<string> excludedTypes = new List<string>();
 
 		protected CppCompilation compilation = new CppCompilation();
@@ -59,6 +59,7 @@ namespace SkiaSharpGenerator
 				{
 					var version = Directory.GetDirectories(root)
 						.OrderByDescending(d => Version.TryParse(Path.GetFileName(d), out var v) ? v : new Version(0, 0, 0))
+						.ThenBy(d => d, StringComparer.Ordinal)
 						.FirstOrDefault();
 					if (version is not null)
 					{
@@ -155,20 +156,22 @@ namespace SkiaSharpGenerator
 			}
 
 			var headers = new List<string>();
-			foreach (var header in config.Headers)
+			foreach (var header in config.Headers.OrderBy(h => h.Key, StringComparer.Ordinal))
 			{
 				var path = Path.Combine(SkiaRoot, header.Key);
 				options.IncludeFolders.Add(path);
-				foreach (var filter in header.Value)
-				{
-					headers.AddRange(Directory.EnumerateFiles(path, filter));
-				}
 			}
 
-			foreach (var filter in config.Exclude.Files)
-			{
-				excludedFiles.AddRange(Directory.EnumerateFiles(SkiaRoot, filter));
-			}
+			headers.AddRange(StableOrdering.EnumerateFiles(
+				SkiaRoot,
+				config.Headers,
+				Directory.EnumerateFiles));
+
+			excludedFiles.UnionWith(StableOrdering.EnumerateFiles(
+				SkiaRoot,
+				config.Exclude.Files,
+				Directory.EnumerateFiles)
+				.Select(path => StableOrdering.NormalizePath(SkiaRoot, path)));
 
 			foreach (var filter in config.Exclude.Types)
 			{

--- a/utils/SkiaSharpGenerator/Cookies/CookieDetector.cs
+++ b/utils/SkiaSharpGenerator/Cookies/CookieDetector.cs
@@ -117,7 +117,7 @@ namespace SkiaSharpGenerator
 				return (Method: m.Name, Signature: returnSig + paramsSig);
 			});
 
-			return methods.OrderBy(s => s.Signature).ToArray();
+			return methods.OrderBy(s => s.Signature, StringComparer.Ordinal).ToArray();
 
 			static string GetSignature(MethodDefinition method, TypeReference ret)
 			{

--- a/utils/SkiaSharpGenerator/Generate/GenerateCommand.cs
+++ b/utils/SkiaSharpGenerator/Generate/GenerateCommand.cs
@@ -59,16 +59,15 @@ namespace SkiaSharpGenerator
 
 		protected override bool OnInvoke(IEnumerable<string> extras)
 		{
-			var dir = Path.GetDirectoryName(OutputPath);
-			if (!Directory.Exists(dir))
-				Directory.CreateDirectory(dir);
+			var outputPath = Path.GetFullPath(OutputPath!);
+			var dir = Path.GetDirectoryName(outputPath)!;
+			Directory.CreateDirectory(dir);
 
-			var docStore = OutputPath is not null && File.Exists(OutputPath)
-				? new DocumentationStore(OutputPath)
+			var docStore = File.Exists(outputPath)
+				? new DocumentationStore(outputPath)
 				: null;
 
-			using var file = File.Create(OutputPath);
-			using var writer = new StreamWriter(file);
+			using var writer = CreateOutputWriter(outputPath);
 
 			var generator = new Generator(SourceRoot!, ConfigPath!, writer, docStore);
 			generator.Log = Program.Log;
@@ -92,6 +91,13 @@ namespace SkiaSharpGenerator
 			}
 
 			return true;
+		}
+
+		internal static StreamWriter CreateOutputWriter(string outputPath)
+		{
+			var writer = new StreamWriter(File.Create(outputPath));
+			writer.NewLine = "\n";
+			return writer;
 		}
 	}
 }

--- a/utils/SkiaSharpGenerator/Generate/Generator.cs
+++ b/utils/SkiaSharpGenerator/Generate/Generator.cs
@@ -13,6 +13,7 @@ namespace SkiaSharpGenerator
 			: base(skiaRoot, configFile)
 		{
 			OutputWriter = outputWriter ?? throw new ArgumentNullException(nameof(outputWriter));
+			OutputWriter.NewLine = "\n";
 			PreviousDocumentation = docStore;
 		}
 
@@ -79,10 +80,11 @@ namespace SkiaSharpGenerator
 			writer.WriteLine($"#region Delegates");
 			writer.WriteLine($"#if !USE_LIBRARY_IMPORT");
 
-			var delegates = compilation.Typedefs
+			var delegates = StableOrdering.ByName(
+				compilation.Typedefs
 				.Where(t => t.ElementType.TypeKind == CppTypeKind.Pointer)
-				.Where(t => IncludeNamespace(t.GetDisplayName()))
-				.OrderBy(t => t.GetDisplayName())
+				.Where(t => IncludeNamespace(t.GetDisplayName())),
+				t => t.GetDisplayName())
 				.GroupBy(t => GetNamespace(t.GetDisplayName()));
 
 			foreach (var group in delegates)
@@ -139,10 +141,11 @@ namespace SkiaSharpGenerator
 
 			writer.WriteLine($"#region Structs");
 
-			var classes = compilation.Classes
+			var classes = StableOrdering.ByName(
+				compilation.Classes
 				.Where(c => c.SizeOf != 0)
-				.Where(c => IncludeNamespace(c.GetDisplayName()))
-				.OrderBy(c => c.GetDisplayName())
+				.Where(c => IncludeNamespace(c.GetDisplayName())),
+				c => c.GetDisplayName())
 				.GroupBy(c => GetNamespace(c.GetDisplayName()));
 
 			foreach (var group in classes)
@@ -340,9 +343,10 @@ namespace SkiaSharpGenerator
 
 			writer.WriteLine($"#region Enums");
 
-			var enums = compilation.Enums
-				.Where(e => IncludeNamespace(e.GetDisplayName()))
-				.OrderBy(e => e.GetDisplayName())
+			var enums = StableOrdering.ByName(
+				compilation.Enums
+				.Where(e => IncludeNamespace(e.GetDisplayName())),
+				e => e.GetDisplayName())
 				.GroupBy(e => GetNamespace(e.GetDisplayName()));
 
 			foreach (var group in enums)
@@ -421,8 +425,10 @@ namespace SkiaSharpGenerator
 			writer.WriteLine($"#region Namespaces");
 			writer.WriteLine();
 
-			var namspaces = config.Namespaces.Values;
-			foreach (var ns in namspaces)
+			var namespaces = StableOrdering.ByName(
+				config.Namespaces.Values,
+				ns => $"{config.Namespace}.{ns.CsName}");
+			foreach (var ns in namespaces)
 			{
 				if (string.IsNullOrEmpty(ns.CsName))
 					continue;
@@ -445,8 +451,9 @@ namespace SkiaSharpGenerator
 			writer.WriteLine($"#region Class declarations");
 			writer.WriteLine();
 
-			var classes = compilation.Classes
-				.OrderBy(c => c.GetDisplayName())
+			var classes = StableOrdering.ByName(
+				compilation.Classes,
+				c => c.GetDisplayName())
 				.ToList();
 			foreach (var klass in classes)
 			{
@@ -467,16 +474,18 @@ namespace SkiaSharpGenerator
 		{
 			Log?.LogVerbose("  Writing p/invokes...");
 
-			var functionGroups = compilation.Functions
-				.Where(f => IncludeNamespace(f.Name))
-				.OrderBy(f => f.Name)
-				.GroupBy(f => f.Span.Start.File.ToLower().Replace("\\", "/"))
-				.OrderBy(g => Path.GetDirectoryName(g.Key) + "/" + Path.GetFileName(g.Key));
+			var functions = StableOrdering.ByPathThenName(
+				compilation.Functions.Where(f => IncludeNamespace(f.Name)),
+				SkiaRoot,
+				f => f.Span.Start.File,
+				f => f.Name);
+			var functionGroups = functions.GroupBy(
+				f => StableOrdering.NormalizePath(SkiaRoot, f.Span.Start.File),
+				StringComparer.Ordinal);
 
 			foreach (var group in functionGroups)
 			{
-				var fullPath = Path.GetFullPath(group.Key).ToLower();
-				if (excludedFiles.Any(e => Path.GetFullPath(e).ToLower() == fullPath))
+				if (excludedFiles.Contains(group.Key))
 				{
 					Log?.LogVerbose($"    Skipping file '{group.Key}' because it was in the exclude list.");
 					continue;
@@ -579,10 +588,11 @@ namespace SkiaSharpGenerator
 
 			writer.WriteLine($"#region DelegateProxies");
 
-			var delegates = compilation.Typedefs
+			var delegates = StableOrdering.ByName(
+				compilation.Typedefs
 				.Where(t => t.ElementType.TypeKind == CppTypeKind.Pointer)
-				.Where(t => IncludeNamespace(t.GetDisplayName()))
-				.OrderBy(t => t.GetDisplayName())
+				.Where(t => IncludeNamespace(t.GetDisplayName())),
+				t => t.GetDisplayName())
 				.GroupBy(t => GetNamespace(t.GetDisplayName()));
 
 			foreach (var group in delegates)

--- a/utils/SkiaSharpGenerator/StableOrdering.cs
+++ b/utils/SkiaSharpGenerator/StableOrdering.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SkiaSharpGenerator
+{
+	internal static class StableOrdering
+	{
+		public static IOrderedEnumerable<T> ByName<T>(
+			IEnumerable<T> items,
+			Func<T, string> nameSelector) =>
+			items.OrderBy(nameSelector, StringComparer.Ordinal);
+
+		public static IOrderedEnumerable<T> ByPathThenName<T>(
+			IEnumerable<T> items,
+			string root,
+			Func<T, string> pathSelector,
+			Func<T, string> nameSelector) =>
+			items
+				.OrderBy(item => NormalizePath(root, pathSelector(item)), StringComparer.Ordinal)
+				.ThenBy(nameSelector, StringComparer.Ordinal);
+
+		public static IReadOnlyList<string> EnumerateFiles(
+			string root,
+			IEnumerable<KeyValuePair<string, string[]>> fileGroups,
+			Func<string, string, IEnumerable<string>> enumerateFiles) =>
+			fileGroups
+				.OrderBy(group => group.Key, StringComparer.Ordinal)
+				.SelectMany(group => group.Value
+					.OrderBy(filter => filter, StringComparer.Ordinal)
+					.SelectMany(filter => enumerateFiles(Path.Combine(root, group.Key), filter)))
+				.OrderBy(path => NormalizePath(root, path), StringComparer.Ordinal)
+				.ToArray();
+
+		public static IReadOnlyList<string> EnumerateFiles(
+			string root,
+			IEnumerable<string> filters,
+			Func<string, string, IEnumerable<string>> enumerateFiles) =>
+			filters
+				.OrderBy(filter => filter, StringComparer.Ordinal)
+				.SelectMany(filter => enumerateFiles(root, filter))
+				.OrderBy(path => NormalizePath(root, path), StringComparer.Ordinal)
+				.ToArray();
+
+		public static string NormalizePath(string root, string path)
+		{
+			var relativePath = Path.GetRelativePath(Path.GetFullPath(root), Path.GetFullPath(path));
+			return relativePath.Replace('\\', '/');
+		}
+	}
+}

--- a/utils/SkiaSharpGenerator/Verify/Verifier.cs
+++ b/utils/SkiaSharpGenerator/Verify/Verifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -40,20 +41,19 @@ namespace SkiaSharpGenerator
 		{
 			Log?.LogVerbose("  Making sure all declarations have an implementation...");
 
-			var functionGroups = compilation.Functions
-				.OrderBy(f => f.Name)
-				.GroupBy(f => f.Span.Start.File.ToLower().Replace("\\", "/"))
-				.OrderBy(g => Path.GetDirectoryName(g.Key) + "/" + Path.GetFileName(g.Key));
+			var functions = StableOrdering.ByPathThenName(
+				compilation.Functions,
+				SkiaRoot,
+				f => f.Span.Start.File,
+				f => f.Name);
+			var functionGroups = functions.GroupBy(
+				f => StableOrdering.NormalizePath(SkiaRoot, f.Span.Start.File),
+				StringComparer.Ordinal);
 
-			var allSources = new List<string>();
-			foreach (var source in config.Source)
-			{
-				var path = Path.Combine(SkiaRoot, source.Key);
-				foreach (var filter in source.Value)
-				{
-					allSources.AddRange(Directory.EnumerateFiles(path, filter));
-				}
-			}
+			var allSources = StableOrdering.EnumerateFiles(
+				SkiaRoot,
+				config.Source,
+				Directory.EnumerateFiles);
 
 			var sourcesContents = new Dictionary<string, string>();
 


### PR DESCRIPTION
## Description

Binding generation currently inherits filesystem enumeration order before parsing and uses default culture-sensitive string ordering when emitting declarations. Identical inputs can therefore produce large ordering-only diffs across Windows, macOS, and Linux.

This change makes ordering intrinsic to `SkiaSharpGenerator`: discovered files use normalized ordinal paths, emitted declarations use explicit ordinal keys, and generated files use canonical UTF-8/LF output. The first regeneration establishes that canonical order.

A narrowly triggered workflow generates independently on all three desktop OSes and first compares peer artifacts byte-for-byte without using the checked-in order as its source of truth. Once the hosts agree, it requires that canonical result to match the four committed Skia bindings, catching omitted regeneration and manual generated-code edits.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [x] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — generator and CI behavior only; there are no public API or runtime behavior changes. The one-time `SkiaApi.generated.cs` migration is ordering-only: all 23,630 lines are unchanged.

## Testing

- `dotnet build utils/SkiaSharpGenerator/SkiaSharpGenerator.csproj --no-restore`
- Repository binding regeneration completed successfully and was idempotent
- Verified the committed `SkiaApi.generated.cs` has the same 23,630-line multiset as `main`
- Verified exact committed/generated blob equality and that the stale `main` ordering is rejected
- Fresh main-based PR run: Linux, macOS, and Windows generation plus byte-for-byte comparison passed
- Checked-in binding freshness gate passed on the updated PR run

Focused generator unit tests are intentionally deferred to a follow-up.

## Checklist

- [ ] Tests added or updated — deferred; this PR adds the three-OS byte-comparison workflow
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native or submodule changes
