### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -110,7 +110,7 @@
         "type": "other",
         "other": {
           "name": "VulkanMemoryAllocator",
-          "version": "3.2.1",
+          "version": "3.4.0",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator"
         }
       }
@@ -158,7 +158,7 @@
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "fb2ca3f84f3873cf3ee27e3c8005addda07283c7"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2a9b593bab4b2fd019fa494c8d401ff1fab0b883"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
## Description

Automated Skia milestone bump from m151 to m152.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/325

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Updated `externals/skia` submodule pointer to the merged mono/skia tip
(`71807f51bbbfbc8bf1318faec3b51b31641c78b5`, chrome/m152 merged onto the fork base). Bumped version
surfaces via `scripts/VERSIONS.txt`/`scripts/azure-templates-variables.yml`/`cgmanifest.json`
(milestone 151 → 152, native C API version, Skia hash registrations) using the deterministic
`update_versions.py` helper (idempotent, re-validated).

`cgmanifest.json`: updated `VulkanMemoryAllocator` Component Governance registration from `3.2.1`
to `3.4.0` to match the new tracked revision accepted in the submodule (see the skia-side summary
for why the VMA pin was rolled forward). `libexpat` remains correctly registered at `2.8.1`
(unchanged; this pin was restored, not moved, in the submodule).

No C API changes were required for this sync (`src/c`, `include/c` directory contents identical
before/after the merge), so bindings regeneration
(`python3 .agents/skills/update-skia/scripts/regenerate_bindings.py`) reported **no binding changes**
and **no new generated native functions** — no managed wrapper review was required.

## Testing

- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — succeeded, 0 errors.
- Full unfiltered `dotnet test tests/SkiaSharp.Tests.Console.slnx -p:TargetFramework=net10.0
  -p:TargetFrameworks=net10.0` — **all required hosts passed**:
  - `SkiaSharp.Tests.SingletonInit.dll`: Passed 1, Failed 0, Skipped 0 (Total 1)
  - `SkiaSharp.Tests.dll` (core): Passed 6084, Failed 0, Skipped 33 (Total 6117)
  - `SkiaSharp.Direct3D.Tests.dll`: Passed 2, Failed 0, Skipped 3 (Total 5)
  - `SkiaSharp.Vulkan.Tests.dll`: Passed 23, Failed 0, Skipped 2 (Total 25)
  - No required `GpuPolicy` backend for linux/x64 was skipped; Vulkan executed against the
    provisioned lavapipe ICD with zero failures.
  - Full raw output captured in `test-output.txt`; exit code `0` in `test-exit-code.txt`.

## Human review

- Only the linux/x64 host was built and validated in this automated run. macOS, Windows, Android,
  iOS, and other architectures/backends (Metal, Direct3D hardware paths beyond the software-backed
  smoke coverage here, WASM/Graphite-Dawn) were not exercised and require separate CI/manual
  validation before merge.
- The parent's `externals/skia` gitlink must be re-verified to point at the exact commit merged and
  tested in the linked mono/skia PR before that PR merges, per the required merge sequence (mono/skia
  first, then update this PR's submodule pointer to the merged commit, then merge this PR).
- Two DEPS corrections (expat pin restoration, VMA compatibility roll) were made after the initial
  merge conflict resolution, driven by build failures rather than diff review alone; reviewers should
  read `skia-dependency-decisions.md`'s "Correction" sections for full rationale.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-01T22:34:00Z_
