### PR TITLE
[release] Fix release status on Windows

### DIFF
--- a/.agents/skills/release-status/SKILL.md
+++ b/.agents/skills/release-status/SKILL.md
@@ -50,7 +50,7 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py {commit-sha}
 ```
 
 This outputs:
-- All three pipelines with status icons (✅ ❌ 🔄 ⏳)
+- All three pipelines with status markers (`[OK]`, `[WARN]`, `[FAIL]`, `[RUNNING]`, `[WAITING]`)
 - Build IDs and build numbers
 - Trigger relationships proving which upstream build caused each downstream run
 - Direct ADO links for each build
@@ -61,11 +61,11 @@ This outputs:
 
 | Scenario | Meaning | Next Action |
 |----------|---------|-------------|
-| All ✅ | Packages are on the internal feed | Proceed to `release-testing` |
-| Native ✅, SkiaSharp 🔄 | Managed build in progress | Wait |
-| Native ✅, SkiaSharp ✅, Tests 🔄 | Tests running (packages already available) | Can start `release-testing` |
-| Any ❌ | Pipeline failed | Investigate via ADO link, retry or fix |
-| Native ⚠️ (partiallySucceeded) | Some native platforms had warnings | Usually OK — check which platforms |
+| All `[OK]` | Packages are on the internal feed | Proceed to `release-testing` |
+| Native `[OK]`, SkiaSharp `[RUNNING]` | Managed build in progress | Wait |
+| Native `[OK]`, SkiaSharp `[OK]`, Tests `[RUNNING]` | Tests running (packages already available) | Can start `release-testing` |
+| Any `[FAIL]` | Pipeline failed | Investigate via ADO link, retry or fix |
+| Native `[WARN]` (partiallySucceeded) | Some native platforms had warnings | Usually OK — check which platforms |
 
 ### Job-Level Details (In-Progress Builds)
 
@@ -73,13 +73,13 @@ When a pipeline is `inProgress`, the script queries the ADO timeline API and sho
 breakdown below the pipeline entry:
 
 ```
-┌─ SkiaSharp-Native (ID 26493) — native binaries
-│  🔄 id=14361035    inProgress    pending               4.148.0-rc.1.1+4.148.0-rc.1
-│  
-│  Jobs: 35 ✅ completed | 2 ❌ failed | 8 🔄 running | 3 ⏳ pending
-│  Failed: Job_Name_1, Job_Name_2
-│  Running: Win32 x64, Win32 arm64, iOS, macOS, Mac Catalyst, ...
-│  Pending: Wasm, Linux ARM, Linux ARM64
++- SkiaSharp-Native (ID 26493) - native binaries
+|  [RUNNING] id=14361035    inProgress    pending               4.148.0-rc.1.1+4.148.0-rc.1
+|
+|  Jobs: 35 [OK] completed | 2 [FAIL] failed | 8 [RUNNING] running | 3 [WAITING] pending
+|  Failed: Job_Name_1, Job_Name_2
+|  Running: Win32 x64, Win32 arm64, iOS, macOS, Mac Catalyst, ...
+|  Pending: Wasm, Linux ARM, Linux ARM64
 ```
 
 **Reading job status:**
@@ -99,9 +99,9 @@ Pipeline Chain Status: release/3.119.4
 
 | Pipeline | Status | Build | ADO Link |
 |----------|--------|-------|----------|
-| SkiaSharp-Native | ✅ partiallySucceeded | 3.119.4-stable.2 | [link] |
-| SkiaSharp | 🔄 inProgress | 3.119.4-stable.2 | [link] |
-| SkiaSharp-Tests | ⏳ not triggered | — | — |
+| SkiaSharp-Native | [WARN] partiallySucceeded | 3.119.4-stable.2 | [link] |
+| SkiaSharp | [RUNNING] inProgress | 3.119.4-stable.2 | [link] |
+| SkiaSharp-Tests | [WAITING] not triggered | - | - |
 
 Packages will be available after SkiaSharp (10789) completes.
 ```

--- a/.agents/skills/release-status/scripts/pipeline-status.py
+++ b/.agents/skills/release-status/scripts/pipeline-status.py
@@ -11,6 +11,7 @@ Examples:
 
 import json
 import re
+import shutil
 import subprocess
 import sys
 
@@ -24,17 +25,26 @@ PIPELINES = [
 ]
 
 ICONS = {
-    "succeeded": "✅",
-    "partiallySucceeded": "⚠️",
-    "failed": "❌",
-    "canceled": "🚫",
-    "inProgress": "🔄",
-    "notStarted": "⏳",
+    "succeeded": "[OK]",
+    "partiallySucceeded": "[WARN]",
+    "failed": "[FAIL]",
+    "canceled": "[CANCELED]",
+    "inProgress": "[RUNNING]",
+    "notStarted": "[WAITING]",
 }
 
+
+def output(value="") -> None:
+    print(str(value).encode("ascii", "backslashreplace").decode("ascii"))
+
+
 def az(args: list[str], timeout: int = 30) -> str:
+    az_path = shutil.which("az")
+    if not az_path:
+        sys.exit("ERROR: Azure CLI 'az' was not found on PATH.")
+
     result = subprocess.run(
-        ["az"] + args, capture_output=True, text=True, timeout=timeout
+        [az_path] + args, capture_output=True, text=True, timeout=timeout
     )
     return result.stdout.strip()
 
@@ -109,37 +119,37 @@ def format_job_summary(records: list[dict], cont: str) -> None:
     # Build the summary line
     parts = []
     if completed:
-        parts.append(f"{len(completed)} ✅ completed")
+        parts.append(f"{len(completed)} [OK] completed")
     if failed:
-        parts.append(f"{len(failed)} ❌ failed")
+        parts.append(f"{len(failed)} [FAIL] failed")
     if running:
-        parts.append(f"{len(running)} 🔄 running")
+        parts.append(f"{len(running)} [RUNNING] running")
     if pending:
-        parts.append(f"{len(pending)} ⏳ pending")
+        parts.append(f"{len(pending)} [WAITING] pending")
 
-    print(f"{cont}")
-    print(f"{cont} Jobs: {' | '.join(parts)}")
+    output(cont)
+    output(f"{cont} Jobs: {' | '.join(parts)}")
 
     if failed:
         names = ", ".join(failed[:8])
-        suffix = f", … (+{len(failed) - 8} more)" if len(failed) > 8 else ""
-        print(f"{cont} Failed: {names}{suffix}")
+        suffix = f", ... (+{len(failed) - 8} more)" if len(failed) > 8 else ""
+        output(f"{cont} Failed: {names}{suffix}")
 
     if running:
         names = ", ".join(running[:8])
-        suffix = f", … (+{len(running) - 8} more)" if len(running) > 8 else ""
-        print(f"{cont} Running: {names}{suffix}")
+        suffix = f", ... (+{len(running) - 8} more)" if len(running) > 8 else ""
+        output(f"{cont} Running: {names}{suffix}")
 
     if pending:
         names = ", ".join(pending[:8])
-        suffix = f", … (+{len(pending) - 8} more)" if len(pending) > 8 else ""
-        print(f"{cont} Pending: {names}{suffix}")
+        suffix = f", ... (+{len(pending) - 8} more)" if len(pending) > 8 else ""
+        output(f"{cont} Pending: {names}{suffix}")
 
 
 def icon_for(run: dict) -> str:
     if run["status"] == "completed":
-        return ICONS.get(run.get("result", ""), "❓")
-    return ICONS.get(run["status"], "⏳")
+        return ICONS.get(run.get("result", ""), "[UNKNOWN]")
+    return ICONS.get(run["status"], "[WAITING]")
 
 
 def resolve_branch(ref: str) -> str:
@@ -151,7 +161,7 @@ def resolve_branch(ref: str) -> str:
         for line in result.stdout.splitlines():
             m = re.search(r"origin/(release/\S+)", line)
             if m:
-                print(f"Resolved SHA {ref} → branch: {m.group(1)}")
+                output(f"Resolved SHA {ref} -> branch: {m.group(1)}")
                 return m.group(1)
         sys.exit(f"ERROR: No release branch found containing SHA {ref}")
     return ref
@@ -163,28 +173,28 @@ def main():
 
     branch = resolve_branch(sys.argv[1])
 
-    print(f"\n{'═' * 63}")
-    print(f" Pipeline Chain Status: {branch}")
-    print(f"{'═' * 63}\n")
+    output(f"\n{'=' * 63}")
+    output(f" Pipeline Chain Status: {branch}")
+    output(f"{'=' * 63}\n")
 
     all_runs: list[tuple[dict, list[dict]]] = []
     links: list[str] = []
 
     for i, pipe in enumerate(PIPELINES):
-        prefix = "┌─" if i == 0 else "├─" if i < len(PIPELINES) - 1 else "└─"
-        cont = "│ " if i < len(PIPELINES) - 1 else "  "
+        prefix = "+-"
+        cont = "| " if i < len(PIPELINES) - 1 else "  "
 
-        print(f"{prefix} {pipe['name']} (ID {pipe['id']}) — {pipe['desc']}")
+        output(f"{prefix} {pipe['name']} (ID {pipe['id']}) - {pipe['desc']}")
 
         runs = get_runs(pipe["id"], branch)
         all_runs.append((pipe, runs))
 
         if not runs:
-            print(f"{cont} No runs found — not yet triggered")
+            output(f"{cont} No runs found - not yet triggered")
         else:
             for r in runs:
-                print(f"{cont} {icon_for(r)} id={r['id']:<10}  {r['status']:<12}  "
-                      f"{r.get('result') or 'pending':<20}  {r['buildNumber']}")
+                output(f"{cont} {icon_for(r)} id={r['id']:<10}  {r['status']:<12}  "
+                       f"{r.get('result') or 'pending':<20}  {r['buildNumber']}")
 
             # Show job-level details for in-progress builds
             latest_run = runs[0]
@@ -194,35 +204,35 @@ def main():
                     if records:
                         format_job_summary(records, cont)
                 except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError):
-                    print(f"{cont} (could not fetch job details)")
+                    output(f"{cont} (could not fetch job details)")
 
-            # Show trigger info (skip for first pipeline — it has no upstream)
+            # Show trigger info (skip for first pipeline - it has no upstream)
             if i > 0:
                 trigger = get_trigger_info(runs[0]["id"])
                 if trigger and trigger.get("source"):
                     src = trigger.get("source", "?")
                     pid = trigger.get("pipelineId", "?")
-                    print(f"{cont} ↑ triggered by {src} build {pid}")
+                    output(f"{cont} -> triggered by {src} build {pid}")
             links.append(f"  {pipe['name']}: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId={runs[0]['id']}")
 
-        print(f"{cont}" if i < len(PIPELINES) - 1 else "")
+        output(cont if i < len(PIPELINES) - 1 else "")
 
-    print(f"{'═' * 63}\n")
+    output(f"{'=' * 63}\n")
 
     # Summary
     latest = [(runs[0] if runs else None) for _, runs in all_runs]
     if all(r and r["status"] == "completed" and r.get("result") in ("succeeded", "partiallySucceeded") for r in latest):
-        print("Summary: ✅ All pipelines completed. Packages should be on internal feed.")
+        output("Summary: [OK] All pipelines completed. Packages should be on internal feed.")
     elif latest[0] and not latest[1]:
-        print("Summary: ⏳ Waiting for SkiaSharp to be triggered by SkiaSharp-Native.")
+        output("Summary: [WAITING] Waiting for SkiaSharp to be triggered by SkiaSharp-Native.")
     elif not latest[0]:
-        print("Summary: ⏳ No native build found yet.")
+        output("Summary: [WAITING] No native build found yet.")
     else:
-        print("Summary: 🔄 Pipeline chain in progress or has failures.")
+        output("Summary: [RUNNING] Pipeline chain in progress or has failures.")
 
     if links:
-        print(f"\nADO Links:")
-        print("\n".join(links))
+        output("\nADO Links:")
+        output("\n".join(links))
 
 
 if __name__ == "__main__":

--- a/.agents/skills/release-status/scripts/test_pipeline_status.py
+++ b/.agents/skills/release-status/scripts/test_pipeline_status.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import io
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("pipeline-status.py")
+SPEC = importlib.util.spec_from_file_location("pipeline_status", SCRIPT_PATH)
+pipeline_status = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pipeline_status)
+
+
+class PipelineStatusTests(unittest.TestCase):
+    def test_az_uses_resolved_cmd_launcher(self):
+        az_path = r"C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.CMD"
+
+        with mock.patch.object(
+                pipeline_status.shutil, "which", return_value=az_path) as which, \
+                mock.patch.object(
+                    pipeline_status.subprocess,
+                    "run",
+                    return_value=SimpleNamespace(stdout="[]\n"),
+                ) as run:
+            result = pipeline_status.az(["pipelines", "runs", "list"])
+
+        which.assert_called_once_with("az")
+        self.assertEqual(run.call_args.args[0][0], az_path)
+        self.assertFalse(run.call_args.kwargs.get("shell", False))
+        self.assertEqual(result, "[]")
+
+    def test_az_fails_clearly_when_cli_is_missing(self):
+        with mock.patch.object(pipeline_status.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(
+                    SystemExit, "Azure CLI 'az' was not found on PATH"):
+                pipeline_status.az(["pipelines", "runs", "list"])
+
+    def test_output_escapes_non_ascii_for_legacy_streams(self):
+        buffer = io.BytesIO()
+        stream = io.TextIOWrapper(buffer, encoding="cp1252")
+
+        with mock.patch.object(pipeline_status.sys, "stdout", stream):
+            pipeline_status.output("caf\u00e9 \u2713 \U0001f600")
+            stream.flush()
+
+        self.assertEqual(
+            buffer.getvalue().decode("ascii").splitlines(),
+            ["caf\\xe9 \\u2713 \\U0001f600"],
+        )
+        stream.detach()
+
+    def test_production_script_is_ascii_only(self):
+        SCRIPT_PATH.read_text(encoding="ascii")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Fix the `release-status` launcher and output on Windows. The script now resolves `az` through `shutil.which()` so the official `az.CMD` launcher is passed directly to `subprocess.run`, and it emits ASCII-safe status text through one output function so legacy PowerShell encodings cannot fail before Azure is queried.

Focused tests cover `.CMD` launcher resolution, a missing Azure CLI, non-ASCII dynamic output on a `cp1252` stream, and the production script's ASCII-only source. The skill's literal output examples now match the ASCII markers and tree.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, ...)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, ...)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None. Release tooling only; no SkiaSharp public API or runtime behavior changes.

## Testing

Validated on Windows with:

- `python .agents\skills\release-status\scripts\test_pipeline_status.py -v`
- `python -m py_compile .agents\skills\release-status\scripts\pipeline-status.py .agents\skills\release-status\scripts\test_pipeline_status.py`
- `python -X utf8 .agents\skills\skill-creator\scripts\quick_validate.py .agents\skills\release-status`
- An explicit ASCII byte scan of `pipeline-status.py`
- `git diff --check`

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A - no public API changes
- [x] Native change? N/A - no native changes