### PR TITLE
[skia-sync] Merge upstream chrome/m152 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "9f0d864fd60e9907a8bf5ec84a71d603e6c8db5f"
+          "commitHash": "876a77cd8cdc15b2277e68357dd22f5652e50c54"
         }
       }
     },
@@ -323,7 +323,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "b6d106297ff9ef2ff8094033695d045e87775581",
+      "upstream_merge_commit": "0873ec164a06966b90ae0d43ef783cfb180084ae",
       "upstream_ref": "chrome/m152"
     }
   ]

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "876a77cd8cdc15b2277e68357dd22f5652e50c54"
+          "commitHash": "8f5cc7a4c200ba8ecc5bc6263cf9f8bfe0ba6e6b"
         }
       }
     },


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m152. Targeting release branch `release/4.152.x` (mono/skia `release/4.152.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/349

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the `externals/skia` submodule on `release/4.152.x` to the mono/skia merge of
upstream `chrome/m152`.

- Submodule pointer -> `876a77cd8cdc15b2277e68357dd22f5652e50c54` (the tested merge commit).
- `cgmanifest.json`: skia `commitHash` and `upstream_merge_commit` updated to the merge /
  upstream (`0873ec16`); `chrome_milestone` stays 152.
- Release-line bug-fix mode: no version changes (`VERSIONS.txt`,
  `azure-templates-variables.yml`, native C API version all unchanged).
- Bindings regenerated: **no binding changes, no new native functions** (no C API delta).
  No managed wrapper changes required; public ABI unchanged.
- No dependency/version manifest changes (`skia-dependency-changes.json` = empty).

## Testing

Managed `binding/SkiaSharp/SkiaSharp.csproj` build: 0 errors. Native built from source
(linux/x64). Full unfiltered `tests/SkiaSharp.Tests.Console.slnx` (net10.0, x64), exit 0:

- Core: 6127 passed, 33 skipped
- Vulkan: 23 passed, 2 skipped
- Direct3D: 2 passed, 3 skipped
- Singleton init: 1 passed, 0 skipped

No **required** `GpuPolicy` backend was skipped. Direct3D skips are platform-policy on the
non-Windows validation host.

## Human review

- Validated on Linux/x64 only. Other platforms/backends (Windows, macOS, Linux arm64,
  Android, iOS, WASM) require CI confirmation.
- Underlying change is an upstream internal UAF fix; no SkiaSharp API impact.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-09-03T00:10:31Z_
