### PR TITLE
[skia-sync] Merge upstream chrome/m150 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "64328ce83ff19e37d61169f2a0b761f2572f7b67"
+          "commitHash": "eb86e4b3ee034085b62d3980b3d94629862441e6"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b70519562e2d26d3cf56286d3a13ca25152cfae4"
+          "commitHash": "3d2cfdd2077983b2677ee9ed02c277c765b5c9cd"
         }
       }
     },
@@ -321,7 +321,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861",
+      "upstream_merge_commit": "b8d8440d14e2ce4547cb12abd4641f423e757791",
       "upstream_ref": "chrome/m150"
     }
   ]

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -306,7 +306,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "b70519562e2d26d3cf56286d3a13ca25152cfae4"
+          "commitHash": "64328ce83ff19e37d61169f2a0b761f2572f7b67"
         }
       }
     },
@@ -321,7 +321,7 @@
         }
       },
       "chrome_milestone": 150,
-      "upstream_merge_commit": "a81173f17b197686dc1e6c78515de86e92ddc861",
+      "upstream_merge_commit": "9c7b2dffb2433f5a0cc2b77f06025a09126807ed",
       "upstream_ref": "chrome/m150"
     }
   ]


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m150. Targeting release branch `release/4.150.x` (mono/skia `release/4.150.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/344

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the SkiaSharp product repo to the synced `mono/skia` fork at upstream
Skia `chrome/m150` bug-fix HEAD. Release-line bug-fix mode — no version bump.

- **Submodule pointer:** `externals/skia` gitlink advanced
  `b70519562e2d26d3cf56286d3a13ca25152cfae4` →
  `64328ce83ff19e37d61169f2a0b761f2572f7b67` (the tested mono/skia merge commit).
- **`cgmanifest.json`:**
  - Skia `commitHash` `b70519562e` → `64328ce83f`
  - `upstream_merge_commit` `a81173f17b` → `9c7b2dffb2` (`chrome_milestone` 150,
    `upstream_ref` `chrome/m150` unchanged)
- **Versions:** unchanged. `update_versions.py` reported `m150 -> m150`, GATE
  PASSED — no version-file drift.
- **Dependency metadata:** `skia-dependency-changes.json` = `changes: []`. The
  only DEPS movement (`task_drivers`) is a CIPD `condition:False` infra dep, never
  checked out and not tracked in `cgmanifest.json`, so no manifest change.

### Bindings / wrappers

`regenerate_bindings.py` reported **no binding changes** and **no new generated
functions** (GATE PASSED). No C API functions were added or changed upstream, so
no `*.generated.cs`, managed wrapper, or new test changes were required.
`binding/SkiaSharp/SkiaSharp.csproj` builds with 0 errors.

## Testing

Native library rebuilt from source for `linux/x64` and the full unfiltered
managed solution run against it — all hosts passed (`test-exit-code.txt` = 0):

| Host | Failed | Passed | Skipped |
|---|---|---|---|
| SkiaSharp.Tests | 0 | 5585 | 171 |
| SkiaSharp.Tests.SingletonInit | 0 | 1 | 0 |
| SkiaSharp.Vulkan.Tests | 0 | 2 | 5 |
| SkiaSharp.Direct3D.Tests | 0 | 2 | 3 |

All `GpuPolicy`-required Linux backends (Mesa softpipe/llvmpipe + lavapipe ICD)
initialized and executed. No **required** backend was skipped; remaining skips are
the existing platform/host-policy skips.

Reconciliation gates re-run against final HEAD and passed: `update_versions.py`
(GATE PASSED) and `audit_fork_patches.py --validate` (GATE PASSED, no `TODO`).
Parent gitlink verified equal to the tested mono/skia commit `64328ce83f`.

## Human review

- Merge sequence: merge the paired `mono/skia` PR first, then update this PR's
  submodule pointer to the resulting `release/4.150.x` commit before merging.
- Only `linux/x64` was built and tested here; the Windows/macOS/Android/iOS/WASM
  CI matrix must pass before merge.
- No public API surface change — ABI is preserved (no `*.generated.cs` diff).


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-18T13:40:10Z_
