### PR TITLE
Restore SkiaSharp.Vulkan.Silk.NET package production

### DIFF
--- a/scripts/infra/shared/shared.cake
+++ b/scripts/infra/shared/shared.cake
@@ -143,6 +143,7 @@ var SUPPORTED_NUGETS = new Dictionary<string, Version> {
     { "SkiaSharp.SceneGraph",                          new Version (2, 88, 0) },
     { "SkiaSharp.Resources",                           new Version (2, 88, 0) },
     { "SkiaSharp.Vulkan.SharpVk",                      new Version (2, 80, 0) },
+    { "SkiaSharp.Vulkan.Silk.NET",                     new Version (4, 152, 0) },
     { "SkiaSharp.Direct3D.Vortice",                    new Version (2, 88, 0) },
 };
 

--- a/source/SkiaSharpSource.Linux.slnf
+++ b/source/SkiaSharpSource.Linux.slnf
@@ -26,7 +26,8 @@
       "SkiaSharp.Views\\SkiaSharp.Views.Gtk3\\SkiaSharp.Views.Gtk3.csproj",
       "SkiaSharp.Views\\SkiaSharp.Views.Gtk4\\SkiaSharp.Views.Gtk4.csproj",
       "SkiaSharp.Views\\SkiaSharp.Views\\SkiaSharp.Views.csproj",
-      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.SharpVk\\SkiaSharp.Vulkan.SharpVk.csproj"
+      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.SharpVk\\SkiaSharp.Vulkan.SharpVk.csproj",
+      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.Silk.NET\\SkiaSharp.Vulkan.Silk.NET.csproj"
     ]
   }
 }

--- a/source/SkiaSharpSource.Mac.slnf
+++ b/source/SkiaSharpSource.Mac.slnf
@@ -38,7 +38,8 @@
       "SkiaSharp.Views\\SkiaSharp.Views.Gtk3\\SkiaSharp.Views.Gtk3.csproj",
       "SkiaSharp.Views\\SkiaSharp.Views.Gtk4\\SkiaSharp.Views.Gtk4.csproj",
       "SkiaSharp.Views\\SkiaSharp.Views\\SkiaSharp.Views.csproj",
-      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.SharpVk\\SkiaSharp.Vulkan.SharpVk.csproj"
+      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.SharpVk\\SkiaSharp.Vulkan.SharpVk.csproj",
+      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.Silk.NET\\SkiaSharp.Vulkan.Silk.NET.csproj"
     ]
   }
 }

--- a/source/SkiaSharpSource.Windows.slnf
+++ b/source/SkiaSharpSource.Windows.slnf
@@ -43,6 +43,7 @@
       "SkiaSharp.Views\\SkiaSharp.Views.WindowsForms\\SkiaSharp.Views.WindowsForms.csproj",
       "SkiaSharp.Views\\SkiaSharp.Views\\SkiaSharp.Views.csproj",
       "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.SharpVk\\SkiaSharp.Vulkan.SharpVk.csproj",
+      "SkiaSharp.Vulkan\\SkiaSharp.Vulkan.Silk.NET\\SkiaSharp.Vulkan.Silk.NET.csproj",
       "SkiaSharp.Direct3D\\SkiaSharp.Direct3D.Vortice\\SkiaSharp.Direct3D.Vortice.csproj"
     ]
   }


### PR DESCRIPTION
## Description

Restores `SkiaSharp.Vulkan.Silk.NET` to normal package production. The project already belongs to the full source solution and Vulkan test solutions, but the platform-specific solution filters used by managed CI builds and NuGet packing selected only the SharpVk Vulkan package. Adding Silk.NET to those filters and to `SUPPORTED_NUGETS` ensures stable and preview package builds produce and track it consistently.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

**Behavior**

Platform package builds produce `SkiaSharp.Vulkan.Silk.NET` again. There are no managed or native API changes.

## Testing

- `dotnet cake --target=externals-download` completed successfully.
- `dotnet sln source/SkiaSharpSource.{Windows,Mac,Linux}.slnf list` confirmed each platform filter selects `SkiaSharp.Vulkan.Silk.NET.csproj`.
- `dotnet pack source/SkiaSharp.Vulkan/SkiaSharp.Vulkan.Silk.NET/SkiaSharp.Vulkan.Silk.NET.csproj --configuration Release` produced `SkiaSharp.Vulkan.Silk.NET.4.152.0.nupkg`.
- The repository test solution ran 6,159 core tests plus singleton, Direct3D, and Vulkan hosts. Two unrelated stream ownership failures passed when rerun individually; the run remains red only for the existing macOS `ganesh-gl/DiagonalLines` golden mismatch (1,832 outlier pixels versus 1,310 allowed). This packaging-only change does not affect rendering; CI will provide the authoritative platform validation.
- No focused regression test was added; package CI validates the selected solution filters and produced package inventory.

## Checklist

- [x] Tests added or updated (not applicable for this inventory-only change; validation is documented above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later (not applicable: no API changes)
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated (not applicable: no native changes)