### PR TITLE
[skills] Close pr-commit-message gaps found in release message reviews

### DIFF
--- a/.agents/skills/pr-commit-message/SKILL.md
+++ b/.agents/skills/pr-commit-message/SKILL.md
@@ -34,7 +34,10 @@ high-cost failures before drafting:
 - For each candidate universal, bound, count, or inequality, privately record the complete
   search universe and check it for counterexamples. Proof over a subset cannot support a
   claim about the whole API, repository, platform set, or generated surface. One outlier
-  means the quantified wording must be narrowed or removed.
+  means the quantified wording must be narrowed or removed. When that universe is a family
+  of similar artifacts such as workflows, projects, targets, or packages, list its members
+  and the dimension being generalized, then read that dimension on each member. Families
+  that look uniform usually are not, and reading two of five is how a false universal ships.
 - Inspect human discussion on the current PR and every related or superseded PR whose work or
   feedback is carried forward. Adopted feedback needs source-backed attribution or a required
   `Missing context:` line when the contributor's email cannot be verified.
@@ -130,6 +133,15 @@ Apply these boundary rules:
   each independently justifies safe adoption.
 - Review-found correctness or safety changes remain explicit decisions, or become topics
   when they have independent search intent.
+- A shared mechanism, guard, or contract that several topics route through is itself a topic
+  when it carries a guarantee, invariant, or safety rule that none of its consumers own. It
+  is easy to mistake for plumbing precisely because it appears everywhere; distributing it
+  as a sentence inside each consumer leaves that guarantee without a home and hides why the
+  consumers became uniform.
+- A removal, replacement, or move belongs to the topic that performs it, but the departing
+  component still needs its name, the behavior that left with it, and where that
+  responsibility now lives. This message is the only thing a future search for the deleted
+  name will find.
 
 Use a counterfactual independence test before collapsing any candidate: if its correction
 were reverted while the proposed parent remained, would a distinct failure, constraint, or
@@ -172,7 +184,10 @@ Start the body with verified references. Use labels only for the relationship th
 - `Fixes:` for an issue the PR closes
 - `Context:` for related issues, PRs, runs, announcements, documentation, URLs, or exact
   commit SHAs
-- `Requires:` for a companion PR or dependency that must land
+- `Requires:` for the immediate companion PR or dependency this change is built on and
+  cannot merge without. In a stack, that is the parent you actually build on; an earlier
+  ancestor in the same stack explains context but is not what this change requires, so it
+  belongs under `Context:`
 - `Changes:` for dependency compare views or upstream ranges
 - another label only when recent repository history establishes both its spelling and use
 
@@ -188,6 +203,11 @@ Preserve the content expected for the kind of change:
   project response, and authoritative links
 - **Public API:** programming model, ownership or lifetime rules, native dependency, and
   platform limitations
+- **Configuration or policy split:** each context, the value it receives, and the reason the
+  difference is deliberate. An undocumented split reads as an inconsistency, and the next
+  reader unifies it and reintroduces the failure it was preventing
+- **Removal or migration:** the removed component by name, the behavior that left with it,
+  and where that responsibility now lives
 
 For multiple topics, use this shape:
 
@@ -211,7 +231,11 @@ For multiple topics, use this shape:
 <trailers>
 ```
 
-Name sections after the actual problem or decision, not `Changes` or `Implementation`.
+Name sections after the actual problem or decision, not `Changes` or `Implementation`. A
+component, file, or artifact category is not the decision either; prefer the boundary,
+failure, or rule the section resolves. Lead the overview with the governing design rather
+than with provenance or scope bookkeeping — where the work was extracted from is one fact
+the message can state, not the reason the change exists.
 Use bullets for explicit decisions inside a topic, not as a substitute for topic sections.
 Keep exception snippets, logs, reference lists, and bullets in-family for the target
 repository.
@@ -241,11 +265,23 @@ Check the final draft by claim type:
   outlier. Narrow or remove the qualifier when any counterexample exists.
 - **Precision:** verify exception names, predicates, revisions, versions, test counts,
   benchmark values, platform claims, and validation results against their exact sources.
-  Prefer durable validation evidence; omit transient pending, queued, or action-required
-  status unless it explains a shipped design decision.
+  Re-read measurements and counts at the current head; a number captured before a later
+  push was true when observed and is wrong now. Prefer durable validation evidence; omit
+  transient pending, queued, or action-required status unless it explains a shipped design
+  decision.
+- **Coverage and capability claims:** describe what tests, validation, or a guard actually
+  assert, in the terms the assertions use, rather than the capability they gesture at.
+  "Covers remote branch authority" and "covers guarded pushes and direct-invocation guards"
+  read as equivalent until someone relies on the first one and finds nothing behind it.
+- **Safety and non-behavior claims:** replace an adjective such as read-only, safe,
+  isolated, advisory, or deterministic with the specific thing that cannot happen and to
+  which neighboring system. The adjective is what a later change quietly violates, because
+  nothing in it says which guarantee was load-bearing.
 - **Causal rationale:** verify reasons copied from PR descriptions, commits, or comments.
   Preserve meaningful non-goals and limitations, but label inference as inference or omit
-  uncertain precision.
+  uncertain precision. A non-goal is durable when it states a lasting reason; "deferred",
+  "excluded by request", or "out of scope for review size" is development chronology and
+  stops being true the moment the follow-up lands.
 - **Mixed-truth sentences:** split a verified fact from an unsupported qualifier instead of
   accepting the whole sentence because half is true.
 
@@ -267,8 +303,10 @@ retain both.
 Accept a `(name, email)` pair only when that exact email appears in a relevant commit author
 entry, a co-author trailer, or the non-null `email` field returned by
 `gh api users/<login>`. Never infer an address from a name or organization, construct a
-GitHub noreply address, or mine unrelated commits. If a contributing human reviewer has no
-verified email, omit the trailer and report:
+GitHub noreply address, or mine unrelated commits. A trailer your own environment or house
+style would normally append is not evidence either; it belongs here only when this PR's own
+commits record it. If a contributing human reviewer has no verified email, omit the trailer
+and report:
 
 ```text
 Missing context: verified email for @login
@@ -281,8 +319,9 @@ updaters and automated review accounts; they are not missing human contributors.
 coding agents when they authored code or appear in a co-author trailer.
 
 Every eligible candidate in the resulting attribution map must appear exactly once in the
-trailers, or in `Missing context:` when a contributing human lacks a verified email. Place
-trailers at the end of the message after a blank line, one per line.
+trailers, or in `Missing context:` when a contributing human lacks a verified email. Trailers
+are part of the commit message, so place them inside the fenced block at the end after a
+blank line, one per line; only `Missing context:` lines belong outside the fence.
 
 ### 6. Format and check the final output
 
@@ -291,7 +330,9 @@ After drafting and attribution, confirm:
 1. Every substantive changed path maps to a topic, explicit decision, or derivative, and
    `section count == material-topic count` whenever that count is two or more.
 2. Every topic explains need or symptom, cause or constraint, chosen change, and evidence;
-   every explicit decision and decisive anchor has one visible home.
+   every explicit decision and decisive anchor has one visible home. Sibling sections carry
+   comparable evidence; an asymmetry there is usually a dropped anchor rather than a
+   genuinely unverified topic.
 3. Every precise, relational, causal, quantified, and validation claim has its completed
    proof entry; no proof over a subset is worded as a whole-surface claim.
 4. Every eligible attribution candidate, including relevant PR and commit authors, appears

--- a/.agents/skills/pr-commit-message/SKILL.md
+++ b/.agents/skills/pr-commit-message/SKILL.md
@@ -283,7 +283,10 @@ Check the final draft by claim type:
   "excluded by request", or "out of scope for review size" is development chronology and
   stops being true the moment the follow-up lands.
 - **Mixed-truth sentences:** split a verified fact from an unsupported qualifier instead of
-  accepting the whole sentence because half is true.
+  accepting the whole sentence because half is true. Watch for two distinct things the
+  evidence calls by the same role word — a control, a baseline, a fixture, a config — and
+  confirm which one each clause is about before joining them, because merging them yields a
+  sentence whose halves are both true and whose join is not.
 
 ### 5. Build source-backed attribution
 

--- a/.agents/skills/pr-commit-message/evals/evals.json
+++ b/.agents/skills/pr-commit-message/evals/evals.json
@@ -42,6 +42,110 @@
       "prompt": "Write a concise but informative merge commit message for PR #3614 in mono/SkiaSharp. It removes a cached designMode field and LicenseManager check from SKControl and SKGLControl because the built-in DesignMode property already handles Windows Forms design-time detection correctly. The change was extracted from #3553.",
       "expected_output": "The message should stay compact, explain that the custom design-time detection was redundant, and optionally preserve the provenance that this was extracted from a broader PR.",
       "files": []
+    },
+    {
+      "id": 8,
+      "name": "shared-mechanism-topic-count",
+      "prompt": "Write the squash commit message for PR #5120 in acme/toolbox. I am offline, so work only from this dump; do not try to fetch anything.\n\nPR title: [build] Replace ad-hoc shell invocations in the packaging scripts\nPR description, in the author's own words: \"Cleans up the three packaging scripts and adds some tests.\"\n\nChanged files:\n  M scripts/pack-nuget.ps1\n  M scripts/sign-artifacts.ps1\n  M scripts/publish-feed.ps1\n  A scripts/Exec.Common.psm1\n  A scripts/Feed.Common.psm1\n  A tests/Packaging.Tests.ps1\n  M (26 more files, almost all call-site updates)\n\nNotes I took while reading the diff, in no particular order:\n\n- publish-feed.ps1 used to take its feed URL from an environment variable. That is how run 88213 pushed to a public feed. It now requires an explicit -Feed and rejects any feed outside the allow-list.\n- Exec.Common.psm1 runs every external process from an explicit repository root.\n- pack-nuget.ps1 read versions from a checked-in copy of versions.props that had drifted, so packages shipped with the previous night's version number. It now reads the generated Versions.g.props.\n- Feed.Common.psm1 retries transient feed reads three times with backoff.\n- sign-artifacts.ps1 signed everything under artifacts/, including *.symbols.nupkg, which the signing service rejects, so the signing step failed intermittently. It now filters to *.nupkg excluding *.symbols.nupkg.\n- Both modules print any skipped mutation as a copyable command that names the -Push guard which suppressed it.\n- After this PR, no production entry point calls git or dotnet nuget directly; every call goes through the two modules.\n- tests/Packaging.Tests.ps1 has 41 tests. They assert: no production script contains a direct git or dotnet nuget call; the Versions.g.props selection; the symbols filter; the allow-list rejection; and that skipped mutations print their guard name. Nothing in it contacts a feed.\n- Harness passes 41/41 at head. A publish-feed.ps1 dry run printed 6 skipped commands and wrote nothing.",
+      "expected_output": "Four named topic sections, one of them dedicated to the shared execution/guard modules and their harness rather than distributing that guarantee across the three script sections.",
+      "files": [],
+      "expectations": [
+        "The shared execution/guard layer (Exec.Common.psm1 and Feed.Common.psm1) has its own named topic section rather than appearing only as sentences inside the three per-script sections",
+        "The section covering the shared layer carries the guarantees that belong to it: the explicit repository root, the three-retry backoff, the guard-named skipped-mutation output, and that no production entry point calls git or dotnet nuget directly",
+        "All three per-script root-cause anchors survive and stay attached to their own script: the drifted versions.props copy, the rejected *.symbols.nupkg, and run 88213",
+        "The message does not claim the harness covers real feed publication, and describes its coverage in the terms the 41 tests assert",
+        "The message does not adopt the author's vague framing ('cleans up the three packaging scripts and adds some tests') as the overview"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "heterogeneous-family-universals",
+      "prompt": "Draft the merge commit message for PR #5188 in acme/toolbox. Offline: use only what is below.\n\nThe PR description says, verbatim:\n\n  \"Adds the packaging workflow family. Every one of these workflows is a\n  maintainer-triggered manual job that defaults its mutation inputs to false\n  and refuses to run off the default branch, so nothing here can fire on its\n  own. Also drops the old publisher tool.\"\n\nHere are the `on:` blocks I pulled out of the four added workflow files:\n\n.github/workflows/pack-dispatch.yml\n  on:\n    workflow_dispatch:\n      inputs: {base, release, apply, push}\n\n.github/workflows/sign-dispatch.yml\n  on:\n    workflow_dispatch:\n      inputs: {version, push}\n\n.github/workflows/packaging-tests.yml\n  on:\n    pull_request:\n      paths: [\"scripts/**\", \".github/workflows/*.yml\"]\n    push:\n      branches: [main]\n\n.github/workflows/refresh-allowlist.yml\n  on:\n    schedule:\n      - cron: \"0 7 * * *\"\n    workflow_dispatch:\n\nOther things in the diff: pack-dispatch and sign-dispatch both default apply/push to false and have a job-level guard that exits unless the ref is the default branch. sign-dispatch.yml ends with a step that dispatches refresh-allowlist, wrapped in `if: inputs.version does not contain '-'`. The PR also deletes tools/legacy-publisher/ (publisher.py, publisher_feed.py, 22 tests); feed publication moved to the hosted packaging pipeline and nothing in the repo calls the tool now.",
+      "expected_output": "No false universal about how the workflows are triggered; the CI-only and scheduled workflows are both represented; the stable-only dispatch is stated as conditional; the deleted tool is named with its reason.",
+      "files": [],
+      "expectations": [
+        "The message does not repeat the PR description's universal claim that every workflow is a manually triggered job that cannot fire on its own",
+        "packaging-tests.yml is represented as running on pull requests and pushes to main, and is not described as manually dispatched or guarded by a mutation input",
+        "refresh-allowlist.yml is represented as running on a daily schedule in addition to manual dispatch",
+        "The mutation-input default and default-branch guard are attributed only to pack-dispatch and sign-dispatch, not to the whole family",
+        "The follow-on allow-list dispatch is described as conditional on a stable (non-prerelease) version rather than unconditional",
+        "The removed tools/legacy-publisher is named explicitly, with what it did and where that responsibility now lives"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "coverage-and-safety-claims",
+      "prompt": "Write the merge commit message for PR #5205 in acme/toolbox. Offline; use only what is below.\n\nThe PR description says, verbatim:\n\n  \"Makes release verification safe and read-only. The suite fully covers the\n  publish and release path, so we can trust the result end to end.\"\n\nCommits on the branch, oldest first:\n  a1c9f02  2026-03-02  Add verification receipt check\n  7b31e88  2026-03-04  Address review: drop the commit-status wait\n  e04ad51  2026-03-06  Rescan coverage after rebase   <- current head\n\nCoverage scan output found in the PR conversation:\n  posted 2026-03-02 -> \"1,204 tracked files, 3 uncovered\"; resolver picked runtime 9.0.0-nightly.25510.4\n  posted 2026-03-06 -> \"1,231 tracked files, 0 uncovered\"; resolver picked runtime 9.0.0-nightly.25522.1\n\nWhat the diff actually does: the verification workflow writes its result into the job summary. Nothing in the publish path reads it. The workflow has no write permissions on releases or tags. Before this PR the workflow set a commit status and the publish job had a `needs`/wait on that status; that wait is deleted in 7b31e88.\n\ntests/Verify.Tests.ps1, full list of test names:\n  RejectsMissingReceipt, RejectsMalformedReceipt, RejectsEmptyReceipt, RejectsUnsignedReceipt,\n  RejectsMismatchedCommit, RejectsMismatchedBranch, RejectsMismatchedRepo, RejectsShortSha,\n  AcceptsExactVersion, AcceptsExactVersionWithBuildMetadata, AcceptsStableVersion, AcceptsHotfixVersion, AcceptsRcVersion,\n  PrintsSkippedCommands, PrintsGuardName, PrintsCopyablePush,\n  DoesNotWriteWhenPushIsFalse, DoesNotWriteWhenValidationFails\nThere is no test that runs the publish job and none that calls a real GitHub release.",
+      "expected_output": "Uses only the current-head measurements, states concretely what the workflow cannot do rather than relying on an adjective, and scopes the test claim to what the 18 tests assert.",
+      "files": [],
+      "expectations": [
+        "The message reports 1,231 tracked files with none uncovered as the shipped measurement and does not present the 1,204/3-uncovered figures as the result of this change",
+        "The message reports runtime 9.0.0-nightly.25522.1 and does not present 25510.4 as the shipped value",
+        "The message does not repeat the PR description's claim that the suite fully covers the publish and release path",
+        "Test coverage is described in the terms the 18 test names actually assert (receipt validation, identity mismatch rejection, version acceptance, skipped-command output, no-write behaviour) rather than as end-to-end release verification",
+        "The message states concretely what the verification workflow cannot do (does not gate, block, or mutate publication, holds no release/tag write permission) rather than relying only on adjectives such as safe, read-only, or advisory",
+        "The message records that the publish job's wait on the verification commit status was removed"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "stacked-pr-relationships",
+      "prompt": "Create the squash commit message for PR #5240 in acme/toolbox. Offline; use only what is below.\n\nBranch topology I pulled with `gh pr view --json headRefName,baseRefName`:\n  #5188  head: feat/pkg-workflows      base: main\n  #5205  head: feat/verify-advisory    base: feat/pkg-workflows\n  #5240  head: feat/verify-template    base: feat/verify-advisory\nAll three are still open.\n\nThe #5240 description says, verbatim:\n\n  \"Part of the packaging workflow effort. Requires #5188. Also needs the\n  shared template change in acme/pipeline-templates#77 before the template\n  reference resolves. Fixes #5100. See also #4990.\"\n\nI checked the linked items:\n  #5100 -> issue, \"verification receipts disagree between the two dispatch workflows\", open, and this PR closes it\n  #4990 -> issue, \"packaging pipeline design notes\", open, background discussion only, this PR does not close it\n  #5188 -> pull request, \"Add packaging workflow family\"\n  acme/pipeline-templates#77 -> pull request, \"Add shared verification receipt template\", open, must merge first\n\n#5240 does not modify any file that #5188 touches; all of its changes are on top of files #5205 introduced.\n\nThe change itself: the verification workflow now reads its receipt from the shared template instead of an inline copy, which removes the drift that made the two dispatch workflows report disagreeing receipts.",
+      "expected_output": "Fixes for #5100 only; Requires names the immediate parent #5205 and the cross-repo companion; #5188 is Context or omitted, never a requirement; #4990 is Context.",
+      "files": [],
+      "expectations": [
+        "Issue #5100 appears under a Fixes: label",
+        "PR #5205 appears under a Requires: label as the dependency this change is built on",
+        "acme/pipeline-templates#77 appears under a Requires: label",
+        "PR #5188 is not placed under a Requires: label despite the PR description saying 'Requires #5188'; it appears as Context: or is omitted",
+        "Issue #4990 is not presented as fixed or required; it appears as Context: or is omitted",
+        "No reference is mislabelled by entity type \u2014 the issues are not called PRs and the PRs are not called issues"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "mixed-context-configuration",
+      "prompt": "Write the merge commit message for PR #5262 in acme/toolbox. Offline; use only what is below.\n\nThe diff touches three things.\n\n(a) tests/integration/NuGet.config \u2014 the `acme-builds` source is removed, leaving:\n      nuget.org, dotnet-public\n\n(b) tests/integration/IntegrationHostBase.cs and tests/integration/LinuxSmokeTests.cs \u2014 both build a temporary NuGet.config at runtime, and both still write three sources:\n      nuget.org, dotnet-public, acme-builds\n    Neither file is changed by this PR.\n\n(c) docs/dev/package-sources.md \u2014 new file.\n\nFrom the PR conversation:\n  - A reviewer on the earlier PR #5199 wrote: \"these two configs should match, let's just add acme-builds to the checked-in one so the sources are consistent everywhere.\" That change was made in #5199.\n  - Verification run 91104, after #5199 merged, reported success for version 2.4.0. Investigating it showed the package it restored came from acme-builds, not from nuget.org.\n  - The post-publication verification run is the thing that uses the checked-in config; its whole purpose is to prove that a published version resolves from the public source.\n  - The runtime-generated configs are used by ordinary CI and by the nightly job, which have to restore packages that are not published anywhere public yet.\n\nVerification on this PR: both service indexes returned HTTP 200, and the three integration smoke tests passed against 2.4.0 and 2.4.0-rc.2.",
+      "expected_output": "Both configurations named with their contexts and source lists, the reason the split is deliberate, and enough for a future maintainer not to re-unify it.",
+      "files": [],
+      "expectations": [
+        "The message states that the checked-in integration config drops acme-builds while the runtime-generated configs from IntegrationHostBase/LinuxSmokeTests deliberately keep it",
+        "The message explains why the split is deliberate: post-publication verification must prove resolution from the public source, while CI and nightly runs must restore unpublished build-feed packages",
+        "The message preserves the concrete failure anchor \u2014 run 91104 reporting success against a package restored from acme-builds",
+        "The message does not describe the difference between the two configurations as an inconsistency, drift, or cleanup to be unified",
+        "The message gives a future maintainer the reason not to re-add acme-builds to the checked-in config"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "attribution-verified-emails",
+      "prompt": "Draft the squash commit message and trailers for PR #5301 in acme/toolbox. Offline; this is the complete evidence set I pulled.\n\n`gh pr view 5301 --json commits` gave, per commit:\n  c1 authors: [{name: Dana Whitfield, email: dana@whitfield.dev}]  messageBody: \"\"\n  c2 authors: [{name: Dana Whitfield, email: dana@whitfield.dev}]  messageBody: \"Co-authored-by: Priya Raman <priya.raman@example.org>\"\n  c3 authors: [{name: Dana Whitfield, email: dana@whitfield.dev}]  messageBody: \"co-authored-by: Dana Whitfield <dana@whitfield.dev>\"\n  c4 authors: [{name: Dana Whitfield, email: dana@whitfield.dev}]  messageBody: \"Co-authored-by: Priya Raman <priya.raman@example.org>\"\n  c5 authors: [{name: renovate[bot], email: bot@renovateapp.com}]  messageBody: \"\"\n\nReviews on #5301:\n  @sam-oduya \u2014 substantive review that changed the design; they asked for the retry to be bounded, and it now retries three times instead of looping forever. `gh api users/sam-oduya` returns \"email\": null.\n  @copilot-pull-request-reviewer[bot] \u2014 automated review, no feedback adopted.\n\nSuperseded PR #5290 was closed in favour of this one and its implementation was carried over wholesale. `gh pr view 5290 --json commits` gives one commit authored by [{name: Lin Huang, email: lin.huang@example.org}].\n\nThe change itself: the feed client retried transient reads in an unbounded loop, so a feed outage hung the packaging job until the six-hour runner timeout. It now retries three times with backoff and then fails with the underlying status code.",
+      "expected_output": "Verified co-authors once each including the carried-forward author, bots excluded, and a Missing context line for the reviewer with no verifiable email placed outside the commit message.",
+      "files": [],
+      "expectations": [
+        "Dana Whitfield appears exactly once in the trailers despite appearing as a commit author on four commits and in a lowercase co-author trailer",
+        "Priya Raman appears exactly once as a co-author trailer despite appearing on two commits",
+        "Lin Huang appears as a co-author trailer because the superseded PR's implementation was carried forward",
+        "Neither renovate[bot] nor the automated review account appears in the trailers",
+        "No email is invented for @sam-oduya; a 'Missing context: verified email for @sam-oduya' line appears outside the fenced commit message",
+        "Every email in the trailers appears verbatim in the supplied evidence \u2014 no address is constructed, and no GitHub noreply address is invented for anyone"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "control-single-topic-compact",
+      "prompt": "Write a merge commit message for PR #5318 in acme/toolbox. Offline; this is everything.\n\n`gh pr view 5318 --json commits` gives two commits, both authored by [{name: Rui Almeida, email: rui@almeida.dev}], with empty messageBody. There are no reviews and no comments.\n\nThe diff removes a cached `_isDesignMode` field and a `LicenseManager` probe from HostPanel and GLHostPanel, and points the four read sites at the base class's own `DesignMode` property, which already reports design time correctly on every runtime the project still supports. Four files, about 30 deleted lines. No runtime behaviour change and no new tests; the existing designer tests were not touched.\n\nThe PR description says it was split out of #5277, which is still open.",
+      "expected_output": "A compact single-topic message with no forced section markers that still explains the redundancy and keeps the #5277 provenance.",
+      "files": [],
+      "expectations": [
+        "The message contains no `~~ ... ~~` section markers",
+        "The body prose is short \u2014 roughly 12 lines or fewer, excluding subject, reference lines, and trailers",
+        "The message explains that the per-class design-time detection was redundant because the base DesignMode property already reports correctly",
+        "PR #5277 is not placed under a Requires: label; it appears as Context: or the provenance is stated without claiming a dependency",
+        "Rui Almeida appears as the only credited human, and no additional co-author is invented",
+        "No trailer uses an address absent from the supplied evidence \u2014 in particular no constructed GitHub noreply address, and no automated-tool trailer that the evidence does not record",
+        "The message invents no verification evidence, test runs, or issue references that the notes do not support"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

Five completed release-PR message reviews (#4889, #4895, #4907, #4908, #4910) each needed the same kinds of correction before the message was usable. Auditing the pre/post pairs showed most corrections traced back to a rule the `pr-commit-message` skill never stated, rather than to one-off drafting slips. This adds those rules and rebuilds the skill's eval set so the cases actually test the judgement the reviews had to perform.

Worked through the repository's `skill-creator` workflow: snapshot the baseline, build a private pre/post evidence matrix, run with-skill vs baseline evals, grade with independent grader subagents, aggregate, and review.

**Instruction gaps closed** (each traced to a specific correction):

| Change | Backed by |
|---|---|
| A shared mechanism carrying a guarantee its consumers don't own is a topic | #4889 — shared command safety collapsed into siblings |
| A removal keeps its name, departed behavior, and new home | #4889 — deleted `release-status` runtime under-covered |
| `Requires:` is the *immediate* dependency; a stack ancestor is `Context:` | #4907, #4910 — both required a grandparent PR |
| Enumerate a family's members along the dimension generalized | #4889 — "every workflow was one manual job", falsified by a scheduled and a CI-only workflow in the same directory |
| Coverage claims stated in the terms the assertions use | #4889 — claimed "remote branch authority"; tests asserted guarded pushes and invocation guards |
| Safety adjectives replaced by what cannot happen, and to whom | #4907 "read-only" → never gates or mutates publication; #4895 marker ownership |
| Re-read measurements at current head | #4910 — 4,793→4,798 files, nightly 26429.2→26431.1 |
| Config splits and removals added to the per-change-kind content list | #4910 — build-feed vs public-package boundary |
| Scope-negotiation notes are chronology | #4910 — dropped "excluded by request" bullets |
| Sibling sections carry comparable evidence | #4895 — final review added the missing regression-coverage sentence |
| House-style trailers are not evidence; trailers go inside the fence | Observed during evals (see Testing) |
| Split two entities the evidence calls by the same role word | Reproduced 2/2 in live drafting runs against this PR (see Testing) |

#4908 needed no corrections and is kept as a control case, so the changes are checked against a PR the skill already handled well.

Net +44 lines in SKILL.md (+56/-12), which is now 352 lines against the 500-line guideline. Name, description, intent, and section structure are unchanged.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — repository skill and its eval set only. No public API, no runtime or build behavior, and no generated output changes. The `merge-message` workflow reads `.agents/skills/pr-commit-message/SKILL.md` at runtime and does not embed it, so no `.lock.yml` regeneration is required.

## Testing

Evaluated with the `skill-creator` loop: 7 cases × 2 configurations (revised vs. the pre-edit snapshot), graded by independent grader subagents that were not told which configuration was which.

**The first pass proved nothing and is reported as such.** It scored 33/35 vs 32/35, inside run-to-run noise. The evals were at fault: the prompts handed over the conclusions ("the difference is deliberate", "cannot merge before it"), the notes were numbered so the topic count was given away, and one assertion hard-coded a section count from a single PR. Both graders independently flagged the assertions as non-discriminating.

The cases were rebuilt to present raw evidence plus the stale claim that caused the real correction — a PR description asserting a false universal its own trigger blocks contradict, a description requiring the wrong PR in a stack, a reviewer inviting the config unification that previously let a verification run pass against a build feed, and two revisions of a measurement with neither labelled current.

| Eval | revised | baseline |
|---|---|---|
| shared-mechanism-topic-count | **5/5** | 4/5 |
| heterogeneous-family-universals | 6/6 | 6/6 |
| coverage-and-safety-claims | **5/6** | 4/6 |
| stacked-pr-relationships | **6/6** | 5/6 |
| mixed-context-configuration | 4/5 | 4/5 |
| attribution-verified-emails | 6/6 | 6/6 |
| control-single-topic-compact | 7/7 | 7/7 |
| **total** | **39/41 (95.1%)** | **36/41 (87.8%)** |

At least equal on every eval, winning three. An arithmetic audit caught three grader summary miscounts, which were corrected downward before aggregation; the corrections are symmetric.

The wins are the targeted gaps. On the stack case the baseline left `#5205` in body prose and emitted no `Requires:` line for it — the exact #4907/#4910 failure — while the revised skill emits `Requires: acme/toolbox#5205`. On the shared-mechanism case the baseline folded the guard layer in with the test harness; the revised skill gives it its own home. On the safety case the baseline led with "safe to run" before giving concrete permissions.

Both configurations already refused the false universal and the overclaimed coverage, so those two additions are insurance rather than proven wins on this set. Neither caused a regression, and the control case stayed compact in both.

The eval runs also caught two real defects in the revised skill, both fixed and re-verified: a run invented a `Co-authored-by: Copilot <…@users.noreply.github.com>` trailer from no evidence, and a run placed a trailer outside the fenced block where it would never reach the commit. After the fixes, the two trailer-sensitive cases re-ran at 7/7 and 6/6.

### Live validation on this PR

The skill was then run against **this PR itself** — four independent agents, the
plain prompt "give me a commit message for the pr 4912", graded by a script that
re-derives ground truth from the live PR (2 changed files, 0 closing issues,
2 commit authors, 0 human reviewers). All four passed 15/15 mechanical checks.
Two traps were avoided every time: the bot-reported -414.5 KB package-size
delta, which a docs-only PR cannot cause, and the superseded 33/35 eval figures
that sit in this description beside the shipped 39/41.

Two runs then produced the *same* semantic defect independently — joining an
eval-rebuild clause to the fact that #4908 needed no corrections, because this
description happens to use "control case" for both #4908 and the compact eval.
The mixed-truth check covered the symptom but not the cause, so it now names the
case where two entities share a role word. The two follow-up runs kept them
apart, one stating the distinction outright. That is the second commit.

A third finding was recorded and deliberately not encoded: one run asserted an
unsupported detail about where `release-status` responsibilities moved. It did
not reproduce, and patching on a single sample is the overfitting this PR
otherwise avoids.

Validated with `skill-creator/scripts/quick_validate.py` ("Skill is valid!"). No rendering change, so no screenshots apply.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated

