### PR TITLE
[CI] Simplify artifact downloads to exact build IDs

### DIFF
--- a/documentation/dev/updating-dotnet-version.md
+++ b/documentation/dev/updating-dotnet-version.md
@@ -134,7 +134,6 @@ Keep each distro/OS suffix unchanged when updating either kind of image. For exa
 Before merging a .NET upgrade PR, verify these items:
 
 - [ ] **`nuget.config`** — Must NOT contain `nuget.org` source (disallowed in CI)
-- [ ] **`scripts/azure-pipelines-complete.yml`** — `buildExternals` parameter must be reset to `'latest'` (not a specific build ID)
 - [ ] **All CI stages pass** — Tests, samples, API diff, and package stages must be green
 - [ ] **Documentation updated** — `documentation/dev/updating-dotnet-version.md` reflects any new learnings
 
@@ -217,7 +216,7 @@ Workloads are pinned via the `DOTNET_WORKLOAD_VERSION` pipeline variable, which 
 ## CI Troubleshooting
 
 ### Reusing Native Artifacts
-To speed up CI iteration when debugging managed code issues, set the `buildExternals` parameter to a previous build ID that has successful native stages. This skips native compilation and downloads artifacts from the specified build instead.
+Native artifacts are reused automatically through content-based caching: `scripts/infra/caching/repo-deps.py` hashes the native inputs and `Cache@2` restores a matching build, which sets `CACHE_SKIP` and skips native compilation. Nothing needs to be set by hand, and there is no way to point a run at an arbitrary previous build ID — artifacts are only ever downloaded from the current run or from an exact connected pipeline run.
 
 ### SDK Version Mismatch
 If CI agents don't have the exact SDK version in `global.json`, use `"rollForward": "latestPatch"` to accept any patch version in the same feature band (e.g., `10.0.100` accepts `10.0.102`).

--- a/scripts/azure-templates-steps-download-artifacts.yml
+++ b/scripts/azure-templates-steps-download-artifacts.yml
@@ -1,55 +1,32 @@
 parameters:
-  sourceBuildId: ''
   artifacts: [ ] # name, dir, currentRun
   condition: succeeded()
 
 steps:
   - ${{ if ne(length(parameters.artifacts), 0) }}:
+    # Artifacts always come from one exact, already-completed build. Connected
+    # pipelines (such as Tests) get it from the SkiaSharp pipeline resource,
+    # while combined pipelines build and consume their own artifacts.
     - pwsh: |
-        $buildId = "${{ parameters.sourceBuildId }}"
-        if ($env:RESOURCES_PIPELINE_SKIASHARP_RUNID) {
-          $buildId = $env:RESOURCES_PIPELINE_SKIASHARP_RUNID
-          Write-Host "Using RESOURCES_PIPELINE_SKIASHARP_RUNID = '$env:RESOURCES_PIPELINE_SKIASHARP_RUNID'"
-        }
-        if (-not $buildId) {
-          $buildId = $env:BUILD_BUILDID
-          Write-Host "Using BUILD_BUILDID = '$env:BUILD_BUILDID'"
-        }
-        $versionType = 'specific'
-        if ($buildId -eq 'latest') {
-          $versionType = 'latestFromBranch'
-        }
-        $pipelineId = "$env:SYSTEM_DEFINITIONID"
-        if ($env:RESOURCES_PIPELINE_SKIASHARP_PIPELINEID) {
-          $pipelineId = $env:RESOURCES_PIPELINE_SKIASHARP_PIPELINEID
-          Write-Host "Using RESOURCES_PIPELINE_SKIASHARP_PIPELINEID = '$env:RESOURCES_PIPELINE_SKIASHARP_PIPELINEID'"
-        }
-        $branchName = "$env:BUILD_SOURCEBRANCH"
-        if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
-          $branchName = "refs/heads/$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
-        }
+        $buildId = if ($env:RESOURCES_PIPELINE_SKIASHARP_RUNID) { $env:RESOURCES_PIPELINE_SKIASHARP_RUNID } else { $env:BUILD_BUILDID }
+        $pipelineId = if ($env:RESOURCES_PIPELINE_SKIASHARP_PIPELINEID) { $env:RESOURCES_PIPELINE_SKIASHARP_PIPELINEID } else { $env:SYSTEM_DEFINITIONID }
         Write-Host "DOWNLOAD_BUILD_ID = '$buildId'"
         Write-Host "DOWNLOAD_PIPELINE_ID = '$pipelineId'"
-        Write-Host "DOWNLOAD_BRANCH = '$branchName'"
-        Write-Host "DOWNLOAD_VERSION_TYPE = '$versionType'"
         Write-Host "##vso[task.setvariable variable=DOWNLOAD_BUILD_ID]$buildId"
         Write-Host "##vso[task.setvariable variable=DOWNLOAD_PIPELINE_ID]$pipelineId"
-        Write-Host "##vso[task.setvariable variable=DOWNLOAD_BRANCH]$branchName"
-        Write-Host "##vso[task.setvariable variable=DOWNLOAD_VERSION_TYPE]$versionType"
-      displayName: Ensure all the variables are set for the download
+      displayName: Resolve the build that artifacts are downloaded from
       condition: ${{ parameters.condition }}
 
   - ${{ each artifact in parameters.artifacts }}:
     - task: DownloadBuildArtifacts@1
-      displayName: Download the pre-built ${{ artifact.name }} artifacts from ${{ iif(artifact.currentRun, 'the current run', 'the previous run') }}
+      displayName: Download the pre-built ${{ artifact.name }} artifacts from ${{ iif(artifact.currentRun, 'the current run', 'the source run') }}
       condition: ${{ parameters.condition }}
       retryCountOnTaskFailure: 3
       inputs:
         buildType: 'specific'
         project: '$(System.TeamProjectId)'
         pipeline: ${{ iif(artifact.currentRun, '$(System.DefinitionId)', '$(DOWNLOAD_PIPELINE_ID)') }}
-        branchName: ${{ iif(artifact.currentRun, '$(Build.SourceBranch)', '$(DOWNLOAD_BRANCH)') }}
-        buildVersionToDownload: ${{ iif(artifact.currentRun, 'specific', '$(DOWNLOAD_VERSION_TYPE)') }}
+        buildVersionToDownload: 'specific'
         buildId: ${{ iif(artifact.currentRun, '$(Build.BuildId)', '$(DOWNLOAD_BUILD_ID)') }}
         downloadType: 'single'
         allowPartiallySucceededBuilds: true


### PR DESCRIPTION
## Description

The artifact downloader still carried the machinery for reusing native artifacts from an arbitrary earlier build: a `sourceBuildId` parameter, a `latest` → `latestFromBranch` fallback, and the `DOWNLOAD_VERSION_TYPE` / `DOWNLOAD_BRANCH` variables that went with it.

That capability belonged to the old `buildExternals` / `DOWNLOAD_EXTERNALS` flow, where a run could be pointed at an exact prior native build (or `latest`) instead of compiling. Content-based `Cache@2` replaced that build-reuse decision in #3826, and the last caller passing `sourceBuildId` was deleted in the same change. Nothing has passed it since.

Downloads now resolve to exactly one of two sources: the current run, or the exact upstream run of the `SkiaSharp` pipeline resource for connected pipelines such as Tests.

### Why the removal is safe

I traced every current call path — public 345, internal Build 1642, and Tests 1630:

- **Only one caller.** `scripts/azure-templates-jobs-bootstrapper.yml` is the sole consumer of the download template, and it passes only `condition` and `artifacts`. A tree-wide search for `sourceBuildId` / `latestFromBranch` / `DOWNLOAD_VERSION_TYPE` / `DOWNLOAD_BRANCH` / `DOWNLOAD_EXTERNALS` across `scripts/`, `.github/`, `.agents/`, `eng/` and `documentation/` returns no other producer or consumer.
- **`latest` was unreachable.** `$buildId -eq 'latest'` could only be true via `sourceBuildId` (no caller), `RESOURCES_PIPELINE_SKIASHARP_RUNID` (always a numeric run ID) or `BUILD_BUILDID` (always numeric). So `buildVersionToDownload` was already always `specific` in every pipeline.
- **`branchName` was inert.** In `DownloadBuildArtifactsV1`, `branchName` is gated on `buildVersionToDownload == latestFromBranch` and is only forwarded to pipeline resolution on that branch. With `specific`, omitting it is behaviour-neutral rather than merely tolerated — so dropping `DOWNLOAD_BRANCH` and the PR-target-branch selection is a no-op.
- **Combined pipelines were already self-referential.** In public 345 and internal 1642 the non-`currentRun` path resolved to the same pipeline and the same build as the `currentRun` path; only the ignored `branchName` differed.
- **Tests 1630 is unaffected.** It keeps resolving through `RESOURCES_PIPELINE_SKIASHARP_RUNID` / `_PIPELINEID`, both retained.

The `DOWNLOAD_PIPELINE_ID` resolution is kept even though `DownloadBuildArtifacts@1` does not read `definition` on the `specific` path, because `task.json` marks that input required when `buildType == specific` and an empty value risks an "input required" failure.

Also drops the stale `buildExternals` guidance from `documentation/dev/updating-dotnet-version.md` — it instructed contributors to set and then reset a pipeline parameter that no longer exists — and replaces it with how native artifact reuse actually works today (`repo-deps.py` hashing + `Cache@2` + `CACHE_SKIP`).

## Changes

**ABI-affecting changes: None.** This is CI/build infrastructure and documentation only; no managed or native API surface is touched.

- `scripts/azure-templates-steps-download-artifacts.yml` — removed the `sourceBuildId` parameter, the `latest` → `latestFromBranch` selection, the `DOWNLOAD_VERSION_TYPE` and `DOWNLOAD_BRANCH` variables, and the `branchName` task input. `buildVersionToDownload` is now the literal `specific`. The resolver step now sets only `DOWNLOAD_BUILD_ID` and `DOWNLOAD_PIPELINE_ID`.
- `documentation/dev/updating-dotnet-version.md` — removed the `buildExternals` pre-merge checklist item and rewrote the "Reusing Native Artifacts" troubleshooting section to describe content-based caching.

## Required skia PR

None.

## Areas Affected

- [x] Build/CI infrastructure
- [x] Documentation
- [ ] SkiaSharp managed API
- [ ] HarfBuzzSharp
- [ ] Native code / C API
- [ ] Samples
- [ ] Tests

## Testing

No new test was added: the change is a pure deletion of unreachable YAML branches, and the repo's existing PowerShell validation pattern only fits extracted script files. Extracting the six-line resolver into a script purely to unit-test it was more boilerplate than logic, so the resolver stays inline. Validation performed:

- **YAML parse** — all 24 pipeline definitions (`scripts/*.yml` + `es-metadata.yml`) parse cleanly with PyYAML, 0 failures.
- **Cache coverage** — `python3 scripts/infra/caching/repo-deps.py validate` → `[PASS] All files covered!`, `Uncovered: 0`.
- **Existing pipeline tests** — `SetBuildVariables.Tests.ps1` and `PrepareApiScanInputs.Tests.ps1` both pass unchanged.
- **Task-behaviour verification** — confirmed against `DownloadBuildArtifactsV1` `task.json` and the agent plugin that `branchName` and `definition` are unread when `buildVersionToDownload` is `specific`.
- **Dead-code audit** — independently re-verified by a second review pass; no remaining producer or consumer of any removed variable, and `git log -S sourceBuildId` confirms #3826 removed the last one.

Full CI on this PR exercises the change directly: every job that downloads artifacts (native merge, package, and the 21 test-stage download sites) runs through the modified template.

No rendering behaviour changes, so no before/after screenshots apply.