### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "7853af4777c21d31ed86924782c90dd1f6994751"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "upstream_merge_commit": "86bb2f25f46f4d620b4a26e738f59a9b6c22d2eb"
     }
   ]
 }


### PR DESCRIPTION
Automated upstream bug-fix sync for m151.

**Companion skia PR:** https://github.com/mono/skia/pull/317

## Summary

Same-milestone (m151 → m151) bug-fix sync of the `externals/skia` submodule to the tip of upstream `chrome/m151`. No version bump; only `cgmanifest.json`'s commit hashes and the submodule pointer change.

Paired mono/skia PR: `skia-sync/m151` → `skiasharp`.

## Breaking change analysis

None. Same-milestone bug-fix sync — no removed, renamed, or signature-changed APIs. The 2 upstream commits are:

- `[M151] Address incorrect handling of a map pointer in SkRP` — internal SkSL raster-pipeline codegen fix, no public API surface.
- `Roll infra dep to 055b758…` — upstream infra tooling, does not affect Skia runtime.

## Version / binding updates

- `cgmanifest.json`
  - `commitHash`: `459baa5540…` → `7853af4777…` (new mono/skia merge commit)
  - `upstream_merge_commit`: `755b89e0a8…` → `86bb2f25f4…` (new upstream tip)
  - `chrome_milestone`: unchanged (151)
- `scripts/VERSIONS.txt`, `scripts/azure-templates-variables.yml`: unchanged (same-milestone sync).
- `externals/skia/include/c/sk_types.h`: `SK_C_INCREMENT` unchanged (0).

## C# changes

**None.** `regenerate-bindings.ps1` reports "No changes to bindings (C API signatures unchanged)" and "No new functions found". `binding/SkiaSharp/SkiaApi.generated.cs` is byte-identical to `main`.

## Build / test results

- **Native (Linux x64)**: `dotnet cake --target=externals-linux --arch=x64` ✅ (built from source, 19m 26s).
- **C# build**: `dotnet build binding/SkiaSharp/SkiaSharp.csproj` ✅ 0 errors, 4 pre-existing NETSDK1202 EOL warnings.
- **Full test suite** (`SkiaSharp.Tests.Console`): **169 failed / 5914 passed / 34 skipped**.

### Test failures — human attention required

All 169 failures share the same root cause:

```
Xunit.MicrosoftTestingPlatform.XunitException: System.Exception : Failed to open X display.
   at SkiaSharp.Tests.GlxContext..ctor()
   at SkiaSharp.Tests.DefaultTestConfig.CreateGlContext()
```

These are GPU/GLX tests (`SKRuntimeEffectTest+Gpu.*`, `GRContextTest.*`, GL-backed surface/canvas tests) failing because the workflow sandbox has **no X display server**. Per the automated workflow's rules this is a **host-dependency gap** (missing Xvfb / `DISPLAY`), NOT a Skia regression — the sync itself introduced zero C API or binding changes, so no test behavior could have changed. Recorded here for the workflow maintainer:

- **Action for humans**: either provision an X display (e.g. Xvfb) in the `Install native build dependencies` step of the update-skia workflow, OR set `SKIASHARP_TEST_SKIP_GPU=1` for this specific agent (per `GpuPolicy`) so GLX tests are declared-skipped rather than failing on capability gaps.
- Full log uploaded as `test-output.txt` artifact.

Non-GPU tests all passed. There is no evidence that this sync affects behavior in any way beyond the intended upstream bug-fix in `SkSLRasterPipelineCodeGenerator`.

## Items needing human attention

1. **Test environment**: workflow sandbox lacks an X display, causing all 169 GLX-backed GPU tests to fail with "Failed to open X display". Not a sync regression. See "Build / test results" above.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).