### PR TITLE
[infra] Hard-wrap generated merge messages

### DIFF
--- a/.agents/skills/pr-commit-message/SKILL.md
+++ b/.agents/skills/pr-commit-message/SKILL.md
@@ -213,8 +213,16 @@ For multiple topics, use this shape:
 
 Name sections after the actual problem or decision, not `Changes` or `Implementation`.
 Use bullets for explicit decisions inside a topic, not as a substitute for topic sections.
-Keep exception snippets, logs, reference lists, bullets, and wrapping in-family for the
-target repository.
+Keep exception snippets, logs, reference lists, and bullets in-family for the target
+repository.
+
+Hard-wrap ordinary prose with literal newline characters at the width observed in recent
+target-repository merge messages; SkiaSharp's established cap is 80 columns. Code fences and
+commit-message renderers do not add this formatting, so visual wrapping in a UI is not a
+substitute. Preserve constructs that should remain on one line: the subject when reasonable,
+reference and compare URLs, section markers, code or log lines, and attribution trailers.
+Indivisible tokens may exceed the cap. Reflow bullet continuations using the repository's
+established indentation.
 
 ### 4. Run one claim-proof pass
 
@@ -290,7 +298,10 @@ After drafting and attribution, confirm:
    exactly once as a source-backed trailer or required missing-context item.
 5. The message answers what a future maintainer would otherwise have to reopen the PR to
    learn, without file-by-file narration or repeated prose.
-6. The response contains exactly one fenced `text` block with only the polished commit
+6. Scan the fenced message after all other edits and reflow every ordinary prose line over
+   the observed cap. Exempt one-line constructs and indivisible tokens only where splitting
+   would damage them.
+7. The response contains exactly one fenced `text` block with only the polished commit
    message; it has no introduction, explanation, summary, or other response prose.
 
 After these checks pass, return the fenced message. Put any required `Missing context:`


### PR DESCRIPTION
## Description

Require generated merge commit messages to contain literal hard wraps at the target repository's observed width. The hosted `gpt-5.6-terra` run for PR #3993 produced ordinary prose lines of 234, 297, and 118 characters, and both the add-comment safe output and the resulting GitHub comment preserved those lines. Code fences and commit-message renderers therefore cannot be relied on to add newline characters.

The skill now establishes the observed repository width as the output contract (80 columns for SkiaSharp), preserves one-line constructs and indivisible tokens, reflows bullet continuations with repository indentation, and performs a final scan of the fenced message for overlong ordinary prose.

Hosted evidence: https://github.com/mono/SkiaSharp/actions/runs/31038951456 and https://github.com/mono/SkiaSharp/pull/3993#issuecomment-5196324695

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — workflow/skill guidance only; no public API or runtime behavior changes.

## Testing

- `python .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/pr-commit-message` passed.
- Re-ran the same effective merge-message workflow prompt for PR #3993 with `gpt-5.6-terra`, replacing only the production comment action with an artifact write.
- The revised output contained exactly one `text` fence with no surrounding prose. Its maximum ordinary prose line was 77 columns, with zero ordinary lines over 80. The only over-cap line was an indivisible 83-character `Co-authored-by` trailer, which the skill explicitly preserves.
- `git diff --check` passed.
- SkiaSharp builds and tests were not run because this changes workflow guidance only.

## Checklist

- [x] Tests added or updated (not applicable; existing validation plus the targeted Terra regression is described above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Not applicable; no public API changed
- [x] Native change? Not applicable; no native code changed
