### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "2c07e1836200c2c5d70adba70cbda473ea99e4c8"
+          "commitHash": "bdd0c3a8eaba1afa7148f02bba3a07f94e682847"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11,6 +11,12 @@
           "version": "1.6.58",
           "downloadUrl": "https://github.com/pnggroup/libpng"
         }
+      },
+      "skia_dependency": {
+        "name": "libpng",
+        "revision": "3061454d980de7d53608f594194cfac722721d2a",
+        "version_reviewed_identity": "https://skia.googlesource.com/third_party/libpng.git@3061454d980de7d53608f594194cfac722721d2a",
+        "version_source": "third_party/externals/libpng/png.h: PNG_LIBPNG_VER_STRING \"1.6.58\""
       }
     },
     {
@@ -22,6 +28,12 @@
           "version": "1.3.2",
           "downloadUrl": "https://github.com/madler/zlib"
         }
+      },
+      "skia_dependency": {
+        "name": "zlib",
+        "revision": "89921383f1f51331f48a2dc843403779770ea3a9",
+        "version_reviewed_identity": "https://chromium.googlesource.com/chromium/src/third_party/zlib@89921383f1f51331f48a2dc843403779770ea3a9",
+        "version_source": "third_party/externals/zlib/zlib.h: ZLIB_VERSION \"1.3.2.1-motley\" (base upstream 1.3.2)"
       }
     },
     {
@@ -32,6 +44,12 @@
           "version": "3.1.4.1",
           "downloadUrl": "https://github.com/libjpeg-turbo/libjpeg-turbo"
         }
+      },
+      "skia_dependency": {
+        "name": "libjpeg-turbo",
+        "revision": "9217719d3a58633923b096af4c1d50d304768a64",
+        "version_reviewed_identity": "https://github.com/libjpeg-turbo/libjpeg-turbo.git@9217719d3a58633923b096af4c1d50d304768a64",
+        "version_source": "third_party/externals/libjpeg-turbo/CMakeLists.txt: set(VERSION 3.1.4.1)"
       }
     },
     {
@@ -42,6 +60,12 @@
           "version": "1.6.0",
           "downloadUrl": "https://github.com/webmproject/libwebp"
         }
+      },
+      "skia_dependency": {
+        "name": "libwebp",
+        "revision": "4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "version_reviewed_identity": "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "version_source": "third_party/externals/libwebp/configure.ac: AC_INIT([libwebp], [1.6.0])"
       }
     },
     {
@@ -52,6 +76,12 @@
           "version": "2.14.3",
           "downloadUrl": "https://gitlab.freedesktop.org/freetype/freetype"
         }
+      },
+      "skia_dependency": {
+        "name": "freetype",
+        "revision": "0a0221a1347e2f1e07c395263540026e9a0aa7c7",
+        "version_reviewed_identity": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@0a0221a1347e2f1e07c395263540026e9a0aa7c7",
+        "version_source": "third_party/externals/freetype/include/freetype/freetype.h: FREETYPE_MAJOR 2, FREETYPE_MINOR 14, FREETYPE_PATCH 3"
       }
     },
     {
@@ -62,6 +92,12 @@
           "version": "14.2.1",
           "downloadUrl": "https://github.com/harfbuzz/harfbuzz"
         }
+      },
+      "skia_dependency": {
+        "name": "harfbuzz",
+        "revision": "56feae4035bdd48f62ba2b8d8c16232d4d89b3a4",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@56feae4035bdd48f62ba2b8d8c16232d4d89b3a4",
+        "version_source": "third_party/externals/harfbuzz/src/hb-version.h: HB_VERSION_STRING \"14.2.1\""
       }
     },
     {
@@ -72,6 +108,12 @@
           "version": "2.8.1",
           "downloadUrl": "https://github.com/libexpat/libexpat"
         }
+      },
+      "skia_dependency": {
+        "name": "expat",
+        "revision": "c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
+        "version_source": "third_party/externals/expat/lib/expat.h: XML_MAJOR_VERSION 2, XML_MINOR_VERSION 8, XML_MICRO_VERSION 1"
       }
     },
     {
@@ -82,6 +124,12 @@
           "version": "1.2.0",
           "downloadUrl": "https://github.com/google/brotli"
         }
+      },
+      "skia_dependency": {
+        "name": "brotli",
+        "revision": "028fb5a23661f123017c060daa546b55cf4bde29",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/google/brotli.git@028fb5a23661f123017c060daa546b55cf4bde29",
+        "version_source": "third_party/externals/brotli/c/common/version.h: BROTLI_VERSION_MAJOR 1, MINOR 2, PATCH 0"
       }
     },
     {
@@ -92,6 +140,12 @@
           "version": "0.3.3",
           "downloadUrl": "https://github.com/google/wuffs-mirror-release-c"
         }
+      },
+      "skia_dependency": {
+        "name": "wuffs",
+        "revision": "e3f919ccfe3ef542cfc983a82146070258fb57f8",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+        "version_source": "third_party/externals/wuffs/release/c/wuffs-v0.3.c: WUFFS_VERSION_STRING \"0.3.3+3399.20230408\""
       }
     },
     {
@@ -102,6 +156,12 @@
           "version": "1.4.0",
           "downloadUrl": "https://android.googlesource.com/platform/external/dng_sdk"
         }
+      },
+      "skia_dependency": {
+        "name": "dng_sdk",
+        "revision": "dbe0a676450d9b8c71bf00688bb306409b779e90",
+        "version_reviewed_identity": "https://android.googlesource.com/platform/external/dng_sdk.git@dbe0a676450d9b8c71bf00688bb306409b779e90",
+        "version_source": "third_party/externals/dng_sdk/source/dng_flags.h: dngVersion_1_4_0_0 (dngVersion_Current)"
       }
     },
     {
@@ -113,6 +173,12 @@
           "version": "3.2.1",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator"
         }
+      },
+      "skia_dependency": {
+        "name": "vulkanmemoryallocator",
+        "revision": "c788c52156f3ef7bc7ab769cb03c110a53ac8fcb",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@c788c52156f3ef7bc7ab769cb03c110a53ac8fcb",
+        "version_source": "third_party/externals/vulkanmemoryallocator/README.md: Version 3.2.1"
       }
     },
     {
@@ -123,6 +189,12 @@
           "version": "vulkan-sdk-1.3.275.0",
           "downloadUrl": "https://github.com/KhronosGroup/SPIRV-Cross"
         }
+      },
+      "skia_dependency": {
+        "name": "spirv-cross",
+        "revision": "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+        "version_source": "DEPS pins SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3 (Vulkan SDK 1.3.275.0 tag revision; repo has no in-tree version constant)"
       }
     },
     {
@@ -134,6 +206,12 @@
           "version": "2.0.0-development",
           "downloadUrl": "https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator"
         }
+      },
+      "skia_dependency": {
+        "name": "d3d12allocator",
+        "revision": "169895d529dfce00390a20e69c2f516066fe7a3b",
+        "version_reviewed_identity": "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+        "version_source": "third_party/externals/d3d12allocator/src/D3D12MemAlloc.h: Version 2.0.0-development"
       }
     },
     {
@@ -144,6 +222,12 @@
           "version": "1.4.345",
           "downloadUrl": "https://github.com/KhronosGroup/Vulkan-Headers"
         }
+      },
+      "skia_dependency": {
+        "name": "vulkan-headers",
+        "revision": "74d8a6cb930c68ef617b202c3ff3c59d919e086b",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@74d8a6cb930c68ef617b202c3ff3c59d919e086b",
+        "version_source": "third_party/externals/vulkan-headers/include/vulkan/vulkan_core.h: VK_HEADER_VERSION 345 (VK_MAKE_API_VERSION 1.4.345)"
       }
     },
     {
@@ -155,6 +239,12 @@
           "version": "0.0.0",
           "downloadUrl": "https://android.googlesource.com/platform/external/piex"
         }
+      },
+      "skia_dependency": {
+        "name": "piex",
+        "revision": "bb217acdca1cc0c16b704669dd6f91a1b509c406",
+        "version_reviewed_identity": "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+        "version_source": "third_party/externals/piex: unversioned Android platform snapshot (no upstream release version); manifest 0.0.0"
       }
     },
     {
@@ -216,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "4998e69e2ed8fbdc46d4d0602393d24b62d36295"
+          "commitHash": "2c07e1836200c2c5d70adba70cbda473ea99e4c8"
         }
       }
     },
@@ -231,7 +321,8 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "c3226a9bcd777ce15adb61e7181aac2aa57cf6da"
+      "upstream_merge_commit": "86bb2f25f46f4d620b4a26e738f59a9b6c22d2eb",
+      "upstream_ref": "chrome/m151"
     }
   ]
 }


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m151. Targeting release branch `release/4.151.x` (mono/skia `release/4.151.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/342

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advances the `externals/skia` submodule pointer to the release-line M151
bug-fix sync merge commit `2c07e1836200c2c5d70adba70cbda473ea99e4c8` (upstream
`chrome/m151` target `86bb2f25f46f4d620b4a26e738f59a9b6c22d2eb`).

- **Submodule pointer:** `4998e69e2e…` → `2c07e1836200c2c5d70adba70cbda473ea99e4c8`.
- **Versions frozen** (bug-fix mode): `m151 -> m151`. No milestone, soname,
  or package version bumps; only Skia hashes advanced. `update_versions.py`
  GATE PASSED.
- **`cgmanifest.json`:** advanced the Skia `upstream_merge_commit`
  (`c3226a9bcd…` → `86bb2f25f4…`) and backfilled `version_source` evidence for
  15 legacy tracked dependencies (a compliance requirement; no version values
  changed).
- **Binding regeneration** produced **zero new native functions** and **no
  binding diff** — expected, since no C API changed. HarfBuzz generated file
  reverted per fork policy.
- **No managed wrapper or test changes** were required.

## Testing

Full unfiltered solution run (`dotnet test tests/SkiaSharp.Tests.Console.sln
-p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0`), exit code **0**.
Every maintained host executed and passed:

| Host | Passed | Skipped | Failed |
|---|---|---|---|
| Core (`SkiaSharp.Tests`) | 5721 | 181 | 0 |
| SingletonInit | 1 | 0 | 0 |
| Vulkan | 2 | 10 | 0 |
| Direct3D | 2 | 3 | 0 |

The Vulkan GPU backend (Mesa lavapipe ICD) initialized and executed; **no
`GpuPolicy`-required backend was skipped**. Remaining skips are the existing
platform/capability-gap skips (e.g. Direct3D on Linux). Native build:
`libSkiaSharp.so.151.0.0` from source, linux/x64.

## Human review

- Only `linux/x64` was built and validated. Windows (Direct3D), macOS/iOS
  (Metal), Android, Mac Catalyst, and WASM require CI validation.
- Merge sequence: merge the paired `mono/skia` PR first, then update this
  PR's submodule pointer to the resulting `release/4.151.x` commit before
  merging here.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-05T00:27:22Z_
