### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "33cee02f38f1b01cc9a0339c80e2c389528c519b"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2a9b593bab4b2fd019fa494c8d401ff1fab0b883"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated Skia milestone bump from m151 to m152.

**Companion skia PR:** https://github.com/mono/skia/pull/327

# mono/SkiaSharp: sync to Skia milestone 152

Bumps the Skia submodule from milestone **m151** → **m152**. Head branch: `skia-sync/m152`. Companion mono/skia PR: `skia-sync/m152` (merge commit `5602a505b4`, upstream tip `2a9b593bab`).

## Version updates

- `scripts/VERSIONS.txt` — milestone `151→152`, soname `151.0.0→152.0.0`, all `4.151.x → 4.152.x`
- `cgmanifest.json` — `chrome_milestone: 152`, `commitHash` + `upstream_merge_commit` updated
- `scripts/azure-templates-variables.yml` — `SKIASHARP_VERSION: 4.152.0`
- `externals/skia/include/c/sk_types.h` — `SK_C_INCREMENT` reset to `0` (no C-API changes this milestone)
- Submodule pointer bumped to `5602a505b4`

## Binding changes

**None.** `pwsh ./utils/generate.ps1` produced no diffs; no new C API functions were added upstream (HarfBuzz-managed generation reverted as expected). No C# wrapper changes required.

## Build

- **Linux x64** native build: **green** (`dotnet cake --target=externals-linux --arch=x64`, ~9 min after DEPS resolution). No new `--gnArgs` required.
- C# build: **0 errors** (only pre-existing Android EOL warnings).
- **Not verified in this workflow**: Windows/macOS/iOS/Android/WASM native builds.

## Tests

Ran `dotnet test tests/SkiaSharp.Tests.Console.slnx` on Linux x64 (headless — no GPU display/ICD available in the container).

- **SkiaSharp.Tests.dll**: 5914 passed / **170 failed** / 33 skipped
- **SkiaSharp.Vulkan.Tests.dll**: 4 passed / **19 failed** / 2 skipped
- All other assemblies: passed

Full log at `test-output.txt` (artifact).

### Failure breakdown

**Environmental (no GPU in container — ~162 of 170):**
Nearly all `SkiaSharp.Tests` failures are `+Gpu` classes, `ganesh-gl` renderer tests, `GRContextTest`, `GRGlInterface`, `SKSurfaceTest.Gpu*`, `SKImageTest` texture tests, `SKGraphicsTest.CanGetMemoryDumpOnGpu*`, `SKRuntimeEffectTest+Gpu`, `SKBlenderTest+Gpu`, etc. These trip `GpuPolicy.RequireOrSkip` on `ganesh-gl` which is required on `Desktop | NanoServer`; the CI sandbox has no display so no GL context can be created. Same for all 19 Vulkan failures (no Vulkan ICD).

**Non-environmental (needs human review — 8 tests):**

| Test | Note |
|---|---|
| `SKColorSpaceTest.ColorSpaceIsNotDisposedPrematurely` | Refcount assertion `Expected: 4, Actual: 3` at `SKColorSpaceTest.cs:172` — likely upstream m152 changed `SkColorSpace` internal ref-counting. Investigate before merge. |
| `SKImageTest.RasterImageIsValidAlways` | Raster path; may be same refcount/lifetime family as above. |
| `VisualMatrixTests.RenderMatchesGolden(raster, RedRoundedRectOnWhite)` | Raster golden mismatch |
| `VisualMatrixTests.RenderMatchesGolden(raster, Text)` | Raster golden mismatch |
| `VisualMatrixTests.RenderMatchesGolden(raster, FilledCircle)` | Raster golden mismatch |
| `VisualMatrixTests.RenderMatchesGolden(raster, DiagonalLines)` | Raster golden mismatch |
| `VisualMatrixTests.RenderMatchesGolden(raster, GradientBlend)` | Raster golden mismatch |
| `GRGlInterfaceTest.CreateDefaultInterfaceIsValid` / `AssembleInterfaceIsValid` | GL interface probe — likely environmental (no GL), but included here since not `+Gpu`. |

The five raster golden mismatches are the expected shape of a milestone rendering-diff and normally get golden refreshes as part of the sync PR after visual review — please regenerate under `tests/Tests/SkiaSharp/Visual/Goldens/raster/` after verifying the new output is acceptable.

## Items needing human attention

1. **Refcount regression** — `SKColorSpaceTest.ColorSpaceIsNotDisposedPrematurely` (and possibly `RasterImageIsValidAlways`). Triage whether m152 changed `SkColorSpace` sharing semantics or if a wrapper needs adjustment.
2. **Raster goldens** — 5 raster tests need updated golden PNGs (visual review required).
3. **Cross-platform builds/tests** — only Linux x64 verified here. Windows/macOS/iOS/Android/WASM need CI validation (the DEPS updates for VMA + vulkan-headers are the highest-risk items on Windows/Android).
4. **GPU/Vulkan tests in this workflow** — this Linux CI sandbox has no display / no Vulkan ICD, so ~162 GPU test failures are environmental. The workflow did **not** set `SKIASHARP_TEST_SKIP_GPU=all` because per `GpuPolicy` a missing GL/Vulkan on Linux is a **failure**, not a skip. Cross-platform CI on hosts with real GPUs will re-run these.
5. **DEPS resolution** — see companion mono/skia PR summary; VMA and vulkan-headers were advanced to upstream (required by Skia code), other fork-pinned deps were kept.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).