### PR TITLE
Improve NuGet package READMEs

### DIFF
--- a/binding/Directory.Build.targets
+++ b/binding/Directory.Build.targets
@@ -25,6 +25,10 @@ It provides a comprehensive 2D API that can be used across mobile, server and de
 
   <PropertyGroup Condition="'$(PackagingGroup)' == 'HarfBuzzSharp'">
     <PackageDescription Condition="'$(PackageDescription)' == ''">HarfBuzzSharp is a cross-platform OpenType text shaping engine for .NET platforms.</PackageDescription>
+    <PackageReadmeResourceLinks>- [HarfBuzzSharp API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/harfbuzzsharp)
+- [HarfBuzz documentation](https://harfbuzz.github.io/)
+- [SkiaSharp.HarfBuzz integration package](https://www.nuget.org/packages/SkiaSharp.HarfBuzz)
+- [Package selection and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)</PackageReadmeResourceLinks>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)NativeAssets.Build.targets" Condition="$(MSBuildProjectName.Contains('.NativeAssets.'))" />

--- a/binding/HarfBuzzSharp/PACKAGE-README.md
+++ b/binding/HarfBuzzSharp/PACKAGE-README.md
@@ -1,0 +1,66 @@
+# HarfBuzzSharp
+
+[![NuGet](https://img.shields.io/nuget/v/HarfBuzzSharp?style=flat-square&label=NuGet)](https://www.nuget.org/packages/HarfBuzzSharp)
+[![NuGet downloads](https://img.shields.io/nuget/dt/HarfBuzzSharp?style=flat-square&label=Downloads)](https://www.nuget.org/packages/HarfBuzzSharp)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+
+**HarfBuzzSharp** provides .NET bindings for the [HarfBuzz](https://harfbuzz.github.io/) OpenType text shaping engine. It converts Unicode text into correctly selected and positioned glyphs for complex scripts, ligatures, kerning, variable fonts, bidirectional text, and advanced typographic features.
+
+## Capabilities
+
+- Shape text for Arabic, Indic, Southeast Asian, and other complex writing systems.
+- Apply OpenType features, language, script, and direction settings.
+- Inspect glyph IDs, clusters, advances, and offsets.
+- Read OpenType variation axes, names, metrics, color glyph data, and layout information.
+- Run on Windows, macOS, Linux, Android, iOS, Mac Catalyst, tvOS, Tizen, and WebAssembly.
+- Integrate with SkiaSharp rendering through [`SkiaSharp.HarfBuzz`](https://www.nuget.org/packages/SkiaSharp.HarfBuzz).
+
+## Get started
+
+Install the package:
+
+```bash
+dotnet add package HarfBuzzSharp
+```
+
+Shape a string using an OpenType font:
+
+```csharp
+using HarfBuzzSharp;
+
+using var blob = Blob.FromFile("NotoSansArabic-Regular.ttf");
+using var face = new Face(blob, 0);
+using var font = new Font(face);
+font.SetScale(face.UnitsPerEm, face.UnitsPerEm);
+
+using var buffer = new HarfBuzzSharp.Buffer();
+buffer.AddUtf8("مرحبا بالعالم");
+buffer.GuessSegmentProperties();
+
+font.Shape(buffer);
+
+foreach (var glyph in buffer.GlyphInfos)
+    Console.WriteLine($"Glyph {glyph.Codepoint}, cluster {glyph.Cluster}");
+```
+
+For drawing shaped text with SkiaSharp, install `SkiaSharp.HarfBuzz` and use `SKShaper`:
+
+```bash
+dotnet add package SkiaSharp.HarfBuzz
+```
+
+> **Linux and WebAssembly:** add the matching `HarfBuzzSharp.NativeAssets.*` package directly to the application project when the target does not receive native assets transitively. See the [package deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md).
+
+## Documentation and resources
+
+- [HarfBuzzSharp API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/harfbuzzsharp)
+- [SkiaSharp.HarfBuzz API reference](https://learn.microsoft.com/dotnet/api/skiasharp.harfbuzz)
+- [HarfBuzz documentation](https://harfbuzz.github.io/)
+- [SkiaSharp package and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+- [SkiaSharp samples](https://github.com/mono/SkiaSharp/tree/main/samples)
+
+## Feedback and contributing
+
+HarfBuzzSharp is part of the open-source SkiaSharp project from Microsoft. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+
+HarfBuzzSharp is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).

--- a/binding/NativeAssets.Build.targets
+++ b/binding/NativeAssets.Build.targets
@@ -10,6 +10,16 @@
     <DebugSymbols>false</DebugSymbols>
     <!-- Don't generate docs -->
     <SkipMDocGenerateDocs>true</SkipMDocGenerateDocs>
+
+    <!-- NuGet README -->
+    <PackageReadmePrimaryPackage>$(PackagingGroup)</PackageReadmePrimaryPackage>
+    <PackageDescription>$(MSBuildProjectName) provides native runtime assets for $(PackageReadmePrimaryPackage).</PackageDescription>
+    <PackageReadmeSummary>**$(MSBuildProjectName)** provides the native runtime assets used by [**$(PackageReadmePrimaryPackage)**](https://www.nuget.org/packages/$(PackageReadmePrimaryPackage)) for this deployment target.</PackageReadmeSummary>
+    <PackageReadmeNotice>&gt; This is a runtime assets package. Most developers should start with `$(PackageReadmePrimaryPackage)` and add this package directly to the **application project** only when the deployment target requires it.</PackageReadmeNotice>
+    <PackageReadmeIncludesPackageNotes>true</PackageReadmeIncludesPackageNotes>
+    <PackageReadmeAdditionalDetails Condition="'$(PackageNotes)' != ''">## Package details
+
+$(PackageNotes)</PackageReadmeAdditionalDetails>
   </PropertyGroup>
 
   <ItemGroup>

--- a/binding/SkiaSharp.Resources/SkiaSharp.Resources.csproj
+++ b/binding/SkiaSharp.Resources/SkiaSharp.Resources.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>SkiaSharp.Resources</AssemblyName>
     <PackagingGroup>SkiaSharp.Resources</PackagingGroup>
     <Title>SkiaSharp Resource Providers</Title>
-    <PackageDescription>SkiaSharp Skottie provides a Lottie implementation using the SkiaSharp library.</PackageDescription>
+    <PackageDescription>SkiaSharp.Resources provides resource loading and management support for SkiaSharp scene graphs and Skottie animations.</PackageDescription>
     <PackageTags>skottie;lottie</PackageTags>
     <Nullable>enable</Nullable>
 

--- a/binding/SkiaSharp.SceneGraph/SkiaSharp.SceneGraph.csproj
+++ b/binding/SkiaSharp.SceneGraph/SkiaSharp.SceneGraph.csproj
@@ -4,8 +4,8 @@
     <RootNamespace>SkiaSharp.SceneGraph</RootNamespace>
     <AssemblyName>SkiaSharp.SceneGraph</AssemblyName>
     <PackagingGroup>SkiaSharp.SceneGraph</PackagingGroup>
-    <Title>SkiaSharp Skottie</Title>
-    <PackageDescription>SkiaSharp Skottie provides a Lottie implementation using the SkiaSharp library.</PackageDescription>
+    <Title>SkiaSharp Scene Graph</Title>
+    <PackageDescription>SkiaSharp.SceneGraph provides a scene graph API for composing and rendering structured graphics with SkiaSharp.</PackageDescription>
     <PackageTags>skottie;lottie</PackageTags>
     <Nullable>enable</Nullable>
 

--- a/binding/SkiaSharp.SceneGraph/SkiaSharp.SceneGraph.csproj
+++ b/binding/SkiaSharp.SceneGraph/SkiaSharp.SceneGraph.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>SkiaSharp.SceneGraph</AssemblyName>
     <PackagingGroup>SkiaSharp.SceneGraph</PackagingGroup>
     <Title>SkiaSharp Scene Graph</Title>
-    <PackageDescription>SkiaSharp.SceneGraph provides a scene graph API for composing and rendering structured graphics with SkiaSharp.</PackageDescription>
+    <PackageDescription>SkiaSharp.SceneGraph provides invalidation tracking support for SkiaSharp.Skottie animations.</PackageDescription>
     <PackageTags>skottie;lottie</PackageTags>
     <Nullable>enable</Nullable>
 

--- a/binding/SkiaSharp/PACKAGE-README.md
+++ b/binding/SkiaSharp/PACKAGE-README.md
@@ -6,8 +6,6 @@
 
 **SkiaSharp** is a cross-platform 2D graphics API for .NET powered by Google's [Skia](https://skia.org/) graphics engine. Draw vector graphics, render text, process images, apply shaders and filters, and produce consistent output across mobile, desktop, server, and WebAssembly applications.
 
-[![Explore the live SkiaSharp Gallery](https://raw.githubusercontent.com/mono/SkiaSharp/main/samples/Gallery/screenshots/home.png)](https://mono.github.io/SkiaSharp/gallery/)
-
 ## What you can build
 
 - **Rich 2D graphics** - paths, shapes, text, images, color spaces, shaders, filters, blend modes, and more.

--- a/binding/SkiaSharp/PACKAGE-README.md
+++ b/binding/SkiaSharp/PACKAGE-README.md
@@ -1,0 +1,85 @@
+# SkiaSharp
+
+[![NuGet](https://img.shields.io/nuget/v/SkiaSharp?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp)
+[![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+
+**SkiaSharp** is a cross-platform 2D graphics API for .NET powered by Google's [Skia](https://skia.org/) graphics engine. Draw vector graphics, render text, process images, apply shaders and filters, and produce consistent output across mobile, desktop, server, and WebAssembly applications.
+
+[![Explore the live SkiaSharp Gallery](https://raw.githubusercontent.com/mono/SkiaSharp/main/samples/Gallery/screenshots/home.png)](https://mono.github.io/SkiaSharp/gallery/)
+
+## What you can build
+
+- **Rich 2D graphics** - paths, shapes, text, images, color spaces, shaders, filters, blend modes, and more.
+- **Cross-platform** - Windows, macOS, Linux, Android, iOS, Mac Catalyst, tvOS, Tizen, and WebAssembly.
+- **CPU and GPU rendering** - software rasterization plus OpenGL, Metal, Vulkan, and Direct3D integrations.
+- **Broad output support** - render to pixels, encode common image formats, create PDFs, or generate SVG.
+- **Native performance with an idiomatic C# API** - the same Skia engine used by Chrome, Android, Flutter, and many other products.
+- **Open source** - developed in the open by Microsoft and the .NET community under the MIT license.
+
+## Get started
+
+Install the package:
+
+```bash
+dotnet add package SkiaSharp
+```
+
+Create an image and save it as a PNG:
+
+```csharp
+using SkiaSharp;
+
+var info = new SKImageInfo(640, 360);
+using var surface = SKSurface.Create(info);
+var canvas = surface.Canvas;
+
+canvas.Clear(new SKColor(0x0B, 0x10, 0x20));
+
+using var shader = SKShader.CreateLinearGradient(
+    new SKPoint(0, 0),
+    new SKPoint(info.Width, info.Height),
+    new[] { new SKColor(0x44, 0x88, 0xFF), new SKColor(0xB8, 0x44, 0xE8) },
+    SKShaderTileMode.Clamp);
+using var paint = new SKPaint
+{
+    IsAntialias = true,
+    Shader = shader,
+};
+
+canvas.DrawCircle(info.Width / 2f, info.Height / 2f, 120, paint);
+
+using var image = surface.Snapshot();
+using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+using var output = File.Create("hello-skiasharp.png");
+data.SaveTo(output);
+```
+
+> **Linux:** add [SkiaSharp.NativeAssets.Linux](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux) to the application project for fontconfig integration, or [SkiaSharp.NativeAssets.Linux.NoDependencies](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux.NoDependencies) for minimal containers and explicit font loading. See the [package deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md) for details.
+
+## Choose the right integration
+
+| Scenario | Package |
+| --- | --- |
+| Draw into bitmaps, images, surfaces, PDFs, and SVG | `SkiaSharp` |
+| .NET MAUI controls | [`SkiaSharp.Views.Maui.Controls`](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls) |
+| Blazor WebAssembly components | [`SkiaSharp.Views.Blazor`](https://www.nuget.org/packages/SkiaSharp.Views.Blazor) |
+| Android, iOS, Mac Catalyst, macOS, tvOS, and Tizen native views | [`SkiaSharp.Views`](https://www.nuget.org/packages/SkiaSharp.Views) |
+| WPF, Windows Forms, WinUI, or GTK controls | Use the matching `SkiaSharp.Views.*` package |
+| Complex text shaping | [`SkiaSharp.HarfBuzz`](https://www.nuget.org/packages/SkiaSharp.HarfBuzz) |
+| Lottie animation playback | [`SkiaSharp.Skottie`](https://www.nuget.org/packages/SkiaSharp.Skottie) |
+
+## Learn and explore
+
+- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/) - conceptual guides and tutorials
+- [API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/skiasharp)
+- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/) - interactive samples running in Blazor WebAssembly
+- [SkiaFiddle](https://mono.github.io/SkiaSharp/fiddle/) - experiment with SkiaSharp in your browser
+- [Samples](https://github.com/mono/SkiaSharp/tree/main/samples) - buildable console, mobile, desktop, web, and UI examples
+- [Release notes](https://mono.github.io/SkiaSharp/docs/releases/) - new features and API changes
+
+## Feedback and contributing
+
+SkiaSharp is built in the open. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to help improve the project.
+
+SkiaSharp is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).

--- a/source/SkiaSharp.NuGet.targets
+++ b/source/SkiaSharp.NuGet.targets
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <PackageTags Condition="$(PackagingGroup.StartsWith('SkiaSharp'))">graphics;cross-platform;skiasharp;skia;$(PackageTags);ios;android;linux;windows;tvos;macos;tizen</PackageTags>
     <PackageTags Condition="$(PackagingGroup.StartsWith('HarfBuzzSharp'))">graphics;text;cross-platform;harfbuzzsharp;harfbuzz;$(PackageTags);ios;android;linux;windows;tvos;macos;tizen</PackageTags>
-    <PackageDescription Condition="'$(PackageNotes)' != ''">$(PackageDescription)
+    <PackageDescription Condition="'$(PackageNotes)' != '' and '$(PackageReadmeIncludesPackageNotes)' != 'true'">$(PackageDescription)
 
 $(PackageNotes)</PackageDescription>
   </PropertyGroup>
@@ -28,16 +28,75 @@ $(PackageNotes)</PackageDescription>
     ===================================================================================================================
     _GeneratePackageReadmeFile
 
-    Generate the package README file.
+    Generate the package README file. A project can provide a custom README by
+    placing PACKAGE-README.md beside the project file or setting PackageReadmeSource.
+
+    All other packages receive a useful generated README rather than exposing the
+    short NuGet package description as the entire document.
     ===================================================================================================================
   -->
   <Target Name="_GeneratePackageReadmeFile"
           BeforeTargets="_GetPackageFiles"
           Condition="'$(PackageDescription)' != ''">
-    <WriteLinesToFile File="$(IntermediateOutputPath)$(PackageReadmeFile)" Lines="$(PackageDescription)" Overwrite="True" />
+    <PropertyGroup>
+      <_PackageReadmeOutput>$(IntermediateOutputPath)$(PackageReadmeFile)</_PackageReadmeOutput>
+      <_PackageReadmeSource Condition="'$(PackageReadmeSource)' != ''">$(PackageReadmeSource)</_PackageReadmeSource>
+      <_PackageReadmeSource Condition="'$(_PackageReadmeSource)' == '' and Exists('$(MSBuildProjectDirectory)/PACKAGE-README.md')">$(MSBuildProjectDirectory)/PACKAGE-README.md</_PackageReadmeSource>
+
+      <_PackageReadmeApiUrl>$(PackageReadmeApiUrl)</_PackageReadmeApiUrl>
+      <_PackageReadmeApiUrl Condition="'$(_PackageReadmeApiUrl)' == ''">https://learn.microsoft.com/dotnet/api/skiasharp</_PackageReadmeApiUrl>
+      <_PackageReadmeResourceLinks>$(PackageReadmeResourceLinks)</_PackageReadmeResourceLinks>
+      <_PackageReadmeResourceLinks Condition="'$(_PackageReadmeResourceLinks)' == ''">- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/)
+- [API reference on Microsoft Learn]($(_PackageReadmeApiUrl))
+- [Package selection and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/)
+- [SkiaFiddle](https://mono.github.io/SkiaSharp/fiddle/) - experiment with SkiaSharp in your browser</_PackageReadmeResourceLinks>
+
+      <_PackageReadmeSummary>$(PackageReadmeSummary)</_PackageReadmeSummary>
+      <_PackageReadmeSummary Condition="'$(_PackageReadmeSummary)' == ''">$(PackageDescription)</_PackageReadmeSummary>
+      <_PackageReadmeNotice>$(PackageReadmeNotice)</_PackageReadmeNotice>
+      <_PackageReadmeAdditionalDetails>$(PackageReadmeAdditionalDetails)</_PackageReadmeAdditionalDetails>
+      <_PackageReadmeNoticeSection Condition="'$(_PackageReadmeNotice)' != ''">$(_PackageReadmeNotice)
+
+</_PackageReadmeNoticeSection>
+      <_PackageReadmeAdditionalDetailsSection Condition="'$(_PackageReadmeAdditionalDetails)' != ''">$(_PackageReadmeAdditionalDetails)
+
+</_PackageReadmeAdditionalDetailsSection>
+
+      <_PackageReadmeContents># $(PackageId)
+
+[![NuGet](https://img.shields.io/nuget/v/$(PackageId)?style=flat-square&amp;label=NuGet)](https://www.nuget.org/packages/$(PackageId))
+[![NuGet downloads](https://img.shields.io/nuget/dt/$(PackageId)?style=flat-square&amp;label=Downloads)](https://www.nuget.org/packages/$(PackageId))
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+
+$(_PackageReadmeSummary)
+
+$(_PackageReadmeNoticeSection)## Installation
+
+```bash
+dotnet add package $(PackageId)
+```
+
+$(_PackageReadmeAdditionalDetailsSection)## Documentation and resources
+
+$(_PackageReadmeResourceLinks)
+
+## Feedback and contributing
+
+SkiaSharp is an open-source project from Microsoft, released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md). Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and see the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.</_PackageReadmeContents>
+    </PropertyGroup>
+
+    <Copy SourceFiles="$(_PackageReadmeSource)"
+          DestinationFiles="$(_PackageReadmeOutput)"
+          Condition="'$(_PackageReadmeSource)' != ''" />
+    <WriteLinesToFile File="$(_PackageReadmeOutput)"
+                     Lines="$(_PackageReadmeContents)"
+                     Encoding="UTF-8"
+                     Overwrite="True"
+                     Condition="'$(_PackageReadmeSource)' == ''" />
     <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)$(PackageReadmeFile)" />
-      <None Include="$(IntermediateOutputPath)$(PackageReadmeFile)" PackagePath="$(PackageReadmeFile)" Pack="True" />
+      <FileWrites Include="$(_PackageReadmeOutput)" />
+      <None Include="$(_PackageReadmeOutput)" PackagePath="$(PackageReadmeFile)" Pack="True" />
     </ItemGroup>
   </Target>
 

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/PACKAGE-README.md
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/PACKAGE-README.md
@@ -1,0 +1,86 @@
+# SkiaSharp.Views.Maui.Controls
+
+[![NuGet](https://img.shields.io/nuget/v/SkiaSharp.Views.Maui.Controls?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls)
+[![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp.Views.Maui.Controls?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+
+**SkiaSharp.Views.Maui.Controls** adds SkiaSharp rendering controls and image sources to .NET MAUI applications. Put a CPU- or GPU-backed canvas alongside standard MAUI controls, draw with the full SkiaSharp API, and share the same rendering code across Android, iOS, Mac Catalyst, and Windows.
+
+## What you get
+
+- `SKCanvasView` for CPU-rendered, on-demand drawing.
+- `SKGLView` for hardware-accelerated drawing and continuous render loops.
+- `SKImageImageSource`, `SKBitmapImageSource`, `SKPixmapImageSource`, and `SKPictureImageSource` for MAUI images.
+- XAML support, data binding, touch input, invalidation, and density-aware canvas sizing.
+- Native handlers for Android, iOS, Mac Catalyst, and Windows.
+
+## Get started
+
+Install the package:
+
+```bash
+dotnet add package SkiaSharp.Views.Maui.Controls
+```
+
+Register SkiaSharp in `MauiProgram.cs`:
+
+```csharp
+using SkiaSharp.Views.Maui.Controls.Hosting;
+
+public static MauiApp CreateMauiApp() =>
+    MauiApp
+        .CreateBuilder()
+        .UseMauiApp<App>()
+        .UseSkiaSharp()
+        .Build();
+```
+
+Add a canvas to a XAML page:
+
+```xml
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls">
+
+    <skia:SKCanvasView PaintSurface="OnPaintSurface" />
+
+</ContentPage>
+```
+
+Draw in the `PaintSurface` handler:
+
+```csharp
+using SkiaSharp;
+using SkiaSharp.Views.Maui;
+
+private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+{
+    var canvas = e.Surface.Canvas;
+    canvas.Clear(SKColors.White);
+
+    using var paint = new SKPaint
+    {
+        Color = SKColors.CornflowerBlue,
+        IsAntialias = true,
+    };
+
+    canvas.DrawCircle(e.Info.Width / 2f, e.Info.Height / 2f, 120, paint);
+}
+```
+
+Call `InvalidateSurface()` whenever state changes and the view should redraw. Use `SKGLView` when the scene benefits from GPU rendering or a continuous animation loop.
+
+## Documentation and resources
+
+- [SkiaSharp .NET MAUI guides](https://mono.github.io/SkiaSharp/docs/guides/)
+- [API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/skiasharp.views.maui.controls)
+- [Buildable .NET MAUI sample](https://github.com/mono/SkiaSharp/tree/main/samples/Basic/Maui)
+- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/) - explore the rendering API in your browser
+- [SkiaSharp package and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+
+## Feedback and contributing
+
+SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+
+This package is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/SkiaSharp.Views.Maui.Core.csproj
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/SkiaSharp.Views.Maui.Core.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(MauiTargetFrameworks)</TargetFrameworks>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
     <PackagingGroup>SkiaSharp.Views.Maui.Core</PackagingGroup>
+    <PackageReadmeNotice>&gt; Most .NET MAUI applications should install [SkiaSharp.Views.Maui.Controls](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls), which includes this shared infrastructure package.</PackageReadmeNotice>
     <RootNamespace>SkiaSharp.Views.Maui.Core</RootNamespace>
     <AssemblyName>SkiaSharp.Views.Maui.Core</AssemblyName>
     <Nullable>Enable</Nullable>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/PACKAGE-README.md
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/PACKAGE-README.md
@@ -1,0 +1,80 @@
+# SkiaSharp.Views.Blazor
+
+[![NuGet](https://img.shields.io/nuget/v/SkiaSharp.Views.Blazor?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp.Views.Blazor)
+[![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp.Views.Blazor?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp.Views.Blazor)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+
+**SkiaSharp.Views.Blazor** brings SkiaSharp to Blazor WebAssembly with ready-to-use Razor components. Draw with the same SkiaSharp API used by native .NET applications while the package handles the browser canvas, JavaScript interop, input events, and WebAssembly native assets.
+
+[![Open the live SkiaSharp Blazor Gallery](https://raw.githubusercontent.com/mono/SkiaSharp/main/samples/Gallery/screenshots/home.png)](https://mono.github.io/SkiaSharp/gallery/)
+
+## What you get
+
+- `SKCanvasView` for CPU-rendered, on-demand drawing to an HTML canvas.
+- `SKGLView` for WebGL-backed rendering and continuous animation.
+- Pointer, wheel, and touch input events.
+- Density-aware sizing and explicit invalidation.
+- Transitive WebAssembly native assets and build integration.
+
+## Get started
+
+Install the package into a Blazor WebAssembly project:
+
+```bash
+dotnet add package SkiaSharp.Views.Blazor
+```
+
+Add the namespaces to `_Imports.razor`:
+
+```razor
+@using SkiaSharp
+@using SkiaSharp.Views.Blazor
+```
+
+Add a canvas to a Razor component:
+
+```razor
+<SKCanvasView OnPaintSurface="OnPaintSurface"
+              IgnorePixelScaling="true" />
+
+@code {
+    private void OnPaintSurface(SKPaintSurfaceEventArgs e)
+    {
+        var canvas = e.Surface.Canvas;
+        canvas.Clear(SKColors.White);
+
+        using var paint = new SKPaint
+        {
+            Color = SKColors.CornflowerBlue,
+            IsAntialias = true,
+        };
+
+        canvas.DrawCircle(
+            e.Info.Width / 2f,
+            e.Info.Height / 2f,
+            Math.Min(e.Info.Width, e.Info.Height) * 0.3f,
+            paint);
+    }
+}
+```
+
+The package supplies its browser interop automatically. Use .NET 8 or later for a complete WebAssembly application with the supported native assets. For animated or GPU-heavy scenes, switch to `SKGLView` and enable its render loop.
+
+## See it running
+
+- [Live Blazor WebAssembly Gallery](https://mono.github.io/SkiaSharp/gallery/) - interactive SkiaSharp examples with no installation
+- [Buildable Blazor WebAssembly sample](https://github.com/mono/SkiaSharp/tree/main/samples/Basic/BlazorWebAssembly)
+- [SkiaFiddle](https://mono.github.io/SkiaSharp/fiddle/) - experiment with drawing code in your browser
+
+## Documentation and resources
+
+- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/)
+- [Blazor API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/skiasharp.views.blazor)
+- [Core SkiaSharp API reference](https://learn.microsoft.com/dotnet/api/skiasharp)
+- [WebAssembly package guidance](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+
+## Feedback and contributing
+
+SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+
+This package is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/PACKAGE-README.md
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/PACKAGE-README.md
@@ -6,8 +6,6 @@
 
 **SkiaSharp.Views.Blazor** brings SkiaSharp to Blazor WebAssembly with ready-to-use Razor components. Draw with the same SkiaSharp API used by native .NET applications while the package handles the browser canvas, JavaScript interop, input events, and WebAssembly native assets.
 
-[![Open the live SkiaSharp Blazor Gallery](https://raw.githubusercontent.com/mono/SkiaSharp/main/samples/Gallery/screenshots/home.png)](https://mono.github.io/SkiaSharp/gallery/)
-
 ## What you get
 
 - `SKCanvasView` for CPU-rendered, on-demand drawing to an HTML canvas.

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Desktop.Common/SkiaSharp.Views.Desktop.Common.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Desktop.Common/SkiaSharp.Views.Desktop.Common.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>SkiaSharp.Views.Desktop</RootNamespace>
     <AssemblyName>SkiaSharp.Views.Desktop.Common</AssemblyName>
     <PackagingGroup>SkiaSharp.Views.Desktop.Common</PackagingGroup>
+    <PackageReadmeNotice>&gt; This is a shared infrastructure package. Most applications should install the package for their UI framework, such as `SkiaSharp.Views.WPF`, `SkiaSharp.Views.WindowsForms`, or `SkiaSharp.Views.Gtk3`.</PackageReadmeNotice>
     <DefineConstants>$(DefineConstants);__DESKTOP__</DefineConstants>
     <Title>SkiaSharp Views &amp; Layers for Desktop</Title>
   </PropertyGroup>

--- a/source/SkiaSharp.Views/SkiaSharp.Views/PACKAGE-README.md
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/PACKAGE-README.md
@@ -1,0 +1,78 @@
+# SkiaSharp.Views
+
+[![NuGet](https://img.shields.io/nuget/v/SkiaSharp.Views?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp.Views)
+[![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp.Views?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp.Views)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+
+**SkiaSharp.Views** provides native SkiaSharp drawing views for Android, iOS, Mac Catalyst, macOS, tvOS, and Tizen applications. Each view owns the platform rendering surface and raises a familiar `PaintSurface` event so application code can draw with `SKCanvas`.
+
+## What you get
+
+- `SKCanvasView` for CPU-rendered, on-demand drawing.
+- GPU-backed views using OpenGL, Metal, or the platform's accelerated rendering surface.
+- Touch and input helpers, density-aware sizing, and explicit invalidation.
+- Platform-native view types that fit directly into each UI framework.
+
+## Get started
+
+Install the package into a native platform application:
+
+```bash
+dotnet add package SkiaSharp.Views
+```
+
+Create the platform `SKCanvasView` and handle `PaintSurface`:
+
+```csharp
+private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+{
+    var canvas = e.Surface.Canvas;
+    canvas.Clear(SKColors.White);
+
+    using var paint = new SKPaint
+    {
+        Color = SKColors.CornflowerBlue,
+        IsAntialias = true,
+    };
+
+    canvas.DrawCircle(e.Info.Width / 2f, e.Info.Height / 2f, 120, paint);
+}
+```
+
+The namespace and native base type vary by target:
+
+| Target | Namespace | Primary view |
+| --- | --- | --- |
+| Android | `SkiaSharp.Views.Android` | `SKCanvasView` |
+| iOS and Mac Catalyst | `SkiaSharp.Views.iOS` | `SKCanvasView` |
+| macOS | `SkiaSharp.Views.Mac` | `SKCanvasView` |
+| tvOS | `SkiaSharp.Views.tvOS` | `SKCanvasView` |
+| Tizen | `SkiaSharp.Views.Tizen` | `SKCanvasView` |
+
+## Using another UI framework?
+
+Choose the package that matches the application framework:
+
+| Framework | Package |
+| --- | --- |
+| .NET MAUI | [`SkiaSharp.Views.Maui.Controls`](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls) |
+| Blazor WebAssembly | [`SkiaSharp.Views.Blazor`](https://www.nuget.org/packages/SkiaSharp.Views.Blazor) |
+| Windows Forms | [`SkiaSharp.Views.WindowsForms`](https://www.nuget.org/packages/SkiaSharp.Views.WindowsForms) |
+| WPF | [`SkiaSharp.Views.WPF`](https://www.nuget.org/packages/SkiaSharp.Views.WPF) |
+| WinUI 3 | [`SkiaSharp.Views.WinUI`](https://www.nuget.org/packages/SkiaSharp.Views.WinUI) |
+| GTK 3 or GTK 4 | [`SkiaSharp.Views.Gtk3`](https://www.nuget.org/packages/SkiaSharp.Views.Gtk3) or [`SkiaSharp.Views.Gtk4`](https://www.nuget.org/packages/SkiaSharp.Views.Gtk4) |
+| Uno Platform | [`SkiaSharp.Views.Uno.WinUI`](https://www.nuget.org/packages/SkiaSharp.Views.Uno.WinUI) |
+
+## Documentation and resources
+
+- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/)
+- Platform API reference on Microsoft Learn: [Android](https://learn.microsoft.com/dotnet/api/skiasharp.views.android), [iOS and Mac Catalyst](https://learn.microsoft.com/dotnet/api/skiasharp.views.ios), [macOS](https://learn.microsoft.com/dotnet/api/skiasharp.views.mac), and [Tizen](https://learn.microsoft.com/dotnet/api/skiasharp.views.tizen)
+- [Platform samples](https://github.com/mono/SkiaSharp/tree/main/samples/Basic)
+- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/)
+- [Package selection and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+
+## Feedback and contributing
+
+SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+
+This package is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).


### PR DESCRIPTION
## Description

NuGet package READMEs were generated from the short `PackageDescription`, leaving every package page with little more than one sentence. This adds polished, package-specific onboarding for the five primary packages (`SkiaSharp`, `HarfBuzzSharp`, `SkiaSharp.Views`, `SkiaSharp.Views.Maui.Controls`, and `SkiaSharp.Views.Blazor`) with capabilities, installation, working examples, package selection, Microsoft Learn/API links, DocFX guides, the live Blazor Gallery, SkiaFiddle, support, and contribution information.

Each rich `PACKAGE-README.md` is co-located with its project. The shared packaging target discovers that convention and generates a professional fallback README for the other 36 packable projects. Package-specific guidance is expressed through explicit MSBuild properties: native-assets metadata lives in `NativeAssets.Build.targets`, while infrastructure-package notices live in their projects. Native package descriptions and two incorrect SceneGraph/Resources descriptions are also corrected.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — package documentation and NuGet metadata only; no public API or runtime behavior changes.

## Testing

- Generated and inspected `README.md` for all 41 packable projects: 5 co-located custom READMEs and 36 generated fallbacks.
- Packed representative `SkiaSharp` and `SkiaSharp.NativeAssets.Linux.NoDependencies` NuGets and verified the embedded README, `<readme>` metadata, concise native package description, and package-notes placement.
- Checked all 52 links in the custom package READMEs and validated Markdown structure/code fences.
- Ran `dotnet test tests/SkiaSharp.Tests.Console.slnx -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0`. The SingletonInit, Direct3D, and Vulkan hosts passed. In the core host, 6,098 passed and 23 skipped; two transient stream/GC failures passed when rerun in isolation. The existing local `ganesh-gl/DiagonalLines` golden comparison remains outside tolerance on this Mac (1,832 pixels versus 1,310 allowed); all other focused visual cases passed (19 passed, 5 skipped). This PR does not change rendering code or golden images.

No tests were added because the change is package documentation and shared pack metadata; the package-generation and packed-artifact checks above cover the changed behavior.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated