### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "7fd19ec06d0149cff1030f3aee02cb9fb49b9e72"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2a9b593bab4b2fd019fa494c8d401ff1fab0b883"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated Skia milestone bump from m151 to m152.

**Companion skia PR:** https://github.com/mono/skia/pull/330

# [skia-sync] Update skia to milestone 152

Bumps the Skia submodule from `chrome/m151` to `chrome/m152` and updates all SkiaSharp version metadata.

## Version changes

| File | Change |
|------|--------|
| `scripts/VERSIONS.txt` | `libSkiaSharp` milestone `151 → 152`, `SK_C_INCREMENT` reset to `0`, `libSkiaSharp` nuget `4.151.0 → 4.152.0` (and ~30 dependent nuget lines) |
| `cgmanifest.json` | `commitHash`, `version`, `chrome_milestone`, `upstream_merge_commit` updated |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION → 4.152.0` |
| `externals/skia/include/c/sk_types.h` | `SK_C_INCREMENT` already `0`, no change needed |
| `externals/skia` submodule pointer | `a0dd0727 → 13bf4ab0` (mono/skia `skia-sync/m152` head) |

`update-versions.ps1` reported ✅ (no stale references).

## Submodule (companion PR)

The `externals/skia` submodule points to the companion mono/skia PR branch `skia-sync/m152`. See the mono/skia PR summary for merge/conflict details.

## Breaking change analysis

Reviewed upstream release notes for m152 (from `RELEASE_NOTES.md`):

| Change | Category | C API impact |
|--------|----------|--------------|
| `ContextOptions::fAvoidDepth` (Graphite) | New API 🟢 | None (not exposed via C API) |
| `SkRRect::contains(const SkPoint&)` | New API 🟢 | None (C API uses `sk_rrect_contains_point` with rect, not point yet) |
| `SkPath::updateBoundsCache()` removed | Removed 🔴 | Not called from `src/c/**` (verified via grep) |
| New `SkIcoRustDecoder` (opt-in) | New API 🟢 | Not built (`skia_use_rust_ico_decode` not enabled) |

No C API surface changes were required. Binding regeneration produced no diff to `SkiaApi.generated.cs`.

## Bindings

- Ran `pwsh .agents/skills/update-skia/scripts/regenerate-bindings.ps1`.
- Reverted `HarfBuzzSharp` bindings (per policy).
- Result: **no changes** to generated bindings (C API signatures unchanged).
- No new `internal static` functions on the diff against `origin/main`.

## Build & test results (Linux x64)

- **Native build:** ✅ `dotnet cake --target=externals-linux --arch=x64` — succeeded after bumping VMA in the submodule (see mono/skia PR).
- **C# build:** ✅ `dotnet build binding/SkiaSharp/SkiaSharp.csproj` — 0 errors.
- **Tests:** `dotnet test tests/SkiaSharp.Tests.Console.slnx`
  - `SkiaSharp.Tests.SingletonInit`: 1/1 passed
  - `SkiaSharp.Tests`: 5915 passed / 169 failed / 33 skipped
  - `SkiaSharp.Direct3D.Tests`: 2 passed / 3 skipped (as expected off Windows)
  - `SkiaSharp.Vulkan.Tests`: 4 passed / 19 failed / 2 skipped

  **All 169 core failures are `System.Exception: Failed to open X display`** and all 19 Vulkan failures are `vkCreateInstance failed`. These are host-environment gaps in the sandbox (no X server, no Vulkan ICD available), not sync-caused regressions. Per workflow instructions we do not hack around these here.

  Full log: `/tmp/gh-aw/agent/test-output.txt` (artifact).

## Items needing human attention

- **Sandbox lacks GPU/display**: 169 core + 19 Vulkan tests fail with `Failed to open X display` / `vkCreateInstance failed`. This is a workflow environment gap — the `Install native build dependencies` step should provision Xvfb and a Vulkan ICD (e.g. mesa `libvulkan1` + `mesa-vulkan-drivers` and `xvfb-run`) so `GpuPolicy` can require these backends. Please verify on the CI leg that these backends come up green.
- **VMA revision bump** (companion PR) — confirm the new VMA revision is acceptable to ship.
- **Only Linux x64 native binaries built here.** Windows/macOS/iOS/Android/WASM must be validated by CI.

Companion mono/skia PR: `skia-sync/m152` → `skiasharp`.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).