### PR TITLE
Backport review-skia-update skill to 4.151.x

### DIFF
--- a/.agents/skills/review-skia-update/references/csharp-review.md
+++ b/.agents/skills/review-skia-update/references/csharp-review.md
@@ -54,7 +54,9 @@ Skia updates often change platform behavior. Check:
 Check `tests/Tests/` for:
 - New tests covering new APIs
 - Updated tests reflecting changed behavior
-- No skipped tests (except hardware-dependent: GPU, display)
+- No newly skipped tests. GPU coverage is defined by the existing host/platform
+  `GpuPolicy`; missing hardware or a failed bring-up for a required backend is a failure.
+  Flag any PR that adds or expands a skip instead of fixing the environment or backend.
 
 ## Output Format
 

--- a/.agents/skills/review-skia-update/scripts/check_companion.py
+++ b/.agents/skills/review-skia-update/scripts/check_companion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Check companion SkiaSharp PR: categorize changed files and produce diffs.
 
-Compares the companion PR branch against the SkiaSharp main branch.
+Compares the companion PR branch against the companion PR's actual base commit.
 Filters out generated files (*Api.generated.cs) and produces the same
 sourceFile structure used by upstream/interop integrity checks.
 """
@@ -67,7 +67,7 @@ def run_check(
     """
     eprint("▸ Companion PR file analysis")
 
-    # Find the merge base between main and the PR
+    # Find the merge base between the companion base and the PR head.
     merge_base = git_run(
         ["merge-base", base_ref, pr_ref],
         cwd=repo_root,

--- a/.agents/skills/review-skia-update/scripts/check_generated_files.py
+++ b/.agents/skills/review-skia-update/scripts/check_generated_files.py
@@ -3,10 +3,10 @@
 
 Assumes the working tree is already checked out to the correct state
 (SkiaSharp companion PR + skia submodule at PR head — done by the orchestrator).
-Runs utils/generate.ps1, then uses git diff to check if the regenerated
-files match what's checked in. Any diff = FAIL.
-HarfBuzzSharp is excluded — harfbuzz updates are never part of a Skia update,
-so the generated file is reverted to HEAD before comparison.
+Runs the local Python binding helper, then uses git diff to
+check if the regenerated files match what's checked in. Any diff = FAIL.
+The generator owns deterministic ordering across hosts. The helper restores
+HarfBuzzSharp because HarfBuzz updates are separate.
 """
 import argparse
 import os
@@ -34,10 +34,21 @@ def run_check(repo_root: str, output_dir: str) -> dict:
     generator_log = os.path.join(output_dir, "generator-output.log")
 
     # --- Step 1: Run the generator and capture raw output as proof of execution ---
-    eprint(f"🔄 Running utils/generate.ps1 (capturing output to {generator_log})...")
+    helper = os.path.join(
+        repo_root,
+        ".agents",
+        "skills",
+        "review-skia-update",
+        "scripts",
+        "regenerate_bindings.py",
+    )
+    eprint(
+        "🔄 Running review-skia-update/scripts/regenerate_bindings.py "
+        f"(capturing output to {generator_log})..."
+    )
     try:
         proc = subprocess.Popen(
-            ["pwsh", "./utils/generate.ps1"],
+            [sys.executable, helper],
             cwd=repo_root,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/.agents/skills/review-skia-update/scripts/regenerate_bindings.py
+++ b/.agents/skills/review-skia-update/scripts/regenerate_bindings.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+"""Regenerate and review the maintained native bindings during Phase 08.
+
+This helper runs every generator configuration and reports new P/Invoke
+functions that may need a hand-written wrapper decision. The generator itself
+owns deterministic ordering across hosts.
+"""
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+PROJECTS = (
+    (
+        "libSkiaSharp.json",
+        "externals/skia",
+        "SkiaSharp/SkiaApi.generated.cs",
+    ),
+    (
+        "libSkiaSharp.Skottie.json",
+        "externals/skia",
+        "SkiaSharp.Skottie/SkottieApi.generated.cs",
+    ),
+    (
+        "libSkiaSharp.SceneGraph.json",
+        "externals/skia",
+        "SkiaSharp.SceneGraph/SceneGraphApi.generated.cs",
+    ),
+    (
+        "libSkiaSharp.Resources.json",
+        "externals/skia",
+        "SkiaSharp.Resources/ResourcesApi.generated.cs",
+    ),
+    (
+        "libHarfBuzzSharp.json",
+        "externals/skia/third_party/externals/harfbuzz",
+        "HarfBuzzSharp/HarfBuzzApi.generated.cs",
+    ),
+)
+
+
+def run(repo_root: Path, *args: str, capture: bool = False) -> str:
+    result = subprocess.run(
+        [*args],
+        cwd=repo_root,
+        check=True,
+        capture_output=capture,
+        text=True,
+    )
+    return result.stdout if capture else ""
+
+
+def select_projects(config: str | None):
+    """Select one generator config or the complete maintained binding set."""
+    if config is None:
+        return PROJECTS
+    name = Path(config).name
+    selected = tuple(project for project in PROJECTS if project[0] == name)
+    if not selected:
+        valid = ", ".join(project[0] for project in PROJECTS)
+        raise ValueError(f"Unknown config '{config}'. Valid configs: {valid}")
+    return selected
+
+
+def added_internal_functions(diff: str) -> list[str]:
+    """Extract newly generated P/Invoke declarations from a Git diff."""
+    return [
+        line[1:].strip()
+        for line in diff.splitlines()
+        if line.startswith("+") and not line.startswith("+++") and "internal static" in line
+    ]
+
+
+def regenerate(repo_root: Path, config: str | None = None) -> None:
+    """Run every selected generator and summarize wrapper work."""
+    generator_project = (
+        repo_root / "utils" / "SkiaSharpGenerator" / "SkiaSharpGenerator.csproj"
+    )
+    generated_directory = repo_root / "output" / "generated"
+    generated_directory.mkdir(parents=True, exist_ok=True)
+
+    run(repo_root, "dotnet", "build", str(generator_project))
+    for config_name, source_root, output in select_projects(config):
+        output_path = repo_root / "binding" / output
+        command = (
+            "dotnet",
+            "run",
+            "--no-build",
+            "--no-launch-profile",
+            f"--project={generator_project}",
+            "--",
+            "generate",
+            "--config",
+            str(repo_root / "binding" / config_name),
+            "--root",
+            str(repo_root / source_root),
+            "--output",
+            str(output_path),
+        )
+        print(" ".join(str(part) for part in command))
+        run(repo_root, *command)
+        shutil.copy2(output_path, generated_directory / output_path.name)
+
+    harfbuzz = "binding/HarfBuzzSharp/HarfBuzzApi.generated.cs"
+    harfbuzz_status = subprocess.run(
+        ["git", "diff", "--quiet", "--", harfbuzz],
+        cwd=repo_root,
+        check=False,
+    ).returncode
+    if harfbuzz_status == 1:
+        run(repo_root, "git", "restore", "--source=HEAD", "--", harfbuzz)
+        print(f"Reverted {harfbuzz}; HarfBuzz updates are separate.")
+    elif harfbuzz_status != 0:
+        raise RuntimeError("Could not inspect the HarfBuzz binding diff.")
+
+    binding_stat = run(repo_root, "git", "diff", "--stat", "--", "binding/", capture=True)
+    print("Binding diff summary:")
+    print(binding_stat.rstrip() or "  No binding changes.")
+
+    skia_diff = run(
+        repo_root,
+        "git",
+        "diff",
+        "--",
+        "binding/SkiaSharp/SkiaApi.generated.cs",
+        capture=True,
+    )
+    functions = added_internal_functions(skia_diff)
+    if functions:
+        print("New generated functions requiring wrapper review:")
+        for function in functions:
+            print(f"  {function}")
+    else:
+        print("No new generated functions.")
+
+    print("GATE PASSED: binding regeneration completed.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Regenerate SkiaSharp bindings and report wrapper work."
+    )
+    parser.add_argument("--config")
+    parser.add_argument("--repo-root", type=Path)
+    args = parser.parse_args()
+    repo_root = (
+        args.repo_root.resolve()
+        if args.repo_root
+        else Path(__file__).resolve().parents[4]
+    )
+    regenerate(repo_root, args.config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/review-skia-update/scripts/run_review.py
+++ b/.agents/skills/review-skia-update/scripts/run_review.py
@@ -100,6 +100,37 @@ def extract_skia_milestone_from_cgmanifest(cgmanifest: dict):
     return None
 
 
+def extract_skia_upstream_commit_from_cgmanifest(cgmanifest: dict):
+    """Extract the exact upstream Skia commit recorded by cgmanifest.json."""
+    for reg in cgmanifest.get("registrations", []):
+        comp = reg.get("component", {}).get("other", {})
+        if comp.get("name") == "skia":
+            commit = reg.get("upstream_merge_commit", "").strip()
+            return commit or None
+    return None
+
+
+def extract_skia_upstream_ref_from_cgmanifest(cgmanifest: dict):
+    """Extract the authoritative upstream ref, with milestone fallback for old manifests."""
+    for reg in cgmanifest.get("registrations", []):
+        comp = reg.get("component", {}).get("other", {})
+        if comp.get("name") == "skia":
+            upstream_ref = reg.get("upstream_ref", "").strip()
+            return upstream_ref or extract_skia_milestone_from_cgmanifest(cgmanifest)
+    return None
+
+
+def recorded_commit_belongs_to_upstream(cwd: str, commit: str, upstream_ref: str) -> bool:
+    """Return whether a recorded commit belongs to the fetched upstream branch history."""
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", commit, upstream_ref],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Run all mechanical checks for a Skia update review."
@@ -250,9 +281,21 @@ def main():
 
     old_cgmanifest = load_json_at_git_ref(repo_root, companion_base_sha, "cgmanifest.json")
     old_milestone = extract_skia_milestone_from_cgmanifest(old_cgmanifest)
+    old_upstream_ref = extract_skia_upstream_ref_from_cgmanifest(old_cgmanifest)
+    old_upstream_sha = extract_skia_upstream_commit_from_cgmanifest(old_cgmanifest)
     if not old_milestone:
         raise RuntimeError(
             f"Could not determine old upstream milestone from companion PR base "
+            f"{companion_base_sha[:12]}:cgmanifest.json"
+        )
+    if not old_upstream_sha:
+        raise RuntimeError(
+            f"Could not determine old upstream commit from companion PR base "
+            f"{companion_base_sha[:12]}:cgmanifest.json"
+        )
+    if not old_upstream_ref:
+        raise RuntimeError(
+            f"Could not determine old upstream ref from companion PR base "
             f"{companion_base_sha[:12]}:cgmanifest.json"
         )
 
@@ -276,50 +319,78 @@ def main():
     # Check cgmanifest.json from companion PR head
     companion_head_sha = companion_pr.get("headRefOid", "").strip()
     cgmanifest_milestone = None
+    new_upstream_ref = None
+    new_upstream_sha = None
     if companion_head_sha and len(companion_head_sha) >= 7:
         new_cgmanifest = load_json_at_git_ref(repo_root, companion_head_sha, "cgmanifest.json")
         cgmanifest_milestone = extract_skia_milestone_from_cgmanifest(new_cgmanifest)
+        new_upstream_ref = extract_skia_upstream_ref_from_cgmanifest(new_cgmanifest)
+        new_upstream_sha = extract_skia_upstream_commit_from_cgmanifest(new_cgmanifest)
     if cgmanifest_milestone and cgmanifest_milestone != caller_milestone:
         eprint(
             f"   ⚠ cgmanifest.json records {cgmanifest_milestone}, "
             f"but --milestone says {caller_milestone}"
         )
+    if not new_upstream_sha:
+        raise RuntimeError(
+            f"Could not determine new upstream commit from companion PR head "
+            f"{companion_head_sha[:12]}:cgmanifest.json"
+        )
+    if not new_upstream_ref:
+        raise RuntimeError(
+            f"Could not determine new upstream ref from companion PR head "
+            f"{companion_head_sha[:12]}:cgmanifest.json"
+        )
 
-    new_milestone = caller_milestone
-
-    eprint(f"   New upstream: {new_milestone}")
-    eprint(f"   Old upstream: {old_milestone}")
+    eprint(f"   New upstream: {new_upstream_ref}")
+    eprint(f"   Old upstream: {old_upstream_ref}")
 
     # 1e. Fetch git refs
     eprint("▸ Fetching git refs...")
     ensure_remote(skia_root, "upstream", "https://github.com/google/skia.git")
-    run_git(["fetch", "upstream", old_milestone, new_milestone], cwd=skia_root)
+    run_git(
+        ["fetch", "upstream", *dict.fromkeys([old_upstream_ref, new_upstream_ref])],
+        cwd=skia_root,
+    )
     # Fetch the base branch and the PR head via GitHub's PR ref. This works for
     # both same-repo and fork PRs — the branch name only exists on the fork's
     # remote, but refs/pull/{N}/head is always available on origin.
     skia_base_ref = pr.get("baseRefName", "skiasharp")
     run_git(["fetch", "origin", skia_base_ref, f"pull/{skia_pr_number}/head"], cwd=skia_root)
 
-    # Verify upstream branches exist
-    old_result = subprocess.run(
-        ["git", "rev-parse", f"upstream/{old_milestone}"],
-        cwd=skia_root, capture_output=True, text=True,
-    )
-    if old_result.returncode != 0:
-        raise RuntimeError(f"Old upstream branch upstream/{old_milestone} not found: {old_result.stderr.strip()}")
-    old_upstream_sha = old_result.stdout.strip()
-    if not old_upstream_sha or len(old_upstream_sha) < 7:
-        raise RuntimeError(f"Old upstream branch upstream/{old_milestone} resolved to invalid SHA: {old_upstream_sha!r}")
+    # Milestone branches can advance after an update. The exact commits recorded by
+    # the companion base/head are authoritative for the diff-of-diffs review.
+    for label, sha in (("old", old_upstream_sha), ("new", new_upstream_sha)):
+        present = subprocess.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            cwd=skia_root,
+            capture_output=True,
+            text=True,
+        )
+        if present.returncode != 0:
+            run_git(["fetch", "--no-tags", "upstream", sha], cwd=skia_root)
+        verify = subprocess.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            cwd=skia_root,
+            capture_output=True,
+            text=True,
+        )
+        if verify.returncode != 0:
+            raise RuntimeError(
+                f"Recorded {label} upstream commit {sha!r} is unavailable: "
+                f"{verify.stderr.strip()}"
+            )
 
-    new_result = subprocess.run(
-        ["git", "rev-parse", f"upstream/{new_milestone}"],
-        cwd=skia_root, capture_output=True, text=True,
-    )
-    if new_result.returncode != 0:
-        raise RuntimeError(f"New upstream branch upstream/{new_milestone} not found: {new_result.stderr.strip()}")
-    new_upstream_sha = new_result.stdout.strip()
-    if not new_upstream_sha or len(new_upstream_sha) < 7:
-        raise RuntimeError(f"New upstream branch upstream/{new_milestone} resolved to invalid SHA: {new_upstream_sha!r}")
+    for label, sha, upstream_ref in (
+        ("old", old_upstream_sha, f"upstream/{old_upstream_ref}"),
+        ("new", new_upstream_sha, f"upstream/{new_upstream_ref}"),
+    ):
+        if not recorded_commit_belongs_to_upstream(skia_root, sha, upstream_ref):
+            raise RuntimeError(
+                f"Recorded {label} upstream commit {sha} does not belong to "
+                f"{upstream_ref}. The companion cgmanifest may contain a fork head "
+                "instead of the exact upstream commit."
+            )
 
     # Use PR metadata for base SHA; fall back to resolving the ref
     base_sha = pr.get("baseRefOid", "").strip()
@@ -439,8 +510,8 @@ def main():
     try:
         source_result = check_source.run_check(
             skia_root=skia_root,
-            old_upstream_branch=f"upstream/{old_milestone}",
-            new_upstream_branch=f"upstream/{new_milestone}",
+            old_upstream_branch=old_upstream_sha,
+            new_upstream_branch=new_upstream_sha,
             base_sha=base_sha,
             pr_head=pr_head_sha,
             output_dir=output_dir,
@@ -457,7 +528,7 @@ def main():
             skia_root=skia_root,
             base_sha=base_sha,
             pr_head=pr_head_sha,
-            upstream_branch=f"upstream/{new_milestone}",
+            upstream_branch=new_upstream_sha,
             output_dir=output_dir,
         )
     except Exception as exc:
@@ -468,11 +539,10 @@ def main():
     # Step 5 — Companion PR Files
     eprint("═══ Step 5 — Companion PR ═══")
     try:
-        run_git(["fetch", "origin", "main"], cwd=repo_root)
         companion_result = check_companion.run_check(
             repo_root=repo_root,
-            base_ref="origin/main",
-            pr_ref="HEAD",
+            base_ref=companion_base_sha,
+            pr_ref=companion_head_sha,
             output_dir=output_dir,
         )
     except Exception as exc:
@@ -494,8 +564,8 @@ def main():
             "prTitle": pr["title"],
             "prState": pr["state"],
             "prAuthor": pr.get("author", {}).get("login", ""),
-            "oldUpstreamBranch": old_milestone,
-            "upstreamBranch": new_milestone,
+            "oldUpstreamBranch": old_upstream_ref,
+            "upstreamBranch": new_upstream_ref,
             "shas": {
                 "prHead": pr_head_sha,
                 "base": base_sha,

--- a/.agents/skills/review-skia-update/scripts/run_review_test.py
+++ b/.agents/skills/review-skia-update/scripts/run_review_test.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import patch
+
+from run_review import (
+    extract_skia_milestone_from_cgmanifest,
+    extract_skia_upstream_commit_from_cgmanifest,
+    extract_skia_upstream_ref_from_cgmanifest,
+    recorded_commit_belongs_to_upstream,
+)
+
+
+class RunReviewTests(unittest.TestCase):
+    def test_extracts_exact_skia_registration(self) -> None:
+        manifest = {
+            "registrations": [
+                {"component": {"other": {"name": "other", "version": "1"}}},
+                {
+                    "component": {
+                        "other": {
+                            "name": "skia",
+                            "version": "chrome/m152",
+                        }
+                    },
+                    "chrome_milestone": 152,
+                    "upstream_merge_commit": "abc123",
+                },
+            ]
+        }
+
+        self.assertEqual(
+            "chrome/m152", extract_skia_milestone_from_cgmanifest(manifest)
+        )
+        self.assertEqual(
+            "abc123", extract_skia_upstream_commit_from_cgmanifest(manifest)
+        )
+        self.assertEqual(
+            "chrome/m152", extract_skia_upstream_ref_from_cgmanifest(manifest)
+        )
+
+    def test_returns_none_when_skia_registration_is_missing(self) -> None:
+        manifest = {"registrations": []}
+
+        self.assertIsNone(extract_skia_milestone_from_cgmanifest(manifest))
+        self.assertIsNone(extract_skia_upstream_commit_from_cgmanifest(manifest))
+        self.assertIsNone(extract_skia_upstream_ref_from_cgmanifest(manifest))
+
+    def test_extracts_explicit_main_upstream_ref(self) -> None:
+        manifest = {
+            "registrations": [
+                {
+                    "component": {
+                        "other": {
+                            "name": "skia",
+                            "version": "chrome/m152",
+                        }
+                    },
+                    "chrome_milestone": 152,
+                    "upstream_ref": "main",
+                    "upstream_merge_commit": "abc123",
+                },
+            ]
+        }
+
+        self.assertEqual(
+            "main", extract_skia_upstream_ref_from_cgmanifest(manifest)
+        )
+
+    @patch("run_review.subprocess.run")
+    def test_accepts_commit_from_upstream_history(self, run) -> None:
+        run.return_value.returncode = 0
+
+        self.assertTrue(
+            recorded_commit_belongs_to_upstream(
+                "/repo",
+                "target-sha",
+                "upstream/chrome/m152",
+            )
+        )
+
+    @patch("run_review.subprocess.run")
+    def test_rejects_fork_head_as_upstream_commit(self, run) -> None:
+        run.return_value.returncode = 1
+
+        self.assertFalse(
+            recorded_commit_belongs_to_upstream(
+                "/repo",
+                "fork-head",
+                "upstream/chrome/m152",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Description of Change**

Backport the complete `.agents/skills/review-skia-update` skill from `origin/main` to `release/4.151.x`, including references, scripts, viewer, the local `regenerate_bindings.py` helper, and focused tests.

**Bugs Fixed**

- Fixes #

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**PR Checklist**

- [x] Has tests (focused Python tests included and passing)
- [x] Rebased on top of main at time of PR
- [x] Merged related skia PRs
- [x] Changes adhere to coding standard
- [x] Updated documentation

Validation: `python -m unittest run_review_test.py` (5 passed); `python -m compileall -q .agents\skills\review-skia-update\scripts`; exact-tree comparison against `origin/main` passed.