### PR TITLE
Guard the docs-sync force push with an explicit lease

### DIFF
--- a/.github/workflows/auto-docs-submodule-sync.yml
+++ b/.github/workflows/auto-docs-submodule-sync.yml
@@ -56,6 +56,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Record what the remote holds BEFORE we rewrite the branch locally, so the push
+          # below can state its own expectation instead of relying on whatever
+          # refs/remotes/origin/$BRANCH happens to hold. An empty value is a valid lease
+          # meaning "the branch must not exist yet", which is what the very first run sees.
+          REMOTE_SHA=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)
+          echo "remote $BRANCH is at: ${REMOTE_SHA:-<absent>}"
+
           # Always start fresh from main — avoids stale commit accumulation
           git checkout -B "$BRANCH" origin/main
 
@@ -69,7 +76,13 @@ jobs:
 
           Latest: $LATEST_MSG"
 
-          git push origin "$BRANCH" --force
+          # Guarded force: rejected with "stale info" if anything moved the branch after we
+          # read REMOTE_SHA above. Never an unguarded --force (see AGENTS.md). The explicit
+          # <ref>:<sha> form is used rather than a bare --force-with-lease because a bare
+          # lease reads refs/remotes/origin/$BRANCH, which only exists here because the
+          # checkout step sets fetch-depth: 0; with the action's default depth that ref is
+          # absent and every push after the first would be rejected, silently stalling the sync.
+          git push origin "$BRANCH" --force-with-lease="refs/heads/$BRANCH:$REMOTE_SHA"
 
           # Create PR if one doesn't already exist
           existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')


### PR DESCRIPTION
## Description

`Sync - Docs Submodule` runs daily and force-pushes its PR branch:

```bash
git checkout -B "$BRANCH" origin/main
...
git push origin "$BRANCH" --force        # <- unguarded
```

An unguarded `--force` overwrites whatever the branch holds with no diagnostic. If a maintainer pushes a fixup onto the automation PR — the natural thing to do when a submodule bump needs a tweak — the next scheduled run discards it silently. AGENTS.md forbids unguarded `--force` for exactly this reason.

This captures the remote tip **before** `checkout -B` rewrites the branch locally and pushes with an explicit lease:

```bash
REMOTE_SHA=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)
echo "remote $BRANCH is at: ${REMOTE_SHA:-<absent>}"
git checkout -B "$BRANCH" origin/main
...
git push origin "$BRANCH" --force-with-lease="refs/heads/$BRANCH:$REMOTE_SHA"
```

**Why the explicit `<ref>:<sha>` form and not a bare `--force-with-lease`.** A bare lease has no argument of its own — it checks the remote against `refs/remotes/origin/$BRANCH`. That ref is present here *only* because the checkout step happens to set `fetch-depth: 0`, which makes `actions/checkout` fetch every branch:

```ts
// actions/checkout src/git-source-provider.ts:188
if (settings.fetchDepth <= 0) {
  let refSpec = refHelper.getRefSpecForAllHistory(...)   // -> '+refs/heads/*:refs/remotes/origin/*'
```

At the action's **default** `fetch-depth: 1` the refspec is narrowed to the checked-out branch, that tracking ref does not exist, and — measured below — a bare lease then rejects *every* push once the branch exists, silently stalling the sync. So a bare lease here is load-bearing on an unrelated setting in a different step. The explicit form states its expectation locally and is correct regardless of fetch configuration.

> **Correcting a premise.** This change was originally motivated by the idea that a bare `--force-with-lease` after `checkout -B` "degrades to a plain force". **That is not true on git 2.53.0** — I tested it. A bare lease with no recorded expectation *fails closed* (rejects), it never forces. The real defect being fixed is the plain `--force` on the line above; the choice of the explicit form over the bare one is about the `fetch-depth` coupling, not about degradation. Recording this so the next reader does not inherit the wrong reason.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — CI-only, no public API or behavior change. The only observable difference is that the sync job now fails loudly instead of clobbering a concurrently-updated branch.

## Testing

A workflow that runs once a day on a schedule can't be exercised in a PR, so I verified the git semantics directly against throwaway local bare remotes (`git version 2.53.0`), reproducing the workflow's exact sequence — `ls-remote` -> `checkout -B $BRANCH origin/main` -> push — and including a second clone acting as the concurrent third party.

| # | Tracking ref for `$BRANCH` | Remote state | Push form | Result |
| --- | --- | --- | --- | --- |
| a | absent | branch absent (first run) | explicit, empty lease | `* [new branch]`, **exit 0** |
| g | present | unchanged (normal daily run) | explicit | `+ 5e213a5...387ad81 (forced update)`, **exit 0** |
| b | present | third party moved it | explicit | `! [rejected] (stale info)`, **exit 1** |
| h | **absent** (`fetch-depth: 1`) | branch exists | explicit | `+ 387ad81...5b704d7 (forced update)`, **exit 0** |
| c2 | **absent** (`fetch-depth: 1`) | branch exists | **bare** | `! [rejected] (stale info)`, **exit 1** — sync would stall |
| f | present | third party moved it | **bare** | `! [rejected] (stale info)`, exit 1 |
| d | absent | branch absent | **bare** | `* [new branch]`, exit 0 |

Rows **a**, **g**, **b** are the three states the workflow actually passes through, and the explicit lease is correct in all three: it creates the branch on the first run, updates it on a normal run, and refuses to clobber a concurrent change. Row **h** vs **c2** is the isolated difference between the two forms — the explicit lease is the only one that survives losing `fetch-depth: 0`. Rows **d**/**f** are why I struck the "degrades to a force" claim: the bare lease never forced in any configuration I could construct.

Sample of the concurrent-move rejection (row b):

```console
$ REMOTE_SHA=$(git ls-remote origin refs/heads/auto/docs-sync | cut -f1)   # 10c93df...
$ # third party pushes f286652 behind our back
$ git checkout -qB auto/docs-sync origin/main && git commit -qam c2
$ git push origin auto/docs-sync --force-with-lease="refs/heads/auto/docs-sync:$REMOTE_SHA"
 ! [rejected]        auto/docs-sync -> auto/docs-sync (stale info)
error: failed to push some refs to '../remote.git'
$ echo $?
1
```

Also note `git ls-remote` failing (network blip) leaves `REMOTE_SHA` empty, which is the "must not exist" lease — so the failure mode is a rejected push, not an unguarded one.

**Gates run:**

| Gate | Result |
| --- | --- |
| Parse every `.github/workflows/*.yml` with PyYAML | `parsed 28 workflow files, 0 failures` |
| `bash -n` on the extracted `Create or update PR` run block | OK |

No unit test added — this is a shell step inside a scheduled workflow with no test harness, and the behavior under test is git's, verified directly above.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated
