### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -110,7 +110,7 @@
         "type": "other",
         "other": {
           "name": "VulkanMemoryAllocator",
-          "version": "3.2.1",
+          "version": "3.4.0",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator"
         }
       }
@@ -158,7 +158,7 @@
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "6c0b60e6361761c682c0737ac64638178c3ce85c"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2a9b593bab4b2fd019fa494c8d401ff1fab0b883"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
## Description

Automated Skia milestone bump from m151 to m152.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/322

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the SkiaSharp parent to Chrome milestone **m152**.

- **Submodule pointer:** `externals/skia` advanced from
  `a0dd072787a63edb9c7c6e358c2ec5ea83f1b300` to the m152 sync tip
  `6c0b60e6361761c682c0737ac64638178c3ce85c` (head branch `skia-sync/m152`, base
  `mattleibow-dev-vulkan-sync-validation`). The submodule change is a genuine two-parent
  merge of upstream `chrome/m152` (`2a9b593bab4b2fd019fa494c8d401ff1fab0b883`) plus two
  ABI-neutral post-merge adaptations (VMA 3.2.1→3.4.0 roll; restored SK_USE_VMA fallback
  in `GrVkGpu::Make`). See the mono/skia summary for details.
- **Version surfaces:**
  - `scripts/VERSIONS.txt` — Skia `m151`→`m152`, `libSkiaSharp` milestone 152 and soname
    `152.0.0`, `SkiaSharp` assembly/file `4.152.0.0` (all package rows bumped).
  - `cgmanifest.json` — Skia registration to `chrome/m152` / milestone 152 / merge commit,
    submodule commit hash, and VulkanMemoryAllocator version `3.2.1`→`3.4.0`.
  - `scripts/azure-templates-variables.yml` — version variables updated.
- **Bindings:** `regenerate_bindings.py` reported **no binding changes** — upstream made
  zero C API changes in the m151→m152 range (HarfBuzz pin preserved and auto-reverted).
  No `*.generated.cs`, managed wrapper, or public API surface changes. ABI unchanged.
- Managed build of `binding/SkiaSharp/SkiaSharp.csproj` succeeds (only EOL-framework
  warnings).

## Testing

Native built from source for **Linux / x64**; the managed test host loads
`libSkiaSharp.so.152.0.0`. Full unfiltered solution
(`tests/SkiaSharp.Tests.Console.slnx`, net10.0/x64) — exit code 0:

| Host | Passed | Skipped | Failed |
|---|---|---|---|
| SkiaSharp.Tests (Core) | 6084 | 33 | 0 |
| SkiaSharp.Vulkan.Tests | 23 | 2 | 0 |
| SkiaSharp.Direct3D.Tests | 2 | 3 | 0 |
| SkiaSharp.Tests.SingletonInit | 1 | 0 | 0 |

All 9 Vulkan failures observed before the fix (`GRContext.CreateVulkan returned null`)
were resolved by restoring the SK_USE_VMA fallback allocator in the submodule. All
`GpuPolicy`-required Linux backends executed (Vulkan via Mesa lavapipe under Xvfb). No
**required** backend was skipped; recorded skips are platform-policy skips and
explicitly-checked capability gaps.

## Human review

- No managed API surface changed (no C API deltas in range); a full managed-surface
  review is not needed beyond confirming the regeneration produced no diff.
- Non-Linux platforms (Windows, macOS, iOS, Android, WASM) and non-Vulkan GPU backends
  were not built or executed here; verify via CI before merge.
- Merge order per skill: merge mono/skia first, then repoint this PR's submodule to the
  resulting `skiasharp`-branch commit before merging the parent.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-01T15:27:53Z_
