### PR TITLE
Enable TransparentBackground for SkiaSharp.Views.WPF.SKGLElement

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKGLElement.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKGLElement.cs
@@ -50,7 +50,12 @@ namespace SkiaSharp.Views.WPF
 		private void Initialize()
 		{
 			designMode = DesignerProperties.GetIsInDesignMode(this);
-			var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false };
+#if NETCOREAPP
+			var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false, TransparentBackground = true};
+#else
+			var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false};
+
+#endif
 
 			this.Render += OnPaint;
 


### PR DESCRIPTION
## Description

This pull request fixes the difference in transparency behavior between `SkiaSharp.Views.WPF.SKGLElement` and `SkiaSharp.Views.WPF.SKElement`. (SKGLElement did not allow transparent backgrounds, SKElement did)

**Related issues**

**Required skia PR**

None.

<!--
Touching the C API or the externals/skia submodule? Replace "None." above with:

Requires https://github.com/mono/skia/pull/<number>

Native changes also require committing inside externals/skia (then `git add externals/skia`
here) and re-running `pwsh ./utils/generate.ps1` to regenerate + commit SkiaApi.generated.cs.
-->

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [x] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Enables the `TransparentBackground `flag inside `GLWpfControlSettings `if it is available

<!--
Scope: your PUBLIC API surface and any observable BEHAVIOR — NOT a file-by-file
list. The diff already shows which files changed; the "what & why" narrative
belongs in Description above. A CI-only or refactor PR that changes neither can
just leave "None." (a short qualifier is fine, e.g.
"None — CI-only, no public API or behavior change.").

Otherwise copy the parts that apply over "None." and delete the rest:

**Public API**

STRICT stable ABI — additive only: no removals, no signature or return-type
changes; deprecate with [Obsolete] rather than removing. List the exact signatures:

```csharp
// added
public bool SKPath.TryGetTightBounds(out SKRect bounds);

// deprecated (kept for compatibility)
[Obsolete("Use TryGetTightBounds instead.")]
public SKRect SKPath.GetTightBounds();
```

**Behavior**

What an app would notice after upgrading — rendering output, defaults, thrown
exceptions, threading, or memory ownership — and the impact. Keep it to a line or two.
-->

## Testing
Manually tested:
| Before | After |
| --- | --- |
| <img width="786" height="443" alt="image" src="https://github.com/user-attachments/assets/18f5ed3c-f1a8-403c-8e21-b46429f9fa2a" />| <img width="786" height="443" alt="image" src="https://github.com/user-attachments/assets/e2107c12-4daa-4cdf-a04e-c3a63d1df207" /> |

MainWindow.xaml:
```
<Window x:Class="SkiaGLCheck.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:skia="clr-namespace:SkiaSharp.Views.WPF;assembly=SkiaSharp.Views.WPF"
        xmlns:local="clr-namespace:SkiaGLCheck"
        mc:Ignorable="d"
        Title="MainWindow" Height="450" Width="800"
        Background="White">
    <Grid>
        <Label>This text was not visible before.</Label>
        <skia:SKGLElement PaintSurface="SKGLElement_PaintSurface"/>
    </Grid>
</Window>
```

MainWindow.xaml.cs:
```
using SkiaSharp;
using System.Windows;

namespace SkiaGLCheck
{
    /// <summary>
    /// Interaction logic for MainWindow.xaml
    /// </summary>
    public partial class MainWindow : Window
    {
        public MainWindow()
        {
            InitializeComponent();
        }

        private void SKGLElement_PaintSurface(object sender, SkiaSharp.Views.Desktop.SKPaintGLSurfaceEventArgs e)
        {
            e.Surface.Canvas.Clear(SKColors.Transparent);
        }
    }
}
```

<!--
How did you verify this? Add or update tests where relevant, and note which
backends/platforms you ran on (CPU, GPU/Metal/Vulkan/ANGLE, Windows/macOS/Linux/
Android/iOS/tvOS/Tizen/WASM) and anything you could NOT test.

Rendering change? Mention golden-image updates (tests/Content/Goldens/) and copy
this in to show the difference:

<details>
<summary>Screenshots (before / after)</summary>

| Before | After |
| --- | --- |
|  |  |

</details>
-->

## Checklist

- [ ] Tests added or updated (if omitted, explain why above)
- [ ] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated
