### PR TITLE
Add Darc package publishing and retrieval

### DIFF
--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -181,10 +181,58 @@ python3 .agents/skills/release-status/scripts/pipeline-status.py release/{versio
 
 The JSON report links downstream runs through `triggerInfo.pipelineId`, provides
 immutable source/run metadata, and derives exact test/public package versions.
-Packages appear on the internal feed after the selected `SkiaSharp` (ID 10789)
-run completes. Wait for the selected `SkiaSharp-Tests` run and both exact
-packages before beginning release-testing unless the user explicitly overrides
-the test wait.
+The internal package pipeline (ID 1642) produces the signed packages and BAR
+manifest; the connected test pipeline is ID 1630. Wait for the selected tests
+run and retrieve both exact packages with the BAR flow below before beginning
+release-testing unless the user explicitly overrides the test wait.
+
+#### BAR channels and signed-package retrieval
+
+The internal package pipeline generates an Arcade V3 asset manifest from the
+signed NuGets, registers that manifest in the Build Asset Registry (BAR), and
+then calls `darc add-build-to-channel --default-channels`. The branch must have
+an enabled internal default-channel mapping in the `maestro-configuration`
+repository. The pipeline deliberately requires that mapping; it does not fall
+back to a public channel or an ad-hoc feed.
+
+A channel is BAR metadata, not package storage. Channel promotion publishes the
+manifest's NuGet assets to the Azure DevOps feeds configured for that channel
+and records those feed URLs as BAR asset locations. `darc gather-drop` reads the
+BAR metadata and downloads each package from a registered location.
+
+Install the matching Darc CLI with `eng/common/darc-init.ps1` or
+`eng/common/darc-init.sh`, then resolve and download a pinned build:
+
+```bash
+export SKIASHARP_AZDO_PAT='...' # Build Read + Packaging Read for dnceng/internal
+python3 scripts/infra/darc/download-darc-packages.py \
+  --channel 'SkiaSharp Internal Testing' \
+  --expected-commit '{full-40-character-sha}' \
+  --expected-branch 'refs/heads/release/{version}' \
+  --expected-package 'SkiaSharp={exact-version}' \
+  --expected-package 'HarfBuzzSharp={exact-version}' \
+  --azdev-pat-env SKIASHARP_AZDO_PAT \
+  --output-dir output/darc/{bar-build}
+```
+
+For a known BAR build, replace `--channel` with `--build-id {id}` and add
+`--expected-channel '{channel}'`. The script resolves exactly one build, checks
+the repository, full commit, branch, and channel, invokes `darc gather-drop`
+with registered locations only, rejects missing or duplicate package
+identities, verifies every NuGet signature, and writes
+`darc-provenance.json` with SHA-512 hashes. Use the reported
+`download.packageSource` as the local NuGet source.
+
+BAR access uses the caller's Azure CLI or interactive Maestro login by default;
+CI should use the `Darc: Maestro Production` service connection. Downloading
+from an internal Azure DevOps feed additionally requires an Azure DevOps token,
+passed by environment-variable name so it is not persisted in evidence.
+Like Darc itself, the token is passed to the Darc child process as an argument;
+run this only on a trusted single-tenant machine or build agent.
+
+Adding a default-channel mapping or running `darc add-build-to-channel` is a
+producer/promotion operation. `get-latest-build`, `get-build`, and
+`gather-drop` are consumer operations; they never promote a build.
 
 ### Stage 3: Testing (release-testing skill)
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -206,7 +206,7 @@ Install the matching Darc CLI with `eng/common/darc-init.ps1` or
 ```bash
 export SKIASHARP_AZDO_PAT='...' # Build Read + Packaging Read for dnceng/internal
 python3 scripts/infra/darc/download-darc-packages.py \
-  --channel 'SkiaSharp Internal Testing' \
+  --channel 'General Testing Internal' \
   --expected-commit '{full-40-character-sha}' \
   --expected-branch 'refs/heads/release/{version}' \
   --expected-package 'SkiaSharp={exact-version}' \
@@ -229,6 +229,11 @@ from an internal Azure DevOps feed additionally requires an Azure DevOps token,
 passed by environment-variable name so it is not persisted in evidence.
 Like Darc itself, the token is passed to the Darc child process as an argument;
 run this only on a trusted single-tenant machine or build agent.
+
+`General Testing Internal` is the existing non-production Maestro channel for
+this workflow. Its NuGet assets are stored in the private
+`general-testing-internal` Azure DevOps feed; SkiaSharp does not need a
+repository-specific feed for release testing.
 
 Adding a default-channel mapping or running `darc add-build-to-channel` is a
 producer/promotion operation. `get-latest-build`, `get-build`, and

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -235,6 +235,66 @@ this workflow. Its NuGet assets are stored in the private
 `general-testing-internal` Azure DevOps feed; SkiaSharp does not need a
 repository-specific feed for release testing.
 
+The required cross-repository configuration is a separate
+`maestro-configuration` pull request against its `production` branch. Create
+`configuration/default-channels/mono-skiasharp.yml` with:
+
+```yaml
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: main
+  Channel: General Testing Internal
+  Enabled: true
+
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: release/3.119.x
+  Channel: General Testing Internal
+  Enabled: true
+
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: release/4.148.x
+  Channel: General Testing Internal
+  Enabled: true
+
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: release/4.150.x
+  Channel: General Testing Internal
+  Enabled: true
+
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: release/4.151.x
+  Channel: General Testing Internal
+  Enabled: true
+
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: release/4.152.0-preview.1
+  Channel: General Testing Internal
+  Enabled: true
+```
+
+Maestro default-channel mappings are exact; do not use a wildcard for release
+branches. Remove obsolete release entries as maintenance lines close, and add
+the next exact release branch when it is created.
+
+Before merging that configuration, the SkiaSharp publishing branch can be
+validated by temporarily adding this entry to the same file:
+
+```yaml
+- Repository: https://dev.azure.com/dnceng/internal/_git/dotnet-SkiaSharp
+  Branch: mattleibow-darc-release-packages
+  Channel: General Testing Internal
+  Enabled: true
+```
+
+Queue package pipeline 1642 for that branch with both `forceRealSigning=true`
+and `runApiScan=true`. Remove the temporary entry after confirming the BAR build,
+channel assignment, feed location, and downloaded-package evidence.
+
+Pipeline 1642 must be authorized to use the `Darc: Maestro Production` service
+connection and the `Publish-Build-Assets` and
+`AzureDevOps-Artifact-Feeds-Pats` variable groups. A local or downstream
+consumer needs Build Read and Packaging Read access to `dnceng/internal`;
+credentials must not be committed to either repository.
+
 Adding a default-channel mapping or running `darc add-build-to-channel` is a
 producer/promotion operation. `get-latest-build`, `get-build`, and
 `gather-drop` are consumer operations; they never promote a build.

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Artifact Include="$(ArtifactsShippingPackagesDir)**\*.nupkg" Kind="Package" />
+  </ItemGroup>
+</Project>

--- a/scripts/azure-pipelines-package.yml
+++ b/scripts/azure-pipelines-package.yml
@@ -111,6 +111,7 @@ extends:
           buildPipelineType: 'package'
           enableSigning: ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}
           forceRealSigning: ${{ parameters.forceRealSigning }}
+          enablePublishing: ${{ or(eq(parameters.forceRealSigning, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}
           buildAgentHost: ${{ parameters.buildAgentHost }}
           buildAgentWindows: ${{ parameters.buildAgentWindows }}
           buildAgentMac: ${{ parameters.buildAgentMac }}
@@ -119,3 +120,22 @@ extends:
         - template: /scripts/azure-templates-stages-apiscan.yml@self
           parameters:
             buildAgentWindows: ${{ parameters.buildAgentWindows }}
+      - ${{ if or(eq(parameters.forceRealSigning, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+        - stage: publish_build_assets
+          displayName: Register signed packages in BAR
+          dependsOn:
+            - signing
+            - ${{ if or(eq(parameters.runApiScan, 'true'), and(eq(variables['System.TeamProject'], 'internal'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))) }}:
+              - api_scan
+          jobs:
+            - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+              parameters:
+                is1ESPipeline: true
+                publishingVersion: 3
+        - template: /eng/common/templates-official/post-build/post-build.yml@self
+          parameters:
+            publishingInfraVersion: 3
+            is1ESPipeline: true
+            requireDefaultChannels: true
+            validateDependsOn:
+              - publish_build_assets

--- a/scripts/azure-templates-stages-signing.yml
+++ b/scripts/azure-templates-stages-signing.yml
@@ -4,6 +4,9 @@ parameters:
   - name: useRealSigning
     type: boolean
     default: false
+  - name: enablePublishing
+    type: boolean
+    default: false
 
 stages:
   - stage: signing
@@ -134,3 +137,15 @@ stages:
                 Get-ChildItem $source -Filter '*-*.nupkg' -File |
                   Copy-Item -Destination $destination
               displayName: Create signed preview package view
+
+            - ${{ if eq(parameters.enablePublishing, true) }}:
+              - powershell: >
+                  eng\common\build.ps1
+                  -configuration Release
+                  -publish
+                  -ci
+                  /p:OfficialBuildId=$(ARCADE_OFFICIAL_BUILD_ID)
+                  /p:DotNetPublishUsingPipelines=true
+                displayName: Generate Arcade V3 asset manifest
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/scripts/azure-templates-stages.yml
+++ b/scripts/azure-templates-stages.yml
@@ -36,6 +36,9 @@ parameters:
   - name: enableCaching
     type: boolean
     default: false
+  - name: enablePublishing
+    type: boolean
+    default: false
 
 stages:
 
@@ -65,6 +68,7 @@ stages:
     - template: /scripts/azure-templates-stages-signing.yml@self
       parameters:
         buildAgent: ${{ parameters.buildAgentWindows }}
+        enablePublishing: ${{ parameters.enablePublishing }}
         ${{ if or(eq(parameters.forceRealSigning, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
          useRealSigning: true
         ${{ else }}:

--- a/scripts/infra/darc/download-darc-packages.py
+++ b/scripts/infra/darc/download-darc-packages.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Resolve one BAR build and download its signed SkiaSharp NuGet assets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+
+
+BAR_URI = "https://maestro.dot.net"
+DEFAULT_REPOSITORY = "https://github.com/mono/SkiaSharp"
+PACKAGE_NAME_PATTERN = r"^(?:SkiaSharp|HarfBuzzSharp)(?:\..*)?$"
+REQUIRED_PACKAGE_IDS = {"SkiaSharp", "HarfBuzzSharp"}
+SECRET_OPTIONS = {"--azdev-pat", "-p", "--password"}
+
+
+class DownloadError(RuntimeError):
+    """The requested package drop could not be proven or downloaded safely."""
+
+
+def normalized_repository(value: str) -> str:
+    normalized = value.strip().rstrip("/").lower()
+    return normalized[:-4] if normalized.endswith(".git") else normalized
+
+
+def redact(args: list[str]) -> list[str]:
+    result = list(args)
+    for index, value in enumerate(result[:-1]):
+        if value in SECRET_OPTIONS:
+            result[index + 1] = "***"
+    return result
+
+
+def run(args: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as error:
+        raise DownloadError(
+            f"{args[0]} was not found; run eng/common/darc-init.ps1 or "
+            "eng/common/darc-init.sh first"
+        ) from error
+    except subprocess.TimeoutExpired as error:
+        raise DownloadError(
+            f"command timed out after {timeout}s: "
+            f"{subprocess.list2cmdline(redact(args))}"
+        ) from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise DownloadError(
+            f"command failed ({result.returncode}): "
+            f"{subprocess.list2cmdline(redact(args))}\n{detail}"
+        )
+    return result
+
+
+def parse_json_output(text: str):
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(text):
+        if character not in "[{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[index:])
+            return value
+        except json.JSONDecodeError:
+            pass
+    raise DownloadError("Darc returned no valid JSON")
+
+
+def auth_arguments(args) -> tuple[list[str], dict]:
+    command = ["--bar-uri", args.bar_uri]
+    evidence = {
+        "barUri": args.bar_uri,
+        "barAuthentication": "default",
+        "azureDevOpsAuthentication": "default",
+    }
+    if args.ci:
+        command.append("--ci")
+    for option, env_name, evidence_name in (
+        ("-p", args.bar_password_env, "barAuthentication"),
+        ("--azdev-pat", args.azdev_pat_env, "azureDevOpsAuthentication"),
+    ):
+        if not env_name:
+            continue
+        value = os.environ.get(env_name)
+        if not value:
+            raise DownloadError(
+                f"environment variable {env_name} is required but empty"
+            )
+        command.extend([option, value])
+        evidence[evidence_name] = f"environment:{env_name}"
+    return command, evidence
+
+
+def darc_json(
+    darc: str,
+    command: list[str],
+    auth: list[str],
+    *,
+    timeout: int = 120,
+):
+    result = run(
+        [
+            darc,
+            *command,
+            *auth,
+            "--output-format",
+            "json",
+        ],
+        timeout=timeout,
+    )
+    return parse_json_output(result.stdout)
+
+
+def build_matches(
+    build: dict,
+    *,
+    repository: str,
+    commit: str,
+    channel: str | None,
+) -> bool:
+    channels = build.get("channels") or []
+    return (
+        normalized_repository(str(build.get("repository") or ""))
+        == normalized_repository(repository)
+        and str(build.get("commit") or "").lower() == commit.lower()
+        and (
+            channel is None
+            or any(
+                str(item).casefold() == channel.casefold()
+                for item in channels
+            )
+        )
+    )
+
+
+def select_build(builds, *, repository: str, commit: str, channel: str | None):
+    if not isinstance(builds, list):
+        raise DownloadError("Darc build query did not return a JSON array")
+    matches = {
+        int(build["id"]): build
+        for build in builds
+        if isinstance(build, dict)
+        and build.get("id") is not None
+        and build_matches(
+            build,
+            repository=repository,
+            commit=commit,
+            channel=channel,
+        )
+    }
+    if len(matches) != 1:
+        raise DownloadError(
+            "expected exactly one BAR build matching repository, commit, and "
+            f"channel; found {len(matches)}"
+        )
+    build = next(iter(matches.values()))
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", str(build.get("commit") or "")):
+        raise DownloadError("BAR build does not contain a full commit SHA")
+    return build
+
+
+def resolve_build(args, auth: list[str]) -> dict:
+    if args.build_id is not None:
+        builds = darc_json(
+            args.darc,
+            ["get-build", "--id", str(args.build_id)],
+            auth,
+        )
+        channel = args.expected_channel
+    else:
+        builds = darc_json(
+            args.darc,
+            [
+                "get-latest-build",
+                "--repo",
+                args.repository,
+                "--channel",
+                args.channel,
+            ],
+            auth,
+        )
+        channel = args.channel
+    build = select_build(
+        builds,
+        repository=args.repository,
+        commit=args.expected_commit,
+        channel=channel,
+    )
+    if args.build_id is not None and int(build["id"]) != args.build_id:
+        raise DownloadError(
+            f"Darc returned BAR build {build['id']}, expected {args.build_id}"
+        )
+    if args.expected_branch:
+        branch = str(build.get("branch") or "")
+        if branch.casefold() != args.expected_branch.casefold():
+            raise DownloadError(
+                f"BAR build branch {branch!r} does not match "
+                f"{args.expected_branch!r}"
+            )
+    return build
+
+
+def prepare_output(output: Path) -> None:
+    if output.exists() and any(output.iterdir()):
+        raise DownloadError(f"output directory is not empty: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+
+
+def gather_drop(args, auth: list[str], build: dict, output: Path) -> list[str]:
+    command = [
+        args.darc,
+        "gather-drop",
+        "--id",
+        str(build["id"]),
+        "--output-dir",
+        str(output),
+        "--asset-filter",
+        PACKAGE_NAME_PATTERN,
+        "--no-workarounds",
+        "--include-released",
+        "--overwrite",
+        *auth,
+    ]
+    run(command, timeout=args.download_timeout)
+    return redact(command)
+
+
+def package_identity(path: Path) -> tuple[str, str]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            nuspecs = [
+                name
+                for name in archive.namelist()
+                if name.lower().endswith(".nuspec") and "/" not in name
+            ]
+            if len(nuspecs) != 1:
+                raise DownloadError(
+                    f"{path.name} contains {len(nuspecs)} root nuspec files"
+                )
+            root = ET.fromstring(archive.read(nuspecs[0]))
+    except (OSError, zipfile.BadZipFile, ET.ParseError) as error:
+        raise DownloadError(f"invalid NuGet package {path}: {error}") from error
+    metadata = next(
+        (element for element in root if element.tag.rsplit("}", 1)[-1] == "metadata"),
+        None,
+    )
+    if metadata is None:
+        raise DownloadError(f"{path.name} has no nuspec metadata")
+    values = {
+        element.tag.rsplit("}", 1)[-1]: (element.text or "").strip()
+        for element in metadata
+    }
+    package_id = values.get("id", "")
+    version = values.get("version", "")
+    if not package_id or not version:
+        raise DownloadError(f"{path.name} has no package id or version")
+    return package_id, version
+
+
+def inspect_packages(
+    output: Path,
+    expected: set[tuple[str, str]],
+) -> list[dict]:
+    package_root = output / "shipping" / "packages"
+    paths = sorted(package_root.glob("*.nupkg"))
+    if not paths:
+        raise DownloadError("Darc downloaded no shipping NuGet packages")
+    packages = []
+    identities = set()
+    for path in paths:
+        package_id, version = package_identity(path)
+        if not re.fullmatch(r"(?:SkiaSharp|HarfBuzzSharp)(?:\..*)?", package_id):
+            raise DownloadError(f"unexpected package in Darc drop: {package_id}")
+        identity = (package_id, version)
+        if identity in identities:
+            raise DownloadError(
+                f"duplicate package identity in Darc drop: {package_id} {version}"
+            )
+        identities.add(identity)
+        packages.append(
+            {
+                "id": package_id,
+                "version": version,
+                "file": str(path.relative_to(output)),
+                "size": path.stat().st_size,
+                "sha512": hashlib.sha512(path.read_bytes()).hexdigest(),
+            }
+        )
+    missing_ids = REQUIRED_PACKAGE_IDS - {item[0] for item in identities}
+    if missing_ids:
+        raise DownloadError(
+            "Darc drop is missing required package IDs: "
+            + ", ".join(sorted(missing_ids))
+        )
+    missing = expected - identities
+    if missing:
+        raise DownloadError(
+            "Darc drop is missing expected packages: "
+            + ", ".join(f"{name} {version}" for name, version in sorted(missing))
+        )
+    return packages
+
+
+def parse_expected(values: list[str]) -> set[tuple[str, str]]:
+    expected = set()
+    for value in values:
+        package_id, separator, version = value.partition("=")
+        if not separator or not package_id or not version:
+            raise DownloadError(
+                f"invalid --expected-package {value!r}; use ID=VERSION"
+            )
+        expected.add((package_id, version))
+    missing_ids = REQUIRED_PACKAGE_IDS - {item[0] for item in expected}
+    if missing_ids:
+        raise DownloadError(
+            "--expected-package must pin exact versions for: "
+            + ", ".join(sorted(missing_ids))
+        )
+    return expected
+
+
+def verify_signatures(dotnet: str, output: Path, packages: list[dict]) -> list[str]:
+    command = [
+        dotnet,
+        "nuget",
+        "verify",
+        "--all",
+        "--verbosity",
+        "minimal",
+        *[str(output / package["file"]) for package in packages],
+    ]
+    run(command, timeout=600)
+    return command
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--build-id", type=int)
+    selector.add_argument("--channel")
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--expected-channel")
+    parser.add_argument("--expected-branch")
+    parser.add_argument("--expected-package", action="append", required=True)
+    parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path)
+    parser.add_argument("--darc", default=shutil.which("darc") or "darc")
+    parser.add_argument("--dotnet", default=shutil.which("dotnet") or "dotnet")
+    parser.add_argument("--bar-uri", default=BAR_URI)
+    parser.add_argument("--bar-password-env")
+    parser.add_argument("--azdev-pat-env")
+    parser.add_argument("--ci", action="store_true")
+    parser.add_argument("--download-timeout", type=int, default=1800)
+    return parser
+
+
+def execute(args) -> dict:
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", args.expected_commit):
+        raise DownloadError("--expected-commit must be a full 40-character SHA")
+    if args.channel and args.expected_channel:
+        raise DownloadError(
+            "--expected-channel is only valid with --build-id; "
+            "--channel already pins it"
+        )
+    expected = parse_expected(args.expected_package)
+    output = args.output_dir.resolve()
+    prepare_output(output)
+    auth, auth_evidence = auth_arguments(args)
+    build = resolve_build(args, auth)
+    gather_command = gather_drop(args, auth, build, output)
+    packages = inspect_packages(output, expected)
+    verification_command = verify_signatures(args.dotnet, output, packages)
+    manifest = output / "manifest.json"
+    if not manifest.is_file():
+        raise DownloadError("Darc did not emit manifest.json")
+    evidence_path = (
+        args.evidence.resolve()
+        if args.evidence
+        else output / "darc-provenance.json"
+    )
+    report = {
+        "schemaVersion": 1,
+        "selector": {
+            "buildId": args.build_id,
+            "channel": args.channel,
+            "expectedCommit": args.expected_commit.lower(),
+            "expectedChannel": args.expected_channel,
+            "expectedBranch": args.expected_branch,
+            "repository": args.repository,
+        },
+        "resolvedBuild": build,
+        "authentication": auth_evidence,
+        "download": {
+            "command": gather_command,
+            "manifest": str(manifest),
+            "manifestSha512": hashlib.sha512(manifest.read_bytes()).hexdigest(),
+            "packageSource": str(output / "shipping" / "packages"),
+        },
+        "packages": packages,
+        "signatureVerification": {
+            "command": verification_command,
+            "verified": True,
+        },
+    }
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(json.dumps(report, indent=2) + "\n", encoding="ascii")
+    return report
+
+
+def main() -> int:
+    parser = create_parser()
+    args = parser.parse_args()
+    try:
+        report = execute(args)
+    except DownloadError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/infra/darc/tests/test_download_darc_packages.py
+++ b/scripts/infra/darc/tests/test_download_darc_packages.py
@@ -1,0 +1,204 @@
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+import zipfile
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "download-darc-packages.py"
+SPEC = importlib.util.spec_from_file_location("download_darc_packages", SCRIPT)
+download = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(download)
+
+COMMIT = "a" * 40
+CHANNEL = "SkiaSharp Internal Testing"
+REPOSITORY = "https://github.com/mono/SkiaSharp"
+
+
+def build(build_id=42, *, channels=None, commit=COMMIT):
+    return {
+        "id": build_id,
+        "repository": REPOSITORY,
+        "branch": "refs/heads/release/4.0.0",
+        "commit": commit,
+        "buildNumber": "4.0.0-preview.1",
+        "azdoBuildId": 100,
+        "channels": channels if channels is not None else [CHANNEL],
+    }
+
+
+def write_package(root: Path, package_id: str, version: str, suffix=""):
+    path = root / "shipping" / "packages" / (
+        f"{package_id}.{version}{suffix}.nupkg"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nuspec = (
+        "<package><metadata>"
+        f"<id>{package_id}</id><version>{version}</version>"
+        "</metadata></package>"
+    )
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(f"{package_id}.nuspec", nuspec)
+    return path
+
+
+def arguments(output: Path, **overrides):
+    values = {
+        "build_id": None,
+        "channel": CHANNEL,
+        "expected_commit": COMMIT,
+        "expected_channel": None,
+        "expected_branch": None,
+        "expected_package": [
+            "SkiaSharp=4.0.0-preview.1",
+            "HarfBuzzSharp=9.0.0-preview.1",
+        ],
+        "repository": REPOSITORY,
+        "output_dir": output,
+        "evidence": None,
+        "darc": "darc",
+        "dotnet": "dotnet",
+        "bar_uri": download.BAR_URI,
+        "bar_password_env": None,
+        "azdev_pat_env": None,
+        "ci": True,
+        "download_timeout": 30,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class DownloadDarcPackagesTests(unittest.TestCase):
+    def test_channel_resolution_downloads_pinned_build_and_emits_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "drop"
+
+            def fake_run(command, *, timeout):
+                if command[1] == "get-latest-build":
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout="log\n" + json.dumps([build()]),
+                        stderr="",
+                    )
+                if command[0] == "dotnet":
+                    self.assertEqual(command[1:4], ["nuget", "verify", "--all"])
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+                self.assertEqual(command[1], "gather-drop")
+                self.assertIn("--no-workarounds", command)
+                self.assertNotIn("--latest-location", command)
+                self.assertEqual(command[command.index("--id") + 1], "42")
+                write_package(output, "SkiaSharp", "4.0.0-preview.1")
+                write_package(output, "HarfBuzzSharp", "9.0.0-preview.1")
+                (output / "manifest.json").write_text("{}\n", encoding="ascii")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with mock.patch.object(download, "run", side_effect=fake_run):
+                report = download.execute(arguments(output))
+
+            self.assertEqual(report["resolvedBuild"]["id"], 42)
+            self.assertEqual(len(report["packages"]), 2)
+            self.assertTrue(report["signatureVerification"]["verified"])
+            self.assertEqual(
+                report["download"]["packageSource"],
+                str((output / "shipping" / "packages").resolve()),
+            )
+            evidence = json.loads(
+                (output / "darc-provenance.json").read_text(encoding="ascii")
+            )
+            self.assertEqual(evidence["selector"]["expectedCommit"], COMMIT)
+
+    def test_rejects_ambiguous_exact_matches(self):
+        with self.assertRaisesRegex(
+            download.DownloadError,
+            "expected exactly one BAR build",
+        ):
+            download.select_build(
+                [build(41), build(42)],
+                repository=REPOSITORY,
+                commit=COMMIT,
+                channel=CHANNEL,
+            )
+
+    def test_rejects_build_not_on_exact_channel(self):
+        with self.assertRaisesRegex(
+            download.DownloadError,
+            "expected exactly one BAR build",
+        ):
+            download.select_build(
+                [build(channels=["SkiaSharp Internal Testing Preview"])],
+                repository=REPOSITORY,
+                commit=COMMIT,
+                channel=CHANNEL,
+            )
+
+    def test_rejects_missing_required_package(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            write_package(output, "SkiaSharp", "4.0.0-preview.1")
+            with self.assertRaisesRegex(
+                download.DownloadError,
+                "missing required package IDs: HarfBuzzSharp",
+            ):
+                download.inspect_packages(output, set())
+
+    def test_rejects_duplicate_package_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            write_package(output, "SkiaSharp", "4.0.0-preview.1")
+            write_package(
+                output,
+                "SkiaSharp",
+                "4.0.0-preview.1",
+                suffix=".duplicate",
+            )
+            write_package(output, "HarfBuzzSharp", "9.0.0-preview.1")
+            with self.assertRaisesRegex(
+                download.DownloadError,
+                "duplicate package identity",
+            ):
+                download.inspect_packages(output, set())
+
+    def test_redacts_credentials(self):
+        self.assertEqual(
+            download.redact(
+                ["darc", "gather-drop", "--azdev-pat", "secret", "-p", "bar"]
+            ),
+            ["darc", "gather-drop", "--azdev-pat", "***", "-p", "***"],
+        )
+
+    def test_requires_exact_versions_for_both_base_packages(self):
+        with self.assertRaisesRegex(
+            download.DownloadError,
+            "must pin exact versions for: HarfBuzzSharp",
+        ):
+            download.parse_expected(["SkiaSharp=4.0.0-preview.1"])
+
+    def test_pipeline_enables_v3_registration_after_signing(self):
+        root = SCRIPT.parents[3]
+        package_pipeline = (
+            root / "scripts/azure-pipelines-package.yml"
+        ).read_text(encoding="ascii")
+        signing = (
+            root / "scripts/azure-templates-stages-signing.yml"
+        ).read_text(encoding="ascii")
+        publishing = (root / "eng/Publishing.props").read_text(encoding="ascii")
+        self.assertIn("enablePublishing: ${{ or(", package_pipeline)
+        self.assertIn("publish_build_assets", package_pipeline)
+        self.assertIn("requireDefaultChannels: true", package_pipeline)
+        self.assertIn("-publish", signing)
+        self.assertIn("<PublishingVersion>3</PublishingVersion>", publishing)
+        self.assertIn(
+            '<Artifact Include="$(ArtifactsShippingPackagesDir)**\\*.nupkg"',
+            publishing,
+        )
+
+    def test_files_are_ascii(self):
+        SCRIPT.read_text(encoding="ascii")
+        Path(__file__).read_text(encoding="ascii")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds the producer and consumer halves needed to use SkiaSharp release packages through Darc/Maestro without treating a channel as binary storage.

The internal package pipeline now generates an Arcade V3 manifest from the real-signed NuGets, registers the build/assets in BAR after API Scan, validates them, and promotes through enabled default channels. A fail-closed downloader resolves one BAR build, verifies repository/commit/branch/channel identity, gathers only registered SkiaSharp/HarfBuzzSharp assets, requires exact base-package versions, verifies NuGet signatures, and emits SHA-512 provenance evidence.

Maestro already provides `General Testing Internal` (channel ID 1647), mapped to the private `general-testing-internal` Azure Artifacts feed. The release guide records the exact separate `maestro-configuration` file, branch mappings, permissions, and temporary validation-branch entry required after approval; this PR intentionally does not modify that repository.

This is stacked on `dev/dnceng-pipelines`; it must not merge before the parent CI migration.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — release infrastructure and operator tooling only; no public API or runtime behavior changes.

## Testing

- `python3 -m unittest discover -s scripts/infra/darc/tests -v` (9 passed)
- Parsed all changed YAML with PyYAML and ran `git diff --check`.
- Ran the actual Arcade `-publish` target locally with `PushToLocalStorage=true`; it generated `AssetManifest/sign_nugets.xml` and staged the declared shipping package.
- Ran `dotnet nuget verify --all` against a signed package.
- Installed Darc `1.1.0-beta.26413.1` and verified the relevant `get-build`, `get-latest-build`, `gather-drop`, and `add-build-to-channel` CLI options.
- Verified `maestro-configuration` production contains `General Testing Internal` and no SkiaSharp default-channel mapping; verified Arcade maps channel ID 1647 to `https://pkgs.dev.azure.com/dnceng/internal/_packaging/general-testing-internal/nuget/v3/index.json`.
- Live BAR registration/promotion remains intentionally unrun until the separate default-channel configuration is approved and pipeline 1642 service-connection/variable-group permissions are confirmed.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native changes