### PR TITLE
Reserve HarfBuzzSharp versions by Skia milestone

### DIFF
--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -180,20 +180,23 @@ binary — the soname/file lines drive the actual native `.so` soname and DLL
 |-------|-------------|-------------------|
 | `harfbuzz` | `release` | `X.Y.Z` |
 | `HarfBuzz` | `soname` | `0.<60000 + X*100 + Y*10 + Z>.0` (e.g. 14.2.1 → `0.61421.0`) |
-| `HarfBuzzSharp` | `file` | `X.Y.Z.N` |
-| `HarfBuzzSharp` + all `HarfBuzzSharp.NativeAssets.*` | `nuget` | `X.Y.Z.N` (≈10 lines) |
+| `HarfBuzzSharp` | `file` | `X.Y.Z` (`N = 0`) |
+| `HarfBuzzSharp` + all `HarfBuzzSharp.NativeAssets.*` | `nuget` | `X.Y.Z` (`N = 0`, ≈10 lines) |
 
-`N` reserves 100 revisions per Skia milestone. Its bucket base is
-`(Skia milestone - 150) * 100`: M150 uses 0–99, M151 uses 100–199, M152 uses
-200–299, and so on. A native HarfBuzz update resets `N` to the current
-milestone's bucket base, not to zero. M150's zero bucket may use the normalized
-3-part form `X.Y.Z`.
+HarfBuzz upgrades are made on `main` and are not backported to older release
+lines. The upgrade resets package revision `N` to zero and makes the current
+Skia milestone the base for `X.Y.Z`; the normalized 3-part form represents
+`X.Y.Z.0`.
+
+If later Skia milestones continue using the same native HarfBuzz version, each
+milestone adds 100 to the bucket base. For example, if M152 adopts 14.3.1,
+M152 uses revisions 0–99, M153 uses 100–199, and M154 uses 200–299.
 
 The soname formula and package bucket formula are documented in comments next
 to their lines. Verify the result with
 `grep -E "harfbuzz|HarfBuzz" scripts/VERSIONS.txt`: the native release and
-soname must match `X.Y.Z`, while every HarfBuzzSharp file/NuGet entry must use
-the same bucketed package version.
+soname must match `X.Y.Z`, while every HarfBuzzSharp file/NuGet entry must
+reset to the same `X.Y.Z` package version.
 
 ### Phase 4: Build & Test
 

--- a/.agents/skills/native-dependency-update/SKILL.md
+++ b/.agents/skills/native-dependency-update/SKILL.md
@@ -171,16 +171,29 @@ Cross-reference against `externals/skia/third_party/{dep}/BUILD.gn` — new sour
 
 #### VERSIONS.txt updates (harfbuzz)
 
-When bumping **harfbuzz** to `{major}.{minor}.{micro}`, update ALL of these lines in `scripts/VERSIONS.txt` (they otherwise drift out of sync with the binary — the soname/file lines drive the actual native `.so` soname and DLL `FileVersion`):
+When bumping **harfbuzz** to `{major}.{minor}.{micro}`, update ALL of these
+lines in `scripts/VERSIONS.txt` (they otherwise drift out of sync with the
+binary — the soname/file lines drive the actual native `.so` soname and DLL
+`FileVersion`):
 
 | Entry | Line format | Value for `X.Y.Z` |
 |-------|-------------|-------------------|
 | `harfbuzz` | `release` | `X.Y.Z` |
 | `HarfBuzz` | `soname` | `0.<60000 + X*100 + Y*10 + Z>.0` (e.g. 14.2.1 → `0.61421.0`) |
-| `HarfBuzzSharp` | `file` | `X.Y.Z` |
-| `HarfBuzzSharp` + all `HarfBuzzSharp.NativeAssets.*` | `nuget` | `X.Y.Z` (≈10 lines) |
+| `HarfBuzzSharp` | `file` | `X.Y.Z.N` |
+| `HarfBuzzSharp` + all `HarfBuzzSharp.NativeAssets.*` | `nuget` | `X.Y.Z.N` (≈10 lines) |
 
-The soname formula is documented in a comment directly above the `HarfBuzz soname` line. Verify your result with `grep -E "harfbuzz|HarfBuzz" scripts/VERSIONS.txt` — no stale version should remain.
+`N` reserves 100 revisions per Skia milestone. Its bucket base is
+`(Skia milestone - 150) * 100`: M150 uses 0–99, M151 uses 100–199, M152 uses
+200–299, and so on. A native HarfBuzz update resets `N` to the current
+milestone's bucket base, not to zero. M150's zero bucket may use the normalized
+3-part form `X.Y.Z`.
+
+The soname formula and package bucket formula are documented in comments next
+to their lines. Verify the result with
+`grep -E "harfbuzz|HarfBuzz" scripts/VERSIONS.txt`: the native release and
+soname must match `X.Y.Z`, while every HarfBuzzSharp file/NuGet entry must use
+the same bucketed package version.
 
 ### Phase 4: Build & Test
 

--- a/.agents/skills/release-branch/scripts/tests/test_release_scripts.py
+++ b/.agents/skills/release-branch/scripts/tests/test_release_scripts.py
@@ -281,11 +281,15 @@ class ReleaseScriptTests(unittest.TestCase):
             release.increment_harfbuzz("14.2.1.1"),
             "14.2.1.2",
         )
+        self.assertEqual(
+            release.increment_harfbuzz("14.2.1.200"),
+            "14.2.1.201",
+        )
 
     def test_next_versions(self):
         self.assertEqual(
-            release.calculate_next_versions("4.151.2", "14.2.1.2"),
-            ("4.151.3", "14.2.1.3"),
+            release.calculate_next_versions("4.151.2", "14.2.1.102"),
+            ("4.151.3", "14.2.1.103"),
         )
 
     def test_update_version_files_supports_four_part_hotfix(self):

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -79,7 +79,8 @@ the release so it stays auditable, reproducible, and safe from garbage collectio
 
 ### HarfBuzzSharp Versioning
 
-HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`.
+HarfBuzzSharp versions are modeled as `X.Y.Z.N`. Revision zero is written in
+the normalized 3-part form `X.Y.Z`.
 
 | Digits | Meaning |
 |--------|---------|
@@ -105,10 +106,10 @@ ordered and prevents them from publishing the same package version.
 
 **When native HarfBuzz upgrades:** Reset `N` to zero and make the adopting
 milestone the new base. For example, an M152 upgrade from `14.2.1.203` to
-HarfBuzz 14.3.1 becomes `14.3.1` (the normalized form of `14.3.1.0`), and
-M153 would start at `14.3.1.100`. HarfBuzz upgrades are made on `main` and are
-not backported; older release lines remain on their existing native HarfBuzz
-version and revision buckets.
+HarfBuzz 14.3.1 becomes `14.3.1` (`N = 0`), and M153 would start at
+`14.3.1.100`. HarfBuzz upgrades are made on `main` and are not backported;
+older release lines remain on their existing native HarfBuzz version and
+revision buckets.
 
 ### Feeds
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -79,16 +79,31 @@ the release so it stays auditable, reproducible, and safe from garbage collectio
 
 ### HarfBuzzSharp Versioning
 
-HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`
+HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`.
 
 | Digits | Meaning |
 |--------|---------|
 | X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
-| N | Incremented with each SkiaSharp release |
+| N | Skia milestone bucket plus the release revision within that milestone |
 
-**Why 4 digits?** HarfBuzzSharp packages are released with SkiaSharp even when there are no HarfBuzz changes. The 4th digit keeps them in sync.
+Each Skia milestone reserves 100 revision values:
 
-**When native HarfBuzz upgrades:** Reset to 3-digit version (e.g., `8.3.1.4` → `8.4.0`).
+| Skia milestone | HarfBuzzSharp revisions |
+|----------------|----------------------------|
+| M150 | 0–99 |
+| M151 | 100–199 |
+| M152 | 200–299 |
+
+The bucket base is `(Skia milestone - 150) * 100`. Releases increment within
+their milestone's bucket, so M151 might use `14.2.1.100`, `14.2.1.101`, and
+`14.2.1.102` while M152 starts at `14.2.1.200`. This keeps parallel Skia
+release lines ordered and prevents them from publishing the same package
+version.
+
+**When native HarfBuzz upgrades:** Keep the current Skia milestone bucket and
+reset its release revision. For example, an M152 upgrade from `14.2.1.203` to
+HarfBuzz 14.3.1 becomes `14.3.1.200`. M150's zero bucket may be written as the
+3-digit version (for example, `14.3.1` instead of `14.3.1.0`).
 
 ### Feeds
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -86,24 +86,29 @@ HarfBuzzSharp uses 4-digit versions: `X.Y.Z.N`.
 | X.Y.Z | Native HarfBuzz version (e.g., `8.3.1`) |
 | N | Skia milestone bucket plus the release revision within that milestone |
 
-Each Skia milestone reserves 100 revision values:
+For each native HarfBuzz `X.Y.Z`, the Skia milestone that first adopts it is
+the base milestone. It reserves 100 revision values, and each later milestone
+that continues using the same native version advances to the next bucket:
 
-| Skia milestone | HarfBuzzSharp revisions |
-|----------------|----------------------------|
-| M150 | 0–99 |
-| M151 | 100–199 |
-| M152 | 200–299 |
+| Milestone relative to the base | HarfBuzzSharp revisions |
+|--------------------------------|----------------------------|
+| Base milestone | 0–99 |
+| Base + 1 | 100–199 |
+| Base + 2 | 200–299 |
 
-The bucket base is `(Skia milestone - 150) * 100`. Releases increment within
-their milestone's bucket, so M151 might use `14.2.1.100`, `14.2.1.101`, and
-`14.2.1.102` while M152 starts at `14.2.1.200`. This keeps parallel Skia
-release lines ordered and prevents them from publishing the same package
-version.
+The bucket base is
+`(current Skia milestone - HarfBuzz adoption milestone) * 100`. For example,
+HarfBuzz 14.2.1 was adopted by M150, so M150 uses `14.2.1` through
+`14.2.1.99`, M151 uses `14.2.1.100` through `14.2.1.199`, and M152 uses
+`14.2.1.200` through `14.2.1.299`. This keeps parallel Skia release lines
+ordered and prevents them from publishing the same package version.
 
-**When native HarfBuzz upgrades:** Keep the current Skia milestone bucket and
-reset its release revision. For example, an M152 upgrade from `14.2.1.203` to
-HarfBuzz 14.3.1 becomes `14.3.1.200`. M150's zero bucket may be written as the
-3-digit version (for example, `14.3.1` instead of `14.3.1.0`).
+**When native HarfBuzz upgrades:** Reset `N` to zero and make the adopting
+milestone the new base. For example, an M152 upgrade from `14.2.1.203` to
+HarfBuzz 14.3.1 becomes `14.3.1` (the normalized form of `14.3.1.0`), and
+M153 would start at `14.3.1.100`. HarfBuzz upgrades are made on `main` and are
+not backported; older release lines remain on their existing native HarfBuzz
+version and revision buckets.
 
 ### Feeds
 

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -80,9 +80,12 @@ HarfBuzz                soname      0.61421.0
 SkiaSharp               assembly    4.152.0.0
 SkiaSharp               file        4.152.0.0
 
+# HarfBuzzSharp package revision N = (Skia milestone - 150) * 100 + release revision.
+# M150 = 0-99, M151 = 100-199, M152 = 200-299, ...
+# Reset N to the current milestone bucket base when native HarfBuzz changes.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.1
+HarfBuzzSharp           file        14.2.1.200
 
 # nuget versions
 # SkiaSharp
@@ -118,13 +121,13 @@ SkiaSharp.Vulkan.SharpVk                        nuget       4.152.0
 SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.0
 SkiaSharp.Direct3D.Vortice                      nuget       4.152.0
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.1
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1
+HarfBuzzSharp                                   nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.200
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.200

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -80,9 +80,9 @@ HarfBuzz                soname      0.61421.0
 SkiaSharp               assembly    4.152.0.0
 SkiaSharp               file        4.152.0.0
 
-# HarfBuzzSharp package revision N = (Skia milestone - 150) * 100 + release revision.
-# M150 = 0-99, M151 = 100-199, M152 = 200-299, ...
-# Reset N to the current milestone bucket base when native HarfBuzz changes.
+# HarfBuzzSharp package revision N reserves 100 values per Skia milestone.
+# The milestone adopting native X.Y.Z uses 0-99; later milestones add 100.
+# Native HarfBuzz upgrades reset N to 0 and establish a new base milestone.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
 HarfBuzzSharp           file        14.2.1.200


### PR DESCRIPTION
## Description

Reserve 100 HarfBuzzSharp package revisions per Skia milestone while a native HarfBuzz version remains in use. The milestone that first adopts an upstream `X.Y.Z` starts at revision zero, and each later milestone that remains on that native version adds 100.

HarfBuzz 14.2.1 was adopted by M150, so M150 uses revisions 0-99, M151 uses 100-199, and M152 uses 200-299. Main therefore uses HarfBuzzSharp 14.2.1.200, while the native HarfBuzz release and soname remain unchanged.

A future native HarfBuzz upgrade on `main` resets the package revision to zero and makes that milestone the new base. HarfBuzz upgrades are not backported to older release lines. The release documentation, dependency-update workflow, and release-script tests now capture this policy.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — package version allocation only; no public API or runtime behavior changes.

## Testing

- `python3 .agents/skills/release-branch/scripts/tests/test_release_scripts.py`
- Verified all 11 HarfBuzzSharp file/NuGet entries use `14.2.1.200` and native HarfBuzz remains `14.2.1` with soname `0.61421.0`.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native or submodule changes