### PR TITLE
Require deterministic Android native symbol identity

### DIFF
--- a/native/android/build.cake
+++ b/native/android/build.cake
@@ -37,7 +37,7 @@ Task("libSkiaSharp")
             $"skia_enable_graphite=true " +
             $"skia_enable_skottie=true " +
             $"extra_cflags=[ '-DSKIA_C_DLL', '-DSK_AVOID_SLOW_RASTER_PIPELINE_BLURS', '-DSK_ENABLE_LEGACY_SHADERCONTEXT', '-DHAVE_SYSCALL_GETRANDOM', '-DXML_DEV_URANDOM', '-g', '-ggdb3' ] " +
-            $"extra_ldflags=[ '-Wl,-z,max-page-size=16384' ] " +
+            $"extra_ldflags=[ '-Wl,--build-id=sha1', '-Wl,-z,max-page-size=16384' ] " +
             $"ndk='{ANDROID_NDK_HOME}' " +
             $"ndk_api=21");
 

--- a/native/android/libHarfBuzzSharp/jni/HarfBuzzSharp.mk
+++ b/native/android/libHarfBuzzSharp/jni/HarfBuzzSharp.mk
@@ -8,7 +8,7 @@ LOCAL_MODULE           := HarfBuzzSharp
 
 LOCAL_C_INCLUDES       := . $(src_root) $(ext_root)
 
-LOCAL_LDFLAGS          := -Wl,--gc-sections -Wl,-z,max-page-size=16384
+LOCAL_LDFLAGS          := -Wl,--gc-sections -Wl,--build-id=sha1 -Wl,-z,max-page-size=16384
 
 LOCAL_CFLAGS           := -DNDEBUG                                                                  \
                           -DHAVE_CONFIG_OVERRIDE_H -DHAVE_OT -DHB_NO_FALLBACK_SHAPE                 \

--- a/scripts/infra/native/android/ndk.cake
+++ b/scripts/infra/native/android/ndk.cake
@@ -59,6 +59,25 @@ FilePath ExtractAndStripSymbols(FilePath so)
     Information($"Linking stripped binary to symbols file...");
     RunProcess(objcopy.FullPath, $"--add-gnu-debuglink=\"{symbolsFile}\" \"{so}\"");
 
+    // dotnet-symbol resolves ELF modules and split debug files by GNU build ID.
+    var readelf = GetFiles($"{prebuilt}/*/bin/llvm-readelf*").FirstOrDefault() ?? throw new Exception("Could not find llvm-readelf");
+    RunProcess(readelf.FullPath, $"-n \"{so}\"", out var moduleNotes);
+    RunProcess(readelf.FullPath, $"-n \"{symbolsFile}\"", out var symbolNotes);
+    var moduleBuildId = System.Text.RegularExpressions.Regex.Match(
+        string.Join(Environment.NewLine, moduleNotes),
+        @"Build ID:\s*(?<id>[0-9a-f]+)",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase).Groups["id"].Value;
+    var symbolBuildId = System.Text.RegularExpressions.Regex.Match(
+        string.Join(Environment.NewLine, symbolNotes),
+        @"Build ID:\s*(?<id>[0-9a-f]+)",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase).Groups["id"].Value;
+    if (string.IsNullOrEmpty(moduleBuildId) || !string.Equals(moduleBuildId, symbolBuildId, StringComparison.OrdinalIgnoreCase))
+        throw new Exception($"The Android module and symbol file must have the same GNU build ID: '{moduleBuildId}' != '{symbolBuildId}'.");
+
+    RunProcess(readelf.FullPath, $"--string-dump=.gnu_debuglink \"{so}\"", out var debugLink);
+    if (!debugLink.Any(line => line.Contains(symbolsFile.GetFilename().ToString())))
+        throw new Exception($"{so} does not reference {symbolsFile.GetFilename()} through .gnu_debuglink.");
+
     // Report final sizes
     var strippedSize = new System.IO.FileInfo(so.FullPath).Length;
     var symbolsSize = new System.IO.FileInfo(symbolsFile.FullPath).Length;
@@ -69,6 +88,7 @@ FilePath ExtractAndStripSymbols(FilePath so)
     Information($"  Original size:   {originalSize / 1024.0 / 1024.0:F1} MB ({originalSize:N0} bytes)");
     Information($"  Stripped binary: {strippedSize / 1024.0 / 1024.0:F1} MB ({strippedSize:N0} bytes)");
     Information($"  Symbols file:    {symbolsSize / 1024.0 / 1024.0:F1} MB ({symbolsSize:N0} bytes)");
+    Information($"  GNU build ID:    {moduleBuildId}");
     Information($"  Space saved:     {savedBytes / 1024.0 / 1024.0:F1} MB ({savedBytes:N0} bytes, {savedPercent:F1}%)");
 
     return symbolsFile;


### PR DESCRIPTION
## Description

Emit deterministic SHA-1 GNU build IDs for the Android SkiaSharp and HarfBuzzSharp native libraries. After splitting debug symbols, the Android build now requires the stripped module and `.so.dbg` file to retain the same nonempty build ID and requires `.gnu_debuglink` to name the matching symbol file. This gives symbol tooling a stable identity for resolving split Android debug artifacts.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — build-only native symbol metadata enforcement; no public API or runtime behavior changes.

## Testing

- `dotnet cake native/android/build.cake --target=Default --configuration=Release --arch=arm64 --ndk="$HOME/Library/Android/sdk/ndk/29.0.14206865"` source-built both Android libraries and passed the new post-strip checks.
  - `libSkiaSharp.so` and `libSkiaSharp.so.dbg`: matching build ID `eedaeb4a564e6d4a0d8ab0c6c2d273f5de5d84d2`; debug link `libSkiaSharp.so.dbg`.
  - `libHarfBuzzSharp.so` and `libHarfBuzzSharp.so.dbg`: matching build ID `adbfa4ee04450149c06c855117eba2dd6c76771c`; debug link `libHarfBuzzSharp.so.dbg`.
- Independently verified both identity pairs and debug-link names with the NDK `llvm-readelf`.
- `dotnet cake --target=externals-macos --arch=arm64` passed to produce host natives from source.
- `dotnet test tests/SkiaSharp.Tests.Console.slnx -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0` passed 6,142 tests across all hosts; one unrelated existing macOS `ganesh-gl/DiagonalLines` visual-golden comparison failed. CI will provide the authoritative artifact and test validation.

No focused unit test was added because the behavior is exercised and enforced directly by the Android source-build symbol extraction step.

## Checklist

- [ ] Tests added or updated (not added; build-time enforcement and source-build validation are described above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A
- [x] Native change? Android linker/symbol metadata only; no Skia/C API change, generated binding change, or companion `mono/skia` PR required