### PR TITLE
[performance] Build Android native assets on Linux

### DIFF
--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -8,7 +8,7 @@ Information("Android NDK Path: {0}", ANDROID_NDK_HOME);
 
 Task("libSkiaSharp")
     .IsDependentOn("git-sync-deps")
-    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows())
+    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows() || IsRunningOnLinux())
     .Does(() =>
 {
     Build("x86", "x86");
@@ -48,7 +48,7 @@ Task("libSkiaSharp")
 });
 
 Task("libHarfBuzzSharp")
-    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows())
+    .WithCriteria(IsRunningOnMacOs() || IsRunningOnWindows() || IsRunningOnLinux())
     .Does(() =>
 {
     Build("x86");

--- a/scripts/azure-templates-stages-native-linux.yml
+++ b/scripts/azure-templates-stages-native-linux.yml
@@ -14,6 +14,20 @@ stages:
     dependsOn: prepare
     jobs:
 
+      - ${{ each arch in split('x86,x64,arm,arm64', ',') }}:
+        - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android (Linux)
+          parameters:
+            name: native_android_${{ arch }}_linux
+            displayName: Android ${{ arch }}
+            buildAgent: ${{ parameters.buildAgentLinuxNative }}
+            use1ESPipelineTemplates: ${{ parameters.use1ESPipelineTemplates }}
+            docker: scripts/infra/native/android/docker
+            target: externals-android
+            cacheJob: native/android
+            enableCaching: ${{ parameters.enableCaching }}
+            additionalArgs: --buildarch=${{ arch }}
+            skipInstall: true
+
       - template: /scripts/azure-templates-jobs-linux-matrix.yml@self # Build Native Linux (Linux)
         parameters:
           enableCaching: ${{ parameters.enableCaching }}
@@ -75,4 +89,3 @@ stages:
               - arch: ${{ arch }}
                 variant: bionic
                 docker: scripts/infra/native/linux/docker/bionic
-

--- a/scripts/azure-templates-stages-native-macos.yml
+++ b/scripts/azure-templates-stages-native-macos.yml
@@ -11,42 +11,6 @@ stages:
     displayName: Native macOS
     dependsOn: prepare
     jobs:
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|x86 (macOS)
-        parameters:
-          name: native_android_x86_macos
-          displayName: Android x86
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x86
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|x64 (macOS)
-        parameters:
-          name: native_android_x64_macos
-          displayName: Android x64
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x64
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|arm (macOS)
-        parameters:
-          name: native_android_arm_macos
-          displayName: Android arm
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native Android|arm64 (macOS)
-        parameters:
-          name: native_android_arm64_macos
-          displayName: Android arm64
-          buildAgent: ${{ parameters.buildAgentMacNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self # Build Native iOS (macOS)
         parameters:
           name: native_ios_macos

--- a/scripts/azure-templates-stages-native-merge.yml
+++ b/scripts/azure-templates-stages-native-merge.yml
@@ -21,10 +21,10 @@ stages:
           buildAgent: ${{ parameters.buildAgentHost }}
           requiredArtifacts:
             # Android
-            - name: native_android_x86_windows
-            - name: native_android_x64_windows
-            - name: native_android_arm_windows
-            - name: native_android_arm64_windows
+            - name: native_android_x86_linux
+            - name: native_android_x64_linux
+            - name: native_android_arm_linux
+            - name: native_android_arm64_linux
             # Tizen
             - name: native_tizen_x64_linux
             - name: native_tizen_arm64_linux

--- a/scripts/azure-templates-stages-native-windows.yml
+++ b/scripts/azure-templates-stages-native-windows.yml
@@ -10,42 +10,6 @@ stages:
     displayName: Native Windows
     dependsOn: prepare
     jobs:
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|x86 (Win)
-        parameters:
-          name: native_android_x86_windows
-          displayName: Android x86
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x86
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|x64 (Win)
-        parameters:
-          name: native_android_x64_windows
-          displayName: Android x64
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=x64
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|arm (Win)
-        parameters:
-          name: native_android_arm_windows
-          displayName: Android arm
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm
-      - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Android|arm64 (Win)
-        parameters:
-          name: native_android_arm64_windows
-          displayName: Android arm64
-          buildAgent: ${{ parameters.buildAgentWindowsNative }}
-          target: externals-android
-          cacheJob: native/android
-          enableCaching: ${{ parameters.enableCaching }}
-          additionalArgs: --buildarch=arm64
       - template: /scripts/azure-templates-jobs-bootstrapper.yml@self   # Build Native Win32|x86 (Win)
         parameters:
           name: native_win32_x86_windows

--- a/scripts/infra/native/android/docker/Dockerfile
+++ b/scripts/infra/native/android/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-android-amd64@sha256:8627dd84187534066002691c1cafc31dd037f1cccd28361801a967ab664fb81c
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+ARG DOTNET_SDK_VERSION=10.0.108
+ARG DOTNET_SDK_SHA512=e32f76b768017718aa5a3a51fcac4b617ab4428c5f2d10b1b30f07dd7f1ea3dad4df917df48d855d78a347d635e48ce0ec309787899c53a32c4c10dd216b6b19
+ARG ANDROID_NDK_VERSION=27.2.12479018
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}
+
+RUN test "$(basename "${ANDROID_NDK_ROOT}")" = "${ANDROID_NDK_VERSION}" \
+    && test -x "${ANDROID_NDK_ROOT}/ndk-build" \
+    && command -v ninja \
+    && curl -fsSL --retry 5 --retry-all-errors "https://builds.dotnet.microsoft.com/dotnet/Sdk/${DOTNET_SDK_VERSION}/dotnet-sdk-${DOTNET_SDK_VERSION}-linux-x64.tar.gz" -o dotnet-sdk.tar.gz \
+    && echo "${DOTNET_SDK_SHA512}  dotnet-sdk.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -xzf dotnet-sdk.tar.gz -C /usr/share/dotnet \
+    && rm dotnet-sdk.tar.gz \
+    && dotnet --info
+
+WORKDIR /work
+
+COPY ./startup.sh /
+RUN chmod +x /startup.sh
+
+ENTRYPOINT ["/startup.sh"]

--- a/scripts/infra/native/android/docker/startup.sh
+++ b/scripts/infra/native/android/docker/startup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Android NDK: ${ANDROID_NDK_HOME}"
+echo "Container CPUs: $(nproc)"
+echo "Ninja: $(ninja --version)"
+
+exec "$@"


### PR DESCRIPTION
## Description

Build the four shipping Android native ABIs in parallel on Linux using a dedicated thin Azure Linux Android container instead of provisioning Windows hosts.

The image uses Microsoft's prepared `dotnet-buildtools/prereqs` Azure Linux 3.0 Android image pinned by immutable manifest digest. It validates the included NDK as r27c (`27.2.12479018`), installs .NET SDK 10.0.108 from the official archive after verifying its published SHA-512, and confirms Ninja is available. The startup log records the NDK path, Ninja version, and container CPU count.

Windows and macOS Android jobs are removed per the final host-coverage decision. The four Linux artifacts become the canonical inputs to native merge. The existing Cake path still performs the same GN/NDK builds, feature configuration, debug-symbol extraction, stripping, GNU debug links, and 16 KiB LOAD-alignment checks.

### Performance

Uncached public definition-345 runs:

| ABI | Windows baseline 1556384 | Linux container 1559377 |
|---|---:|---:|
| x86 | 20m07s | **14m57s** |
| x64 | 20m47s | **15m59s** |
| arm | 20m58s | **14m35s** |
| arm64 | 21m08s | **15m11s** |
| **Total agent time** | **83m00s** | **60m43s** |
| **Critical Android job** | **21m08s** | **15m59s** |

This saves **22m17s / 26.8%** of Android agent time and **5m09s / 24.4%** on the Android critical path. The Linux jobs spent 1m54s-2m08s building the thin image and 11m13s-11m29s in the source bootstrapper. Native Linux stage duration was 26m15s; build queue wait was 6m25s.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [x] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — CI-only; no public API, ABI, shipped Android ABI, package content, security scan, or observable runtime behavior changes.

## Testing

[Uncached public definition-345 build 1559377](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1559377) validated merge commit `e047804f60d6c23673c501b38c256fb5eed39cad` end to end:

- Android x86, x64, arm, and arm64 source jobs succeeded in 14m57s, 15m59s, 14m35s, and 15m11s.
- Native Windows, macOS, Linux, WASM, and Tizen source stages succeeded.
- Full native, Linux, and WASM merge jobs succeeded in 17m23s, 7m47s, and 4m29s.
- Native merge explicitly downloaded and moved all four `native_android_*_linux` artifacts; `native`, `native_linux`, and `native_wasm` artifacts published successfully.
- Every Linux and Windows-baseline ABI artifact contains exactly `libSkiaSharp.so`, `libSkiaSharp.so.dbg`, `libHarfBuzzSharp.so`, and `libHarfBuzzSharp.so.dbg`.
- ELF class/machine matches x86, x86-64, ARM EABI5, and AArch64 respectively.
- Candidate and Windows baseline dynamic-symbol name sets match exactly for both libraries on every ABI: SkiaSharp 3520/3506/3521/3511 symbols and HarfBuzzSharp 5813/5806/5868/5816 symbols.
- `DT_NEEDED` sets match exactly for all eight library comparisons.
- Every candidate and baseline LOAD segment is 16 KiB aligned, and every stripped `.so` contains its GNU debug link.
- Expected host/build-path-dependent binary and debug bytes differ, while loader requirements and shipping interfaces are unchanged.
- Auto-injected Component Detection remained present on each Android job; no scanning or artifact-publication templates were bypassed.
- Azure Pipelines preview compiled exactly four Android source jobs on `buildAgentLinuxNative`, with no Windows/macOS Android source jobs.

The complete run succeeded before automation resumed, so downstream stages were not canceled in time; this does not affect the native timing or artifact evidence above.

## Checklist

- [x] Tests added or updated (not applicable: CI-only host change; validated with uncached source builds, native merges, ELF comparison, and the full public pipeline)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A
- [x] Native change? N/A; no C API/submodule change or companion `mono/skia` PR required
