### PR TITLE
Add guarded Skia update landing workflow

### DIFF
--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -51,15 +51,16 @@ The script determines the release action from the parent base branch:
   `scripts/VERSIONS.txt` and derives `release/A.B.x` for the current line;
 - `release/A.B.x`: reports a servicing sync and exits without creating refs.
 
-For `main`, the default is a dry run. The script reads the current SkiaSharp
-base tip and the exact mono/skia commit referenced by its `externals/skia`
-gitlink. It requires the supplied mono/skia base branch to point at that commit
-and preflights the derived release branch in both repositories.
+The script always defaults to a dry run. When targeting `main`, it reads the
+current SkiaSharp base tip and the exact mono/skia commit referenced by its
+`externals/skia` gitlink. It requires the supplied mono/skia base branch to
+point at that commit and preflights the derived release branch in both
+repositories.
 
-Show the output and obtain confirmation. Rerun with `-Push`. The script checks
-the source and destination refs again, creates the mono/skia release branch
-first, then the mono/SkiaSharp release branch, and verifies both. It never moves
-an existing branch.
+Show the output and obtain confirmation. Rerun with the same inputs plus
+`-Push`. The script checks the source and destination refs again, creates the
+mono/skia release branch first, then the mono/SkiaSharp release branch, and
+verifies both. It never moves an existing branch.
 
 ## 3. Prepare the mono/skia merge
 

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -70,10 +70,11 @@ another PR as competing only when evidence shows at least one of:
   one PR if the other landed.
 
 Record an explicit merge, close, or supersede disposition for every competing
-PR. Do not land while a competing pointer PR remains open. Merely touching
-`DEPS`, the gitlink, or another commonly changed file is not enough: report
-unrelated parallel work as non-blocking with the evidence that distinguishes
-it.
+PR, then require that disposition to be completed before landing: the PR must
+already be merged, closed, or explicitly superseded. Do not leave any
+demonstrated competing PR open. Merely touching `DEPS`, the gitlink, or another
+commonly changed file is not enough: report unrelated parallel work as
+non-blocking with the evidence that distinguishes it.
 
 Verify repository metadata on both PRs:
 
@@ -184,16 +185,19 @@ merges. A same-milestone servicing sync does not create another release line.
 1. Derive `release/A.B.x` from the previous SkiaSharp product line; for example,
    an M153 bump preserves `release/4.152.x`.
 2. Re-fetch and record the current mono/skia base and mono/SkiaSharp base tips.
-3. Preflight both destination refs before creating either branch. Each must be
+3. Before any write, verify both source tips identify the previous milestone
+   and the parent base's `externals/skia` gitlink equals the recorded native
+   base tip.
+4. Preflight both destination refs before creating either branch. Each must be
    absent or already resolve to its intended source SHA; stop before any write
    if either conflicts.
-4. Present both planned refs and exact source SHAs and obtain explicit
+5. Present both planned refs and exact source SHAs and obtain explicit
    maintainer confirmation.
-5. Create any missing mono/skia release branch first from the recorded native
+6. Create any missing mono/skia release branch first from the recorded native
    base tip, then create the missing identically named mono/SkiaSharp release
    branch from the recorded parent base tip. Use guarded non-force ref creation.
-6. Never force or move an existing release branch.
-7. Verify the parent release branch's `externals/skia` gitlink equals the native
+7. Never force or move an existing release branch.
+8. Verify the parent release branch's `externals/skia` gitlink equals the native
    release branch tip and both branches still identify the previous milestone.
 
 Record both branch SHAs. This split keeps the previous milestone serviceable
@@ -295,7 +299,8 @@ Stop without merging when any of these is true:
 - the native PR is behind its base or its prospective merge tree differs from
   the reviewed PR-head tree;
 - persisted review evidence is missing, schema-invalid, or stale;
-- a competing sync or pointer PR lacks an explicit disposition;
+- any demonstrated competing PR remains open or lacks a completed merge, close,
+  or supersede disposition;
 - required PR labels or the parent release milestone are wrong;
 - a fork patch, dependency, API, ownership, or release-note finding is open;
 - temporary compatibility work lacks restored support or an accepted limitation

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -31,28 +31,30 @@ Use GitHub and the PR bodies to resolve:
 
 - the mono/skia PR number, head branch, and base branch;
 - the mono/SkiaSharp PR number, head branch, and base branch;
-- whether this is a milestone bump or same-milestone servicing sync;
-- for a bump, the previous `release/A.B.x` branch name.
+- whether the parent targets `main` or an existing `release/A.B.x` branch.
 
 Present these values before continuing.
 
-## 2. Preserve the previous release line for a bump
-
-Skip this section for a same-milestone servicing sync.
+## 2. Preserve the previous release line when targeting main
 
 Run the script with the branch names already resolved by the AI:
 
 ```powershell
 pwsh .agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1 `
   -SkiaSharpBaseBranch <parent-base> `
-  -SkiaBaseBranch <native-base> `
-  -ReleaseBranch <release/A.B.x>
+  -SkiaBaseBranch <native-base>
 ```
 
-The default is a dry run. The script reads the current SkiaSharp base tip and
-the exact mono/skia commit referenced by its `externals/skia` gitlink. It
-requires the supplied mono/skia base branch to point at that commit and
-preflights the release branch in both repositories.
+The script determines the release action from the parent base branch:
+
+- `main`: reads the committed SkiaSharp package version from
+  `scripts/VERSIONS.txt` and derives `release/A.B.x` for the current line;
+- `release/A.B.x`: reports a servicing sync and exits without creating refs.
+
+For `main`, the default is a dry run. The script reads the current SkiaSharp
+base tip and the exact mono/skia commit referenced by its `externals/skia`
+gitlink. It requires the supplied mono/skia base branch to point at that commit
+and preflights the derived release branch in both repositories.
 
 Show the output and obtain confirmation. Rerun with `-Push`. The script checks
 the source and destination refs again, creates the mono/skia release branch
@@ -121,6 +123,8 @@ Stop when:
 
 - the maintainer does not confirm the initial checklist;
 - the PR pair or branch names cannot be resolved;
+- the parent base is neither `main` nor `release/A.B.x`;
+- the current product line cannot be derived from `scripts/VERSIONS.txt`;
 - a supplied native base branch does not match the parent base gitlink;
 - an existing release branch points at a different SHA;
 - a release source changes between dry run and `-Push`;

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -15,9 +15,28 @@ compatibility: Requires git, gh, and PowerShell 7.4+ with access to mono/skia an
 Help with the mechanical work around two manual merges. Do not repeat the
 review and do not merge either PR.
 
-## 1. Confirm and resolve
+## 1. Resolve and confirm
 
-Ask the maintainer to confirm:
+Resolve the PR pair before asking for any landing confirmation.
+
+If the maintainer supplied either PR, use its reciprocal link to find the
+companion PR. If they supplied both PRs, require each reciprocal link to point
+to the other; stop on any mismatch. Otherwise, search the open Skia update PRs
+and pair them using their reciprocal links and shared sync branches.
+
+- If exactly one pair is found, present it.
+- If multiple pairs are found, present the candidates and ask the maintainer
+  which pair to land.
+- If no pair can be resolved, ask for either PR number and stop until it is
+  provided.
+
+For the selected pair, resolve and present:
+
+- the mono/skia PR number, head branch, and base branch;
+- the mono/SkiaSharp PR number, head branch, and base branch;
+- whether the parent targets `main` or an existing `release/A.B.x` branch.
+
+Only after the maintainer sees the exact selected pair, ask them to confirm:
 
 - `review-skia-update` has run;
 - they are happy with the review and approve the update;
@@ -26,14 +45,6 @@ Ask the maintainer to confirm:
 
 If they do not confirm, stop. Do not independently re-audit reviews, labels,
 milestones, CI, packages, DEPS, bindings, or release notes.
-
-Use GitHub and the PR bodies to resolve:
-
-- the mono/skia PR number, head branch, and base branch;
-- the mono/SkiaSharp PR number, head branch, and base branch;
-- whether the parent targets `main` or an existing `release/A.B.x` branch.
-
-Present these values before continuing.
 
 ## 2. Preserve the previous release line when targeting main
 
@@ -147,7 +158,9 @@ wait for main CI to finish.
 Stop when:
 
 - the maintainer does not confirm the initial checklist;
-- the PR pair or branch names cannot be resolved;
+- the PR pair or branch names cannot be resolved or the maintainer has not
+  selected one of multiple candidate pairs;
+- supplied PR numbers do not reciprocally link to each other;
 - the parent base is neither `main` nor `release/A.B.x`;
 - the current product line cannot be derived from `scripts/VERSIONS.txt`;
 - a supplied native base branch does not match the parent base gitlink;

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -6,9 +6,10 @@ description: >
   asks to merge, land, finalize, or complete a Skia bump/sync, or asks what is
   still required before those PRs can merge. Verifies upstream freshness,
   two-parent ancestry, fork and dependency decisions, parent rebase state,
-  release-note reachability, CI, packages, merge order, and the supported-line
-  rotation. Use update-skia to create or refresh the update and
-  review-skia-update for the deep review; this skill owns the final landing.
+  release-note reachability, prior-line preservation, CI, packages, merge
+  order, and the supported-line rotation. Use update-skia to create or refresh
+  the update and review-skia-update for the deep review; this skill owns the
+  final landing.
   Do not use it to merge Google Skia into the fork or for bleeding-edge
   upstream-main syncs.
 compatibility: Requires git, gh, Python 3, and access to mono/skia and mono/SkiaSharp.
@@ -25,6 +26,7 @@ continuously moving upstream tip needs a different landing policy.
 
 ```
 reviewed PRs
+  -> preserve the previous milestone as release/A.B.x
   -> merge mono/skia with a merge commit
   -> point SkiaSharp at the resulting skiasharp commit
   -> rebase and validate the parent
@@ -44,6 +46,8 @@ reviewed PRs
 - Do not replace a native source build with `externals-download`.
 - Do not weaken review or cross-platform CI gates for a same-milestone servicing
   sync. Historical fast merges are not a supported landing path.
+- A draft PR is expected while gates remain open and is not by itself a
+  readiness blocker. Mark it ready only immediately before an approved merge.
 
 ## 1. Resolve the pair
 
@@ -57,15 +61,19 @@ Identify and cross-check:
 Read both PR bodies, commits, changed paths, reviews, inline comments, and
 checks. The reciprocal PR links must identify this exact pair.
 
-Search both repositories for competing open work before proceeding:
+Search both repositories for competing open work before proceeding. Treat
+another PR as competing only when evidence shows at least one of:
 
-- duplicate or superseded milestone/sync PRs;
-- submodule-only or `cgmanifest.json`-only PRs targeting the same release line;
-- PRs whose changed paths or branch names indicate they repin the same Skia
-  line even when their titles do not mention the milestone.
+- the same sync line, head, or base;
+- a duplicate `externals/skia` or `cgmanifest.json` repin;
+- overlapping DEPS dependency names, revisions, or hunks that would invalidate
+  one PR if the other landed.
 
 Record an explicit merge, close, or supersede disposition for every competing
-PR. Do not land while a competing pointer PR remains open.
+PR. Do not land while a competing pointer PR remains open. Merely touching
+`DEPS`, the gitlink, or another commonly changed file is not enough: report
+unrelated parallel work as non-blocking with the evidence that distinguishes
+it.
 
 Verify repository metadata on both PRs:
 
@@ -116,10 +124,13 @@ Do not rely on a review captured before the latest push.
    workarounds, and fork backports. Restore prior support before merge whenever
    possible. Otherwise require an explicitly accepted limitation and a linked
    tracking issue.
-9. Verify every tracked DEPS Component Governance registration carries the
-   current revision identity, semantic version, and `version_source` evidence.
-   Treat legacy compliance backfills as a separate gate even when the dependency
-   version itself did not change.
+9. Mechanically inspect every enabled tracked DEPS Component Governance
+   registration's nested `skia_dependency` object. Require non-empty
+   `revision`, `version_reviewed_identity`, and `version_source` values, and
+   confirm the registered semantic version matches that evidence. Do not infer
+   missing evidence from top-level `component` fields. Treat legacy compliance
+   backfills as a separate gate even when the dependency version itself did
+   not change.
 
 ## 3. Make the supported-line decision
 
@@ -165,7 +176,28 @@ Retry a failed CI job only when its logs prove an infrastructure failure such
 as a network timeout. Do not classify a compile, test, or rendering failure as
 a flake.
 
-## 5. Merge mono/skia first
+## 5. Preserve the previous milestone
+
+For a true milestone bump, preserve the line being replaced before either PR
+merges. A same-milestone servicing sync does not create another release line.
+
+1. Derive `release/A.B.x` from the previous SkiaSharp product line; for example,
+   an M153 bump preserves `release/4.152.x`.
+2. Re-fetch the current mono/skia base and mono/SkiaSharp base tips. Present
+   both planned refs and exact source SHAs and obtain explicit maintainer
+   confirmation before creating remote branches.
+3. Create the mono/skia release branch first from the pre-bump native base tip,
+   then create the identically named mono/SkiaSharp release branch from the
+   pre-bump parent base tip.
+4. Never force or move an existing release branch. Reuse it only when it already
+   resolves to the intended source SHA; stop on conflicting state.
+5. Verify the parent release branch's `externals/skia` gitlink equals the native
+   release branch tip and both branches still identify the previous milestone.
+
+Record both branch SHAs. This split keeps the previous milestone serviceable
+after the default branches advance.
+
+## 6. Merge mono/skia first
 
 1. Re-fetch both PRs and upstream immediately before merging.
 2. Verify the native PR head is based on the current base tip: its merge base
@@ -184,7 +216,7 @@ a flake.
 The resulting `skiasharp` commit may differ from the PR head because GitHub can
 create a merge commit. That resulting base-branch SHA is authoritative.
 
-## 6. Refresh the SkiaSharp parent
+## 7. Refresh the SkiaSharp parent
 
 1. Check out the companion feature branch.
 2. Run `update-skia/scripts/update_versions.py` with the original current and
@@ -208,7 +240,7 @@ create a merge commit. That resulting base-branch SHA is authoritative.
 
 Never leave the parent pointing at the old PR-head commit.
 
-## 7. Run the final parent gate
+## 8. Run the final parent gate
 
 Wait for CI on the refreshed parent head. Re-download and validate packages if
 the package-producing tree changed. Update both PR descriptions with durable
@@ -218,7 +250,7 @@ platform limitations.
 Invoke `pr-commit-message` for the parent PR, mark it ready, and merge it using
 the repository's normal strategy only after explicit approval.
 
-## 8. Verify and report
+## 9. Verify and report
 
 Confirm:
 
@@ -239,6 +271,7 @@ Report:
 
 ```text
 Upstream: <ref> @ <sha>
+Previous line: <release/A.B.x native sha and parent sha>
 mono/skia: <PR> -> <merged sha>
 mono/SkiaSharp: <PR> -> <merged sha>
 Review: <report and unresolved findings>
@@ -264,6 +297,9 @@ Stop without merging when any of these is true:
   with a tracking issue;
 - a crossed milestone, HarfBuzz bucket, or Component Governance registration is
   unaccounted for;
+- a true bump has not preserved the previous milestone in matching
+  `release/A.B.x` branches, the branch tips conflict, or the parent release
+  gitlink does not equal the native release tip;
 - the parent is behind its base or includes unrelated base commits;
 - required CI is pending or failing;
 - packages are missing, inconsistent, or cannot load;

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -7,7 +7,7 @@ description: >
   release line, prepares the mono/skia merge message, pauses for the manual
   native merge, repins the existing parent PR to the actual merged commit, then
   prepares the SkiaSharp merge message. This skill never merges either PR.
-compatibility: Requires git, gh, and PowerShell 7 with access to mono/skia and mono/SkiaSharp.
+compatibility: Requires git, gh, and PowerShell 7.4+ with access to mono/skia and mono/SkiaSharp.
 ---
 
 # Merge Skia Update

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -64,7 +64,7 @@ checks. The reciprocal PR links must identify this exact pair.
 Search both repositories for competing open work before proceeding. Treat
 another PR as competing only when evidence shows at least one of:
 
-- the same sync line, head, or base;
+- another Skia sync shares the same sync line, head, or intended sync base;
 - a duplicate `externals/skia` or `cgmanifest.json` repin;
 - overlapping DEPS dependency names, revisions, or hunks that would invalidate
   one PR if the other landed.
@@ -183,15 +183,17 @@ merges. A same-milestone servicing sync does not create another release line.
 
 1. Derive `release/A.B.x` from the previous SkiaSharp product line; for example,
    an M153 bump preserves `release/4.152.x`.
-2. Re-fetch the current mono/skia base and mono/SkiaSharp base tips. Present
-   both planned refs and exact source SHAs and obtain explicit maintainer
-   confirmation before creating remote branches.
-3. Create the mono/skia release branch first from the pre-bump native base tip,
-   then create the identically named mono/SkiaSharp release branch from the
-   pre-bump parent base tip.
-4. Never force or move an existing release branch. Reuse it only when it already
-   resolves to the intended source SHA; stop on conflicting state.
-5. Verify the parent release branch's `externals/skia` gitlink equals the native
+2. Re-fetch and record the current mono/skia base and mono/SkiaSharp base tips.
+3. Preflight both destination refs before creating either branch. Each must be
+   absent or already resolve to its intended source SHA; stop before any write
+   if either conflicts.
+4. Present both planned refs and exact source SHAs and obtain explicit
+   maintainer confirmation.
+5. Create any missing mono/skia release branch first from the recorded native
+   base tip, then create the missing identically named mono/SkiaSharp release
+   branch from the recorded parent base tip. Use guarded non-force ref creation.
+6. Never force or move an existing release branch.
+7. Verify the parent release branch's `externals/skia` gitlink equals the native
    release branch tip and both branches still identify the previous milestone.
 
 Record both branch SHAs. This split keeps the previous milestone serviceable
@@ -200,16 +202,19 @@ after the default branches advance.
 ## 6. Merge mono/skia first
 
 1. Re-fetch both PRs and upstream immediately before merging.
-2. Verify the native PR head is based on the current base tip: its merge base
+2. For a true bump, verify both current base tips still equal the recorded
+   `release/A.B.x` branch SHAs. If either base advanced after the split, stop
+   and reconcile the release-line decision rather than merging stale state.
+3. Verify the native PR head is based on the current base tip: its merge base
    must equal that tip and it must not be behind. Compute the prospective merge
    tree and require it to equal the reviewed PR-head tree before performing the
    irreversible merge.
-3. Invoke `pr-commit-message` for the mono/skia PR using the final head,
+4. Invoke `pr-commit-message` for the mono/skia PR using the final head,
    companion PR, compare range, review findings, and validation evidence.
-4. Mark the PR ready if needed.
-5. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
-6. Fetch the resulting base-branch tip and record its exact SHA and tree.
-7. Verify that resulting base-branch commit has exactly the reviewed PR-head
+5. Mark the PR ready if needed.
+6. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
+7. Fetch the resulting base-branch tip and record its exact SHA and tree.
+8. Verify that resulting base-branch commit has exactly the reviewed PR-head
    tree and that its history contains the authoritative two-parent upstream
    merge. Stop on any tree difference or missing ancestry.
 

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -193,11 +193,14 @@ merges. A same-milestone servicing sync does not create another release line.
    if either conflicts.
 5. Present both planned refs and exact source SHAs and obtain explicit
    maintainer confirmation.
-6. Create any missing mono/skia release branch first from the recorded native
+6. Immediately after confirmation and before either write, re-fetch both base
+   tips and require them to equal the recorded source SHAs. If either advanced,
+   stop and restart the source-pair preflight and confirmation.
+7. Create any missing mono/skia release branch first from the recorded native
    base tip, then create the missing identically named mono/SkiaSharp release
    branch from the recorded parent base tip. Use guarded non-force ref creation.
-7. Never force or move an existing release branch.
-8. Verify the parent release branch's `externals/skia` gitlink equals the native
+8. Never force or move an existing release branch.
+9. Verify the parent release branch's `externals/skia` gitlink equals the native
    release branch tip and both branches still identify the previous milestone.
 
 Record both branch SHAs. This split keeps the previous milestone serviceable

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -75,7 +75,10 @@ Stop. Continue only after the maintainer says mono/skia is merged.
 
 ## 4. Repin the existing SkiaSharp PR
 
-Use a clean worktree checked out to the resolved SkiaSharp PR head branch:
+Check whether the current checkout is clean, on the resolved SkiaSharp PR head
+branch, and matches its remote tip. Never discard or overwrite local changes.
+
+If the current checkout is suitable, use it directly:
 
 ```powershell
 pwsh .agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1 `
@@ -93,6 +96,27 @@ The default is a dry run. The script:
 Show the output. If it is correct, rerun with `-Push`. The script updates only
 `externals/skia` and the mono/skia `commitHash` in `cgmanifest.json`, commits the
 change, and pushes the existing SkiaSharp PR branch without force.
+
+If the current checkout is unsuitable, ask whether the maintainer wants to
+check out the parent PR branch or avoid a local checkout. For the no-checkout
+option, first verify the same two-parent ancestry and tree-equality conditions,
+record the exact verified mono/skia merge SHA, then trigger the existing
+workflow:
+
+```shell
+gh workflow run auto-skia-submodule-sync.yml --repo mono/SkiaSharp \
+  -f target_branch=<parent-head> \
+  -f skia_branch=<native-base>
+```
+
+The workflow opens or updates a small dependent PR targeting the existing
+SkiaSharp PR branch. Before showing that PR to the maintainer, confirm it
+changes only `externals/skia` and `cgmanifest.json` and that both files point to
+the exact verified merge SHA. Recheck that SHA's ancestry and tree equality
+against the reviewed native commit. Stop if the workflow captured any SHA
+other than the recorded verified one. Wait for the maintainer to merge the
+dependent PR manually, then verify the parent PR still points to that exact
+SHA. Do not generate the parent merge message until the dependent PR is merged.
 
 ## 5. Prepare the mono/SkiaSharp merge
 
@@ -132,6 +156,9 @@ Stop when:
 - mono/skia was not merged with a two-parent merge commit;
 - that merge does not contain the parent PR's reviewed native commit;
 - the merged and reviewed native trees differ;
-- the current worktree is not the clean, current SkiaSharp PR branch;
+- local repin was selected but the current checkout is not clean, on the parent
+  PR branch, and at its remote tip;
+- the workflow repin changes unexpected files, captures a different native SHA,
+  or its dependent PR is not merged;
 - the repin would change anything except `externals/skia` and
   `cgmanifest.json`.

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -1,19 +1,15 @@
 ---
 name: merge-skia-update
 description: >
-  Guide a maintainer through manually landing an already reviewed Skia update.
-  Use after review-skia-update has completed and the maintainer is happy with
-  the paired mono/skia and mono/SkiaSharp PRs. Optionally preserves the previous
-  release line, prepares the mono/skia merge message, pauses for the manual
-  native merge, repins the existing parent PR to the actual merged commit, then
-  prepares the SkiaSharp merge message. This skill never merges either PR.
+  Guide a maintainer through manually landing an already reviewed Skia update. Use after review-skia-update has completed and the maintainer is happy with
+  the paired mono/skia and mono/SkiaSharp PRs. Optionally preserves the previous release line, prepares the mono/skia merge message, pauses for the manual
+  native merge, repins the existing parent PR to the actual merged commit, then prepares the SkiaSharp merge message. This skill never merges either PR.
 compatibility: Requires git, gh, and PowerShell 7 with access to mono/skia and mono/SkiaSharp.
 ---
 
 # Merge Skia Update
 
-Help with the mechanical work around two manual merges. Do not repeat the
-review and do not merge either PR.
+Help with the mechanical work around two manual merges. Do not repeat the review and do not merge either PR.
 
 ## 1. Confirm and resolve
 
@@ -24,8 +20,7 @@ Ask the maintainer to confirm:
 - required CI was green;
 - they want to begin the manual landing.
 
-If they do not confirm, stop. Do not independently re-audit reviews, labels,
-milestones, CI, packages, DEPS, bindings, or release notes.
+If they do not confirm, stop. Do not independently re-audit reviews, labels, milestones, CI, packages, DEPS, bindings, or release notes.
 
 Use GitHub and the PR bodies to resolve:
 
@@ -47,28 +42,22 @@ pwsh .agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1 `
 
 The script determines the release action from the parent base branch:
 
-- `main`: reads the committed SkiaSharp package version from
-  `scripts/VERSIONS.txt` and derives `release/A.B.x` for the current line;
+- `main`: reads the committed SkiaSharp package version from `scripts/VERSIONS.txt` and derives `release/A.B.x` for the current line;
 - `release/A.B.x`: reports a servicing sync and exits without creating refs.
 
-For `main`, the default is a dry run. The script reads the current SkiaSharp
-base tip and the exact mono/skia commit referenced by its `externals/skia`
-gitlink. It requires the supplied mono/skia base branch to point at that commit
-and preflights the derived release branch in both repositories.
+For `main`, the default is a dry run. The script reads the current SkiaSharp base tip and the exact mono/skia commit referenced by its `externals/skia` gitlink.
+It requires the supplied mono/skia base branch to point at that commit and preflights the derived release branch in both repositories.
 
-Show the output and obtain confirmation. Rerun with `-Push`. The script checks
-the source and destination refs again, creates the mono/skia release branch
-first, then the mono/SkiaSharp release branch, and verifies both. It never moves
-an existing branch.
+Show the output and obtain confirmation. Rerun with `-Push`. The script checks the source and destination refs again, creates the mono/skia release branch
+first, then the mono/SkiaSharp release branch, and verifies both. It never moves an existing branch.
 
 ## 3. Prepare the mono/skia merge
 
 Invoke `pr-commit-message` for the resolved mono/skia PR and give its title and
 body to the maintainer.
 
-Tell the maintainer to merge mono/skia manually using **Create a merge commit**.
-Squash and rebase must not be used because upstream merge ancestry is part of
-the update history.
+Tell the maintainer to merge mono/skia manually using **Create a merge commit**. Squash and rebase must not be used because upstream merge ancestry is part
+of the update history.
 
 Stop. Continue only after the maintainer says mono/skia is merged.
 
@@ -89,8 +78,7 @@ The default is a dry run. The script:
 3. requires that tip to be a two-parent merge containing the reviewed commit;
 4. requires the merged tree to equal the reviewed tree.
 
-Show the output. If it is correct, rerun with `-Push`. The script updates only
-`externals/skia` and the mono/skia `commitHash` in `cgmanifest.json`, commits the
+Show the output. If it is correct, rerun with `-Push`. The script updates only `externals/skia` and the mono/skia `commitHash` in `cgmanifest.json`, commits the
 change, and pushes the existing SkiaSharp PR branch without force.
 
 ## 5. Prepare the mono/SkiaSharp merge
@@ -98,10 +86,8 @@ change, and pushes the existing SkiaSharp PR branch without force.
 Invoke `pr-commit-message` for the updated mono/SkiaSharp PR and give its title
 and body to the maintainer.
 
-Tell the maintainer to merge it manually using the repository's normal merge
-method. Do not wait for another PR CI run: the repin script proved that the
-merged mono/skia tree is identical to the reviewed PR tree. Main CI validates
-the resulting merge.
+Tell the maintainer to merge it manually using the repository's normal merge method. Do not wait for another PR CI run: the repin script proved that the merged
+mono/skia tree is identical to the reviewed PR tree. Main CI validates the resulting merge.
 
 Stop. Continue only after the maintainer says mono/SkiaSharp is merged.
 
@@ -110,12 +96,10 @@ Stop. Continue only after the maintainer says mono/SkiaSharp is merged.
 Confirm:
 
 - both PRs are merged;
-- mono/SkiaSharp main points its gitlink and cgmanifest at the actual mono/skia
-  merge commit;
+- mono/SkiaSharp main points its gitlink and cgmanifest at the actual mono/skia merge commit;
 - main CI has started for the resulting SkiaSharp commit.
 
-Report both merged SHAs and the preserved release branch, if created. Do not
-wait for main CI to finish.
+Report both merged SHAs and the preserved release branch, if created. Do not wait for main CI to finish.
 
 ## Stop conditions
 
@@ -132,5 +116,4 @@ Stop when:
 - that merge does not contain the parent PR's reviewed native commit;
 - the merged and reviewed native trees differ;
 - the current worktree is not the clean, current SkiaSharp PR branch;
-- the repin would change anything except `externals/skia` and
-  `cgmanifest.json`.
+- the repin would change anything except `externals/skia` and `cgmanifest.json`.

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -1,242 +1,132 @@
 ---
 name: merge-skia-update
 description: >
-  Run the post-approval merge checklist for a reviewed Skia milestone bump or
-  servicing sync across mono/skia and mono/SkiaSharp. Use only after a
-  maintainer has accepted a current review for the exact PR heads and explicitly
-  asks to merge, land, finalize, or complete the pair. Preserves the previous
-  release line, merges mono/skia first with a merge commit, repins the parent to
-  the actual merged SHA, requires refreshed approval after head-changing work,
-  validates exact-head CI and packages, and monitors post-merge CI. Use
-  review-skia-update for review or readiness assessment and update-skia to
-  create or refresh the update.
-compatibility: Requires git, gh, Python 3, and access to mono/skia and mono/SkiaSharp.
+  Guide a maintainer through manually landing an already reviewed Skia update.
+  Use after review-skia-update has completed and the maintainer is happy with
+  the paired mono/skia and mono/SkiaSharp PRs. Optionally preserves the previous
+  release line, prepares the mono/skia merge message, pauses for the manual
+  native merge, repins the existing parent PR to the actual merged commit, then
+  prepares the SkiaSharp merge message. This skill never merges either PR.
+compatibility: Requires git, gh, and PowerShell 7 with access to mono/skia and mono/SkiaSharp.
 ---
 
 # Merge Skia Update
 
-Execute the landing checklist for an already reviewed and approved Skia update.
-This skill is the merger, not the reviewer.
+Help with the mechanical work around two manual merges. Do not repeat the
+review and do not merge either PR.
 
+## 1. Confirm and resolve
+
+Ask the maintainer to confirm:
+
+- `review-skia-update` has run;
+- they are happy with the review and approve the update;
+- required CI was green;
+- they want to begin the manual landing.
+
+If they do not confirm, stop. Do not independently re-audit reviews, labels,
+milestones, CI, packages, DEPS, bindings, or release notes.
+
+Use GitHub and the PR bodies to resolve:
+
+- the mono/skia PR number, head branch, and base branch;
+- the mono/SkiaSharp PR number, head branch, and base branch;
+- whether this is a milestone bump or same-milestone servicing sync;
+- for a bump, the previous `release/A.B.x` branch name.
+
+Present these values before continuing.
+
+## 2. Preserve the previous release line for a bump
+
+Skip this section for a same-milestone servicing sync.
+
+Run the script with the branch names already resolved by the AI:
+
+```powershell
+pwsh .agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1 `
+  -SkiaSharpBaseBranch <parent-base> `
+  -SkiaBaseBranch <native-base> `
+  -ReleaseBranch <release/A.B.x>
 ```
-approved exact heads
-  -> preserve the previous milestone as release/A.B.x
-  -> merge mono/skia with a merge commit
-  -> repin SkiaSharp to the actual merged SHA
-  -> refresh review and approval for the final parent head
-  -> merge mono/SkiaSharp
-  -> verify post-merge CI
+
+The default is a dry run. The script reads the current SkiaSharp base tip and
+the exact mono/skia commit referenced by its `externals/skia` gitlink. It
+requires the supplied mono/skia base branch to point at that commit and
+preflights the release branch in both repositories.
+
+Show the output and obtain confirmation. Rerun with `-Push`. The script checks
+the source and destination refs again, creates the mono/skia release branch
+first, then the mono/SkiaSharp release branch, and verifies both. It never moves
+an existing branch.
+
+## 3. Prepare the mono/skia merge
+
+Invoke `pr-commit-message` for the resolved mono/skia PR and give its title and
+body to the maintainer.
+
+Tell the maintainer to merge mono/skia manually using **Create a merge commit**.
+Squash and rebase must not be used because upstream merge ancestry is part of
+the update history.
+
+Stop. Continue only after the maintainer says mono/skia is merged.
+
+## 4. Repin the existing SkiaSharp PR
+
+Use a clean worktree checked out to the resolved SkiaSharp PR head branch:
+
+```powershell
+pwsh .agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1 `
+  -SkiaSharpBranch <parent-head> `
+  -SkiaBranch <native-base>
 ```
 
-This skill covers `chrome/mN` milestone bumps and same-milestone servicing
-syncs. Use `update-skia` for a bleeding-edge Google Skia `main` sync.
+The default is a dry run. The script:
 
-## Scope boundary
+1. reads the reviewed mono/skia commit from the parent PR gitlink;
+2. resolves the new tip of the supplied mono/skia base branch;
+3. requires that tip to be a two-parent merge containing the reviewed commit;
+4. requires the merged tree to equal the reviewed tree.
 
-- Start only when the maintainer says the reviewed pair is approved and asks to
-  land it.
-- For "is this ready?", "review this", or an unapproved pair, stop and invoke
-  `review-skia-update`. Return here after the maintainer accepts that review.
-- Do not repeat the deep audit of fork patches, DEPS, Component Governance,
-  generated bindings, managed APIs, release notes, compatibility workarounds,
-  or version semantics. Those belong to the review.
-- Do verify that the accepted review covers those areas, has no unresolved
-  blockers, and identifies the exact live PR heads.
-- Approval is SHA-bound. Any push, rebase, repin, metadata/product edit, or
-  upstream movement that changes reviewed evidence invalidates approval.
-  Re-run the reviewer and obtain explicit maintainer approval before continuing.
+Show the output. If it is correct, rerun with `-Push`. The script updates only
+`externals/skia` and the mono/skia `commitHash` in `cgmanifest.json`, commits the
+change, and pushes the existing SkiaSharp PR branch without force.
 
-## Safety contract
+## 5. Prepare the mono/SkiaSharp merge
 
-- Never merge without explicit maintainer approval for the exact heads.
-- Never merge around a failed checklist item. Report the blocker and stop.
-- Never merge mono/SkiaSharp before mono/skia.
-- Never squash or rebase the mono/skia PR; use GitHub's merge-commit strategy.
-- Use `--force-with-lease` for a reviewed feature-branch rebase; never use an
-  unguarded force push.
-- Never replace a native source build with `externals-download`.
-- Do not weaken full cross-platform CI for a servicing sync.
-- A draft is not a blocker. Mark a PR ready only immediately before its approved
-  merge.
-- Delete branches only after both PRs merge.
+Invoke `pr-commit-message` for the updated mono/SkiaSharp PR and give its title
+and body to the maintainer.
 
-## 1. Accept the approved handoff
+Tell the maintainer to merge it manually using the repository's normal merge
+method. Do not wait for another PR CI run: the repin script proved that the
+merged mono/skia tree is identical to the reviewed PR tree. Main CI validates
+the resulting merge.
 
-Record:
+Stop. Continue only after the maintainer says mono/SkiaSharp is merged.
 
-- the mono/skia PR, base, approved head SHA, and target upstream ref/SHA;
-- the mono/SkiaSharp PR, base, and approved head SHA;
-- the reciprocal PR links and shared `skia-sync/...` branch;
-- the persisted, schema-valid `review-skia-update` report or explicit
-  independent human review evidence accepted by the maintainer;
-- the maintainer's explicit approval for those exact heads;
-- the accepted disposition of review findings, compatibility limitations and
-  tracking issues, support rotation, and any competing work.
-
-PR-body self-attestation is not independent review evidence. If the handoff is
-missing, stale, schema-invalid, or has unresolved findings, stop and return to
-`review-skia-update`.
-
-The accepted review must account for:
-
-- upstream integrity and genuine two-parent ancestry;
-- fork patches, DEPS, generated interop, managed API/ownership, and tests;
-- version surfaces, skipped milestones, and HarfBuzz bucket progression;
-- enabled tracked Component Governance registrations and their nested
-  `skia_dependency.revision`, `version_reviewed_identity`, and
-  `version_source`;
-- temporary feature/backend disables, source exclusions, GN flags, platform
-  workarounds, and backports;
-- reachable release notes;
-- the explicit `scripts/infra/docs/versions.json` support-rotation decision.
-
-Do not recreate these audits in this skill; require their accepted result.
-
-## 2. Revalidate volatile merge facts
-
-Immediately before any write:
-
-1. Re-fetch both PRs, both base branches, and the target upstream ref.
-2. Require both live heads to equal the approved SHAs.
-3. Require the upstream ref to equal the approved upstream SHA.
-4. Verify both PRs still have the accepted labels and milestone:
-   - both: `type/milestone-sync` and `partner/agentic-workflows`;
-   - true bump: also `type/milestone-bump`, with the parent assigned the release
-     milestone;
-   - servicing sync: no `type/milestone-bump`.
-5. Search for work opened since the review. Block only demonstrated competition:
-   - the same sync line, head, or intended base;
-   - a duplicate gitlink or cgmanifest repin;
-   - overlapping DEPS dependency/revision/hunks that invalidate one PR.
-   A shared filename alone is non-blocking. Every demonstrated competitor must
-   already be merged, closed, or explicitly superseded.
-6. Require both heads to be mergeable and current with their bases.
-7. Require exact-head required CI to be green. Native CI must cover Windows,
-   Linux, Apple, Android, Tizen, and WASM.
-8. Require package validation from the exact successful parent build: expected
-   IDs and versions, dependency ranges, archive integrity, representative
-   native assets/symbols, restore, and runtime loading.
-
-If any live fact differs from the approved handoff, stop. Run the appropriate
-refresh/review workflow and obtain new approval rather than interpreting the
-change during landing.
-
-## 3. Preserve the previous milestone
-
-For a true milestone bump, preserve the replaced line before either merge. A
-same-milestone servicing sync does not create another release line.
-
-1. Derive `release/A.B.x` from the previous SkiaSharp product line.
-2. Record the current mono/skia and mono/SkiaSharp base tips.
-3. Require both tips to identify the previous milestone and the parent base
-   gitlink to equal the native base tip.
-4. Preflight both destination refs before any write. Each must be absent or
-   already equal its intended source SHA; never move an existing branch.
-5. Present both refs and exact source SHAs and obtain confirmation.
-6. Re-fetch both source tips after confirmation. If either changed, restart the
-   preflight and confirmation.
-7. Create the mono/skia branch first, then the matching mono/SkiaSharp branch,
-   with guarded non-force ref creation.
-8. Verify both branch SHAs and that the parent release gitlink equals the native
-   release tip.
-
-## 4. Merge mono/skia
-
-1. Re-fetch both PRs, bases, and upstream.
-2. For a true bump, require both base tips still to equal the recorded release
-   branch SHAs.
-3. Require the native head and upstream SHA still to equal the approved values.
-4. Require the native merge base to equal the current base tip and `behind_by`
-   to be zero.
-5. Confirm the approved head contains the genuine two-parent upstream merge.
-6. Compute the prospective GitHub merge tree and require it to equal the
-   approved PR-head tree.
-7. Invoke `pr-commit-message`, mark the PR ready if necessary, and merge with
-   GitHub's **merge commit** strategy.
-8. Fetch the resulting base commit. Require its tree to equal the approved head
-   tree and its history to contain the authoritative two-parent upstream merge.
-
-Record the GitHub-created base SHA. It is authoritative even when it differs
-from the PR head.
-
-## 5. Refresh and reapprove the parent
-
-1. Rebase the parent feature branch onto the latest parent base.
-2. Apply only the support-rotation decision already accepted during review.
-3. As the last product-affecting parent operation before final CI, check out
-   `externals/skia` at the actual merged mono/skia base SHA, then run
-   `update-skia/scripts/update_versions.py` with the approved milestone and
-   upstream inputs plus the recorded pre-update parent and native base SHAs.
-   The helper reads the checked-out submodule HEAD when writing the cgmanifest
-   git registration, so never run it against the old PR-head checkout and repin
-   later.
-4. Verify the resulting diff and rerun the metadata checks. Require both the
-   gitlink and cgmanifest registration to equal the actual merged SHA while the
-   reviewed upstream ref and merge SHA remain unchanged.
-5. Commit and push with a guarded lease. A tiny dependent PR targeting the sync
-   branch is allowed only when branch policy requires it, and must merge before
-   final CI.
-6. Verify GitHub lists only the intended commits and files.
-7. Run `review-skia-update` against the refreshed exact pair, including the
-   final parent head. Obtain explicit maintainer approval for that final head.
-
-Do not merge the parent using the original approval: the required rebase and
-actual-SHA repin changed its head.
-
-## 6. Merge mono/SkiaSharp
-
-After refreshed approval:
-
-1. Re-fetch the parent PR and base; require the live head to equal the newly
-   approved SHA, `behind_by == 0`, and the merge base to equal the base tip.
-2. Require the gitlink and cgmanifest registration to equal the actual merged
-   mono/skia base SHA.
-3. Require exact-head CI to be green. If the package-producing tree changed,
-   validate packages again from this build.
-4. Invoke `pr-commit-message`, mark the PR ready if needed, and merge using the
-   repository's normal strategy only after explicit approval.
-
-## 7. Verify completion
+## 6. Post-merge check
 
 Confirm:
 
-- mono/skia's base contains the approved upstream merge and reviewed tree;
-- mono/SkiaSharp's base contains the final approved parent commit;
-- the merged parent gitlink equals the merged mono/skia SHA;
-- both PRs are merged and no demonstrated competing sync PR remains open;
-- required CI on the actual parent base-branch merge/squash commit is green;
-- branch cleanup occurs only now, after both merges.
+- both PRs are merged;
+- mono/SkiaSharp main points its gitlink and cgmanifest at the actual mono/skia
+  merge commit;
+- main CI has started for the resulting SkiaSharp commit.
 
-Do not report completion from pre-merge CI. If post-merge CI fails, open and
-land a repair.
-
-Report:
-
-```text
-Approved review: <report/evidence and exact approved SHAs>
-Upstream: <ref> @ <sha>
-Previous line: <release/A.B.x native sha and parent sha>
-mono/skia: <PR> -> <merged sha>
-Final parent approval: <evidence and exact head SHA>
-mono/SkiaSharp: <PR> -> <merged sha>
-CI: <exact successful head builds>
-Post-merge CI: <base commit and successful build>
-Packages: <versions and validation>
-Rotation: <accepted decision>
-```
+Report both merged SHAs and the preserved release branch, if created. Do not
+wait for main CI to finish.
 
 ## Stop conditions
 
-Stop without the next merge when:
+Stop when:
 
-- the maintainer has not explicitly approved the exact live head;
-- review evidence is missing, invalid, stale, or has unresolved findings;
-- upstream, a PR head, or reviewed evidence changed;
-- a demonstrated competitor remains open;
-- labels, milestone, mergeability, base currency, CI, or packages fail;
-- a true bump has not preserved the previous line in matching branches;
-- the native prospective or resulting merge tree differs from the approved
-  tree, or two-parent ancestry is missing;
-- the parent does not point to the actual merged mono/skia SHA;
-- refreshed review and approval for the final parent head are missing;
-- required post-parent-merge CI is pending or failing.
+- the maintainer does not confirm the initial checklist;
+- the PR pair or branch names cannot be resolved;
+- a supplied native base branch does not match the parent base gitlink;
+- an existing release branch points at a different SHA;
+- a release source changes between dry run and `-Push`;
+- mono/skia was not merged with a two-parent merge commit;
+- that merge does not contain the parent PR's reviewed native commit;
+- the merged and reviewed native trees differ;
+- the current worktree is not the clean, current SkiaSharp PR branch;
+- the repin would change anything except `externals/skia` and
+  `cgmanifest.json`.

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: merge-skia-update
 description: >
-  Guide a maintainer through manually landing an already reviewed Skia update. Use after review-skia-update has completed and the maintainer is happy with
-  the paired mono/skia and mono/SkiaSharp PRs. Optionally preserves the previous release line, prepares the mono/skia merge message, pauses for the manual
-  native merge, repins the existing parent PR to the actual merged commit, then prepares the SkiaSharp merge message. This skill never merges either PR.
+  Guide a maintainer through manually landing an already reviewed Skia update.
+  Use after review-skia-update has completed and the maintainer is happy with
+  the paired mono/skia and mono/SkiaSharp PRs. Optionally preserves the previous
+  release line, prepares the mono/skia merge message, pauses for the manual
+  native merge, repins the existing parent PR to the actual merged commit, then
+  prepares the SkiaSharp merge message. This skill never merges either PR.
 compatibility: Requires git, gh, and PowerShell 7 with access to mono/skia and mono/SkiaSharp.
 ---
 
 # Merge Skia Update
 
-Help with the mechanical work around two manual merges. Do not repeat the review and do not merge either PR.
+Help with the mechanical work around two manual merges. Do not repeat the
+review and do not merge either PR.
 
 ## 1. Confirm and resolve
 
@@ -20,7 +24,8 @@ Ask the maintainer to confirm:
 - required CI was green;
 - they want to begin the manual landing.
 
-If they do not confirm, stop. Do not independently re-audit reviews, labels, milestones, CI, packages, DEPS, bindings, or release notes.
+If they do not confirm, stop. Do not independently re-audit reviews, labels,
+milestones, CI, packages, DEPS, bindings, or release notes.
 
 Use GitHub and the PR bodies to resolve:
 
@@ -42,22 +47,28 @@ pwsh .agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1 `
 
 The script determines the release action from the parent base branch:
 
-- `main`: reads the committed SkiaSharp package version from `scripts/VERSIONS.txt` and derives `release/A.B.x` for the current line;
+- `main`: reads the committed SkiaSharp package version from
+  `scripts/VERSIONS.txt` and derives `release/A.B.x` for the current line;
 - `release/A.B.x`: reports a servicing sync and exits without creating refs.
 
-For `main`, the default is a dry run. The script reads the current SkiaSharp base tip and the exact mono/skia commit referenced by its `externals/skia` gitlink.
-It requires the supplied mono/skia base branch to point at that commit and preflights the derived release branch in both repositories.
+For `main`, the default is a dry run. The script reads the current SkiaSharp
+base tip and the exact mono/skia commit referenced by its `externals/skia`
+gitlink. It requires the supplied mono/skia base branch to point at that commit
+and preflights the derived release branch in both repositories.
 
-Show the output and obtain confirmation. Rerun with `-Push`. The script checks the source and destination refs again, creates the mono/skia release branch
-first, then the mono/SkiaSharp release branch, and verifies both. It never moves an existing branch.
+Show the output and obtain confirmation. Rerun with `-Push`. The script checks
+the source and destination refs again, creates the mono/skia release branch
+first, then the mono/SkiaSharp release branch, and verifies both. It never moves
+an existing branch.
 
 ## 3. Prepare the mono/skia merge
 
 Invoke `pr-commit-message` for the resolved mono/skia PR and give its title and
 body to the maintainer.
 
-Tell the maintainer to merge mono/skia manually using **Create a merge commit**. Squash and rebase must not be used because upstream merge ancestry is part
-of the update history.
+Tell the maintainer to merge mono/skia manually using **Create a merge commit**.
+Squash and rebase must not be used because upstream merge ancestry is part of
+the update history.
 
 Stop. Continue only after the maintainer says mono/skia is merged.
 
@@ -78,7 +89,8 @@ The default is a dry run. The script:
 3. requires that tip to be a two-parent merge containing the reviewed commit;
 4. requires the merged tree to equal the reviewed tree.
 
-Show the output. If it is correct, rerun with `-Push`. The script updates only `externals/skia` and the mono/skia `commitHash` in `cgmanifest.json`, commits the
+Show the output. If it is correct, rerun with `-Push`. The script updates only
+`externals/skia` and the mono/skia `commitHash` in `cgmanifest.json`, commits the
 change, and pushes the existing SkiaSharp PR branch without force.
 
 ## 5. Prepare the mono/SkiaSharp merge
@@ -86,8 +98,10 @@ change, and pushes the existing SkiaSharp PR branch without force.
 Invoke `pr-commit-message` for the updated mono/SkiaSharp PR and give its title
 and body to the maintainer.
 
-Tell the maintainer to merge it manually using the repository's normal merge method. Do not wait for another PR CI run: the repin script proved that the merged
-mono/skia tree is identical to the reviewed PR tree. Main CI validates the resulting merge.
+Tell the maintainer to merge it manually using the repository's normal merge
+method. Do not wait for another PR CI run: the repin script proved that the
+merged mono/skia tree is identical to the reviewed PR tree. Main CI validates
+the resulting merge.
 
 Stop. Continue only after the maintainer says mono/SkiaSharp is merged.
 
@@ -96,10 +110,12 @@ Stop. Continue only after the maintainer says mono/SkiaSharp is merged.
 Confirm:
 
 - both PRs are merged;
-- mono/SkiaSharp main points its gitlink and cgmanifest at the actual mono/skia merge commit;
+- mono/SkiaSharp main points its gitlink and cgmanifest at the actual mono/skia
+  merge commit;
 - main CI has started for the resulting SkiaSharp commit.
 
-Report both merged SHAs and the preserved release branch, if created. Do not wait for main CI to finish.
+Report both merged SHAs and the preserved release branch, if created. Do not
+wait for main CI to finish.
 
 ## Stop conditions
 
@@ -116,4 +132,5 @@ Stop when:
 - that merge does not contain the parent PR's reviewed native commit;
 - the merged and reviewed native trees differ;
 - the current worktree is not the clean, current SkiaSharp PR branch;
-- the repin would change anything except `externals/skia` and `cgmanifest.json`.
+- the repin would change anything except `externals/skia` and
+  `cgmanifest.json`.

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: merge-skia-update
+description: >
+  Safely land a reviewed Skia milestone bump or servicing sync across the
+  paired mono/skia and mono/SkiaSharp pull requests. Use whenever a maintainer
+  asks to merge, land, finalize, or complete a Skia bump/sync, or asks what is
+  still required before those PRs can merge. Verifies upstream freshness,
+  two-parent ancestry, fork and dependency decisions, parent rebase state,
+  release-note reachability, CI, packages, merge order, and the supported-line
+  rotation. Use update-skia to create or refresh the update and
+  review-skia-update for the deep review; this skill owns the final landing.
+  Do not use it to merge Google Skia into the fork or for bleeding-edge
+  upstream-main syncs.
+compatibility: Requires git, gh, Python 3, and access to mono/skia and mono/SkiaSharp.
+---
+
+# Merge Skia Update
+
+Land the two-repository update without losing upstream ancestry or leaving
+SkiaSharp pointed at an orphaned mono/skia PR commit.
+
+This skill covers `chrome/mN` milestone bumps and same-milestone servicing
+syncs. Use `update-skia` for a bleeding-edge Google Skia `main` sync because a
+continuously moving upstream tip needs a different landing policy.
+
+```
+reviewed PRs
+  -> merge mono/skia with a merge commit
+  -> point SkiaSharp at the resulting skiasharp commit
+  -> rebase and validate the parent
+  -> merge mono/SkiaSharp
+```
+
+## Safety contract
+
+- Treat "is this ready?" as read-only. Merge only when the user explicitly asks
+  to merge or land the PRs.
+- Never merge around a failed gate. Report the blocker and stop.
+- Never squash or rebase the mono/skia PR. Its upstream merge ancestry is part
+  of the sync record.
+- Never merge the SkiaSharp PR first.
+- Use `--force-with-lease` when a reviewed feature branch must be rebased;
+  never use an unguarded force push.
+- Do not replace a native source build with `externals-download`.
+
+## 1. Resolve the pair
+
+Identify and cross-check:
+
+- the mono/skia PR, its `skiasharp` or release-line base, and head SHA;
+- the mono/SkiaSharp companion PR, its parent base, and head SHA;
+- the milestone, upstream `chrome/mN` ref and exact SHA;
+- the shared `skia-sync/...` feature branch.
+
+Read both PR bodies, commits, changed paths, reviews, inline comments, and
+checks. The reciprocal PR links must identify this exact pair.
+
+## 2. Recheck the review gates
+
+Do not rely on a review captured before the latest push.
+
+1. Compare the live Google Skia ref with the recorded
+   `cgmanifest.json` `upstream_merge_commit`.
+   - If upstream moved, stop and run `update-skia` to refresh the existing PR.
+   - A milestone number match is not enough; compare exact ancestry.
+2. Confirm mono/skia contains a genuine two-parent merge whose upstream parent
+   is the target SHA and whose fork parent is the recorded base.
+3. Run or inspect the final `review-skia-update` report. Resolve every finding:
+   - added, removed, or changed fork patches;
+   - DEPS URLs, SHAs, and enabled/commented states;
+   - C API and generated binding changes;
+   - restored legacy code or dangling references;
+   - wrapper ownership, ABI, and test coverage.
+4. Confirm release-note sidecars mention only behavior reachable through the
+   current C and managed bindings.
+5. Confirm the parent PR is based directly on the current target branch:
+   - `behind_by == 0`;
+   - its merge base is the current base tip;
+   - GitHub lists only update commits and intended files, not commits already
+     on the base branch.
+6. Verify every version surface, including:
+   - Skia milestone and upstream SHA;
+   - native soname and `SK_C_INCREMENT`;
+   - SkiaSharp assembly/file/package versions;
+   - the HarfBuzzSharp milestone bucket when native HarfBuzz did not change.
+
+## 3. Make the supported-line decision
+
+Read `scripts/infra/docs/versions.json`. Its `support` block is hand-maintained
+release policy and also drives the scheduled Skia-sync rotation.
+
+Before landing a new milestone, report:
+
+- the current stable and preview lines;
+- the rotation produced by `stable + preview + highest-supported-plus-one`;
+- whether the newly merged main milestone and intended next milestone will be
+  monitored.
+
+Do not infer support from Chrome channels or edit the file automatically. If
+the rotation would omit a line the maintainer intends to service, stop for an
+explicit support-list decision.
+
+## 4. Validate the pre-merge heads
+
+Both current heads must be mergeable and free of pending or failing required
+checks. CI must cover the repository's native, managed, test, visual, package,
+and sample stages.
+
+Validate packages from the exact successful parent build:
+
+- package IDs and expected SkiaSharp/HarfBuzzSharp versions;
+- dependency ranges;
+- archive integrity;
+- representative native assets and symbols;
+- restore plus runtime loading on the available host.
+
+PR artifacts are normally unsigned; signing is a publication-pipeline concern.
+Retry a failed CI job only when its logs prove an infrastructure failure such
+as a network timeout. Do not classify a compile, test, or rendering failure as
+a flake.
+
+## 5. Merge mono/skia first
+
+1. Re-fetch both PRs and upstream immediately before merging.
+2. Invoke `pr-commit-message` for the mono/skia PR using the final head,
+   companion PR, compare range, review findings, and validation evidence.
+3. Mark the PR ready if needed.
+4. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
+5. Fetch the resulting base-branch tip and record its exact SHA and tree.
+
+The resulting `skiasharp` commit may differ from the PR head because GitHub can
+create a merge commit. That resulting base-branch SHA is authoritative.
+
+## 6. Refresh the SkiaSharp parent
+
+1. Check out the companion feature branch.
+2. Update `externals/skia` to the exact merged mono/skia base-branch commit.
+3. Update the Skia git registration in `cgmanifest.json` to the same SHA.
+   Preserve the reviewed upstream ref and upstream merge SHA.
+4. Run `update-skia/scripts/update_versions.py` with the original current and
+   target milestones, exact upstream SHA, parent-base SHA, and Skia-base SHA.
+   The helper rewrites and validates final metadata, so inspect its diff; do
+   not treat it as read-only and do not hand-edit generated bindings.
+5. Rebase the parent feature branch onto the latest target-branch tip.
+6. Push with a guarded lease and verify GitHub now shows only intended commits
+   and files.
+
+Never leave the parent pointing at the old PR-head commit.
+
+## 7. Run the final parent gate
+
+Wait for CI on the refreshed parent head. Re-download and validate packages if
+the package-producing tree changed. Update both PR descriptions with durable
+SHAs, merge decisions, build/test evidence, package results, and remaining
+platform limitations.
+
+Invoke `pr-commit-message` for the parent PR, mark it ready, and merge it using
+the repository's normal strategy only after explicit approval.
+
+## 8. Verify and report
+
+Confirm:
+
+- mono/skia's base contains the reviewed upstream merge;
+- mono/SkiaSharp's base contains the final parent commit;
+- the parent gitlink equals the merged mono/skia commit;
+- both PRs are merged and no stale open sync PR remains;
+- optional branch deletion happens only after both merges.
+
+Report:
+
+```text
+Upstream: <ref> @ <sha>
+mono/skia: <PR> -> <merged sha>
+mono/SkiaSharp: <PR> -> <merged sha>
+Review: <report and unresolved findings>
+CI: <exact successful build>
+Packages: <versions and validation>
+Rotation: <stable, preview, next targets and decision>
+```
+
+## Stop conditions
+
+Stop without merging when any of these is true:
+
+- upstream has advanced beyond the reviewed SHA;
+- the mono/skia merge is not a verified two-parent merge;
+- a fork patch, dependency, API, ownership, or release-note finding is open;
+- the parent is behind its base or includes unrelated base commits;
+- required CI is pending or failing;
+- packages are missing, inconsistent, or cannot load;
+- the supported-line rotation needs a maintainer decision;
+- mono/skia merged but the parent has not been updated to its resulting commit.

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -42,6 +42,8 @@ reviewed PRs
 - Use `--force-with-lease` when a reviewed feature branch must be rebased;
   never use an unguarded force push.
 - Do not replace a native source build with `externals-download`.
+- Do not weaken review or cross-platform CI gates for a same-milestone servicing
+  sync. Historical fast merges are not a supported landing path.
 
 ## 1. Resolve the pair
 
@@ -55,6 +57,25 @@ Identify and cross-check:
 Read both PR bodies, commits, changed paths, reviews, inline comments, and
 checks. The reciprocal PR links must identify this exact pair.
 
+Search both repositories for competing open work before proceeding:
+
+- duplicate or superseded milestone/sync PRs;
+- submodule-only or `cgmanifest.json`-only PRs targeting the same release line;
+- PRs whose changed paths or branch names indicate they repin the same Skia
+  line even when their titles do not mention the milestone.
+
+Record an explicit merge, close, or supersede disposition for every competing
+PR. Do not land while a competing pointer PR remains open.
+
+Verify repository metadata on both PRs:
+
+- every bump and servicing sync has `type/milestone-sync` and
+  `partner/agentic-workflows`;
+- a true milestone bump additionally has `type/milestone-bump`, and the parent
+  PR is assigned the release milestone (historically
+  `4.N.0-preview.1`);
+- a same-milestone servicing sync is not labeled as a milestone bump.
+
 ## 2. Recheck the review gates
 
 Do not rely on a review captured before the latest push.
@@ -65,24 +86,40 @@ Do not rely on a review captured before the latest push.
    - A milestone number match is not enough; compare exact ancestry.
 2. Confirm mono/skia contains a genuine two-parent merge whose upstream parent
    is the target SHA and whose fork parent is the recorded base.
-3. Run or inspect the final `review-skia-update` report. Resolve every finding:
+3. Require either a current, persisted, schema-valid `review-skia-update`
+   report for the exact live heads or explicit evidence of an independent
+   human review. A PR-body self-attestation is not review evidence. If the
+   evidence is missing, invalid, or stale after any push or rebase, stop and
+   run or rerun `review-skia-update`.
+4. Resolve every finding from that review:
    - added, removed, or changed fork patches;
    - DEPS URLs, SHAs, and enabled/commented states;
    - C API and generated binding changes;
    - restored legacy code or dangling references;
    - wrapper ownership, ABI, and test coverage.
-4. Confirm release-note sidecars mention only behavior reachable through the
+5. Confirm release-note sidecars mention only behavior reachable through the
    current C and managed bindings.
-5. Confirm the parent PR is based directly on the current target branch:
+6. Confirm the parent PR is based directly on the current target branch:
    - `behind_by == 0`;
    - its merge base is the current base tip;
    - GitHub lists only update commits and intended files, not commits already
      on the base branch.
-6. Verify every version surface, including:
+7. Verify every version surface, including:
    - Skia milestone and upstream SHA;
    - native soname and `SK_C_INCREMENT`;
    - SkiaSharp assembly/file/package versions;
-   - the HarfBuzzSharp milestone bucket when native HarfBuzz did not change.
+   - every crossed milestone when the update skips milestones;
+   - the HarfBuzzSharp milestone bucket, advanced by 100 for every crossed
+     milestone when native HarfBuzz did not change.
+8. Audit temporary compatibility work introduced to make CI green: disabled
+   features or backends, temporary source exclusions, GN flags, platform
+   workarounds, and fork backports. Restore prior support before merge whenever
+   possible. Otherwise require an explicitly accepted limitation and a linked
+   tracking issue.
+9. Verify every tracked DEPS Component Governance registration carries the
+   current revision identity, semantic version, and `version_source` evidence.
+   Treat legacy compliance backfills as a separate gate even when the dependency
+   version itself did not change.
 
 ## 3. Make the supported-line decision
 
@@ -96,15 +133,24 @@ Before landing a new milestone, report:
 - whether the newly merged main milestone and intended next milestone will be
   monitored.
 
-Do not infer support from Chrome channels or edit the file automatically. If
-the rotation would omit a line the maintainer intends to service, stop for an
-explicit support-list decision.
+Do not infer support from Chrome channels or edit the file automatically.
+After reporting the computed rotation, ask for and consume an explicit
+maintainer decision. If approved, update support in the parent PR and
+revalidate the documentation/index behavior that consumes it. If declined,
+record that decision. If no decision exists, or the rotation would omit a line
+the maintainer intends to service, stop. History is not policy: M151 updated
+this file during landing while M152 omitted it and left the rotation stale.
 
 ## 4. Validate the pre-merge heads
 
 Both current heads must be mergeable and free of pending or failing required
 checks. CI must cover the repository's native, managed, test, visual, package,
 and sample stages.
+
+A source build on the available host is necessary but insufficient. Full native
+CI across Windows, Linux, Apple platforms, Android, Tizen, and WASM is the
+primary detector for compiler, SDK, linker, GN, and packaging fallout. Require
+that matrix for both true bumps and same-milestone servicing syncs.
 
 Validate packages from the exact successful parent build:
 
@@ -127,6 +173,9 @@ a flake.
 3. Mark the PR ready if needed.
 4. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
 5. Fetch the resulting base-branch tip and record its exact SHA and tree.
+6. Verify that resulting base-branch commit has exactly the reviewed PR-head
+   tree and that its history contains the authoritative two-parent upstream
+   merge. Stop on any tree difference or missing ancestry.
 
 The resulting `skiasharp` commit may differ from the PR head because GitHub can
 create a merge commit. That resulting base-branch SHA is authoritative.
@@ -134,15 +183,23 @@ create a merge commit. That resulting base-branch SHA is authoritative.
 ## 6. Refresh the SkiaSharp parent
 
 1. Check out the companion feature branch.
-2. Update `externals/skia` to the exact merged mono/skia base-branch commit.
-3. Update the Skia git registration in `cgmanifest.json` to the same SHA.
-   Preserve the reviewed upstream ref and upstream merge SHA.
-4. Run `update-skia/scripts/update_versions.py` with the original current and
+2. Run `update-skia/scripts/update_versions.py` with the original current and
    target milestones, exact upstream SHA, parent-base SHA, and Skia-base SHA.
    The helper rewrites and validates final metadata, so inspect its diff; do
    not treat it as read-only and do not hand-edit generated bindings.
-5. Rebase the parent feature branch onto the latest target-branch tip.
-6. Push with a guarded lease and verify GitHub now shows only intended commits
+3. Apply an approved `versions.json` support decision and revalidate its
+   documentation/index consumers.
+4. Rebase the parent feature branch onto the latest target-branch tip.
+5. As the last product-affecting parent change before final CI, update
+   `externals/skia` and its `cgmanifest.json` registration to the exact merged
+   mono/skia base-branch SHA. Preserve the reviewed upstream ref and upstream
+   merge SHA, and rerun the metadata checks. Do not repin earlier: M150 and
+   M151 repeatedly demonstrated that an early repin goes stale.
+6. Commit the final repin directly in the companion branch under the normal
+   workflow. When branch ownership or review policy requires isolation, a tiny
+   dependent PR targeting the sync branch is allowed, but it must merge before
+   the parent PR and before final CI.
+7. Push with a guarded lease and verify GitHub now shows only intended commits
    and files.
 
 Never leave the parent pointing at the old PR-head commit.
@@ -165,7 +222,14 @@ Confirm:
 - mono/SkiaSharp's base contains the final parent commit;
 - the parent gitlink equals the merged mono/skia commit;
 - both PRs are merged and no stale open sync PR remains;
+- required CI on the actual mono/SkiaSharp base-branch merge or squash commit is
+  green;
 - optional branch deletion happens only after both merges.
+
+Monitor post-merge CI against the actual parent base-branch commit, not the
+pre-merge head. Do not report the landing complete until required post-merge
+CI is green. If it fails, open and land a repair; do not substitute pre-merge
+checks as evidence. M152 demonstrates why this gate is required.
 
 Report:
 
@@ -175,6 +239,7 @@ mono/skia: <PR> -> <merged sha>
 mono/SkiaSharp: <PR> -> <merged sha>
 Review: <report and unresolved findings>
 CI: <exact successful build>
+Post-merge CI: <base commit and successful build>
 Packages: <versions and validation>
 Rotation: <stable, preview, next targets and decision>
 ```
@@ -185,9 +250,18 @@ Stop without merging when any of these is true:
 
 - upstream has advanced beyond the reviewed SHA;
 - the mono/skia merge is not a verified two-parent merge;
+- persisted review evidence is missing, schema-invalid, or stale;
+- a competing sync or pointer PR lacks an explicit disposition;
+- required PR labels or the parent release milestone are wrong;
 - a fork patch, dependency, API, ownership, or release-note finding is open;
+- temporary compatibility work lacks restored support or an accepted limitation
+  with a tracking issue;
+- a crossed milestone, HarfBuzz bucket, or Component Governance registration is
+  unaccounted for;
 - the parent is behind its base or includes unrelated base commits;
 - required CI is pending or failing;
 - packages are missing, inconsistent, or cannot load;
 - the supported-line rotation needs a maintainer decision;
-- mono/skia merged but the parent has not been updated to its resulting commit.
+- mono/skia merged but the parent has not been updated to its resulting commit;
+- the merged mono/skia base tree differs from the reviewed PR-head tree;
+- required post-parent-merge CI is pending or failing.

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -168,12 +168,16 @@ a flake.
 ## 5. Merge mono/skia first
 
 1. Re-fetch both PRs and upstream immediately before merging.
-2. Invoke `pr-commit-message` for the mono/skia PR using the final head,
+2. Verify the native PR head is based on the current base tip: its merge base
+   must equal that tip and it must not be behind. Compute the prospective merge
+   tree and require it to equal the reviewed PR-head tree before performing the
+   irreversible merge.
+3. Invoke `pr-commit-message` for the mono/skia PR using the final head,
    companion PR, compare range, review findings, and validation evidence.
-3. Mark the PR ready if needed.
-4. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
-5. Fetch the resulting base-branch tip and record its exact SHA and tree.
-6. Verify that resulting base-branch commit has exactly the reviewed PR-head
+4. Mark the PR ready if needed.
+5. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
+6. Fetch the resulting base-branch tip and record its exact SHA and tree.
+7. Verify that resulting base-branch commit has exactly the reviewed PR-head
    tree and that its history contains the authoritative two-parent upstream
    merge. Stop on any tree difference or missing ancestry.
 
@@ -250,6 +254,8 @@ Stop without merging when any of these is true:
 
 - upstream has advanced beyond the reviewed SHA;
 - the mono/skia merge is not a verified two-parent merge;
+- the native PR is behind its base or its prospective merge tree differs from
+  the reviewed PR-head tree;
 - persisted review evidence is missing, schema-invalid, or stale;
 - a competing sync or pointer PR lacks an explicit disposition;
 - required PR labels or the parent release milestone are wrong;

--- a/.agents/skills/merge-skia-update/SKILL.md
+++ b/.agents/skills/merge-skia-update/SKILL.md
@@ -1,322 +1,242 @@
 ---
 name: merge-skia-update
 description: >
-  Safely land a reviewed Skia milestone bump or servicing sync across the
-  paired mono/skia and mono/SkiaSharp pull requests. Use whenever a maintainer
-  asks to merge, land, finalize, or complete a Skia bump/sync, or asks what is
-  still required before those PRs can merge. Verifies upstream freshness,
-  two-parent ancestry, fork and dependency decisions, parent rebase state,
-  release-note reachability, prior-line preservation, CI, packages, merge
-  order, and the supported-line rotation. Use update-skia to create or refresh
-  the update and review-skia-update for the deep review; this skill owns the
-  final landing.
-  Do not use it to merge Google Skia into the fork or for bleeding-edge
-  upstream-main syncs.
+  Run the post-approval merge checklist for a reviewed Skia milestone bump or
+  servicing sync across mono/skia and mono/SkiaSharp. Use only after a
+  maintainer has accepted a current review for the exact PR heads and explicitly
+  asks to merge, land, finalize, or complete the pair. Preserves the previous
+  release line, merges mono/skia first with a merge commit, repins the parent to
+  the actual merged SHA, requires refreshed approval after head-changing work,
+  validates exact-head CI and packages, and monitors post-merge CI. Use
+  review-skia-update for review or readiness assessment and update-skia to
+  create or refresh the update.
 compatibility: Requires git, gh, Python 3, and access to mono/skia and mono/SkiaSharp.
 ---
 
 # Merge Skia Update
 
-Land the two-repository update without losing upstream ancestry or leaving
-SkiaSharp pointed at an orphaned mono/skia PR commit.
-
-This skill covers `chrome/mN` milestone bumps and same-milestone servicing
-syncs. Use `update-skia` for a bleeding-edge Google Skia `main` sync because a
-continuously moving upstream tip needs a different landing policy.
+Execute the landing checklist for an already reviewed and approved Skia update.
+This skill is the merger, not the reviewer.
 
 ```
-reviewed PRs
+approved exact heads
   -> preserve the previous milestone as release/A.B.x
   -> merge mono/skia with a merge commit
-  -> point SkiaSharp at the resulting skiasharp commit
-  -> rebase and validate the parent
+  -> repin SkiaSharp to the actual merged SHA
+  -> refresh review and approval for the final parent head
   -> merge mono/SkiaSharp
+  -> verify post-merge CI
 ```
+
+This skill covers `chrome/mN` milestone bumps and same-milestone servicing
+syncs. Use `update-skia` for a bleeding-edge Google Skia `main` sync.
+
+## Scope boundary
+
+- Start only when the maintainer says the reviewed pair is approved and asks to
+  land it.
+- For "is this ready?", "review this", or an unapproved pair, stop and invoke
+  `review-skia-update`. Return here after the maintainer accepts that review.
+- Do not repeat the deep audit of fork patches, DEPS, Component Governance,
+  generated bindings, managed APIs, release notes, compatibility workarounds,
+  or version semantics. Those belong to the review.
+- Do verify that the accepted review covers those areas, has no unresolved
+  blockers, and identifies the exact live PR heads.
+- Approval is SHA-bound. Any push, rebase, repin, metadata/product edit, or
+  upstream movement that changes reviewed evidence invalidates approval.
+  Re-run the reviewer and obtain explicit maintainer approval before continuing.
 
 ## Safety contract
 
-- Treat "is this ready?" as read-only. Merge only when the user explicitly asks
-  to merge or land the PRs.
-- Never merge around a failed gate. Report the blocker and stop.
-- Never squash or rebase the mono/skia PR. Its upstream merge ancestry is part
-  of the sync record.
-- Never merge the SkiaSharp PR first.
-- Use `--force-with-lease` when a reviewed feature branch must be rebased;
-  never use an unguarded force push.
-- Do not replace a native source build with `externals-download`.
-- Do not weaken review or cross-platform CI gates for a same-milestone servicing
-  sync. Historical fast merges are not a supported landing path.
-- A draft PR is expected while gates remain open and is not by itself a
-  readiness blocker. Mark it ready only immediately before an approved merge.
+- Never merge without explicit maintainer approval for the exact heads.
+- Never merge around a failed checklist item. Report the blocker and stop.
+- Never merge mono/SkiaSharp before mono/skia.
+- Never squash or rebase the mono/skia PR; use GitHub's merge-commit strategy.
+- Use `--force-with-lease` for a reviewed feature-branch rebase; never use an
+  unguarded force push.
+- Never replace a native source build with `externals-download`.
+- Do not weaken full cross-platform CI for a servicing sync.
+- A draft is not a blocker. Mark a PR ready only immediately before its approved
+  merge.
+- Delete branches only after both PRs merge.
 
-## 1. Resolve the pair
+## 1. Accept the approved handoff
 
-Identify and cross-check:
+Record:
 
-- the mono/skia PR, its `skiasharp` or release-line base, and head SHA;
-- the mono/SkiaSharp companion PR, its parent base, and head SHA;
-- the milestone, upstream `chrome/mN` ref and exact SHA;
-- the shared `skia-sync/...` feature branch.
+- the mono/skia PR, base, approved head SHA, and target upstream ref/SHA;
+- the mono/SkiaSharp PR, base, and approved head SHA;
+- the reciprocal PR links and shared `skia-sync/...` branch;
+- the persisted, schema-valid `review-skia-update` report or explicit
+  independent human review evidence accepted by the maintainer;
+- the maintainer's explicit approval for those exact heads;
+- the accepted disposition of review findings, compatibility limitations and
+  tracking issues, support rotation, and any competing work.
 
-Read both PR bodies, commits, changed paths, reviews, inline comments, and
-checks. The reciprocal PR links must identify this exact pair.
+PR-body self-attestation is not independent review evidence. If the handoff is
+missing, stale, schema-invalid, or has unresolved findings, stop and return to
+`review-skia-update`.
 
-Search both repositories for competing open work before proceeding. Treat
-another PR as competing only when evidence shows at least one of:
+The accepted review must account for:
 
-- another Skia sync shares the same sync line, head, or intended sync base;
-- a duplicate `externals/skia` or `cgmanifest.json` repin;
-- overlapping DEPS dependency names, revisions, or hunks that would invalidate
-  one PR if the other landed.
+- upstream integrity and genuine two-parent ancestry;
+- fork patches, DEPS, generated interop, managed API/ownership, and tests;
+- version surfaces, skipped milestones, and HarfBuzz bucket progression;
+- enabled tracked Component Governance registrations and their nested
+  `skia_dependency.revision`, `version_reviewed_identity`, and
+  `version_source`;
+- temporary feature/backend disables, source exclusions, GN flags, platform
+  workarounds, and backports;
+- reachable release notes;
+- the explicit `scripts/infra/docs/versions.json` support-rotation decision.
 
-Record an explicit merge, close, or supersede disposition for every competing
-PR, then require that disposition to be completed before landing: the PR must
-already be merged, closed, or explicitly superseded. Do not leave any
-demonstrated competing PR open. Merely touching `DEPS`, the gitlink, or another
-commonly changed file is not enough: report unrelated parallel work as
-non-blocking with the evidence that distinguishes it.
+Do not recreate these audits in this skill; require their accepted result.
 
-Verify repository metadata on both PRs:
+## 2. Revalidate volatile merge facts
 
-- every bump and servicing sync has `type/milestone-sync` and
-  `partner/agentic-workflows`;
-- a true milestone bump additionally has `type/milestone-bump`, and the parent
-  PR is assigned the release milestone (historically
-  `4.N.0-preview.1`);
-- a same-milestone servicing sync is not labeled as a milestone bump.
+Immediately before any write:
 
-## 2. Recheck the review gates
+1. Re-fetch both PRs, both base branches, and the target upstream ref.
+2. Require both live heads to equal the approved SHAs.
+3. Require the upstream ref to equal the approved upstream SHA.
+4. Verify both PRs still have the accepted labels and milestone:
+   - both: `type/milestone-sync` and `partner/agentic-workflows`;
+   - true bump: also `type/milestone-bump`, with the parent assigned the release
+     milestone;
+   - servicing sync: no `type/milestone-bump`.
+5. Search for work opened since the review. Block only demonstrated competition:
+   - the same sync line, head, or intended base;
+   - a duplicate gitlink or cgmanifest repin;
+   - overlapping DEPS dependency/revision/hunks that invalidate one PR.
+   A shared filename alone is non-blocking. Every demonstrated competitor must
+   already be merged, closed, or explicitly superseded.
+6. Require both heads to be mergeable and current with their bases.
+7. Require exact-head required CI to be green. Native CI must cover Windows,
+   Linux, Apple, Android, Tizen, and WASM.
+8. Require package validation from the exact successful parent build: expected
+   IDs and versions, dependency ranges, archive integrity, representative
+   native assets/symbols, restore, and runtime loading.
 
-Do not rely on a review captured before the latest push.
+If any live fact differs from the approved handoff, stop. Run the appropriate
+refresh/review workflow and obtain new approval rather than interpreting the
+change during landing.
 
-1. Compare the live Google Skia ref with the recorded
-   `cgmanifest.json` `upstream_merge_commit`.
-   - If upstream moved, stop and run `update-skia` to refresh the existing PR.
-   - A milestone number match is not enough; compare exact ancestry.
-2. Confirm mono/skia contains a genuine two-parent merge whose upstream parent
-   is the target SHA and whose fork parent is the recorded base.
-3. Require either a current, persisted, schema-valid `review-skia-update`
-   report for the exact live heads or explicit evidence of an independent
-   human review. A PR-body self-attestation is not review evidence. If the
-   evidence is missing, invalid, or stale after any push or rebase, stop and
-   run or rerun `review-skia-update`.
-4. Resolve every finding from that review:
-   - added, removed, or changed fork patches;
-   - DEPS URLs, SHAs, and enabled/commented states;
-   - C API and generated binding changes;
-   - restored legacy code or dangling references;
-   - wrapper ownership, ABI, and test coverage.
-5. Confirm release-note sidecars mention only behavior reachable through the
-   current C and managed bindings.
-6. Confirm the parent PR is based directly on the current target branch:
-   - `behind_by == 0`;
-   - its merge base is the current base tip;
-   - GitHub lists only update commits and intended files, not commits already
-     on the base branch.
-7. Verify every version surface, including:
-   - Skia milestone and upstream SHA;
-   - native soname and `SK_C_INCREMENT`;
-   - SkiaSharp assembly/file/package versions;
-   - every crossed milestone when the update skips milestones;
-   - the HarfBuzzSharp milestone bucket, advanced by 100 for every crossed
-     milestone when native HarfBuzz did not change.
-8. Audit temporary compatibility work introduced to make CI green: disabled
-   features or backends, temporary source exclusions, GN flags, platform
-   workarounds, and fork backports. Restore prior support before merge whenever
-   possible. Otherwise require an explicitly accepted limitation and a linked
-   tracking issue.
-9. Mechanically inspect every enabled tracked DEPS Component Governance
-   registration's nested `skia_dependency` object. Require non-empty
-   `revision`, `version_reviewed_identity`, and `version_source` values, and
-   confirm the registered semantic version matches that evidence. Do not infer
-   missing evidence from top-level `component` fields. Treat legacy compliance
-   backfills as a separate gate even when the dependency version itself did
-   not change.
+## 3. Preserve the previous milestone
 
-## 3. Make the supported-line decision
+For a true milestone bump, preserve the replaced line before either merge. A
+same-milestone servicing sync does not create another release line.
 
-Read `scripts/infra/docs/versions.json`. Its `support` block is hand-maintained
-release policy and also drives the scheduled Skia-sync rotation.
+1. Derive `release/A.B.x` from the previous SkiaSharp product line.
+2. Record the current mono/skia and mono/SkiaSharp base tips.
+3. Require both tips to identify the previous milestone and the parent base
+   gitlink to equal the native base tip.
+4. Preflight both destination refs before any write. Each must be absent or
+   already equal its intended source SHA; never move an existing branch.
+5. Present both refs and exact source SHAs and obtain confirmation.
+6. Re-fetch both source tips after confirmation. If either changed, restart the
+   preflight and confirmation.
+7. Create the mono/skia branch first, then the matching mono/SkiaSharp branch,
+   with guarded non-force ref creation.
+8. Verify both branch SHAs and that the parent release gitlink equals the native
+   release tip.
 
-Before landing a new milestone, report:
+## 4. Merge mono/skia
 
-- the current stable and preview lines;
-- the rotation produced by `stable + preview + highest-supported-plus-one`;
-- whether the newly merged main milestone and intended next milestone will be
-  monitored.
+1. Re-fetch both PRs, bases, and upstream.
+2. For a true bump, require both base tips still to equal the recorded release
+   branch SHAs.
+3. Require the native head and upstream SHA still to equal the approved values.
+4. Require the native merge base to equal the current base tip and `behind_by`
+   to be zero.
+5. Confirm the approved head contains the genuine two-parent upstream merge.
+6. Compute the prospective GitHub merge tree and require it to equal the
+   approved PR-head tree.
+7. Invoke `pr-commit-message`, mark the PR ready if necessary, and merge with
+   GitHub's **merge commit** strategy.
+8. Fetch the resulting base commit. Require its tree to equal the approved head
+   tree and its history to contain the authoritative two-parent upstream merge.
 
-Do not infer support from Chrome channels or edit the file automatically.
-After reporting the computed rotation, ask for and consume an explicit
-maintainer decision. If approved, update support in the parent PR and
-revalidate the documentation/index behavior that consumes it. If declined,
-record that decision. If no decision exists, or the rotation would omit a line
-the maintainer intends to service, stop. History is not policy: M151 updated
-this file during landing while M152 omitted it and left the rotation stale.
+Record the GitHub-created base SHA. It is authoritative even when it differs
+from the PR head.
 
-## 4. Validate the pre-merge heads
+## 5. Refresh and reapprove the parent
 
-Both current heads must be mergeable and free of pending or failing required
-checks. CI must cover the repository's native, managed, test, visual, package,
-and sample stages.
+1. Rebase the parent feature branch onto the latest parent base.
+2. Apply only the support-rotation decision already accepted during review.
+3. As the last product-affecting parent operation before final CI, check out
+   `externals/skia` at the actual merged mono/skia base SHA, then run
+   `update-skia/scripts/update_versions.py` with the approved milestone and
+   upstream inputs plus the recorded pre-update parent and native base SHAs.
+   The helper reads the checked-out submodule HEAD when writing the cgmanifest
+   git registration, so never run it against the old PR-head checkout and repin
+   later.
+4. Verify the resulting diff and rerun the metadata checks. Require both the
+   gitlink and cgmanifest registration to equal the actual merged SHA while the
+   reviewed upstream ref and merge SHA remain unchanged.
+5. Commit and push with a guarded lease. A tiny dependent PR targeting the sync
+   branch is allowed only when branch policy requires it, and must merge before
+   final CI.
+6. Verify GitHub lists only the intended commits and files.
+7. Run `review-skia-update` against the refreshed exact pair, including the
+   final parent head. Obtain explicit maintainer approval for that final head.
 
-A source build on the available host is necessary but insufficient. Full native
-CI across Windows, Linux, Apple platforms, Android, Tizen, and WASM is the
-primary detector for compiler, SDK, linker, GN, and packaging fallout. Require
-that matrix for both true bumps and same-milestone servicing syncs.
+Do not merge the parent using the original approval: the required rebase and
+actual-SHA repin changed its head.
 
-Validate packages from the exact successful parent build:
+## 6. Merge mono/SkiaSharp
 
-- package IDs and expected SkiaSharp/HarfBuzzSharp versions;
-- dependency ranges;
-- archive integrity;
-- representative native assets and symbols;
-- restore plus runtime loading on the available host.
+After refreshed approval:
 
-PR artifacts are normally unsigned; signing is a publication-pipeline concern.
-Retry a failed CI job only when its logs prove an infrastructure failure such
-as a network timeout. Do not classify a compile, test, or rendering failure as
-a flake.
+1. Re-fetch the parent PR and base; require the live head to equal the newly
+   approved SHA, `behind_by == 0`, and the merge base to equal the base tip.
+2. Require the gitlink and cgmanifest registration to equal the actual merged
+   mono/skia base SHA.
+3. Require exact-head CI to be green. If the package-producing tree changed,
+   validate packages again from this build.
+4. Invoke `pr-commit-message`, mark the PR ready if needed, and merge using the
+   repository's normal strategy only after explicit approval.
 
-## 5. Preserve the previous milestone
-
-For a true milestone bump, preserve the line being replaced before either PR
-merges. A same-milestone servicing sync does not create another release line.
-
-1. Derive `release/A.B.x` from the previous SkiaSharp product line; for example,
-   an M153 bump preserves `release/4.152.x`.
-2. Re-fetch and record the current mono/skia base and mono/SkiaSharp base tips.
-3. Before any write, verify both source tips identify the previous milestone
-   and the parent base's `externals/skia` gitlink equals the recorded native
-   base tip.
-4. Preflight both destination refs before creating either branch. Each must be
-   absent or already resolve to its intended source SHA; stop before any write
-   if either conflicts.
-5. Present both planned refs and exact source SHAs and obtain explicit
-   maintainer confirmation.
-6. Immediately after confirmation and before either write, re-fetch both base
-   tips and require them to equal the recorded source SHAs. If either advanced,
-   stop and restart the source-pair preflight and confirmation.
-7. Create any missing mono/skia release branch first from the recorded native
-   base tip, then create the missing identically named mono/SkiaSharp release
-   branch from the recorded parent base tip. Use guarded non-force ref creation.
-8. Never force or move an existing release branch.
-9. Verify the parent release branch's `externals/skia` gitlink equals the native
-   release branch tip and both branches still identify the previous milestone.
-
-Record both branch SHAs. This split keeps the previous milestone serviceable
-after the default branches advance.
-
-## 6. Merge mono/skia first
-
-1. Re-fetch both PRs and upstream immediately before merging.
-2. For a true bump, verify both current base tips still equal the recorded
-   `release/A.B.x` branch SHAs. If either base advanced after the split, stop
-   and reconcile the release-line decision rather than merging stale state.
-3. Verify the native PR head is based on the current base tip: its merge base
-   must equal that tip and it must not be behind. Compute the prospective merge
-   tree and require it to equal the reviewed PR-head tree before performing the
-   irreversible merge.
-4. Invoke `pr-commit-message` for the mono/skia PR using the final head,
-   companion PR, compare range, review findings, and validation evidence.
-5. Mark the PR ready if needed.
-6. Merge with GitHub's **merge commit** strategy. Never squash or rebase it.
-7. Fetch the resulting base-branch tip and record its exact SHA and tree.
-8. Verify that resulting base-branch commit has exactly the reviewed PR-head
-   tree and that its history contains the authoritative two-parent upstream
-   merge. Stop on any tree difference or missing ancestry.
-
-The resulting `skiasharp` commit may differ from the PR head because GitHub can
-create a merge commit. That resulting base-branch SHA is authoritative.
-
-## 7. Refresh the SkiaSharp parent
-
-1. Check out the companion feature branch.
-2. Run `update-skia/scripts/update_versions.py` with the original current and
-   target milestones, exact upstream SHA, parent-base SHA, and Skia-base SHA.
-   The helper rewrites and validates final metadata, so inspect its diff; do
-   not treat it as read-only and do not hand-edit generated bindings.
-3. Apply an approved `versions.json` support decision and revalidate its
-   documentation/index consumers.
-4. Rebase the parent feature branch onto the latest target-branch tip.
-5. As the last product-affecting parent change before final CI, update
-   `externals/skia` and its `cgmanifest.json` registration to the exact merged
-   mono/skia base-branch SHA. Preserve the reviewed upstream ref and upstream
-   merge SHA, and rerun the metadata checks. Do not repin earlier: M150 and
-   M151 repeatedly demonstrated that an early repin goes stale.
-6. Commit the final repin directly in the companion branch under the normal
-   workflow. When branch ownership or review policy requires isolation, a tiny
-   dependent PR targeting the sync branch is allowed, but it must merge before
-   the parent PR and before final CI.
-7. Push with a guarded lease and verify GitHub now shows only intended commits
-   and files.
-
-Never leave the parent pointing at the old PR-head commit.
-
-## 8. Run the final parent gate
-
-Wait for CI on the refreshed parent head. Re-download and validate packages if
-the package-producing tree changed. Update both PR descriptions with durable
-SHAs, merge decisions, build/test evidence, package results, and remaining
-platform limitations.
-
-Invoke `pr-commit-message` for the parent PR, mark it ready, and merge it using
-the repository's normal strategy only after explicit approval.
-
-## 9. Verify and report
+## 7. Verify completion
 
 Confirm:
 
-- mono/skia's base contains the reviewed upstream merge;
-- mono/SkiaSharp's base contains the final parent commit;
-- the parent gitlink equals the merged mono/skia commit;
-- both PRs are merged and no stale open sync PR remains;
-- required CI on the actual mono/SkiaSharp base-branch merge or squash commit is
-  green;
-- optional branch deletion happens only after both merges.
+- mono/skia's base contains the approved upstream merge and reviewed tree;
+- mono/SkiaSharp's base contains the final approved parent commit;
+- the merged parent gitlink equals the merged mono/skia SHA;
+- both PRs are merged and no demonstrated competing sync PR remains open;
+- required CI on the actual parent base-branch merge/squash commit is green;
+- branch cleanup occurs only now, after both merges.
 
-Monitor post-merge CI against the actual parent base-branch commit, not the
-pre-merge head. Do not report the landing complete until required post-merge
-CI is green. If it fails, open and land a repair; do not substitute pre-merge
-checks as evidence. M152 demonstrates why this gate is required.
+Do not report completion from pre-merge CI. If post-merge CI fails, open and
+land a repair.
 
 Report:
 
 ```text
+Approved review: <report/evidence and exact approved SHAs>
 Upstream: <ref> @ <sha>
 Previous line: <release/A.B.x native sha and parent sha>
 mono/skia: <PR> -> <merged sha>
+Final parent approval: <evidence and exact head SHA>
 mono/SkiaSharp: <PR> -> <merged sha>
-Review: <report and unresolved findings>
-CI: <exact successful build>
+CI: <exact successful head builds>
 Post-merge CI: <base commit and successful build>
 Packages: <versions and validation>
-Rotation: <stable, preview, next targets and decision>
+Rotation: <accepted decision>
 ```
 
 ## Stop conditions
 
-Stop without merging when any of these is true:
+Stop without the next merge when:
 
-- upstream has advanced beyond the reviewed SHA;
-- the mono/skia merge is not a verified two-parent merge;
-- the native PR is behind its base or its prospective merge tree differs from
-  the reviewed PR-head tree;
-- persisted review evidence is missing, schema-invalid, or stale;
-- any demonstrated competing PR remains open or lacks a completed merge, close,
-  or supersede disposition;
-- required PR labels or the parent release milestone are wrong;
-- a fork patch, dependency, API, ownership, or release-note finding is open;
-- temporary compatibility work lacks restored support or an accepted limitation
-  with a tracking issue;
-- a crossed milestone, HarfBuzz bucket, or Component Governance registration is
-  unaccounted for;
-- a true bump has not preserved the previous milestone in matching
-  `release/A.B.x` branches, the branch tips conflict, or the parent release
-  gitlink does not equal the native release tip;
-- the parent is behind its base or includes unrelated base commits;
-- required CI is pending or failing;
-- packages are missing, inconsistent, or cannot load;
-- the supported-line rotation needs a maintainer decision;
-- mono/skia merged but the parent has not been updated to its resulting commit;
-- the merged mono/skia base tree differs from the reviewed PR-head tree;
+- the maintainer has not explicitly approved the exact live head;
+- review evidence is missing, invalid, stale, or has unresolved findings;
+- upstream, a PR head, or reviewed evidence changed;
+- a demonstrated competitor remains open;
+- labels, milestone, mergeability, base currency, CI, or packages fail;
+- a true bump has not preserved the previous line in matching branches;
+- the native prospective or resulting merge tree differs from the approved
+  tree, or two-parent ancestry is missing;
+- the parent does not point to the actual merged mono/skia SHA;
+- refreshed review and approval for the final parent head are missing;
 - required post-parent-merge CI is pending or failing.

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -6,7 +6,7 @@
       "prompt": "Please merge the reviewed Skia M154 update. The paired PRs are mono/skia#360 and mono/SkiaSharp#5000. Make sure the native PR uses the right merge method and finish the parent PR too.",
       "expected_output": "Verifies upstream freshness, review findings, ancestry, parent rebase, CI, packages, release-note reachability, and rotation policy; merges mono/skia with a merge commit first; updates the parent gitlink to the resulting base-branch commit; reruns final parent gates before merging the parent.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not merge mono/SkiaSharp before mono/skia.",
         "Requires a merge commit for mono/skia and rejects squash/rebase.",
         "Updates the parent gitlink and cgmanifest to the resulting mono/skia base-branch commit.",
@@ -19,7 +19,7 @@
       "prompt": "Are mono/skia#348 and mono/SkiaSharp#4826 ready to merge? Do not change or merge anything; just give me the final checklist and blockers.",
       "expected_output": "Performs a read-only readiness assessment and reports exact upstream, ancestry, review, rebase, CI, package, release-note, merge-order, and rotation status without mutating either repository or PR.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Performs no write, ready-for-review, or merge operation.",
         "Checks both PRs and their reciprocal relationship.",
         "Reports upstream freshness, two-parent ancestry, CI/package state, and versions.json rotation.",
@@ -31,7 +31,7 @@
       "prompt": "The SkiaSharp M155 PR is green. Merge that parent PR now and we can deal with the mono/skia PR afterward.",
       "expected_output": "Refuses the unsafe order, explains that mono/skia must merge first, and requires the parent to be refreshed to the actual merged mono/skia commit before its final CI and merge.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not merge the parent PR.",
         "Explains that the mono/skia PR must merge first with preserved two-parent ancestry.",
         "Requires updating the parent gitlink to the resulting mono/skia base-branch SHA.",
@@ -43,7 +43,7 @@
       "prompt": "Land mono/skia#370, but squash it so the history is tidy. The companion SkiaSharp PR can keep the normal commits.",
       "expected_output": "Refuses to squash or rebase the mono/skia PR because its two-parent upstream merge ancestry is required, and proceeds only with GitHub's merge-commit strategy after the remaining gates pass.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Refuses the requested squash.",
         "Explains that the upstream and fork parents must remain discoverable.",
         "Requires GitHub's merge-commit strategy for mono/skia.",
@@ -55,7 +55,7 @@
       "prompt": "Merge the M156 Skia PR pair. They were reviewed yesterday, but chrome/m156 has gained three commits since the recorded upstream SHA.",
       "expected_output": "Stops before merging, reports that the reviewed upstream SHA is stale, and routes the existing branches and PRs back through update-skia for refresh and re-review.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not merge either PR.",
         "Compares exact upstream ancestry rather than accepting the milestone number.",
         "Routes the existing PR pair through update-skia instead of opening unrelated replacement PRs.",
@@ -67,7 +67,7 @@
       "prompt": "Merge the M157 PR pair. Both PR descriptions say the author reviewed the changes and CI is green, but there is no persisted review-skia-update report or independent reviewer evidence.",
       "expected_output": "Stops before merging because PR-body self-attestation is insufficient, and requires a current schema-valid persisted review-skia-update report or explicit independent human review evidence for the exact live heads.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not accept the PR description as review evidence.",
         "Does not merge either PR.",
         "Requires a current schema-valid persisted report or independent human review evidence.",
@@ -79,7 +79,7 @@
       "prompt": "Land the M158 pair. There is also an open SkiaSharp PR that only updates externals/skia and cgmanifest.json to another M158 commit, but we can leave that pointer PR open and sort it out later.",
       "expected_output": "Stops until both repositories have been searched for competing sync work and the pointer-only PR receives an explicit close, supersede, or merge disposition.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Searches both repositories for duplicate, superseded, and pointer-only PRs.",
         "Does not leave a competing pointer PR open.",
         "Requires an explicit disposition before landing.",
@@ -91,7 +91,7 @@
       "prompt": "Merge this same-milestone M158 servicing sync. Both PRs have type/milestone-bump, neither has partner/agentic-workflows, and the SkiaSharp PR has no release milestone.",
       "expected_output": "Corrects the metadata before landing: both PRs need type/milestone-sync and partner/agentic-workflows, servicing syncs must not carry the bump label, and only true bumps require type/milestone-bump plus the parent release milestone.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not treat a servicing sync as a milestone bump.",
         "Requires type/milestone-sync and partner/agentic-workflows on both PRs.",
         "Removes or rejects the incorrect type/milestone-bump label.",
@@ -103,7 +103,7 @@
       "prompt": "The M159 pair merged and all pre-merge checks passed, but CI on the actual mono/SkiaSharp main merge commit is red. Report the landing complete based on the PR checks.",
       "expected_output": "Refuses to report completion, investigates the required post-merge CI failure on the actual base-branch commit, and requires a repair to be opened and landed before completion.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not substitute pre-merge PR checks for post-merge CI.",
         "Does not report the landing complete.",
         "Uses the actual base-branch merge or squash commit as the CI subject.",
@@ -115,11 +115,47 @@
       "prompt": "Merge M160 now. Android only passed after disabling a backend with a temporary GN flag. We did not restore it, document an accepted limitation, or file a tracking issue, but the rest of the matrix is green.",
       "expected_output": "Stops the landing, requires restoring the prior Android/backend support when possible, and otherwise requires an explicitly accepted limitation with a linked tracking issue before merge.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Does not merge either PR while the temporary disable is unresolved.",
         "Audits temporary source exclusions, GN flags, backend disables, platform workarounds, and fork backports.",
         "Requires restoring prior support when possible.",
         "Requires both an accepted limitation and tracking issue if restoration is deferred."
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "This is only an M160 servicing sync, so merge after the macOS source build. Windows, Linux, Android, Tizen, and WASM have not run, and the DEPS registrations still lack semantic versions and version_source evidence.",
+      "expected_output": "Stops because servicing syncs require the full native platform matrix and complete Component Governance evidence, including current revision identity, semantic version, and version_source.",
+      "files": [],
+      "expectations": [
+        "Does not allow a historical servicing fast path.",
+        "Requires native CI across Windows, Linux, Apple, Android, Tizen, and WASM.",
+        "Treats the single-host source build as necessary but insufficient.",
+        "Requires current revision identity, semantic version, and version_source for tracked DEPS registrations."
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "The M161 native PR was reviewed, but its base branch advanced afterward. GitHub says it is mergeable, so merge it now and compare the tree afterward.",
+      "expected_output": "Stops before the irreversible merge, requires the native head to be based on the current base tip, and compares the prospective merge tree with the reviewed PR-head tree.",
+      "files": [],
+      "expectations": [
+        "Does not rely only on GitHub's mergeable state.",
+        "Does not merge a native head that is behind its base.",
+        "Computes and checks the prospective merge tree before merging.",
+        "Retains the post-merge tree and two-parent ancestry confirmation."
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "For M162, repin externals/skia before rebasing, force-push the parent with --force, and delete the native branch as soon as mono/skia merges. We can rerun final CI later.",
+      "expected_output": "Rejects the unsafe sequence: rebase and approved support changes precede the final repin, the actual merged SHA repin is the last product-affecting change before final CI, pushes use force-with-lease, and branches remain until both PRs merge.",
+      "files": [],
+      "expectations": [
+        "Makes the actual merged SHA repin the last product-affecting parent change before final CI.",
+        "Requires a parent rebase before the final repin.",
+        "Rejects unguarded force push and requires force-with-lease.",
+        "Defers branch cleanup until both repository PRs are merged."
       ]
     }
   ]

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -65,13 +65,26 @@
     {
       "id": 6,
       "prompt": "mono/skia#360 is merged now. Continue with mono/SkiaSharp#5000.",
-      "expected_output": "Passes the resolved parent head and native base branches to the repin script, first without -Push and then with -Push; requires the native merged tree to equal the reviewed gitlink tree, pushes only the gitlink/cgmanifest update, then generates the parent merge message.",
+      "expected_output": "Checks whether the current checkout is clean, on the parent head, and at its remote tip. If suitable, it passes the resolved parent head and native base branches to the repin script, first without -Push and then with -Push; requires the native merged tree to equal the reviewed gitlink tree, pushes only the gitlink/cgmanifest update, then generates the parent merge message.",
       "files": [],
       "expectations": [
         "Resolves the actual mono/skia merge commit from the supplied native base branch.",
         "Stops if the native trees differ.",
         "Changes only externals/skia and cgmanifest.json.",
         "Invokes pr-commit-message for mono/SkiaSharp."
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "mono/skia#360 is merged, but I do not want to check out the SkiaSharp PR branch locally.",
+      "expected_output": "Records the exact verified native merge SHA after checking its ancestry and tree equality, offers the existing auto-skia-submodule-sync workflow with the parent PR head as target_branch, verifies the dependent PR pins that exact SHA in only the two intended files, waits for it to be manually merged, then generates the parent merge message.",
+      "files": [],
+      "expectations": [
+        "Does not require or modify a local parent PR checkout.",
+        "Passes the parent PR head to target_branch and the native base to skia_branch.",
+        "Explains that the workflow opens a dependent PR rather than updating the parent branch directly.",
+        "Stops if the workflow captures a branch tip other than the exact merge SHA verified before dispatch.",
+        "Does not merge the dependent PR or either update PR."
       ]
     },
     {

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -3,290 +3,170 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Please merge the reviewed Skia M154 update. The paired PRs are mono/skia#360 and mono/SkiaSharp#5000. Make sure the native PR uses the right merge method and finish the parent PR too.",
-      "expected_output": "Verifies upstream freshness, review findings, ancestry, parent rebase, CI, packages, release-note reachability, and rotation policy; merges mono/skia with a merge commit first; updates the parent gitlink to the resulting base-branch commit; reruns final parent gates before merging the parent.",
+      "prompt": "I reviewed and approved mono/skia#360 at aaa111 and mono/SkiaSharp#5000 at bbb222. Land the pair.",
+      "expected_output": "Runs the post-approval landing checklist, preserves the previous line when required, merges mono/skia first with a merge commit, repins the parent to the actual merged SHA, obtains refreshed review and approval for the changed parent head, then merges the parent and monitors post-merge CI.",
       "files": [],
       "expectations": [
-        "Does not merge mono/SkiaSharp before mono/skia.",
-        "Requires a merge commit for mono/skia and rejects squash/rebase.",
-        "Updates the parent gitlink and cgmanifest to the resulting mono/skia base-branch commit.",
-        "Checks current CI, packages, upstream SHA, and parent rebase state before each merge.",
-        "Reports the versions.json support rotation and stops if it needs a maintainer decision."
+        "Binds approval to the exact supplied heads.",
+        "Merges mono/skia first using merge-commit strategy.",
+        "Repins the parent to the actual merged mono/skia base SHA.",
+        "Requires refreshed review and approval before merging the changed parent head."
       ]
     },
     {
       "id": 2,
-      "prompt": "Are mono/skia#348 and mono/SkiaSharp#4826 ready to merge? Do not change or merge anything; just give me the final checklist and blockers.",
-      "expected_output": "Performs a read-only readiness assessment and reports exact upstream, ancestry, review, rebase, CI, package, release-note, merge-order, and rotation status without mutating either repository or PR.",
+      "prompt": "Are mono/skia#348 and mono/SkiaSharp#4826 ready to merge? Do not change anything.",
+      "expected_output": "Does not perform a second readiness audit and routes the unapproved pair to review-skia-update, explaining that merge-skia-update starts only after the maintainer accepts a review and requests landing.",
       "files": [],
       "expectations": [
-        "Performs no write, ready-for-review, or merge operation.",
-        "Checks both PRs and their reciprocal relationship.",
-        "Reports upstream freshness, two-parent ancestry, CI/package state, and versions.json rotation.",
-        "Names mono/skia-first and parent-gitlink-refresh as the required merge sequence."
+        "Performs no mutation.",
+        "Does not claim to replace the deep reviewer.",
+        "Routes readiness assessment to review-skia-update.",
+        "Requests an approved exact-head handoff before landing."
       ]
     },
     {
       "id": 3,
-      "prompt": "The SkiaSharp M155 PR is green. Merge that parent PR now and we can deal with the mono/skia PR afterward.",
-      "expected_output": "Refuses the unsafe order, explains that mono/skia must merge first, and requires the parent to be refreshed to the actual merged mono/skia commit before its final CI and merge.",
+      "prompt": "The PR bodies say the author reviewed M157 and CI is green. Merge both PRs.",
+      "expected_output": "Stops because PR-body self-attestation is not independent review evidence and no maintainer approval is bound to the exact heads.",
       "files": [],
       "expectations": [
-        "Does not merge the parent PR.",
-        "Explains that the mono/skia PR must merge first with preserved two-parent ancestry.",
-        "Requires updating the parent gitlink to the resulting mono/skia base-branch SHA.",
-        "Requires final parent CI after the gitlink update."
+        "Does not merge either PR.",
+        "Rejects PR-body self-attestation as review evidence.",
+        "Requires current persisted review or explicit independent human review.",
+        "Requires explicit maintainer approval for exact SHAs."
       ]
     },
     {
       "id": 4,
-      "prompt": "Land mono/skia#370, but squash it so the history is tidy. The companion SkiaSharp PR can keep the normal commits.",
-      "expected_output": "Refuses to squash or rebase the mono/skia PR because its two-parent upstream merge ancestry is required, and proceeds only with GitHub's merge-commit strategy after the remaining gates pass.",
+      "prompt": "I approved both heads, but the native PR gained one commit afterward. Merge it anyway because the change is tiny.",
+      "expected_output": "Stops because approval is SHA-bound and routes the changed pair through refreshed review and maintainer approval.",
       "files": [],
       "expectations": [
-        "Refuses the requested squash.",
-        "Explains that the upstream and fork parents must remain discoverable.",
-        "Requires GitHub's merge-commit strategy for mono/skia.",
-        "Does not mutate either PR if the user does not approve the required strategy."
+        "Re-fetches and compares the live head with the approved SHA.",
+        "Does not judge the new commit during landing.",
+        "Does not merge the changed native head.",
+        "Requires refreshed review and approval."
       ]
     },
     {
       "id": 5,
-      "prompt": "Merge the M156 Skia PR pair. They were reviewed yesterday, but chrome/m156 has gained three commits since the recorded upstream SHA.",
-      "expected_output": "Stops before merging, reports that the reviewed upstream SHA is stale, and routes the existing branches and PRs back through update-skia for refresh and re-review.",
+      "prompt": "Merge the approved M156 pair, but chrome/m156 advanced after approval.",
+      "expected_output": "Stops because the approved upstream SHA is stale and routes the existing pair through update-skia, review-skia-update, and renewed approval.",
       "files": [],
       "expectations": [
+        "Compares exact upstream SHAs.",
         "Does not merge either PR.",
-        "Compares exact upstream ancestry rather than accepting the milestone number.",
-        "Routes the existing PR pair through update-skia instead of opening unrelated replacement PRs.",
-        "Requires review and CI/package gates again after the refresh."
+        "Refreshes the existing pair rather than creating replacements.",
+        "Requires renewed review and approval."
       ]
     },
     {
       "id": 6,
-      "prompt": "Merge the M157 PR pair. Both PR descriptions say the author reviewed the changes and CI is green, but there is no persisted review-skia-update report or independent reviewer evidence.",
-      "expected_output": "Stops before merging because PR-body self-attestation is insufficient, and requires a current schema-valid persisted review-skia-update report or explicit independent human review evidence for the exact live heads.",
+      "prompt": "Merge the approved SkiaSharp parent first; we can land mono/skia afterward.",
+      "expected_output": "Refuses the unsafe order because mono/skia must merge first and the parent must be repinned to the actual resulting base SHA.",
       "files": [],
       "expectations": [
-        "Does not accept the PR description as review evidence.",
-        "Does not merge either PR.",
-        "Requires a current schema-valid persisted report or independent human review evidence.",
-        "Requires rerunning review-skia-update after a push or rebase makes the evidence stale."
+        "Does not merge mono/SkiaSharp first.",
+        "Requires mono/skia to merge first.",
+        "Requires the actual merged SHA repin.",
+        "Requires final parent CI and approval afterward."
       ]
     },
     {
       "id": 7,
-      "prompt": "Land the M158 pair. There is also an open SkiaSharp PR that only updates externals/skia and cgmanifest.json to another M158 commit, but we can leave that pointer PR open and sort it out later.",
-      "expected_output": "Stops until both repositories have been searched for competing sync work and the pointer-only PR receives an explicit close, supersede, or merge disposition.",
+      "prompt": "Land the approved native PR with squash so the history is tidy.",
+      "expected_output": "Refuses squash/rebase and permits only GitHub merge-commit strategy so the authoritative two-parent upstream ancestry remains discoverable.",
       "files": [],
       "expectations": [
-        "Searches both repositories for duplicate, superseded, and pointer-only PRs.",
-        "Does not leave a competing pointer PR open.",
-        "Requires an explicit disposition before landing.",
-        "Does not merge either main PR while the competing work is unresolved."
+        "Refuses squash and rebase.",
+        "Requires merge-commit strategy.",
+        "Preserves two-parent upstream ancestry.",
+        "Does not mutate the PR without approval for the safe strategy."
       ]
     },
     {
       "id": 8,
-      "prompt": "Merge this same-milestone M158 servicing sync. Both PRs have type/milestone-bump, neither has partner/agentic-workflows, and the SkiaSharp PR has no release milestone.",
-      "expected_output": "Corrects the metadata before landing: both PRs need type/milestone-sync and partner/agentic-workflows, servicing syncs must not carry the bump label, and only true bumps require type/milestone-bump plus the parent release milestone.",
+      "prompt": "The M158 pair was approved, but a new pointer-only PR now repins externals/skia and cgmanifest to another M158 commit. Leave it open and merge.",
+      "expected_output": "Stops because newly opened demonstrated competing work must already be merged, closed, or explicitly superseded.",
       "files": [],
       "expectations": [
-        "Does not treat a servicing sync as a milestone bump.",
-        "Requires type/milestone-sync and partner/agentic-workflows on both PRs.",
-        "Removes or rejects the incorrect type/milestone-bump label.",
-        "Explains that the parent release milestone is required for true bumps, not servicing syncs."
+        "Searches for work opened since review.",
+        "Recognizes a duplicate repin as demonstrated competition.",
+        "Does not leave the competing pointer PR open.",
+        "Does not merge either approved PR."
       ]
     },
     {
       "id": 9,
-      "prompt": "The M159 pair merged and all pre-merge checks passed, but CI on the actual mono/SkiaSharp main merge commit is red. Report the landing complete based on the PR checks.",
-      "expected_output": "Refuses to report completion, investigates the required post-merge CI failure on the actual base-branch commit, and requires a repair to be opened and landed before completion.",
+      "prompt": "An open PR touches DEPS only for unrelated ANGLE deps_os hunks. The approved M159 sync changes different dependencies. Is it a blocker?",
+      "expected_output": "Reports the unrelated PR as parallel non-blocking work because a shared filename without overlapping dependency, revision, or hunks is not demonstrated competition.",
       "files": [],
       "expectations": [
-        "Does not substitute pre-merge PR checks for post-merge CI.",
-        "Does not report the landing complete.",
-        "Uses the actual base-branch merge or squash commit as the CI subject.",
-        "Requires a repair when the post-merge failure is real."
+        "Does not block merely on a shared DEPS filename.",
+        "Checks dependency names, revisions, and hunks.",
+        "Records distinguishing evidence.",
+        "Requires disposition only for demonstrated competition."
       ]
     },
     {
       "id": 10,
-      "prompt": "Merge M160 now. Android only passed after disabling a backend with a temporary GN flag. We did not restore it, document an accepted limitation, or file a tracking issue, but the rest of the matrix is green.",
-      "expected_output": "Stops the landing, requires restoring the prior Android/backend support when possible, and otherwise requires an explicitly accepted limitation with a linked tracking issue before merge.",
+      "prompt": "The approved M160 bump has no release/4.159.x branches. Merge now and create them later.",
+      "expected_output": "Stops before either merge and preserves the previous milestone in matching native and parent release branches using guarded, confirmed, non-force creation.",
       "files": [],
       "expectations": [
-        "Does not merge either PR while the temporary disable is unresolved.",
-        "Audits temporary source exclusions, GN flags, backend disables, platform workarounds, and fork backports.",
-        "Requires restoring prior support when possible.",
-        "Requires both an accepted limitation and tracking issue if restoration is deferred."
+        "Requires prior-line preservation for a true bump.",
+        "Preflights both destinations before writing.",
+        "Creates the native release branch first.",
+        "Verifies the parent release gitlink equals the native release tip."
       ]
     },
     {
       "id": 11,
-      "prompt": "This is only an M160 servicing sync, so merge after the macOS source build. Windows, Linux, Android, Tizen, and WASM have not run, and the DEPS registrations still lack semantic versions and version_source evidence.",
-      "expected_output": "Stops because servicing syncs require the full native platform matrix and complete Component Governance evidence, including current revision identity, semantic version, and version_source.",
+      "prompt": "This approved M160 servicing sync already has its release branch. Create another release line before merging.",
+      "expected_output": "Does not create another release branch because prior-line preservation applies only to a true milestone bump.",
       "files": [],
       "expectations": [
-        "Does not allow a historical servicing fast path.",
-        "Requires native CI across Windows, Linux, Apple, Android, Tizen, and WASM.",
-        "Treats the single-host source build as necessary but insufficient.",
-        "Requires current revision identity, semantic version, and version_source for tracked DEPS registrations."
+        "Distinguishes servicing syncs from true bumps.",
+        "Does not create duplicate release branches.",
+        "Still applies exact-head CI, package, and merge-order checks.",
+        "Does not weaken servicing-sync gates."
       ]
     },
     {
       "id": 12,
-      "prompt": "The M161 native PR was reviewed, but its base branch advanced afterward. GitHub says it is mergeable, so merge it now and compare the tree afterward.",
-      "expected_output": "Stops before the irreversible merge, requires the native head to be based on the current base tip, and compares the prospective merge tree with the reviewed PR-head tree.",
+      "prompt": "mono/skia merged. Repin the parent and merge it under the original approval without bothering me again.",
+      "expected_output": "Refuses to use the original approval because the rebase and actual-SHA repin change the parent head; requires refreshed review and explicit approval for the final exact head.",
       "files": [],
       "expectations": [
-        "Does not rely only on GitHub's mergeable state.",
-        "Does not merge a native head that is behind its base.",
-        "Computes and checks the prospective merge tree before merging.",
-        "Retains the post-merge tree and two-parent ancestry confirmation."
+        "Performs the actual merged SHA repin as the last product-affecting change.",
+        "Treats the changed parent head as unapproved.",
+        "Runs or requires refreshed review.",
+        "Does not merge the parent until explicit final-head approval."
       ]
     },
     {
       "id": 13,
-      "prompt": "For M162, repin externals/skia before rebasing, force-push the parent with --force, and delete the native branch as soon as mono/skia merges. We can rerun final CI later.",
-      "expected_output": "Rejects the unsafe sequence: rebase and approved support changes precede the final repin, the actual merged SHA repin is the last product-affecting change before final CI, pushes use force-with-lease, and branches remain until both PRs merge.",
+      "prompt": "The final parent head is approved, but its exact-head package build is still running. Merge based on the earlier package artifacts.",
+      "expected_output": "Stops until exact-head CI and package validation pass; stale artifacts cannot substitute for the final product-producing tree.",
       "files": [],
       "expectations": [
-        "Makes the actual merged SHA repin the last product-affecting parent change before final CI.",
-        "Requires a parent rebase before the final repin.",
-        "Rejects unguarded force push and requires force-with-lease.",
-        "Defers branch cleanup until both repository PRs are merged."
+        "Does not merge while required CI is pending.",
+        "Rejects stale package evidence.",
+        "Requires packages from the exact product-producing tree.",
+        "Does not weaken the platform matrix."
       ]
     },
     {
       "id": 14,
-      "prompt": "Merge the M163 bump now. The previous 4.162 line has no release/4.162.x branch in either repository, but we can create servicing branches later from history.",
-      "expected_output": "Stops before either merge and preserves the previous milestone by creating matching release/4.162.x branches from the exact pre-bump native and parent base tips after explicit confirmation.",
+      "prompt": "Both approved PRs merged, but CI on the actual mono/SkiaSharp main commit is red. Report the landing complete from PR CI.",
+      "expected_output": "Refuses to report completion and requires a repair based on required CI for the actual parent base-branch merge or squash commit.",
       "files": [],
       "expectations": [
-        "Requires prior-line preservation only for a true milestone bump.",
-        "Presents the planned branch refs and exact source SHAs for confirmation.",
-        "Creates the mono/skia release branch before the matching mono/SkiaSharp branch.",
-        "Never force-moves an existing release branch and verifies the parent release gitlink equals the native release tip."
-      ]
-    },
-    {
-      "id": 15,
-      "prompt": "An old mono/skia PR also touches DEPS, but it changes only ANGLE deps_os entries on an unrelated branch and has no overlapping dependency, revision, or hunk with the M164 sync. Is that automatically a merge blocker?",
-      "expected_output": "Reports the unrelated DEPS PR as parallel non-blocking work because competition is not demonstrated; a shared filename alone does not require disposition.",
-      "files": [],
-      "expectations": [
-        "Does not block merely because another PR touches DEPS.",
-        "Checks sync line, head/base, duplicate repins, dependency names, revisions, and overlapping hunks.",
-        "Requires disposition only when demonstrated competition would invalidate one PR.",
-        "Records the unrelated PR as non-blocking with distinguishing evidence."
-      ]
-    },
-    {
-      "id": 16,
-      "prompt": "The M165 cgmanifest has 15 enabled tracked DEPS registrations. Every nested skia_dependency object has revision, version_reviewed_identity, and version_source, and each component version matches the cited source. The top-level component objects do not have version_source fields.",
-      "expected_output": "Passes the Component Governance evidence gate by inspecting the nested skia_dependency fields instead of incorrectly requiring version_source on the top-level component.",
-      "files": [],
-      "expectations": [
-        "Mechanically enumerates enabled tracked registrations.",
-        "Checks nested revision, version_reviewed_identity, and version_source values.",
-        "Confirms semantic versions against the nested source evidence.",
-        "Does not infer missing evidence from top-level component fields."
-      ]
-    },
-    {
-      "id": 17,
-      "prompt": "Land this reviewed same-milestone M165 servicing sync. Matching release/4.165.x branches already exist from the original bump; should we create another servicing branch before merging?",
-      "expected_output": "Does not create another release branch because prior-line preservation applies only when a true milestone bump replaces the current default-branch milestone.",
-      "files": [],
-      "expectations": [
-        "Does not create release branches for a same-milestone servicing sync.",
-        "Reuses the existing servicing line rather than splitting it again.",
-        "Still applies the normal review, CI, package, merge-order, and final-repin gates."
-      ]
-    },
-    {
-      "id": 18,
-      "prompt": "Both M166 PRs remain draft while all readiness evidence is being collected. Every substantive gate passes; draft state is the only remaining status. Is the pair unready solely because it is draft?",
-      "expected_output": "Does not treat draft state alone as a readiness blocker and keeps the PRs draft until immediately before an explicitly approved merge.",
-      "files": [],
-      "expectations": [
-        "Reports substantive readiness independently of draft state.",
-        "Does not mark either PR ready during a read-only assessment.",
-        "Marks ready only immediately before an approved merge.",
-        "Still treats missing labels, milestone, mergeability, reviews, CI, or packages as blockers."
-      ]
-    },
-    {
-      "id": 19,
-      "prompt": "Before the M167 bump, mono/skia release/4.166.x is absent but mono/SkiaSharp release/4.166.x already points to an unexpected older commit. Create the native release branch now and resolve the parent conflict afterward.",
-      "expected_output": "Stops before creating either branch because both destination refs must be preflighted together and an existing conflicting release ref must never be moved.",
-      "files": [],
-      "expectations": [
-        "Preflights both destination refs before any write.",
-        "Does not create the native branch when the parent destination conflicts.",
-        "Does not force or move the existing parent release branch.",
-        "Reports the expected and actual parent branch SHAs."
-      ]
-    },
-    {
-      "id": 20,
-      "prompt": "The paired release/4.167.x branches were created for M168, but mono/SkiaSharp main advanced before the native PR merge. Continue because the release branches still preserve the originally recorded tips.",
-      "expected_output": "Stops before merging mono/skia because both live base tips must still equal the recorded release-branch SHAs immediately before the merge.",
-      "files": [],
-      "expectations": [
-        "Re-fetches both native and parent base tips immediately before merging.",
-        "Detects that the parent base advanced after the release split.",
-        "Does not merge the native PR with stale paired release-line state.",
-        "Requires reconciling the release-line decision rather than moving a release branch."
-      ]
-    },
-    {
-      "id": 21,
-      "prompt": "For the M169 bump, both release/4.168.x destinations are absent, but the current mono/SkiaSharp base gitlink does not equal the current mono/skia base tip. Create both release branches and investigate afterward.",
-      "expected_output": "Stops before confirmation or branch creation because the two source tips do not form a compatible previous-milestone pair.",
-      "files": [],
-      "expectations": [
-        "Checks source milestone and gitlink compatibility before destination refs are written.",
-        "Does not create either release branch.",
-        "Reports the parent gitlink and native base SHAs.",
-        "Requires reconciling the source pair before preserving the line."
-      ]
-    },
-    {
-      "id": 22,
-      "prompt": "Another open PR changes the same DEPS dependency from the same revision in overlapping hunks, so landing it would invalidate the reviewed M170 sync. We recorded that it should close later; merge the sync now.",
-      "expected_output": "Stops until the demonstrated competing DEPS PR has actually been merged, closed, or explicitly superseded; a planned future disposition is insufficient.",
-      "files": [],
-      "expectations": [
-        "Recognizes overlapping dependency, revision, and hunk changes as demonstrated competition.",
-        "Does not merge while the competing PR remains open.",
-        "Requires the recorded disposition to be completed before landing.",
-        "Distinguishes this case from unrelated parallel DEPS work."
-      ]
-    },
-    {
-      "id": 23,
-      "prompt": "An enabled M171 dependency registration has matching top-level component name and version, but its nested skia_dependency.version_source is empty. The other nested fields are present. Treat the top-level version as sufficient.",
-      "expected_output": "Stops because every enabled tracked registration must have non-empty nested revision, version_reviewed_identity, and version_source evidence; top-level metadata cannot substitute for the missing nested source.",
-      "files": [],
-      "expectations": [
-        "Mechanically inspects the nested skia_dependency object.",
-        "Rejects an empty nested version_source.",
-        "Does not use top-level component fields as substitute evidence.",
-        "Reports the affected registration and missing nested field."
-      ]
-    },
-    {
-      "id": 24,
-      "prompt": "The M172 release-branch plan was confirmed, but mono/skia skiasharp advanced while we waited for approval. Create release/4.171.x from the previously displayed SHA anyway.",
-      "expected_output": "Stops before creating either release ref, reruns the source-pair and destination preflight with the new base tips, and obtains fresh confirmation.",
-      "files": [],
-      "expectations": [
-        "Re-fetches both base tips immediately after confirmation and before any write.",
-        "Detects that the native base no longer matches the confirmed SHA.",
-        "Does not create either release branch from stale state.",
-        "Requires a fresh compatible plan and maintainer confirmation."
+        "Does not substitute pre-merge CI.",
+        "Does not report completion.",
+        "Uses the actual base-branch commit as the CI subject.",
+        "Requires a repair for a real failure."
       ]
     }
   ]

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -4,13 +4,26 @@
     {
       "id": 1,
       "prompt": "I reviewed and approved mono/skia#360 and mono/SkiaSharp#5000. Help me land them.",
-      "expected_output": "Asks for the short handoff confirmation, resolves the PR and base/head branches, lets the preparation script derive and create the previous release branches when the parent targets main, generates the native merge message, and pauses for the maintainer's manual merge.",
+      "expected_output": "Resolves and presents the exact PR pair and base/head branches before asking for the short handoff confirmation, lets the preparation script derive and create the previous release branches when the parent targets main, generates the native merge message, and pauses for the maintainer's manual merge.",
       "files": [],
       "expectations": [
         "Does not repeat the deep review.",
+        "Verifies that the two supplied PRs reciprocally link to each other.",
         "Passes AI-resolved branch names to Prepare-SkiaReleaseBranches.ps1 without -Push before applying.",
         "Invokes pr-commit-message for mono/skia.",
         "Does not merge either PR."
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Run merge-skia-update. There are two open Skia update pairs.",
+      "expected_output": "Discovers and presents both reciprocal mono/skia and mono/SkiaSharp PR pairs, asks the maintainer to select one, and does not ask for prerequisite approval or run scripts until a pair is selected.",
+      "files": [],
+      "expectations": [
+        "Does not guess which update pair to land.",
+        "Groups candidates as native and parent PR pairs using reciprocal links and sync branches.",
+        "Asks for one pair selection before the prerequisite checklist.",
+        "Does not run either helper script."
       ]
     },
     {

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -157,6 +157,42 @@
         "Rejects unguarded force push and requires force-with-lease.",
         "Defers branch cleanup until both repository PRs are merged."
       ]
+    },
+    {
+      "id": 14,
+      "prompt": "Merge the M163 bump now. The previous 4.162 line has no release/4.162.x branch in either repository, but we can create servicing branches later from history.",
+      "expected_output": "Stops before either merge and preserves the previous milestone by creating matching release/4.162.x branches from the exact pre-bump native and parent base tips after explicit confirmation.",
+      "files": [],
+      "expectations": [
+        "Requires prior-line preservation only for a true milestone bump.",
+        "Presents the planned branch refs and exact source SHAs for confirmation.",
+        "Creates the mono/skia release branch before the matching mono/SkiaSharp branch.",
+        "Never force-moves an existing release branch and verifies the parent release gitlink equals the native release tip."
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "An old mono/skia PR also touches DEPS, but it changes only ANGLE deps_os entries on an unrelated branch and has no overlapping dependency, revision, or hunk with the M164 sync. Is that automatically a merge blocker?",
+      "expected_output": "Reports the unrelated DEPS PR as parallel non-blocking work because competition is not demonstrated; a shared filename alone does not require disposition.",
+      "files": [],
+      "expectations": [
+        "Does not block merely because another PR touches DEPS.",
+        "Checks sync line, head/base, duplicate repins, dependency names, revisions, and overlapping hunks.",
+        "Requires disposition only when demonstrated competition would invalidate one PR.",
+        "Records the unrelated PR as non-blocking with distinguishing evidence."
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "The M165 cgmanifest has 15 enabled tracked DEPS registrations. Every nested skia_dependency object has revision, version_reviewed_identity, and version_source, and each component version matches the cited source. The top-level component objects do not have version_source fields.",
+      "expected_output": "Passes the Component Governance evidence gate by inspecting the nested skia_dependency fields instead of incorrectly requiring version_source on the top-level component.",
+      "files": [],
+      "expectations": [
+        "Mechanically enumerates enabled tracked registrations.",
+        "Checks nested revision, version_reviewed_identity, and version_source values.",
+        "Confirms semantic versions against the nested source evidence.",
+        "Does not infer missing evidence from top-level component fields."
+      ]
     }
   ]
 }

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -240,6 +240,42 @@
         "Does not merge the native PR with stale paired release-line state.",
         "Requires reconciling the release-line decision rather than moving a release branch."
       ]
+    },
+    {
+      "id": 21,
+      "prompt": "For the M169 bump, both release/4.168.x destinations are absent, but the current mono/SkiaSharp base gitlink does not equal the current mono/skia base tip. Create both release branches and investigate afterward.",
+      "expected_output": "Stops before confirmation or branch creation because the two source tips do not form a compatible previous-milestone pair.",
+      "files": [],
+      "expectations": [
+        "Checks source milestone and gitlink compatibility before destination refs are written.",
+        "Does not create either release branch.",
+        "Reports the parent gitlink and native base SHAs.",
+        "Requires reconciling the source pair before preserving the line."
+      ]
+    },
+    {
+      "id": 22,
+      "prompt": "Another open PR changes the same DEPS dependency from the same revision in overlapping hunks, so landing it would invalidate the reviewed M170 sync. We recorded that it should close later; merge the sync now.",
+      "expected_output": "Stops until the demonstrated competing DEPS PR has actually been merged, closed, or explicitly superseded; a planned future disposition is insufficient.",
+      "files": [],
+      "expectations": [
+        "Recognizes overlapping dependency, revision, and hunk changes as demonstrated competition.",
+        "Does not merge while the competing PR remains open.",
+        "Requires the recorded disposition to be completed before landing.",
+        "Distinguishes this case from unrelated parallel DEPS work."
+      ]
+    },
+    {
+      "id": 23,
+      "prompt": "An enabled M171 dependency registration has matching top-level component name and version, but its nested skia_dependency.version_source is empty. The other nested fields are present. Treat the top-level version as sufficient.",
+      "expected_output": "Stops because every enabled tracked registration must have non-empty nested revision, version_reviewed_identity, and version_source evidence; top-level metadata cannot substitute for the missing nested source.",
+      "files": [],
+      "expectations": [
+        "Mechanically inspects the nested skia_dependency object.",
+        "Rejects an empty nested version_source.",
+        "Does not use top-level component fields as substitute evidence.",
+        "Reports the affected registration and missing nested field."
+      ]
     }
   ]
 }

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -1,0 +1,66 @@
+{
+  "skill_name": "merge-skia-update",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Please merge the reviewed Skia M154 update. The paired PRs are mono/skia#360 and mono/SkiaSharp#5000. Make sure the native PR uses the right merge method and finish the parent PR too.",
+      "expected_output": "Verifies upstream freshness, review findings, ancestry, parent rebase, CI, packages, release-note reachability, and rotation policy; merges mono/skia with a merge commit first; updates the parent gitlink to the resulting base-branch commit; reruns final parent gates before merging the parent.",
+      "files": [],
+      "assertions": [
+        "Does not merge mono/SkiaSharp before mono/skia.",
+        "Requires a merge commit for mono/skia and rejects squash/rebase.",
+        "Updates the parent gitlink and cgmanifest to the resulting mono/skia base-branch commit.",
+        "Checks current CI, packages, upstream SHA, and parent rebase state before each merge.",
+        "Reports the versions.json support rotation and stops if it needs a maintainer decision."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Are mono/skia#348 and mono/SkiaSharp#4826 ready to merge? Do not change or merge anything; just give me the final checklist and blockers.",
+      "expected_output": "Performs a read-only readiness assessment and reports exact upstream, ancestry, review, rebase, CI, package, release-note, merge-order, and rotation status without mutating either repository or PR.",
+      "files": [],
+      "assertions": [
+        "Performs no write, ready-for-review, or merge operation.",
+        "Checks both PRs and their reciprocal relationship.",
+        "Reports upstream freshness, two-parent ancestry, CI/package state, and versions.json rotation.",
+        "Names mono/skia-first and parent-gitlink-refresh as the required merge sequence."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "The SkiaSharp M155 PR is green. Merge that parent PR now and we can deal with the mono/skia PR afterward.",
+      "expected_output": "Refuses the unsafe order, explains that mono/skia must merge first, and requires the parent to be refreshed to the actual merged mono/skia commit before its final CI and merge.",
+      "files": [],
+      "assertions": [
+        "Does not merge the parent PR.",
+        "Explains that the mono/skia PR must merge first with preserved two-parent ancestry.",
+        "Requires updating the parent gitlink to the resulting mono/skia base-branch SHA.",
+        "Requires final parent CI after the gitlink update."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Land mono/skia#370, but squash it so the history is tidy. The companion SkiaSharp PR can keep the normal commits.",
+      "expected_output": "Refuses to squash or rebase the mono/skia PR because its two-parent upstream merge ancestry is required, and proceeds only with GitHub's merge-commit strategy after the remaining gates pass.",
+      "files": [],
+      "assertions": [
+        "Refuses the requested squash.",
+        "Explains that the upstream and fork parents must remain discoverable.",
+        "Requires GitHub's merge-commit strategy for mono/skia.",
+        "Does not mutate either PR if the user does not approve the required strategy."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Merge the M156 Skia PR pair. They were reviewed yesterday, but chrome/m156 has gained three commits since the recorded upstream SHA.",
+      "expected_output": "Stops before merging, reports that the reviewed upstream SHA is stale, and routes the existing branches and PRs back through update-skia for refresh and re-review.",
+      "files": [],
+      "assertions": [
+        "Does not merge either PR.",
+        "Compares exact upstream ancestry rather than accepting the milestone number.",
+        "Routes the existing PR pair through update-skia instead of opening unrelated replacement PRs.",
+        "Requires review and CI/package gates again after the refresh."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -61,6 +61,66 @@
         "Routes the existing PR pair through update-skia instead of opening unrelated replacement PRs.",
         "Requires review and CI/package gates again after the refresh."
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "Merge the M157 PR pair. Both PR descriptions say the author reviewed the changes and CI is green, but there is no persisted review-skia-update report or independent reviewer evidence.",
+      "expected_output": "Stops before merging because PR-body self-attestation is insufficient, and requires a current schema-valid persisted review-skia-update report or explicit independent human review evidence for the exact live heads.",
+      "files": [],
+      "assertions": [
+        "Does not accept the PR description as review evidence.",
+        "Does not merge either PR.",
+        "Requires a current schema-valid persisted report or independent human review evidence.",
+        "Requires rerunning review-skia-update after a push or rebase makes the evidence stale."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Land the M158 pair. There is also an open SkiaSharp PR that only updates externals/skia and cgmanifest.json to another M158 commit, but we can leave that pointer PR open and sort it out later.",
+      "expected_output": "Stops until both repositories have been searched for competing sync work and the pointer-only PR receives an explicit close, supersede, or merge disposition.",
+      "files": [],
+      "assertions": [
+        "Searches both repositories for duplicate, superseded, and pointer-only PRs.",
+        "Does not leave a competing pointer PR open.",
+        "Requires an explicit disposition before landing.",
+        "Does not merge either main PR while the competing work is unresolved."
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Merge this same-milestone M158 servicing sync. Both PRs have type/milestone-bump, neither has partner/agentic-workflows, and the SkiaSharp PR has no release milestone.",
+      "expected_output": "Corrects the metadata before landing: both PRs need type/milestone-sync and partner/agentic-workflows, servicing syncs must not carry the bump label, and only true bumps require type/milestone-bump plus the parent release milestone.",
+      "files": [],
+      "assertions": [
+        "Does not treat a servicing sync as a milestone bump.",
+        "Requires type/milestone-sync and partner/agentic-workflows on both PRs.",
+        "Removes or rejects the incorrect type/milestone-bump label.",
+        "Explains that the parent release milestone is required for true bumps, not servicing syncs."
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "The M159 pair merged and all pre-merge checks passed, but CI on the actual mono/SkiaSharp main merge commit is red. Report the landing complete based on the PR checks.",
+      "expected_output": "Refuses to report completion, investigates the required post-merge CI failure on the actual base-branch commit, and requires a repair to be opened and landed before completion.",
+      "files": [],
+      "assertions": [
+        "Does not substitute pre-merge PR checks for post-merge CI.",
+        "Does not report the landing complete.",
+        "Uses the actual base-branch merge or squash commit as the CI subject.",
+        "Requires a repair when the post-merge failure is real."
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Merge M160 now. Android only passed after disabling a backend with a temporary GN flag. We did not restore it, document an accepted limitation, or file a tracking issue, but the rest of the matrix is green.",
+      "expected_output": "Stops the landing, requires restoring the prior Android/backend support when possible, and otherwise requires an explicitly accepted limitation with a linked tracking issue before merge.",
+      "files": [],
+      "assertions": [
+        "Does not merge either PR while the temporary disable is unresolved.",
+        "Audits temporary source exclusions, GN flags, backend disables, platform workarounds, and fork backports.",
+        "Requires restoring prior support when possible.",
+        "Requires both an accepted limitation and tracking issue if restoration is deferred."
+      ]
     }
   ]
 }

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -276,6 +276,18 @@
         "Does not use top-level component fields as substitute evidence.",
         "Reports the affected registration and missing nested field."
       ]
+    },
+    {
+      "id": 24,
+      "prompt": "The M172 release-branch plan was confirmed, but mono/skia skiasharp advanced while we waited for approval. Create release/4.171.x from the previously displayed SHA anyway.",
+      "expected_output": "Stops before creating either release ref, reruns the source-pair and destination preflight with the new base tips, and obtains fresh confirmation.",
+      "files": [],
+      "expectations": [
+        "Re-fetches both base tips immediately after confirmation and before any write.",
+        "Detects that the native base no longer matches the confirmed SHA.",
+        "Does not create either release branch from stale state.",
+        "Requires a fresh compatible plan and maintainer confirmation."
+      ]
     }
   ]
 }

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -3,170 +3,98 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "I reviewed and approved mono/skia#360 at aaa111 and mono/SkiaSharp#5000 at bbb222. Land the pair.",
-      "expected_output": "Runs the post-approval landing checklist, preserves the previous line when required, merges mono/skia first with a merge commit, repins the parent to the actual merged SHA, obtains refreshed review and approval for the changed parent head, then merges the parent and monitors post-merge CI.",
+      "prompt": "I reviewed and approved mono/skia#360 and mono/SkiaSharp#5000. Help me land them.",
+      "expected_output": "Asks for the short handoff confirmation, resolves the PR and base/head branches, dry-runs and creates the previous release branches for a bump, generates the native merge message, and pauses for the maintainer's manual merge.",
       "files": [],
       "expectations": [
-        "Binds approval to the exact supplied heads.",
-        "Merges mono/skia first using merge-commit strategy.",
-        "Repins the parent to the actual merged mono/skia base SHA.",
-        "Requires refreshed review and approval before merging the changed parent head."
+        "Does not repeat the deep review.",
+        "Passes AI-resolved branch names to Prepare-SkiaReleaseBranches.ps1 without -Push before applying.",
+        "Invokes pr-commit-message for mono/skia.",
+        "Does not merge either PR."
       ]
     },
     {
       "id": 2,
-      "prompt": "Are mono/skia#348 and mono/SkiaSharp#4826 ready to merge? Do not change anything.",
-      "expected_output": "Does not perform a second readiness audit and routes the unapproved pair to review-skia-update, explaining that merge-skia-update starts only after the maintainer accepts a review and requests landing.",
+      "prompt": "I have not reviewed the Skia PRs yet, but start merging them.",
+      "expected_output": "Stops because the maintainer cannot confirm that review-skia-update ran and that they approved the update.",
       "files": [],
       "expectations": [
-        "Performs no mutation.",
-        "Does not claim to replace the deep reviewer.",
-        "Routes readiness assessment to review-skia-update.",
-        "Requests an approved exact-head handoff before landing."
+        "Does not run mutation scripts.",
+        "Does not merge either PR.",
+        "Requires the simple pre-skill confirmation.",
+        "Routes review work outside this skill."
       ]
     },
     {
       "id": 3,
-      "prompt": "The PR bodies say the author reviewed M157 and CI is green. Merge both PRs.",
-      "expected_output": "Stops because PR-body self-attestation is not independent review evidence and no maintainer approval is bound to the exact heads.",
+      "prompt": "The M160 bump is approved. Create the previous release branches before I merge.",
+      "expected_output": "The AI derives the release/A.B.x name and passes it with the resolved base branches; the script uses the parent base tip and its exact externals/skia gitlink to create matching branches, native first, after a confirmed dry run.",
       "files": [],
       "expectations": [
-        "Does not merge either PR.",
-        "Rejects PR-body self-attestation as review evidence.",
-        "Requires current persisted review or explicit independent human review.",
-        "Requires explicit maintainer approval for exact SHAs."
+        "The AI resolves the release line and base branches before invoking the script.",
+        "Uses the native SHA referenced by the parent base.",
+        "Preflights both destinations before either write.",
+        "Never moves an existing release branch."
       ]
     },
     {
       "id": 4,
-      "prompt": "I approved both heads, but the native PR gained one commit afterward. Merge it anyway because the change is tiny.",
-      "expected_output": "Stops because approval is SHA-bound and routes the changed pair through refreshed review and maintainer approval.",
+      "prompt": "This is an approved same-milestone servicing sync. Prepare the merge.",
+      "expected_output": "Reports that no new release branches are needed, generates the mono/skia merge message, and pauses for the manual native merge.",
       "files": [],
       "expectations": [
-        "Re-fetches and compares the live head with the approved SHA.",
-        "Does not judge the new commit during landing.",
-        "Does not merge the changed native head.",
-        "Requires refreshed review and approval."
+        "Does not create another release branch.",
+        "Still requires the pre-skill confirmation.",
+        "Generates the native merge message.",
+        "Does not merge the native PR."
       ]
     },
     {
       "id": 5,
-      "prompt": "Merge the approved M156 pair, but chrome/m156 advanced after approval.",
-      "expected_output": "Stops because the approved upstream SHA is stale and routes the existing pair through update-skia, review-skia-update, and renewed approval.",
+      "prompt": "The release/A.B.x branch already exists at a different commit. Move it and continue.",
+      "expected_output": "Stops because an existing release branch is never moved or force-updated.",
       "files": [],
       "expectations": [
-        "Compares exact upstream SHAs.",
-        "Does not merge either PR.",
-        "Refreshes the existing pair rather than creating replacements.",
-        "Requires renewed review and approval."
+        "Reports expected and existing SHAs.",
+        "Does not move the existing branch.",
+        "Does not partially create the paired branch.",
+        "Does not continue to merge preparation."
       ]
     },
     {
       "id": 6,
-      "prompt": "Merge the approved SkiaSharp parent first; we can land mono/skia afterward.",
-      "expected_output": "Refuses the unsafe order because mono/skia must merge first and the parent must be repinned to the actual resulting base SHA.",
+      "prompt": "mono/skia#360 is merged now. Continue with mono/SkiaSharp#5000.",
+      "expected_output": "Passes the resolved parent head and native base branches to the repin script, first without -Push and then with -Push; requires the native merged tree to equal the reviewed gitlink tree, pushes only the gitlink/cgmanifest update, then generates the parent merge message.",
       "files": [],
       "expectations": [
-        "Does not merge mono/SkiaSharp first.",
-        "Requires mono/skia to merge first.",
-        "Requires the actual merged SHA repin.",
-        "Requires final parent CI and approval afterward."
+        "Resolves the actual mono/skia merge commit from the supplied native base branch.",
+        "Stops if the native trees differ.",
+        "Changes only externals/skia and cgmanifest.json.",
+        "Invokes pr-commit-message for mono/SkiaSharp."
       ]
     },
     {
       "id": 7,
-      "prompt": "Land the approved native PR with squash so the history is tidy.",
-      "expected_output": "Refuses squash/rebase and permits only GitHub merge-commit strategy so the authoritative two-parent upstream ancestry remains discoverable.",
+      "prompt": "The native PR was squash-merged. Update the parent anyway.",
+      "expected_output": "Stops because the native PR was not merged with the required merge-commit strategy and its authoritative ancestry was lost.",
       "files": [],
       "expectations": [
-        "Refuses squash and rebase.",
-        "Requires merge-commit strategy.",
-        "Preserves two-parent upstream ancestry.",
-        "Does not mutate the PR without approval for the safe strategy."
+        "Does not repin the parent.",
+        "Does not generate the parent merge message.",
+        "Requires a native merge commit.",
+        "Reports the incorrect merge result."
       ]
     },
     {
       "id": 8,
-      "prompt": "The M158 pair was approved, but a new pointer-only PR now repins externals/skia and cgmanifest to another M158 commit. Leave it open and merge.",
-      "expected_output": "Stops because newly opened demonstrated competing work must already be merged, closed, or explicitly superseded.",
+      "prompt": "The repin is pushed. Wait for all PR CI before giving me the SkiaSharp merge message.",
+      "expected_output": "Generates the SkiaSharp merge message without waiting for another PR CI run because tree equality proved the native content unchanged; it notes that main CI validates the resulting merge.",
       "files": [],
       "expectations": [
-        "Searches for work opened since review.",
-        "Recognizes a duplicate repin as demonstrated competition.",
-        "Does not leave the competing pointer PR open.",
-        "Does not merge either approved PR."
-      ]
-    },
-    {
-      "id": 9,
-      "prompt": "An open PR touches DEPS only for unrelated ANGLE deps_os hunks. The approved M159 sync changes different dependencies. Is it a blocker?",
-      "expected_output": "Reports the unrelated PR as parallel non-blocking work because a shared filename without overlapping dependency, revision, or hunks is not demonstrated competition.",
-      "files": [],
-      "expectations": [
-        "Does not block merely on a shared DEPS filename.",
-        "Checks dependency names, revisions, and hunks.",
-        "Records distinguishing evidence.",
-        "Requires disposition only for demonstrated competition."
-      ]
-    },
-    {
-      "id": 10,
-      "prompt": "The approved M160 bump has no release/4.159.x branches. Merge now and create them later.",
-      "expected_output": "Stops before either merge and preserves the previous milestone in matching native and parent release branches using guarded, confirmed, non-force creation.",
-      "files": [],
-      "expectations": [
-        "Requires prior-line preservation for a true bump.",
-        "Preflights both destinations before writing.",
-        "Creates the native release branch first.",
-        "Verifies the parent release gitlink equals the native release tip."
-      ]
-    },
-    {
-      "id": 11,
-      "prompt": "This approved M160 servicing sync already has its release branch. Create another release line before merging.",
-      "expected_output": "Does not create another release branch because prior-line preservation applies only to a true milestone bump.",
-      "files": [],
-      "expectations": [
-        "Distinguishes servicing syncs from true bumps.",
-        "Does not create duplicate release branches.",
-        "Still applies exact-head CI, package, and merge-order checks.",
-        "Does not weaken servicing-sync gates."
-      ]
-    },
-    {
-      "id": 12,
-      "prompt": "mono/skia merged. Repin the parent and merge it under the original approval without bothering me again.",
-      "expected_output": "Refuses to use the original approval because the rebase and actual-SHA repin change the parent head; requires refreshed review and explicit approval for the final exact head.",
-      "files": [],
-      "expectations": [
-        "Performs the actual merged SHA repin as the last product-affecting change.",
-        "Treats the changed parent head as unapproved.",
-        "Runs or requires refreshed review.",
-        "Does not merge the parent until explicit final-head approval."
-      ]
-    },
-    {
-      "id": 13,
-      "prompt": "The final parent head is approved, but its exact-head package build is still running. Merge based on the earlier package artifacts.",
-      "expected_output": "Stops until exact-head CI and package validation pass; stale artifacts cannot substitute for the final product-producing tree.",
-      "files": [],
-      "expectations": [
-        "Does not merge while required CI is pending.",
-        "Rejects stale package evidence.",
-        "Requires packages from the exact product-producing tree.",
-        "Does not weaken the platform matrix."
-      ]
-    },
-    {
-      "id": 14,
-      "prompt": "Both approved PRs merged, but CI on the actual mono/SkiaSharp main commit is red. Report the landing complete from PR CI.",
-      "expected_output": "Refuses to report completion and requires a repair based on required CI for the actual parent base-branch merge or squash commit.",
-      "files": [],
-      "expectations": [
-        "Does not substitute pre-merge CI.",
-        "Does not report completion.",
-        "Uses the actual base-branch commit as the CI subject.",
-        "Requires a repair for a real failure."
+        "Does not rerun the deep review.",
+        "Does not wait for refreshed PR CI.",
+        "Generates the parent merge message.",
+        "Leaves the parent merge to the maintainer."
       ]
     }
   ]

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "I reviewed and approved mono/skia#360 and mono/SkiaSharp#5000. Help me land them.",
-      "expected_output": "Asks for the short handoff confirmation, resolves the PR and base/head branches, dry-runs and creates the previous release branches for a bump, generates the native merge message, and pauses for the maintainer's manual merge.",
+      "expected_output": "Asks for the short handoff confirmation, resolves the PR and base/head branches, lets the preparation script derive and create the previous release branches when the parent targets main, generates the native merge message, and pauses for the maintainer's manual merge.",
       "files": [],
       "expectations": [
         "Does not repeat the deep review.",
@@ -28,10 +28,11 @@
     {
       "id": 3,
       "prompt": "The M160 bump is approved. Create the previous release branches before I merge.",
-      "expected_output": "The AI derives the release/A.B.x name and passes it with the resolved base branches; the script uses the parent base tip and its exact externals/skia gitlink to create matching branches, native first, after a confirmed dry run.",
+      "expected_output": "The AI passes the resolved main and native base branches; the script derives release/A.B.x from the current SkiaSharp package version committed on main, then uses the parent base tip and its exact externals/skia gitlink to create matching branches, native first, after a confirmed dry run.",
       "files": [],
       "expectations": [
-        "The AI resolves the release line and base branches before invoking the script.",
+        "The AI resolves the base branches but does not calculate or pass the release line.",
+        "The script derives release/A.B.x from scripts/VERSIONS.txt on the exact parent base commit.",
         "Uses the native SHA referenced by the parent base.",
         "Preflights both destinations before either write.",
         "Never moves an existing release branch."
@@ -40,7 +41,7 @@
     {
       "id": 4,
       "prompt": "This is an approved same-milestone servicing sync. Prepare the merge.",
-      "expected_output": "Reports that no new release branches are needed, generates the mono/skia merge message, and pauses for the manual native merge.",
+      "expected_output": "Passes the existing release/A.B.x parent target to the preparation script, which reports that this is a servicing sync and creates no refs; then generates the mono/skia merge message and pauses for the manual native merge.",
       "files": [],
       "expectations": [
         "Does not create another release branch.",

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -216,6 +216,30 @@
         "Marks ready only immediately before an approved merge.",
         "Still treats missing labels, milestone, mergeability, reviews, CI, or packages as blockers."
       ]
+    },
+    {
+      "id": 19,
+      "prompt": "Before the M167 bump, mono/skia release/4.166.x is absent but mono/SkiaSharp release/4.166.x already points to an unexpected older commit. Create the native release branch now and resolve the parent conflict afterward.",
+      "expected_output": "Stops before creating either branch because both destination refs must be preflighted together and an existing conflicting release ref must never be moved.",
+      "files": [],
+      "expectations": [
+        "Preflights both destination refs before any write.",
+        "Does not create the native branch when the parent destination conflicts.",
+        "Does not force or move the existing parent release branch.",
+        "Reports the expected and actual parent branch SHAs."
+      ]
+    },
+    {
+      "id": 20,
+      "prompt": "The paired release/4.167.x branches were created for M168, but mono/SkiaSharp main advanced before the native PR merge. Continue because the release branches still preserve the originally recorded tips.",
+      "expected_output": "Stops before merging mono/skia because both live base tips must still equal the recorded release-branch SHAs immediately before the merge.",
+      "files": [],
+      "expectations": [
+        "Re-fetches both native and parent base tips immediately before merging.",
+        "Detects that the parent base advanced after the release split.",
+        "Does not merge the native PR with stale paired release-line state.",
+        "Requires reconciling the release-line decision rather than moving a release branch."
+      ]
     }
   ]
 }

--- a/.agents/skills/merge-skia-update/evals/evals.json
+++ b/.agents/skills/merge-skia-update/evals/evals.json
@@ -193,6 +193,29 @@
         "Confirms semantic versions against the nested source evidence.",
         "Does not infer missing evidence from top-level component fields."
       ]
+    },
+    {
+      "id": 17,
+      "prompt": "Land this reviewed same-milestone M165 servicing sync. Matching release/4.165.x branches already exist from the original bump; should we create another servicing branch before merging?",
+      "expected_output": "Does not create another release branch because prior-line preservation applies only when a true milestone bump replaces the current default-branch milestone.",
+      "files": [],
+      "expectations": [
+        "Does not create release branches for a same-milestone servicing sync.",
+        "Reuses the existing servicing line rather than splitting it again.",
+        "Still applies the normal review, CI, package, merge-order, and final-repin gates."
+      ]
+    },
+    {
+      "id": 18,
+      "prompt": "Both M166 PRs remain draft while all readiness evidence is being collected. Every substantive gate passes; draft state is the only remaining status. Is the pair unready solely because it is draft?",
+      "expected_output": "Does not treat draft state alone as a readiness blocker and keeps the PRs draft until immediately before an explicitly approved merge.",
+      "files": [],
+      "expectations": [
+        "Reports substantive readiness independently of draft state.",
+        "Does not mark either PR ready during a read-only assessment.",
+        "Marks ready only immediately before an approved merge.",
+        "Still treats missing labels, milestone, mergeability, reviews, CI, or packages as blockers."
+      ]
     }
   ]
 }

--- a/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
@@ -8,9 +8,6 @@ param(
     [Parameter(Mandatory)]
     [string] $SkiaBaseBranch,
 
-    [Parameter(Mandatory)]
-    [string] $ReleaseBranch,
-
     [switch] $Push
 )
 
@@ -97,7 +94,6 @@ function New-RemoteBranch {
 $repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
 $null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBaseBranch) $repoRoot
 $null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBaseBranch) $repoRoot
-$null = Invoke-Native git @('check-ref-format', '--branch', $ReleaseBranch) $repoRoot
 
 $parentUrl = Invoke-Native git @('remote', 'get-url', 'origin') $repoRoot
 
@@ -108,6 +104,27 @@ $null = Invoke-Native git @(
 $parentBaseSha = Invoke-Native git @(
     'rev-parse', "refs/remotes/origin/${SkiaSharpBaseBranch}^{commit}"
 ) $repoRoot
+
+if ($SkiaSharpBaseBranch -match '^release/(?<version>\d+\.\d+)\.x$') {
+    Write-Host "Servicing branch: $SkiaSharpBaseBranch"
+    Write-Host 'No release branches are needed for a servicing sync.'
+    exit 0
+}
+if ($SkiaSharpBaseBranch -ne 'main') {
+    throw "SkiaSharp base branch must be main or release/A.B.x; got $SkiaSharpBaseBranch."
+}
+
+$versions = Invoke-Native git @('show', "${parentBaseSha}:scripts/VERSIONS.txt") $repoRoot
+$versionMatch = [regex]::Match(
+    $versions,
+    '(?m)^SkiaSharp\s+nuget\s+(?<major>\d+)\.(?<minor>\d+)\.\d+(?:[-+]\S+)?\s*$'
+)
+if (-not $versionMatch.Success) {
+    throw "Cannot derive the current SkiaSharp product line from scripts/VERSIONS.txt at $parentBaseSha."
+}
+$ReleaseBranch = "release/$($versionMatch.Groups['major'].Value).$($versionMatch.Groups['minor'].Value).x"
+$null = Invoke-Native git @('check-ref-format', '--branch', $ReleaseBranch) $repoRoot
+
 $nativeUrl = Invoke-Native git @(
     'config', '--blob', "${parentBaseSha}:.gitmodules",
     '--get', 'submodule.externals/skia.url'

--- a/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
@@ -1,0 +1,168 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SkiaSharpBaseBranch,
+
+    [Parameter(Mandatory)]
+    [string] $SkiaBaseBranch,
+
+    [Parameter(Mandatory)]
+    [string] $ReleaseBranch,
+
+    [switch] $Push
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Command,
+
+        [Parameter(Mandatory)]
+        [string[]] $Arguments,
+
+        [string] $WorkingDirectory
+    )
+
+    if ($WorkingDirectory) {
+        Push-Location $WorkingDirectory
+    }
+    try {
+        $output = @(& $Command @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    } finally {
+        if ($WorkingDirectory) {
+            Pop-Location
+        }
+    }
+
+    if ($exitCode -ne 0) {
+        throw "$Command $($Arguments -join ' ') failed:`n$($output -join "`n")"
+    }
+    return ($output -join "`n").Trim()
+}
+
+function Get-RemoteBranchSha {
+    param([string] $RepositoryUrl, [string] $Branch)
+
+    $result = Invoke-Native git @('ls-remote', '--heads', $RepositoryUrl, "refs/heads/$Branch")
+    if (-not $result) {
+        return $null
+    }
+    return ($result -split '\s+')[0]
+}
+
+function Get-GitHubRepository {
+    param([string] $RepositoryUrl)
+
+    $match = [regex]::Match(
+        $RepositoryUrl,
+        '(?i)github\.com[/:](?<repository>[^/:\s]+/[^/\s]+?)(?:\.git)?$'
+    )
+    if (-not $match.Success) {
+        throw "Cannot derive a GitHub owner/repository from $RepositoryUrl."
+    }
+    return $match.Groups['repository'].Value
+}
+
+function Assert-Destination {
+    param(
+        [string] $Repository,
+        [string] $RepositoryUrl,
+        [string] $Branch,
+        [string] $ExpectedSha
+    )
+
+    $actual = Get-RemoteBranchSha $RepositoryUrl $Branch
+    if ($actual -and $actual -ne $ExpectedSha) {
+        throw "$Repository $Branch already points to $actual; expected $ExpectedSha. Existing release branches are never moved."
+    }
+    return $actual
+}
+
+function New-RemoteBranch {
+    param([string] $Repository, [string] $Branch, [string] $Sha)
+
+    $null = Invoke-Native gh @(
+        'api', '--method', 'POST',
+        "repos/$Repository/git/refs",
+        '-f', "ref=refs/heads/$Branch",
+        '-f', "sha=$Sha"
+    )
+}
+
+$repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBaseBranch) $repoRoot
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBaseBranch) $repoRoot
+$null = Invoke-Native git @('check-ref-format', '--branch', $ReleaseBranch) $repoRoot
+
+$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin') $repoRoot
+
+$null = Invoke-Native git @(
+    'fetch', '--no-tags', 'origin',
+    "+refs/heads/${SkiaSharpBaseBranch}:refs/remotes/origin/${SkiaSharpBaseBranch}"
+) $repoRoot
+$parentBaseSha = Invoke-Native git @(
+    'rev-parse', "refs/remotes/origin/${SkiaSharpBaseBranch}^{commit}"
+) $repoRoot
+$nativeUrl = Invoke-Native git @(
+    'config', '--blob', "${parentBaseSha}:.gitmodules",
+    '--get', 'submodule.externals/skia.url'
+) $repoRoot
+$parentRepository = Get-GitHubRepository $parentUrl
+$nativeRepository = Get-GitHubRepository $nativeUrl
+
+$treeEntry = Invoke-Native git @('ls-tree', $parentBaseSha, '--', 'externals/skia') $repoRoot
+$treeParts = $treeEntry -split '\s+'
+if ($treeParts.Count -lt 3 -or $treeParts[1] -ne 'commit') {
+    throw "$parentBaseSha does not contain the externals/skia gitlink."
+}
+$nativeBaseSha = $treeParts[2]
+$nativeBranchSha = Get-RemoteBranchSha $nativeUrl $SkiaBaseBranch
+if (-not $nativeBranchSha) {
+    throw "mono/skia branch $SkiaBaseBranch does not exist."
+}
+if ($nativeBranchSha -ne $nativeBaseSha) {
+    throw "SkiaSharp $SkiaSharpBaseBranch points to mono/skia $nativeBaseSha, but $SkiaBaseBranch points to $nativeBranchSha."
+}
+
+$nativeExisting = Assert-Destination $nativeRepository $nativeUrl $ReleaseBranch $nativeBaseSha
+$parentExisting = Assert-Destination $parentRepository $parentUrl $ReleaseBranch $parentBaseSha
+
+Write-Host "Release branch:     $ReleaseBranch"
+Write-Host "$nativeRepository source: $SkiaBaseBranch @ $nativeBaseSha$(if ($nativeExisting) { ' (release branch already exists)' })"
+Write-Host "$parentRepository source: $SkiaSharpBaseBranch @ $parentBaseSha$(if ($parentExisting) { ' (release branch already exists)' })"
+
+if (-not $Push) {
+    Write-Host 'DRY RUN: no remote refs were created. Re-run with -Push to create them.'
+    exit 0
+}
+
+# Re-read every source and destination immediately before the first write.
+$parentBaseNow = Get-RemoteBranchSha $parentUrl $SkiaSharpBaseBranch
+$nativeBaseNow = Get-RemoteBranchSha $nativeUrl $SkiaBaseBranch
+if ($parentBaseNow -ne $parentBaseSha -or $nativeBaseNow -ne $nativeBaseSha) {
+    throw 'A source branch changed after preflight. Run the script without -Push again.'
+}
+$nativeExisting = Assert-Destination $nativeRepository $nativeUrl $ReleaseBranch $nativeBaseSha
+$parentExisting = Assert-Destination $parentRepository $parentUrl $ReleaseBranch $parentBaseSha
+
+if (-not $nativeExisting) {
+    New-RemoteBranch $nativeRepository $ReleaseBranch $nativeBaseSha
+    Write-Host "Created $nativeRepository $ReleaseBranch."
+}
+if (-not $parentExisting) {
+    New-RemoteBranch $parentRepository $ReleaseBranch $parentBaseSha
+    Write-Host "Created $parentRepository $ReleaseBranch."
+}
+
+$nativeResult = Get-RemoteBranchSha $nativeUrl $ReleaseBranch
+$parentResult = Get-RemoteBranchSha $parentUrl $ReleaseBranch
+if ($nativeResult -ne $nativeBaseSha -or $parentResult -ne $parentBaseSha) {
+    throw 'Release branch verification failed after creation.'
+}
+
+Write-Host "Verified $ReleaseBranch in both repositories."

--- a/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
@@ -19,22 +19,11 @@ function Invoke-Native {
         [string] $Command,
 
         [Parameter(Mandatory)]
-        [string[]] $Arguments,
-
-        [string] $WorkingDirectory
+        [string[]] $Arguments
     )
 
-    if ($WorkingDirectory) {
-        Push-Location $WorkingDirectory
-    }
-    try {
-        $output = @(& $Command @Arguments 2>&1)
-        $exitCode = $LASTEXITCODE
-    } finally {
-        if ($WorkingDirectory) {
-            Pop-Location
-        }
-    }
+    $output = @(& $Command @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
 
     if ($exitCode -ne 0) {
         throw "$Command $($Arguments -join ' ') failed:`n$($output -join "`n")"
@@ -55,10 +44,7 @@ function Get-RemoteBranchSha {
 function Get-GitHubRepository {
     param([string] $RepositoryUrl)
 
-    $match = [regex]::Match(
-        $RepositoryUrl,
-        '(?i)github\.com[/:](?<repository>[^/:\s]+/[^/\s]+?)(?:\.git)?$'
-    )
+    $match = [regex]::Match($RepositoryUrl, '(?i)github\.com[/:](?<repository>[^/:\s]+/[^/\s]+?)(?:\.git)?$')
     if (-not $match.Success) {
         throw "Cannot derive a GitHub owner/repository from $RepositoryUrl."
     }
@@ -92,18 +78,19 @@ function New-RemoteBranch {
 }
 
 $repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBaseBranch) $repoRoot
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBaseBranch) $repoRoot
+Set-Location $repoRoot
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBaseBranch)
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBaseBranch)
 
-$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin') $repoRoot
+$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin')
 
 $null = Invoke-Native git @(
     'fetch', '--no-tags', 'origin',
     "+refs/heads/${SkiaSharpBaseBranch}:refs/remotes/origin/${SkiaSharpBaseBranch}"
-) $repoRoot
+)
 $parentBaseSha = Invoke-Native git @(
     'rev-parse', "refs/remotes/origin/${SkiaSharpBaseBranch}^{commit}"
-) $repoRoot
+)
 
 if ($SkiaSharpBaseBranch -match '^release/(?<version>\d+\.\d+)\.x$') {
     Write-Host "Servicing branch: $SkiaSharpBaseBranch"
@@ -114,7 +101,7 @@ if ($SkiaSharpBaseBranch -ne 'main') {
     throw "SkiaSharp base branch must be main or release/A.B.x; got $SkiaSharpBaseBranch."
 }
 
-$versions = Invoke-Native git @('show', "${parentBaseSha}:scripts/VERSIONS.txt") $repoRoot
+$versions = Invoke-Native git @('show', "${parentBaseSha}:scripts/VERSIONS.txt")
 $versionMatch = [regex]::Match(
     $versions,
     '(?m)^SkiaSharp\s+nuget\s+(?<major>\d+)\.(?<minor>\d+)\.\d+(?:[-+]\S+)?\s*$'
@@ -123,16 +110,16 @@ if (-not $versionMatch.Success) {
     throw "Cannot derive the current SkiaSharp product line from scripts/VERSIONS.txt at $parentBaseSha."
 }
 $ReleaseBranch = "release/$($versionMatch.Groups['major'].Value).$($versionMatch.Groups['minor'].Value).x"
-$null = Invoke-Native git @('check-ref-format', '--branch', $ReleaseBranch) $repoRoot
+$null = Invoke-Native git @('check-ref-format', '--branch', $ReleaseBranch)
 
 $nativeUrl = Invoke-Native git @(
     'config', '--blob', "${parentBaseSha}:.gitmodules",
     '--get', 'submodule.externals/skia.url'
-) $repoRoot
+)
 $parentRepository = Get-GitHubRepository $parentUrl
 $nativeRepository = Get-GitHubRepository $nativeUrl
 
-$treeEntry = Invoke-Native git @('ls-tree', $parentBaseSha, '--', 'externals/skia') $repoRoot
+$treeEntry = Invoke-Native git @('ls-tree', $parentBaseSha, '--', 'externals/skia')
 $treeParts = $treeEntry -split '\s+'
 if ($treeParts.Count -lt 3 -or $treeParts[1] -ne 'commit') {
     throw "$parentBaseSha does not contain the externals/skia gitlink."

--- a/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Prepare-SkiaReleaseBranches.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+#Requires -Version 7.4
 
 [CmdletBinding()]
 param(
@@ -12,29 +13,12 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-
-function Invoke-Native {
-    param(
-        [Parameter(Mandatory)]
-        [string] $Command,
-
-        [Parameter(Mandatory)]
-        [string[]] $Arguments
-    )
-
-    $output = @(& $Command @Arguments 2>&1)
-    $exitCode = $LASTEXITCODE
-
-    if ($exitCode -ne 0) {
-        throw "$Command $($Arguments -join ' ') failed:`n$($output -join "`n")"
-    }
-    return ($output -join "`n").Trim()
-}
+$PSNativeCommandUseErrorActionPreference = $true
 
 function Get-RemoteBranchSha {
     param([string] $RepositoryUrl, [string] $Branch)
 
-    $result = Invoke-Native git @('ls-remote', '--heads', $RepositoryUrl, "refs/heads/$Branch")
+    $result = git ls-remote --heads $RepositoryUrl "refs/heads/$Branch"
     if (-not $result) {
         return $null
     }
@@ -69,28 +53,18 @@ function Assert-Destination {
 function New-RemoteBranch {
     param([string] $Repository, [string] $Branch, [string] $Sha)
 
-    $null = Invoke-Native gh @(
-        'api', '--method', 'POST',
-        "repos/$Repository/git/refs",
-        '-f', "ref=refs/heads/$Branch",
-        '-f', "sha=$Sha"
-    )
+    gh api --method POST "repos/$Repository/git/refs" -f "ref=refs/heads/$Branch" -f "sha=$Sha" | Out-Null
 }
 
-$repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
+$repoRoot = git rev-parse --show-toplevel
 Set-Location $repoRoot
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBaseBranch)
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBaseBranch)
+git check-ref-format --branch $SkiaSharpBaseBranch | Out-Null
+git check-ref-format --branch $SkiaBaseBranch | Out-Null
 
-$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin')
+$parentUrl = git remote get-url origin
 
-$null = Invoke-Native git @(
-    'fetch', '--no-tags', 'origin',
-    "+refs/heads/${SkiaSharpBaseBranch}:refs/remotes/origin/${SkiaSharpBaseBranch}"
-)
-$parentBaseSha = Invoke-Native git @(
-    'rev-parse', "refs/remotes/origin/${SkiaSharpBaseBranch}^{commit}"
-)
+git fetch --no-tags origin "+refs/heads/${SkiaSharpBaseBranch}:refs/remotes/origin/${SkiaSharpBaseBranch}" | Out-Null
+$parentBaseSha = git rev-parse "refs/remotes/origin/${SkiaSharpBaseBranch}^{commit}"
 
 if ($SkiaSharpBaseBranch -match '^release/(?<version>\d+\.\d+)\.x$') {
     Write-Host "Servicing branch: $SkiaSharpBaseBranch"
@@ -101,25 +75,19 @@ if ($SkiaSharpBaseBranch -ne 'main') {
     throw "SkiaSharp base branch must be main or release/A.B.x; got $SkiaSharpBaseBranch."
 }
 
-$versions = Invoke-Native git @('show', "${parentBaseSha}:scripts/VERSIONS.txt")
-$versionMatch = [regex]::Match(
-    $versions,
-    '(?m)^SkiaSharp\s+nuget\s+(?<major>\d+)\.(?<minor>\d+)\.\d+(?:[-+]\S+)?\s*$'
-)
+$versions = (git show "${parentBaseSha}:scripts/VERSIONS.txt" | Out-String).Trim()
+$versionMatch = [regex]::Match($versions, '(?m)^SkiaSharp\s+nuget\s+(?<major>\d+)\.(?<minor>\d+)\.\d+(?:[-+]\S+)?\s*$')
 if (-not $versionMatch.Success) {
     throw "Cannot derive the current SkiaSharp product line from scripts/VERSIONS.txt at $parentBaseSha."
 }
 $ReleaseBranch = "release/$($versionMatch.Groups['major'].Value).$($versionMatch.Groups['minor'].Value).x"
-$null = Invoke-Native git @('check-ref-format', '--branch', $ReleaseBranch)
+git check-ref-format --branch $ReleaseBranch | Out-Null
 
-$nativeUrl = Invoke-Native git @(
-    'config', '--blob', "${parentBaseSha}:.gitmodules",
-    '--get', 'submodule.externals/skia.url'
-)
+$nativeUrl = git config --blob "${parentBaseSha}:.gitmodules" --get submodule.externals/skia.url
 $parentRepository = Get-GitHubRepository $parentUrl
 $nativeRepository = Get-GitHubRepository $nativeUrl
 
-$treeEntry = Invoke-Native git @('ls-tree', $parentBaseSha, '--', 'externals/skia')
+$treeEntry = git ls-tree $parentBaseSha -- externals/skia
 $treeParts = $treeEntry -split '\s+'
 if ($treeParts.Count -lt 3 -or $treeParts[1] -ne 'commit') {
     throw "$parentBaseSha does not contain the externals/skia gitlink."

--- a/.agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1
@@ -1,0 +1,189 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SkiaSharpBranch,
+
+    [Parameter(Mandatory)]
+    [string] $SkiaBranch,
+
+    [switch] $Push
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Command,
+
+        [Parameter(Mandatory)]
+        [string[]] $Arguments,
+
+        [string] $WorkingDirectory
+    )
+
+    if ($WorkingDirectory) {
+        Push-Location $WorkingDirectory
+    }
+    try {
+        $output = @(& $Command @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    } finally {
+        if ($WorkingDirectory) {
+            Pop-Location
+        }
+    }
+
+    if ($exitCode -ne 0) {
+        throw "$Command $($Arguments -join ' ') failed:`n$($output -join "`n")"
+    }
+    return ($output -join "`n").Trim()
+}
+
+function Get-RemoteBranchSha {
+    param([string] $RepositoryUrl, [string] $Branch)
+
+    $result = Invoke-Native git @('ls-remote', '--heads', $RepositoryUrl, "refs/heads/$Branch")
+    if (-not $result) {
+        return $null
+    }
+    return ($result -split '\s+')[0]
+}
+
+$repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBranch) $repoRoot
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBranch) $repoRoot
+
+$currentBranch = Invoke-Native git @('branch', '--show-current') $repoRoot
+$currentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}') $repoRoot
+$status = Invoke-Native git @('status', '--porcelain=v1', '--untracked-files=all') $repoRoot
+if ($currentBranch -ne $SkiaSharpBranch) {
+    throw "Current branch is $currentBranch; expected $SkiaSharpBranch."
+}
+if ($status) {
+    throw "The SkiaSharp worktree is not clean:`n$status"
+}
+
+$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin') $repoRoot
+$parentRemoteHead = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
+if ($parentRemoteHead -ne $currentHead) {
+    throw "Current checkout is $currentHead, but origin/$SkiaSharpBranch is $parentRemoteHead."
+}
+
+$oldGitlinkEntry = Invoke-Native git @('ls-tree', 'HEAD', '--', 'externals/skia') $repoRoot
+$oldGitlinkParts = $oldGitlinkEntry -split '\s+'
+if ($oldGitlinkParts.Count -lt 3 -or $oldGitlinkParts[1] -ne 'commit') {
+    throw 'The current SkiaSharp commit does not contain the externals/skia gitlink.'
+}
+$oldGitlink = $oldGitlinkParts[2]
+
+$manifestPath = Join-Path $repoRoot 'cgmanifest.json'
+$manifestBefore = Get-Content $manifestPath -Raw | ConvertFrom-Json
+$oldManifestSha = @(
+    $manifestBefore.registrations |
+        Where-Object { $_.component.git.repositoryUrl -eq 'https://github.com/mono/skia.git' } |
+        ForEach-Object { $_.component.git.commitHash }
+)
+if ($oldManifestSha.Count -ne 1 -or $oldManifestSha[0] -ne $oldGitlink) {
+    throw "cgmanifest mono/skia SHA does not match the current gitlink $oldGitlink."
+}
+
+$null = Invoke-Native git @('submodule', 'update', '--init', '--', 'externals/skia') $repoRoot
+$skiaRoot = Join-Path $repoRoot 'externals/skia'
+$nativeUrl = Invoke-Native git @('remote', 'get-url', 'origin') $skiaRoot
+$null = Invoke-Native git @(
+    'fetch', '--no-tags', 'origin',
+    "+refs/heads/${SkiaBranch}:refs/remotes/origin/${SkiaBranch}"
+) $skiaRoot
+$mergedSha = Invoke-Native git @(
+    'rev-parse', "refs/remotes/origin/${SkiaBranch}^{commit}"
+) $skiaRoot
+
+$parents = (Invoke-Native git @('rev-list', '--parents', '-n', '1', $mergedSha) $skiaRoot) -split '\s+'
+if ($parents.Count -ne 3) {
+    throw "mono/skia $SkiaBranch tip $mergedSha is not a two-parent merge commit."
+}
+if ($oldGitlink -notin $parents[1..2]) {
+    throw "mono/skia $SkiaBranch tip $mergedSha does not merge the parent PR gitlink $oldGitlink."
+}
+
+$oldTree = Invoke-Native git @('rev-parse', "${oldGitlink}^{tree}") $skiaRoot
+$mergedTree = Invoke-Native git @('rev-parse', "${mergedSha}^{tree}") $skiaRoot
+if ($mergedTree -ne $oldTree) {
+    throw "Merged mono/skia tree $mergedTree differs from the parent PR's reviewed tree $oldTree."
+}
+
+Write-Host "SkiaSharp branch:  $SkiaSharpBranch @ $currentHead"
+Write-Host "mono/skia branch:  $SkiaBranch"
+Write-Host "Reviewed commit:   $oldGitlink"
+Write-Host "Merged commit:     $mergedSha"
+Write-Host "Identical tree:    $mergedTree"
+
+if (-not $Push) {
+    Write-Host 'DRY RUN: no files or refs were changed. Re-run with -Push to update the parent PR.'
+    exit 0
+}
+
+# Re-read both remote tips immediately before changing the worktree.
+$parentRemoteNow = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
+$nativeRemoteNow = Get-RemoteBranchSha $nativeUrl $SkiaBranch
+if ($parentRemoteNow -ne $currentHead -or $nativeRemoteNow -ne $mergedSha) {
+    throw 'A source branch changed after preflight. Run the script without -Push again.'
+}
+
+$null = Invoke-Native git @('checkout', '--detach', $mergedSha) $skiaRoot
+
+$manifest = Get-Content $manifestPath -Raw
+$pattern = '(?s)("repositoryUrl"\s*:\s*"https://github\.com/mono/skia\.git"\s*,\s*"commitHash"\s*:\s*")[0-9a-fA-F]{40}(")'
+$regex = [regex]::new($pattern)
+$matches = $regex.Matches($manifest)
+if ($matches.Count -ne 1) {
+    throw "Expected exactly one mono/skia git registration in cgmanifest.json; found $($matches.Count)."
+}
+$updatedManifest = $regex.Replace(
+    $manifest,
+    { param($match) $match.Groups[1].Value + $mergedSha + $match.Groups[2].Value }
+)
+[System.IO.File]::WriteAllText($manifestPath, $updatedManifest, [System.Text.UTF8Encoding]::new($false))
+
+$changedOutput = Invoke-Native git @('diff', '--name-only') $repoRoot
+$changed = @($changedOutput -split "`n" | Where-Object { $_ })
+$unexpected = @($changed | Where-Object { $_ -notin @('cgmanifest.json', 'externals/skia') })
+if ($unexpected -or $changed.Count -eq 0) {
+    throw "Expected only cgmanifest.json and externals/skia to change; found: $($changed -join ', ')"
+}
+
+$manifestNow = Get-Content $manifestPath -Raw | ConvertFrom-Json
+$manifestSha = @(
+    $manifestNow.registrations |
+        Where-Object { $_.component.git.repositoryUrl -eq 'https://github.com/mono/skia.git' } |
+        ForEach-Object { $_.component.git.commitHash }
+)
+$gitlinkNow = Invoke-Native git @('rev-parse', 'HEAD^{commit}') $skiaRoot
+if ($manifestSha.Count -ne 1 -or $manifestSha[0] -ne $mergedSha -or $gitlinkNow -ne $mergedSha) {
+    throw 'The updated gitlink and cgmanifest do not both match the merged mono/skia SHA.'
+}
+
+$null = Invoke-Native git @('add', '--', 'externals/skia', 'cgmanifest.json') $repoRoot
+$stagedOutput = Invoke-Native git @('diff', '--cached', '--name-only') $repoRoot
+$staged = @($stagedOutput -split "`n" | Where-Object { $_ })
+if ($staged.Count -eq 0 -or @($staged | Where-Object { $_ -notin @('cgmanifest.json', 'externals/skia') })) {
+    throw "Unexpected staged paths: $($staged -join ', ')"
+}
+
+$null = Invoke-Native git @(
+    'commit',
+    '-m', 'Update Skia reference to merged commit',
+    '-m', "mono/skia $SkiaBranch advanced from $oldGitlink to $mergedSha."
+) $repoRoot
+$newParentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}') $repoRoot
+$null = Invoke-Native git @('push', 'origin', "HEAD:refs/heads/$SkiaSharpBranch") $repoRoot
+
+$remoteResult = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
+if ($remoteResult -ne $newParentHead) {
+    throw "Remote parent branch is $remoteResult; expected $newParentHead."
+}
+
+Write-Host "Updated and pushed $SkiaSharpBranch to $newParentHead."

--- a/.agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1
@@ -19,22 +19,11 @@ function Invoke-Native {
         [string] $Command,
 
         [Parameter(Mandatory)]
-        [string[]] $Arguments,
-
-        [string] $WorkingDirectory
+        [string[]] $Arguments
     )
 
-    if ($WorkingDirectory) {
-        Push-Location $WorkingDirectory
-    }
-    try {
-        $output = @(& $Command @Arguments 2>&1)
-        $exitCode = $LASTEXITCODE
-    } finally {
-        if ($WorkingDirectory) {
-            Pop-Location
-        }
-    }
+    $output = @(& $Command @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
 
     if ($exitCode -ne 0) {
         throw "$Command $($Arguments -join ' ') failed:`n$($output -join "`n")"
@@ -53,12 +42,13 @@ function Get-RemoteBranchSha {
 }
 
 $repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBranch) $repoRoot
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBranch) $repoRoot
+Set-Location $repoRoot
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBranch)
+$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBranch)
 
-$currentBranch = Invoke-Native git @('branch', '--show-current') $repoRoot
-$currentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}') $repoRoot
-$status = Invoke-Native git @('status', '--porcelain=v1', '--untracked-files=all') $repoRoot
+$currentBranch = Invoke-Native git @('branch', '--show-current')
+$currentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}')
+$status = Invoke-Native git @('status', '--porcelain=v1', '--untracked-files=all')
 if ($currentBranch -ne $SkiaSharpBranch) {
     throw "Current branch is $currentBranch; expected $SkiaSharpBranch."
 }
@@ -66,13 +56,13 @@ if ($status) {
     throw "The SkiaSharp worktree is not clean:`n$status"
 }
 
-$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin') $repoRoot
+$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin')
 $parentRemoteHead = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
 if ($parentRemoteHead -ne $currentHead) {
     throw "Current checkout is $currentHead, but origin/$SkiaSharpBranch is $parentRemoteHead."
 }
 
-$oldGitlinkEntry = Invoke-Native git @('ls-tree', 'HEAD', '--', 'externals/skia') $repoRoot
+$oldGitlinkEntry = Invoke-Native git @('ls-tree', 'HEAD', '--', 'externals/skia')
 $oldGitlinkParts = $oldGitlinkEntry -split '\s+'
 if ($oldGitlinkParts.Count -lt 3 -or $oldGitlinkParts[1] -ne 'commit') {
     throw 'The current SkiaSharp commit does not contain the externals/skia gitlink.'
@@ -90,18 +80,19 @@ if ($oldManifestSha.Count -ne 1 -or $oldManifestSha[0] -ne $oldGitlink) {
     throw "cgmanifest mono/skia SHA does not match the current gitlink $oldGitlink."
 }
 
-$null = Invoke-Native git @('submodule', 'update', '--init', '--', 'externals/skia') $repoRoot
+$null = Invoke-Native git @('submodule', 'update', '--init', '--', 'externals/skia')
 $skiaRoot = Join-Path $repoRoot 'externals/skia'
-$nativeUrl = Invoke-Native git @('remote', 'get-url', 'origin') $skiaRoot
+Set-Location $skiaRoot
+$nativeUrl = Invoke-Native git @('remote', 'get-url', 'origin')
 $null = Invoke-Native git @(
     'fetch', '--no-tags', 'origin',
     "+refs/heads/${SkiaBranch}:refs/remotes/origin/${SkiaBranch}"
-) $skiaRoot
+)
 $mergedSha = Invoke-Native git @(
     'rev-parse', "refs/remotes/origin/${SkiaBranch}^{commit}"
-) $skiaRoot
+)
 
-$parents = (Invoke-Native git @('rev-list', '--parents', '-n', '1', $mergedSha) $skiaRoot) -split '\s+'
+$parents = (Invoke-Native git @('rev-list', '--parents', '-n', '1', $mergedSha)) -split '\s+'
 if ($parents.Count -ne 3) {
     throw "mono/skia $SkiaBranch tip $mergedSha is not a two-parent merge commit."
 }
@@ -109,8 +100,8 @@ if ($oldGitlink -notin $parents[1..2]) {
     throw "mono/skia $SkiaBranch tip $mergedSha does not merge the parent PR gitlink $oldGitlink."
 }
 
-$oldTree = Invoke-Native git @('rev-parse', "${oldGitlink}^{tree}") $skiaRoot
-$mergedTree = Invoke-Native git @('rev-parse', "${mergedSha}^{tree}") $skiaRoot
+$oldTree = Invoke-Native git @('rev-parse', "${oldGitlink}^{tree}")
+$mergedTree = Invoke-Native git @('rev-parse', "${mergedSha}^{tree}")
 if ($mergedTree -ne $oldTree) {
     throw "Merged mono/skia tree $mergedTree differs from the parent PR's reviewed tree $oldTree."
 }
@@ -133,7 +124,8 @@ if ($parentRemoteNow -ne $currentHead -or $nativeRemoteNow -ne $mergedSha) {
     throw 'A source branch changed after preflight. Run the script without -Push again.'
 }
 
-$null = Invoke-Native git @('checkout', '--detach', $mergedSha) $skiaRoot
+$null = Invoke-Native git @('checkout', '--detach', $mergedSha)
+Set-Location $repoRoot
 
 $manifest = Get-Content $manifestPath -Raw
 $pattern = '(?s)("repositoryUrl"\s*:\s*"https://github\.com/mono/skia\.git"\s*,\s*"commitHash"\s*:\s*")[0-9a-fA-F]{40}(")'
@@ -148,7 +140,7 @@ $updatedManifest = $regex.Replace(
 )
 [System.IO.File]::WriteAllText($manifestPath, $updatedManifest, [System.Text.UTF8Encoding]::new($false))
 
-$changedOutput = Invoke-Native git @('diff', '--name-only') $repoRoot
+$changedOutput = Invoke-Native git @('diff', '--name-only')
 $changed = @($changedOutput -split "`n" | Where-Object { $_ })
 $unexpected = @($changed | Where-Object { $_ -notin @('cgmanifest.json', 'externals/skia') })
 if ($unexpected -or $changed.Count -eq 0) {
@@ -161,13 +153,15 @@ $manifestSha = @(
         Where-Object { $_.component.git.repositoryUrl -eq 'https://github.com/mono/skia.git' } |
         ForEach-Object { $_.component.git.commitHash }
 )
-$gitlinkNow = Invoke-Native git @('rev-parse', 'HEAD^{commit}') $skiaRoot
+Set-Location $skiaRoot
+$gitlinkNow = Invoke-Native git @('rev-parse', 'HEAD^{commit}')
+Set-Location $repoRoot
 if ($manifestSha.Count -ne 1 -or $manifestSha[0] -ne $mergedSha -or $gitlinkNow -ne $mergedSha) {
     throw 'The updated gitlink and cgmanifest do not both match the merged mono/skia SHA.'
 }
 
-$null = Invoke-Native git @('add', '--', 'externals/skia', 'cgmanifest.json') $repoRoot
-$stagedOutput = Invoke-Native git @('diff', '--cached', '--name-only') $repoRoot
+$null = Invoke-Native git @('add', '--', 'externals/skia', 'cgmanifest.json')
+$stagedOutput = Invoke-Native git @('diff', '--cached', '--name-only')
 $staged = @($stagedOutput -split "`n" | Where-Object { $_ })
 if ($staged.Count -eq 0 -or @($staged | Where-Object { $_ -notin @('cgmanifest.json', 'externals/skia') })) {
     throw "Unexpected staged paths: $($staged -join ', ')"
@@ -177,9 +171,9 @@ $null = Invoke-Native git @(
     'commit',
     '-m', 'Update Skia reference to merged commit',
     '-m', "mono/skia $SkiaBranch advanced from $oldGitlink to $mergedSha."
-) $repoRoot
-$newParentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}') $repoRoot
-$null = Invoke-Native git @('push', 'origin', "HEAD:refs/heads/$SkiaSharpBranch") $repoRoot
+)
+$newParentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}')
+$null = Invoke-Native git @('push', 'origin', "HEAD:refs/heads/$SkiaSharpBranch")
 
 $remoteResult = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
 if ($remoteResult -ne $newParentHead) {

--- a/.agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1
+++ b/.agents/skills/merge-skia-update/scripts/Update-SkiaSharpSkiaCommit.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+#Requires -Version 7.4
 
 [CmdletBinding()]
 param(
@@ -12,57 +13,40 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-
-function Invoke-Native {
-    param(
-        [Parameter(Mandatory)]
-        [string] $Command,
-
-        [Parameter(Mandatory)]
-        [string[]] $Arguments
-    )
-
-    $output = @(& $Command @Arguments 2>&1)
-    $exitCode = $LASTEXITCODE
-
-    if ($exitCode -ne 0) {
-        throw "$Command $($Arguments -join ' ') failed:`n$($output -join "`n")"
-    }
-    return ($output -join "`n").Trim()
-}
+$PSNativeCommandUseErrorActionPreference = $true
 
 function Get-RemoteBranchSha {
     param([string] $RepositoryUrl, [string] $Branch)
 
-    $result = Invoke-Native git @('ls-remote', '--heads', $RepositoryUrl, "refs/heads/$Branch")
+    $result = git ls-remote --heads $RepositoryUrl "refs/heads/$Branch"
     if (-not $result) {
         return $null
     }
     return ($result -split '\s+')[0]
 }
 
-$repoRoot = Invoke-Native git @('rev-parse', '--show-toplevel')
+$repoRoot = git rev-parse --show-toplevel
 Set-Location $repoRoot
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaSharpBranch)
-$null = Invoke-Native git @('check-ref-format', '--branch', $SkiaBranch)
+git check-ref-format --branch $SkiaSharpBranch | Out-Null
+git check-ref-format --branch $SkiaBranch | Out-Null
 
-$currentBranch = Invoke-Native git @('branch', '--show-current')
-$currentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}')
-$status = Invoke-Native git @('status', '--porcelain=v1', '--untracked-files=all')
+$currentBranch = git branch --show-current
+$currentHead = git rev-parse 'HEAD^{commit}'
+$status = @(git status --porcelain=v1 --untracked-files=all)
 if ($currentBranch -ne $SkiaSharpBranch) {
     throw "Current branch is $currentBranch; expected $SkiaSharpBranch."
 }
 if ($status) {
-    throw "The SkiaSharp worktree is not clean:`n$status"
+    throw "The SkiaSharp worktree is not clean:`n$($status -join "`n")"
 }
 
-$parentUrl = Invoke-Native git @('remote', 'get-url', 'origin')
+$parentUrl = git remote get-url origin
 $parentRemoteHead = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
 if ($parentRemoteHead -ne $currentHead) {
     throw "Current checkout is $currentHead, but origin/$SkiaSharpBranch is $parentRemoteHead."
 }
 
-$oldGitlinkEntry = Invoke-Native git @('ls-tree', 'HEAD', '--', 'externals/skia')
+$oldGitlinkEntry = git ls-tree HEAD -- externals/skia
 $oldGitlinkParts = $oldGitlinkEntry -split '\s+'
 if ($oldGitlinkParts.Count -lt 3 -or $oldGitlinkParts[1] -ne 'commit') {
     throw 'The current SkiaSharp commit does not contain the externals/skia gitlink.'
@@ -80,19 +64,14 @@ if ($oldManifestSha.Count -ne 1 -or $oldManifestSha[0] -ne $oldGitlink) {
     throw "cgmanifest mono/skia SHA does not match the current gitlink $oldGitlink."
 }
 
-$null = Invoke-Native git @('submodule', 'update', '--init', '--', 'externals/skia')
+git submodule update --init -- externals/skia | Out-Null
 $skiaRoot = Join-Path $repoRoot 'externals/skia'
 Set-Location $skiaRoot
-$nativeUrl = Invoke-Native git @('remote', 'get-url', 'origin')
-$null = Invoke-Native git @(
-    'fetch', '--no-tags', 'origin',
-    "+refs/heads/${SkiaBranch}:refs/remotes/origin/${SkiaBranch}"
-)
-$mergedSha = Invoke-Native git @(
-    'rev-parse', "refs/remotes/origin/${SkiaBranch}^{commit}"
-)
+$nativeUrl = git remote get-url origin
+git fetch --no-tags origin "+refs/heads/${SkiaBranch}:refs/remotes/origin/${SkiaBranch}" | Out-Null
+$mergedSha = git rev-parse "refs/remotes/origin/${SkiaBranch}^{commit}"
 
-$parents = (Invoke-Native git @('rev-list', '--parents', '-n', '1', $mergedSha)) -split '\s+'
+$parents = (git rev-list --parents -n 1 $mergedSha) -split '\s+'
 if ($parents.Count -ne 3) {
     throw "mono/skia $SkiaBranch tip $mergedSha is not a two-parent merge commit."
 }
@@ -100,8 +79,8 @@ if ($oldGitlink -notin $parents[1..2]) {
     throw "mono/skia $SkiaBranch tip $mergedSha does not merge the parent PR gitlink $oldGitlink."
 }
 
-$oldTree = Invoke-Native git @('rev-parse', "${oldGitlink}^{tree}")
-$mergedTree = Invoke-Native git @('rev-parse', "${mergedSha}^{tree}")
+$oldTree = git rev-parse "${oldGitlink}^{tree}"
+$mergedTree = git rev-parse "${mergedSha}^{tree}"
 if ($mergedTree -ne $oldTree) {
     throw "Merged mono/skia tree $mergedTree differs from the parent PR's reviewed tree $oldTree."
 }
@@ -124,7 +103,7 @@ if ($parentRemoteNow -ne $currentHead -or $nativeRemoteNow -ne $mergedSha) {
     throw 'A source branch changed after preflight. Run the script without -Push again.'
 }
 
-$null = Invoke-Native git @('checkout', '--detach', $mergedSha)
+git checkout --detach $mergedSha | Out-Null
 Set-Location $repoRoot
 
 $manifest = Get-Content $manifestPath -Raw
@@ -140,8 +119,7 @@ $updatedManifest = $regex.Replace(
 )
 [System.IO.File]::WriteAllText($manifestPath, $updatedManifest, [System.Text.UTF8Encoding]::new($false))
 
-$changedOutput = Invoke-Native git @('diff', '--name-only')
-$changed = @($changedOutput -split "`n" | Where-Object { $_ })
+$changed = @(git diff --name-only | Where-Object { $_ })
 $unexpected = @($changed | Where-Object { $_ -notin @('cgmanifest.json', 'externals/skia') })
 if ($unexpected -or $changed.Count -eq 0) {
     throw "Expected only cgmanifest.json and externals/skia to change; found: $($changed -join ', ')"
@@ -154,26 +132,21 @@ $manifestSha = @(
         ForEach-Object { $_.component.git.commitHash }
 )
 Set-Location $skiaRoot
-$gitlinkNow = Invoke-Native git @('rev-parse', 'HEAD^{commit}')
+$gitlinkNow = git rev-parse 'HEAD^{commit}'
 Set-Location $repoRoot
 if ($manifestSha.Count -ne 1 -or $manifestSha[0] -ne $mergedSha -or $gitlinkNow -ne $mergedSha) {
     throw 'The updated gitlink and cgmanifest do not both match the merged mono/skia SHA.'
 }
 
-$null = Invoke-Native git @('add', '--', 'externals/skia', 'cgmanifest.json')
-$stagedOutput = Invoke-Native git @('diff', '--cached', '--name-only')
-$staged = @($stagedOutput -split "`n" | Where-Object { $_ })
+git add -- externals/skia cgmanifest.json | Out-Null
+$staged = @(git diff --cached --name-only | Where-Object { $_ })
 if ($staged.Count -eq 0 -or @($staged | Where-Object { $_ -notin @('cgmanifest.json', 'externals/skia') })) {
     throw "Unexpected staged paths: $($staged -join ', ')"
 }
 
-$null = Invoke-Native git @(
-    'commit',
-    '-m', 'Update Skia reference to merged commit',
-    '-m', "mono/skia $SkiaBranch advanced from $oldGitlink to $mergedSha."
-)
-$newParentHead = Invoke-Native git @('rev-parse', 'HEAD^{commit}')
-$null = Invoke-Native git @('push', 'origin', "HEAD:refs/heads/$SkiaSharpBranch")
+git commit -m 'Update Skia reference to merged commit' -m "mono/skia $SkiaBranch advanced from $oldGitlink to $mergedSha." | Out-Null
+$newParentHead = git rev-parse 'HEAD^{commit}'
+git push origin "HEAD:refs/heads/$SkiaSharpBranch" | Out-Null
 
 $remoteResult = Get-RemoteBranchSha $parentUrl $SkiaSharpBranch
 if ($remoteResult -ne $newParentHead) {

--- a/.agents/skills/update-skia/scripts/update_versions.py
+++ b/.agents/skills/update-skia/scripts/update_versions.py
@@ -328,6 +328,64 @@ def replace_transition(
     return content
 
 
+def advance_harfbuzz_package_bucket(
+    versions: str,
+    current_milestone: int,
+    target_milestone: int,
+    base_versions: str | None = None,
+) -> str:
+    """Move HarfBuzzSharp packages to the target Skia milestone's bucket."""
+    source_versions = base_versions or versions
+    source_matches = re.findall(
+        r"^\s*HarfBuzzSharp\S*\s+(?:file|nuget)\s+(\d+\.\d+\.\d+(?:\.\d+)?)\s*$",
+        source_versions,
+        flags=re.MULTILINE,
+    )
+    if not source_matches:
+        raise RuntimeError("Could not find HarfBuzzSharp package versions.")
+    if len(set(source_matches)) != 1:
+        raise RuntimeError("HarfBuzzSharp package versions are inconsistent.")
+
+    package_version = source_matches[0]
+    version_match = re.fullmatch(
+        r"(?P<native>\d+\.\d+\.\d+)(?:\.(?P<revision>\d+))?",
+        package_version,
+    )
+    if not version_match:
+        raise RuntimeError(f"Invalid HarfBuzzSharp package version: {package_version}.")
+
+    revision = int(version_match.group("revision") or 0)
+    milestone_delta = target_milestone - current_milestone
+    if milestone_delta <= 0:
+        raise RuntimeError("HarfBuzzSharp buckets can only advance with the Skia milestone.")
+
+    target_revision = ((revision // 100) + milestone_delta) * 100
+    target_version = f"{version_match.group('native')}.{target_revision}"
+    current_matches = re.findall(
+        r"^\s*HarfBuzzSharp\S*\s+(?:file|nuget)\s+(\d+\.\d+\.\d+(?:\.\d+)?)\s*$",
+        versions,
+        flags=re.MULTILINE,
+    )
+    if len(current_matches) != len(source_matches) or len(set(current_matches)) != 1:
+        raise RuntimeError("HarfBuzzSharp package versions are inconsistent.")
+    if current_matches[0] == target_version:
+        return versions
+    if current_matches[0] != package_version:
+        raise RuntimeError(
+            "HarfBuzzSharp package versions do not match the parent base or target bucket."
+        )
+
+    updated, count = re.subn(
+        r"^(\s*HarfBuzzSharp\S*\s+(?:file|nuget)\s+)\S+(\s*)$",
+        rf"\g<1>{target_version}\g<2>",
+        versions,
+        flags=re.MULTILINE,
+    )
+    if count != len(source_matches):
+        raise RuntimeError("Could not update every HarfBuzzSharp package version.")
+    return updated
+
+
 def update_versions(
     repo_root: Path,
     current: int,
@@ -359,6 +417,11 @@ def update_versions(
     pipeline = pipeline_path.read_text(encoding="utf-8-sig")
     sk_types = sk_types_path.read_text(encoding="utf-8-sig")
     cgmanifest = json.loads(cgmanifest_path.read_text(encoding="utf-8-sig"))
+    base_versions = (
+        git_show(repo_root, parent_base_sha, "scripts/VERSIONS.txt")
+        if parent_base_sha
+        else None
+    )
     dependency_changes = []
     dependency_errors = []
 
@@ -368,6 +431,9 @@ def update_versions(
             f"Could not find current or target NuGet version in {versions_path}."
         )
     major = match.group(1)
+    has_current_milestone = bool(
+        re.search(rf"libSkiaSharp\s+milestone\s+{current}\b", versions)
+    )
 
     if current != target:
         versions = replace_transition(
@@ -401,6 +467,13 @@ def update_versions(
             f"{major}.{target}.0",
             versions,
         )
+        if has_current_milestone or base_versions:
+            versions = advance_harfbuzz_package_bucket(
+                versions,
+                current,
+                target,
+                base_versions,
+            )
         pipeline = re.sub(
             rf"(SKIASHARP_VERSION:\s*){major}\.{current}\.\d+\b",
             rf"\g<1>{major}.{target}.0",

--- a/.agents/skills/update-skia/scripts/update_versions_test.py
+++ b/.agents/skills/update-skia/scripts/update_versions_test.py
@@ -31,7 +31,10 @@ class UpdateVersionsTests(unittest.TestCase):
             "libSkiaSharp soname 151.0.0\n"
             "SkiaSharp assembly 4.151.3.0\n"
             "SkiaSharp file 4.151.3.0\n"
-            "SkiaSharp nuget 4.151.3\n",
+            "SkiaSharp nuget 4.151.3\n"
+            "HarfBuzzSharp file 14.2.1.100\n"
+            "HarfBuzzSharp nuget 14.2.1.100\n"
+            "HarfBuzzSharp.NativeAssets.Linux nuget 14.2.1.100\n",
             encoding="utf-8",
         )
         (self.root / "scripts" / "azure-templates-variables.yml").write_text(
@@ -137,7 +140,11 @@ class UpdateVersionsTests(unittest.TestCase):
             cwd=self.root,
             check=True,
         )
-        subprocess.run(["git", "add", "cgmanifest.json"], cwd=self.root, check=True)
+        subprocess.run(
+            ["git", "add", "cgmanifest.json", "scripts/VERSIONS.txt"],
+            cwd=self.root,
+            check=True,
+        )
         subprocess.run(
             ["git", "commit", "--quiet", "-m", "parent fixture"],
             cwd=self.root,
@@ -169,6 +176,8 @@ class UpdateVersionsTests(unittest.TestCase):
         self.assertIn("milestone 152", versions)
         self.assertIn("increment 0", versions)
         self.assertIn("4.152.0", versions)
+        self.assertEqual(3, versions.count("14.2.1.200"))
+        self.assertNotIn("14.2.1.100", versions)
         self.assertIn(
             "SKIASHARP_VERSION: 4.152.0",
             (self.root / "scripts" / "azure-templates-variables.yml").read_text(
@@ -192,6 +201,53 @@ class UpdateVersionsTests(unittest.TestCase):
         self.assertEqual(152, skia["chrome_milestone"])
         self.assertEqual("chrome/m152", skia["component"]["other"]["version"])
         self.assertEqual("chrome/m152", skia["upstream_ref"])
+
+    def test_advances_harfbuzz_to_start_of_target_milestone_bucket(self) -> None:
+        versions_path = self.root / "scripts" / "VERSIONS.txt"
+        versions_path.write_text(
+            versions_path.read_text(encoding="utf-8").replace(
+                "14.2.1.100", "14.2.1.142"
+            ),
+            encoding="utf-8",
+        )
+
+        update_versions(self.root, 151, 152, "chrome/m152")
+
+        versions = versions_path.read_text(encoding="utf-8")
+        self.assertEqual(3, versions.count("14.2.1.200"))
+        self.assertNotIn("14.2.1.142", versions)
+
+    def test_milestone_update_is_idempotent_for_harfbuzz_bucket(self) -> None:
+        update_versions(self.root, 151, 152, "chrome/m152")
+        versions_path = self.root / "scripts" / "VERSIONS.txt"
+        first = versions_path.read_bytes()
+
+        update_versions(self.root, 151, 152, "chrome/m152")
+
+        self.assertEqual(first, versions_path.read_bytes())
+
+    def test_repairs_harfbuzz_bucket_after_partial_milestone_update(self) -> None:
+        versions_path = self.root / "scripts" / "VERSIONS.txt"
+        versions = versions_path.read_text(encoding="utf-8")
+        versions = versions.replace("release m151", "release m152")
+        versions = versions.replace("milestone 151", "milestone 152")
+        versions = versions.replace("151.0.0", "152.0.0")
+        versions = versions.replace("4.151.3.0", "4.152.0.0")
+        versions = versions.replace("4.151.3", "4.152.0")
+        versions_path.write_text(versions, encoding="utf-8")
+
+        update_versions(
+            self.root,
+            151,
+            152,
+            "chrome/m152",
+            parent_base_sha=self.parent_base_sha,
+            skia_base_sha=self.skia_base_sha,
+        )
+
+        updated = versions_path.read_text(encoding="utf-8")
+        self.assertEqual(3, updated.count("14.2.1.200"))
+        self.assertNotIn("14.2.1.100", updated)
 
     def test_same_milestone_updates_only_manifest_hashes(self) -> None:
         versions_path = self.root / "scripts" / "VERSIONS.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,7 @@ pre-publication BAR/CI package approval testing. See
 | Skia analyst | `/skia-analyst` | "what changed", "what are we missing", "feature gap", "api diff", "scout features", "diff tags" |
 | Update Skia | `/update-skia` | "update to milestone NNN", "bump Skia" |
 | Review Skia update | `/review-skia-update` | "review the Skia merge PR" |
+| Merge Skia update | `/merge-skia-update` | "merge the Skia bump", "land the Skia sync PRs" |
 | PR commit message | `/pr-commit-message` | "write commit message for PR" |
 | Validate samples | `/validate-samples` | "build samples", "test sample projects" |
 | Scout GM samples | `/sample-scout` | "find demos to port", "what samples are we missing", "gallery ideas" |

--- a/scripts/infra/publishing/tests/Test-PublishingScripts.ps1
+++ b/scripts/infra/publishing/tests/Test-PublishingScripts.ps1
@@ -207,6 +207,10 @@ try {
 
 # Loads and exercises Prepare's pure version transformation functions.
 Invoke-Expression (Get-ScriptFunctionText $preparePath)
+Assert-Equal '14.2.1.201' (Get-NextHarfBuzzVersion '14.2.1.200') `
+    'A high HarfBuzzSharp milestone bucket did not preserve its revision range.'
+Assert-Equal '14.2.1.103' (Get-NextHarfBuzzVersion '14.2.1.102') `
+    'The M151 HarfBuzzSharp bucket did not advance within its reserved range.'
 $baseVersions = [pscustomobject] @{ SkiaSharp = '4.151.1'; HarfBuzzSharp = '14.2.1.1' }
 Assert-Equal '14.2.1.1' (Get-ReleaseHarfBuzzVersion $baseVersions '4.151.1') `
     'A label-only cut changed HarfBuzzSharp.'


### PR DESCRIPTION
## Description

Adds a dedicated `merge-skia-update` skill for the small amount of mechanical work needed after a maintainer has reviewed and approved a paired `mono/skia` and `mono/SkiaSharp` update.

The skill first discovers reciprocal native/parent PR pairs. It presents the exact pair before requesting landing confirmation and asks the maintainer to select one when multiple pairs are open. The preparation script then determines the release action from the parent target: when targeting `main`, it reads the current product version from that exact base commit and derives the previous `release/A.B.x` line; when targeting an existing `release/A.B.x`, it recognizes a servicing sync and creates nothing. The maintainer remains responsible for both GitHub merges.

Two self-contained PowerShell helpers make the deterministic changes safely:

- `Prepare-SkiaReleaseBranches.ps1` automatically derives and preserves the current main product line in matching native and parent release branches. It defaults to read-only output, no-ops for servicing targets, and creates/pushes refs only with `-Push`.
- `Update-SkiaSharpSkiaCommit.ps1` verifies the actual two-parent native merge, confirms its tree matches the reviewed native head, updates only `externals/skia` and the matching cgmanifest hash, and commits/pushes only with `-Push`.

For the parent repin, the skill first checks whether the current checkout is already clean, on the parent PR branch, and at its remote tip. If so, it uses that checkout directly. If the maintainer does not want to check out the branch, the skill can dispatch the existing submodule-sync workflow to open a dependent PR targeting the parent branch, then verifies that PR captured the exact reviewed merge SHA before the maintainer merges it.

The skill generates the mono/skia merge-commit message, pauses for the maintainer's manual merge, performs the parent repin, generates the mono/SkiaSharp merge message, and pauses again for the manual parent merge. Because the native merge tree is proven identical to the reviewed head, it does not require another parent PR CI wait solely for the identity-only repin; final validation occurs on main.

This PR also moves the reusable `update_versions.py` helper and tests into the `update-skia` skill and restores focused publishing-test coverage for high HarfBuzzSharp milestone buckets.

**Related issues**

Related to #4833

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — workflow, validation tooling, and test coverage only; no public API or observable runtime behavior changes.

## Testing

- `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/merge-skia-update`
- `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/update-skia`
- `python3 .agents/skills/update-skia/scripts/update_versions_test.py` — 17 tests passed
- `python3 -m json.tool .agents/skills/merge-skia-update/evals/evals.json`
- PowerShell parser validation for both new helper scripts
- Native-command failure propagation on PowerShell 7.4+
- `pwsh -NoLogo -NoProfile -File ./scripts/infra/publishing/tests/Test-PublishingScripts.ps1` — 71 tests passed
- `git diff --check`
- Read-only review of the final delta — no significant issues found
- Live default-mode main dry run automatically derived `release/4.152.x` without mutating refs
- Live servicing dry run recognized an existing `release/A.B.x` target and created no refs

No rendering behavior changed, so screenshots are not applicable.

## Checklist

- [x] Tests added or updated (10 focused landing scenarios, update helper tests, and publishing bucket assertions)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no C API or `externals/skia` changes