### PR TITLE
Fix the ci-status workflow registry and guard it with a test

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -69,19 +69,35 @@ standard Darc/Maestro stages.
 | Pages - PR Staging - Cleanup | mono/SkiaSharp | PR close events | Stale staging deploys accumulate |
 | Pages - PR Staging - Sweep Stale | mono/SkiaSharp | Daily (06:00 UTC) | Stale staging deploys accumulate |
 | Sync - Samples | mono/SkiaSharp | Push/PR to `samples/` | Sample projects broken if failing |
-| API Diff | mono/SkiaSharp | Weekly (Sun 00:00 UTC) | API regression detection |
+| Tests - Binding Generation Determinism | mono/SkiaSharp | Push/PR | Generated bindings drift undetected |
 | Sync - Docs Submodule | mono/SkiaSharp | Daily (10:00 UTC) | API docs get out of sync |
-| Sync - Release Notes & API Diffs | mono/SkiaSharp | Push to main/release/tags | Release notes stop auto-updating |
-| Sync - Skia Upstream | mono/SkiaSharp | Daily (07:00 UTC) | Upstream tracking breaks |
-| Nightly Fix Finder | mono/SkiaSharp | Nightly | Nightly automation health |
-| Sync - Issue Triage | mono/SkiaSharp | Daily (04:05 UTC) + issue events | Triage automation stops |
-| Sync - Agentic Data | mono/SkiaSharp | Push to main | AI workflow data lost |
+| Sync - Skia Submodule | mono/SkiaSharp | Daily (10:30 UTC) | Skia submodule pin goes stale |
+| Sync - Release Notes & API Diffs | mono/SkiaSharp | Push to main + daily | Release notes stop auto-updating |
+| Sync - Skia Upstream | mono/SkiaSharp | Every 6h | Upstream tracking breaks |
+| Fixer - Memory Leak | mono/SkiaSharp | Every 12h | Leak-hunting automation stops |
+| Fixer - Performance | mono/SkiaSharp | Every 12h | Perf-hunting automation stops |
+| Sync - Issue Triage | mono/SkiaSharp | Daily | Triage automation stops |
+| Sync - Issue Template Versions | mono/SkiaSharp | Daily (09:00 UTC) | Bug template advertises stale versions |
+| Sync - Agentic Data | mono/SkiaSharp | Workflow run events | AI workflow data lost |
+| Track - Artifact Sizes | mono/SkiaSharp | Nightly + PR sweep | Package size tracking/PR reports stop |
+| Track - Benchmarks | mono/SkiaSharp | Every 6h | Benchmark trend tracking stops |
+| Release - Prepare | mono/SkiaSharp | Workflow dispatch | Release branches cannot be cut |
+| Release - Finish | mono/SkiaSharp | Workflow dispatch | Releases cannot be finalized |
+| Release - Milestones | mono/SkiaSharp | Workflow dispatch | Milestone reconciliation stops |
+| Update GitHub Release summaries | mono/SkiaSharp | Workflow dispatch | Release bodies go stale |
+| Release - Tooling Tests | mono/SkiaSharp | Push/PR to release tooling | Release scripts regress unnoticed |
 | PR - Backport | mono/SkiaSharp | PR label/comment | Cherry-picks to release branches fail |
 | PR - Rebase | mono/SkiaSharp | PR comment | PR rebase automation broken |
 | PR - Artifacts Comment | mono/SkiaSharp | Workflow run events | Build links not posted to PRs |
+| Merge Message | mono/SkiaSharp | PR comment events | Merge commit messages not drafted |
 | Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch | XML docs stop being written |
 | Automerge Docs | mono/SkiaSharp-API-docs | PR events | Doc PRs won't auto-merge |
 | Go Live | mono/SkiaSharp-API-docs | Workflow dispatch | Docs don't publish to live |
+
+> Schedules above are deliberately imprecise for gh-aw generated `*.lock.yml` workflows
+> ("Every 6h", "Daily"). The compiler re-jitters their cron on every upgrade, so a literal
+> `HH:MM UTC` here would silently go stale. `scripts/tests/test_workflow_registry.py`
+> enforces this: any time it *does* find documented must match the workflow file.
 
 ---
 
@@ -227,10 +243,14 @@ For each tracked GitHub Actions workflow:
 - Whether failures are related to AzDO failures (same commit?) or independent
 - Categorize by severity:
   - **High**: Pages - Deploy, Sync - Samples, Sync - Release Notes & API Diffs, Sync - Skia Upstream,
-    Auto API Docs Writer (broken = user-facing impact or release process blocked)
-  - **Medium**: Sync - Docs Submodule, Nightly Fix Finder, Sync - Issue Triage,
+    Release - Prepare, Release - Finish, Release - Tooling Tests, Auto API Docs Writer
+    (broken = user-facing impact or release process blocked)
+  - **Medium**: Sync - Docs Submodule, Sync - Skia Submodule, Fixer - Memory Leak, Fixer - Performance,
+    Sync - Issue Triage, Sync - Issue Template Versions, Tests - Binding Generation Determinism,
+    Release - Milestones, Update GitHub Release summaries,
     PR - Backport, Pages - Go Live! (broken = automation degraded, manual workaround exists)
   - **Low**: Pages - PR Staging - Cleanup, Pages - PR Staging - Sweep Stale, PR - Rebase, PR - Artifacts Comment,
+    Merge Message, Track - Artifact Sizes, Track - Benchmarks,
     Sync - Agentic Data (broken = cosmetic/housekeeping)
 
 GitHub Actions failures don't block releases directly (AzDO owns that), but they

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -64,6 +64,7 @@ GITHUB_WORKFLOWS = [
     # mono/SkiaSharp — Build & Docs (push-triggered, main + release/*)
     {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Pages - Deploy", "scope": "branch", "trigger": "push"},
     {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Sync - Samples", "scope": "branch", "trigger": "push"},
+    {"repo": "mono/SkiaSharp", "workflow": "binding-generation-determinism.yml", "name": "Tests - Binding Generation Determinism", "scope": "branch", "trigger": "push"},
     # mono/SkiaSharp — Release-path push workflow (main + release/*)
     {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Sync - Release Notes & API Diffs", "scope": "branch", "trigger": "push"},
     # mono/SkiaSharp — Automation & Sync (global: scheduled/dispatch, not branch-specific)
@@ -73,13 +74,26 @@ GITHUB_WORKFLOWS = [
     {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Sync - Docs Submodule", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-skia-submodule-sync.yml", "name": "Sync - Skia Submodule", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Sync - Skia Upstream", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "nightly-fix-finder.lock.yml", "name": "Nightly Fix Finder", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "memory-leak-fixer.lock.yml", "name": "Fixer - Memory Leak", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "performance-fixer.lock.yml", "name": "Fixer - Performance", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Sync - Issue Triage", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Sync - Agentic Data", "scope": "global", "trigger": "push"},
+    {"repo": "mono/SkiaSharp", "workflow": "auto-update-issue-template-versions.yml", "name": "Sync - Issue Template Versions", "scope": "global", "trigger": "schedule"},
+    # persist-aw-data runs off workflow_run, not push — see tests/test_workflow_registry.py
+    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Sync - Agentic Data", "scope": "global", "trigger": "event"},
+    # mono/SkiaSharp — Tracking dashboards (global: scheduled)
+    {"repo": "mono/SkiaSharp", "workflow": "track-artifact-sizes.yml", "name": "Track - Artifact Sizes", "scope": "global", "trigger": "schedule"},
+    {"repo": "mono/SkiaSharp", "workflow": "track-benchmarks.yml", "name": "Track - Benchmarks", "scope": "global", "trigger": "schedule"},
+    # mono/SkiaSharp — Release path (dispatch-driven, plus the tooling test gate)
+    {"repo": "mono/SkiaSharp", "workflow": "release-prepare.yml", "name": "Release - Prepare", "scope": "global", "trigger": "dispatch"},
+    {"repo": "mono/SkiaSharp", "workflow": "release-finish.yml", "name": "Release - Finish", "scope": "global", "trigger": "dispatch"},
+    {"repo": "mono/SkiaSharp", "workflow": "release-milestones.yml", "name": "Release - Milestones", "scope": "global", "trigger": "dispatch"},
+    {"repo": "mono/SkiaSharp", "workflow": "update-github-release-summaries.yml", "name": "Update GitHub Release summaries", "scope": "global", "trigger": "dispatch"},
+    {"repo": "mono/SkiaSharp", "workflow": "release-tooling-tests.yml", "name": "Release - Tooling Tests", "scope": "branch", "trigger": "push"},
     # mono/SkiaSharp — PR Utilities (global: triggered by PR events, not branch-specific)
     {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "PR - Backport", "scope": "global", "trigger": "event"},
     {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "PR - Rebase", "scope": "global", "trigger": "event"},
     {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "PR - Artifacts Comment", "scope": "global", "trigger": "event"},
+    {"repo": "mono/SkiaSharp", "workflow": "merge-message.lock.yml", "name": "Merge Message", "scope": "global", "trigger": "event"},
     # mono/SkiaSharp-API-docs (global: scheduled/dispatch/PR events)
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer", "scope": "global", "trigger": "schedule"},
     {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs", "scope": "global", "trigger": "event"},

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Guards the ci-status workflow registry against drift.
+
+The registry is a hand-maintained list of workflow *filenames*. Nothing previously
+checked those filenames against the repository, and the failure mode is not an error —
+it is a plausible-looking dashboard row.
+
+Two real examples this suite would have caught:
+
+* ``nightly-fix-finder.lock.yml`` was tracked but has never existed on ``main``; it only
+  ever lived on an unmerged branch. GitHub still has the workflow registered from that
+  branch push, so the API returns it as ``state: active`` with 17 successful runs from
+  2026-05-15 rather than 404ing. Because the entry is ``scope: global`` the collector
+  queries it with no branch filter, so those stale branch runs are reported as the
+  workflow's current health — a green row for a workflow that does not exist.
+* ``SKILL.md`` advertised an "API Diff" workflow. That one *did* exist (added 2026-05-22,
+  removed 2026-06-18 when it was folded into "Sync - Release Notes & API Diffs"), so the
+  row was a stale leftover quietly duplicating a workflow already listed below it.
+
+These tests assert that every ``mono/SkiaSharp`` entry names a file that exists on this
+branch, that the declared ``trigger`` still matches that file's ``on:`` block, and that the
+display name matches. They parse the committed workflow YAML — including generated
+``.lock.yml`` files, which carry their own ``on:`` block — so they never need the gh-aw
+compiler to run and are not brittle to lock regeneration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import unittest
+
+import yaml
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILL_DIR = os.path.dirname(SCRIPTS_DIR)
+REPO_ROOT = os.path.abspath(os.path.join(SKILL_DIR, "..", "..", ".."))
+WORKFLOW_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
+
+
+def _load_collector():
+    """Import ci-status.py, whose hyphenated name is not a valid module identifier."""
+    path = os.path.join(SCRIPTS_DIR, "ci-status.py")
+    spec = importlib.util.spec_from_file_location("ci_status_collector", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+COLLECTOR = _load_collector()
+GITHUB_WORKFLOWS = COLLECTOR.GITHUB_WORKFLOWS
+
+# `on:` keys that satisfy each declared trigger. A workflow may legitimately carry more
+# triggers than it is tracked for (most also allow workflow_dispatch), so this checks the
+# declared trigger is *present*, not that it is exclusive.
+TRIGGER_KEYS = {
+    "schedule": {"schedule"},
+    "dispatch": {"workflow_dispatch"},
+    "push": {"push", "pull_request"},
+    "event": {
+        "issue_comment", "issues", "pull_request", "pull_request_target",
+        "pull_request_review", "workflow_run", "push",
+    },
+}
+
+
+def local_workflows():
+    """Entries owned by this repository (the rest live in mono/SkiaSharp-API-docs)."""
+    return [w for w in GITHUB_WORKFLOWS if w["repo"] == "mono/SkiaSharp"]
+
+
+def load_workflow(name):
+    with open(os.path.join(WORKFLOW_DIR, name), encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def on_block(data):
+    # YAML 1.1 parses a bare `on:` key as the boolean True.
+    return data.get("on", data.get(True)) or {}
+
+
+def on_keys(data):
+    block = on_block(data)
+    if isinstance(block, str):
+        return {block}
+    if isinstance(block, list):
+        return set(block)
+    return set(block or {})
+
+
+def crons_for(workflow_file):
+    block = on_block(load_workflow(workflow_file))
+    if not isinstance(block, dict):
+        return []
+    return [s.get("cron") for s in (block.get("schedule") or [])
+            if isinstance(s, dict) and s.get("cron")]
+
+
+class RegistryTests(unittest.TestCase):
+    def test_registry_is_not_empty(self):
+        self.assertTrue(local_workflows(), "No mono/SkiaSharp workflows are tracked.")
+
+    def test_every_tracked_workflow_file_exists(self):
+        missing = [w["workflow"] for w in local_workflows()
+                   if not os.path.isfile(os.path.join(WORKFLOW_DIR, w["workflow"]))]
+        self.assertEqual([], missing,
+                         f"ci-status tracks workflow files that do not exist: {missing}")
+
+    def test_declared_trigger_matches_the_workflow(self):
+        mismatched = []
+        for entry in local_workflows():
+            if not os.path.isfile(os.path.join(WORKFLOW_DIR, entry["workflow"])):
+                continue  # reported by the test above
+            keys = on_keys(load_workflow(entry["workflow"]))
+            if not (keys & TRIGGER_KEYS[entry["trigger"]]):
+                mismatched.append(
+                    f"{entry['workflow']} declares trigger={entry['trigger']} "
+                    f"but on={sorted(keys)}")
+        self.assertEqual([], mismatched, "; ".join(mismatched))
+
+    def test_display_names_match_the_workflow_name(self):
+        wrong = []
+        for entry in local_workflows():
+            if not os.path.isfile(os.path.join(WORKFLOW_DIR, entry["workflow"])):
+                continue
+            actual = load_workflow(entry["workflow"]).get("name")
+            if actual and actual != entry["name"]:
+                wrong.append(
+                    f"{entry['workflow']}: registry={entry['name']!r} file={actual!r}")
+        self.assertEqual([], wrong, "; ".join(wrong))
+
+    def test_no_duplicate_entries(self):
+        seen = [(w["repo"], w["workflow"]) for w in GITHUB_WORKFLOWS]
+        self.assertEqual(len(seen), len(set(seen)), "Duplicate workflow entries are tracked.")
+
+    def test_scheduled_workflows_really_have_a_cron(self):
+        """A workflow tracked as scheduled but with no cron would always look idle."""
+        missing = []
+        for entry in local_workflows():
+            if entry["trigger"] != "schedule":
+                continue
+            if not os.path.isfile(os.path.join(WORKFLOW_DIR, entry["workflow"])):
+                continue
+            if not crons_for(entry["workflow"]):
+                missing.append(entry["workflow"])
+        self.assertEqual([], missing, f"Tracked as scheduled but define no cron: {missing}")
+
+
+class SkillDocTests(unittest.TestCase):
+    """The skill's table must not advertise workflows the collector does not track."""
+
+    def _skill_text(self):
+        with open(os.path.join(SKILL_DIR, "SKILL.md"), encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_skill_table_only_names_tracked_workflows(self):
+        rows = [ln for ln in self._skill_text().splitlines() if ln.startswith("| ")]
+        tracked = {w["name"] for w in GITHUB_WORKFLOWS}
+        for removed in ("Nightly Fix Finder", "API Diff"):
+            if removed in tracked:
+                continue
+            offending = [r for r in rows if r.startswith(f"| {removed} |")]
+            self.assertEqual(
+                [], offending,
+                f"SKILL.md still advertises {removed!r}, which no tracked workflow provides.")
+
+    def test_documented_schedules_match_the_workflow(self):
+        """Any schedule the table states must be true of the workflow it names.
+
+        gh-aw re-jitters the cron of every generated lock on upgrade, so a documented
+        `HH:MM UTC` or literal cron silently goes stale the next time the compiler runs.
+        Either omit the precision or keep it correct — this test refuses the third option.
+        """
+        rows = [ln for ln in self._skill_text().splitlines() if ln.startswith("| ")]
+        by_name = {w["name"]: w["workflow"] for w in local_workflows()}
+        stale = []
+        unresolved = []
+        for row in rows:
+            cells = [c.strip() for c in row.strip().strip("|").split("|")]
+            if len(cells) < 3 or cells[1] != "mono/SkiaSharp":
+                continue  # header, separator, or a row owned by another repository
+            name = cells[0]
+            if name not in by_name:
+                # A renamed workflow must fail loudly rather than silently disabling the
+                # schedule check for its row.
+                unresolved.append(name)
+                continue
+            if not os.path.isfile(os.path.join(WORKFLOW_DIR, by_name[name])):
+                continue
+            crons = crons_for(by_name[name])
+            trigger_cell = cells[2]
+
+            for literal in re.findall(r"`([^`]*\*[^`]*)`", trigger_cell):
+                if literal not in crons:
+                    stale.append(f"{name}: documents cron {literal!r}, file has {crons}")
+
+            for hh, mm in re.findall(r"\b(\d{1,2}):(\d{2}) UTC", trigger_cell):
+                actual = {(c.split()[1], c.split()[0]) for c in crons if len(c.split()) >= 2}
+                if (str(int(hh)), str(int(mm))) not in actual:
+                    stale.append(f"{name}: documents {hh}:{mm} UTC, file has {crons}")
+        # Report both independently: an unresolved row must not mask a stale schedule.
+        self.assertEqual([], stale, "; ".join(stale))
+        self.assertEqual([], unresolved,
+                         f"SKILL.md rows name untracked workflows: {unresolved}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

`GITHUB_WORKFLOWS` in `ci-status.py` is a hand-maintained list of workflow *filenames*, and nothing checked those filenames against the repository. Three defects had accumulated. None of them surfaces as an error — that is the point of this PR.

### 1. A tracked workflow that has never existed on `main`

`nightly-fix-finder.lock.yml` was in the registry. It is not in `.github/workflows`, and it never was:

```console
$ git merge-base --is-ancestor dfc7524a532 origin/main    # the commit that added it
NO - never merged into main
$ git branch -a --contains dfc7524a532
  remotes/origin/mattleibow/dev-nightly-fix-finder        # only ever on this branch
```

**I expected this to fail as a 404. It does not.** GitHub registered the workflow when it was pushed on that branch, and the registration outlives the branch:

```console
$ gh api repos/mono/SkiaSharp/actions/workflows/nightly-fix-finder.lock.yml
{"name":"Nightly Fix Finder","path":".github/workflows/nightly-fix-finder.lock.yml","state":"active", ...}

$ gh api .../nightly-fix-finder.lock.yml/runs
total_count: 17
2026-05-15T23:51:19Z mattleibow/dev-nightly-fix-finder success
2026-05-15T23:46:04Z mattleibow/dev-nightly-fix-finder success
```

The entry is `scope: "global"`, and `collect_github_data` queries global entries with **no branch filter**:

```python
runs_raw = get_github_workflow_runs(wf["repo"], wf["workflow"], branch=None, top=top_builds)
```

So the dashboard doesn't under-report — it renders **"Nightly Fix Finder: healthy"** off 17 successes from an unmerged branch, frozen since May. A green row for a workflow that does not exist is worse than a missing row.

### 2. A trigger that doesn't match the workflow

`persist-aw-data.yml` was tracked as `trigger: "push"`, but its `on:` block is `workflow_dispatch, workflow_run` — no `push` at all. Branch/trigger classification drives how the collector queries and how the skill grades severity.

### 3. Documentation describing workflows that aren't there

- **"API Diff"** — the original note for this work said it "never existed". That is wrong, and I corrected it: `api-diff.yml` *was* added 2026-05-22 (#4038) and removed 2026-06-18 in #4184, *"Unify API-diff + release-notes into one agentic workflow"*. GitHub still lists it as `state: deleted`. So the row was a stale leftover quietly duplicating **Sync - Release Notes & API Diffs**, which is listed four rows below it.
- **"Sync - Skia Upstream | Daily (07:00 UTC)"** — the actual cron is `17 */6 * * *`, i.e. every six hours, not daily, and not at 07:00.
- **"Sync - Issue Triage | … + issue events"** — `auto-triage.lock.yml` triggers on `schedule` and `workflow_dispatch` only. There are no issue events.

### What this changes

Fixes the above, and adds the **11 workflows the registry never covered** — the release path (`release-prepare`, `release-finish`, `release-milestones`, `update-github-release-summaries`, `release-tooling-tests`), the fixers, both tracking dashboards, binding-determinism, issue-template sync, and merge-message. Coverage goes from 15 to **26 of the 28 workflows on `main`**, with no phantoms:

```console
workflow files on main : 28
tracked by ci-status   : 26
UNTRACKED              : ['copilot-setup-steps.yml', 'manage-nuget-feed.yml']
tracked-but-missing    : []
```

`copilot-setup-steps.yml` is agent environment setup, not repo CI health. `manage-nuget-feed.yml` is being deleted in #4929.

And adds `scripts/tests/test_workflow_registry.py` so this cannot rot again silently. It asserts every tracked file exists, the declared trigger appears in the file's `on:` block, display names match, scheduled entries really define a cron, there are no duplicates, and any schedule `SKILL.md` states agrees with the workflow.

**On documenting gh-aw schedules:** lock-file crons are re-jittered by the compiler on every upgrade, so a literal `HH:MM UTC` goes stale the next time it runs. Those rows are deliberately imprecise ("Every 6h", "Daily"), hand-written workflows keep their exact times, and the test enforces the rule rather than trusting it.

### CI wiring — handled in #4915, not here

Its natural home is `.github/workflows/automation-tooling-tests.yml`, which **#4915 adds**. That file does not exist on `main` yet, so this PR could not add a step to it, and I did not create a competing workflow that would only need deleting once #4915 lands.

I also could not simply register that workflow in the registry to compensate: doing so makes my own test fail on `main`, which I verified rather than assumed (mutation C below).

**This is now resolved on the #4915 side** — the step is wired there (`48c02bd8bce`), along with `.agents/skills/ci-status/**` added to that workflow's `pull_request` and `push` path filters. The two PRs stay independent in either merge order, because the step tolerates this suite not existing yet.

That tolerance is deliberately narrow, and worth understanding before anyone "simplifies" it. The obvious one-liner —

```yaml
run: python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py"
```

— has a silent-pass path of exactly the kind this PR exists to remove. `unittest discover` against a directory containing no matching tests prints `NO TESTS RAN`; it exits **5** on Python ≥ 3.12 but **0** on older runtimes, so on an older interpreter a renamed-away suite would report green while running nothing. The wired step therefore also asserts that `.agents/skills/ci-status/scripts` (which exists on `main` today) is still present, and treats zero-discovery as a failure — so a move or rename is loud instead of masquerading as "not merged yet".

Once this PR merges, that tolerance branch is unreachable and should be dropped in favour of calling `unittest` directly.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — tooling and skill documentation only. No public API or runtime behavior change. The observable effect is that the ci-status dashboard covers 26 workflows instead of 15 and no longer reports a nonexistent one as healthy.

## Testing

Every registry entry was re-derived from the workflows actually on `main` rather than copied forward — I enumerated all 28 files with PyYAML and read each `name`, `on:` block and cron, then wrote the table from that output.

**Red/green — the new test against the unfixed registry on `main`:**

```console
$ git show origin/main:.../ci-status.py > ...   # restore the pre-fix registry + SKILL.md
$ python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py"

FAIL: test_every_tracked_workflow_file_exists
  ci-status tracks workflow files that do not exist: ['nightly-fix-finder.lock.yml']
FAIL: test_declared_trigger_matches_the_workflow
  persist-aw-data.yml declares trigger=push but on=['workflow_dispatch', 'workflow_run']
FAIL: test_documented_schedules_match_the_workflow
  SKILL.md rows name untracked workflows: ['API Diff']
FAIL: test_skill_table_only_names_tracked_workflows
  SKILL.md still advertises 'API Diff', which no tracked workflow provides.

Ran 8 tests — FAILED (failures=4)
```

It catches all four real defects. With the fix applied:

```console
$ python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py"
Ran 8 tests in 1.67s
OK
```

**Mutation testing** — a green suite proves little, so I broke it three ways on purpose:

| # | Mutation | Result |
| --- | --- | --- |
| A | Restore the old claim `Sync - Skia Upstream \| Daily (07:00 UTC)` | `FAIL … documents 07:00 UTC, file has ['17 */6 * * *']` |
| B | Document a literal lock cron `` `0 */12 * * *` `` for Fixer - Memory Leak | `FAIL … documents cron '0 */12 * * *', file has ['13 */12 * * *']` |
| C | Track `automation-tooling-tests.yml` (the #4915 file) | `FAIL … files that do not exist: ['automation-tooling-tests.yml']` |

A confirms the schedule guard catches the exact bug that was on main. B confirms the gh-aw re-jitter rule is enforced, not merely documented — note it caught the *wrong* literal, since the real jittered cron is `13 */12`. C is why the test is unwired: it is direct evidence that registering #4915's workflow here would break `main`.

I also fixed two weaknesses found while doing this: `test_skill_table_only_names_tracked_workflows` used `assertNotIn` against the whole file and dumped ~10 KB of SKILL.md into the failure message, and the `unresolved` assertion fired before the `stale` one, masking schedule drift whenever a row was also unrecognised. Both now report independently and print only the offending rows.

**Gates run:**

| Gate | Result |
| --- | --- |
| `python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests` | `Ran 8 tests … OK` |
| Collector still imports; registry sizes | 29 entries — 26 `mono/SkiaSharp`, 3 API-docs |
| `python3 .agents/skills/ci-status/scripts/ci-status.py --help` | parses, usage printed |
| Parse every `.github/workflows/*.yml` with PyYAML | `parsed 28 workflow files, 0 failures` |
| `python3 scripts/infra/caching/repo-deps.py validate` | `[PASS] All files covered!` |

I did not run the collector end-to-end: it needs an authenticated `az` CLI against `dnceng-public` and `dnceng/internal`, which isn't available here. The registry data it depends on is fully covered by the unit tests above, and `--help` proves the module still loads.

No `*.lock.yml` was modified.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated

