### PR TITLE
Add Apple pointer hover and scroll input

### DIFF
--- a/samples/Basic/Maui/README.md
+++ b/samples/Basic/Maui/README.md
@@ -37,9 +37,11 @@ A freehand drawing canvas with a color palette, brush size slider, and clear but
 
 - **`SKCanvasView`** — Software-rendered canvas invalidated on demand after each stroke or clear.
 - **`SKPath`** — Freehand strokes captured as paths with `MoveTo` and `LineTo` from touch events.
-- **`SKTouchEventArgs`** — Cross-platform touch tracking for press, move, and release.
+- **`SKTouchEventArgs`** — Cross-platform contact tracking for drawing, two-contact pinch resizing, passive pointer hover, and wheel/trackpad scroll resizing.
 - **Color palette** — Six selectable colors with dark/light mode variants.
-- **Brush size** — Adjustable stroke width via a MAUI `Slider` control.
+- **Brush size** — Adjustable via a MAUI `Slider`, mouse wheel/trackpad scroll, or a two-contact pinch.
+
+On iPadOS and Mac Catalyst, moving a mouse or trackpad pointer over the canvas displays the current brush outline. Trackpad magnification is not represented by `SKTouchEventArgs`; the pinch interaction in this sample uses two real touch contacts.
 
 ## Requirements
 

--- a/samples/Basic/Maui/README.md
+++ b/samples/Basic/Maui/README.md
@@ -41,7 +41,7 @@ A freehand drawing canvas with a color palette, brush size slider, and clear but
 - **Color palette** — Six selectable colors with dark/light mode variants.
 - **Brush size** — Adjustable via a MAUI `Slider`, mouse wheel/trackpad scroll, or a two-contact pinch.
 
-On iPadOS and Mac Catalyst, moving a mouse or trackpad pointer over the canvas displays the current brush outline. Trackpad magnification is not represented by `SKTouchEventArgs`; the pinch interaction in this sample uses two real touch contacts.
+On iPadOS and Mac Catalyst, moving a mouse or trackpad pointer over the canvas displays the current brush outline. The sample interprets `WheelDelta` using the proposed [v120 convention](https://github.com/mono/SkiaSharp/issues/3533): 120 units represent one discrete wheel notch, while smaller magnitudes preserve precision scrolling. Trackpad magnification is not represented by `SKTouchEventArgs`; the pinch interaction in this sample uses two real touch contacts.
 
 ## Requirements
 

--- a/samples/Basic/Maui/README.md
+++ b/samples/Basic/Maui/README.md
@@ -41,7 +41,7 @@ A freehand drawing canvas with a color palette, brush size slider, and clear but
 - **Color palette** — Six selectable colors with dark/light mode variants.
 - **Brush size** — Adjustable via a MAUI `Slider`, mouse wheel/trackpad scroll, or a two-contact pinch.
 
-On iPadOS and Mac Catalyst, moving a mouse or trackpad pointer over the canvas displays the current brush outline. The sample interprets `WheelDelta` using the proposed [v120 convention](https://github.com/mono/SkiaSharp/issues/3533): 120 units represent one discrete wheel notch, while smaller magnitudes preserve precision scrolling. Trackpad magnification is not represented by `SKTouchEventArgs`; the pinch interaction in this sample uses two real touch contacts.
+On iPadOS and Mac Catalyst, moving a mouse or trackpad pointer over the canvas displays the current brush outline. The sample treats 120 `WheelDelta` units as one nominal compatibility notch while preserving smaller integer deltas from precision scrolling. Apple maps UIKit point translation to this legacy scale using a browser-style content-scroll sensitivity, not a hardware detent calibration. [#3533](https://github.com/mono/SkiaSharp/issues/3533) tracks a future fractional two-axis scroll API. Trackpad magnification is not represented by `SKTouchEventArgs`; the pinch interaction in this sample uses two real touch contacts.
 
 ## Requirements
 

--- a/samples/Basic/Maui/SkiaSharpSample/DrawingPage.xaml.cs
+++ b/samples/Basic/Maui/SkiaSharpSample/DrawingPage.xaml.cs
@@ -11,6 +11,8 @@ namespace SkiaSharpSample;
 
 public partial class DrawingPage : ContentPage
 {
+	const float WheelDeltaPerNotch = 120f;
+
 	static readonly (SKColor Light, SKColor Dark)[] colorPalette =
 	{
 		(SKColors.Black, SKColors.White),
@@ -153,7 +155,7 @@ public partial class DrawingPage : ContentPage
 				break;
 
 			case SKTouchAction.WheelChanged:
-				SetBrushSize(brushSize + e.WheelDelta / 120f);
+				SetBrushSize(brushSize + e.WheelDelta / WheelDeltaPerNotch);
 				break;
 		}
 		e.Handled = true;

--- a/samples/Basic/Maui/SkiaSharpSample/DrawingPage.xaml.cs
+++ b/samples/Basic/Maui/SkiaSharpSample/DrawingPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
@@ -21,7 +22,11 @@ public partial class DrawingPage : ContentPage
 	};
 
 	readonly List<(SKPath Path, SKColor Color, float Width)> strokes = new();
+	readonly Dictionary<long, SKPoint> activeTouches = new();
 	SKPathBuilder? currentBuilder;
+	long? strokeTouchId;
+	float? previousPinchDistance;
+	SKPoint? hoverPoint;
 	SKColor currentColor;
 	float brushSize = 4f;
 
@@ -68,34 +73,87 @@ public partial class DrawingPage : ContentPage
 	{
 		switch (e.ActionType)
 		{
+			case SKTouchAction.Entered:
+				hoverPoint = e.Location;
+				skiaView.InvalidateSurface();
+				break;
+
 			case SKTouchAction.Pressed:
-				currentBuilder = new SKPathBuilder();
-				currentBuilder.MoveTo(e.Location);
+				activeTouches[e.Id] = e.Location;
+				hoverPoint = null;
+				if (activeTouches.Count == 1)
+				{
+					strokeTouchId = e.Id;
+					currentBuilder = new SKPathBuilder();
+					currentBuilder.MoveTo(e.Location);
+				}
+				else if (activeTouches.Count >= 2)
+				{
+					currentBuilder?.Dispose();
+					currentBuilder = null;
+					strokeTouchId = null;
+					previousPinchDistance = activeTouches.Count == 2 ? GetPinchDistance() : null;
+				}
 				break;
 
 			case SKTouchAction.Moved:
-				currentBuilder?.LineTo(e.Location);
+				if (!e.InContact)
+				{
+					hoverPoint = e.Location;
+				}
+				else
+				{
+					activeTouches[e.Id] = e.Location;
+					if (activeTouches.Count == 2)
+					{
+						var distance = GetPinchDistance();
+						if (previousPinchDistance is > 0)
+							SetBrushSize(brushSize * distance / previousPinchDistance.Value);
+						previousPinchDistance = distance;
+					}
+					else if (activeTouches.Count > 2)
+					{
+						previousPinchDistance = null;
+					}
+					else if (strokeTouchId == e.Id)
+					{
+						currentBuilder?.LineTo(e.Location);
+					}
+				}
 				skiaView.InvalidateSurface();
 				break;
 
 			case SKTouchAction.Released:
-				if (currentBuilder != null)
+				activeTouches.Remove(e.Id);
+				if (strokeTouchId == e.Id && currentBuilder != null)
 				{
 					strokes.Add((currentBuilder.Detach(), currentColor, brushSize));
 					currentBuilder = null;
-					skiaView.InvalidateSurface();
 				}
+				if (strokeTouchId == e.Id)
+					strokeTouchId = null;
+				previousPinchDistance = activeTouches.Count == 2 ? GetPinchDistance() : null;
+				skiaView.InvalidateSurface();
 				break;
 
 			case SKTouchAction.Cancelled:
-				currentBuilder?.Dispose();
-				currentBuilder = null;
+				activeTouches.Remove(e.Id);
+				if (strokeTouchId == e.Id)
+				{
+					currentBuilder?.Dispose();
+					currentBuilder = null;
+					strokeTouchId = null;
+				}
+				previousPinchDistance = activeTouches.Count == 2 ? GetPinchDistance() : null;
+				break;
+
+			case SKTouchAction.Exited:
+				hoverPoint = null;
+				skiaView.InvalidateSurface();
 				break;
 
 			case SKTouchAction.WheelChanged:
-				brushSize = Math.Clamp(brushSize + e.WheelDelta, 1f, 50f);
-				brushSlider.Value = brushSize;
-				brushLabel.Text = $"{brushSize:F0}";
+				SetBrushSize(brushSize + e.WheelDelta / 120f);
 				break;
 		}
 		e.Handled = true;
@@ -128,6 +186,27 @@ public partial class DrawingPage : ContentPage
 			paint.StrokeWidth = brushSize;
 			canvas.DrawPath(path, paint);
 		}
+
+		if (hoverPoint is { } hover)
+		{
+			paint.Color = currentColor.WithAlpha(128);
+			paint.StrokeWidth = 1;
+			canvas.DrawCircle(hover, brushSize / 2f + 2f, paint);
+		}
+	}
+
+	private float GetPinchDistance()
+	{
+		var points = activeTouches.Values.Take(2).ToArray();
+		return points.Length == 2 ? SKPoint.Distance(points[0], points[1]) : 0;
+	}
+
+	private void SetBrushSize(float value)
+	{
+		brushSize = Math.Clamp(value, 1f, 50f);
+		brushSlider.Value = brushSize;
+		brushLabel.Text = $"{brushSize:F0}";
+		skiaView.InvalidateSurface();
 	}
 
 	private void OnColorClicked(object sender, EventArgs e)
@@ -150,8 +229,7 @@ public partial class DrawingPage : ContentPage
 
 	private void OnSliderValueChanged(object sender, ValueChangedEventArgs e)
 	{
-		brushSize = (float)e.NewValue;
-		brushLabel.Text = $"{brushSize:F0}";
+		SetBrushSize((float)e.NewValue);
 	}
 
 	private void OnClearClicked(object sender, EventArgs e)
@@ -161,6 +239,9 @@ public partial class DrawingPage : ContentPage
 		strokes.Clear();
 		currentBuilder?.Dispose();
 		currentBuilder = null;
+		activeTouches.Clear();
+		strokeTouchId = null;
+		previousPinchDistance = null;
 		skiaView.InvalidateSurface();
 	}
 }

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
@@ -10,6 +10,8 @@ namespace SkiaSharp.Views.Maui.Platform
 {
 	internal class SKTouchHandler : UIGestureRecognizer
 	{
+		// UIKit exposes points but no authoritative points-per-notch value,
+		// so this v120 calibration is empirical.
 		private const double ScrollPointsPerNotch = 40.0;
 
 		private Action<SKTouchEventArgs>? onTouchAction;

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
@@ -10,15 +10,12 @@ namespace SkiaSharp.Views.Maui.Platform
 {
 	internal class SKTouchHandler : UIGestureRecognizer
 	{
-		// UIKit exposes points but no authoritative points-per-notch value,
-		// so this v120 calibration is empirical.
-		private const double ScrollPointsPerNotch = 40.0;
-
 		private Action<SKTouchEventArgs>? onTouchAction;
 		private Func<double, double, SKPoint>? scalePixels;
 		private UIHoverGestureRecognizer? hoverGestureRecognizer;
 		private UIPanGestureRecognizer? scrollGestureRecognizer;
 		private ScrollGestureRecognizerDelegate? scrollGestureRecognizerDelegate;
+		private readonly LegacyWheelDeltaProjector wheelDeltaProjector = new();
 		private CGPoint? lastPointerLocation;
 
 		public SKTouchHandler(Action<SKTouchEventArgs> onTouchAction, Func<double, double, SKPoint> scalePixels)
@@ -130,6 +127,7 @@ namespace SkiaSharp.Views.Maui.Platform
 				scrollGestureRecognizer ??= new UIPanGestureRecognizer(OnScroll)
 				{
 					AllowedScrollTypesMask = UIScrollTypeMask.All,
+					AllowedTouchTypes = Array.Empty<NSNumber>(),
 					MaximumNumberOfTouches = 0,
 					CancelsTouchesInView = false,
 					Delegate = scrollGestureRecognizerDelegate,
@@ -146,6 +144,7 @@ namespace SkiaSharp.Views.Maui.Platform
 			if (scrollGestureRecognizer != null && view.GestureRecognizers?.Contains(scrollGestureRecognizer) == true)
 				view.RemoveGestureRecognizer(scrollGestureRecognizer);
 
+			wheelDeltaProjector.Reset();
 			lastPointerLocation = null;
 		}
 
@@ -171,15 +170,25 @@ namespace SkiaSharp.Views.Maui.Platform
 
 		private void OnScroll(UIPanGestureRecognizer recognizer)
 		{
-			if ((recognizer.State != UIGestureRecognizerState.Began &&
-				recognizer.State != UIGestureRecognizerState.Changed) ||
-				recognizer.View is not { } view)
+			if (recognizer.View is not { } view)
+				return;
+
+			var state = recognizer.State;
+			if (state is UIGestureRecognizerState.Cancelled or UIGestureRecognizerState.Failed)
+			{
+				recognizer.SetTranslation(CGPoint.Empty, view);
+				wheelDeltaProjector.Reset();
+				return;
+			}
+			if (state is not UIGestureRecognizerState.Began and
+				not UIGestureRecognizerState.Changed and
+				not UIGestureRecognizerState.Ended)
 				return;
 
 			var translation = recognizer.TranslationInView(view);
 			recognizer.SetTranslation(CGPoint.Empty, view);
 
-			var wheelDelta = NormalizeWheelDelta(translation.Y);
+			var wheelDelta = wheelDeltaProjector.Project(translation.Y, state);
 			if (wheelDelta == 0)
 				return;
 
@@ -207,15 +216,37 @@ namespace SkiaSharp.Views.Maui.Platform
 			return args.Handled;
 		}
 
-		internal static int NormalizeWheelDelta(double translationY)
+		internal sealed class LegacyWheelDeltaProjector
 		{
-			if (translationY == 0)
-				return 0;
+			// Browsers use 40 logical pixels per Cocoa tick as a content-scroll
+			// compatibility policy. UIKit only provides point translation, so
+			// this is sensitivity for legacy v120 events, not hardware calibration.
+			private const double LegacyWheelDeltaDistance = 40.0;
+			private const double WheelDeltaPerNominalNotch = 120.0;
+			private const double WholeDeltaTolerance = 1e-10;
 
-			var delta = (int)Math.Round(
-				-translationY * 120.0 / ScrollPointsPerNotch,
-				MidpointRounding.AwayFromZero);
-			return delta == 0 ? -Math.Sign(translationY) : delta;
+			private double remainder;
+
+			public int Project(double translationY, UIGestureRecognizerState state)
+			{
+				if (state == UIGestureRecognizerState.Began)
+					remainder = 0;
+
+				remainder -= translationY * WheelDeltaPerNominalNotch / LegacyWheelDeltaDistance;
+				var nearestWholeDelta = Math.Round(remainder);
+				if (Math.Abs(remainder - nearestWholeDelta) < WholeDeltaTolerance)
+					remainder = nearestWholeDelta;
+				var delta = (int)Math.Truncate(remainder);
+				remainder -= delta;
+
+				if (state == UIGestureRecognizerState.Ended)
+					remainder = 0;
+
+				return delta;
+			}
+
+			public void Reset() =>
+				remainder = 0;
 		}
 
 		private sealed class ScrollGestureRecognizerDelegate : UIGestureRecognizerDelegate

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -9,8 +10,14 @@ namespace SkiaSharp.Views.Maui.Platform
 {
 	internal class SKTouchHandler : UIGestureRecognizer
 	{
+		private const double ScrollPointsPerNotch = 40.0;
+
 		private Action<SKTouchEventArgs>? onTouchAction;
 		private Func<double, double, SKPoint>? scalePixels;
+		private UIHoverGestureRecognizer? hoverGestureRecognizer;
+		private UIPanGestureRecognizer? scrollGestureRecognizer;
+		private ScrollGestureRecognizerDelegate? scrollGestureRecognizerDelegate;
+		private CGPoint? lastPointerLocation;
 
 		public SKTouchHandler(Action<SKTouchEventArgs> onTouchAction, Func<double, double, SKPoint> scalePixels)
 		{
@@ -33,9 +40,11 @@ namespace SkiaSharp.Views.Maui.Platform
 				if (enableTouchEvents && view.GestureRecognizers?.Contains(this) != true)
 				{
 					view.AddGestureRecognizer(this);
+					AddPointerRecognizers(view);
 				}
 				else if (!enableTouchEvents && view.GestureRecognizers?.Contains(this) == true)
 				{
+					RemovePointerRecognizers(view);
 					view.RemoveGestureRecognizer(this);
 				}
 			}
@@ -45,6 +54,14 @@ namespace SkiaSharp.Views.Maui.Platform
 		{
 			// clean the view
 			SetEnabled(view, false);
+
+			hoverGestureRecognizer?.Dispose();
+			hoverGestureRecognizer = null;
+			scrollGestureRecognizer?.Dispose();
+			scrollGestureRecognizer = null;
+			scrollGestureRecognizerDelegate?.Dispose();
+			scrollGestureRecognizerDelegate = null;
+			lastPointerLocation = null;
 
 			// remove references
 			onTouchAction = null;
@@ -92,6 +109,119 @@ namespace SkiaSharp.Views.Maui.Platform
 			{
 				FireEvent(SKTouchAction.Cancelled, touch, false);
 			}
+		}
+
+		private void AddPointerRecognizers(UIView view)
+		{
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
+			{
+				hoverGestureRecognizer ??= new UIHoverGestureRecognizer(OnHover)
+				{
+					CancelsTouchesInView = false,
+				};
+				view.AddGestureRecognizer(hoverGestureRecognizer);
+			}
+
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 4))
+			{
+				scrollGestureRecognizerDelegate ??= new ScrollGestureRecognizerDelegate();
+				scrollGestureRecognizer ??= new UIPanGestureRecognizer(OnScroll)
+				{
+					AllowedScrollTypesMask = UIScrollTypeMask.All,
+					MaximumNumberOfTouches = 0,
+					CancelsTouchesInView = false,
+					Delegate = scrollGestureRecognizerDelegate,
+				};
+				view.AddGestureRecognizer(scrollGestureRecognizer);
+			}
+		}
+
+		private void RemovePointerRecognizers(UIView view)
+		{
+			if (hoverGestureRecognizer != null && view.GestureRecognizers?.Contains(hoverGestureRecognizer) == true)
+				view.RemoveGestureRecognizer(hoverGestureRecognizer);
+
+			if (scrollGestureRecognizer != null && view.GestureRecognizers?.Contains(scrollGestureRecognizer) == true)
+				view.RemoveGestureRecognizer(scrollGestureRecognizer);
+
+			lastPointerLocation = null;
+		}
+
+		private void OnHover(UIHoverGestureRecognizer recognizer)
+		{
+			var action = recognizer.State switch
+			{
+				UIGestureRecognizerState.Began => SKTouchAction.Entered,
+				UIGestureRecognizerState.Changed => SKTouchAction.Moved,
+				UIGestureRecognizerState.Ended or UIGestureRecognizerState.Cancelled => SKTouchAction.Exited,
+				_ => (SKTouchAction?)null,
+			};
+			if (action == null || recognizer.View is not { } view)
+				return;
+
+			var location = recognizer.LocationInView(view);
+			lastPointerLocation = location;
+			FirePointerEvent(action.Value, recognizer, location);
+
+			if (action == SKTouchAction.Exited)
+				lastPointerLocation = null;
+		}
+
+		private void OnScroll(UIPanGestureRecognizer recognizer)
+		{
+			if ((recognizer.State != UIGestureRecognizerState.Began &&
+				recognizer.State != UIGestureRecognizerState.Changed) ||
+				recognizer.View is not { } view)
+				return;
+
+			var translation = recognizer.TranslationInView(view);
+			recognizer.SetTranslation(CGPoint.Empty, view);
+
+			var wheelDelta = NormalizeWheelDelta(translation.Y);
+			if (wheelDelta == 0)
+				return;
+
+			var location = lastPointerLocation ?? recognizer.LocationInView(view);
+			FirePointerEvent(SKTouchAction.WheelChanged, recognizer, location, wheelDelta);
+		}
+
+		private bool FirePointerEvent(SKTouchAction actionType, UIGestureRecognizer recognizer, CGPoint location, int wheelDelta = 0)
+		{
+			if (onTouchAction == null || scalePixels == null)
+				return false;
+
+			var id = ((IntPtr)recognizer.Handle).ToInt64();
+			var point = scalePixels(location.X, location.Y);
+			var args = new SKTouchEventArgs(
+				id,
+				actionType,
+				SKMouseButton.Unknown,
+				SKTouchDeviceType.Mouse,
+				point,
+				false,
+				wheelDelta,
+				0);
+			onTouchAction(args);
+			return args.Handled;
+		}
+
+		internal static int NormalizeWheelDelta(double translationY)
+		{
+			if (translationY == 0)
+				return 0;
+
+			var delta = (int)Math.Round(
+				-translationY * 120.0 / ScrollPointsPerNotch,
+				MidpointRounding.AwayFromZero);
+			return delta == 0 ? -Math.Sign(translationY) : delta;
+		}
+
+		private sealed class ScrollGestureRecognizerDelegate : UIGestureRecognizerDelegate
+		{
+			public override bool ShouldRecognizeSimultaneously(
+				UIGestureRecognizer gestureRecognizer,
+				UIGestureRecognizer otherGestureRecognizer) =>
+				otherGestureRecognizer is UIPinchGestureRecognizer;
 		}
 
 		private bool FireEvent(SKTouchAction actionType, UITouch touch, bool inContact)

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Platform/Apple/SKTouchHandler.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using CoreGraphics;
 using Foundation;
@@ -8,13 +9,13 @@ using UIKit;
 
 namespace SkiaSharp.Views.Maui.Platform
 {
-	internal class SKTouchHandler : UIGestureRecognizer
+	internal sealed class SKTouchHandler
 	{
 		private Action<SKTouchEventArgs>? onTouchAction;
 		private Func<double, double, SKPoint>? scalePixels;
-		private UIHoverGestureRecognizer? hoverGestureRecognizer;
-		private UIPanGestureRecognizer? scrollGestureRecognizer;
-		private ScrollGestureRecognizerDelegate? scrollGestureRecognizerDelegate;
+		private readonly TouchGestureRecognizer touchGestureRecognizer;
+		private readonly UIGestureRecognizer[] gestureRecognizers;
+		private readonly ScrollGestureRecognizerDelegate? scrollGestureRecognizerDelegate;
 		private readonly LegacyWheelDeltaProjector wheelDeltaProjector = new();
 		private CGPoint? lastPointerLocation;
 
@@ -23,29 +24,64 @@ namespace SkiaSharp.Views.Maui.Platform
 			this.onTouchAction = onTouchAction;
 			this.scalePixels = scalePixels;
 
+			var recognizers = new List<UIGestureRecognizer>();
+
+			touchGestureRecognizer = new TouchGestureRecognizer(FireTouchEvent);
+			recognizers.Add(touchGestureRecognizer);
+
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
+			{
+				recognizers.Add(new UIHoverGestureRecognizer(OnHover)
+				{
+					CancelsTouchesInView = false,
+				});
+			}
+
+			if (OperatingSystem.IsIOSVersionAtLeast(13, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 4))
+			{
+				scrollGestureRecognizerDelegate = new ScrollGestureRecognizerDelegate();
+				recognizers.Add(new UIPanGestureRecognizer(OnScroll)
+				{
+					AllowedScrollTypesMask = UIScrollTypeMask.All,
+					AllowedTouchTypes = Array.Empty<NSNumber>(),
+					MaximumNumberOfTouches = 0,
+					CancelsTouchesInView = false,
+					Delegate = scrollGestureRecognizerDelegate,
+				});
+			}
+
+			gestureRecognizers = recognizers.ToArray();
 			DisablesUserInteraction = false;
 		}
 
 		public bool DisablesUserInteraction { get; set; }
 
+		public UIView? View =>
+			touchGestureRecognizer.View;
+
 		public void SetEnabled(UIView view, bool enableTouchEvents)
 		{
-			if (view != null)
+			if (!view.UserInteractionEnabled || DisablesUserInteraction)
+				view.UserInteractionEnabled = enableTouchEvents;
+
+			if (enableTouchEvents)
 			{
-				if (!view.UserInteractionEnabled || DisablesUserInteraction)
+				foreach (var recognizer in gestureRecognizers)
 				{
-					view.UserInteractionEnabled = enableTouchEvents;
+					if (recognizer.View != view)
+						view.AddGestureRecognizer(recognizer);
 				}
-				if (enableTouchEvents && view.GestureRecognizers?.Contains(this) != true)
+			}
+			else
+			{
+				foreach (var recognizer in gestureRecognizers)
 				{
-					view.AddGestureRecognizer(this);
-					AddPointerRecognizers(view);
+					if (recognizer.View == view)
+						view.RemoveGestureRecognizer(recognizer);
 				}
-				else if (!enableTouchEvents && view.GestureRecognizers?.Contains(this) == true)
-				{
-					RemovePointerRecognizers(view);
-					view.RemoveGestureRecognizer(this);
-				}
+
+				wheelDeltaProjector.Reset();
+				lastPointerLocation = null;
 			}
 		}
 
@@ -54,98 +90,13 @@ namespace SkiaSharp.Views.Maui.Platform
 			// clean the view
 			SetEnabled(view, false);
 
-			hoverGestureRecognizer?.Dispose();
-			hoverGestureRecognizer = null;
-			scrollGestureRecognizer?.Dispose();
-			scrollGestureRecognizer = null;
+			foreach (var recognizer in gestureRecognizers)
+				recognizer.Dispose();
 			scrollGestureRecognizerDelegate?.Dispose();
-			scrollGestureRecognizerDelegate = null;
-			lastPointerLocation = null;
 
 			// remove references
 			onTouchAction = null;
 			scalePixels = null;
-		}
-
-		public override void TouchesBegan(NSSet touches, UIEvent evt)
-		{
-			base.TouchesBegan(touches, evt);
-
-			foreach (UITouch touch in touches.Cast<UITouch>())
-			{
-				if (!FireEvent(SKTouchAction.Pressed, touch, true))
-				{
-					IgnoreTouch(touch, evt);
-				}
-			}
-		}
-
-		public override void TouchesMoved(NSSet touches, UIEvent evt)
-		{
-			base.TouchesMoved(touches, evt);
-
-			foreach (UITouch touch in touches.Cast<UITouch>())
-			{
-				FireEvent(SKTouchAction.Moved, touch, true);
-			}
-		}
-
-		public override void TouchesEnded(NSSet touches, UIEvent evt)
-		{
-			base.TouchesEnded(touches, evt);
-
-			foreach (UITouch touch in touches.Cast<UITouch>())
-			{
-				FireEvent(SKTouchAction.Released, touch, false);
-			}
-		}
-
-		public override void TouchesCancelled(NSSet touches, UIEvent evt)
-		{
-			base.TouchesCancelled(touches, evt);
-
-			foreach (UITouch touch in touches.Cast<UITouch>())
-			{
-				FireEvent(SKTouchAction.Cancelled, touch, false);
-			}
-		}
-
-		private void AddPointerRecognizers(UIView view)
-		{
-			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
-			{
-				hoverGestureRecognizer ??= new UIHoverGestureRecognizer(OnHover)
-				{
-					CancelsTouchesInView = false,
-				};
-				view.AddGestureRecognizer(hoverGestureRecognizer);
-			}
-
-			if (OperatingSystem.IsIOSVersionAtLeast(13, 4) || OperatingSystem.IsMacCatalystVersionAtLeast(13, 4))
-			{
-				scrollGestureRecognizerDelegate ??= new ScrollGestureRecognizerDelegate();
-				scrollGestureRecognizer ??= new UIPanGestureRecognizer(OnScroll)
-				{
-					AllowedScrollTypesMask = UIScrollTypeMask.All,
-					AllowedTouchTypes = Array.Empty<NSNumber>(),
-					MaximumNumberOfTouches = 0,
-					CancelsTouchesInView = false,
-					Delegate = scrollGestureRecognizerDelegate,
-				};
-				view.AddGestureRecognizer(scrollGestureRecognizer);
-			}
-		}
-
-		private void RemovePointerRecognizers(UIView view)
-		{
-			if (hoverGestureRecognizer != null && view.GestureRecognizers?.Contains(hoverGestureRecognizer) == true)
-				view.RemoveGestureRecognizer(hoverGestureRecognizer);
-
-			if (scrollGestureRecognizer != null && view.GestureRecognizers?.Contains(scrollGestureRecognizer) == true)
-				view.RemoveGestureRecognizer(scrollGestureRecognizer);
-
-			wheelDeltaProjector.Reset();
-			lastPointerLocation = null;
 		}
 
 		private void OnHover(UIHoverGestureRecognizer recognizer)
@@ -257,7 +208,7 @@ namespace SkiaSharp.Views.Maui.Platform
 				otherGestureRecognizer is UIPinchGestureRecognizer;
 		}
 
-		private bool FireEvent(SKTouchAction actionType, UITouch touch, bool inContact)
+		private bool FireTouchEvent(SKTouchAction actionType, UITouch touch, bool inContact)
 		{
 			if (onTouchAction == null || scalePixels == null)
 				return false;
@@ -270,6 +221,51 @@ namespace SkiaSharp.Views.Maui.Platform
 			var args = new SKTouchEventArgs(id, actionType, point, inContact);
 			onTouchAction(args);
 			return args.Handled;
+		}
+
+		private sealed class TouchGestureRecognizer : UIGestureRecognizer
+		{
+			private readonly Func<SKTouchAction, UITouch, bool, bool> fireEvent;
+
+			public TouchGestureRecognizer(Func<SKTouchAction, UITouch, bool, bool> fireEvent)
+			{
+				this.fireEvent = fireEvent;
+			}
+
+			public override void TouchesBegan(NSSet touches, UIEvent evt)
+			{
+				base.TouchesBegan(touches, evt);
+
+				foreach (UITouch touch in touches.Cast<UITouch>())
+				{
+					if (!fireEvent(SKTouchAction.Pressed, touch, true))
+						IgnoreTouch(touch, evt);
+				}
+			}
+
+			public override void TouchesMoved(NSSet touches, UIEvent evt)
+			{
+				base.TouchesMoved(touches, evt);
+
+				foreach (UITouch touch in touches.Cast<UITouch>())
+					fireEvent(SKTouchAction.Moved, touch, true);
+			}
+
+			public override void TouchesEnded(NSSet touches, UIEvent evt)
+			{
+				base.TouchesEnded(touches, evt);
+
+				foreach (UITouch touch in touches.Cast<UITouch>())
+					fireEvent(SKTouchAction.Released, touch, false);
+			}
+
+			public override void TouchesCancelled(NSSet touches, UIEvent evt)
+			{
+				base.TouchesCancelled(touches, evt);
+
+				foreach (UITouch touch in touches.Cast<UITouch>())
+					fireEvent(SKTouchAction.Cancelled, touch, false);
+			}
 		}
 	}
 }

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Properties/SkiaSharpViewsMauiAssemblyInfo.cs
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Core/Properties/SkiaSharpViewsMauiAssemblyInfo.cs
@@ -11,3 +11,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("SkiaSharp.Views.Maui.Core")]
 [assembly: InternalsVisibleTo("SkiaSharp.Views.Maui.Controls")]
+[assembly: InternalsVisibleTo("SkiaSharp.Tests.Devices")]

--- a/tests/SkiaSharp.Tests.Devices/Tests/Apple/ApplePointerInputTests.cs
+++ b/tests/SkiaSharp.Tests.Devices/Tests/Apple/ApplePointerInputTests.cs
@@ -135,6 +135,8 @@ public class ApplePointerInputTests : SKUITests
 		var platformView = Assert.IsAssignableFrom<UIView>(view.Handler!.PlatformView);
 		var recognizers = platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>();
 
+		var touch = Assert.Single(recognizers.Where(recognizer =>
+			recognizer.GetType().DeclaringType == typeof(SKTouchHandler)));
 		var hover = Assert.Single(recognizers.OfType<UIHoverGestureRecognizer>());
 		Assert.False(hover.CancelsTouchesInView);
 
@@ -154,6 +156,7 @@ public class ApplePointerInputTests : SKUITests
 
 		SetTouchEvents(view, false);
 
+		Assert.DoesNotContain(touch, platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>());
 		Assert.DoesNotContain(hover, platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>());
 		Assert.DoesNotContain(scroll, platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>());
 

--- a/tests/SkiaSharp.Tests.Devices/Tests/Apple/ApplePointerInputTests.cs
+++ b/tests/SkiaSharp.Tests.Devices/Tests/Apple/ApplePointerInputTests.cs
@@ -19,11 +19,94 @@ public class AppleWheelDeltaTests
 	[InlineData(40, -120)]
 	[InlineData(-2, 6)]
 	[InlineData(2, -6)]
-	[InlineData(-0.1, 1)]
-	[InlineData(0.1, -1)]
 	[InlineData(0, 0)]
-	public void WheelTranslationUsesIncrementalV120Units(double translationY, int expected) =>
-		Assert.Equal(expected, SKTouchHandler.NormalizeWheelDelta(translationY));
+	public void WheelTranslationUsesIncrementalV120Units(double translationY, int expected)
+	{
+		var projector = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(expected, projector.Project(translationY, UIGestureRecognizerState.Began));
+	}
+
+	[Fact]
+	public void FractionalWheelTranslationIsPreservedAcrossCallbacks()
+	{
+		var projector = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(0, projector.Project(-0.1, UIGestureRecognizerState.Began));
+		Assert.Equal(0, projector.Project(-0.1, UIGestureRecognizerState.Changed));
+		Assert.Equal(0, projector.Project(-0.1, UIGestureRecognizerState.Changed));
+		Assert.Equal(1, projector.Project(-0.1, UIGestureRecognizerState.Changed));
+	}
+
+	[Theory]
+	[InlineData(-1, -0.1, 3)]
+	[InlineData(1, 0.1, -3)]
+	public void WheelProjectionIsInvariantToCallbackPartitioning(
+		double singleTranslation,
+		double partitionedTranslation,
+		int expected)
+	{
+		var singleCallback = new SKTouchHandler.LegacyWheelDeltaProjector();
+		var partitionedCallbacks = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		var singleTotal = singleCallback.Project(singleTranslation, UIGestureRecognizerState.Began);
+		var partitionedTotal = partitionedCallbacks.Project(partitionedTranslation, UIGestureRecognizerState.Began);
+		for (var i = 1; i < 10; i++)
+			partitionedTotal += partitionedCallbacks.Project(partitionedTranslation, UIGestureRecognizerState.Changed);
+
+		Assert.Equal(expected, singleTotal);
+		Assert.Equal(singleTotal, partitionedTotal);
+	}
+
+	[Fact]
+	public void EndedTranslationIsProjectedBeforeRemainderIsDropped()
+	{
+		var projector = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(0, projector.Project(-0.25, UIGestureRecognizerState.Began));
+		Assert.Equal(2, projector.Project(-0.5, UIGestureRecognizerState.Changed));
+		Assert.Equal(1, projector.Project(-0.25, UIGestureRecognizerState.Ended));
+		Assert.Equal(0, projector.Project(0, UIGestureRecognizerState.Began));
+	}
+
+	[Fact]
+	public void EndedOnlyTranslationIsProjected()
+	{
+		var projector = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(3, projector.Project(-1, UIGestureRecognizerState.Ended));
+	}
+
+	[Fact]
+	public void SubUnitTranslationDoesNotForceWheelDelta()
+	{
+		var projector = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(0, projector.Project(-0.1, UIGestureRecognizerState.Began));
+		Assert.Equal(0, projector.Project(0, UIGestureRecognizerState.Ended));
+	}
+
+	[Fact]
+	public void ProjectorsDoNotShareRemainders()
+	{
+		var first = new SKTouchHandler.LegacyWheelDeltaProjector();
+		var second = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(0, first.Project(-0.3, UIGestureRecognizerState.Began));
+		Assert.Equal(0, second.Project(-0.1, UIGestureRecognizerState.Began));
+		Assert.Equal(1, first.Project(-0.1, UIGestureRecognizerState.Changed));
+		Assert.Equal(0, second.Project(-0.1, UIGestureRecognizerState.Changed));
+	}
+
+	[Fact]
+	public void ResetDropsCancelledGestureRemainder()
+	{
+		var projector = new SKTouchHandler.LegacyWheelDeltaProjector();
+
+		Assert.Equal(0, projector.Project(-0.3, UIGestureRecognizerState.Began));
+		projector.Reset();
+		Assert.Equal(0, projector.Project(-0.1, UIGestureRecognizerState.Changed));
+	}
 }
 
 [Collection("SKUITests")]
@@ -60,6 +143,7 @@ public class ApplePointerInputTests : SKUITests
 			.Where(recognizer =>
 				recognizer.AllowedScrollTypesMask == UIScrollTypeMask.All &&
 				recognizer.MaximumNumberOfTouches == 0));
+		Assert.Empty(scroll.AllowedTouchTypes);
 		Assert.False(scroll.CancelsTouchesInView);
 		Assert.NotNull(scroll.Delegate);
 

--- a/tests/SkiaSharp.Tests.Devices/Tests/Apple/ApplePointerInputTests.cs
+++ b/tests/SkiaSharp.Tests.Devices/Tests/Apple/ApplePointerInputTests.cs
@@ -1,0 +1,93 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using SkiaSharp.Views.Maui.Controls;
+using SkiaSharp.Views.Maui.Controls.Tests;
+using SkiaSharp.Views.Maui.Platform;
+using UIKit;
+using Xunit;
+
+namespace SkiaSharp.Views.Maui.Tests;
+
+public class AppleWheelDeltaTests
+{
+	[Theory]
+	[InlineData(-40, 120)]
+	[InlineData(40, -120)]
+	[InlineData(-2, 6)]
+	[InlineData(2, -6)]
+	[InlineData(-0.1, 1)]
+	[InlineData(0.1, -1)]
+	[InlineData(0, 0)]
+	public void WheelTranslationUsesIncrementalV120Units(double translationY, int expected) =>
+		Assert.Equal(expected, SKTouchHandler.NormalizeWheelDelta(translationY));
+}
+
+[Collection("SKUITests")]
+public class ApplePointerInputTests : SKUITests
+{
+	[UIFact]
+	public Task SKCanvasViewAddsPointerRecognizers() =>
+		AssertPointerRecognizers(new SKCanvasView());
+
+	[UIFact]
+	public Task SKGLViewAddsPointerRecognizers() =>
+		AssertPointerRecognizers(new SKGLView());
+
+	private async Task AssertPointerRecognizers(View view)
+	{
+		SetTouchEvents(view, true);
+		var page = new ContentPage
+		{
+			Content = view,
+		};
+
+		await CurrentPage.Navigation.PushAsync(page);
+		await view.WaitForLoaded();
+		await view.WaitForLayout();
+
+		var platformView = Assert.IsAssignableFrom<UIView>(view.Handler!.PlatformView);
+		var recognizers = platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>();
+
+		var hover = Assert.Single(recognizers.OfType<UIHoverGestureRecognizer>());
+		Assert.False(hover.CancelsTouchesInView);
+
+		var scroll = Assert.Single(recognizers
+			.OfType<UIPanGestureRecognizer>()
+			.Where(recognizer =>
+				recognizer.AllowedScrollTypesMask == UIScrollTypeMask.All &&
+				recognizer.MaximumNumberOfTouches == 0));
+		Assert.False(scroll.CancelsTouchesInView);
+		Assert.NotNull(scroll.Delegate);
+
+		using var pinch = new UIPinchGestureRecognizer();
+		using var tap = new UITapGestureRecognizer();
+		Assert.True(scroll.Delegate.ShouldRecognizeSimultaneously(scroll, pinch));
+		Assert.False(scroll.Delegate.ShouldRecognizeSimultaneously(scroll, tap));
+
+		SetTouchEvents(view, false);
+
+		Assert.DoesNotContain(hover, platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>());
+		Assert.DoesNotContain(scroll, platformView.GestureRecognizers ?? Array.Empty<UIGestureRecognizer>());
+
+		await CurrentPage.Navigation.PopAsync();
+	}
+
+	private static void SetTouchEvents(View view, bool enabled)
+	{
+		switch (view)
+		{
+			case SKCanvasView canvasView:
+				canvasView.EnableTouchEvents = enabled;
+				break;
+			case SKGLView glView:
+				glView.EnableTouchEvents = enabled;
+				break;
+			default:
+				throw new ArgumentException("Expected a SkiaSharp view.", nameof(view));
+		}
+	}
+}


### PR DESCRIPTION
## Description

Adds first-class passive pointer hover and wheel/two-finger trackpad scrolling to the shared Apple MAUI input path used by `SKCanvasView`, `SKGLView`, and the Mac Catalyst Metal path. Applications no longer need platform-specific adapters to receive these inputs through the existing `Touch` event.

The root cause was that Apple input was represented by one direct-contact `UIGestureRecognizer`, which only observed UIKit's `TouchesBegan`, `TouchesMoved`, `TouchesEnded`, and `TouchesCancelled` callbacks. UIKit exposes passive hover and indirect scrolling through separate recognizers, so those sources had no path into `SKTouchEventArgs`.

`SKTouchHandler` is now the coordinator for the complete Apple input path. It owns direct-contact, hover, and scroll recognizers as peers and manages their attachment, removal, state reset, and disposal together. Contact handling remains isolated in its own recognizer, preserving the existing touch semantics instead of layering pointer setup onto the contact recognizer.

Hover uses `UIHoverGestureRecognizer` and maps naturally to the existing contract:

- `Began` -> `SKTouchAction.Entered`
- `Changed` -> non-contact `SKTouchAction.Moved`
- `Ended` / `Cancelled` -> `SKTouchAction.Exited`
- mouse device type, unknown button, zero pressure, and coordinates scaled by the existing Canvas/GL/Metal proxy

Scrolling uses a scroll-only `UIPanGestureRecognizer` with all indirect scroll types enabled, direct touch types explicitly disabled, zero maximum direct touches, and touch cancellation disabled. Ordinary contact touch and mouse click-drag remain on the direct-contact recognizer. Scroll and pinch recognizers may recognize simultaneously, but broad simultaneity with contact input is intentionally not enabled.

`WheelDelta` is a pragmatic, best-effort vertical compatibility projection because the current public API is a one-dimensional `int`. The handler:

- treats 40 UIKit logical points as 120 nominal compatibility units;
- negates UIKit's down-positive Y translation so positive remains up/forward;
- preserves smaller whole integer deltas for precision scrolling;
- accumulates fractional remainder per handler, making the emitted sum invariant to callback partitioning;
- processes `Began`, `Changed`, and residual `Ended` translation;
- drops only a terminal sub-unit remainder and never forces +/-1 for sub-unit movement;
- keeps the latest hover location as the stable wheel focal point.

Chromium and WebKit use a 40-logical-pixel-per-Cocoa-tick distance as browser content-scrolling compatibility policy while retaining richer raw two-axis data. This PR uses the same style of legacy sensitivity; **40 is not an Apple hardware calibration or points-per-detent guarantee**.

[#3533](https://github.com/mono/SkiaSharp/issues/3533) remains the follow-up for authoritative fractional two-axis scroll delta, unit/mode, and discrete/continuous metadata. Horizontal translation is not exposed by this PR. Trackpad magnification also remains separate because `SKTouchEventArgs` has no coherent scale, focal-point, or gesture-lifecycle representation; this PR does not synthesize fake contacts or wheel events for pinch.

Fixes #3523
Fixes #3524
Fixes #3537

**Related history**

- [#826](https://github.com/mono/SkiaSharp/issues/826) requests old Xamarin.Forms AppKit trackpad pan/magnify support but has no implementation to revive.
- [#1293](https://github.com/mono/SkiaSharp/pull/1293) is a stale legacy multi-platform input PR and does not implement Apple hover, wheel, or pinch delivery.
- [#1048](https://github.com/mono/SkiaSharp/issues/1048) / [#1367](https://github.com/mono/SkiaSharp/pull/1367) concern direct-touch reset/cancellation, not indirect input.
- [#3528](https://github.com/mono/SkiaSharp/pull/3528) proposed unmerged Blazor pointer/wheel support.
- [#716](https://github.com/mono/SkiaSharp/pull/716) and [#1079](https://github.com/mono/SkiaSharp/pull/1079) are merged Windows precedents that pass native 120-based wheel deltas through unchanged.
- [#1089](https://github.com/mono/SkiaSharp/pull/1089) is a merged legacy GTK precedent that handles discrete +/-120 but loses smooth two-axis data.
- [SkiaSharp.Extended#326](https://github.com/mono/SkiaSharp.Extended/pull/326) provided the live Mac Catalyst reproduction and proved hover, scrolling, recognizer coexistence, and click-drag behavior before this functionality moved into SkiaSharp proper.

A search of open and closed issues, pull requests, branches, and commit history found no older direct Apple hover/trackpad implementation to revive.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update
- [x] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, ...)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

- Apple input now has one coordinator with uniform lifecycle ownership of contact, hover, and scroll recognizers.
- Apple MAUI views emit `Entered`, non-contact `Moved`, and `Exited` for passive pointer hover.
- Apple MAUI views emit incremental `WheelChanged` through stock `SKCanvasView.Touch` / `SKGLView.Touch` for mouse wheel and two-finger trackpad scrolling.
- The scroll recognizer cannot consume direct touches or ordinary click-drag.
- Fractional point translation is accumulated independently per handler before best-effort legacy integer projection.
- Terminal scroll translation is no longer lost.
- The MAUI Drawing sample visualizes hover and uses wheel/trackpad scroll plus real two-contact pinch to adjust brush size.

No public API or ABI changes.

## Testing

- Apple MAUI Core builds passed for `net10.0-maccatalyst` and `net10.0-ios` after the coordinator refactor.
- Apple device-test app builds passed for Mac Catalyst, including the coordinator attachment/removal assertions.
- The MAUI Drawing sample built and launched locally as a Mac Catalyst app from the current branch.
- Full Mac Catalyst device run before the structural refactor: 1,249 discovered; 1,165 passed; 83 skipped; all Apple projection, Canvas/GL recognizer wiring, touch-exclusion, removal, and handler leak tests passed. The sole failure is the existing unseeded Graphite Metal visual matrix.
- Required unfiltered console solution: singleton initialization, Vulkan, and Direct3D passed. Core completed 6,135 passed and 23 skipped with two unrelated failures: the existing Ganesh-GL `DiagonalLines` golden mismatch and a transient managed-stream GC assertion that passed on focused rerun.
- CI package `4.152.0-pr.4913.26451.29` from Azure build [1577884](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1577884) verified packaged hover and incremental wheel delivery through public `SKCanvasView.Touch` before the additive projection correction.
- Physical Mac Catalyst validation in SkiaSharp.Extended#326 confirmed pointer hover, wheel/two-finger scrolling, ordinary click-drag, and pinch/scroll coexistence.

No screenshots are included because this changes input event delivery rather than rendering output.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes
- [x] New/changed public API? No
- [x] Native change? No