### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "409aad73a2579c2306607b40fcbd3166bc8aea13"
+          "commitHash": "96caaf84225bf02141ba265fb9c4de0a712bfaa3"
         }
       }
     },
@@ -231,7 +231,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a7fb0b3c2e109e4e68f50bf823cf6b8d524c4a0c"
+      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "96caaf84225bf02141ba265fb9c4de0a712bfaa3"
+          "commitHash": "73959289693c85303585463d7998de32c6249457"
         }
       }
     },


### PR DESCRIPTION
Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

**Companion skia PR:** https://github.com/mono/skia/pull/336

## Release-line bug-fix sync (m150 → m150)

Same-milestone sync on `release/4.150.x`. Advances the `externals/skia`
submodule to pick up two upstream m150 bug fixes from `chrome/m150`.
No milestone/soname/nuget version bump per release-line policy.

## Breaking change analysis

None. Upstream diff on the m150 line only touches SkSL raster-pipeline codegen
internals and infra tooling — no public header changes, no C API surface
changes, no ABI impact. `git diff` on `binding/**` after regeneration is
empty, confirming no bindings changed.

## Version / binding updates

Only `cgmanifest.json` changes in the parent repo:

- `commitHash`: `409aad73…` → `96caaf84…` (mono/skia merge commit on `skia-sync/release-4.150.x`)
- `upstream_merge_commit`: `a7fb0b3c…` → `a81173f1…` (upstream/chrome/m150 tip)

`scripts/VERSIONS.txt`, `scripts/azure-templates-variables.yml`, and
`externals/skia/include/c/sk_types.h` (`SK_C_INCREMENT`) are unchanged, as
required for a release-line sync.

## C# changes

None. `pwsh ./utils/generate.ps1` (invoked via `dotnet run` since the
sandbox's `pwsh` install is missing its cmdlet assemblies — see below)
regenerated every project and produced a zero-line diff against
`binding/`. HarfBuzz was reverted proactively but had no changes either.

## Build / test results

- **Native (Linux x64)**: `dotnet cake --target=externals-linux --arch=x64` ✅
  (`libSkiaSharp` 14m13s, `libHarfBuzzSharp` 1m10s, total 15m35s).
- **Managed**: `dotnet build binding/SkiaSharp/SkiaSharp.csproj` ✅ 0 errors.
- **Tests**: `dotnet test tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj` ✅
  `Passed: 5584, Failed: 0, Skipped: 172, Total: 5756` (2m48s).
  Full log at workflow artifact `test-output.txt`.

## Items needing human attention

- **Sandbox `pwsh` is broken.** `/opt/microsoft/powershell/7`'s
  `Microsoft.PowerShell.Commands.Management.dll` /
  `Microsoft.PowerShell.Commands.Utility.dll` live in the pwsh install root
  but the module manifests can't resolve them, so every basic cmdlet
  (`New-Item`, `Get-ChildItem`, `Write-Host`, …) fails with
  "term not recognized" and `startIndex cannot be larger than length of
  string`. This broke both `.agents/skills/update-skia/scripts/update-versions.ps1`
  and `.agents/skills/update-skia/scripts/regenerate-bindings.ps1` and
  `utils/generate.ps1` in this workflow. Worked around by (a) editing
  `cgmanifest.json` from Python (only field changes needed for a
  release-line sync) and (b) invoking the generator directly with
  `dotnet run --project=utils/SkiaSharpGenerator/…`. **Fix the workflow's
  `Install native build dependencies`/agent image so `pwsh` cmdlets load;
  otherwise every future run of this skill in the sandbox will hit the same
  wall.**
- No other items.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).