### PR TITLE
Document HarfBuzzSharp milestone version buckets

### DIFF
--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -73,16 +73,19 @@ the release so it stays auditable, reproducible, and safe from garbage collectio
 
 ### HarfBuzzSharp Versioning
 
-HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`
+HarfBuzzSharp uses four-part versions: `X.Y.Z.N`.
 
-| Digits | Meaning |
-|--------|---------|
-| X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
-| N | Incremented with each SkiaSharp release |
+| Part | Meaning |
+|------|---------|
+| X.Y.Z | Native HarfBuzz version (e.g., `14.2.1`) |
+| N | Release revision from the current Skia milestone's 100-number bucket |
 
-**Why 4 digits?** HarfBuzzSharp packages are released with SkiaSharp even when there are no HarfBuzz changes. The 4th digit keeps them in sync.
+The bucket base is `(Skia milestone - 150) * 100`: M150 uses revisions
+0-99, M151 uses 100-199, M152 uses 200-299, and so on. Each release
+increments the revision within the current milestone's bucket.
 
-**When native HarfBuzz upgrades:** Reset to 3-digit version (e.g., `8.3.1.4` → `8.4.0`).
+When native HarfBuzz is upgraded, update `X.Y.Z` and reset `N` to the
+current Skia milestone's bucket base.
 
 ### Feeds
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -73,19 +73,16 @@ the release so it stays auditable, reproducible, and safe from garbage collectio
 
 ### HarfBuzzSharp Versioning
 
-HarfBuzzSharp uses four-part versions: `X.Y.Z.N`.
+HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`
 
-| Part | Meaning |
-|------|---------|
-| X.Y.Z | Native HarfBuzz version (e.g., `14.2.1`) |
-| N | Release revision from the current Skia milestone's 100-number bucket |
+| Digits | Meaning |
+|--------|---------|
+| X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
+| N | Incremented with each SkiaSharp release |
 
-The bucket base is `(Skia milestone - 150) * 100`: M150 uses revisions
-0-99, M151 uses 100-199, M152 uses 200-299, and so on. Each release
-increments the revision within the current milestone's bucket.
+**Why 4 digits?** HarfBuzzSharp packages are released with SkiaSharp even when there are no HarfBuzz changes. The 4th digit keeps them in sync.
 
-When native HarfBuzz is upgraded, update `X.Y.Z` and reset `N` to the
-current Skia milestone's bucket base.
+**When native HarfBuzz upgrades:** Reset to 3-digit version (e.g., `8.3.1.4` → `8.4.0`).
 
 ### Feeds
 

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -79,6 +79,9 @@ HarfBuzz                soname      0.61421.0
 SkiaSharp               assembly    4.150.0.0
 SkiaSharp               file        4.150.4.0
 
+# HarfBuzzSharp revisions use 100-number Skia milestone buckets:
+# M150 = 0-99, M151 = 100-199, M152 = 200-299; base = (Skia milestone - 150) * 100.
+# Releases increment within the bucket; a native HarfBuzz upgrade resets to the current bucket base.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
 HarfBuzzSharp           file        14.2.1.4
@@ -115,7 +118,7 @@ SkiaSharp.SceneGraph                            nuget       4.150.4
 SkiaSharp.Resources                             nuget       4.150.4
 SkiaSharp.Vulkan.SharpVk                        nuget       4.150.4
 SkiaSharp.Direct3D.Vortice                      nuget       4.150.4
-# HarfBuzzSharp
+# HarfBuzzSharp (uses the milestone revision bucket policy above)
 HarfBuzzSharp                                   nuget       14.2.1.4
 HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.4
 HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.4

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -79,9 +79,10 @@ HarfBuzz                soname      0.61421.0
 SkiaSharp               assembly    4.150.0.0
 SkiaSharp               file        4.150.4.0
 
-# HarfBuzzSharp revisions use 100-number Skia milestone buckets:
-# M150 = 0-99, M151 = 100-199, M152 = 200-299; base = (Skia milestone - 150) * 100.
-# Releases increment within the bucket; a native HarfBuzz upgrade resets to the current bucket base.
+# HarfBuzzSharp uses 100-number Skia milestone buckets for each native X.Y.Z:
+# the milestone first adopting X.Y.Z uses 0-99; each later milestone on that X.Y.Z adds 100.
+# Releases increment within the bucket; a native upgrade on main resets to 0.
+# Older release lines keep their existing native X.Y.* and assigned milestone bucket.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
 HarfBuzzSharp           file        14.2.1.4


### PR DESCRIPTION
**Description of Change**

Adds comments to `scripts/VERSIONS.txt` documenting the HarfBuzzSharp revision-bucket policy. Each native HarfBuzz `X.Y.Z` starts its own sequence: the Skia milestone that first adopts it uses revisions 0-99, and each later milestone that remains on that same native version advances by 100. Releases increment within the assigned bucket; a native upgrade on `main` resets the revision to 0, while older release lines retain their existing native version and bucket.

No version values, native HarfBuzz release, or HarfBuzz soname are changed.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**Testing**

Not run; this PR changes comments in the version file only.

**PR Checklist**

- [ ] Has tests (not required for a comment-only change)
- [x] Rebased on top of `release/4.150.x` at time of PR
- [x] Merged related skia PRs (none required)
- [x] Changes adhere to coding standard
- [ ] Updated documentation (not applicable; release-guide changes were removed)