### PR TITLE
[skia-sync] Merge upstream chrome/m151 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "bdd0c3a8eaba1afa7148f02bba3a07f94e682847"
+          "commitHash": "a1adf52824eb3d2a391b487f963b003dcd73483b"
         }
       }
     },
@@ -321,7 +321,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "86bb2f25f46f4d620b4a26e738f59a9b6c22d2eb",
+      "upstream_merge_commit": "66cca05ab345fb894cc80ed412e2fa79f687f5d9",
       "upstream_ref": "chrome/m151"
     }
   ]

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "66cd2dabe6389b8420b770dd4ece26e26a25d16e"
+          "commitHash": "098aeb5e4aa2e7f74e120e78200bbe0412ed57c5"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "bdd0c3a8eaba1afa7148f02bba3a07f94e682847"
+          "commitHash": "66cd2dabe6389b8420b770dd4ece26e26a25d16e"
         }
       }
     },
@@ -321,7 +321,7 @@
         }
       },
       "chrome_milestone": 151,
-      "upstream_merge_commit": "86bb2f25f46f4d620b4a26e738f59a9b6c22d2eb",
+      "upstream_merge_commit": "7ad44b72c93c242f96f2563edb566439fe816c0a",
       "upstream_ref": "chrome/m151"
     }
   ]


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m151. Targeting release branch `release/4.151.x` (mono/skia `release/4.151.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/343

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the `externals/skia` submodule on `skia-sync/release-4.151.x` to the
tested mono/skia merge commit
`66cd2dabe6389b8420b770dd4ece26e26a25d16e` (upstream `chrome/m151` tip
`7ad44b72c93c242f96f2563edb566439fe816c0a`). Companion mono/skia PR carries the
actual Skia merge.

Parent commit `3a4fe1a08`:

- `externals/skia` gitlink → `66cd2dabe6389b8420b770dd4ece26e26a25d16e`.
- `cgmanifest.json` skia registration: `commitHash` →
  `66cd2dabe6…`, `upstream_merge_commit` → `7ad44b72c…`. `chrome_milestone`
  stays 151.

Release-line bug-fix mode: `scripts/VERSIONS.txt`, assembly/file/package
versions, and the native C API version are intentionally unchanged
(`update_versions.py` gate passed for this mode). No managed ABI change.

**Bindings:** `regenerate_bindings.py` produced no changes (no C API change in
the upstream range); no `*.generated.cs` edits. No hand-written wrapper or test
changes required.

**Dependencies:** `skia-dependency-changes.json` = zero tracked dependency
changes; no manifest version drift.

## Testing

Native library rebuilt from source on Linux/x64 (`externals-linux --arch=x64`);
`externals-download` was not used. Managed binding builds clean.

Full unfiltered `tests/SkiaSharp.Tests.Console.sln` (net10.0/x64), software GL
(Mesa softpipe) + Vulkan (lavapipe), exit code 0:

- Core: 5721 passed / 181 skipped / 0 failed
- SingletonInit: 1 passed / 0 skipped / 0 failed
- Vulkan: 2 passed / 10 skipped / 0 failed
- Direct3D: 2 passed / 3 skipped / 0 failed

No **required** GPU backend was skipped; skips are platform-policy and
explicitly-checked capability gaps.

## Human review

- Parent gitlink equals the exact mono/skia commit used by the green test run.
- Only Linux/x64 was validated here. Windows, macOS (arm64/x64), Android, iOS,
  and WASM packages/tests were **not** run locally and require CI.
- Merge order: merge the mono/skia PR first, then update this PR's submodule
  pointer to the resulting `release/4.151.x` commit before merging.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-18T19:25:58Z_
