### PR TITLE
[skia-sync] Update skia to milestone 153

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "168702d071aaec2b051006b29354f6776b88ab41"
+          "commitHash": "ca4e52cbb95210aaf4cc5d2deaa32b478a28429a"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "9f0d864fd60e9907a8bf5ec84a71d603e6c8db5f"
+          "commitHash": "168702d071aaec2b051006b29354f6776b88ab41"
         }
       }
     },
@@ -318,13 +318,13 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m152",
+          "version": "chrome/m153",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 152,
-      "upstream_merge_commit": "b6d106297ff9ef2ff8094033695d045e87775581",
-      "upstream_ref": "chrome/m152"
+      "chrome_milestone": 153,
+      "upstream_merge_commit": "9d07e5bad9e3e21da2426946e589daa647218271",
+      "upstream_ref": "chrome/m153"
     }
   ]
 }

--- a/documentation/docfx/releases/_sources/4.153.0.notes.md
+++ b/documentation/docfx/releases/_sources/4.153.0.notes.md
@@ -15,10 +15,3 @@ Skia now tries `FcFontMatch` before falling back to the previous `FcFontSort` pa
 that depend on the exact fallback face selected by fontconfig may see different text metrics or
 glyphs after upgrading. Use an explicit family/style or bundled typeface when deterministic font
 selection matters.
-
-### Ganesh filtering of subset YUVA images is corrected
-
-Ganesh now preserves the requested subset when flattening YUVA images for image filters and uses
-linear sampling for subset edges. GPU-rendered filters over video or other multiplanar images may
-produce slightly different edge pixels; this is an upstream correctness fix and requires no API
-migration.

--- a/documentation/docfx/releases/_sources/4.153.0.notes.md
+++ b/documentation/docfx/releases/_sources/4.153.0.notes.md
@@ -1,0 +1,24 @@
+# Manual additions for 4.153.0
+
+> Maintainer-authored behavioral notes for the Skia m153 engine update. These cover
+> customer-visible changes that do not appear in the managed API diff.
+
+## Breaking changes
+
+No managed API, native ABI, or C API breaking changes were identified in the m153 sync.
+
+## Customer-visible engine behavior
+
+### Linux font fallback may select a different face
+
+Skia now tries `FcFontMatch` before falling back to the previous `FcFontSort` path. Applications
+that depend on the exact fallback face selected by fontconfig may see different text metrics or
+glyphs after upgrading. Use an explicit family/style or bundled typeface when deterministic font
+selection matters.
+
+### Ganesh filtering of subset YUVA images is corrected
+
+Ganesh now preserves the requested subset when flattening YUVA images for image filters and uses
+linear sampling for subset edges. GPU-rendered filters over video or other multiplanar images may
+produce slightly different edge pixels; this is an upstream correctness fix and requires no API
+migration.

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m152
+skia                                            release     m153
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,19 +66,19 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   152
+libSkiaSharp            milestone   153
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      152.0.0
+libSkiaSharp            soname      153.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.152.0.0
-SkiaSharp               file        4.152.0.0
+SkiaSharp               assembly    4.153.0.0
+SkiaSharp               file        4.153.0.0
 
 # HarfBuzzSharp package revision N reserves 100 values per Skia milestone.
 # The milestone adopting native X.Y.Z uses 0-99; later milestones add 100.
@@ -89,37 +89,37 @@ HarfBuzzSharp           file        14.2.1.200
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.152.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.152.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.152.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.0
-SkiaSharp.NativeAssets.Android                  nuget       4.152.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.152.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.152.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.152.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.152.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.152.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.152.0
-SkiaSharp.Views                                 nuget       4.152.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.152.0
-SkiaSharp.Views.Gtk3                            nuget       4.152.0
-SkiaSharp.Views.Gtk4                            nuget       4.152.0
-SkiaSharp.Views.WindowsForms                    nuget       4.152.0
-SkiaSharp.Views.WPF                             nuget       4.152.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.152.0
-SkiaSharp.Views.WinUI                           nuget       4.152.0
-SkiaSharp.Views.Maui.Core                       nuget       4.152.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.152.0
-SkiaSharp.Views.Blazor                          nuget       4.152.0
-SkiaSharp.HarfBuzz                              nuget       4.152.0
-SkiaSharp.Skottie                               nuget       4.152.0
-SkiaSharp.SceneGraph                            nuget       4.152.0
-SkiaSharp.Resources                             nuget       4.152.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
+SkiaSharp                                       nuget       4.153.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.153.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.153.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.153.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.153.0
+SkiaSharp.NativeAssets.Android                  nuget       4.153.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.153.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.153.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.153.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.153.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.153.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.153.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.153.0
+SkiaSharp.Views                                 nuget       4.153.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.153.0
+SkiaSharp.Views.Gtk3                            nuget       4.153.0
+SkiaSharp.Views.Gtk4                            nuget       4.153.0
+SkiaSharp.Views.WindowsForms                    nuget       4.153.0
+SkiaSharp.Views.WPF                             nuget       4.153.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.153.0
+SkiaSharp.Views.WinUI                           nuget       4.153.0
+SkiaSharp.Views.Maui.Core                       nuget       4.153.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.153.0
+SkiaSharp.Views.Blazor                          nuget       4.153.0
+SkiaSharp.HarfBuzz                              nuget       4.153.0
+SkiaSharp.Skottie                               nuget       4.153.0
+SkiaSharp.SceneGraph                            nuget       4.153.0
+SkiaSharp.Resources                             nuget       4.153.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.153.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.153.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.153.0
 # HarfBuzzSharp
 HarfBuzzSharp                                   nuget       14.2.1.200
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.200

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -85,7 +85,7 @@ SkiaSharp               file        4.153.0.0
 # Native HarfBuzz upgrades reset N to 0 and establish a new base milestone.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.1.200
+HarfBuzzSharp           file        14.2.1.300
 
 # nuget versions
 # SkiaSharp
@@ -121,13 +121,13 @@ SkiaSharp.Vulkan.SharpVk                        nuget       4.153.0
 SkiaSharp.Vulkan.Silk.NET                       nuget       4.153.0
 SkiaSharp.Direct3D.Vortice                      nuget       4.153.0
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.200
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.200
+HarfBuzzSharp                                   nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.300
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.300

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -1,7 +1,7 @@
 variables:
   # NOTE: Update this value when bumping the SkiaSharp version. It must match
   # the SkiaSharp NuGet version in scripts/VERSIONS.txt.
-  SKIASHARP_VERSION: 4.152.0
+  SKIASHARP_VERSION: 4.153.0
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranch)


### PR DESCRIPTION
## Description

Advance SkiaSharp from Skia m152 to m153, preserve the latest `main` packaging/CI work, and address the release-versioning issue found during deep review.

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/348

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [x] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

**Public API**

None. Independent regeneration found no generated binding changes, and the managed/C API ABI is unchanged.

**Behavior**

Linux fontconfig matching now tries `FcFontMatch` before the previous sorted fallback, so applications relying on the exact fallback face may observe different metrics or glyphs. Other upstream M153 release-note features are not exposed by the current SkiaSharp C/managed bindings or build configuration.

**Packaging and tooling**

- Advances the Skia gitlink to the genuine two-parent m153 merge `168702d071aa`, the native soname to `153.0.0`, and SkiaSharp packages to `4.153.0`.
- Reserves HarfBuzzSharp `14.2.1.300` for the M153 milestone bucket. Deep review found that carrying M152's `.200` bucket forward would collide with servicing releases.
- Updates `update_versions.py` so future milestone syncs advance HarfBuzzSharp buckets deterministically, reset servicing offsets, repair partial runs from the parent base, and remain idempotent.
- Adds `_sources/4.153.0.notes.md` for the reachable Linux font-fallback behavior that API diffs cannot detect.

## Testing

- `review-skia-update`: generated bindings **PASS**; 108 C/Xamarin interop patches unchanged; no added/removed shim code.
- macOS ARM64 native libraries built from source with `dotnet cake --target=externals-macos --arch=arm64`; `externals-download` was not used.
- `update_versions_test.py`: 17/17 passed, including fresh, partial, servicing-offset, and idempotency bucket cases.
- Azure build [1577894](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1577894) succeeded: all native, managed, package, test, visual, and sample stages passed; all 120 checks were green. The later history-only rebase and unreachable-note removal preserved every non-note file in that tested tree byte-for-byte.
- Downloaded all 41 try packages: 31 SkiaSharp packages at `4.153.0-pr.4826.26451.32` and 10 HarfBuzzSharp packages at `14.2.1.300-pr.4826.26451.32`. Archive integrity, package/dependency metadata, representative native assets, and a macOS SkiaSharp/HarfBuzzSharp runtime smoke test passed. PR artifacts are intentionally unsigned.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? No public API changed; no API-docs issue required
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated