### PR TITLE
Fix a paths-ignore typo and pin the rebase checkout

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -39,8 +39,8 @@ on:
       - 'native/nanoserver/**'
       - 'README.md'                    # repo meta docs — not rendered on the site
       - 'CONTRIBUTING.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'SECURITY.md'
+      - 'CODE-OF-CONDUCT.md'
+      - 'SECURITY.md'                  # not present today; kept so adding it stays a no-op
       - '.agents/**'                   # agent skills/workflows — not built into the site
       - 'cgmanifest.json'              # component-governance manifest — not a site input
   workflow_dispatch:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/rebase')
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
## Description

Two unrelated one-line workflow defects. Both are silent — nothing in CI reports either one.

**1. `build-site.yml` — a `paths-ignore` entry that can never match.**

The PR-preview skip list names `CODE_OF_CONDUCT.md` (underscores). The file in this repo is `CODE-OF-CONDUCT.md` (hyphens). Confirmed against the index rather than the working tree, since macOS filesystems are case- and not punctuation-forgiving:

```console
$ git ls-files --error-unmatch CODE-OF-CONDUCT.md   # TRACKED
$ git ls-files --error-unmatch CODE_OF_CONDUCT.md   # absent
```

`paths-ignore` skips a run only when **every** changed file matches an entry, so a non-matching entry fails *open*: a PR touching only the code of conduct has been building and deploying a full staging site preview this whole time. Wasted work rather than a bad deploy — which is exactly why nobody noticed.

**2. `rebase.yml` — `actions/checkout@v2`.**

```console
$ gh api repos/actions/checkout/contents/action.yml?ref=v2 | ... 
runs:
  using: node12
```

Runners stopped providing Node 12 in August 2023. GitHub does not rewrite the action's metadata; it forcibly executes the bundle on whatever Node it currently supports. So `checkout@v2`'s node12-era `dist/index.js` is being run on a runtime its maintainers never tested it against, it receives no security fixes, and `@v2` is a mutable tag.

This is latent rather than broken-in-production: the job is gated on `startsWith(github.event.comment.body, '/rebase')`, so every recorded run is `skipped`. It surfaces the first time someone actually types `/rebase`.

```console
$ gh run list --workflow=rebase.yml --limit 10
2026-09-02T23:27:39Z skipped ...
2026-09-02T19:24:18Z skipped ...    # all skipped — the gate, not the checkout
```

Pinned to `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`, which is already the dominant pin in this repo (**36** other uses) and which I verified really is v7.0.1:

```console
$ gh api repos/actions/checkout/git/ref/tags/v7.0.1 --jq '.object.sha + " " + .object.type'
3d3c42e5aac5ba805825da76410c181273ba90b1 commit
```

**On `SECURITY.md` — kept deliberately, not overlooked.** It is listed in the same `paths-ignore` block and does not exist (`git ls-files --error-unmatch SECURITY.md` -> absent), so it is fair to ask whether it should go too. I kept it, because the two entries fail in opposite directions:

- `CODE_OF_CONDUCT.md` was a *broken intent* — it was written to match a file that exists, and silently didn't. That is a bug.
- `SECURITY.md` is a *correct but unexercised intent* — a conventional GitHub community-health file that simply hasn't been added yet. A `paths-ignore` entry that matches nothing costs nothing at runtime, whereas dropping it means that whenever someone adds `SECURITY.md`, it silently starts triggering full site previews — reintroducing the very waste this PR removes.

Added a trailing comment so the next reader doesn't re-flag it as dead config.

**Out of scope, noted:** 16 workflows still use the floating `actions/checkout@v4`. Those are on a supported, consistent major and are a separate bulk-pinning change; `@v2` was the sole outlier on an unsupported runtime. `cirrus-actions/rebase@1.7` in the same file is also a mutable tag — left alone, since swapping a third-party action's pin deserves its own review.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — CI-only, no public API or behavior change. Observable effects: code-of-conduct-only PRs stop building a staging preview, and `/rebase` runs on a supported, SHA-pinned checkout.

## Testing

Both changes are in trigger/`uses:` metadata that only GitHub evaluates, so verification was about proving the *premises* rather than executing the workflows.

| Claim | How verified | Result |
| --- | --- | --- |
| The ignored filename is wrong | `git ls-files --error-unmatch` on both spellings (index, not filesystem — macOS is case-insensitive and would have masked this) | `CODE-OF-CONDUCT.md` TRACKED / `CODE_OF_CONDUCT.md` absent |
| `SECURITY.md` genuinely absent | same, plus repo-wide `find` excluding `externals/` | absent everywhere |
| `checkout@v2` is on a dead runtime | fetched `action.yml` at `ref=v2` | `using: node12` |
| The new pin is really v7.0.1 | `gh api .../git/ref/tags/v7.0.1` | `3d3c42e5…b1 commit` — exact match |
| The new pin is what the repo already uses | counted pins across `.github/workflows/*.yml` | 36 existing uses of that exact SHA |
| `rebase.yml` isn't silently failing today | `gh run list --workflow=rebase.yml` | all runs `skipped` — latent, not active |

**Gates run:**

| Gate | Result |
| --- | --- |
| Parse every `.github/workflows/*.yml` with PyYAML | `parsed 28 workflow files, 0 failures` |

I did **not** touch any `*.lock.yml`. A repo-wide grep for `CODE_OF_CONDUCT` also hits several `.lock.yml` files, but those are gh-aw compiler output embedding gh-aw's own generic `protected_files` default list — not repo-specific config, and regenerating them is the compiler's job.

No unit test added: there is no harness that evaluates `paths-ignore` or `uses:` pins, and adding one for two literals would cost more than it catches.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated
