### PR TITLE
[skia-sync] Update skia to milestone 152

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "459baa5540781da098eb71fc751b06322a1c1477"
+          "commitHash": "d9fc5d944f2661bf1cf7541ac44efe041beab80e"
         }
       }
     },
@@ -226,12 +226,12 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m151",
+          "version": "chrome/m152",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 151,
-      "upstream_merge_commit": "755b89e0a89dfc1e7a07e0bc259db23ae8196b76"
+      "chrome_milestone": 152,
+      "upstream_merge_commit": "2a9b593bab4b2fd019fa494c8d401ff1fab0b883"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m151
+skia                                            release     m152
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   151
+libSkiaSharp            milestone   152
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      151.0.0
+libSkiaSharp            soname      152.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.151.0.0
-SkiaSharp               file        4.151.0.0
+SkiaSharp               assembly    4.152.0.0
+SkiaSharp               file        4.152.0.0
 
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
@@ -86,37 +86,37 @@ HarfBuzzSharp           file        14.2.1
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.151.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.151.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.151.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.151.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.151.0
-SkiaSharp.NativeAssets.Android                  nuget       4.151.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.151.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.151.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.151.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.151.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.151.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.151.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.151.0
-SkiaSharp.Views                                 nuget       4.151.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.151.0
-SkiaSharp.Views.Gtk3                            nuget       4.151.0
-SkiaSharp.Views.Gtk4                            nuget       4.151.0
-SkiaSharp.Views.WindowsForms                    nuget       4.151.0
-SkiaSharp.Views.WPF                             nuget       4.151.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.151.0
-SkiaSharp.Views.WinUI                           nuget       4.151.0
-SkiaSharp.Views.Maui.Core                       nuget       4.151.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.151.0
-SkiaSharp.Views.Blazor                          nuget       4.151.0
-SkiaSharp.HarfBuzz                              nuget       4.151.0
-SkiaSharp.Skottie                               nuget       4.151.0
-SkiaSharp.SceneGraph                            nuget       4.151.0
-SkiaSharp.Resources                             nuget       4.151.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.151.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.151.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.151.0
+SkiaSharp                                       nuget       4.152.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
+SkiaSharp.NativeAssets.Android                  nuget       4.152.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
+SkiaSharp.Views                                 nuget       4.152.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
+SkiaSharp.Views.Gtk3                            nuget       4.152.0
+SkiaSharp.Views.Gtk4                            nuget       4.152.0
+SkiaSharp.Views.WindowsForms                    nuget       4.152.0
+SkiaSharp.Views.WPF                             nuget       4.152.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
+SkiaSharp.Views.WinUI                           nuget       4.152.0
+SkiaSharp.Views.Maui.Core                       nuget       4.152.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
+SkiaSharp.Views.Blazor                          nuget       4.152.0
+SkiaSharp.HarfBuzz                              nuget       4.152.0
+SkiaSharp.Skottie                               nuget       4.152.0
+SkiaSharp.SceneGraph                            nuget       4.152.0
+SkiaSharp.Resources                             nuget       4.152.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -3,7 +3,7 @@ variables:
   # It must match the SkiaSharp nuget version in scripts/VERSIONS.txt.
   # SKIASHARP_VERSION is used in the BUILD_NUMBER counter expression below,
   # which requires a compile-time constant (cannot be derived dynamically).
-  SKIASHARP_VERSION: 4.151.0
+  SKIASHARP_VERSION: 4.152.0
   FEATURE_NAME_PREFIX: 'feature/'
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)


### PR DESCRIPTION
Automated Skia milestone bump from m151 to m152.

**Companion skia PR:** https://github.com/mono/skia/pull/335

## mono/SkiaSharp — Update Skia to milestone 152

Bumps the Skia submodule from m151 to m152 (upstream `chrome/m152`, tip `2a9b593bab`).

Requires the paired mono/skia PR to land first (see submodule branch `skia-sync/m152`).

### Version updates

| File | Change |
|---|---|
| `scripts/VERSIONS.txt` | `libSkiaSharp milestone`: 151 → 152; NuGet `4.151.0` → `4.152.0` (all ~30 lines); `SK_C_INCREMENT` reset to 0 |
| `cgmanifest.json` | `chrome_milestone`: 151 → 152; `commitHash`/`version`: submodule HEAD `9dbe988c1a…`; `upstream_merge_commit`: `2a9b593bab…` |
| `scripts/azure-templates-variables.yml` | `SKIASHARP_VERSION`: 4.151.0 → 4.152.0 |
| `externals/skia/include/c/sk_types.h` | `SK_C_INCREMENT` reset to 0 (committed inside the submodule PR) |

### Breaking change analysis (m151 → m152)

From upstream `RELEASE_NOTES.md`:

| Change | Impact on SkiaSharp |
|---|---|
| `SkPath::updateBoundsCache()` removed | 🟢 Not referenced anywhere in `externals/skia/src/c`, `include/c`, or `binding/SkiaSharp/` (grep clean) — no wrapper affected |
| `SkRRect::contains(const SkPoint&)` added | 🟢 Additive; no C API impact yet |
| `skgpu::graphite::ContextOptions::fAvoidDepth` added | 🟢 Additive; graphite-only, not surfaced through the C API |
| `SkIcoRustDecoder` (opt-in via `skia_use_rust_ico_decode`) | 🟢 Opt-in; not enabled in our `build.cake` |

No HIGH/MEDIUM-risk C++ API changes intersect our C shim. Consistent with regenerating produced zero binding diff.

### Binding regeneration

`pwsh ./utils/generate.ps1` (via `regenerate-bindings.ps1`) produced **no diff** in `binding/SkiaSharp/SkiaApi.generated.cs` — C API signatures are unchanged this milestone. `binding/HarfBuzzSharp/HarfBuzzApi.generated.cs` was auto-reverted (HarfBuzz updates ship separately, per skill policy). No new `+internal static` bindings; no new C# wrappers needed.

### Native build (Linux x64)

- First attempt failed on `VulkanAMDMemoryAllocator.cpp`: upstream m152 uses newer VMA APIs (`VmaAllocationCreateInfo::minAlignment`, `vkGetPhysicalDeviceProperties2KHR` in `VmaVulkanFunctions`) that our old VMA pin didn't have.
- Fix (in the mono/skia PR): roll `vulkanmemoryallocator` and `vulkan-headers` `DEPS` pins to upstream m152 SHAs.
- After the DEPS bump: `dotnet cake --target=externals-linux --arch=x64` → succeeded (`libSkiaSharp` in ~12m, `libHarfBuzzSharp` in ~1m, soname `libSkiaSharp.so.0.152.0.0`).

### C# build & tests

- `dotnet build binding/SkiaSharp/SkiaSharp.csproj` → 0 errors, 4 warnings (all pre-existing NETSDK1202 `net9.0-android` EOL notices).
- `dotnet test tests/SkiaSharp.Tests.Console.slnx` with `SKIASHARP_TEST_SKIP_GPU=all`:
  - `SkiaSharp.Tests.dll`: **Failed 0, Passed 5922, Skipped 202**
  - `SkiaSharp.Direct3D.Tests.dll`: Passed 2, Skipped 3 (D3D unavailable on Linux — expected)
  - `SkiaSharp.Vulkan.Tests.dll`: Passed 4, Skipped 21 (no Vulkan ICD in sandbox — see below)
  - `SkiaSharp.Tests.SingletonInit.dll`: Passed 1
- Full log at `/tmp/gh-aw/agent/test-output.txt` (uploaded as workflow artifact).

### Items needing human attention

- **GPU tests only pass when `SKIASHARP_TEST_SKIP_GPU=all` is set** in this sandbox. Without it: 169 ganesh-gl tests fail with `System.Exception: Failed to open X display` (no X server) and 19 Vulkan tests fail with `System.InvalidOperationException: vkCreateInstance failed` (no Vulkan ICD). These are host-environment gaps for this runner — not milestone regressions (would fail identically on m151 in the same sandbox). Fixing them requires installing an X server / a Vulkan ICD (Mesa lavapipe or swiftshader) at workflow-setup time. Per the workflow prompt, host-dependency gaps are workflow bugs, not code hacks.
- **Native build was only exercised on Linux x64.** macOS/Windows/iOS/Android/WASM builds will be exercised by CI on the PR; the VMA / vulkan-headers `DEPS` bump is expected to be a no-op there (same VMA sources compile), but worth watching in the AzDO native pipeline.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).