### PR TITLE
[infra] Align release ecosystem references with dnceng

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -3,7 +3,7 @@ name: ci-status
 description: >
   Check the CI build health and automation status of SkiaSharp across main and
   recent release branches. Collects the last N builds from the AzDO pipeline chain
-  (Public + Native → Managed → Tests) and all GitHub Actions workflows from
+  (Public plus the combined Build and connected Tests) and all GitHub Actions workflows from
   mono/SkiaSharp and mono/SkiaSharp-API-docs, providing a daily dashboard view
   with AI-powered analysis of failures, regressions, and flakes.
 
@@ -30,15 +30,15 @@ description: >
 Provide a dashboard view of SkiaSharp CI health across main and recent release branches,
 with AI-powered analysis to identify patterns, regressions, and actionable fixes.
 
-Unlike the `release-status` skill (which tracks a single release through the pipeline chain),
-this skill gives a **broad overview** of CI health across multiple branches simultaneously.
+This skill gives a **broad overview** of CI health across multiple branches,
+including the current dnceng Build and Tests pipelines.
 
 ## Pipelines Tracked
 
 ### Prerequisites
 
 The collector script requires:
-- **`az` CLI** — authenticated with access to `dnceng-public/public` and `devdiv/DevDiv` orgs
+- **`az` CLI** — authenticated with access to `dnceng-public/public` and `dnceng/internal`
 - **`gh` CLI** — authenticated with read access to `mono/SkiaSharp` and `mono/SkiaSharp-API-docs`
 - **Git remotes** — fetched recently so `git branch -r` returns up-to-date release branches
 
@@ -48,13 +48,17 @@ The collector script requires:
 |---------------|-------------|---------------|-----|
 | `mono-SkiaSharp` | dnceng-public/public | 345 | [link](https://dev.azure.com/dnceng-public/public/_build?definitionId=345&_a=summary) |
 
-### Internal Release Chain (devdiv/DevDiv org — triggers on release/* branches)
+### Internal Release Chain (dnceng/internal — triggers on release/* branches)
 
 | Order | Pipeline Name | Definition ID | URL |
 |-------|---------------|---------------|-----|
-| 1 | `SkiaSharp-Native` | 26493 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493) |
-| 2 | `SkiaSharp` | 10789 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=10789) |
-| 3 | `SkiaSharp-Tests` | 15756 | [link](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=15756) |
+| 1 | `skiasharp-package` | 1642 | [link](https://dev.azure.com/dnceng/internal/_build?definitionId=1642) |
+| 2 | `skiasharp-tests` | 1630 | [link](https://dev.azure.com/dnceng/internal/_build?definitionId=1630) |
+
+Tests consumes the folder-qualified pipeline resource
+`\dotnet\skiasharp\skiasharp-package`. The Build pipeline owns native and
+managed compilation, real signing, BAR registration/validation, and Arcade's
+standard Darc/Maestro stages.
 
 ### GitHub Actions (mono/SkiaSharp and mono/SkiaSharp-API-docs)
 
@@ -168,16 +172,20 @@ Group all errors/warnings across all branches and pipelines by **normalized sign
 
 ### 2.3 Pipeline Chain Analysis (MANDATORY — always perform, even when failures look independent)
 
-The Internal chain is sequential: **Native → Managed → Tests**. A red pipeline is NOT automatically an independent failure — it is often a downstream casualty of an upstream break.
+The Internal chain is sequential: **Build -> Tests**. A red Tests run is not
+automatically an independent failure; it may be a downstream casualty of the
+exact Build resource it consumed.
 
 For **every** branch that has ≥1 red internal pipeline, you MUST:
-1. Find the earliest-in-chain failing pipeline (Native before Managed before Tests).
-2. Decide whether each later red pipeline is an **independent failure** (its own distinct error) or a **cascade** (failed because the upstream artifact never built / a shared error).
-3. **Collapse cascades** into the upstream root cause so a single break is not counted as 2–3 problems.
+1. Identify whether the connected Build failed before Tests.
+2. Decide whether a red Tests run is an **independent failure** (its own distinct
+   error) or a **cascade** from the exact Build resource.
+3. **Collapse cascades** into the Build root cause so a single break is not
+   counted twice.
 
 Emit one explicit sentence per affected branch, even if the answer is "no cascade":
-- Cascade: `"release/X: 3 red internal pipelines — root-caused to {Native}; Managed+Tests were blocked downstream, not independently broken."`
-- Independent: `"release/X: Native and Tests both red but with unrelated errors ({errA} vs {errB}) — two independent failures, not a cascade."`
+- Cascade: `"release/X: Build and Tests are red; Tests consumed that exact Build and is a downstream cascade, not an independent break."`
+- Independent: `"release/X: Build and Tests are both red but have unrelated errors ({errA} vs {errB}) — two independent failures."`
 
 ⚠️ Do not skip this step or list internal pipelines as separate equal-weight failures without first stating the chain verdict. This is the most common analysis miss.
 
@@ -331,12 +339,12 @@ After rendering, present a brief summary in chat and point to the files:
 🟡 CI is degraded — release/3.119.x is blocked by a Guardian TSA upload failure; main is green.
 
 📊 AzDO Health:
-  main                         ✅ Public | ✅ Native | ✅ Managed | ✅ Tests
-  release/4.147.0-preview.3    ❌ Public | ⚠️ Native | ✅ Managed | ✅ Tests
-  release/3.119.x              ❌ Public | ⚠️ Native | ⚠️ Managed | ❌ Tests
+  main                         ✅ Public | ✅ Build | ✅ Tests
+  release/4.147.0-preview.3    ❌ Public | ⚠️ Build | ✅ Tests
+  release/3.119.x              ❌ Public | ⚠️ Build | ❌ Tests
 
 🔗 Chain verdict:
-  release/3.119.x: Tests red independently (Guardian TSA); Native/Managed warnings only — no cascade.
+  release/3.119.x: Tests red independently (Guardian TSA); Build warning only — no cascade.
   release/4.147.0-preview.3: Public CI red (CS0016 errors); internal chain unaffected.
 
 🐙 GitHub Actions:
@@ -373,12 +381,12 @@ If asked to dig deeper:
 | Question | Use |
 |----------|-----|
 | "Is main green?" | **ci-status** |
-| "How's the release/3.119.4 build doing?" | **release-status** |
+| "How's the release/3.119.4 build doing?" | **ci-status** |
 | "Daily CI check" | **ci-status** |
-| "Are packages ready for release X?" | **release-status** |
+| "Are public packages ready to finalize?" | **release-publish** dry-run |
 | "Any CI failures across the board?" | **ci-status** |
 | "What automation is failing?" | **ci-status** |
-| "Trace the pipeline chain for branch X" | **release-status** |
+| "Trace the pipeline chain for branch X" | **ci-status** |
 | "Why is CI red?" | **ci-status** (with analysis) |
 | "Is release/X shippable?" | **ci-status** (risk assessment) |
 | "GitHub Actions status?" | **ci-status** |

--- a/.agents/skills/ci-status/evals/evals.json
+++ b/.agents/skills/ci-status/evals/evals.json
@@ -5,12 +5,12 @@
       "id": 0,
       "name": "daily-health-check",
       "prompt": "Is main green right now? Give me a quick read on CI health across our branches.",
-      "expected_output": "A concise health summary covering main and recent release branches, showing the status of each pipeline (Public, Native, Managed, Tests), with a clear verdict on whether main is passing.",
+      "expected_output": "A concise health summary covering main and recent release branches, showing the status of each pipeline (Public, Build, Tests), with a clear verdict on whether main is passing.",
       "files": [],
       "expectations": [
         "States a clear verdict on whether main is currently green/passing",
         "Covers recent release/* branches, not just main",
-        "Reports per-pipeline status naming the pipelines (Public, Native, Managed/SkiaSharp, Tests)",
+        "Reports per-pipeline status naming the pipelines (Public, skiasharp-package/Build, skiasharp-tests/Tests)",
         "Includes at least one concrete ADO build ID or build results link as evidence",
         "Stays concise — a quick read rather than an exhaustive multi-section report"
       ]

--- a/.agents/skills/ci-status/references/report-schema.md
+++ b/.agents/skills/ci-status/references/report-schema.md
@@ -112,8 +112,8 @@ Array of chain analysis verdicts. One entry per branch with ≥1 red internal pi
 {
   "branch": "release/3.119.x",
   "verdict": "cascade",
-  "summary": "Tests red independently (Guardian TSA); Native/Managed warnings only — no cascade.",
-  "rootPipeline": "SkiaSharp-Tests",
+  "summary": "Tests red independently (Guardian TSA); Build warning only - no cascade.",
+  "rootPipeline": "skiasharp-tests",
   "cascadedPipelines": []
 }
 ```
@@ -136,7 +136,7 @@ Array of chain analysis verdicts. One entry per branch with ≥1 red internal pi
   "severity": "high",
   "footprint": {
     "branches": ["release/3.119.x"],
-    "pipelines": ["mono-SkiaSharp", "SkiaSharp-Tests"]
+    "pipelines": ["mono-SkiaSharp", "skiasharp-tests"]
   },
   "firstSeen": "2026-05-25T10:00:00Z",
   "lastSeen": "2026-05-29T10:00:00Z",

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -13,7 +13,7 @@ Options:
 
 Queries Azure DevOps for:
   Public CI:  mono-SkiaSharp — dnceng-public/public, def 345
-  Internal:   SkiaSharp-Native (26493) → SkiaSharp (10789) → SkiaSharp-Tests (15756)
+  Internal:   skiasharp-package (1642) -> skiasharp-tests (1630)
 """
 
 import argparse
@@ -25,8 +25,8 @@ import urllib.request
 from datetime import datetime, timezone
 from collections import defaultdict
 
-ORG_DEVDIV = "https://devdiv.visualstudio.com"
-PROJECT_DEVDIV = "DevDiv"
+ORG_DNCENG = "https://dev.azure.com/dnceng"
+PROJECT_DNCENG = "internal"
 
 ORG_DNCENG_PUBLIC = "https://dev.azure.com/dnceng-public"
 PROJECT_DNCENG_PUBLIC = "public"
@@ -37,12 +37,12 @@ PUBLIC_PIPELINES = [
     {"name": "mono-SkiaSharp", "id": 345, "org": ORG_DNCENG_PUBLIC, "project": PROJECT_DNCENG_PUBLIC},
 ]
 
-# Internal release pipeline chain — runs on release/* branches
-# Lives in devdiv/DevDiv org
+# Internal release pipeline chain - runs on release/* branches.
+# The combined Build registers signed assets in BAR; Tests consumes that exact
+# pipeline resource.
 INTERNAL_PIPELINES = [
-    {"name": "SkiaSharp-Native", "id": 26493, "org": ORG_DEVDIV, "project": PROJECT_DEVDIV},
-    {"name": "SkiaSharp", "id": 10789, "org": ORG_DEVDIV, "project": PROJECT_DEVDIV},
-    {"name": "SkiaSharp-Tests", "id": 15756, "org": ORG_DEVDIV, "project": PROJECT_DEVDIV},
+    {"name": "skiasharp-package", "id": 1642, "org": ORG_DNCENG, "project": PROJECT_DNCENG},
+    {"name": "skiasharp-tests", "id": 1630, "org": ORG_DNCENG, "project": PROJECT_DNCENG},
 ]
 
 ICONS = {

--- a/.agents/skills/ci-status/scripts/render-ci-status-md.py
+++ b/.agents/skills/ci-status/scripts/render-ci-status-md.py
@@ -165,7 +165,7 @@ def render(data):
     if chain:
         lines.append("## Pipeline Chain Analysis")
         lines.append("")
-        lines.append("The internal chain is sequential: **Native → Managed → Tests**. "
+        lines.append("The internal chain is sequential: **Build -> Tests**. "
                      "Failures may cascade downstream.")
         lines.append("")
         for entry in chain:

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -2,7 +2,8 @@
 name: security-audit
 description: >
   Audit SkiaSharp's native dependencies for security vulnerabilities and CVEs,
-  including Component Governance (CG) alerts from the SkiaSharp-Native and SkiaSharp Azure DevOps pipelines.
+  including Component Governance (CG) alerts from the combined
+  skiasharp-package Azure DevOps pipeline.
   Read-only investigation that produces a status report with recommendations.
 
   Use when user asks to:
@@ -12,7 +13,7 @@ description: >
   - Get an overview of open vulnerabilities
   - See what security work is pending
   - Check Component Governance alerts
-  - Review CG alerts from the native build pipeline
+  - Review CG alerts from the official combined Build pipeline
 
   Triggers: "security audit", "audit CVEs", "CVE status", "what security issues are open",
   "check vulnerability status", "security overview", "what CVEs need fixing",
@@ -302,8 +303,9 @@ submodules, etc.
 
 ### Step 7: Query Component Governance Alerts
 
-CG scans Docker container images and build-time deps from both ADO pipelines. CG alerts are
-invisible to GitHub Issues and NVD searches alone.
+CG scans Docker container images and build-time dependencies from the combined
+`skiasharp-package` ADO pipeline. CG alerts are invisible to GitHub Issues and
+NVD searches alone.
 
 > 🛑 **THIS STEP TAKES 5–7 MINUTES.** The CG script queries 60+ jobs across 8+ builds. This
 > is NORMAL and NON-NEGOTIABLE. Use `initial_wait: 600` (or higher). Do NOT skip, fabricate
@@ -317,7 +319,7 @@ invisible to GitHub Issues and NVD searches alone.
 - Alert categories (Alpine, Debian, npm, Rust, NuGet)
 - Key Dockerfiles for fixes
 - How to embed the raw `alerts` array in the report (do NOT summarize)
-- Portal links
+- CG portal and exact Build links
 
 ---
 

--- a/.agents/skills/security-audit/references/cg-alerts.md
+++ b/.agents/skills/security-audit/references/cg-alerts.md
@@ -1,12 +1,13 @@
 # Component Governance (CG) Alerts
 
-CG scans Docker container images and build-time dependencies used by the SkiaSharp-Native
-and SkiaSharp Azure DevOps pipelines. It flags CVEs in OS packages, npm dependencies, Rust
-crates, and NuGet packages used during the build.
+CG scans Docker container images and build-time dependencies used by the
+combined `skiasharp-package` Azure DevOps pipeline. It flags CVEs in OS
+packages, npm dependencies, Rust crates, and NuGet packages used during the
+build.
 
-> ⚠️ **MANDATORY:** The audit MUST include CG alerts from BOTH the **SkiaSharp-Native**
-> (pipeline 26493) and **SkiaSharp** (pipeline 10789) pipelines — together they make up the
-> shipped build.
+> ⚠️ **MANDATORY:** The audit MUST include CG alerts from
+> **skiasharp-package** (pipeline 1642). It builds native and managed assets,
+> performs real signing, and registers the shipped packages in BAR.
 
 ## Why This Matters
 
@@ -70,51 +71,46 @@ python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
   --branch main --output output/ai/cg-alerts-cache.json
 
-# Query only the native pipeline
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
-  --pipeline native --output output/ai/cg-alerts-cache.json
-
-# Query only the managed pipeline
-python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
-  --pipeline managed --output output/ai/cg-alerts-cache.json
-
 # Query a specific build
 python3 .agents/skills/security-audit/scripts/query-cg-alerts.py \
   --build-id 14176611 --output output/ai/cg-alerts-cache.json
 ```
 
+## CG Portal
+
+**Alerts:** https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-SkiaSharp
+
+The Component Governance registration, alerts, repository identity, and scan
+pipeline live in the dnceng `internal` project.
+
 ### What the Script Does
 
-1. Discovers the latest completed build from `main` AND all active `release/*` branches for BOTH pipelines.
+1. Discovers the latest completed Build from `main` and every active `release/*` branch.
 2. Identifies ALL CG logs in each build (every job, no sampling — this is security).
 3. Parses and deduplicates all CVEs across builds, pipelines, and jobs.
 4. Sorts by severity and reports which branches and pipelines are affected.
 
-> **Note:** There is no build-independent CG REST API. The `governance.visualstudio.com`
-> service does not expose alert data through any documented endpoint. The CG portal UI
-> aggregates from build results internally. Our script achieves the same result by
-> enumerating every CG log in the latest build of every active branch (no sampling), which
-> reports ALL active registration-level alerts.
+> **Note:** There is no documented build-independent CG alerts API. The script
+> enumerates every Component Governance log in the latest Build of every active
+> branch (no sampling) and reports all alerts observed by those scans.
 
 ## Manual Approach (for Debugging)
 
 ```bash
-# 1. Get latest build ID (native pipeline)
-BUILD_ID=$(az pipelines runs list --pipeline-id 26493 \
-  --org https://devdiv.visualstudio.com --project DevDiv \
+# 1. Get latest combined Build ID
+BUILD_ID=$(az pipelines runs list --pipeline-id 1642 \
+  --org https://dev.azure.com/dnceng --project internal \
   --top 1 --query "[0].id" -o tsv)
-
-# For managed pipeline, use --pipeline-id 10789 instead
 
 # 2. Get timeline to find CG log IDs
 az devops invoke --area build --resource timeline \
-  --route-parameters project=DevDiv buildId=$BUILD_ID \
-  --org https://devdiv.visualstudio.com -o json
+  --route-parameters project=internal buildId=$BUILD_ID \
+  --org https://dev.azure.com/dnceng -o json
 
 # 3. Parse CVEs from a specific CG log
 az devops invoke --area build --resource logs \
-  --route-parameters project=DevDiv buildId=$BUILD_ID logId={LOG_ID} \
-  --org https://devdiv.visualstudio.com -o json
+  --route-parameters project=internal buildId=$BUILD_ID logId={LOG_ID} \
+  --org https://dev.azure.com/dnceng -o json
 ```
 
 ## CG Alert Categories
@@ -172,7 +168,7 @@ The script output has this structure (include ALL fields as-is):
         "severity": "Medium",
         "sources": ["Alpine 3.17"],
         "branches": ["main"],
-        "pipelines": ["SkiaSharp-Native"],
+        "pipelines": ["skiasharp-package"],
         "paths": ["/some/path/to/manifest"]
       }
     ]
@@ -187,9 +183,9 @@ The script output has this structure (include ALL fields as-is):
 - Replace `alerts` with `uniqueCVEs` or `categories`
 - Write `totalAlerts: N` without including the actual N alerts
 
-## CG Portal Links
+## CG Build Link
 
-- **Registration:** https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321
-- **Native pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=26493
-- **Managed pipeline:** https://dev.azure.com/devdiv/DevDiv/_build?definitionId=10789
-- **Alert type filter:** Append `?_a=alerts&typeId={typeId}&alerts-view-option=active` to the registration URL
+- **Combined Build pipeline:** https://dev.azure.com/dnceng/internal/_build?definitionId=1642
+
+Use the exact Build run URL emitted by the script for audit evidence. Do not
+substitute a latest branch build after collection.

--- a/.agents/skills/security-audit/scripts/query-cg-alerts.py
+++ b/.agents/skills/security-audit/scripts/query-cg-alerts.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """
-Query all Component Governance (CG) alerts for SkiaSharp pipelines.
+Query Component Governance (CG) alerts for the SkiaSharp Build pipeline.
 
-Queries BOTH the SkiaSharp-Native (native libraries) and SkiaSharp (managed C#)
-pipelines since together they make up the shipped build. Automatically queries
-the latest builds from main AND active release branches, then deduplicates
-alerts across all builds to give a complete picture.
+The combined skiasharp-package pipeline builds native and managed assets,
+signs, and registers the shipped packages in BAR. The script queries its latest
+completed builds from main and active release branches, then deduplicates alerts
+across all builds.
 
 Prerequisites:
   - az CLI installed and authenticated
   - az devops extension installed
-  - Default org/project configured: az devops configure --defaults organization=https://devdiv.visualstudio.com project=DevDiv
+  - Default org/project configured: az devops configure --defaults organization=https://dev.azure.com/dnceng project=internal
 
 Usage:
-  python3 query-cg-alerts.py --output FILE [--branch BRANCH] [--text] [--verbose] [--pipeline PIPELINE] [--build-id BUILD_ID]
+  python3 query-cg-alerts.py --output FILE [--branch BRANCH] [--text] [--verbose] [--build-id BUILD_ID]
 
   # Standard usage — query all branches, write JSON to file (progress on stdout)
   python3 query-cg-alerts.py --output output/ai/cg-alerts-cache.json
@@ -26,9 +26,6 @@ Usage:
 
   # Query only a specific branch
   python3 query-cg-alerts.py --branch main --output output/ai/cg-alerts-cache.json
-
-  # Query only the native pipeline
-  python3 query-cg-alerts.py --pipeline native --output output/ai/cg-alerts-cache.json
 
   # Query a specific build
   python3 query-cg-alerts.py --build-id 14176611 --output output/ai/cg-alerts-cache.json
@@ -48,13 +45,12 @@ import urllib.request
 from collections import defaultdict
 from datetime import datetime, timezone
 
-ORG = "https://devdiv.visualstudio.com"
-PROJECT = "DevDiv"
+ORG = "https://dev.azure.com/dnceng"
+PROJECT = "internal"
 
-# Both pipelines together make up the shipped build
+# The combined pipeline owns native and managed shipped assets.
 PIPELINES = {
-    "native": {"id": 26493, "name": "SkiaSharp-Native"},
-    "managed": {"id": 10789, "name": "SkiaSharp"},
+    "build": {"id": 1642, "name": "skiasharp-package"},
 }
 
 # Branches to query by default (main + any active release branches)
@@ -231,8 +227,6 @@ def main():
     parser = argparse.ArgumentParser(description="Query CG alerts for SkiaSharp pipelines")
     parser.add_argument("--build-id", type=int, help="Specific build ID (skips branch discovery)")
     parser.add_argument("--branch", type=str, help="Query only this branch (e.g., 'main' or 'release/3.119.x')")
-    parser.add_argument("--pipeline", type=str, choices=["native", "managed", "both"], default="both",
-                        help="Which pipeline to query (default: both)")
     parser.add_argument("--text", action="store_true", help="Also print human-readable text summary to stdout")
     parser.add_argument("--output", "-o", type=str, required=True, help="Write JSON output to this file (required). Progress prints to stdout.")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show per-job progress (each CG log parsed)")
@@ -240,11 +234,7 @@ def main():
 
     token = get_token()
 
-    # Determine which pipelines to query
-    if args.pipeline == "both":
-        pipelines_to_query = list(PIPELINES.items())
-    else:
-        pipelines_to_query = [(args.pipeline, PIPELINES[args.pipeline])]
+    pipelines_to_query = [("build", PIPELINES["build"])]
 
     # Determine which builds to query
     builds_to_query = []  # list of (build_id, branch, build_number, pipeline_type)
@@ -255,9 +245,15 @@ def main():
         build = api_get(token, url)
         if build:
             branch = build.get("sourceBranch", "").replace("refs/heads/", "")
-            # Determine pipeline type from definition
             def_id = build.get("definition", {}).get("id")
-            ptype = "native" if def_id == PIPELINES["native"]["id"] else "managed"
+            if def_id != PIPELINES["build"]["id"]:
+                print(
+                    f"ERROR: Build {args.build_id} belongs to definition "
+                    f"{def_id}, expected {PIPELINES['build']['id']}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            ptype = "build"
             builds_to_query.append((args.build_id, branch, build.get("buildNumber", "unknown"), ptype))
         else:
             print(f"ERROR: Build {args.build_id} not found", file=sys.stderr)

--- a/.agents/skills/security-audit/scripts/validate-security-audit.py
+++ b/.agents/skills/security-audit/scripts/validate-security-audit.py
@@ -119,7 +119,7 @@ elif cg:
     if not cg.get("builds"):
         errors.append(
             "cgAlerts.builds is empty — no builds were queried. "
-            "The CG script must discover and query builds from both pipelines."
+            "The CG script must discover and query combined Build runs."
         )
 
     # Detect fabricated timestamps (midnight UTC = clearly fake)

--- a/.agents/skills/security-audit/scripts/viewer.html
+++ b/.agents/skills/security-audit/scripts/viewer.html
@@ -87,8 +87,9 @@
   <!-- Component Governance Alerts -->
   <div class="card mb-4" id="cg-section" style="display:none;">
     <div class="card-header bg-white d-flex align-items-center">
-      <i class="bi bi-shield-exclamation me-2"></i><strong>Component Governance (Build Pipeline)</strong>
-      <a href="https://devdiv.visualstudio.com/DevDiv/_componentGovernance/113321?_a=alerts&typeId=29227950&alerts-view-option=active" target="_blank" class="ms-2 small">Open in AzDO</a>
+      <i class="bi bi-shield-exclamation me-2"></i><strong>Component Governance</strong>
+      <a href="https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-SkiaSharp" target="_blank" class="ms-2 small">Open alerts</a>
+      <a href="https://dev.azure.com/dnceng/internal/_build?definitionId=1642" target="_blank" class="ms-2 small">Open scan pipeline</a>
       <span class="ms-auto" id="cg-badge"></span>
     </div>
     <div class="card-body">
@@ -626,7 +627,7 @@ function renderCgAlerts(cg) {
   const pipes = cg.pipelines || [];
   if (pipes.length > 0) {
     document.getElementById('cg-pipelines').innerHTML = `<i class="bi bi-gear me-1"></i>Scanned: ${pipes.map(p =>
-      `<a href="https://dev.azure.com/devdiv/DevDiv/_build?definitionId=${p.id}" target="_blank">${esc(p.name)}</a>`
+      `<a href="https://dev.azure.com/dnceng/internal/_build?definitionId=${p.id}" target="_blank">${esc(p.name)}</a>`
     ).join(', ')}`;
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Single source of truth for all commands:
 > after native changes will cause `EntryPointNotFoundException` at runtime because the downloaded
 > binaries don't contain your new functions.
 
-> **Note:** For optional public-package smoke testing, see `/release-testing`.
+> **Note:** For pre-publication BAR/CI package approval testing, see `/release-testing`.
 
 **Recovery Commands:**
 
@@ -389,7 +389,7 @@ Custom slash commands are available for specialized workflows. Use these for com
 Repository release branches are normally created with the **Release - Prepare**
 GitHub workflow, which runs `scripts/infra/publishing/prepare-release.ps1`. The
 release skills remain available for publication, milestone maintenance, and
-optional public-package smoke testing. See
+pre-publication BAR/CI package approval testing. See
 [`documentation/dev/releasing.md`](documentation/dev/releasing.md).
 
 ### When to Use Commands
@@ -409,7 +409,7 @@ optional public-package smoke testing. See
 | Prepare release branches | `/release-branch` | "release now", "start release X" |
 | Finalize release | `/release-publish` | "finish release", "tag release" |
 | Maintain release milestones | `/release-milestones` | "reconcile milestones", "advance milestone schedule" |
-| Smoke-test a public release | `/release-testing` | "smoke test release", "verify public packages" |
+| Approve release CI/BAR packages | `/release-testing` | "approve release packages", "validate BAR packages" |
 | Release notes | `/release-notes` | "generate release notes", "regenerate 3.119.x", "write release notes for" |
 | Skia analyst | `/skia-analyst` | "what changed", "what are we missing", "feature gap", "api diff", "scout features", "diff tags" |
 | Update Skia | `/update-skia` | "update to milestone NNN", "bump Skia" |

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ nuget install SkiaSharp
 
 _Because there are multiple distros of Linux, and we cannot possibly support them all, we have a separate NuGet package that will contain the supported binaries for a few distros: [SkiaSharp.NativeAssets.Linux](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux). ([distros](https://github.com/mono/SkiaSharp/issues/453)) ([more info](https://github.com/mono/SkiaSharp/issues/312))_
 
-There is also a early access feed that you can use to get the latest and greatest, before it goes out to the public:
+There is also an early access feed that you can use to get the latest and greatest, before it goes out to the public:
 
 ```
-https://aka.ms/skiasharp-eap/index.json
+https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json
 ```
 
 ## Building SkiaSharp

--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/README.md
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/README.md
@@ -44,7 +44,7 @@ CI workflow (`.github/workflows/track-benchmarks.yml`) parses via
 `track-benchmarks.yml` runs daily (and on every PR/push) on Linux, Windows and macOS.
 For each OS it benchmarks several **version roles**:
 
-- `nightly` — the newest `-nightly.*` build from the [EAP feed](https://aka.ms/skiasharp-eap/index.json) (the daily trend);
+- `nightly` — the newest `-nightly.*` build from the [dotnet-libraries feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json) (the daily trend);
 - `curr-stable` / `prev-stable` / `prev-major` — released baselines (same roles as the artifact-size tracker);
 - `pr` — a **full source build** (native + managed) of the checkout, so native/C-API
   changes show up in the ⭐ "this PR" column. See the sibling

--- a/benchmarks/SkiaSharp.Benchmarks.Tracking/nuget.config
+++ b/benchmarks/SkiaSharp.Benchmarks.Tracking/nuget.config
@@ -3,14 +3,13 @@
   Standalone feed set for the tracking benchmarks. `<clear />` detaches this
   project from any inherited sources so it resolves ONLY from:
     * dotnet-public (dnceng public mirror) for BenchmarkDotNet + its dependencies, and
-    * the SkiaSharp Early Access Preview feed for the daily `-nightly.*` builds
-      (https://aka.ms/skiasharp-eap/index.json).
+    * dotnet-libraries for the daily SkiaSharp `-nightly.*` builds.
   nuget.org is intentionally NOT used.
 -->
 <configuration>
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="skiasharp-eap" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/skiasharp/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/documentation/dev/building-samples.md
+++ b/documentation/dev/building-samples.md
@@ -6,10 +6,10 @@ This guide explains how to build SkiaSharp samples using CI-produced NuGet packa
 
 Official builds register wrapper packages as non-shipping assets in the same BAR
 as the product packages. The Maestro `SkiaSharp` channel routes them to the
-separate **SkiaSharp Transport** Azure DevOps feed:
+shared **dotnet-libraries-transport** Azure DevOps feed:
 
 ```
-https://pkgs.dev.azure.com/dnceng/public/_packaging/skiasharp-transport/nuget/v3/index.json
+https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json
 ```
 
 These wrapper packages bundle the real NuGet packages inside their `tools/` directory:
@@ -91,7 +91,7 @@ These arguments control **which CI build** to fetch from the feed:
 | Argument | Environment variable | Default | Purpose |
 |----------|---------------------|---------|---------|
 | `--gitBranch` | `GIT_BRANCH_NAME` | `""` | Fetch by branch name |
-| `--previewFeed` | — | SkiaSharp Transport URL | Override the NuGet feed |
+| `--previewFeed` | — | dotnet-libraries-transport URL | Override the NuGet feed |
 
 ### For building samples (`samples`)
 
@@ -168,4 +168,4 @@ Some platforms are disabled by default:
 May need a newer `Microsoft.WindowsAppSDK` version.
 
 ### NuGet feed authentication
-The SkiaSharp Transport feed is public — no authentication required.
+The dotnet-libraries-transport feed is public — no authentication required.

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -97,6 +97,9 @@ Pushing a `release/*` branch triggers the current dnceng release chain:
 | `skiasharp-package` | 1642 | Build, signing, API Scan, BAR registration, packages |
 | `skiasharp-tests` | 1630 | Tests consuming the exact Build pipeline resource |
 
+Arcade routes `IsShipping=true` packages to `dotnet-libraries` and
+`IsShipping=false` build inputs to `dotnet-libraries-transport`.
+
 The team-owned release process reviews the connected Build and Tests runs,
 selects their exact BAR/packages, and publishes them to NuGet.org through its
 protected publication pipeline. Repository automation does not query, queue, or

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -5,7 +5,8 @@ branches, the dnceng pipelines to build and test them, and the team-owned
 publication pipeline to publish packages.
 
 ```text
-Release - Prepare -> dnceng Build/Tests -> team publication -> GitHub release/milestones
+Release - Prepare -> dnceng Build/Tests + BAR -> release-testing approval
+    -> team publication -> GitHub release/milestones
 ```
 
 ## Safety
@@ -100,10 +101,35 @@ Pushing a `release/*` branch triggers the current dnceng release chain:
 Arcade routes `IsShipping=true` packages to `dotnet-libraries` and
 `IsShipping=false` build inputs to `dotnet-libraries-transport`.
 
-The team-owned release process reviews the connected Build and Tests runs,
-selects their exact BAR/packages, and publishes them to NuGet.org through its
-protected publication pipeline. Repository automation does not query, queue, or
-approve this internal boundary.
+The team-owned release process selects the exact connected Build and Tests runs
+and their BAR. Before publication, use
+[release-testing](../../.agents/skills/release-testing/SKILL.md) with the exact
+SkiaSharp CI package version:
+
+```bash
+python3 .agents/skills/release-testing/scripts/plan-release-tests.py 4.150.3
+```
+
+The planner asks Maestro which BAR produced that version. If more than one
+build produced it, pass the release-approved BAR explicitly:
+
+```bash
+python3 .agents/skills/release-testing/scripts/plan-release-tests.py \
+  4.150.3 --bar-id 329644
+```
+
+The planner resolves the BAR asset's GUID-backed per-build V3 and flat-container
+feed through Darc. It downloads exact `SkiaSharp` and `SkiaSharp.HarfBuzz`
+packages from that feed, derives the exact `HarfBuzzSharp` dependency, and
+requires all three packages to report the selected build's source branch and
+commit. Every runner receives the same package versions and GUID feed;
+`dotnet-public` supplies dependencies.
+
+The skill runs the approved host/device matrix and records the human
+release-approval gate. Failed required coverage blocks approval, but the skill
+does not publish packages or change BAR state. After approval, the team
+publishes the selected BAR to NuGet.org through its protected publication
+pipeline.
 
 ## 3. Create the public GitHub Release
 
@@ -179,19 +205,6 @@ also expose `apply` and `push`. The same script can be run locally:
 
 It derives both bug-report version dropdowns from published GitHub Releases and
 preserves every unrelated line in the issue form.
-
-## Optional public-package smoke testing
-
-After an exact package version is public, use
-[release-testing](../../.agents/skills/release-testing/SKILL.md) for
-host/device smoke testing:
-
-```bash
-python3 .agents/skills/release-testing/scripts/plan-release-tests.py \
-  4.153.0-preview.1.26431.1
-```
-
-This is advisory validation. It does not unlock or mutate publication state.
 
 ## Version reference
 

--- a/documentation/dev/releasing.md
+++ b/documentation/dev/releasing.md
@@ -101,6 +101,10 @@ Pushing a `release/*` branch triggers the current dnceng release chain:
 Arcade routes `IsShipping=true` packages to `dotnet-libraries` and
 `IsShipping=false` build inputs to `dotnet-libraries-transport`.
 
+Release-testing smoke-tests the exact selected CI artifacts on the approved
+host/device targets before team publication. NuGet.org is not a planner or
+runner source for this gate.
+
 The team-owned release process selects the exact connected Build and Tests runs
 and their BAR. Before publication, use
 [release-testing](../../.agents/skills/release-testing/SKILL.md) with the exact

--- a/documentation/dev/versioning.md
+++ b/documentation/dev/versioning.md
@@ -30,8 +30,8 @@ Official CI derives package build suffixes from Arcade's
 `4.152.0-preview.0.26418.3` from build `20260818.3`.
 
 > **Note:** There are two Azure DevOps feeds:
-> - **Signed builds** (`skiasharp`): the permanent target feed for regular packages (`SkiaSharp`, `HarfBuzzSharp`, etc.) promoted through Maestro after testing
-> - **Transport** (`skiasharp-transport`): unsigned, non-shipping build-input packages (`_NuGets`, `_NativeAssets`, etc.) routed separately by the same BAR/channel promotion
+> - **Signed builds** (`dotnet-libraries`): the permanent target feed for regular packages (`SkiaSharp`, `HarfBuzzSharp`, etc.) promoted through Maestro after testing
+> - **Transport** (`dotnet-libraries-transport`): unsigned, non-shipping build-input packages (`_NuGets`, `_NativeAssets`, etc.) routed separately by the same BAR/channel promotion
 
 Typically, the pre-release labels are:
  - `-alpha` is very early and has not really been tested

--- a/documentation/dev/writing-docs.md
+++ b/documentation/dev/writing-docs.md
@@ -104,7 +104,7 @@ cd ..
 dotnet cake --target=docs-download-output
 ```
 
-This downloads NuGet packages from the SkiaSharp Transport feed. By default it fetches from the `main` branch. To use a different branch:
+This downloads NuGet packages from the dotnet-libraries-transport feed. By default it fetches from the `main` branch. To use a different branch:
 
 ```bash
 dotnet cake --target=docs-download-output --gitBranch=my-feature-branch
@@ -144,7 +144,7 @@ For detailed XML documentation patterns and review criteria, see:
 
 | Target | Description |
 |--------|-------------|
-| `docs-download-output` | Downloads the `_nugets` package from the SkiaSharp Transport Azure Artifacts feed |
+| `docs-download-output` | Downloads the `_nugets` package from the dotnet-libraries-transport Azure Artifacts feed |
 | `docs-api-diff` | Generates the committed release-site API diffs under `documentation/docfx/releases/` from published NuGet.org packages; incremental and scoped with `--force`, `--minVersion`, `--maxVersion` |
 | `docs-update-frameworks` | Extracts assemblies, builds `frameworks.xml` with monikers, runs `mdoc update` to generate XML API docs |
 | `docs-format-docs` | Cleans XML output, removes duplicates, syncs extension method docs, reports coverage |

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -559,7 +559,7 @@
             <ul class="skill-list">
               <li><span class="skill-name">release-branch</span><br>Prepare matching SkiaSharp and Skia release branches.</li>
               <li><span class="skill-name">ci-status</span><br>Track public and internal Build/Test health across release branches.</li>
-              <li><span class="skill-name">release-testing</span><br>Optionally smoke-test exact public NuGet packages on real devices.</li>
+              <li><span class="skill-name">release-testing</span><br>Validate exact BAR packages before team publication across the host/device matrix.</li>
               <li><span class="skill-name">release-publish</span><br>Tag and create the GitHub release after the team publishes NuGet packages.</li>
               <li><span class="skill-name">release-milestones</span><br>Reconcile release assignments, dates, rollover, and closure.</li>
               <li><span class="skill-name">release-notes <span class="skill-auto">Automated</span></span><br>Generate the website release notes and API diffs from published NuGets and git history.</li>

--- a/documentation/site/ai/index.html
+++ b/documentation/site/ai/index.html
@@ -556,12 +556,13 @@
 
           <div class="skill-group">
             <h3>Release</h3>
+            <p>Repository-owned workflows and PowerShell scripts perform release mutations; these skills remain thin guidance and observation layers.</p>
             <ul class="skill-list">
-              <li><span class="skill-name">release-branch</span><br>Prepare matching SkiaSharp and Skia release branches.</li>
+              <li><span class="skill-name">release-branch</span><br>Guide the repository-owned Release - Prepare workflow and PowerShell script.</li>
               <li><span class="skill-name">ci-status</span><br>Track public and internal Build/Test health across release branches.</li>
-              <li><span class="skill-name">release-testing</span><br>Validate exact BAR packages before team publication across the host/device matrix.</li>
-              <li><span class="skill-name">release-publish</span><br>Tag and create the GitHub release after the team publishes NuGet packages.</li>
-              <li><span class="skill-name">release-milestones</span><br>Reconcile release assignments, dates, rollover, and closure.</li>
+              <li><span class="skill-name">release-testing</span><br>Physically smoke-test exact BAR artifacts before team publication.</li>
+              <li><span class="skill-name">release-publish</span><br>Guide Release - Finish after the team publishes NuGet packages.</li>
+              <li><span class="skill-name">release-milestones</span><br>Guide repository-owned assignment and milestone scripts.</li>
               <li><span class="skill-name">release-notes <span class="skill-auto">Automated</span></span><br>Generate the website release notes and API diffs from published NuGets and git history.</li>
             </ul>
           </div>

--- a/scripts/infra/perf/_common.py
+++ b/scripts/infra/perf/_common.py
@@ -23,7 +23,10 @@ import urllib.request
 USER_AGENT = "skiasharp-perf-tracker/1.0 (+https://github.com/mono/SkiaSharp)"
 
 # SkiaSharp package feeds.
-EAP_INDEX_URL = "https://aka.ms/skiasharp-eap/index.json"       # daily -nightly.* builds
+EAP_INDEX_URL = (
+    "https://pkgs.dev.azure.com/dnceng/public/"
+    "_packaging/dotnet-libraries/nuget/v3/index.json"
+)  # daily -nightly.* builds
 NUGET_FLATCONTAINER = "https://api.nuget.org/v3-flatcontainer"  # released stables
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?$")
@@ -112,7 +115,7 @@ def feed_versions(flat_base: str, package: str) -> list[str]:
 
 
 def eap_versions(package: str = "SkiaSharp") -> list[str]:
-    """All versions of ``package`` on the SkiaSharp EAP feed (hosts the -nightly.* builds)."""
+    """All versions of ``package`` on dotnet-libraries (hosts the -nightly.* builds)."""
     resources = http_get_json(EAP_INDEX_URL).get("resources", [])
     flat = pick_resource(resources, "PackageBaseAddress/")
     if not flat:

--- a/scripts/infra/perf/benchmarks/render_md.py
+++ b/scripts/infra/perf/benchmarks/render_md.py
@@ -195,7 +195,7 @@ def render_header(histories, oses):
               f"> Columns run newest → oldest. When present, **⭐ this PR** (a full source "
               f"build of SkiaSharp — native + managed — from the branch) is leftmost, then "
               f"🌙 the last {DISPLAY_DAYS} nightlies from the "
-              f"[EAP feed](https://aka.ms/skiasharp-eap/index.json), then released baselines "
+              f"[dotnet-libraries feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json), then released baselines "
               f"(from nuget.org). Each dot compares a cell to the older column on its right: "
               f"{TREND_FASTER} faster · {TREND_SLOWER} slower; < {TREND_PCT:.0%} is noise.", ""]
     return lines

--- a/scripts/infra/perf/benchmarks/resolve_versions.py
+++ b/scripts/infra/perf/benchmarks/resolve_versions.py
@@ -7,7 +7,7 @@ track-benchmarks.yml:
 
     {"nightly": "...", "curr-stable": "...", "prev-stable": "...", "prev-major": "..."}
 
-* nightly     -> newest `-nightly.*` on the SkiaSharp EAP feed.
+* nightly     -> newest `-nightly.*` on the dotnet-libraries feed.
 * curr/prev-* -> released stables from nuget.org's version list (read over plain HTTP;
                  the packages are restored from the build feeds, so nuget.org never
                  appears in a nuget.config).

--- a/scripts/infra/perf/sizes/render_md.py
+++ b/scripts/infra/perf/sizes/render_md.py
@@ -214,7 +214,7 @@ def is_native_package(history: dict, package_id: str) -> bool:
 def _legend() -> list[str]:
     return [
         "> Columns run newest → oldest (left → right): 🌙 daily nightlies from "
-        "the [EAP feed](https://aka.ms/skiasharp-eap/index.json), then the "
+        "the [dotnet-libraries feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json), then the "
         "released reference versions `latest → curr-stable → prev-stable → "
         "prev-major` from NuGet.org. "
         f"Each dot compares a cell to the older column on its right: "

--- a/scripts/infra/perf/sizes/track.py
+++ b/scripts/infra/perf/sizes/track.py
@@ -9,8 +9,8 @@ This script builds/updates a JSON "history" document that records:
 
 Two kinds of data points ("columns") are collected:
 
-  * ``nightly`` -- the latest ``-nightly.*`` build from the official SkiaSharp
-    Early Access Preview feed (https://aka.ms/skiasharp-eap/index.json). Every
+  * ``nightly`` -- the latest ``-nightly.*`` build from the shared
+    dotnet-libraries feed. Every
     package is measured at its family's headline nightly version (SkiaSharp and
     HarfBuzzSharp version independently), keyed by the observation date. The
     newest ``--max-nightly`` days are kept.

--- a/scripts/infra/shared/shared.cake
+++ b/scripts/infra/shared/shared.cake
@@ -102,7 +102,7 @@ var NUGET_DIFF_PRERELEASE = Argument ("nugetDiffPrerelease", false);
 var COVERAGE = Argument ("coverage", false);
 var CHROMEWEBDRIVER = Argument ("chromedriver", EnvironmentVariable ("CHROMEWEBDRIVER"));
 
-var CI_ARTIFACTS_FEED_URL = Argument ("previewFeed", "https://pkgs.dev.azure.com/dnceng/public/_packaging/skiasharp-transport/nuget/v3/index.json");
+var CI_ARTIFACTS_FEED_URL = Argument ("previewFeed", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json");
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // NUGET PACKAGES


### PR DESCRIPTION
## Description

Aligns SkiaSharp's repository-owned CI observers, Component Governance audit, shared-feed documentation, and complete repository release framing with the current dnceng ecosystem.

This independently ports the coherent dnceng observer/feed scope from source commit `086f728b32d3423dc234cbb3e5a0bbec083d1cfe` in #4889. It now builds directly on main after #4907 merged the BAR-specific pre-publication approval implementation:

- `ci-status` models public validation plus `skiasharp-package` (1642) and its connected `skiasharp-tests` (1630) run in `dnceng/internal`.
- `security-audit` queries Component Governance from the combined `skiasharp-package` Build that owns native and managed assets.
- Arcade routes shipping outputs to `dotnet-libraries` and non-shipping build inputs to `dotnet-libraries-transport`; ordinary CI/nightly consumers use those shared feeds.
- the team selects the exact connected Build, Tests, and BAR family before publication. The merged #4907 implementation asks Maestro which BAR produced the version, resolves that BAR asset's GUID-backed per-build V3/flat-container feed through Darc, and validates `SkiaSharp`, `SkiaSharp.HarfBuzz`, and derived `HarfBuzzSharp` against the selected build's source branch and commit.
- #4907 propagates the resolved GUID feed and exact versions through every runner and generated integration project; `dotnet-public` supplies dependencies. Those implementation/integration files are inherited from main and absent from #4910's direct diff.
- failed required coverage blocks human release approval, while release-testing never publishes packages or changes BAR state. NuGet.org belongs only to later protected team publication.
- `documentation/dev/releasing.md`, all three root `AGENTS.md` references, and the release-testing description in `documentation/site/ai/index.html` render that complete final flow; the guide explicitly excludes NuGet.org from approval planner/runner sources.
- the AI site now explains that repository-owned workflows and PowerShell scripts perform release mutations while release skills remain thin guidance and observation layers.

The repository-wide audit confirmed that no stale public-smoke phrases remain outside historical release artifacts. Retained old feed names are intentional: `manage-nuget-feed.ps1` is the historical xamarin migration utility, while the merged #4907 checked-in fallback config is overridden in approval runs by the resolved GUID feed. `SkiaSharp-Tests` in `tests-apple.cake` is a simulator name rather than a pipeline reference.

**Related issues**

Context: https://github.com/mono/SkiaSharp/pull/4907

Context: https://github.com/mono/SkiaSharp/pull/4889

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — infrastructure and contributor documentation only; no public API or runtime behavior changes.

## Testing

- Compiled 15 alignment Python files and validated the ci-status, security-audit, and release-testing skill frontmatters.
- Validated representative CI-status and security-audit reports with their repository validators.
- Ran all 38 release-testing Python tests and the guarded PowerShell preparation behavior suite inherited from main.
- Ran the live planner for `SkiaSharp 4.150.3` with BAR `329644`; it selected build `4.150.3+20260828.7`, source `release/4.150.3@f8a404ff3375872d042404a29189ceb8e3001a41`, and GUID feed `8bf0dc6d-5564-4f8e-8ff2-8167b63c6306` for all three anchors and every runner command.
- Ran `python3 scripts/infra/caching/repo-deps.py validate` (4,800 tracked files, 0 uncovered).
- Parsed changed JSON and NuGet XML configuration files and confirmed the merged #4907 implementation/integration files are inherited from main and absent from the direct diff.
- Resolved current nightlies through `dotnet-libraries` and confirmed both shared feed service indexes return HTTP 200.
- `externals-download` completed from `dotnet-libraries-transport`: 18 wrapper packages produced 462 native files (3.2 GB).
- `docs-download-output` completed from `dotnet-libraries-transport`: `_nugets` plus three dependency chunks produced 41 NuGet packages (570 MB).
- Restored SkiaSharp `4.150.3` and HarfBuzzSharp `14.2.1.3` through the resolved GUID feed with `dotnet-public` dependencies; integration `SmokeTests` passed 3/3.
- [Track - Benchmarks run 33565525986](https://github.com/mono/SkiaSharp/actions/runs/33565525986) completed successfully on this head with all 20 jobs passing.
- Verified three direct commits and 25 direct files: the non-framing alignment plus final framing in `AGENTS.md`, `documentation/dev/releasing.md`, and `documentation/site/ai/index.html`.
- Verified no stale public-smoke phrases remain in the live tree outside historical release artifacts; retained-reference boundaries and `git diff --check` pass.

## Checklist

- [x] Tests added or updated (merged BAR feed propagation exercised)
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A
