### PR TITLE
Modernize the documentation site theme

### DIFF
--- a/documentation/docfx/docfx.json
+++ b/documentation/docfx/docfx.json
@@ -35,6 +35,7 @@
     "externalReference": [],
     "globalMetadata": {
       "_appTitle": "SkiaSharp",
+      "_appName": "SkiaSharp",
       "_enableSearch": true,
       "_appLogoPath": "images/logo.png",
       "_appFaviconPath": "images/favicon.ico",
@@ -46,7 +47,8 @@
     "dest": "../../output/site/docs",
     "template": [
       "default",
-      "modern"
+      "modern",
+      "template"
     ]
   }
 }

--- a/documentation/docfx/template/public/main.css
+++ b/documentation/docfx/template/public/main.css
@@ -1,0 +1,1042 @@
+:root {
+  --sk-paper: #f4f3ef;
+  --sk-paper-sunk: #ecebe5;
+  --sk-paper-raised: #fafaf7;
+  --sk-paper-deep: #e3e2db;
+  --sk-ink: #1f2124;
+  --sk-ink-2: #4a4e54;
+  --sk-ink-3: #676d75;
+  --sk-ink-ghost: #a9afb6;
+  --sk-rule: #d9d8d1;
+  --sk-rule-strong: #bfbeb5;
+  --sk-accent: #b8442a;
+  --sk-accent-ink: #9c3620;
+  --sk-accent-wash: #f3e4de;
+  --sk-info: #2a4457;
+  --sk-info-ink: #22394a;
+  --sk-info-wash: #e2e8ec;
+  --sk-warn: #7a5a22;
+  --sk-warn-ink: #63481a;
+  --sk-warn-wash: #f0e9da;
+  --sk-positive: #3e6357;
+  --sk-positive-ink: #315045;
+  --sk-positive-wash: #e1eae6;
+  --sk-comment: #5f656d;
+  --sk-code-csharp: #2a4457;
+  --sk-code-xaml: #8a642b;
+  --sk-focus: #0b65c2;
+  --sk-grain: rgb(31 33 36 / 3%);
+  --sk-font-display: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+  --sk-font-body: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --sk-font-mono: "Cascadia Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --sk-rule-tooth: repeating-linear-gradient(
+    90deg,
+    var(--sk-rule) 0 3px,
+    transparent 3px 4px
+  );
+  --sk-duration-fast: 90ms;
+  --sk-duration-normal: 150ms;
+  --sk-ease: cubic-bezier(0.2, 0.6, 0.2, 1);
+
+  --bs-body-bg: var(--sk-paper);
+  --bs-body-color: var(--sk-ink);
+  --bs-body-font-family: var(--sk-font-body);
+  --bs-body-line-height: 1.7;
+  --bs-emphasis-color: var(--sk-ink);
+  --bs-secondary-color: var(--sk-ink-2);
+  --bs-secondary-bg: var(--sk-paper-sunk);
+  --bs-tertiary-color: var(--sk-ink-3);
+  --bs-tertiary-bg: var(--sk-paper-deep);
+  --bs-border-color: var(--sk-rule);
+  --bs-border-radius: 1px;
+  --bs-border-radius-sm: 1px;
+  --bs-border-radius-lg: 2px;
+  --bs-link-color: var(--sk-accent-ink);
+  --bs-link-color-rgb: 156, 54, 32;
+  --bs-link-hover-color: #742817;
+  --bs-link-hover-color-rgb: 116, 40, 23;
+  --bs-code-color: var(--sk-ink);
+  --bs-font-monospace: var(--sk-font-mono);
+  --bs-heading-color: var(--sk-ink);
+  --bs-highlight-bg: var(--sk-accent-wash);
+  --bs-focus-ring-color: rgb(11 101 194 / 32%);
+  --bs-focus-ring-width: 2px;
+  --bs-form-control-bg: transparent;
+  --bs-navbar-color: var(--sk-ink-2);
+  --bs-navbar-hover-color: var(--sk-ink);
+  --bs-navbar-active-color: var(--sk-ink);
+  --bs-nav-link-color: var(--sk-ink-2);
+  --bs-nav-link-hover-color: var(--sk-ink);
+  --bs-breadcrumb-divider-color: var(--sk-ink-ghost);
+  --bs-breadcrumb-item-active-color: var(--sk-ink-2);
+}
+
+[data-bs-theme="dark"] {
+  --sk-paper: #16191d;
+  --sk-paper-sunk: #101317;
+  --sk-paper-raised: #1d2126;
+  --sk-paper-deep: #0b0d10;
+  --sk-ink: #e8e9ea;
+  --sk-ink-2: #a9b0b8;
+  --sk-ink-3: #838b94;
+  --sk-ink-ghost: #545c65;
+  --sk-rule: #2a2f35;
+  --sk-rule-strong: #3d444c;
+  --sk-accent: #e4795c;
+  --sk-accent-ink: #f09274;
+  --sk-accent-wash: #2a1913;
+  --sk-info: #7fa9c6;
+  --sk-info-ink: #9cc0d9;
+  --sk-info-wash: #141e26;
+  --sk-warn: #c9a053;
+  --sk-warn-ink: #dbb975;
+  --sk-warn-wash: #241d10;
+  --sk-positive: #74a392;
+  --sk-positive-ink: #90bcab;
+  --sk-positive-wash: #131f1b;
+  --sk-comment: #8a929b;
+  --sk-code-csharp: #7fa9c6;
+  --sk-code-xaml: #c9a053;
+  --sk-focus: #8bcbff;
+  --sk-grain: rgb(232 233 234 / 2.2%);
+
+  --bs-link-color: var(--sk-accent-ink);
+  --bs-link-color-rgb: 240, 146, 116;
+  --bs-link-hover-color: #ffc0ab;
+  --bs-link-hover-color-rgb: 255, 192, 171;
+  --bs-focus-ring-color: rgb(139 203 255 / 38%);
+}
+
+html {
+  scroll-padding-top: 5rem;
+}
+
+body {
+  font-family: var(--sk-font-body);
+  color: var(--sk-ink);
+  background: var(--sk-paper);
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  color: var(--sk-ink);
+  background: var(--sk-accent-wash);
+}
+
+a {
+  text-underline-offset: 0.18em;
+  text-decoration-thickness: 1px;
+  transition:
+    color var(--sk-duration-fast) var(--sk-ease),
+    text-decoration-thickness var(--sk-duration-fast) var(--sk-ease);
+}
+
+a:hover {
+  text-decoration-thickness: 1.5px;
+}
+
+:focus-visible {
+  outline: 2px solid var(--sk-focus) !important;
+  outline-offset: 3px;
+  box-shadow: none !important;
+}
+
+header {
+  min-height: 3.75rem;
+  background-color: var(--sk-paper-raised) !important;
+  background-image:
+    radial-gradient(circle at 20% 30%, var(--sk-grain) 0 0.55px, transparent 0.7px),
+    radial-gradient(circle at 70% 65%, var(--sk-grain) 0 0.45px, transparent 0.65px);
+  background-size: 13px 17px, 19px 23px;
+  border-color: var(--sk-rule) !important;
+  box-shadow: 0 1px 0 var(--sk-rule);
+}
+
+header .container-xxl {
+  position: relative;
+  max-width: 94rem;
+}
+
+.navbar-brand {
+  position: relative;
+  gap: 0.65rem;
+  align-items: center;
+  padding-block: 0.35rem;
+  color: var(--sk-ink);
+  font-family: var(--sk-font-display);
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.navbar-brand:hover {
+  color: var(--sk-accent-ink);
+}
+
+.navbar-brand::after {
+  position: absolute;
+  bottom: 0.16rem;
+  left: 2.85rem;
+  width: 3.8rem;
+  height: 3px;
+  content: "";
+  background: var(--sk-accent);
+  clip-path: polygon(0 25%, 82% 0, 100% 42%, 86% 74%, 0 100%);
+}
+
+#logo {
+  width: auto;
+  height: 2.35rem;
+}
+
+#navbar {
+  gap: 0.6rem;
+}
+
+#navbar .navbar-nav {
+  gap: 0.1rem;
+}
+
+#navbar .nav-link {
+  position: relative;
+  padding-inline: 0.72rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+#navbar .nav-link::after {
+  position: absolute;
+  right: 0.72rem;
+  bottom: 0.28rem;
+  left: 0.72rem;
+  height: 2px;
+  content: "";
+  background: var(--sk-accent);
+  clip-path: polygon(0 35%, 88% 0, 100% 50%, 88% 80%, 0 100%);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--sk-duration-normal) var(--sk-ease);
+}
+
+#navbar .nav-link:hover::after,
+#navbar .nav-link.active::after {
+  transform: scaleX(1);
+}
+
+#search,
+.toc .filter {
+  border-bottom: 1px solid var(--sk-rule-strong);
+  transition: border-color var(--sk-duration-fast) var(--sk-ease);
+}
+
+#search:focus-within,
+.toc .filter:focus-within {
+  border-bottom-color: var(--sk-accent);
+  border-bottom-width: 2px;
+}
+
+#search .form-control,
+.toc .filter .form-control {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--sk-ink);
+}
+
+#search .bi,
+.toc .filter .bi {
+  color: var(--sk-ink-3);
+}
+
+main.container-xxl {
+  max-width: 94rem;
+  padding-top: 1.75rem;
+}
+
+.toc-offcanvas {
+  border-right: 1px solid var(--sk-rule);
+}
+
+.toc {
+  padding-right: 1.35rem;
+  font-size: 0.875rem;
+}
+
+.toc ul {
+  padding-left: 0.85rem;
+}
+
+.toc > div > ul {
+  padding-left: 0;
+}
+
+.toc li {
+  position: relative;
+}
+
+.toc li > a {
+  min-height: 2rem;
+  padding: 0.37rem 0.5rem;
+  border-radius: 1px;
+  color: var(--sk-ink-2);
+  line-height: 1.4;
+  transition:
+    color var(--sk-duration-fast) var(--sk-ease),
+    background-color var(--sk-duration-fast) var(--sk-ease);
+}
+
+.toc li > a:hover {
+  color: var(--sk-ink);
+  background: var(--sk-accent-wash);
+}
+
+.toc li.active > a {
+  color: var(--sk-ink);
+  font-weight: 650;
+}
+
+.toc li.active > a::before {
+  position: absolute;
+  top: 0.92rem;
+  left: -0.65rem;
+  width: 1.25rem;
+  height: 3px;
+  content: "";
+  background: var(--sk-accent);
+  clip-path: polygon(0 30%, 82% 0, 100% 48%, 84% 78%, 0 100%);
+}
+
+.toc li.expanded > ul {
+  border-left: 1px solid var(--sk-rule);
+}
+
+.toc .expand-stub {
+  color: var(--sk-ink-3);
+}
+
+.offcanvas {
+  background: var(--sk-paper);
+  color: var(--sk-ink);
+}
+
+.content {
+  min-width: 0;
+  padding-bottom: 3rem;
+}
+
+.actionbar {
+  min-height: 2.25rem;
+  margin-bottom: 1rem;
+}
+
+.breadcrumb {
+  font-size: 0.8rem;
+  color: var(--sk-ink-3);
+}
+
+.breadcrumb a {
+  color: var(--sk-ink-3);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  color: var(--sk-accent-ink);
+  text-decoration: underline;
+}
+
+article {
+  max-width: 72ch;
+  color: var(--sk-ink);
+  font-size: 1.05rem;
+  line-height: 1.72;
+}
+
+article h1,
+article h2,
+article h3 {
+  color: var(--sk-ink);
+  font-family: var(--sk-font-display);
+  font-weight: 600;
+  letter-spacing: -0.018em;
+}
+
+article h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.2rem, 4vw, 2.65rem);
+  line-height: 1.13;
+}
+
+article h1::before {
+  display: block;
+  width: 6rem;
+  height: 7px;
+  margin-bottom: 1.15rem;
+  content: "";
+  background: var(--sk-accent);
+  clip-path: polygon(0 20%, 76% 0, 100% 36%, 91% 62%, 72% 100%, 0 72%);
+  transform: rotate(-0.35deg);
+}
+
+article h1 + p > em:only-child {
+  display: block;
+  margin: -0.15rem 0 2rem;
+  color: var(--sk-ink-2);
+  font-family: var(--sk-font-display);
+  font-size: 1.16rem;
+  line-height: 1.55;
+}
+
+article h2 {
+  margin-top: 3.5rem;
+  padding-top: 1.05rem;
+  background-image: var(--sk-rule-tooth);
+  background-repeat: no-repeat;
+  background-position: top left;
+  background-size: 100% 1px;
+  font-size: 1.75rem;
+  line-height: 1.25;
+}
+
+article h3 {
+  margin-top: 2.25rem;
+  font-size: 1.3rem;
+  line-height: 1.35;
+}
+
+article h2 > a,
+article h3 > a {
+  color: inherit;
+  text-decoration: none;
+}
+
+article h2 > a:hover,
+article h3 > a:hover {
+  color: var(--sk-accent-ink);
+  text-decoration: underline;
+}
+
+article p,
+article ul,
+article ol {
+  margin-bottom: 1.15rem;
+}
+
+article li {
+  margin-block: 0.28rem;
+}
+
+article li::marker {
+  color: var(--sk-accent);
+}
+
+article a:not(.btn) {
+  color: var(--sk-accent-ink);
+}
+
+article a.external::after {
+  margin-left: 0.15em;
+  color: var(--sk-ink-3);
+  font-size: 0.72em;
+  content: "↗";
+}
+
+article :not(pre) > code {
+  padding: 0 0.08em 0.08em;
+  border-bottom: 1px solid var(--sk-rule-strong);
+  border-radius: 0;
+  background: transparent;
+  color: var(--sk-ink);
+  font-family: var(--sk-font-mono);
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+}
+
+article a > code {
+  color: inherit;
+  border-bottom-color: currentColor;
+}
+
+article pre {
+  --sk-code-line: var(--sk-rule-strong);
+  position: relative;
+  margin: 1.75rem 0;
+  padding-top: 2.2rem;
+  overflow: hidden;
+  border: 1px solid var(--sk-rule);
+  border-left: 3px solid var(--sk-code-line);
+  border-radius: 0;
+  background: var(--sk-paper-sunk);
+  color: var(--sk-ink);
+}
+
+article pre:has(> code.lang-csharp) {
+  --sk-code-line: var(--sk-code-csharp);
+}
+
+article pre:has(> code.lang-xaml),
+article pre:has(> code.lang-xml) {
+  --sk-code-line: var(--sk-code-xaml);
+}
+
+article pre::before {
+  position: absolute;
+  top: 0.56rem;
+  left: 1.1rem;
+  color: var(--sk-code-line);
+  font-family: var(--sk-font-body);
+  font-size: 0.68rem;
+  font-variant-caps: all-small-caps;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  line-height: 1;
+  content: "CODE";
+}
+
+article pre:has(> code.lang-csharp)::before {
+  content: "C#";
+}
+
+article pre:has(> code.lang-xaml)::before {
+  content: "XAML";
+}
+
+article pre:has(> code.lang-xml)::before {
+  content: "XML";
+}
+
+article pre > code,
+article pre > code.hljs {
+  display: block;
+  padding: 0.9rem 1.15rem 1.1rem;
+  overflow: auto;
+  border: 0;
+  background: transparent;
+  color: var(--sk-ink-2);
+  font-family: var(--sk-font-mono);
+  font-size: 0.88rem;
+  line-height: 1.62;
+  tab-size: 4;
+}
+
+article pre .code-action {
+  position: absolute;
+  z-index: 2;
+  top: 0.27rem;
+  right: 0.55rem;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  min-width: 3.4rem;
+  min-height: 1.7rem;
+  padding: 0.15rem 0.3rem;
+  border: 0 !important;
+  border-bottom: 1px solid var(--sk-rule-strong) !important;
+  border-radius: 0;
+  color: var(--sk-ink-3);
+  font-family: var(--sk-font-body);
+  font-size: 0.68rem;
+  font-variant-caps: all-small-caps;
+  letter-spacing: 0.08em;
+}
+
+article pre .code-action::after {
+  content: "Copy";
+}
+
+article pre .code-action.link-success::after {
+  content: "Copied";
+}
+
+article pre .code-action i {
+  display: none;
+}
+
+article pre .code-action:hover {
+  color: var(--sk-accent-ink);
+  border-bottom-color: var(--sk-accent) !important;
+}
+
+.hljs-keyword,
+.hljs-built_in,
+.hljs-literal,
+.hljs-selector-tag {
+  color: var(--sk-info-ink);
+  font-weight: 650;
+}
+
+.hljs-type,
+.hljs-title,
+.hljs-title.class_,
+.hljs-name {
+  color: var(--sk-ink);
+  font-weight: 650;
+}
+
+.hljs-tag {
+  color: var(--sk-ink-2);
+  font-weight: 400;
+}
+
+.hljs-string,
+.hljs-template-string,
+.hljs-regexp {
+  color: var(--sk-accent-ink);
+  font-weight: 400;
+}
+
+.hljs-number,
+.hljs-attr,
+.hljs-symbol,
+.hljs-meta {
+  color: var(--sk-warn-ink);
+  font-weight: 400;
+}
+
+.hljs-comment,
+.hljs-quote,
+.hljs-doctag {
+  color: var(--sk-comment);
+  font-style: italic;
+}
+
+.hljs-variable,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation {
+  color: var(--sk-ink-2);
+}
+
+article .alert {
+  margin-block: 1.75rem;
+  padding: 1rem 1.2rem;
+  border: 0;
+  border-left: 5px solid var(--sk-info);
+  border-radius: 0;
+  background: var(--sk-info-wash);
+  color: var(--sk-ink);
+}
+
+article .alert h5 {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.45rem;
+  color: var(--sk-info-ink);
+  font-family: var(--sk-font-display);
+  font-size: 0.82rem;
+  font-variant-caps: all-small-caps;
+  letter-spacing: 0.08em;
+}
+
+article .alert h5::before {
+  width: 1.25rem;
+  height: 3px;
+  content: "";
+  background: currentColor;
+  clip-path: polygon(0 30%, 82% 0, 100% 50%, 84% 82%, 0 100%);
+}
+
+article .TIP {
+  border-left-color: var(--sk-positive);
+  background: var(--sk-positive-wash);
+}
+
+article .TIP h5 {
+  color: var(--sk-positive-ink);
+}
+
+article .WARNING {
+  border-left-color: var(--sk-warn);
+  background: var(--sk-warn-wash);
+}
+
+article .WARNING h5 {
+  color: var(--sk-warn-ink);
+}
+
+article .IMPORTANT,
+article .CAUTION {
+  border-left-color: var(--sk-accent);
+  background: var(--sk-accent-wash);
+}
+
+article .IMPORTANT h5,
+article .CAUTION h5 {
+  color: var(--sk-accent-ink);
+}
+
+article .table-responsive {
+  margin-block: 1.75rem;
+  border-block: 1px solid var(--sk-rule);
+}
+
+article .table {
+  margin: 0;
+  color: var(--sk-ink);
+  font-size: 0.92rem;
+  font-variant-numeric: tabular-nums;
+  --bs-table-bg: transparent;
+  --bs-table-color: var(--sk-ink);
+  --bs-table-border-color: var(--sk-rule);
+  --bs-table-striped-bg: transparent;
+  --bs-table-hover-bg: var(--sk-accent-wash);
+}
+
+article .table > :not(caption) > * > * {
+  padding: 0.7rem 0.85rem;
+  border-width: 0 0 1px;
+  border-color: var(--sk-rule);
+  background: transparent;
+}
+
+article .table thead th {
+  border-bottom: 2px solid var(--sk-accent);
+  color: var(--sk-ink-2);
+  font-size: 0.78rem;
+  font-variant-caps: all-small-caps;
+  letter-spacing: 0.05em;
+}
+
+article .table tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
+article p:has(> img:only-child),
+article p:has(> a:only-child > img:only-child) {
+  margin-block: 2rem;
+}
+
+article p > img:only-child,
+article p > a:only-child > img:only-child {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  padding: 0.5rem;
+  border: 1px solid var(--sk-rule);
+  border-radius: 1px;
+  background: var(--sk-paper-raised);
+}
+
+article details {
+  margin-block: 1.25rem;
+  padding-block: 0.75rem;
+  border-block: 1px solid var(--sk-rule);
+}
+
+article details > summary {
+  color: var(--sk-ink);
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.skia-hub article > h2:has(> a:not(.anchorjs-link)) {
+  margin-top: 0;
+  padding: 1.45rem 0 0;
+  font-size: 1.35rem;
+}
+
+.skia-hub article > h2:has(> a:not(.anchorjs-link))::before {
+  display: inline-block;
+  width: 1.5rem;
+  height: 3px;
+  margin-right: 0.65rem;
+  vertical-align: 0.25em;
+  content: "";
+  background: var(--sk-accent);
+  clip-path: polygon(0 30%, 82% 0, 100% 50%, 84% 80%, 0 100%);
+}
+
+.skia-hub article > h2 > a:not(.anchorjs-link) {
+  color: var(--sk-ink);
+}
+
+.skia-hub article > h2 > a:not(.anchorjs-link):hover {
+  color: var(--sk-accent-ink);
+}
+
+.skia-hub article > h2:has(> a:not(.anchorjs-link)) + p {
+  margin: 0;
+  padding: 0.4rem 0 1.45rem 2.2rem;
+  color: var(--sk-ink-2);
+}
+
+.skia-releases article h1 {
+  font-variant-numeric: lining-nums tabular-nums;
+}
+
+.skia-releases article > blockquote {
+  margin: 0;
+  padding: 0.55rem 0;
+  border: 0;
+  border-top: 1px solid var(--sk-rule);
+  color: var(--sk-ink-2);
+  font-size: 0.9rem;
+}
+
+.skia-releases article > blockquote + blockquote {
+  border-bottom: 1px solid var(--sk-rule);
+}
+
+.skia-releases article > blockquote p {
+  margin: 0;
+}
+
+.skia-releases article > blockquote strong {
+  color: var(--sk-ink);
+  font-family: var(--sk-font-display);
+  font-weight: 600;
+}
+
+.skia-releases article a[href*="/pull/"] {
+  color: var(--sk-ink-3);
+  font-size: 0.88em;
+  font-variant-numeric: tabular-nums;
+}
+
+.affix {
+  padding-left: 1.25rem;
+  border-left: 1px solid var(--sk-rule);
+}
+
+.affix h5 {
+  padding-bottom: 0.65rem;
+  border-color: var(--sk-rule) !important;
+  color: var(--sk-ink-3);
+  font-family: var(--sk-font-display);
+  font-size: 0.78rem;
+  font-variant-caps: all-small-caps;
+  letter-spacing: 0.06em;
+}
+
+.affix a {
+  color: var(--sk-ink-2) !important;
+  font-size: 0.82rem;
+  text-decoration: none;
+}
+
+.affix a:hover {
+  color: var(--sk-accent-ink) !important;
+  text-decoration: underline;
+}
+
+.next-article {
+  margin-top: 3rem;
+  border-color: var(--sk-rule) !important;
+}
+
+.next-article > div {
+  padding-block: 1rem;
+}
+
+.next-article span {
+  color: var(--sk-ink-3);
+  font-size: 0.72rem;
+  font-variant-caps: all-small-caps;
+  letter-spacing: 0.06em;
+}
+
+.next-article a {
+  color: var(--sk-ink);
+  font-family: var(--sk-font-display);
+  text-decoration: none;
+}
+
+.next-article a:hover {
+  color: var(--sk-accent-ink);
+  text-decoration: underline;
+}
+
+#search-results {
+  max-width: 54rem;
+  background: var(--sk-paper-raised);
+  color: var(--sk-ink);
+}
+
+#search-results .search-list > a {
+  border-color: var(--sk-rule);
+}
+
+#search-results mark {
+  color: var(--sk-ink);
+  background: var(--sk-accent-wash);
+}
+
+footer {
+  position: relative;
+  padding-block: 2.25rem;
+  background-color: var(--sk-paper-sunk);
+  background-image:
+    radial-gradient(circle at 20% 30%, var(--sk-grain) 0 0.55px, transparent 0.7px),
+    radial-gradient(circle at 70% 65%, var(--sk-grain) 0 0.45px, transparent 0.65px);
+  background-size: 13px 17px, 19px 23px;
+  border-color: var(--sk-rule) !important;
+  color: var(--sk-ink-3) !important;
+}
+
+footer .container-xxl {
+  position: relative;
+  max-width: 94rem;
+  padding-top: 0.8rem;
+}
+
+footer .container-xxl::before {
+  position: absolute;
+  top: -0.55rem;
+  left: 0.75rem;
+  width: 5rem;
+  height: 5px;
+  content: "";
+  background: var(--sk-accent);
+  clip-path: polygon(0 20%, 78% 0, 100% 38%, 90% 68%, 72% 100%, 0 72%);
+}
+
+footer a {
+  color: var(--sk-accent-ink);
+}
+
+@media (min-width: 1400px) {
+  main.container-xxl {
+    gap: 2.75rem;
+  }
+
+  .toc-offcanvas {
+    flex: 0 0 16rem;
+  }
+
+  .content {
+    flex: 1 1 48rem;
+    max-width: 48rem;
+  }
+
+  .affix {
+    flex: 0 0 13rem;
+  }
+}
+
+@media (max-width: 1199.98px) {
+  #search {
+    width: 11rem;
+  }
+
+  #navbar .nav-link {
+    padding-inline: 0.5rem;
+  }
+
+  #navbar .nav-link::after {
+    right: 0.5rem;
+    left: 0.5rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  header {
+    min-height: 3.5rem;
+  }
+
+  .navbar-brand {
+    font-size: 1.05rem;
+  }
+
+  .navbar-brand::after {
+    left: 2.55rem;
+    width: 3.2rem;
+  }
+
+  #logo {
+    height: 2.05rem;
+  }
+
+  main.container-xxl {
+    padding-top: 1rem;
+  }
+
+  .content {
+    padding-bottom: 2rem;
+  }
+
+  article {
+    max-width: none;
+    font-size: 1rem;
+    line-height: 1.68;
+  }
+
+  article h1 {
+    font-size: 2.05rem;
+  }
+
+  article h1::before {
+    width: 4.5rem;
+    height: 6px;
+  }
+
+  article h2 {
+    margin-top: 2.75rem;
+    font-size: 1.55rem;
+  }
+
+  article pre {
+    margin-inline: -0.25rem;
+  }
+
+  article pre > code,
+  article pre > code.hljs {
+    font-size: 0.82rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+@media (forced-colors: active) {
+  article h1::before,
+  .navbar-brand::after,
+  #navbar .nav-link::after,
+  .toc li.active > a::before,
+  article .alert h5::before,
+  .skia-hub article > h2:has(> a:not(.anchorjs-link))::before,
+  footer .container-xxl::before {
+    background: CanvasText;
+  }
+
+  article .alert,
+  article pre,
+  article .table-responsive {
+    border: 1px solid CanvasText;
+  }
+}
+
+@media print {
+  header,
+  .toc-offcanvas,
+  .affix,
+  footer,
+  .next-article {
+    display: none !important;
+  }
+
+  body,
+  article,
+  article pre {
+    color: #000 !important;
+    background: #fff !important;
+  }
+
+  article {
+    max-width: none;
+    font-size: 11pt;
+  }
+
+  article h1::before {
+    background: #000;
+  }
+}

--- a/documentation/docfx/template/public/main.js
+++ b/documentation/docfx/template/public/main.js
@@ -1,0 +1,34 @@
+export default {
+  defaultTheme: "auto",
+  showLightbox: (image) =>
+    !image.closest("a") && image.naturalWidth > 640 && image.naturalHeight > 360,
+  configureHljs: (hljs) => {
+    hljs.registerAliases(["xaml"], { languageName: "xml" })
+  },
+  start: () => {
+    const article = document.querySelector("article")
+    if (!article) {
+      return
+    }
+
+    if (article.querySelectorAll(":scope > h2 > a").length >= 3) {
+      document.body.classList.add("skia-hub")
+    }
+
+    if (location.pathname.includes("/releases/")) {
+      document.body.classList.add("skia-releases")
+    }
+
+    article.querySelectorAll("pre").forEach((pre) => {
+      const code = pre.querySelector("code")
+      const language =
+        [...(code?.classList ?? [])]
+          .find((name) => name.startsWith("lang-"))
+          ?.slice(5) ?? "code"
+
+      pre.tabIndex = 0
+      pre.setAttribute("role", "region")
+      pre.setAttribute("aria-label", `${language.toUpperCase()} code sample`)
+    })
+  },
+}

--- a/documentation/site/404.html
+++ b/documentation/site/404.html
@@ -27,17 +27,34 @@
     })();
   </script>
   <style>
-    :root { --text: #1f2328; --text-2: #656d76; --bg: #fff; --accent: #2563eb; }
+    :root {
+      color-scheme: light;
+      --text: #1f2124;
+      --text-2: #676d75;
+      --bg: #f4f3ef;
+      --accent: #9c3620;
+      --font-display: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    }
     @media (prefers-color-scheme: dark) {
-      :root { --text: #e6edf3; --text-2: #8b949e; --bg: #0d1117; --accent: #58a6ff; }
+      :root {
+        color-scheme: dark;
+        --text: #e8e9ea;
+        --text-2: #a9b0b8;
+        --bg: #16191d;
+        --accent: #f09274;
+      }
     }
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      background: var(--bg); color: var(--text);
+      font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+      background:
+        radial-gradient(circle at 15% 20%, rgb(184 68 42 / 9%), transparent 34%),
+        radial-gradient(circle at 84% 78%, rgb(62 99 87 / 8%), transparent 38%),
+        var(--bg);
+      color: var(--text);
       display: flex; align-items: center; justify-content: center;
       min-height: 100vh; margin: 0; text-align: center; padding: 24px;
     }
-    h1 { font-size: 72px; font-weight: 800; margin: 0 0 8px; opacity: 0.15; }
+    h1 { font-family: var(--font-display); font-size: 72px; font-weight: 600; margin: 0 0 8px; opacity: 0.22; }
     h2 { font-size: 20px; font-weight: 600; margin: 0 0 12px; }
     p { color: var(--text-2); margin: 0 0 24px; font-size: 15px; }
     a { color: var(--accent); text-decoration: none; font-weight: 500; }

--- a/documentation/site/ai/ai.css
+++ b/documentation/site/ai/ai.css
@@ -8,8 +8,16 @@
 
 /* Human-review accent — used by the loop legend and "human" nodes.
    Theme-aware so it stays legible on both the light and dark themes. */
-:root { --human: #15a34a; }
-[data-theme="dark"] { --human: #2bd673; }
+:root {
+  --human: #315045;
+  --human-solid: #3e6357;
+  --negative: #9c3620;
+}
+[data-theme="dark"] {
+  --human: #90bcab;
+  --human-solid: #3e6357;
+  --negative: #f09274;
+}
 
 /* ── Hero additions ───────────────────────────────────────── */
 
@@ -125,7 +133,7 @@
 
 .swatch-agent { background: var(--accent); border-color: var(--accent); }
 .swatch-auto { background: var(--bg-subtle); }
-.swatch-human { background: var(--human); border-color: var(--human); }
+.swatch-human { background: var(--human-solid); border-color: var(--human-solid); }
 
 /* ── The loop / pipeline diagram ──────────────────────────── */
 
@@ -569,6 +577,12 @@ a.track-target:hover { text-decoration: underline; }
   align-items: start;
 }
 
+.dash-grid > *,
+.dash-panel,
+.dash-body {
+  min-width: 0;
+}
+
 /* The hero panel (cadence) spans the full width and leads visually. */
 .dash-panel-hero { grid-column: 1 / -1; order: -1; }
 
@@ -799,7 +813,7 @@ a.track-target:hover { text-decoration: underline; }
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: #fff;
-  background: var(--human);
+  background: var(--human-solid);
   border-radius: 999px;
   padding: 1px 8px;
 }
@@ -838,12 +852,10 @@ a.track-target:hover { text-decoration: underline; }
 }
 
 .cad-delta-good { color: var(--human); background: color-mix(in srgb, var(--human) 15%, transparent); }
-.cad-delta-bad { color: #d1602a; background: color-mix(in srgb, #d1602a 15%, transparent); }
+.cad-delta-bad { color: var(--negative); background: color-mix(in srgb, var(--negative) 15%, transparent); }
 .cad-delta-flat { color: var(--text-secondary); background: var(--bg-subtle); }
 
 .cad-pct { opacity: 0.75; font-weight: 600; }
-
-[data-theme="dark"] .cad-delta-bad { color: #f0894f; }
 
 .cad-legend-note {
   margin-top: 12px;
@@ -869,9 +881,29 @@ a.track-target:hover { text-decoration: underline; }
 
 /* ── Panel 3: automation cost cards ───────────────────────── */
 
+.cost-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.cost-summary .cost-metric {
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-subtle));
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  border-radius: var(--radius-sm);
+}
+
+.cost-window {
+  margin: 8px 0 14px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-align: right;
+}
+
 .cost-cards {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -894,14 +926,11 @@ a.track-target:hover { text-decoration: underline; }
 .cost-name a { color: var(--text); }
 .cost-name a:hover { color: var(--accent); }
 
-.cost-cadence {
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--text-secondary);
-  white-space: nowrap;
+.cost-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
 }
-
-.cost-metrics { display: flex; gap: 20px; }
 
 .cost-num {
   display: block;
@@ -926,6 +955,49 @@ a.track-target:hover { text-decoration: underline; }
   line-height: 1.5;
 }
 
+.cost-average {
+  margin-top: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.cost-stale {
+  margin-top: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.cost-run {
+  margin-top: 12px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.cost-model {
+  font-family: var(--font-mono);
+}
+
+.cost-run a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-decoration-color: var(--border);
+}
+
+.cost-run a:hover {
+  color: var(--accent);
+  text-decoration-color: currentColor;
+}
+
 @media (max-width: 720px) {
   .dash-grid { grid-template-columns: 1fr; }
+  .cost-cards { grid-template-columns: 1fr; }
+  .cost-summary { grid-template-columns: 1fr; }
+  .cost-window { text-align: left; }
+  .dash-panel { padding: 18px 16px 16px; }
+  .dash-head { align-items: flex-start; flex-wrap: wrap; }
 }

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -47,15 +47,15 @@
             <strong>AI does not write the graphics engine.</strong> It does the toil: syncing
             upstream, diffing APIs, scaffolding docs, triaging issues, and auditing for CVEs. The
             mechanical steps run as plain scripts, the agent does the judgement work, and every
-            change lands as a normal pull request that a maintainer reviews.
+            code or documentation change is proposed through a normal, reviewable pull request.
           </p>
           <div class="stat-row">
             <div class="stat">
-              <span class="stat-num">4</span>
+              <span class="stat-num">7</span>
               <span class="stat-label">agentic workflows across two repositories</span>
             </div>
             <div class="stat">
-              <span class="stat-num">21</span>
+              <span class="stat-num">23</span>
               <span class="stat-label">reusable skills the workflows and maintainers share</span>
             </div>
             <div class="stat">
@@ -64,7 +64,7 @@
             </div>
             <div class="stat">
               <span class="stat-num">100%</span>
-              <span class="stat-label">changes shipped as human-reviewed PRs</span>
+              <span class="stat-label">code and docs changes proposed as reviewable PRs</span>
             </div>
           </div>
         </div>
@@ -115,14 +115,14 @@
             </footer>
           </article>
 
-          <!-- Panel 3 — What the automation costs (per run) -->
+          <!-- Panel 3 — What the automation costs (rolling week) -->
           <article class="dash-panel" data-panel="cost" aria-busy="true">
             <header class="dash-head">
               <h3>What the automation costs</h3>
               <span class="dash-asof" data-asof>&nbsp;</span>
             </header>
             <div class="dash-body" data-body>
-              <p class="dash-loading">Loading per-run cost&hellip;</p>
+              <p class="dash-loading">Loading weekly cost&hellip;</p>
             </div>
             <footer class="dash-foot">
               <a href="https://github.com/mono/SkiaSharp/tree/main/.github/workflows" target="_blank" rel="noopener" data-source-link>The workflows &rarr;</a>
@@ -143,8 +143,8 @@
 
         <p class="loop-note dash-footer">
           Every figure here is auditable: the downloads come from NuGet, the milestone dates from
-          the Chromium schedule and our own merged bump PRs, and the run costs from the workflow
-          logs. Read the machinery in the
+          the Chromium schedule and our own merged bump PRs, and the run costs from gh-aw usage
+          artifacts. Read the machinery in the
           <a href="https://github.com/mono/SkiaSharp/tree/main/.github/workflows" target="_blank" rel="noopener">mono/SkiaSharp workflows</a>
           directory.
         </p>
@@ -267,7 +267,7 @@
         <p class="section-kicker">Where we use AI</p>
         <h2 class="section-title">The agentic workflows</h2>
         <p class="section-lead">
-          Four workflows run an AI agent. Each one is wired so the agent can only emit a small set
+          Seven workflows run an AI agent. Each one is wired so the agent can only emit a small set
           of constrained outputs, listed as "allowed outputs" below. Everything else is read-only.
         </p>
 
@@ -277,7 +277,7 @@
             <div class="wf-head">
               <h3>Sync - Skia Upstream</h3>
               <span class="badge badge-agentic">Agentic</span>
-              <span class="badge badge-model">claude-opus-4.7</span>
+              <span class="badge badge-model">claude-opus-4.8</span>
             </div>
             <p class="wf-desc">
               Merges new commits from Google's upstream Skia, resolves the conflicts, regenerates
@@ -286,7 +286,7 @@
               which is why it runs on the strongest model.
             </p>
             <dl class="wf-meta">
-              <dt>When</dt><dd>00:00, 06:00, 12:00, and 18:00 UTC daily (every 6 hours), plus manual dispatch</dd>
+              <dt>When</dt><dd>Every 6 hours on a fuzzy schedule, plus manual dispatch</dd>
               <dt>Engine</dt><dd>GitHub Copilot</dd>
               <dt>Allowed outputs</dt><dd>open pull requests (mono/skia submodule + mono/SkiaSharp)</dd>
               <dt>Skill</dt><dd><code>update-skia</code></dd>
@@ -302,7 +302,7 @@
             <div class="wf-head">
               <h3>Sync - Issue Triage</h3>
               <span class="badge badge-agentic">Agentic</span>
-              <span class="badge badge-model">claude-sonnet-4.6</span>
+              <span class="badge badge-model">Copilot default</span>
             </div>
             <p class="wf-desc">
               Reads new and untriaged issues, classifies them by type, area, platform, and backend,
@@ -310,9 +310,9 @@
               a triage report as an artifact rather than posting noise on the issue.
             </p>
             <dl class="wf-meta">
-              <dt>When</dt><dd>04:05 UTC daily, plus manual dispatch for a single issue</dd>
+              <dt>When</dt><dd>Daily on a fuzzy schedule, plus manual dispatch for a single issue</dd>
               <dt>Engine</dt><dd>GitHub Copilot</dd>
-              <dt>Allowed outputs</dt><dd>add labels (up to 10), update the project board</dd>
+              <dt>Allowed outputs</dt><dd>add labels (up to 12), update the project board</dd>
               <dt>Skill</dt><dd><code>issue-triage</code></dd>
               <dt>Repo</dt><dd>mono/SkiaSharp</dd>
             </dl>
@@ -326,7 +326,7 @@
             <div class="wf-head">
               <h3>Sync - Release Notes &amp; API Diffs</h3>
               <span class="badge badge-agentic">Agentic</span>
-              <span class="badge badge-model">claude-sonnet-4.6</span>
+              <span class="badge badge-model">Copilot default</span>
             </div>
             <p class="wf-desc">
               A deterministic prepare job computes the public API diff over every NuGet and
@@ -336,7 +336,7 @@
             <dl class="wf-meta">
               <dt>When</dt><dd>Every push to main and 00:00 UTC daily, plus manual dispatch</dd>
               <dt>Engine</dt><dd>GitHub Copilot</dd>
-              <dt>Allowed outputs</dt><dd>open a pull request to main (<code>[docs]</code> title, documentation label)</dd>
+              <dt>Allowed outputs</dt><dd>open a pull request to main (<code>[docs]</code> title, <code>area/Docs</code> label)</dd>
               <dt>Skill</dt><dd><code>release-notes</code></dd>
               <dt>Repo</dt><dd>mono/SkiaSharp</dd>
             </dl>
@@ -367,6 +367,78 @@
             </dl>
             <p class="wf-foot">
               <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/auto-api-docs-writer.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <!-- Memory leak fixer -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Fixer - Memory Leak</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">claude-opus-4.8</span>
+            </div>
+            <p class="wf-desc">
+              Rotates through native-ownership and disposal risk areas in the managed bindings.
+              A candidate must be proven with a red-to-green regression test before the workflow
+              can file the finding and propose a fix; a quiet run is an explicit success.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>Every 12 hours, plus manual dispatch and pull-request dry runs</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>open one issue and one draft pull request, or report no finding</dd>
+              <dt>Skill</dt><dd><code>memory-leak-fixer</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/memory-leak-fixer.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <!-- Performance fixer -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Fixer - Performance</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">claude-opus-4.8</span>
+            </div>
+            <p class="wf-desc">
+              Searches the managed layer for measurable hot-path overhead. It must prove both a
+              BenchmarkDotNet improvement and behavior parity before it can file the finding and
+              propose a focused optimization.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>Every 12 hours, plus manual dispatch and pull-request dry runs</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>open one issue and one draft pull request, or report no finding</dd>
+              <dt>Skill</dt><dd><code>performance-fixer</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/performance-fixer.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
+            </p>
+          </article>
+
+          <!-- Merge message -->
+          <article class="wf-card">
+            <div class="wf-head">
+              <h3>Merge Message</h3>
+              <span class="badge badge-agentic">Agentic</span>
+              <span class="badge badge-model">gpt-5.6-terra</span>
+            </div>
+            <p class="wf-desc">
+              Reads a pull request's issue links, code changes, commits, reviews, and validation
+              evidence, then drafts a durable merge message that preserves the why for git history.
+              It never edits the branch or submits the review.
+            </p>
+            <dl class="wf-meta">
+              <dt>When</dt><dd>When a maintainer comments <code>/merge-message</code> on a pull request</dd>
+              <dt>Engine</dt><dd>GitHub Copilot</dd>
+              <dt>Allowed outputs</dt><dd>add or refresh one pull-request comment</dd>
+              <dt>Skill</dt><dd><code>pr-commit-message</code></dd>
+              <dt>Repo</dt><dd>mono/SkiaSharp</dd>
+            </dl>
+            <p class="wf-foot">
+              <a href="https://github.com/mono/SkiaSharp/blob/main/.github/workflows/merge-message.md" target="_blank" rel="noopener">View workflow source &rarr;</a>
             </p>
           </article>
         </div>
@@ -420,14 +492,15 @@
           <article class="wf-card">
             <div class="wf-head">
               <h3>Auto-merge docs PR</h3>
-              <span class="badge badge-auto">Automation</span>
+              <span class="badge badge-auto">Paused</span>
             </div>
             <p class="wf-desc">
-              Watches the docs writer's pull request branch and waits for the
+              This optional workflow is currently paused. When enabled, it watches the docs writer's
+              pull request branch and waits for the
               <code>OpenPublishing.Build</code> and <code>PoliCheck Scan</code> checks to pass with
               no new warnings. When they do, it squash-merges the PR. The AI proposes the
-              documentation, and deterministic gates verify it builds and passes policy before it
-              ships.
+              documentation, deterministic gates verify it before it lands on <code>main</code>,
+              and the separate Go Live gate controls publication.
             </p>
             <p class="wf-foot">
               <a href="https://github.com/mono/SkiaSharp-API-docs/blob/main/.github/workflows/automerge-docs.yml" target="_blank" rel="noopener">View workflow source &rarr;</a>
@@ -512,6 +585,14 @@
           </div>
 
           <div class="skill-group">
+            <h3>Performance &amp; reliability</h3>
+            <ul class="skill-list">
+              <li><span class="skill-name">memory-leak-fixer <span class="skill-auto">Automated</span></span><br>Find and fix native ownership or disposal leaks with a red-to-green regression test.</li>
+              <li><span class="skill-name">performance-fixer <span class="skill-auto">Automated</span></span><br>Find managed hot-path overhead and prove a behavior-preserving win with a benchmark.</li>
+            </ul>
+          </div>
+
+          <div class="skill-group">
             <h3>Security &amp; dependencies</h3>
             <ul class="skill-list">
               <li><span class="skill-name">security-audit</span><br>Audit native dependencies for CVEs and Component Governance alerts. Read-only.</li>
@@ -549,8 +630,8 @@
         <p class="section-kicker">How we keep it safe</p>
         <h2 class="section-title">Guardrails</h2>
         <p class="section-lead">
-          The trust story is deliberate. The agents are boxed in by design, and a human signs off
-          on everything that lands.
+          The trust story is deliberate. The agents are boxed in by design, and nothing reaches
+          the public API or documentation site without a human-controlled gate.
         </p>
 
         <div class="guard-grid">
@@ -574,8 +655,8 @@
             <div class="guard-icon">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
             </div>
-            <h3>Human review</h3>
-            <p>Every agentic change arrives as an ordinary pull request. A maintainer reads it, asks for changes, and merges it. Nothing the agent produces ships unreviewed.</p>
+            <h3>Reviewable outputs</h3>
+            <p>Code and documentation edits arrive as ordinary pull requests. Library changes require maintainer review; API docs pass deterministic gates and still need a deliberate go-live step.</p>
           </div>
 
           <div class="guard">
@@ -589,7 +670,7 @@
 
         <p class="loop-note">
           <strong>Transparency.</strong> Everything here runs as public GitHub Actions you can
-          open and inspect, and every agentic run persists its artifacts to the
+          open and inspect, and SkiaSharp's agentic report artifacts are also copied to the
           <a href="https://github.com/mono/SkiaSharp/tree/aw-data" target="_blank" rel="noopener"><code>aw-data</code></a>
           branch. The machinery is not a black box; it is in the open, in the same repositories as
           the code.

--- a/documentation/site/index.html
+++ b/documentation/site/index.html
@@ -296,7 +296,7 @@ canvas.DrawPath(path, new SKPaint {
           </div>
           <div class="feature">
             <h3>Hardware Accelerated</h3>
-            <p>Powered by Google's Skia engine, used extensively in Google products such as Google Chrome, ChromeOS, and Android, in Chromium-based products like Microsoft Edge, in applications like LibreOffice, and in .NET UI frameworks like Uno Platform.</p>
+            <p>Use Skia's OpenGL, Metal, and Vulkan backends to accelerate compositing, shaders, and complex drawing on the GPU.</p>
           </div>
           <div class="feature">
             <h3>.NET Native</h3>

--- a/documentation/site/index.html
+++ b/documentation/site/index.html
@@ -89,7 +89,7 @@
               <pre class="code-preview"><code class="language-csharp">canvas.DrawCircle(<span class="token-number">200</span>, <span class="token-number">150</span>, <span class="token-number">70</span>, <span class="token-keyword">new</span> <span class="token-type">SKPaint</span> {
     Shader = <span class="token-type">SKShader</span>.CreateLinearGradient(
         <span class="token-keyword">new</span> <span class="token-type">SKPoint</span>(<span class="token-number">140</span>, <span class="token-number">80</span>), <span class="token-keyword">new</span> <span class="token-type">SKPoint</span>(<span class="token-number">260</span>, <span class="token-number">220</span>),
-        [<span class="token-number">0xFF60A5FA</span>, <span class="token-number">0xFF8B5CF6</span>], <span class="token-type">SKShaderTileMode</span>.Clamp),
+        [<span class="token-number">0xFFC9A053</span>, <span class="token-number">0xFFB8442A</span>], <span class="token-type">SKShaderTileMode</span>.Clamp),
     IsAntialias = <span class="token-keyword">true</span>
 });
 
@@ -97,7 +97,7 @@
 path.MoveTo(<span class="token-number">110</span>, <span class="token-number">190</span>);
 path.CubicTo(<span class="token-number">150</span>, <span class="token-number">140</span>, <span class="token-number">200</span>, <span class="token-number">210</span>, <span class="token-number">290</span>, <span class="token-number">170</span>);
 canvas.DrawPath(path, <span class="token-keyword">new</span> <span class="token-type">SKPaint</span> {
-    Color = <span class="token-number">0xFF1D4ED8</span>,
+    Color = <span class="token-number">0xFF3E6357</span>,
     StrokeWidth = <span class="token-number">6</span>,
     Style = <span class="token-type">SKPaintStyle</span>.Stroke,
     StrokeCap = <span class="token-type">SKStrokeCap</span>.Round,
@@ -118,7 +118,7 @@ canvas.DrawPath(path, <span class="token-keyword">new</span> <span class="token-
 canvas.DrawCircle(<span class="token-number">200</span>, <span class="token-number">150</span>, <span class="token-number">70</span>, <span class="token-keyword">new</span> <span class="token-type">SKPaint</span> {
     Shader = <span class="token-type">SKShader</span>.CreateLinearGradient(
         <span class="token-keyword">new</span> <span class="token-type">SKPoint</span>(<span class="token-number">140</span>, <span class="token-number">80</span>), <span class="token-keyword">new</span> <span class="token-type">SKPoint</span>(<span class="token-number">260</span>, <span class="token-number">220</span>),
-        [<span class="token-number">0xFF60A5FA</span>, <span class="token-number">0xFF8B5CF6</span>], <span class="token-type">SKShaderTileMode</span>.Clamp),
+        [<span class="token-number">0xFFC9A053</span>, <span class="token-number">0xFFB8442A</span>], <span class="token-type">SKShaderTileMode</span>.Clamp),
     IsAntialias = <span class="token-keyword">true</span>
 });
 
@@ -127,7 +127,7 @@ canvas.DrawCircle(<span class="token-number">200</span>, <span class="token-numb
 path.MoveTo(<span class="token-number">110</span>, <span class="token-number">190</span>);
 path.CubicTo(<span class="token-number">150</span>, <span class="token-number">140</span>, <span class="token-number">200</span>, <span class="token-number">210</span>, <span class="token-number">290</span>, <span class="token-number">170</span>);
 canvas.DrawPath(path, <span class="token-keyword">new</span> <span class="token-type">SKPaint</span> {
-    Color = <span class="token-number">0xFF1D4ED8</span>,
+    Color = <span class="token-number">0xFF3E6357</span>,
     StrokeWidth = <span class="token-number">6</span>,
     Style = <span class="token-type">SKPaintStyle</span>.Stroke,
     StrokeCap = <span class="token-type">SKStrokeCap</span>.Round,
@@ -151,7 +151,7 @@ using var canvas = SKSvgCanvas.Create(bounds, stream);
 canvas.DrawCircle(200, 150, 70, new SKPaint {
     Shader = SKShader.CreateLinearGradient(
         new SKPoint(140, 80), new SKPoint(260, 220),
-        [0xFF60A5FA, 0xFF8B5CF6], SKShaderTileMode.Clamp),
+        [0xFFC9A053, 0xFFB8442A], SKShaderTileMode.Clamp),
     IsAntialias = true
 });
 
@@ -160,7 +160,7 @@ using var path = new SKPath();
 path.MoveTo(110, 190);
 path.CubicTo(150, 140, 200, 210, 290, 170);
 canvas.DrawPath(path, new SKPaint {
-    Color = 0xFF1D4ED8,
+    Color = 0xFF3E6357,
     StrokeWidth = 6,
     Style = SKPaintStyle.Stroke,
     StrokeCap = SKStrokeCap.Round,
@@ -174,12 +174,12 @@ canvas.DrawPath(path, new SKPaint {
                 <svg viewBox="0 0 400 300" aria-hidden="true" focusable="false">
                   <defs>
                     <linearGradient id="gradient_0" gradientUnits="userSpaceOnUse" x1="140" y1="80" x2="260" y2="220">
-                      <stop offset="0" stop-color="#60A5FA" />
-                      <stop offset="1" stop-color="#8B5CF6" />
+                      <stop offset="0" stop-color="#C9A053" />
+                      <stop offset="1" stop-color="#B8442A" />
                     </linearGradient>
                   </defs>
                   <ellipse fill="url(#gradient_0)" cx="200" cy="150" rx="70" ry="70" />
-                  <path fill="none" stroke="#1D4ED8" stroke-width="6" stroke-linecap="round" stroke-miterlimit="4" d="M110 190C150 140 200 210 290 170" />
+                  <path fill="none" stroke="#3E6357" stroke-width="6" stroke-linecap="round" stroke-miterlimit="4" d="M110 190C150 140 200 210 290 170" />
                 </svg>
               </div>
             </div>

--- a/documentation/site/style.css
+++ b/documentation/site/style.css
@@ -9,43 +9,75 @@
 }
 
 :root {
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  --font-mono: "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
+  color-scheme: light;
+  --font-display: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+  --font-sans: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --font-mono: "Cascadia Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --max-width: 1080px;
-  --radius: 12px;
-  --radius-sm: 8px;
+  --radius: 2px;
+  --radius-sm: 1px;
   --transition: 0.2s ease;
-  --bg: #ffffff;
-  --bg-subtle: #f6f8fa;
-  --bg-card: #ffffff;
-  --text: #1f2328;
-  --text-secondary: #656d76;
-  --border: #d0d7de;
-  --accent: #2563eb;
-  --accent-hover: #1d4ed8;
-  --accent-subtle: #dbeafe;
-  --hero-bg: linear-gradient(135deg, #f0f4ff 0%, #e8f0fe 50%, #f5f0ff 100%);
-  --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
-  --card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.1), 0 4px 10px rgba(0, 0, 0, 0.06);
-  --code-bg: #f0f4ff;
-  --footer-bg: #f6f8fa;
+  --bg: #f4f3ef;
+  --bg-subtle: #ecebe5;
+  --bg-card: #fafaf7;
+  --text: #1f2124;
+  --text-secondary: #676d75;
+  --border: #d9d8d1;
+  --border-strong: #bfbeb5;
+  --accent: #9c3620;
+  --accent-hover: #742817;
+  --accent-subtle: #f3e4de;
+  --accent-solid: #9c3620;
+  --accent-solid-hover: #742817;
+  --accent-on-solid: #ffffff;
+  --pigment-info: #2a4457;
+  --pigment-ochre: #7a5a22;
+  --pigment-green: #3e6357;
+  --grain: rgb(31 33 36 / 3%);
+  --hero-bg:
+    radial-gradient(circle at 14% 18%, rgb(184 68 42 / 10%), transparent 32%),
+    radial-gradient(circle at 84% 78%, rgb(62 99 87 / 9%), transparent 36%),
+    var(--bg-subtle);
+  --card-shadow: 0 1px 0 rgb(31 33 36 / 8%), 0 8px 24px rgb(66 57 47 / 5%);
+  --card-shadow-hover: 0 1px 0 rgb(31 33 36 / 10%), 0 14px 30px rgb(66 57 47 / 10%);
+  --code-bg: #101317;
+  --code-bar: #171b20;
+  --code-text: #e8e9ea;
+  --code-muted: #8a929b;
+  --code-keyword: #9cc0d9;
+  --code-type: #e8e9ea;
+  --code-string: #f09274;
+  --code-number: #dbb975;
+  --code-comment: #90bcab;
+  --footer-bg: #ecebe5;
 }
 
 [data-theme="dark"] {
-  --bg: #0d1117;
-  --bg-subtle: #161b22;
-  --bg-card: #161b22;
-  --text: #e6edf3;
-  --text-secondary: #8b949e;
-  --border: #30363d;
-  --accent: #58a6ff;
-  --accent-hover: #79c0ff;
-  --accent-subtle: #1c2d4a;
-  --hero-bg: linear-gradient(135deg, #0d1117 0%, #111827 50%, #0f172a 100%);
-  --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
-  --card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.4), 0 4px 10px rgba(0, 0, 0, 0.3);
-  --code-bg: #1c2333;
-  --footer-bg: #010409;
+  color-scheme: dark;
+  --bg: #16191d;
+  --bg-subtle: #101317;
+  --bg-card: #1d2126;
+  --text: #e8e9ea;
+  --text-secondary: #a9b0b8;
+  --border: #2a2f35;
+  --border-strong: #3d444c;
+  --accent: #f09274;
+  --accent-hover: #ffc0ab;
+  --accent-subtle: #2a1913;
+  --accent-solid: #b8442a;
+  --accent-solid-hover: #cf5a3e;
+  --accent-on-solid: #ffffff;
+  --pigment-info: #9cc0d9;
+  --pigment-ochre: #dbb975;
+  --pigment-green: #90bcab;
+  --grain: rgb(232 233 234 / 2.2%);
+  --hero-bg:
+    radial-gradient(circle at 14% 18%, rgb(228 121 92 / 10%), transparent 32%),
+    radial-gradient(circle at 84% 78%, rgb(116 163 146 / 8%), transparent 36%),
+    var(--bg-subtle);
+  --card-shadow: 0 1px 0 rgb(0 0 0 / 30%), 0 8px 24px rgb(0 0 0 / 12%);
+  --card-shadow-hover: 0 1px 0 rgb(0 0 0 / 40%), 0 14px 30px rgb(0 0 0 / 22%);
+  --footer-bg: #101317;
 }
 
 html {
@@ -58,11 +90,13 @@ body {
   color: var(--text);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 a {
   color: var(--accent);
   text-decoration: none;
+  text-underline-offset: 0.18em;
   transition: color var(--transition);
 }
 
@@ -82,8 +116,13 @@ a:hover {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: var(--bg);
+  background-color: var(--bg-card);
+  background-image:
+    radial-gradient(circle at 20% 30%, var(--grain) 0 0.55px, transparent 0.7px),
+    radial-gradient(circle at 70% 65%, var(--grain) 0 0.45px, transparent 0.65px);
+  background-size: 13px 17px, 19px 23px;
   border-bottom: 1px solid var(--border);
+  box-shadow: 0 1px 0 var(--border);
 }
 
 .header-inner {
@@ -94,16 +133,30 @@ a:hover {
 }
 
 .logo-link {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
   color: var(--text);
-  font-weight: 700;
-  font-size: 18px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: -0.015em;
 }
 
 .logo-link:hover {
   color: var(--text);
+}
+
+.logo-link::after {
+  position: absolute;
+  right: 0;
+  bottom: -3px;
+  left: 40px;
+  height: 3px;
+  content: "";
+  background: var(--accent-solid);
+  clip-path: polygon(0 25%, 82% 0, 100% 42%, 86% 74%, 0 100%);
 }
 
 .logo-img {
@@ -117,14 +170,35 @@ a:hover {
 }
 
 .nav-link {
+  position: relative;
   color: var(--text-secondary);
   font-size: 14px;
   font-weight: 500;
+  padding-block: 18px;
   transition: color var(--transition);
 }
 
 .nav-link:hover {
   color: var(--text);
+}
+
+.nav-link::after {
+  position: absolute;
+  right: 0;
+  bottom: 12px;
+  left: 0;
+  height: 2px;
+  content: "";
+  background: var(--accent-solid);
+  clip-path: polygon(0 35%, 88% 0, 100% 50%, 88% 80%, 0 100%);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.15s cubic-bezier(0.2, 0.6, 0.2, 1);
+}
+
+.nav-link:hover::after,
+.nav-link[aria-current="page"]::after {
+  transform: scaleX(1);
 }
 
 .theme-btn {
@@ -142,7 +216,8 @@ a:hover {
 
 .theme-btn:hover {
   color: var(--text);
-  border-color: var(--text-secondary);
+  border-color: var(--border-strong);
+  background: var(--accent-subtle);
 }
 
 [data-theme="light"] .icon-moon { display: none; }
@@ -163,8 +238,9 @@ a:hover {
 }
 
 .hero-title {
+  font-family: var(--font-display);
   font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 800;
+  font-weight: 600;
   line-height: 1.15;
   letter-spacing: -0.03em;
   margin-top: 48px;
@@ -218,13 +294,13 @@ a:hover {
 }
 
 .btn-primary {
-  background: var(--accent);
-  color: #fff;
+  background: var(--accent-solid);
+  color: var(--accent-on-solid);
 }
 
 .btn-primary:hover {
-  background: var(--accent-hover);
-  color: #fff;
+  background: var(--accent-solid-hover);
+  color: var(--accent-on-solid);
 }
 
 .btn-secondary {
@@ -241,7 +317,7 @@ a:hover {
 .hero-install {
   display: inline-flex;
   align-items: center;
-  background: var(--code-bg);
+  background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 12px 24px;
@@ -274,7 +350,7 @@ a:hover {
 .code-window {
   border-radius: var(--radius);
   overflow: hidden;
-  background: #0f172a;
+  background: var(--code-bg);
   display: flex;
   flex-direction: column;
 }
@@ -291,20 +367,20 @@ a:hover {
   align-items: center;
   gap: 6px;
   padding: 10px 14px;
-  background: rgba(148, 163, 184, 0.12);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: var(--code-bar);
+  border-bottom: 1px solid #2a2f35;
 }
 
 .code-window-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #64748b;
+  background: #3d444c;
 }
 
 .code-window-title {
   margin-left: 6px;
-  color: #cbd5e1;
+  color: var(--code-text);
   font-size: 13px;
   font-weight: 600;
 }
@@ -314,9 +390,9 @@ a:hover {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid rgba(96, 165, 250, 0.25);
-  background: rgba(37, 99, 235, 0.16);
-  color: #dbeafe;
+  border: 1px solid rgb(201 160 83 / 35%);
+  background: rgb(201 160 83 / 10%);
+  color: var(--code-text);
   border-radius: 999px;
   padding: 6px 12px;
   font-size: 12px;
@@ -334,13 +410,13 @@ a:hover {
 }
 
 .copy-code-btn:hover {
-  background: rgba(37, 99, 235, 0.28);
-  border-color: rgba(147, 197, 253, 0.65);
+  background: rgb(201 160 83 / 18%);
+  border-color: rgb(219 185 117 / 72%);
   transform: translateY(-1px);
 }
 
 .copy-code-btn:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid #8bcbff;
   outline-offset: 2px;
 }
 
@@ -356,7 +432,7 @@ a:hover {
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.65;
-  color: #e2e8f0;
+  color: var(--code-text);
   tab-size: 4;
 }
 
@@ -379,7 +455,7 @@ a:hover {
   left: 0;
   right: 0;
   height: 18px;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0));
+  background: linear-gradient(180deg, rgb(16 19 23 / 88%), transparent);
   pointer-events: none;
   z-index: 1;
 }
@@ -390,7 +466,7 @@ a:hover {
   right: 0;
   bottom: 0;
   height: 74px;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.95) 60%, rgba(15, 23, 42, 1));
+  background: linear-gradient(180deg, transparent, rgb(16 19 23 / 95%) 60%, var(--code-bg));
   pointer-events: none;
   z-index: 1;
 }
@@ -401,9 +477,9 @@ a:hover {
   bottom: 10px;
   transform: translateX(-50%);
   z-index: 2;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.95);
-  color: #e2e8f0;
+  border: 1px solid rgb(138 146 155 / 40%);
+  background: rgb(16 19 23 / 95%);
+  color: var(--code-text);
   border-radius: 999px;
   padding: 7px 12px;
   font-size: 12px;
@@ -413,12 +489,12 @@ a:hover {
 }
 
 .expand-code-btn:hover {
-  border-color: rgba(96, 165, 250, 0.55);
-  color: #dbeafe;
+  border-color: rgb(219 185 117 / 70%);
+  color: #dbb975;
 }
 
 .expand-code-btn:focus-visible {
-  outline: 2px solid #93c5fd;
+  outline: 2px solid #8bcbff;
   outline-offset: 2px;
 }
 
@@ -435,23 +511,23 @@ a:hover {
 }
 
 .token-keyword {
-  color: #c084fc;
+  color: var(--code-keyword);
 }
 
 .token-comment {
-  color: #94a3b8;
+  color: var(--code-comment);
 }
 
 .token-type {
-  color: #7dd3fc;
+  color: var(--code-type);
 }
 
 .token-string {
-  color: #86efac;
+  color: var(--code-string);
 }
 
 .token-number {
-  color: #fda4af;
+  color: var(--code-number);
 }
 
 .render-preview {
@@ -477,11 +553,11 @@ a:hover {
   align-items: center;
   width: 100%;
   padding: 16px;
-  border-radius: calc(var(--radius) - 4px);
+  border-radius: var(--radius-sm);
   overflow: hidden;
   background:
-    radial-gradient(circle at top left, rgba(96, 165, 250, 0.14), transparent 38%),
-    radial-gradient(circle at bottom right, rgba(139, 92, 246, 0.12), transparent 42%),
+    radial-gradient(circle at top left, rgb(201 160 83 / 14%), transparent 38%),
+    radial-gradient(circle at bottom right, rgb(62 99 87 / 12%), transparent 42%),
     var(--bg);
 }
 
@@ -498,13 +574,13 @@ a:hover {
   font-size: 13px;
   background: var(--bg-subtle);
   border-left: 3px solid var(--accent);
-  border-radius: 12px;
+  border-radius: var(--radius);
 }
 
 .showcase-callout code {
   display: inline-block;
   padding: 2px 7px;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-card);
   font-family: var(--font-mono);
@@ -633,7 +709,7 @@ a:hover {
 }
 
 .gallery-logo {
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   object-fit: contain;
 }
 
@@ -697,8 +773,9 @@ a:hover {
 }
 
 .card-title {
+  font-family: var(--font-display);
   font-size: 18px;
-  font-weight: 700;
+  font-weight: 600;
   margin-bottom: 8px;
 }
 
@@ -727,11 +804,27 @@ a:hover {
 }
 
 .section-title {
+  position: relative;
+  width: fit-content;
+  margin-inline: auto;
+  padding-bottom: 10px;
+  font-family: var(--font-display);
   font-size: 24px;
-  font-weight: 800;
+  font-weight: 600;
   text-align: center;
   margin-bottom: 40px;
   letter-spacing: -0.02em;
+}
+
+.section-title::after {
+  position: absolute;
+  right: 8%;
+  bottom: 0;
+  left: 4%;
+  height: 3px;
+  content: "";
+  background: var(--accent-solid);
+  clip-path: polygon(0 25%, 82% 0, 100% 42%, 86% 74%, 0 100%);
 }
 
 .features-grid {
@@ -770,7 +863,11 @@ a:hover {
 /* ── Footer ───────────────────────────────────────────────── */
 
 .site-footer {
-  background: var(--footer-bg);
+  background-color: var(--footer-bg);
+  background-image:
+    radial-gradient(circle at 20% 30%, var(--grain) 0 0.55px, transparent 0.7px),
+    radial-gradient(circle at 70% 65%, var(--grain) 0 0.45px, transparent 0.65px);
+  background-size: 13px 17px, 19px 23px;
   border-top: 1px solid var(--border);
   padding: 32px 0;
 }
@@ -806,6 +903,26 @@ a:hover {
 /* ── Responsive ───────────────────────────────────────────── */
 
 @media (max-width: 640px) {
+  .header-inner {
+    gap: 12px;
+  }
+
+  .logo-link span {
+    display: none;
+  }
+
+  .logo-link::after {
+    display: none;
+  }
+
+  .header-nav {
+    gap: 12px;
+  }
+
+  .nav-link {
+    font-size: 13px;
+  }
+
   .hero {
     padding: 48px 0 40px;
   }


### PR DESCRIPTION
## Description

Applies a cohesive **Stroke & Fill** visual language across the DocFX reference site and the static documentation pages. The redesign uses warm paper and earth tones, graphite-inspired details, stronger editorial hierarchy, responsive layouts, and coordinated light and dark themes.

The custom DocFX template also registers XAML as an XML Highlight.js alias, so XAML samples receive syntax coloring instead of rendering as plain monospace text.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — documentation presentation only; no public API or runtime behavior changes.

## Testing

- Built the DocFX site with `dotnet docfx documentation/docfx/docfx.json --warningsAsErrors false`.
- Checked the custom template JavaScript with `node --check documentation/docfx/template/public/main.js`.
- Reviewed the DocFX and static-site previews locally in light and dark themes, including desktop and mobile layouts.
- No tests were added because this changes documentation presentation only.

<details>
<summary>Visual review</summary>

The current production site is the before state. The `Build Site` check provides the branch preview for the redesigned DocFX and static pages.

</details>

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no API changes
- [x] Native change? N/A — no native changes