### PR TITLE
[performance] Build Android on Linux and reduce native/package CI overhead

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -134,7 +134,7 @@ Task ("tests-wasm")
 Task ("nuget")
     .Description ("Pack all NuGets.")
     .IsDependentOn ("nuget-normal")
-    .Does (() => RunCake ("./scripts/infra/package/nuget.cake", "nuget-special"));
+    .IsDependentOn ("nuget-special");
 
 Task ("nuget-normal")
     .Description ("Pack all NuGets (build all required dependencies).")

--- a/build.cake
+++ b/build.cake
@@ -143,7 +143,6 @@ Task ("nuget-normal")
 
 Task ("nuget-special")
     .Description ("Pack all special NuGets.")
-    .IsDependentOn ("libs")
     .Does (() => RunCake ("./scripts/infra/package/nuget.cake", "nuget-special"));
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -134,7 +134,7 @@ Task ("tests-wasm")
 Task ("nuget")
     .Description ("Pack all NuGets.")
     .IsDependentOn ("nuget-normal")
-    .IsDependentOn ("nuget-special");
+    .Does (() => RunCake ("./scripts/infra/package/nuget.cake", "nuget-special"));
 
 Task ("nuget-normal")
     .Description ("Pack all NuGets (build all required dependencies).")

--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -8,7 +8,7 @@ Information("Android NDK Path: {0}", ANDROID_NDK_HOME);
 
 Task("libSkiaSharp")
     .IsDependentOn("git-sync-deps")
-    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows())
+    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows() || IsRunningOnLinux())
     .Does(() =>
 {
     Build("x86", "x86");
@@ -48,7 +48,7 @@ Task("libSkiaSharp")
 });
 
 Task("libHarfBuzzSharp")
-    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows())
+    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows() || IsRunningOnLinux())
     .Does(() =>
 {
     Build("x86");

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -26,9 +26,11 @@ parameters:
   installAndroidSdk: true                       # whether or not to install the Android SDK
   installWindowsSdk: false                      # whether or not to install the Windows SDK
   installDotNet: true                           # whether or not to install the dotnet SDK
+  installDotNetWorkloads: true                  # whether or not to install the .NET workloads
   installLlvm: true                             # whether or not to install the LLVM compiler
   installEmsdk: false                           # whether or not to install the Emscripten SDK
   installNinja: false                           # whether or not to install the ninja build system
+  installNode: true                             # whether or not to install Node.js
   installPreviewSdk: false                      # whether to install the preview .NET SDK ($(DOTNET_VERSION_PREVIEW)) and pin global.json to it
   previewWorkloads: ''                           # workloads to install under the preview .NET SDK (comma-separated, e.g. 'wasm-tools,android')
   installXcode: true                            # whether or not to install Xcode
@@ -204,7 +206,7 @@ jobs:
 
       # install extra bits for the managed builds
       - ${{ if and(not(startsWith(parameters.name, 'native_')), ne(parameters.skipInstall, 'true')) }}:
-        - ${{ if eq(parameters.buildAgent.pool.os, 'windows') }}:
+        - ${{ if and(eq(parameters.installNode, 'true'), eq(parameters.buildAgent.pool.os, 'windows')) }}:
           - task: UseNode@1
             displayName: Install Node.js
             retryCountOnTaskFailure: 3
@@ -247,7 +249,7 @@ jobs:
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
         # install workloads
-        - ${{ if eq(parameters.installDotNet, 'true') }}:
+        - ${{ if and(eq(parameters.installDotNet, 'true'), eq(parameters.installDotNetWorkloads, 'true')) }}:
           - pwsh: .\scripts\infra\managed\install-dotnet-workloads.ps1 -Tizen "$env:DOTNET_WORKLOAD_TIZEN" -Workloads "${{ parameters.dotnetWorkloads }}" -WorkloadSetVersion "$env:DOTNET_WORKLOAD_VERSION"
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             retryCountOnTaskFailure: 3

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -31,6 +31,7 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
   installNinja: false                           # whether or not to install the ninja build system
   installNode: true                             # whether or not to install Node.js
+  checkoutSubmodules: true                      # whether or not to recursively initialize all submodules
   installPreviewSdk: false                      # whether to install the preview .NET SDK ($(DOTNET_VERSION_PREVIEW)) and pin global.json to it
   previewWorkloads: ''                           # workloads to install under the preview .NET SDK (comma-separated, e.g. 'wasm-tools,android')
   installXcode: true                            # whether or not to install Xcode
@@ -121,13 +122,17 @@ jobs:
                 Write-Host "##[section]Cache MISS - full build required"
             }
           displayName: Evaluate cache decision
-        - pwsh: git submodule update --init --recursive
-          displayName: Full checkout (submodules)
-          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+        - ${{ if eq(parameters.checkoutSubmodules, 'true') }}:
+          - pwsh: git submodule update --init --recursive
+            displayName: Full checkout (submodules)
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
 
       - ${{ else }}:
         - checkout: self
-          submodules: recursive
+          ${{ if eq(parameters.checkoutSubmodules, 'true') }}:
+            submodules: recursive
+          ${{ else }}:
+            submodules: false
 
       - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
         displayName: Configure build variables

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -84,12 +84,13 @@ jobs:
         displayName: Get the volume information before the run
         condition: always()
 
-      - task: UsePythonVersion@0
-        displayName: Switch to the correct Python version
-        retryCountOnTaskFailure: 3
-        inputs:
-          versionSpec: '3.x'
-          architecture: 'x64'
+      - ${{ if and(ne(parameters.skipSteps, 'true'), or(not(startsWith(parameters.name, 'native_')), eq(parameters.docker, ''), and(ne(parameters.cacheJob, ''), eq(parameters.enableCaching, true)))) }}:
+        - task: UsePythonVersion@0
+          displayName: Switch to the correct Python version
+          retryCountOnTaskFailure: 3
+          inputs:
+            versionSpec: '3.x'
+            architecture: 'x64'
 
       # prepare - checkout strategy depends on caching
       - ${{ if and(ne(parameters.cacheJob, ''), eq(parameters.enableCaching, true)) }}:
@@ -119,16 +120,25 @@ jobs:
                 Write-Host "##[section]Cache MISS - full build required"
             }
           displayName: Evaluate cache decision
+      - ${{ else }}:
+        - ${{ if or(startsWith(parameters.name, 'native_'), eq(parameters.skipSteps, 'true')) }}:
+          - checkout: self
+            submodules: false
+        - ${{ else }}:
+          - checkout: self
+            submodules: recursive
+        - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
+          displayName: Configure build variables
+
+      # Native source builds only use Skia and depot_tools. Merge-only jobs use no submodules.
+      - ${{ if and(startsWith(parameters.name, 'native_'), ne(parameters.skipSteps, 'true')) }}:
+        - pwsh: git submodule update --init --recursive externals/skia externals/depot_tools
+          displayName: Checkout native build submodules
+          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+      - ${{ if and(not(startsWith(parameters.name, 'native_')), ne(parameters.cacheJob, ''), eq(parameters.enableCaching, true)) }}:
         - pwsh: git submodule update --init --recursive
           displayName: Full checkout (submodules)
           condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-
-      - ${{ else }}:
-        - checkout: self
-          submodules: recursive
-
-      - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
-        displayName: Configure build variables
 
       - pwsh: .\scripts\infra\native\shared\get-free-space.ps1
         displayName: Get the volume information after the checkout
@@ -162,10 +172,11 @@ jobs:
       # install extra bits for the native builds
       - ${{ if and(startsWith(parameters.name, 'native_'), ne(parameters.skipInstall, 'true')) }}:
         # install ninja
-        - pwsh: .\scripts\infra\native\shared\install-ninja.ps1
-          displayName: Install Ninja
-          retryCountOnTaskFailure: 3
-          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+        - ${{ if eq(parameters.docker, '') }}:
+          - pwsh: .\scripts\infra\native\shared\install-ninja.ps1
+            displayName: Install Ninja
+            retryCountOnTaskFailure: 3
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
         - ${{ if not(contains(parameters.name, '_checks_')) }}:
           # install android ndk
           - ${{ if and(eq(parameters.installAndroidNdk, 'true'), contains(parameters.name, '_android_')) }}:
@@ -185,7 +196,7 @@ jobs:
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
 
       # install the bits needed for .NET
-      - ${{ if and(eq(parameters.installDotNet, 'true'), ne(parameters.skipInstall, 'true')) }}:
+      - ${{ if and(eq(parameters.installDotNet, 'true'), ne(parameters.skipInstall, 'true'), or(not(startsWith(parameters.name, 'native_')), eq(parameters.docker, ''))) }}:
         - task: UseDotNet@2
           condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           inputs:

--- a/scripts/azure-templates-stages-native-linux.yml
+++ b/scripts/azure-templates-stages-native-linux.yml
@@ -14,6 +14,20 @@ stages:
     dependsOn: prepare
     jobs:
 
+      - ${{ each arch in split('x86,x64,arm,arm64', ',') }}:
+        - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android (Linux)
+          parameters:
+            name: native_android_${{ arch }}_linux
+            displayName: Android ${{ arch }}
+            buildAgent: ${{ parameters.buildAgentLinuxNative }}
+            use1ESPipelineTemplates: ${{ parameters.use1ESPipelineTemplates }}
+            docker: scripts/infra/native/android/docker
+            target: externals-android
+            cacheJob: native/android
+            enableCaching: ${{ parameters.enableCaching }}
+            additionalArgs: --buildarch=${{ arch }}
+            skipInstall: true
+
       - template: /scripts/azure-templates-jobs-linux-matrix.yml@self # Build Native Linux (Linux)
         parameters:
           enableCaching: ${{ parameters.enableCaching }}
@@ -75,4 +89,3 @@ stages:
               - arch: ${{ arch }}
                 variant: bionic
                 docker: scripts/infra/native/linux/docker/bionic
-

--- a/scripts/azure-templates-stages-native-macos.yml
+++ b/scripts/azure-templates-stages-native-macos.yml
@@ -11,6 +11,46 @@ stages:
     displayName: Native macOS
     dependsOn: prepare
     jobs:
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|x86 (macOS, scheduled)
+        parameters:
+          name: native_android_x86_macos
+          displayName: Android x86
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          target: externals-android
+          cacheJob: native/android
+          enableCaching: ${{ parameters.enableCaching }}
+          additionalArgs: --buildarch=x86
+          condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|x64 (macOS, scheduled)
+        parameters:
+          name: native_android_x64_macos
+          displayName: Android x64
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          target: externals-android
+          cacheJob: native/android
+          enableCaching: ${{ parameters.enableCaching }}
+          additionalArgs: --buildarch=x64
+          condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|arm (macOS, scheduled)
+        parameters:
+          name: native_android_arm_macos
+          displayName: Android arm
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          target: externals-android
+          cacheJob: native/android
+          enableCaching: ${{ parameters.enableCaching }}
+          additionalArgs: --buildarch=arm
+          condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|arm64 (macOS, scheduled)
+        parameters:
+          name: native_android_arm64_macos
+          displayName: Android arm64
+          buildAgent: ${{ parameters.buildAgentMacNative }}
+          target: externals-android
+          cacheJob: native/android
+          enableCaching: ${{ parameters.enableCaching }}
+          additionalArgs: --buildarch=arm64
+          condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native iOS (macOS)
         parameters:
           name: native_ios_macos

--- a/scripts/azure-templates-stages-native-macos.yml
+++ b/scripts/azure-templates-stages-native-macos.yml
@@ -11,42 +11,6 @@ stages:
     displayName: Native macOS
     dependsOn: prepare
     jobs:
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|x86 (macOS)
-        parameters:
-          name: native_android_x86_macos
-          displayName: Android x86
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x86
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|x64 (macOS)
-        parameters:
-          name: native_android_x64_macos
-          displayName: Android x64
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x64
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|arm (macOS)
-        parameters:
-          name: native_android_arm_macos
-          displayName: Android arm
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|arm64 (macOS)
-        parameters:
-          name: native_android_arm64_macos
-          displayName: Android arm64
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native iOS (macOS)
         parameters:
           name: native_ios_macos

--- a/scripts/azure-templates-stages-native-merge.yml
+++ b/scripts/azure-templates-stages-native-merge.yml
@@ -21,10 +21,10 @@ stages:
           buildAgent: ${{ parameters.buildAgentHost }}
           requiredArtifacts:
             # Android
-            - name: native_android_x86_windows
-            - name: native_android_x64_windows
-            - name: native_android_arm_windows
-            - name: native_android_arm64_windows
+            - name: native_android_x86_linux
+            - name: native_android_x64_linux
+            - name: native_android_arm_linux
+            - name: native_android_arm64_linux
             # Tizen
             - name: native_tizen_x64_linux
             - name: native_tizen_arm64_linux

--- a/scripts/azure-templates-stages-native-windows.yml
+++ b/scripts/azure-templates-stages-native-windows.yml
@@ -10,42 +10,6 @@ stages:
     displayName: Native Windows
     dependsOn: prepare
     jobs:
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|x86 (Win)
-        parameters:
-          name: native_android_x86_windows
-          displayName: Android x86
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x86
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|x64 (Win)
-        parameters:
-          name: native_android_x64_windows
-          displayName: Android x64
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x64
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|arm (Win)
-        parameters:
-          name: native_android_arm_windows
-          displayName: Android arm
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|arm64 (Win)
-        parameters:
-          name: native_android_arm64_windows
-          displayName: Android arm64
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Win32|x86 (Win)
         parameters:
           name: native_win32_x86_windows

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -47,23 +47,30 @@ stages:
           name: package_normal_windows
           displayName: Package NuGets
           buildAgent: ${{ parameters.buildAgentWindows}}
-          target: nuget-normal
+          target: nuget
           cacheJob: managed/package
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
+          checkoutSubmodules: false
+          installNode: false
           shouldPublish: false
           requiredArtifacts:
             - name: native
+          preBuildSteps:
+            - pwsh: git submodule update --init --recursive docs
+              displayName: Checkout API documentation
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           postBuildSteps:
             - pwsh: |
-                Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
                 Move-Item -Path '.\output\' -Destination '$(Build.ArtifactStagingDirectory)\output\'
                 New-Item '.\output\' -Type Directory -Force | Out-Null
               displayName: Re-organize the output folder for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
                 Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets\' -Destination '.\output\'
                 Copy-Item -Path '.\scripts\infra\package\SignList.xml' -Destination '.\output\nugets\'
               displayName: Prepare the nugets artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
                 # Create nuget_preview with only prerelease packages (for easier PR testing)
                 New-Item -Path '.\output\nugets-preview\' -ItemType Directory -Force | Out-Null
@@ -71,21 +78,45 @@ stages:
                 $count = (Get-ChildItem -Path '.\output\nugets-preview\' -Filter '*.nupkg').Count
                 Write-Host "Created nuget_preview artifact with $count prerelease packages"
               displayName: Prepare the nugets-preview artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
                 Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-symbols\' -Destination '.\output\'
               displayName: Prepare the nugets-symbols artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
-              displayName: Prepare the build artifact for publishing
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-special\' -Destination '.\output\'
+              displayName: Prepare the nugets-special artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            - pwsh: |
+                New-Item -Path '.\output\package-special\' -ItemType Directory -Force | Out-Null
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\native\' -Destination '.\output\package-special\'
+                $specialLogs = '$(Build.ArtifactStagingDirectory)\output\logs\binlogs\scripts\infra\package\nuget\'
+                if (Test-Path $specialLogs) {
+                  $specialLogsDestination = '.\output\package-special\logs\binlogs\scripts\infra\package\'
+                  New-Item -Path $specialLogsDestination -ItemType Directory -Force | Out-Null
+                  Move-Item -Path $specialLogs -Destination $specialLogsDestination
+                }
+              displayName: Prepare the special build artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            - pwsh: |
+                New-Item -Path '.\output\package-normal\' -ItemType Directory -Force | Out-Null
+                Get-ChildItem -Path '$(Build.ArtifactStagingDirectory)\output\' |
+                  Move-Item -Destination '.\output\package-normal\'
+              displayName: Prepare the normal build artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           publishArtifacts:
             - name: package_normal_windows
-              path: '.\output\output\'
+              path: '.\output\package-normal\'
             - name: nuget
               path: '.\output\nugets'
             - name: nuget_preview
               path: '.\output\nugets-preview'
             - name: nuget_symbols
               path: '.\output\nugets-symbols'
+            - name: package_special_windows
+              path: '.\output\package-special\'
+            - name: nuget_special
+              path: '.\output\nugets-special'
       - template: /scripts/azure-templates-jobs-merger.yml@self # Scan NuGet Artifacts
         parameters:
           name: scan_normal_windows
@@ -106,47 +137,6 @@ stages:
                   -SourcePath ".\output\nugets*\*.*nupkg" `
                   -DestinationPath ".\output\extracted_nugets"
               displayName: Extract all the .nupkg files for scanning
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Package Special NuGets
-        parameters:
-          name: package_special_windows
-          displayName: Package Special NuGets
-          buildAgent: ${{ parameters.buildAgentWindows}}
-          dependsOn: package_normal_windows
-          target: nuget-special
-          cacheJob: managed/package
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --skipExternals="all"
-          installAndroidSdk: false
-          installDotNetWorkloads: false
-          installNode: false
-          shouldPublish: false
-          requiredArtifacts:
-            - name: native
-            - name: nuget
-              dir: nugets
-              currentRun: true
-            - name: nuget_symbols
-              dir: nugets-symbols
-              currentRun: true
-          postBuildSteps:
-            - pwsh: |
-                Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
-                Remove-Item ./output/nugets-symbols/ -Recurse -Force -ErrorAction Continue
-                Move-Item -Path '.\output\' -Destination '$(Build.ArtifactStagingDirectory)\output\'
-                New-Item '.\output\' -Type Directory -Force | Out-Null
-              displayName: Re-organize the output folder for publishing
-            - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-special\' -Destination '.\output\'
-              displayName: Prepare the nugets-special artifact for publishing
-            - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
-              displayName: Prepare the build artifact for publishing
-          publishArtifacts:
-            - name: package_special_windows
-              path: '.\output\output\'
-            - name: nuget_special
-              path: '.\output\nugets-special'
-
   - ${{ if eq(parameters.enableSigning, 'true') }}:
     - stage: signing
       displayName: Sign NuGets

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -47,7 +47,7 @@ stages:
           name: package_normal_windows
           displayName: Package NuGets
           buildAgent: ${{ parameters.buildAgentWindows}}
-          target: nuget
+          target: nuget-normal
           cacheJob: managed/package
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
@@ -61,6 +61,7 @@ stages:
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           postBuildSteps:
             - pwsh: |
+                Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
                 Move-Item -Path '.\output\' -Destination '$(Build.ArtifactStagingDirectory)\output\'
                 New-Item '.\output\' -Type Directory -Force | Out-Null
               displayName: Re-organize the output folder for publishing
@@ -83,39 +84,18 @@ stages:
               displayName: Prepare the nugets-symbols artifact for publishing
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-special\' -Destination '.\output\'
-              displayName: Prepare the nugets-special artifact for publishing
-              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-            - pwsh: |
-                New-Item -Path '.\output\package-special\' -ItemType Directory -Force | Out-Null
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\native\' -Destination '.\output\package-special\'
-                $specialLogs = '$(Build.ArtifactStagingDirectory)\output\logs\binlogs\scripts\infra\package\nuget\'
-                if (Test-Path $specialLogs) {
-                  $specialLogsDestination = '.\output\package-special\logs\binlogs\scripts\infra\package\'
-                  New-Item -Path $specialLogsDestination -ItemType Directory -Force | Out-Null
-                  Move-Item -Path $specialLogs -Destination $specialLogsDestination
-                }
-              displayName: Prepare the special build artifact for publishing
-              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
-            - pwsh: |
-                New-Item -Path '.\output\package-normal\' -ItemType Directory -Force | Out-Null
-                Get-ChildItem -Path '$(Build.ArtifactStagingDirectory)\output\' |
-                  Move-Item -Destination '.\output\package-normal\'
-              displayName: Prepare the normal build artifact for publishing
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
+              displayName: Prepare the build artifact for publishing
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           publishArtifacts:
             - name: package_normal_windows
-              path: '.\output\package-normal\'
+              path: '.\output\output\'
             - name: nuget
               path: '.\output\nugets'
             - name: nuget_preview
               path: '.\output\nugets-preview'
             - name: nuget_symbols
               path: '.\output\nugets-symbols'
-            - name: package_special_windows
-              path: '.\output\package-special\'
-            - name: nuget_special
-              path: '.\output\nugets-special'
       - template: /scripts/azure-templates-jobs-merger.yml@self # Scan NuGet Artifacts
         parameters:
           name: scan_normal_windows
@@ -136,6 +116,50 @@ stages:
                   -SourcePath ".\output\nugets*\*.*nupkg" `
                   -DestinationPath ".\output\extracted_nugets"
               displayName: Extract all the .nupkg files for scanning
+      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Package Special NuGets
+        parameters:
+          name: package_special_windows
+          displayName: Package Special NuGets
+          buildAgent: ${{ parameters.buildAgentWindows}}
+          dependsOn: package_normal_windows
+          target: nuget-special
+          cacheJob: managed/package
+          enableCaching: ${{ parameters.enableCaching }}
+          additionalArgs: --skipExternals="all"
+          checkoutSubmodules: false
+          installAndroidSdk: false
+          installDotNetWorkloads: false
+          installNode: false
+          shouldPublish: false
+          requiredArtifacts:
+            - name: native
+            - name: nuget
+              dir: nugets
+              currentRun: true
+            - name: nuget_symbols
+              dir: nugets-symbols
+              currentRun: true
+          postBuildSteps:
+            - pwsh: |
+                Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
+                Remove-Item ./output/nugets-symbols/ -Recurse -Force -ErrorAction Continue
+                Move-Item -Path '.\output\' -Destination '$(Build.ArtifactStagingDirectory)\output\'
+                New-Item '.\output\' -Type Directory -Force | Out-Null
+              displayName: Re-organize the output folder for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            - pwsh: |
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-special\' -Destination '.\output\'
+              displayName: Prepare the nugets-special artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            - pwsh: |
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
+              displayName: Prepare the build artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+          publishArtifacts:
+            - name: package_special_windows
+              path: '.\output\output\'
+            - name: nuget_special
+              path: '.\output\nugets-special'
   - ${{ if eq(parameters.enableSigning, 'true') }}:
     - stage: signing
       displayName: Sign NuGets

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -116,6 +116,9 @@ stages:
           cacheJob: managed/package
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
+          installAndroidSdk: false
+          installDotNetWorkloads: false
+          installNode: false
           shouldPublish: false
           requiredArtifacts:
             - name: native

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -52,7 +52,6 @@ stages:
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
           checkoutSubmodules: false
-          installNode: false
           shouldPublish: false
           requiredArtifacts:
             - name: native

--- a/scripts/infra/native/android/docker/Dockerfile
+++ b/scripts/infra/native/android/docker/Dockerfile
@@ -1,9 +1,8 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-android-amd64@sha256:8627dd84187534066002691c1cafc31dd037f1cccd28361801a967ab664fb81c
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-android-amd64
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ARG DOTNET_SDK_VERSION=10.0.108
-ARG DOTNET_SDK_SHA512=e32f76b768017718aa5a3a51fcac4b617ab4428c5f2d10b1b30f07dd7f1ea3dad4df917df48d855d78a347d635e48ce0ec309787899c53a32c4c10dd216b6b19
 ARG ANDROID_NDK_VERSION=27.2.12479018
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
@@ -12,11 +11,9 @@ ENV ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}
 RUN test "$(basename "${ANDROID_NDK_ROOT}")" = "${ANDROID_NDK_VERSION}" \
     && test -x "${ANDROID_NDK_ROOT}/ndk-build" \
     && command -v ninja \
-    && curl -fsSL --retry 5 --retry-all-errors "https://builds.dotnet.microsoft.com/dotnet/Sdk/${DOTNET_SDK_VERSION}/dotnet-sdk-${DOTNET_SDK_VERSION}-linux-x64.tar.gz" -o dotnet-sdk.tar.gz \
-    && echo "${DOTNET_SDK_SHA512}  dotnet-sdk.tar.gz" | sha512sum -c - \
-    && mkdir -p /usr/share/dotnet \
-    && tar -xzf dotnet-sdk.tar.gz -C /usr/share/dotnet \
-    && rm dotnet-sdk.tar.gz \
+    && curl -fsSL https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh -o dotnet-install.sh \
+    && bash dotnet-install.sh --version ${DOTNET_SDK_VERSION} --install-dir /usr/share/dotnet --verbose \
+    && rm dotnet-install.sh \
     && dotnet --info
 
 WORKDIR /work

--- a/scripts/infra/native/android/docker/Dockerfile
+++ b/scripts/infra/native/android/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-android-amd64@sha256:8627dd84187534066002691c1cafc31dd037f1cccd28361801a967ab664fb81c
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+ARG DOTNET_SDK_VERSION=10.0.108
+ARG DOTNET_SDK_SHA512=e32f76b768017718aa5a3a51fcac4b617ab4428c5f2d10b1b30f07dd7f1ea3dad4df917df48d855d78a347d635e48ce0ec309787899c53a32c4c10dd216b6b19
+ARG ANDROID_NDK_VERSION=27.2.12479018
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}
+
+RUN test "$(basename "${ANDROID_NDK_ROOT}")" = "${ANDROID_NDK_VERSION}" \
+    && test -x "${ANDROID_NDK_ROOT}/ndk-build" \
+    && command -v ninja \
+    && curl -fsSL --retry 5 --retry-all-errors "https://builds.dotnet.microsoft.com/dotnet/Sdk/${DOTNET_SDK_VERSION}/dotnet-sdk-${DOTNET_SDK_VERSION}-linux-x64.tar.gz" -o dotnet-sdk.tar.gz \
+    && echo "${DOTNET_SDK_SHA512}  dotnet-sdk.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -xzf dotnet-sdk.tar.gz -C /usr/share/dotnet \
+    && rm dotnet-sdk.tar.gz \
+    && dotnet --info
+
+WORKDIR /work
+
+COPY ./startup.sh /
+RUN chmod +x /startup.sh
+
+ENTRYPOINT ["/startup.sh"]

--- a/scripts/infra/native/android/docker/startup.sh
+++ b/scripts/infra/native/android/docker/startup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Android NDK: ${ANDROID_NDK_HOME}"
+echo "Container CPUs: $(nproc)"
+echo "Ninja: $(ninja --version)"
+
+exec "$@"


### PR DESCRIPTION
## Description

Reduce native and package CI wall time and agent consumption without changing package contents, shipped RID/architecture/feature coverage, ABI, signing preparation, security scanning, or deterministic-build behavior.

This PR has three related optimization areas:

1. Remove unused host setup and broad submodule checkout from native jobs.
2. Build the four Android ABIs once in Linux Docker instead of duplicating them on Windows and macOS.
3. Keep normal/special packaging as separate jobs while removing redundant work from the special-package job.

### Native orchestration

- Skip host Ninja and .NET setup for containerized native jobs because their toolchain and Cake invocation run inside the image.
- Skip host Python when it is not needed; retain it whenever cache-key computation runs.
- Retain existing host tools for direct Windows and macOS builds.
- Checkout only `externals/skia` and `externals/depot_tools` for native source jobs; merge-only jobs checkout no submodules.
- Configure build variables once rather than twice on uncached/cache-miss native source builds.

### Android native builds

- Build x86, x64, arm, and arm64 in four parallel Linux Docker jobs.
- Remove all Windows and macOS Android jobs; Linux artifacts are the canonical native-merge inputs.
- Use Microsoft's moving Azure Linux Android prerequisite tag. Cache-miss or cache-disabled builds consume the current base image rather than a pinned digest.
- Validate NDK r27c (`27.2.12479018`) and install .NET SDK 10.0.108 through the same official `dotnet-install.sh` pattern used by the other native Dockerfiles.
- Preserve GN/NDK feature configuration, symbol extraction, stripping, GNU debug links, and 16 KiB LOAD-alignment checks.
- Keep the existing `native/android` output cache. Its key hashes `native/android/**`, `scripts/infra/native/android/**` (including the Dockerfile/startup script), shared native inputs, and Skia/depot_tools SHAs. A remote-only base-tag update is picked up on the next cache miss or cache-disabled run; it does not itself alter the artifact-cache key.

### Package build

- Keep `package_normal_windows` and `package_special_windows` as separate dependent jobs.
- Remove the root `nuget-special -> libs` dependency; special packing only wraps existing native, normal NuGet, and symbol outputs.
- Skip Node, Android SDK/JDK, and .NET workload provisioning in the special job while retaining .NET SDK installation, tool restore, Visual Studio selection, artifact flow, and package logic.
- Checkout only the `docs` submodule required by normal packaging; special packaging checks out no submodules.
- Preserve cache-hit behavior, all six package artifacts, normal/special binlogs, native wrappers, and `SignList.xml`.
- Add workload, Node, and recursive-submodule bootstrapper controls whose defaults preserve every other job.

## Measured results

Every before/after performance table uses the same paired runs:

- **Before:** cold main [1557164](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1557164), exact current main SHA `46ea7244b6ab`, with 65 cache misses and zero hits.
- **After:** cache-disabled final branch [1560012](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1560012), exact PR head `a5bfc32a32f`, succeeded end to end.

Intermediate runs are not used in the performance tables.

### End-to-end

| Metric | Before 1557164 | After 1560012 | Change |
|---|---:|---:|---:|
| Result | Failed in samples | **Succeeded** | Full pipeline green |
| Queue wait | 5m32s | **20s** | **-5m11s / -93.8%** |
| Execution wall | 6h17m44s | **3h30m15s** | **-2h47m29s / -44.3%** |
| Executed jobs | 90 | **86** | **-4 / -4.4%** |
| Raw agent-minutes | 3,087.2 | **1,562.4** | **-1,524.8 / -49.4%** |

Main receives additional default-branch policy-injected work that a manual feature-branch run does not. Raw wall and agent-minute rows are therefore end-to-end operational comparisons, not wholly attributable to this PR. Direct task counts and job-topology changes below remain exact.

### Native pipeline

| Metric | Before 1557164 | After 1560012 | Change |
|---|---:|---:|---:|
| Native source/merge jobs | 63 | **59** | **-4 / -6.3%** |
| Raw native agent-minutes | 2,242.5 | **1,172.1** | **-1,070.4 / -47.7%** |
| Longest source stage | 1h29m56s | **1h05m47s** | **-24m09s / -26.9%** |
| Source start through full merge | 1h55m57s | **1h19m20s** | **-36m37s / -31.6%** |
| Full native merge | 21m12s | **13m08s** | **-8m05s / -38.1%** |
| Linux-only merge | 11m04s | **7m11s** | **-3m52s / -35.1%** |
| WASM-only merge | 8m06s | **4m14s** | **-3m52s / -47.7%** |

Source-stage wall changes were Windows **-67.2%**, macOS **-24.0%**, Linux **-9.7%**, WASM **-26.0%**, and Tizen **+25.3%**. Tizen is reported rather than hidden; no Tizen code or matrix changed.

Host/setup task counts changed as intended: Python selection **88 -> 38**, Ninja installation **61 -> 15**, .NET installation **85 -> 39**, `.NET --info` **125 -> 71**, and build-variable configuration **155 -> 86**. Full recursive submodule checkouts fell from **65 / 91.7 agent-minutes** to zero, replaced by **56 targeted native checkouts / 73.5 minutes**. Artifact-download count remained exactly **119**, with transfer time falling from 27.9 to 24.3 minutes. Docker image builds increased from 43 to 47 because the four Android builds now run in Docker; image setup rose from 78.6 to 97.5 agent-minutes and is included in the totals above.

### Android migration

| Metric | Before 1557164 | After 1560012 | Change |
|---|---:|---:|---:|
| Build hosts / jobs | Windows + macOS / 8 | **Linux / 4** | **-4 jobs** |
| Raw Android agent-minutes | 429.9 | **61.6** | **-368.3 / -85.7%** |
| Critical Android job | 1h14m10s | **15m34s** | **-58m36s / -79.0%** |
| ABI coverage | x86, x64, arm, arm64 | **x86, x64, arm, arm64** | Preserved |

Final Linux jobs completed in 15m14s-15m34s. All four artifacts feed the canonical native merge.

### Package pipeline

| Metric | Before 1557164 | After 1560012 | Change |
|---|---:|---:|---:|
| Normal job wall | 64m18s | **21m22s** | **-42m56s / -66.8%** |
| `nuget-normal` bootstrapper | 28m49s | **8m44s** | **-20m05s / -69.7%** |
| Special job wall | 1h08m07s | **12m51s** | **-55m15s / -81.1%** |
| `nuget-special` bootstrapper | 31m54s | **6m49s** | **-25m05s / -78.6%** |
| Package stage wall | 2h21m00s | **43m36s** | **-1h37m23s / -69.1%** |
| Package scan | 6m59s | **2m40s** | **-4m19s / -61.7%** |
| Published package artifacts | 6 | **6** | Preserved |

All six outputs published. Normal product artifact sizes differ from main by at most 0.12%; the normal build/log artifact differs by 0.35%. `nuget_special` differs by 0.07% and the special build/log artifact by 0.91%.

Managed build and tests are validation, not optimization targets. Both succeeded: managed build in 40m50s and tests in 57m23s. All 33 published candidate test runs report zero failed tests. Samples also succeeded in 1h12m11s; cold main failed its sample stage after 1h44m28s.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [x] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None - CI-only; no public API, C API, ABI, package-content, shipped-asset, signing, scanning, or runtime behavior change.

## Testing

- Final cache-disabled run 1560012 succeeded end to end. Build Analysis reports no known or unmatched failures.
- The final YAML preview contains four `native_android_*_linux` jobs, no Windows/macOS Android jobs, Linux canonical merge inputs, targeted native checkout, and separate normal/special package jobs.
- Cache dependency validation covers all 4,782 tracked files with zero uncovered files. `native/android` includes both Android source directories and the Docker context.
- `dotnet cake --target=nuget --dryrun --skipExternals=all` schedules `libs`, then `nuget-normal`, then `nuget-special`; standalone `nuget-special` does not schedule `libs`.
- Both package jobs and package scanning succeeded; all six package artifact sizes match cold main within 1%.
- All 33 published test runs report zero failed tests; samples succeeded.
- Artifact inventory changes are exactly expected: eight Windows/macOS Android source artifacts became four Linux Android artifacts, the failed-sample artifact became `samples_windows`, and the coverage artifact name contains the new build ID. Every other artifact name is preserved.
- Merged `native` size differs from cold main by 0.04%; `native_linux` and `native_wasm` sizes are exact matches.
- Android ELF/artifact equivalence was independently validated in [1559377](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1559377): exact four-file `.so`/`.so.dbg` inventory, matching ELF class/machine, exported dynamic symbols, `DT_NEEDED`, GNU debug links, and 16 KiB LOAD alignment across every ABI. This supporting run is not used in the performance tables.
- Component Detection remains present on every Android job; no security scan or artifact-publication template is bypassed.
- DevDiv native [15030082](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15030082) and package/signing [15032120](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15032120) succeeded at the exact branch SHA.
- DevDiv tests [15032942](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15032942) passed managed builds, samples, and every test job except one macOS `tests-netcore` job canceled at the 180-minute timeout. That task emitted no test/product error, only existing `CS0618` warnings. Exact-main DevDiv run [15017102](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15017102) and automatic public PR run [1559994](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1559994) had the same macOS 180-minute timeout, while the cache-disabled final run 1560012 passed macOS tests and produced an unchanged macOS artifact. This is a pre-existing macOS hang, not a PR regression, and was accepted as non-blocking after cross-run correlation.
- Current GitHub checks have 108 passes. The remaining visible failures are the aggregate/canceled macOS timeout described above plus three nightly benchmark variants that fail before benchmarks because the required nightly package is absent from the feed; neither failure class is caused by this PR.

## Checklist

- [x] Tests added or updated (not applicable: CI orchestration-only; validated with compiled pipeline previews, uncached native builds, native merges, ELF comparisons, package generation, and public-pipeline runs)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A
- [x] Native change? N/A; no C API/submodule change or companion `mono/skia` PR required