### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11,6 +11,12 @@
           "version": "1.6.58",
           "downloadUrl": "https://github.com/pnggroup/libpng"
         }
+      },
+      "skia_dependency": {
+        "name": "libpng",
+        "revision": "3061454d980de7d53608f594194cfac722721d2a",
+        "version_reviewed_identity": "https://skia.googlesource.com/third_party/libpng.git@3061454d980de7d53608f594194cfac722721d2a",
+        "version_source": "png.h: #define PNG_LIBPNG_VER_STRING \"1.6.58\""
       }
     },
     {
@@ -22,6 +28,12 @@
           "version": "1.3.2",
           "downloadUrl": "https://github.com/madler/zlib"
         }
+      },
+      "skia_dependency": {
+        "name": "zlib",
+        "revision": "89921383f1f51331f48a2dc843403779770ea3a9",
+        "version_reviewed_identity": "https://chromium.googlesource.com/chromium/src/third_party/zlib@89921383f1f51331f48a2dc843403779770ea3a9",
+        "version_source": "zlib.h: #define ZLIB_VERSION \"1.3.2.1-motley\" (Chromium fork of zlib 1.3.2)"
       }
     },
     {
@@ -32,6 +44,12 @@
           "version": "3.1.4.1",
           "downloadUrl": "https://github.com/libjpeg-turbo/libjpeg-turbo"
         }
+      },
+      "skia_dependency": {
+        "name": "libjpeg-turbo",
+        "revision": "9217719d3a58633923b096af4c1d50d304768a64",
+        "version_reviewed_identity": "https://github.com/libjpeg-turbo/libjpeg-turbo.git@9217719d3a58633923b096af4c1d50d304768a64",
+        "version_source": "CMakeLists.txt: set(VERSION 3.1.4.1)"
       }
     },
     {
@@ -42,6 +60,12 @@
           "version": "1.6.0",
           "downloadUrl": "https://github.com/webmproject/libwebp"
         }
+      },
+      "skia_dependency": {
+        "name": "libwebp",
+        "revision": "4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "version_reviewed_identity": "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "version_source": "configure.ac: AC_INIT([libwebp], [1.6.0], ...)"
       }
     },
     {
@@ -52,6 +76,12 @@
           "version": "2.14.3",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
+      },
+      "skia_dependency": {
+        "name": "freetype",
+        "revision": "0a0221a1347e2f1e07c395263540026e9a0aa7c7",
+        "version_reviewed_identity": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@0a0221a1347e2f1e07c395263540026e9a0aa7c7",
+        "version_source": "include/freetype/freetype.h: FREETYPE_MAJOR 2, FREETYPE_MINOR 14, FREETYPE_PATCH 3"
       }
     },
     {
@@ -62,6 +92,12 @@
           "version": "14.2.1",
           "downloadUrl": "https://github.com/harfbuzz/harfbuzz"
         }
+      },
+      "skia_dependency": {
+        "name": "harfbuzz",
+        "revision": "56feae4035bdd48f62ba2b8d8c16232d4d89b3a4",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@56feae4035bdd48f62ba2b8d8c16232d4d89b3a4",
+        "version_source": "src/hb-version.h: #define HB_VERSION_STRING \"14.2.1\""
       }
     },
     {
@@ -72,6 +108,12 @@
           "version": "2.8.1",
           "downloadUrl": "https://github.com/libexpat/libexpat"
         }
+      },
+      "skia_dependency": {
+        "name": "expat",
+        "revision": "c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
+        "version_source": "expat/lib/expat.h: XML_MAJOR_VERSION 2, XML_MINOR_VERSION 8, XML_MICRO_VERSION 1"
       }
     },
     {
@@ -82,6 +124,12 @@
           "version": "1.2.0",
           "downloadUrl": "https://github.com/google/brotli"
         }
+      },
+      "skia_dependency": {
+        "name": "brotli",
+        "revision": "028fb5a23661f123017c060daa546b55cf4bde29",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/google/brotli.git@028fb5a23661f123017c060daa546b55cf4bde29",
+        "version_source": "c/common/version.h: BROTLI_VERSION_MAJOR 1, BROTLI_VERSION_MINOR 2, BROTLI_VERSION_PATCH 0"
       }
     },
     {
@@ -92,6 +140,12 @@
           "version": "0.3.3",
           "downloadUrl": "https://github.com/google/wuffs-mirror-release-c"
         }
+      },
+      "skia_dependency": {
+        "name": "wuffs",
+        "revision": "e3f919ccfe3ef542cfc983a82146070258fb57f8",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+        "version_source": "release/c/wuffs-v0.3.c: #define WUFFS_VERSION_STRING \"0.3.3+3399.20230408\""
       }
     },
     {
@@ -102,6 +156,12 @@
           "version": "1.4.0",
           "downloadUrl": "https://android.googlesource.com/platform/external/dng_sdk"
         }
+      },
+      "skia_dependency": {
+        "name": "dng_sdk",
+        "revision": "dbe0a676450d9b8c71bf00688bb306409b779e90",
+        "version_reviewed_identity": "https://android.googlesource.com/platform/external/dng_sdk.git@dbe0a676450d9b8c71bf00688bb306409b779e90",
+        "version_source": "README.version: Version: 1.4.0"
       }
     },
     {
@@ -113,6 +173,12 @@
           "version": "3.2.1",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator"
         }
+      },
+      "skia_dependency": {
+        "name": "vulkanmemoryallocator",
+        "revision": "c788c52156f3ef7bc7ab769cb03c110a53ac8fcb",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@c788c52156f3ef7bc7ab769cb03c110a53ac8fcb",
+        "version_source": "CMakeLists.txt: project(VMA VERSION 3.2.1 LANGUAGES CXX)"
       }
     },
     {
@@ -123,6 +189,12 @@
           "version": "vulkan-sdk-1.3.275.0",
           "downloadUrl": "https://github.com/KhronosGroup/SPIRV-Cross"
         }
+      },
+      "skia_dependency": {
+        "name": "spirv-cross",
+        "revision": "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+        "version_source": "DEPS-pinned git tag vulkan-sdk-1.3.275.0 (no in-tree semantic version constant; SPIRV-Cross versions by Vulkan SDK tag)"
       }
     },
     {
@@ -134,6 +206,12 @@
           "version": "2.0.0-development",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator"
         }
+      },
+      "skia_dependency": {
+        "name": "d3d12allocator",
+        "revision": "169895d529dfce00390a20e69c2f516066fe7a3b",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+        "version_source": "src/D3D12MemAlloc.h: <b>Version 2.0.0-development</b> (2020-07-16)"
       }
     },
     {
@@ -144,6 +222,12 @@
           "version": "1.4.345",
           "downloadUrl": "https://github.com/KhronosGroup/Vulkan-Headers"
         }
+      },
+      "skia_dependency": {
+        "name": "vulkan-headers",
+        "revision": "74d8a6cb930c68ef617b202c3ff3c59d919e086b",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@74d8a6cb930c68ef617b202c3ff3c59d919e086b",
+        "version_source": "include/vulkan/vulkan_core.h: #define VK_HEADER_VERSION 345 with VK_HEADER_VERSION_COMPLETE 1.4.345"
       }
     },
     {
@@ -155,10 +239,16 @@
           "version": "0.0.0",
           "downloadUrl": "https://android.googlesource.com/platform/external/piex"
         }
+      },
+      "skia_dependency": {
+        "name": "piex",
+        "revision": "bb217acdca1cc0c16b704669dd6f91a1b509c406",
+        "version_reviewed_identity": "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+        "version_source": "No in-tree semantic version; component tracked by DEPS revision only (version 0.0.0 placeholder)"
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -216,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "73959289693c85303585463d7998de32c6249457"
+          "commitHash": "bea5d329ad3d7dfb75464a794318dfc0a235c0ab"
         }
       }
     },
@@ -231,7 +321,8 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861"
+      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861",
+      "upstream_ref": "chrome/m150"
     }
   ]
 }


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/339

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the `externals/skia` submodule pointer to the reconciled m150 merge commit
`bea5d329ad3d7dfb75464a794318dfc0a235c0ab` on `skia-sync/release-4.150.x`, and record
source-backed version evidence for the Skia dependency registrations.

- Release-line bug-fix mode (CURRENT==TARGET==milestone 150, ref != main): versions/milestone
  kept, Skia hash advanced. `update_versions.py` gate passed (m150 -> m150).
- `cgmanifest.json`: added `skia_dependency.version_source` evidence to all 15 tracked
  registrations (libpng, zlib, libjpeg-turbo, libwebp, freetype, harfbuzz, expat, brotli, wuffs,
  dng_sdk, VulkanMemoryAllocator, SPIRV-Cross, D3D12MemoryAllocator, vulkan-headers, piex). No
  dependency revision changed; all recorded semantic versions remain authoritative. Evidence was
  read from the build-hydrated `externals/skia/third_party/externals/*` sources (see decisions doc).
- `skia-dependency-changes.json`: `changes: []` — zero tracked dependency changes.
- No C API, no generated binding changes (regeneration reported none), no managed wrapper or test
  changes required.

## Testing

Native build from source (`dotnet cake --target=externals-linux --arch=x64`) succeeded. Managed
build of `binding/SkiaSharp/SkiaSharp.csproj` clean. Binding regeneration: no changes, no new
native functions.

Full unfiltered solution `tests/SkiaSharp.Tests.Console.sln` (net10.0), all hosts passed
(final gate exit 0):

- SkiaSharp.Tests (Core): Failed 0, Passed 5585, Skipped 171
- SkiaSharp.Tests.SingletonInit: Failed 0, Passed 1, Skipped 0
- SkiaSharp.Vulkan.Tests: Failed 0, Passed 2, Skipped 5
- SkiaSharp.Direct3D.Tests: Failed 0, Passed 2, Skipped 3

All `GpuPolicy`-required Linux backends executed. No **required** backend was skipped; remaining
skips are pre-existing platform/host capability skips.

## Human review

- Confirm `version_source` evidence strings on the 15 unchanged registrations match the cited
  in-tree sources (independent re-read required by the skill).
- The parent gitlink points to the exact tested mono/skia commit `bea5d329ad`; it must be updated
  to the merged `release/4.150.x` commit after the mono/skia PR merges (do not leave it on an
  orphaned PR-head commit).
- Non-Linux platforms were not exercised in this run; standard cross-platform CI matrix required
  before merge.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-04T21:34:52Z_
