### PR TITLE
[skia-sync] Merge upstream chrome/m152 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -250,7 +250,7 @@
       }
     },
     {
-      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia \u2014 version from scripts/VERSIONS.txt",
+      "comment": "ANGLE (Windows-only, WinUI). Cloned separately from Skia — version from scripts/VERSIONS.txt",
       "component": {
         "type": "git",
         "git": {
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "c14bcfbab83b2182977505c251a02c058f83a321"
+          "commitHash": "512b63d61a26354520b04209a41e63ff8ca6b6ef"
         }
       }
     },
@@ -323,7 +323,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "2a9b593bab4b2fd019fa494c8d401ff1fab0b883",
+      "upstream_merge_commit": "b6d106297ff9ef2ff8094033695d045e87775581",
       "upstream_ref": "chrome/m152"
     }
   ]

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "512b63d61a26354520b04209a41e63ff8ca6b6ef"
+          "commitHash": "9f0d864fd60e9907a8bf5ec84a71d603e6c8db5f"
         }
       }
     },


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m152.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/346

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the SkiaSharp submodule to the merged mono/skia `skia-sync/m152` commit and reconcile metadata for the same-milestone (m152) upstream bug-fix sync.

- Submodule `externals/skia`: `c14bcfbab83b2182977505c251a02c058f83a321` → `512b63d61a26354520b04209a41e63ff8ca6b6ef` (tested two-parent merge of upstream `b6d106297ff9ef2ff8094033695d045e87775581`).
- `cgmanifest.json`: skia registration `commitHash` and `upstream_merge_commit` updated to the new merge/upstream SHAs (`chrome_milestone` stays 152).
- `scripts/VERSIONS.txt`, soname, and package/assembly versions **unchanged** — same-milestone bug-fix mode.
- No C API, generated binding (`*.generated.cs`), managed wrapper, enum-mapping, or new-native-function changes (regeneration produced no diff).
- Upstream deltas are two internal Ganesh fixes (`GrGpu::createBackendTexture` stats source; `GrResourceProvider::writePixels` null-return on failure); neither is wrapped by the C API.

## Testing

Native rebuilt from source (linux/x64) — never `externals-download`. Managed build of `binding/SkiaSharp/SkiaSharp.csproj` succeeded. Full unfiltered `tests/SkiaSharp.Tests.Console.slnx` (net10.0), every host green:
- Core: 6091 passed, 33 skipped, 0 failed.
- SingletonInit: 1 passed, 0 failed.
- Vulkan: 23 passed, 2 skipped, 0 failed.
- Direct3D: 2 passed, 3 skipped, 0 failed.

No **required** `GpuPolicy` backend for linux/x64 was skipped; remaining skips are existing platform/host-policy skips.

## Human review

- Merge order: mono/skia PR first, then update this parent PR's submodule pointer to the merged `skiasharp` commit before merging.
- Only linux/x64 was validated locally. Windows/macOS/Android/iOS/Blazor native builds and their test hosts require CI verification.
- Confirm downstream packaging picks up the unchanged m152 versioning (bug-fix hash-only advance).


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-08-18T07:39:11Z_
