### PR TITLE
Retire stale CI branch references

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -42,7 +42,7 @@ The collector script requires:
 - **`gh` CLI** — authenticated with read access to `mono/SkiaSharp` and `mono/SkiaSharp-API-docs`
 - **Git remotes** — fetched recently so `git branch -r` returns up-to-date release branches
 
-### Public CI (dnceng-public/public org — triggers on push/PR to main, develop, release/*)
+### Public CI (dnceng-public/public org — triggers on push/PR to main and release/*)
 
 | Pipeline Name | Org/Project | Definition ID | URL |
 |---------------|-------------|---------------|-----|

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -31,7 +31,7 @@ PROJECT_DEVDIV = "DevDiv"
 ORG_DNCENG_PUBLIC = "https://dev.azure.com/dnceng-public"
 PROJECT_DNCENG_PUBLIC = "public"
 
-# Public CI pipeline — runs on every push/PR to main, develop, release/*
+# Public CI pipeline — runs on every push/PR to main and release/*
 # Lives in the dnceng-public/public org
 PUBLIC_PIPELINES = [
     {"name": "mono-SkiaSharp", "id": 345, "org": ORG_DNCENG_PUBLIC, "project": PROJECT_DNCENG_PUBLIC},

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![HarfBuzzSharp API Docs](https://img.shields.io/badge/docs-harfbuzzsharp-1faece.svg)](https://docs.microsoft.com/dotnet/api/SkiaSharp)
 [![SkiaSharp Guides](https://img.shields.io/badge/docs-guides-1faece.svg)](https://docs.microsoft.com/xamarin/graphics-games/skiasharp/)
 
-[![Build Status](https://dev.azure.com/devdiv/DevDiv/_apis/build/status/Xamarin/Components/SkiaSharp?branchName=main)](https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=10789&branchName=main)
 [![Build Status](https://dev.azure.com/dnceng-public/public/_apis/build/status/345?branchName=main)](https://dev.azure.com/dnceng-public/public/_build?definitionId=345&branchName=main)
 
 SkiaSharp is a cross-platform 2D graphics API for .NET platforms based on Google's

--- a/scripts/azure-pipelines-complete.yml
+++ b/scripts/azure-pipelines-complete.yml
@@ -1,11 +1,9 @@
 trigger:
   - main
-  - develop
   - release/*
 
 pr:
   - main
-  - develop
   - release/*
 
 parameters:

--- a/scripts/azure-pipelines-native.yml
+++ b/scripts/azure-pipelines-native.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
       - main
-      - develop
       - release/*
   paths:
     exclude:


### PR DESCRIPTION
## Description

Retires obsolete CI references after the `develop` branch stopped being an active build target. Public Azure Pipeline triggers now cover only `main` and `release/*`, the CI-status skill describes that supported branch set, and the README shows only the current dnceng-public build badge.

This intentionally leaves the existing DevDiv release-chain implementation unchanged.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None.

## Testing

- Parsed the complete, native, and package Azure Pipeline YAML files with the repository's available PyYAML tooling and asserted the supported trigger/PR branch lists.
- Compiled `.agents/skills/ci-status/scripts/ci-status.py` in memory and ran its `--help` CLI smoke test.
- Confirmed no operational `develop` references remain in `scripts/`, the CI-status skill, or README, and ran `git diff --check`.
- No broad product build was run because this change is limited to CI configuration and documentation.

## Checklist

- [ ] Tests added or updated (not applicable; validation is described above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later (not applicable)
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated (not applicable)
