### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "fe3eafa452a88e0756d713cd3ea795be5bdbc385"
+          "commitHash": "b70519562e2d26d3cf56286d3a13ca25152cfae4"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11,6 +11,12 @@
           "version": "1.6.58",
           "downloadUrl": "https://github.com/pnggroup/libpng"
         }
+      },
+      "skia_dependency": {
+        "name": "libpng",
+        "revision": "3061454d980de7d53608f594194cfac722721d2a",
+        "version_reviewed_identity": "https://skia.googlesource.com/third_party/libpng.git@3061454d980de7d53608f594194cfac722721d2a",
+        "version_source": "externals/skia/third_party/externals/libpng/png.h PNG_LIBPNG_VER_STRING \"1.6.58\""
       }
     },
     {
@@ -22,6 +28,12 @@
           "version": "1.3.2",
           "downloadUrl": "https://github.com/madler/zlib"
         }
+      },
+      "skia_dependency": {
+        "name": "zlib",
+        "revision": "89921383f1f51331f48a2dc843403779770ea3a9",
+        "version_reviewed_identity": "https://chromium.googlesource.com/chromium/src/third_party/zlib@89921383f1f51331f48a2dc843403779770ea3a9",
+        "version_source": "externals/skia/third_party/externals/zlib/zlib.h ZLIB_VERSION \"1.3.2.1-motley\" (Chromium fork of upstream zlib 1.3.2)"
       }
     },
     {
@@ -32,6 +44,12 @@
           "version": "3.1.4.1",
           "downloadUrl": "https://github.com/libjpeg-turbo/libjpeg-turbo"
         }
+      },
+      "skia_dependency": {
+        "name": "libjpeg-turbo",
+        "revision": "9217719d3a58633923b096af4c1d50d304768a64",
+        "version_reviewed_identity": "https://github.com/libjpeg-turbo/libjpeg-turbo.git@9217719d3a58633923b096af4c1d50d304768a64",
+        "version_source": "externals/skia/third_party/externals/libjpeg-turbo/CMakeLists.txt set(VERSION 3.1.4.1)"
       }
     },
     {
@@ -42,6 +60,12 @@
           "version": "1.6.0",
           "downloadUrl": "https://github.com/webmproject/libwebp"
         }
+      },
+      "skia_dependency": {
+        "name": "libwebp",
+        "revision": "4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "version_reviewed_identity": "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "version_source": "externals/skia/third_party/externals/libwebp/configure.ac AC_INIT([libwebp], [1.6.0])"
       }
     },
     {
@@ -52,6 +76,12 @@
           "version": "2.14.3",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
+      },
+      "skia_dependency": {
+        "name": "freetype",
+        "revision": "0a0221a1347e2f1e07c395263540026e9a0aa7c7",
+        "version_reviewed_identity": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@0a0221a1347e2f1e07c395263540026e9a0aa7c7",
+        "version_source": "externals/skia/third_party/externals/freetype/include/freetype/freetype.h FREETYPE_MAJOR 2 / FREETYPE_MINOR 14 / FREETYPE_PATCH 3"
       }
     },
     {
@@ -62,6 +92,12 @@
           "version": "14.2.1",
           "downloadUrl": "https://github.com/harfbuzz/harfbuzz"
         }
+      },
+      "skia_dependency": {
+        "name": "harfbuzz",
+        "revision": "56feae4035bdd48f62ba2b8d8c16232d4d89b3a4",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@56feae4035bdd48f62ba2b8d8c16232d4d89b3a4",
+        "version_source": "externals/skia/third_party/externals/harfbuzz/src/hb-version.h HB_VERSION_MAJOR 14 / HB_VERSION_MINOR 2 / HB_VERSION_MICRO 1"
       }
     },
     {
@@ -72,6 +108,12 @@
           "version": "2.8.1",
           "downloadUrl": "https://github.com/libexpat/libexpat"
         }
+      },
+      "skia_dependency": {
+        "name": "expat",
+        "revision": "c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
+        "version_source": "externals/skia/third_party/externals/expat/expat/lib/expat.h XML_MAJOR_VERSION 2 / XML_MINOR_VERSION 8 / XML_MICRO_VERSION 1"
       }
     },
     {
@@ -82,6 +124,12 @@
           "version": "1.2.0",
           "downloadUrl": "https://github.com/google/brotli"
         }
+      },
+      "skia_dependency": {
+        "name": "brotli",
+        "revision": "028fb5a23661f123017c060daa546b55cf4bde29",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/google/brotli.git@028fb5a23661f123017c060daa546b55cf4bde29",
+        "version_source": "externals/skia/third_party/externals/brotli/c/common/version.h BROTLI_VERSION_MAJOR 1 / MINOR 2 / PATCH 0"
       }
     },
     {
@@ -92,6 +140,12 @@
           "version": "0.3.3",
           "downloadUrl": "https://github.com/google/wuffs-mirror-release-c"
         }
+      },
+      "skia_dependency": {
+        "name": "wuffs",
+        "revision": "e3f919ccfe3ef542cfc983a82146070258fb57f8",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+        "version_source": "externals/skia/third_party/externals/wuffs/release/c/wuffs-v0.3.c WUFFS_VERSION_STRING \"0.3.3+3399.20230408\""
       }
     },
     {
@@ -102,6 +156,12 @@
           "version": "1.4.0",
           "downloadUrl": "https://android.googlesource.com/platform/external/dng_sdk"
         }
+      },
+      "skia_dependency": {
+        "name": "dng_sdk",
+        "revision": "dbe0a676450d9b8c71bf00688bb306409b779e90",
+        "version_reviewed_identity": "https://android.googlesource.com/platform/external/dng_sdk.git@dbe0a676450d9b8c71bf00688bb306409b779e90",
+        "version_source": "externals/skia/third_party/externals/dng_sdk/README.version Version: 1.4.0"
       }
     },
     {
@@ -113,6 +173,12 @@
           "version": "3.2.1",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator"
         }
+      },
+      "skia_dependency": {
+        "name": "vulkanmemoryallocator",
+        "revision": "c788c52156f3ef7bc7ab769cb03c110a53ac8fcb",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@c788c52156f3ef7bc7ab769cb03c110a53ac8fcb",
+        "version_source": "externals/skia/third_party/externals/vulkanmemoryallocator/README.md <b>Version 3.2.1</b>"
       }
     },
     {
@@ -123,6 +189,12 @@
           "version": "vulkan-sdk-1.3.275.0",
           "downloadUrl": "https://github.com/KhronosGroup/SPIRV-Cross"
         }
+      },
+      "skia_dependency": {
+        "name": "spirv-cross",
+        "revision": "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+        "version_source": "externals/skia/third_party/externals/spirv-cross at revision b8fcf307 (2024-02-05); Skia DEPS pins the SPIRV-Cross snapshot shipped in the vulkan-sdk-1.3.275.0 release tag (CMake ABI 0.59.0)"
       }
     },
     {
@@ -134,6 +206,12 @@
           "version": "2.0.0-development",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator"
         }
+      },
+      "skia_dependency": {
+        "name": "d3d12allocator",
+        "revision": "169895d529dfce00390a20e69c2f516066fe7a3b",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+        "version_source": "externals/skia/third_party/externals/d3d12allocator/src/D3D12MemAlloc.h <b>Version 2.0.0-development</b>"
       }
     },
     {
@@ -144,6 +222,12 @@
           "version": "1.4.345",
           "downloadUrl": "https://github.com/KhronosGroup/Vulkan-Headers"
         }
+      },
+      "skia_dependency": {
+        "name": "vulkan-headers",
+        "revision": "74d8a6cb930c68ef617b202c3ff3c59d919e086b",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@74d8a6cb930c68ef617b202c3ff3c59d919e086b",
+        "version_source": "externals/skia/third_party/externals/vulkan-headers/include/vulkan/vulkan_core.h VK_HEADER_VERSION 345 (VK_API_VERSION_1_4)"
       }
     },
     {
@@ -155,6 +239,12 @@
           "version": "0.0.0",
           "downloadUrl": "https://android.googlesource.com/platform/external/piex"
         }
+      },
+      "skia_dependency": {
+        "name": "piex",
+        "revision": "bb217acdca1cc0c16b704669dd6f91a1b509c406",
+        "version_reviewed_identity": "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+        "version_source": "externals/skia/third_party/externals/piex has no upstream version/tag; pinned to revision bb217acd (2018-03-09), recorded as 0.0.0"
       }
     },
     {
@@ -216,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "73959289693c85303585463d7998de32c6249457"
+          "commitHash": "fe3eafa452a88e0756d713cd3ea795be5bdbc385"
         }
       }
     },
@@ -231,7 +321,8 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861"
+      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861",
+      "upstream_ref": "chrome/m150"
     }
   ]
 }


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/341

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the SkiaSharp `release/4.150.x` line to the merged mono/skia
`skia-sync/release-4.150.x` tip (`fe3eafa452a88e0756d713cd3ea795be5bdbc385`).

- **Parent commit:** `ca6d0e43e` on branch `skia-sync/release-4.150.x`.
- **Submodule pointer:** `externals/skia` gitlink advanced from
  `73959289693c85303585463d7998de32c6249457` to the tested merge commit
  `fe3eafa452a88e0756d713cd3ea795be5bdbc385`.
- **`cgmanifest.json`:** backfilled source-verified `version_source` evidence for all 15 tracked
  `skia_dependency` registrations (legacy backfill required by `update_versions.py`). No
  dependency version changed — `skia-dependency-changes.json` has an empty `changes` array.
- **Bindings:** `regenerate_bindings.py` reported **no binding changes** and **no new native
  functions** (expected — no C API surface changed upstream). No `*.generated.cs` edits.
- **Managed wrappers / tests:** none required — no changed native behavior reaches an existing
  wrapper.
- **Build side effect not committed:** `externals/depot_tools` (`gclient_paths.py` dirtied by
  `git-sync-deps`) was intentionally left unstaged.
- Release-line bug-fix mode: SkiaSharp version files stay at m150 (`update_versions.py` reports
  `m150 -> m150`, gate passed); only the submodule hash advances.

## Testing

Native source build (linux/x64, cold, from the merged submodule) succeeded and produced the
`libSkiaSharp.so.150.0.0` loaded by tests. Managed build of `binding/SkiaSharp/SkiaSharp.csproj`
succeeded.

Full unfiltered solution (`tests/SkiaSharp.Tests.Console.sln`, net10.0), all hosts green:

- Core (`SkiaSharp.Tests`): Passed 5585, Skipped 171, Failed 0
- Singleton (`SkiaSharp.Tests.SingletonInit`): Passed 1, Skipped 0, Failed 0
- Direct3D (`SkiaSharp.Direct3D.Tests`): Passed 2, Skipped 3, Failed 0
- Vulkan (`SkiaSharp.Vulkan.Tests`): Passed 2, Skipped 5, Failed 0

GPU backends ran on the pinned software stack (Mesa softpipe + lavapipe, Xvfb `:99`). No
`GpuPolicy`-**required** backend was skipped; remaining skips are the existing
platform/capability skips. Deterministic gates re-verified against final HEAD:
`update_versions.py` GATE PASSED, `audit_fork_patches.py --validate` GATE PASSED (0 TODO). Parent
gitlink equals the exact tested mono/skia commit.

## Human review

- Confirm no downstream SkiaSharp API/behavior change is expected from the SkSL RasterPipeline
  codegen fix (it is internal to Skia's codegen; no public surface change).
- Non-Linux platforms (Windows/macOS/iOS/Android/WASM) were not built/tested here; verify via the
  standard cross-platform CI matrix.
- Merge sequence: merge the mono/skia PR first, then update this parent PR's submodule pointer to
  the resulting `release/4.150.x` commit before merging the parent.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-04T23:04:06Z_
