### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -158,7 +158,7 @@
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -216,7 +216,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "73959289693c85303585463d7998de32c6249457"
+          "commitHash": "945e27121f05c7d6d8187528c9a63367e33b1143"
         }
       }
     },
@@ -231,7 +231,8 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861"
+      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861",
+      "upstream_ref": "chrome/m150"
     }
   ]
 }


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/340

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Release-line bug-fix Skia sync for milestone 150 (`chrome/m150`). Versions unchanged (m150 → m150).

- **Submodule:** advance `externals/skia` to the two-parent upstream merge
  `945e27121f05c7d6d8187528c9a63367e33b1143` on `release/4.150.x`.
- **cgmanifest.json:** update the mono/skia registration commit hash to `945e2712…` and record
  `upstream_ref: chrome/m150`. `upstream_merge_commit` remains
  `a81173f17b197686dc1e6c78515de86e92ddc861`.
- **Version surfaces:** `update_versions.py` gate passes; no milestone/package/native version bump
  (release-line bug-fix mode).
- **Bindings:** `regenerate_bindings.py` produced no binding changes and no new native functions —
  the upstream range has no C API surface change. No hand-written wrapper changes.
- **Dependencies:** `skia-dependency-changes.json` reports zero tracked dependency changes; no
  `cgmanifest` version updates required.

Upstream content merged: SkSL RasterPipeline codegen map-pointer fix (`a81173f17b`) and an infra
CI dependency roll (`4452d2cbf4`). See the mono/skia PR for the C++ detail.

## Testing

Native Linux x64 built from source (never `externals-download`). Full unfiltered console solution:

- SkiaSharp.Tests (Core): Passed 5585, Skipped 171, Failed 0
- SkiaSharp.Tests.SingletonInit: Passed 1, Skipped 0, Failed 0
- SkiaSharp.Direct3D.Tests: Passed 2, Skipped 3, Failed 0
- SkiaSharp.Vulkan.Tests: Passed 2, Skipped 5, Failed 0

No `GpuPolicy`-**required** backend was skipped; skips are the existing platform-policy skips only.

## Human review

- Validated on Linux x64 only. Windows, macOS, Android, iOS, and WASM packaging/rendering were not
  executed and need cross-platform review.
- Depends on the cross-linked mono/skia PR merging first; the parent submodule pointer must be
  updated to the resulting `release/4.150.x` commit before the parent is merged.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-04T22:13:36Z_
