### PR TITLE
[performance] Consolidate package build setup

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -143,7 +143,6 @@ Task ("nuget-normal")
 
 Task ("nuget-special")
     .Description ("Pack all special NuGets.")
-    .IsDependentOn ("libs")
     .Does (() => RunCake ("./scripts/infra/package/nuget.cake", "nuget-special"));
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -134,7 +134,7 @@ Task ("tests-wasm")
 Task ("nuget")
     .Description ("Pack all NuGets.")
     .IsDependentOn ("nuget-normal")
-    .IsDependentOn ("nuget-special");
+    .Does (() => RunCake ("./scripts/infra/package/nuget.cake", "nuget-special"));
 
 Task ("nuget-normal")
     .Description ("Pack all NuGets (build all required dependencies).")

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -26,9 +26,11 @@ parameters:
   installAndroidSdk: true                       # whether or not to install the Android SDK
   installWindowsSdk: false                      # whether or not to install the Windows SDK
   installDotNet: true                           # whether or not to install the dotnet SDK
+  installDotNetWorkloads: true                  # whether or not to install the .NET workloads
   installLlvm: true                             # whether or not to install the LLVM compiler
   installEmsdk: false                           # whether or not to install the Emscripten SDK
   installNinja: false                           # whether or not to install the ninja build system
+  installNode: true                             # whether or not to install Node.js
   installPreviewSdk: false                      # whether to install the preview .NET SDK ($(DOTNET_VERSION_PREVIEW)) and pin global.json to it
   previewWorkloads: ''                           # workloads to install under the preview .NET SDK (comma-separated, e.g. 'wasm-tools,android')
   installXcode: true                            # whether or not to install Xcode
@@ -204,7 +206,7 @@ jobs:
 
       # install extra bits for the managed builds
       - ${{ if and(not(startsWith(parameters.name, 'native_')), ne(parameters.skipInstall, 'true')) }}:
-        - ${{ if eq(parameters.buildAgent.pool.os, 'windows') }}:
+        - ${{ if and(eq(parameters.installNode, 'true'), eq(parameters.buildAgent.pool.os, 'windows')) }}:
           - task: UseNode@1
             displayName: Install Node.js
             retryCountOnTaskFailure: 3
@@ -247,7 +249,7 @@ jobs:
             retryCountOnTaskFailure: 3
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
         # install workloads
-        - ${{ if eq(parameters.installDotNet, 'true') }}:
+        - ${{ if and(eq(parameters.installDotNet, 'true'), eq(parameters.installDotNetWorkloads, 'true')) }}:
           - pwsh: .\scripts\infra\managed\install-dotnet-workloads.ps1 -Tizen "$env:DOTNET_WORKLOAD_TIZEN" -Workloads "${{ parameters.dotnetWorkloads }}" -WorkloadSetVersion "$env:DOTNET_WORKLOAD_VERSION"
             condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             retryCountOnTaskFailure: 3

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -31,6 +31,7 @@ parameters:
   installEmsdk: false                           # whether or not to install the Emscripten SDK
   installNinja: false                           # whether or not to install the ninja build system
   installNode: true                             # whether or not to install Node.js
+  checkoutSubmodules: true                      # whether or not to recursively initialize all submodules
   installPreviewSdk: false                      # whether to install the preview .NET SDK ($(DOTNET_VERSION_PREVIEW)) and pin global.json to it
   previewWorkloads: ''                           # workloads to install under the preview .NET SDK (comma-separated, e.g. 'wasm-tools,android')
   installXcode: true                            # whether or not to install Xcode
@@ -121,13 +122,17 @@ jobs:
                 Write-Host "##[section]Cache MISS - full build required"
             }
           displayName: Evaluate cache decision
-        - pwsh: git submodule update --init --recursive
-          displayName: Full checkout (submodules)
-          condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+        - ${{ if eq(parameters.checkoutSubmodules, 'true') }}:
+          - pwsh: git submodule update --init --recursive
+            displayName: Full checkout (submodules)
+            condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
 
       - ${{ else }}:
         - checkout: self
-          submodules: recursive
+          ${{ if eq(parameters.checkoutSubmodules, 'true') }}:
+            submodules: recursive
+          ${{ else }}:
+            submodules: false
 
       - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
         displayName: Configure build variables

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -47,23 +47,30 @@ stages:
           name: package_normal_windows
           displayName: Package NuGets
           buildAgent: ${{ parameters.buildAgentWindows}}
-          target: nuget-normal
+          target: nuget
           cacheJob: managed/package
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
+          checkoutSubmodules: false
+          installNode: false
           shouldPublish: false
           requiredArtifacts:
             - name: native
+          preBuildSteps:
+            - pwsh: git submodule update --init --recursive docs
+              displayName: Checkout API documentation
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           postBuildSteps:
             - pwsh: |
-                Remove-Item ./output/native/ -Recurse -Force -ErrorAction Continue
                 Move-Item -Path '.\output\' -Destination '$(Build.ArtifactStagingDirectory)\output\'
                 New-Item '.\output\' -Type Directory -Force | Out-Null
               displayName: Re-organize the output folder for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
                 Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets\' -Destination '.\output\'
                 Copy-Item -Path '.\scripts\infra\package\SignList.xml' -Destination '.\output\nugets\'
               displayName: Prepare the nugets artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
                 # Create nuget_preview with only prerelease packages (for easier PR testing)
                 New-Item -Path '.\output\nugets-preview\' -ItemType Directory -Force | Out-Null
@@ -71,21 +78,45 @@ stages:
                 $count = (Get-ChildItem -Path '.\output\nugets-preview\' -Filter '*.nupkg').Count
                 Write-Host "Created nuget_preview artifact with $count prerelease packages"
               displayName: Prepare the nugets-preview artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
                 Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-symbols\' -Destination '.\output\'
               displayName: Prepare the nugets-symbols artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
-              displayName: Prepare the build artifact for publishing
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-special\' -Destination '.\output\'
+              displayName: Prepare the nugets-special artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            - pwsh: |
+                New-Item -Path '.\output\package-special\' -ItemType Directory -Force | Out-Null
+                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\native\' -Destination '.\output\package-special\'
+                $specialLogs = '$(Build.ArtifactStagingDirectory)\output\logs\binlogs\scripts\infra\package\nuget\'
+                if (Test-Path $specialLogs) {
+                  $specialLogsDestination = '.\output\package-special\logs\binlogs\scripts\infra\package\'
+                  New-Item -Path $specialLogsDestination -ItemType Directory -Force | Out-Null
+                  Move-Item -Path $specialLogs -Destination $specialLogsDestination
+                }
+              displayName: Prepare the special build artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
+            - pwsh: |
+                New-Item -Path '.\output\package-normal\' -ItemType Directory -Force | Out-Null
+                Get-ChildItem -Path '$(Build.ArtifactStagingDirectory)\output\' |
+                  Move-Item -Destination '.\output\package-normal\'
+              displayName: Prepare the normal build artifact for publishing
+              condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
           publishArtifacts:
             - name: package_normal_windows
-              path: '.\output\output\'
+              path: '.\output\package-normal\'
             - name: nuget
               path: '.\output\nugets'
             - name: nuget_preview
               path: '.\output\nugets-preview'
             - name: nuget_symbols
               path: '.\output\nugets-symbols'
+            - name: package_special_windows
+              path: '.\output\package-special\'
+            - name: nuget_special
+              path: '.\output\nugets-special'
       - template: /scripts/azure-templates-jobs-merger.yml@self # Scan NuGet Artifacts
         parameters:
           name: scan_normal_windows
@@ -106,47 +137,6 @@ stages:
                   -SourcePath ".\output\nugets*\*.*nupkg" `
                   -DestinationPath ".\output\extracted_nugets"
               displayName: Extract all the .nupkg files for scanning
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Package Special NuGets
-        parameters:
-          name: package_special_windows
-          displayName: Package Special NuGets
-          buildAgent: ${{ parameters.buildAgentWindows}}
-          dependsOn: package_normal_windows
-          target: nuget-special
-          cacheJob: managed/package
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --skipExternals="all"
-          installAndroidSdk: false
-          installDotNetWorkloads: false
-          installNode: false
-          shouldPublish: false
-          requiredArtifacts:
-            - name: native
-            - name: nuget
-              dir: nugets
-              currentRun: true
-            - name: nuget_symbols
-              dir: nugets-symbols
-              currentRun: true
-          postBuildSteps:
-            - pwsh: |
-                Remove-Item ./output/nugets/ -Recurse -Force -ErrorAction Continue
-                Remove-Item ./output/nugets-symbols/ -Recurse -Force -ErrorAction Continue
-                Move-Item -Path '.\output\' -Destination '$(Build.ArtifactStagingDirectory)\output\'
-                New-Item '.\output\' -Type Directory -Force | Out-Null
-              displayName: Re-organize the output folder for publishing
-            - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\nugets-special\' -Destination '.\output\'
-              displayName: Prepare the nugets-special artifact for publishing
-            - pwsh: |
-                Move-Item -Path '$(Build.ArtifactStagingDirectory)\output\' -Destination '.\output\'
-              displayName: Prepare the build artifact for publishing
-          publishArtifacts:
-            - name: package_special_windows
-              path: '.\output\output\'
-            - name: nuget_special
-              path: '.\output\nugets-special'
-
   - ${{ if eq(parameters.enableSigning, 'true') }}:
     - stage: signing
       displayName: Sign NuGets

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -116,6 +116,9 @@ stages:
           cacheJob: managed/package
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
+          installAndroidSdk: false
+          installDotNetWorkloads: false
+          installNode: false
           shouldPublish: false
           requiredArtifacts:
             - name: native

--- a/scripts/azure-templates-stages-package.yml
+++ b/scripts/azure-templates-stages-package.yml
@@ -52,7 +52,6 @@ stages:
           enableCaching: ${{ parameters.enableCaching }}
           additionalArgs: --skipExternals="all"
           checkoutSubmodules: false
-          installNode: false
           shouldPublish: false
           requiredArtifacts:
             - name: native


### PR DESCRIPTION
## Description

Reduce package CI wall time and agent consumption without changing package contents, shipping assets, signing preparation, scanning, determinism, or public behavior:

- Remove the special package target's redundant `libs` dependency; it now only repackages existing native, normal NuGet, and symbol outputs.
- Run normal and special packing in guaranteed sequence on one Windows agent, removing the second package job and its queue, setup, cache, and artifact transfers.
- Checkout only the `docs` submodule required for shipped XML API documentation instead of all recursive submodules.
- Preserve cache-hit behavior and all six existing package artifacts, including native assets, normal/special binlogs, and `SignList.xml`.
- Retain Python, Node, Android SDK/JDK, and .NET workloads once in the combined job because cache-key computation, TypeScript compilation, and managed/mobile target frameworks require them.
- Add reusable bootstrapper controls for workload installation, Node selection, and recursive submodule checkout; defaults preserve every other job's behavior.

Public definition 345 run [1558996](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1558996) succeeded end to end. The combined package job, scan job, component detection, tests, samples, and all six package artifact publications passed.

| Metric | Main 1557164 | Candidate 1558996 |
|---|---:|---:|
| Package stage wall | 141.0 min | **38.0 min** |
| Package job agent-minutes | 132.8 min | **26.1 min** |
| Package build jobs | 2 | **1** |
| Normal-to-special hosted-agent wait | 8m11s | **0** |
| Published package artifacts | 6 | **6** |

The package stage fell **103.0 minutes / 73.1%**, while package-job agent use fell **106.7 minutes / 80.3%**. The final 37:59 consists of the 26:04 combined package job, an 8:13 hosted-agent wait for scanning, and 3:43 of NuGet scanning. That remaining queue is outside package generation and would require changing the scan-job boundary.

Measured redundant work removed with the second package job:

| Task | Main special job | Candidate | Reduction |
|---|---:|---:|---:|
| Managed library rebuild | 25m10.9s | 0 | 25m10.9s |
| Python selection | 1m01s | 0 | 1 task / 1m01s |
| Full recursive submodule checkout | 1m21s | 0 | 1 task / 1m21s |
| .NET SDK install, info, and tool restore | 1m05s | 0 | 4 tasks / 1m05s |
| Node selection | 12s | 0 | 1 task / 12s |
| Android SDK/JDK and .NET workloads | 5m41s | 0 | 7 tasks / 5m41s |
| Native/normal/symbol artifact downloads | 50s | 0 | 3 tasks / 50s |
| Cache key, lookup, and upload | 3m08s | 0 | 3 tasks / 3m08s |

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [x] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — packaging/CI-only; no public API, package content, shipping asset, signing, scanning, deterministic-build requirement, or runtime behavior changes.

## Testing

- Parsed both changed Azure Pipelines YAML templates.
- Verified `dotnet cake --target=nuget-special --dryrun --skipExternals=all` schedules only `nuget-special`, not `libs`.
- Ran standalone `nuget-special` successfully without managed library outputs.
- Ran combined `dotnet cake --target=nuget --skipExternals=all`; `libs`, `nuget-normal`, and ordered special packing completed successfully.
- Generated explicit PR-version special packages and verified the results.
- Simulated post-build output reorganization and verified normal packages, symbols, special packages, native files, and normal/special binlogs retain their artifact layouts.
- Public pipeline 345 run 1558996: combined package job 26m04s, scan 3m43s, package stage 37m59s; all six package artifacts, component detection, scanning, tests, and samples succeeded.
- GitHub reported 112 successful checks. The only three failures were the Windows/Linux/macOS Track - Benchmarks `nightly` jobs, all failing before benchmarks because unpublished package `4.152.0-nightly.17` was absent (`NU1102`). Other benchmark variants and source benchmarks passed, confirming the known external nightly-feed baseline issue is unrelated to this package YAML.

## Checklist

- [x] Tests added or updated (not applicable: packaging orchestration-only change; local Cake validation and the full public pipeline apply)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A
- [x] Native change? N/A; no companion `mono/skia` PR or regenerated bindings required