### PR TITLE
[release] Fix release-testing device matrix

### DIFF
--- a/.agents/skills/release-testing/SKILL.md
+++ b/.agents/skills/release-testing/SKILL.md
@@ -376,7 +376,7 @@ once per .NET band you're validating.
 | LinuxConsoleTests | Once (Docker) | - | ~2min |
 | BlazorTests | Once | - | ~2min |
 | MauiMacCatalystTests | Once | - | ~2min |
-| MauiWindowsTests | Once (Windows host) | - | ~2min |
+| MauiWindowsTests | Once | - | ~2min |
 | MauiiOSTests | ✅ Yes | ✅ Yes | ~2min each |
 | MauiAndroidTests | ✅ Yes | ✅ Yes | ~2min each |
 
@@ -407,6 +407,7 @@ Proceed to **release-publish** ONLY when:
 - ✅ ALL tests pass (no failures)
 - ✅ iOS tests pass on BOTH oldest and newest runtime
 - ✅ Android tests pass on BOTH oldest (API 26) and newest (API 35-36)
+- ✅ Windows tests pass on Windows hosts
 - ✅ Screenshots exist in `output/logs/testlogs/integration/`
 
 ### Skip Policy

--- a/.agents/skills/release-testing/SKILL.md
+++ b/.agents/skills/release-testing/SKILL.md
@@ -179,8 +179,12 @@ The build description contains the internal version in format: `#{base}-{label}.
 
 | Platform | Old Version | New Version |
 |----------|-------------|-------------|
-| Android | API 21-23 (5.0-6.0) | API 35-36 (15-16) |
+| Android | API 26 (8.0/Oreo) | API 35-36 (15-16) |
 | iOS | Oldest available runtime | Newest available runtime |
+
+> **Automation scope:** API 26 is the oldest target supported by the current release-test
+> automation/UiAutomator2 stack. This does not change SkiaSharp's or MAUI's minimum Android
+> product support.
 
 👉 **See [setup.md](references/setup.md)** for device selection details and emulator creation.
 
@@ -190,9 +194,10 @@ The build description contains the internal version in format: `#{base}-{label}.
 Planned test matrix:
   - iOS (old):     [device] ([oldest available iOS runtime])
   - iOS (new):     [device] ([newest available iOS runtime])
-  - Android (old): [device] (Android 6.0 / API 23)
+  - Android (old): [device] (Android 8.0 / API 26)
   - Android (new): [device] (Android 16 / API 36)
   - Mac Catalyst:  Current macOS
+  - MauiWindowsTests: Current Windows (required on Windows; explicit hardware/platform skip on non-Windows)
   - Blazor:        Chromium
   - Console:       .NET runtime
   - Linux (Docker): Docker container (mcr.microsoft.com/dotnet/sdk:8.0)
@@ -248,11 +253,12 @@ dotnet test ... -- --filter-class "*LinuxConsoleTests"
 dotnet test ... -- --filter-class "*BlazorTests"
 dotnet test -p:iOSDevice="iPhone 14 Pro" -p:iOSVersion="16.2" ... -- --filter-class "*MauiiOSTests"
 dotnet test ... -- --filter-class "*MauiMacCatalystTests"
+dotnet test ... -- --filter-class "*MauiWindowsTests"
 
 # Android: specify device ID and expected API level for validation
 dotnet test ... \
   -p:AndroidDeviceId="emulator-5554" \
-  -p:AndroidApiLevel="23" \
+  -p:AndroidApiLevel="26" \
   -- --filter-class "*MauiAndroidTests"
 ```
 
@@ -288,14 +294,14 @@ MSBuild `-p:` properties the test project accepts (all go **before** the `--`):
 2. **Start emulator with WIPE and boot verification:**
    ```bash
    # Start emulator with -wipe-data to ensure clean state (use mode="async" to keep it running)
-   emulator -avd Pixel_API_23 -wipe-data -no-snapshot -no-audio
+   emulator -avd Pixel_API_26 -wipe-data -no-snapshot -no-audio
    
    # Wait for boot (check every 10s until returns "1")
    # This can take 60-120s for a fresh wipe
    adb shell getprop sys.boot_completed
    
    # Verify correct API level
-   adb shell getprop ro.build.version.sdk  # Should match expected (e.g., "23")
+   adb shell getprop ro.build.version.sdk  # Should match expected (e.g., "26")
    ```
 
    ⚠️ **The `-wipe-data` flag is REQUIRED** to ensure a clean emulator state. Without it,
@@ -371,10 +377,13 @@ once per .NET band you're validating.
 | LinuxConsoleTests | Once (Docker) | - | ~2min |
 | BlazorTests | Once | - | ~2min |
 | MauiMacCatalystTests | Once | - | ~2min |
+| MauiWindowsTests | Once (Windows host) | - | ~2min |
 | MauiiOSTests | ✅ Yes | ✅ Yes | ~2min each |
 | MauiAndroidTests | ✅ Yes | ✅ Yes | ~2min each |
 
 **iOS and Android run TWICE:** once on oldest, once on newest.
+`MauiWindowsTests` is required on Windows hosts. On non-Windows hosts, keep it in the matrix and
+record an explicit hardware/platform skip.
 
 ### Providing User Feedback
 
@@ -400,14 +409,16 @@ Proceed to **release-publish** ONLY when:
 
 - ✅ ALL tests pass (no failures)
 - ✅ iOS tests pass on BOTH oldest and newest runtime
-- ✅ Android tests pass on BOTH oldest (API 21-23) and newest (API 35-36)
+- ✅ Android tests pass on BOTH oldest automation target (API 26) and newest (API 35-36)
+- ✅ `MauiWindowsTests` pass on Windows hosts, or are explicitly reported as a hardware/platform
+  skip on non-Windows hosts
 - ✅ Screenshots exist in `output/logs/testlogs/integration/`
 
 ### Skip Policy
 
 **Hardware skips only:**
 - iOS/Mac tests on non-macOS → Skip (hardware unavailable)
-- Windows tests on non-Windows → Skip (hardware unavailable)
+- `MauiWindowsTests` on non-Windows → Explicit hardware/platform skip
 
 **NOT valid skips:**
 - "No Android emulator" → Create one
@@ -429,13 +440,17 @@ Proceed to **release-publish** ONLY when:
 | LinuxConsoleTests | Docker Linux | - | ✅ Passed |
 | BlazorTests | Chromium | - | ✅ Passed |
 | MauiMacCatalystTests | macOS | - | ✅ Passed |
+| MauiWindowsTests | Windows | Current host | ✅ Passed |
 | MauiiOSTests | iOS 16.2 (oldest) | iPhone 14 Pro | ✅ Passed |
 | MauiiOSTests | iOS 18.5 (newest) | iPhone 16 Pro | ✅ Passed |
-| MauiAndroidTests | Android 6.0 (API 23) | Pixel_API_23 | ✅ Passed |
+| MauiAndroidTests | Android 8.0 (API 26) | Pixel_API_26 | ✅ Passed |
 | MauiAndroidTests | Android 16 (API 36) | Pixel_API_36 | ✅ Passed |
 
 Ready for publishing.
 ```
+
+On a non-Windows host, keep the `MauiWindowsTests` row and report
+`⏭️ Skipped — non-Windows hardware/platform` instead of omitting it.
 
 ---
 

--- a/.agents/skills/release-testing/SKILL.md
+++ b/.agents/skills/release-testing/SKILL.md
@@ -436,7 +436,7 @@ Proceed to **release-publish** ONLY when:
 | LinuxConsoleTests | Docker Linux | - | ✅ Passed |
 | BlazorTests | Chromium | - | ✅ Passed |
 | MauiMacCatalystTests | macOS | - | ✅ Passed |
-| MauiWindowsTests | Windows | - | ⏭️ Skipped (non-Windows hardware) |
+| MauiWindowsTests | Windows | - | ✅ Passed |
 | MauiiOSTests | iOS 16.2 (oldest) | iPhone 14 Pro | ✅ Passed |
 | MauiiOSTests | iOS 18.5 (newest) | iPhone 16 Pro | ✅ Passed |
 | MauiAndroidTests | Android 8.0 (API 26) | Pixel_API_26 | ✅ Passed |

--- a/.agents/skills/release-testing/SKILL.md
+++ b/.agents/skills/release-testing/SKILL.md
@@ -182,9 +182,8 @@ The build description contains the internal version in format: `#{base}-{label}.
 | Android | API 26 (8.0/Oreo) | API 35-36 (15-16) |
 | iOS | Oldest available runtime | Newest available runtime |
 
-> **Automation scope:** API 26 is the oldest target supported by the current release-test
-> automation/UiAutomator2 stack. This does not change SkiaSharp's or MAUI's minimum Android
-> product support.
+> API 26 is the floor for the current release-test automation/UiAutomator2 stack, not the
+> minimum Android version supported by SkiaSharp or MAUI.
 
 👉 **See [setup.md](references/setup.md)** for device selection details and emulator creation.
 
@@ -197,7 +196,7 @@ Planned test matrix:
   - Android (old): [device] (Android 8.0 / API 26)
   - Android (new): [device] (Android 16 / API 36)
   - Mac Catalyst:  Current macOS
-  - MauiWindowsTests: Current Windows (required on Windows; explicit hardware/platform skip on non-Windows)
+  - Windows:       Current Windows
   - Blazor:        Chromium
   - Console:       .NET runtime
   - Linux (Docker): Docker container (mcr.microsoft.com/dotnet/sdk:8.0)
@@ -382,8 +381,6 @@ once per .NET band you're validating.
 | MauiAndroidTests | ✅ Yes | ✅ Yes | ~2min each |
 
 **iOS and Android run TWICE:** once on oldest, once on newest.
-`MauiWindowsTests` is required on Windows hosts. On non-Windows hosts, keep it in the matrix and
-record an explicit hardware/platform skip.
 
 ### Providing User Feedback
 
@@ -409,16 +406,14 @@ Proceed to **release-publish** ONLY when:
 
 - ✅ ALL tests pass (no failures)
 - ✅ iOS tests pass on BOTH oldest and newest runtime
-- ✅ Android tests pass on BOTH oldest automation target (API 26) and newest (API 35-36)
-- ✅ `MauiWindowsTests` pass on Windows hosts, or are explicitly reported as a hardware/platform
-  skip on non-Windows hosts
+- ✅ Android tests pass on BOTH oldest (API 26) and newest (API 35-36)
 - ✅ Screenshots exist in `output/logs/testlogs/integration/`
 
 ### Skip Policy
 
 **Hardware skips only:**
 - iOS/Mac tests on non-macOS → Skip (hardware unavailable)
-- `MauiWindowsTests` on non-Windows → Explicit hardware/platform skip
+- Windows tests on non-Windows → Skip (hardware unavailable)
 
 **NOT valid skips:**
 - "No Android emulator" → Create one
@@ -440,7 +435,7 @@ Proceed to **release-publish** ONLY when:
 | LinuxConsoleTests | Docker Linux | - | ✅ Passed |
 | BlazorTests | Chromium | - | ✅ Passed |
 | MauiMacCatalystTests | macOS | - | ✅ Passed |
-| MauiWindowsTests | Windows | Current host | ✅ Passed |
+| MauiWindowsTests | Windows | - | ⏭️ Skipped (non-Windows hardware) |
 | MauiiOSTests | iOS 16.2 (oldest) | iPhone 14 Pro | ✅ Passed |
 | MauiiOSTests | iOS 18.5 (newest) | iPhone 16 Pro | ✅ Passed |
 | MauiAndroidTests | Android 8.0 (API 26) | Pixel_API_26 | ✅ Passed |
@@ -448,9 +443,6 @@ Proceed to **release-publish** ONLY when:
 
 Ready for publishing.
 ```
-
-On a non-Windows host, keep the `MauiWindowsTests` row and report
-`⏭️ Skipped — non-Windows hardware/platform` instead of omitting it.
 
 ---
 

--- a/.agents/skills/release-testing/references/monitoring.md
+++ b/.agents/skills/release-testing/references/monitoring.md
@@ -46,6 +46,9 @@ Docker tests require `SkiaSharp.NativeAssets.Linux.NoDependencies` which bundles
 
 ### MAUI Platform Tests (iOS, Android, MacCatalyst, Windows)
 
+On Windows hosts, `MauiWindowsTests` follows these phases and is required to pass. On non-Windows
+hosts, its result is an explicit hardware/platform skip.
+
 | Phase | Duration | Output Indicator |
 |-------|----------|------------------|
 | Build test project | 5-10s | "Determining projects to restore..." |
@@ -99,10 +102,6 @@ Use a detailed checklist showing sub-steps for MAUI tests:
   - [ ] Deploying to simulator
   - [ ] Running test
 ```
-
-Always include `MauiWindowsTests` in the checklist. On Windows hosts, monitor the same build,
-Appium, deploy, screenshot, and verification phases and require it to pass. On non-Windows hosts,
-mark it explicitly as a hardware/platform skip instead of omitting it.
 
 ### During Long Waits
 

--- a/.agents/skills/release-testing/references/monitoring.md
+++ b/.agents/skills/release-testing/references/monitoring.md
@@ -44,7 +44,7 @@ Update the TODO checklist at each phase. When using `read_bash` during long oper
 **First run is slower** (~90s) due to Docker image layer caching. Subsequent runs use cached layers (~10s).
 Docker tests require `SkiaSharp.NativeAssets.Linux.NoDependencies` which bundles all native deps statically.
 
-### MAUI Platform Tests (iOS, Android, MacCatalyst)
+### MAUI Platform Tests (iOS, Android, MacCatalyst, Windows)
 
 | Phase | Duration | Output Indicator |
 |-------|----------|------------------|
@@ -71,6 +71,7 @@ The **Build MAUI app** phase is the longest and provides **no output**. This is 
 | iOS | 60-90 seconds |
 | Android | 90-120 seconds |
 | MacCatalyst | 45-60 seconds |
+| Windows | 45-120 seconds |
 
 **This silence is expected.** The user needs to know this.
 
@@ -98,6 +99,10 @@ Use a detailed checklist showing sub-steps for MAUI tests:
   - [ ] Deploying to simulator
   - [ ] Running test
 ```
+
+Always include `MauiWindowsTests` in the checklist. On Windows hosts, monitor the same build,
+Appium, deploy, screenshot, and verification phases and require it to pass. On non-Windows hosts,
+mark it explicitly as a hardware/platform skip instead of omitting it.
 
 ### During Long Waits
 
@@ -161,6 +166,11 @@ adb logcat -d | grep -E "(FATAL|crash|died)" | tail -10
 **iOS:**
 ```bash
 xcrun simctl list devices booted
+```
+
+**Windows:**
+```powershell
+Get-Process WinAppDriver -ErrorAction SilentlyContinue
 ```
 
 ---

--- a/.agents/skills/release-testing/references/monitoring.md
+++ b/.agents/skills/release-testing/references/monitoring.md
@@ -46,9 +46,6 @@ Docker tests require `SkiaSharp.NativeAssets.Linux.NoDependencies` which bundles
 
 ### MAUI Platform Tests (iOS, Android, MacCatalyst, Windows)
 
-On Windows hosts, `MauiWindowsTests` follows these phases and is required to pass. On non-Windows
-hosts, its result is an explicit hardware/platform skip.
-
 | Phase | Duration | Output Indicator |
 |-------|----------|------------------|
 | Build test project | 5-10s | "Determining projects to restore..." |
@@ -165,11 +162,6 @@ adb logcat -d | grep -E "(FATAL|crash|died)" | tail -10
 **iOS:**
 ```bash
 xcrun simctl list devices booted
-```
-
-**Windows:**
-```powershell
-Get-Process WinAppDriver -ErrorAction SilentlyContinue
 ```
 
 ---

--- a/.agents/skills/release-testing/references/setup.md
+++ b/.agents/skills/release-testing/references/setup.md
@@ -41,6 +41,9 @@ pwsh bin/Debug/net8.0/playwright.ps1 install chromium
 1. Install [WinAppDriver](https://github.com/microsoft/WinAppDriver/releases)
 2. Enable Developer Mode in Settings
 
+`MauiWindowsTests` is required on Windows hosts. On non-Windows hosts, keep it in the matrix and
+report an explicit hardware/platform skip.
+
 ---
 
 ## Android Setup
@@ -66,8 +69,11 @@ Once SDK is located, verify:
 
 | Type | API Level | Purpose |
 |------|-----------|---------|
-| Old | 21-23 | Minimum supported Android |
+| Old | 26 | Android 8/Oreo; oldest target supported by the current release-test automation stack |
 | New | 35-36 | Latest Android |
+
+API 26 is an automation/UiAutomator2 floor only. It does not change SkiaSharp's or MAUI's minimum
+Android product support.
 
 **To check existing AVDs:** List with `emulator -list-avds`, then check each AVD's `config.ini` for `image.sysdir` containing `android-XX` where XX is the API level.
 
@@ -75,6 +81,8 @@ Once SDK is located, verify:
 
 1. Install system image: `sdkmanager "system-images;android-{API};google_apis;arm64-v8a"`
 2. Create AVD: `avdmanager create avd -n {name} -k "system-images;android-{API};google_apis;arm64-v8a" -d pixel`
+
+For the old automation target, use API 26 and an AVD such as `Pixel_API_26`.
 
 For API 36+, use `google_apis_playstore` instead of `google_apis`.
 
@@ -116,12 +124,14 @@ To find devices for a runtime: `xcrun simctl list devices available | grep -A10 
 Before running release tests, verify:
 
 1. **Android SDK found** — `adb version` works
-2. **Old Android emulator exists** — AVD with API 21-23
+2. **Old Android automation emulator exists** — AVD with API 26
 3. **New Android emulator exists** — AVD with API 35-36
 4. **iOS runtimes available** — at least 2 different versions
 5. **Appium installed** — `which appium` returns path
 6. **Appium drivers installed** — `appium driver list --installed` shows uiautomator2, xcuitest
 7. **Docker available** — `docker info` succeeds (for Linux console tests)
+8. **Windows MAUI path accounted for** — run `MauiWindowsTests` on Windows, or record an explicit
+   hardware/platform skip on non-Windows
 
 **If any check fails:** Fix before proceeding. Do not skip tests.
 

--- a/.agents/skills/release-testing/references/setup.md
+++ b/.agents/skills/release-testing/references/setup.md
@@ -41,9 +41,6 @@ pwsh bin/Debug/net8.0/playwright.ps1 install chromium
 1. Install [WinAppDriver](https://github.com/microsoft/WinAppDriver/releases)
 2. Enable Developer Mode in Settings
 
-`MauiWindowsTests` is required on Windows hosts. On non-Windows hosts, keep it in the matrix and
-report an explicit hardware/platform skip.
-
 ---
 
 ## Android Setup
@@ -69,11 +66,8 @@ Once SDK is located, verify:
 
 | Type | API Level | Purpose |
 |------|-----------|---------|
-| Old | 26 | Android 8/Oreo; oldest target supported by the current release-test automation stack |
+| Old | 26 | Oldest release-test automation target (Android 8/Oreo) |
 | New | 35-36 | Latest Android |
-
-API 26 is an automation/UiAutomator2 floor only. It does not change SkiaSharp's or MAUI's minimum
-Android product support.
 
 **To check existing AVDs:** List with `emulator -list-avds`, then check each AVD's `config.ini` for `image.sysdir` containing `android-XX` where XX is the API level.
 
@@ -130,8 +124,6 @@ Before running release tests, verify:
 5. **Appium installed** — `which appium` returns path
 6. **Appium drivers installed** — `appium driver list --installed` shows uiautomator2, xcuitest
 7. **Docker available** — `docker info` succeeds (for Linux console tests)
-8. **Windows MAUI path accounted for** — run `MauiWindowsTests` on Windows, or record an explicit
-   hardware/platform skip on non-Windows
 
 **If any check fails:** Fix before proceeding. Do not skip tests.
 

--- a/.agents/skills/release-testing/references/setup.md
+++ b/.agents/skills/release-testing/references/setup.md
@@ -76,7 +76,7 @@ Once SDK is located, verify:
 1. Install system image: `sdkmanager "system-images;android-{API};google_apis;arm64-v8a"`
 2. Create AVD: `avdmanager create avd -n {name} -k "system-images;android-{API};google_apis;arm64-v8a" -d pixel`
 
-For the old automation target, use API 26 and an AVD such as `Pixel_API_26`.
+For the old target, use API 26 and an AVD such as `Pixel_API_26`.
 
 For API 36+, use `google_apis_playstore` instead of `google_apis`.
 
@@ -118,7 +118,7 @@ To find devices for a runtime: `xcrun simctl list devices available | grep -A10 
 Before running release tests, verify:
 
 1. **Android SDK found** — `adb version` works
-2. **Old Android automation emulator exists** — AVD with API 26
+2. **Old Android emulator exists** — AVD with API 26
 3. **New Android emulator exists** — AVD with API 35-36
 4. **iOS runtimes available** — at least 2 different versions
 5. **Appium installed** — `which appium` returns path

--- a/.agents/skills/release-testing/references/troubleshooting.md
+++ b/.agents/skills/release-testing/references/troubleshooting.md
@@ -43,7 +43,6 @@ dotnet package search SkiaSharp \
 | `Mac2 driver requires Carthage` | Carthage missing | `brew install carthage` |
 | `Connection refused` | Port conflict | Appium auto-starts on 4723; check for conflicts |
 | `Session creation timeout` | First run building WDA | Wait - WebDriverAgent builds on first iOS/Mac run |
-| UiAutomator2 rejects the Android version during session creation | Emulator is below the current API 26 automation floor | Use an Android 8/Oreo API 26 AVD for the old target |
 | `Invalid bundle identifier` | Wrong bundleId | Tests extract from csproj automatically |
 
 ## Simulator/Emulator Errors
@@ -76,18 +75,14 @@ adb logcat -d | grep -E "(AndroidRuntime|FATAL EXCEPTION)" -A15 | head -30
 | `FATAL EXCEPTION` | Unhandled exception | **Bug - investigate** |
 | `Native crash` | Native library issue | **Bug - investigate** |
 
-### Old Android Automation Target (API 26) Failures
+### Old Android (API 26) Crashes
 
-API 26 is the oldest target supported by the current release-test automation/UiAutomator2 stack.
-This is not a change to SkiaSharp's or MAUI's minimum Android product support.
-
-The API 26 test app may fail due to:
+API 26 may crash due to:
 - Missing APIs that MAUI expects
 - Different permission behavior
 - Slower startup causing timeouts
 
-If the failure occurs only on the old automation target, get the full stack trace and check whether
-it is a known MAUI/SkiaSharp issue.
+If crash only on API 26: get full stack trace, check if known MAUI/SkiaSharp issue.
 
 ## iOS Diagnostics
 

--- a/.agents/skills/release-testing/references/troubleshooting.md
+++ b/.agents/skills/release-testing/references/troubleshooting.md
@@ -43,6 +43,7 @@ dotnet package search SkiaSharp \
 | `Mac2 driver requires Carthage` | Carthage missing | `brew install carthage` |
 | `Connection refused` | Port conflict | Appium auto-starts on 4723; check for conflicts |
 | `Session creation timeout` | First run building WDA | Wait - WebDriverAgent builds on first iOS/Mac run |
+| UiAutomator2 rejects the Android version during session creation | Emulator is below the current API 26 automation floor | Use an Android 8/Oreo API 26 AVD for the old target |
 | `Invalid bundle identifier` | Wrong bundleId | Tests extract from csproj automatically |
 
 ## Simulator/Emulator Errors
@@ -75,14 +76,18 @@ adb logcat -d | grep -E "(AndroidRuntime|FATAL EXCEPTION)" -A15 | head -30
 | `FATAL EXCEPTION` | Unhandled exception | **Bug - investigate** |
 | `Native crash` | Native library issue | **Bug - investigate** |
 
-### Old Android (API 21-23) Crashes
+### Old Android Automation Target (API 26) Failures
 
-Old Android may crash due to:
+API 26 is the oldest target supported by the current release-test automation/UiAutomator2 stack.
+This is not a change to SkiaSharp's or MAUI's minimum Android product support.
+
+The API 26 test app may fail due to:
 - Missing APIs that MAUI expects
 - Different permission behavior
 - Slower startup causing timeouts
 
-If crash only on old Android: get full stack trace, check if known MAUI/SkiaSharp issue.
+If the failure occurs only on the old automation target, get the full stack trace and check whether
+it is a known MAUI/SkiaSharp issue.
 
 ## iOS Diagnostics
 

--- a/tests/SkiaSharp.Tests.Integration/SkiaSharp.Tests.Integration.csproj
+++ b/tests/SkiaSharp.Tests.Integration/SkiaSharp.Tests.Integration.csproj
@@ -29,14 +29,14 @@
     
     <!-- Device configuration - can be overridden via command line -->
     <!-- dotnet test -p:iOSDevice="iPad Pro 13-inch (M4)" -p:iOSVersion="18.5" -->
-    <!-- dotnet test -p:AndroidDevice="Pixel 8" -p:AndroidVersion="14" -p:AndroidDeviceId="emulator-5554" -p:AndroidApiLevel="23" -->
+    <!-- dotnet test -p:AndroidDevice="Pixel_API_26" -p:AndroidVersion="8.0" -p:AndroidDeviceId="emulator-5554" -p:AndroidApiLevel="26" -->
     <iOSDevice Condition="'$(iOSDevice)' == ''"></iOSDevice>
     <iOSVersion Condition="'$(iOSVersion)' == ''"></iOSVersion>
     <AndroidDevice Condition="'$(AndroidDevice)' == ''"></AndroidDevice>
     <AndroidVersion Condition="'$(AndroidVersion)' == ''"></AndroidVersion>
     <!-- AndroidDeviceId: Specific emulator/device UDID (e.g., "emulator-5554") -->
     <AndroidDeviceId Condition="'$(AndroidDeviceId)' == ''"></AndroidDeviceId>
-    <!-- AndroidApiLevel: Expected API level for validation (e.g., "23", "36") -->
+    <!-- AndroidApiLevel: Expected API level for validation (e.g., "26", "36") -->
     <AndroidApiLevel Condition="'$(AndroidApiLevel)' == ''"></AndroidApiLevel>
   </PropertyGroup>
 

--- a/tests/SkiaSharp.Tests.Integration/Tests/MauiAndroidTests.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/MauiAndroidTests.cs
@@ -9,8 +9,8 @@ namespace SkiaSharp.Tests.Integration;
 /// <summary>
 /// Tests that verify SkiaSharp packages work in MAUI Android applications.
 /// Device and version can be configured via MSBuild properties:
-///   dotnet test -p:AndroidDevice="Pixel 8" -p:AndroidVersion="14"
-///   dotnet test -p:AndroidDeviceId="emulator-5554" -p:AndroidApiLevel="23"
+///   dotnet test -p:AndroidDevice="Pixel_API_26" -p:AndroidVersion="8.0"
+///   dotnet test -p:AndroidDeviceId="emulator-5554" -p:AndroidApiLevel="26"
 /// </summary>
 public class MauiAndroidTests(ITestOutputHelper output) : MauiTestBase(output)
 {
@@ -92,7 +92,7 @@ public class MauiAndroidTests(ITestOutputHelper output) : MauiTestBase(output)
 
     /// <summary>
     /// Get the actual API level of the connected device for screenshot naming.
-    /// Returns format like "api23" or "api36".
+    /// Returns format like "api26" or "api36".
     /// </summary>
     protected override async Task<string?> GetDeviceVersionAsync()
     {
@@ -101,7 +101,7 @@ public class MauiAndroidTests(ITestOutputHelper output) : MauiTestBase(output)
     }
 
     /// <summary>
-    /// Get the raw API level number (e.g., "23", "36").
+    /// Get the raw API level number (e.g., "26", "36").
     /// </summary>
     private async Task<string?> GetRawApiLevelAsync()
     {

--- a/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
+++ b/tests/SkiaSharp.Tests.Integration/Tests/MauiTestBase.cs
@@ -160,7 +160,7 @@ public abstract class MauiTestBase(ITestOutputHelper output) : PlatformTestBase(
         var platformLower = PlatformName.ToLowerInvariant().Replace(" ", "");
         
         // Build screenshot name with version and timestamp
-        // e.g., maui-android-api23-20260205-161500-SKCanvasView
+        // e.g., maui-android-api26-20260205-161500-SKCanvasView
         var screenshotName = deviceVersion != null
             ? $"maui-{platformLower}-{deviceVersion}-{timestamp}-{canvasView}"
             : $"maui-{platformLower}-{timestamp}-{canvasView}";


### PR DESCRIPTION
## Description

Updates the documented release-testing device matrix in two focused ways:

- Uses Android 8/Oreo (API 26) as the oldest target for the current release-test automation/UiAutomator2 stack. This does not change SkiaSharp or MAUI product support minimums.
- Adds Windows to the existing test matrix, commands, execution/monitoring tables, and final report so the existing `MauiWindowsTests` path is represented.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — documentation and test-comment updates only; no public API or executable behavior changes.

## Testing

- Parsed `tests/SkiaSharp.Tests.Integration/SkiaSharp.Tests.Integration.csproj` as XML.
- Ran `.agents/skills/skill-creator/scripts/quick_validate.py` for the release-testing skill.
- Checked local Markdown links/anchors and `dotnet test` command consistency, including MTP filter placement after `--`.
- Confirmed no stale API 21-23, API 23, or `Pixel_API_23` references remain in the affected files.
- Ran `git diff --check` and reviewed the `origin/main...HEAD` diff for strict scope.
- Integration tests were not run because executable test behavior is unchanged.

## Checklist

- [x] Tests added or updated (not applicable — documentation/comment-only change)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native changes