### PR TITLE
Move HarfBuzzSharp into the M151 revision bucket

### DIFF
--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -73,16 +73,23 @@ the release so it stays auditable, reproducible, and safe from garbage collectio
 
 ### HarfBuzzSharp Versioning
 
-HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`
+HarfBuzzSharp package and file versions use four parts: `X.Y.Z.N`.
 
 | Digits | Meaning |
 |--------|---------|
 | X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
-| N | Incremented with each SkiaSharp release |
+| N | Revision within the current Skia milestone's 100-revision bucket |
 
-**Why 4 digits?** HarfBuzzSharp packages are released with SkiaSharp even when there are no HarfBuzz changes. The 4th digit keeps them in sync.
+Each milestone reserves 100 revisions: M150 uses `0-99`, M151 uses `100-199`,
+and M152 uses `200-299`. The bucket base is:
 
-**When native HarfBuzz upgrades:** Reset to 3-digit version (e.g., `8.3.1.4` → `8.4.0`).
+```text
+(Skia milestone - 150) * 100
+```
+
+HarfBuzzSharp releases increment `N` within that bucket, including releases
+where the native HarfBuzz version is unchanged. When native HarfBuzz is
+upgraded, change `X.Y.Z` and reset `N` to the current milestone's bucket base.
 
 ### Feeds
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -73,29 +73,16 @@ the release so it stays auditable, reproducible, and safe from garbage collectio
 
 ### HarfBuzzSharp Versioning
 
-HarfBuzzSharp package and file versions use four parts: `X.Y.Z.N`.
+HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`
 
 | Digits | Meaning |
 |--------|---------|
 | X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
-| N | Revision within a 100-revision bucket relative to the milestone that first adopted `X.Y.Z` |
+| N | Incremented with each SkiaSharp release |
 
-For each native HarfBuzz `X.Y.Z`, the Skia milestone that first adopts it is the
-base milestone and uses revisions `0-99`. Each later milestone that stays on the
-same `X.Y.Z` adds 100 to the bucket base:
+**Why 4 digits?** HarfBuzzSharp packages are released with SkiaSharp even when there are no HarfBuzz changes. The 4th digit keeps them in sync.
 
-```text
-(current Skia milestone - adopting Skia milestone) * 100
-```
-
-For example, HarfBuzz `14.2.1` was first adopted by M150, so M150 uses `0-99`,
-M151 uses `100-199`, and M152 uses `200-299`. HarfBuzzSharp releases increment
-`N` within the current bucket.
-
-When `main` upgrades native HarfBuzz, change `X.Y.Z`, reset `N` to `0`, and use
-that milestone as the new base. Native HarfBuzz upgrades are not backported to
-older release lines; those lines remain on their older `X.Y.*` versions and
-continue using the corresponding milestone-relative buckets.
+**When native HarfBuzz upgrades:** Reset to 3-digit version (e.g., `8.3.1.4` → `8.4.0`).
 
 ### Feeds
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -78,18 +78,24 @@ HarfBuzzSharp package and file versions use four parts: `X.Y.Z.N`.
 | Digits | Meaning |
 |--------|---------|
 | X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
-| N | Revision within the current Skia milestone's 100-revision bucket |
+| N | Revision within a 100-revision bucket relative to the milestone that first adopted `X.Y.Z` |
 
-Each milestone reserves 100 revisions: M150 uses `0-99`, M151 uses `100-199`,
-and M152 uses `200-299`. The bucket base is:
+For each native HarfBuzz `X.Y.Z`, the Skia milestone that first adopts it is the
+base milestone and uses revisions `0-99`. Each later milestone that stays on the
+same `X.Y.Z` adds 100 to the bucket base:
 
 ```text
-(Skia milestone - 150) * 100
+(current Skia milestone - adopting Skia milestone) * 100
 ```
 
-HarfBuzzSharp releases increment `N` within that bucket, including releases
-where the native HarfBuzz version is unchanged. When native HarfBuzz is
-upgraded, change `X.Y.Z` and reset `N` to the current milestone's bucket base.
+For example, HarfBuzz `14.2.1` was first adopted by M150, so M150 uses `0-99`,
+M151 uses `100-199`, and M152 uses `200-299`. HarfBuzzSharp releases increment
+`N` within the current bucket.
+
+When `main` upgrades native HarfBuzz, change `X.Y.Z`, reset `N` to `0`, and use
+that milestone as the new base. Native HarfBuzz upgrades are not backported to
+older release lines; those lines remain on their older `X.Y.*` versions and
+continue using the corresponding milestone-relative buckets.
 
 ### Feeds
 

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -80,8 +80,11 @@ SkiaSharp               assembly    4.151.0.0
 SkiaSharp               file        4.151.3.0
 
 # HarfBuzzSharp.dll
+# Revision buckets: M150 uses 0-99, M151 uses 100-199, and M152 uses 200-299.
+# Base = (Skia milestone - 150) * 100; releases increment within the bucket.
+# A native HarfBuzz upgrade resets to the current milestone's bucket base.
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.1.3
+HarfBuzzSharp           file        14.2.1.103
 
 # nuget versions
 # SkiaSharp
@@ -116,13 +119,13 @@ SkiaSharp.Resources                             nuget       4.151.3
 SkiaSharp.Vulkan.SharpVk                        nuget       4.151.3
 SkiaSharp.Direct3D.Vortice                      nuget       4.151.3
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.3
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.3
+HarfBuzzSharp                                   nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.103
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.103

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -80,9 +80,10 @@ SkiaSharp               assembly    4.151.0.0
 SkiaSharp               file        4.151.3.0
 
 # HarfBuzzSharp.dll
-# Revision buckets: M150 uses 0-99, M151 uses 100-199, and M152 uses 200-299.
-# Base = (Skia milestone - 150) * 100; releases increment within the bucket.
-# A native HarfBuzz upgrade resets to the current milestone's bucket base.
+# Revision buckets are relative to the milestone that first adopts native HarfBuzz X.Y.Z.
+# Example: 14.2.1 starts at M150 (0-99), so M151 uses 100-199 and M152 uses 200-299.
+# Releases increment within the bucket. A native upgrade on main resets N to 0 and
+# makes that milestone the new base; older release lines remain on their prior X.Y.*.
 HarfBuzzSharp           assembly    1.0.0.0
 HarfBuzzSharp           file        14.2.1.103
 


### PR DESCRIPTION
**Description of Change**

Moves the HarfBuzzSharp file and NuGet versions to `14.2.1.103`, placing M151 in the second 100-revision bucket relative to M150, which first adopted native HarfBuzz `14.2.1`. Adds an inline policy comment explaining that every native `X.Y.Z` starts at `N=0` in its adopting milestone, later milestones on the same native version add 100, and a native upgrade on `main` establishes a new base while older release lines retain their older `X.Y.*`.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**Required skia PR**

None.

**Testing**

No build or test suite was run because this is a packaging metadata-only change. `git diff --check` passed, the obsolete global M150 formula is absent, and every HarfBuzz version entry was inspected.

**PR Checklist**

- [x] Tests are not required for this packaging metadata-only change (see Testing)
- [x] Based on `release/4.151.x` at the time of the PR
- [x] No related skia PR is required
- [x] Changes adhere to coding standard
- [x] Updated the inline version-policy comment; no release-guide change is included on this servicing branch
