### PR TITLE
Cover Push-ReleaseTag and run the release-notes tests in CI

### DIFF
--- a/.github/workflows/release-tooling-tests.yml
+++ b/.github/workflows/release-tooling-tests.yml
@@ -5,10 +5,13 @@ on:
     paths:
       - ".agents/skills/release-branch/**"
       - ".agents/skills/release-milestones/**"
+      - ".agents/skills/release-notes/**"
       - ".agents/skills/release-publish/**"
       - ".agents/skills/release-testing/**"
       - "tests/SkiaSharp.Tests.Integration/**"
       - ".github/workflows/release-*.yml"
+      - ".github/workflows/update-github-release-summaries.yml"
+      - "scripts/infra/docs/**"
       - "scripts/infra/publishing/**"
       - "scripts/infra/caching/repo-deps.json"
   push:
@@ -16,10 +19,13 @@ on:
     paths:
       - ".agents/skills/release-branch/**"
       - ".agents/skills/release-milestones/**"
+      - ".agents/skills/release-notes/**"
       - ".agents/skills/release-publish/**"
       - ".agents/skills/release-testing/**"
       - "tests/SkiaSharp.Tests.Integration/**"
       - ".github/workflows/release-*.yml"
+      - ".github/workflows/update-github-release-summaries.yml"
+      - "scripts/infra/docs/**"
       - "scripts/infra/publishing/**"
       - "scripts/infra/caching/repo-deps.json"
   workflow_dispatch:
@@ -74,6 +80,12 @@ jobs:
 
       - name: Run release-testing Python tests
         run: python3 -m unittest discover -s .agents/skills/release-testing/scripts/tests -p "test_*.py"
+
+      - name: Run release-notes and GitHub-summary Python tests
+        # Covers the release-note renderer and the GitHub Release summary mutation that
+        # Finish dispatches (release_notes/tests/test_update_github_summaries.py). These
+        # already existed but nothing ran them in CI.
+        run: python3 -m unittest discover -s scripts/infra/docs/release_notes/tests -p "test_*.py"
 
       - name: Run release-testing PowerShell tests
         shell: pwsh

--- a/scripts/infra/publishing/tests/Test-PublishingScripts.ps1
+++ b/scripts/infra/publishing/tests/Test-PublishingScripts.ps1
@@ -135,6 +135,20 @@ $stable = Get-ReleaseIdentity '4.151.1'
 Assert-Equal 'Version 4.151.1' $stable.Title 'Stable release title was incorrect.'
 Assert-Throws { Get-ReleaseIdentity '4.152.0-preview.1' } 'exact public' `
     'An abbreviated version unexpectedly passed exact identity parsing.'
+
+# Resolve-NuGetPackageVersion decides whether Finish must disambiguate an abbreviated
+# preview/rc against nuget.org. Only versions matching the abbreviated shape may reach the
+# network; everything else must be returned untouched. These assertions cover exactly the
+# no-network branches, so they stay deterministic and offline. Deliberately absent:
+# '4.152.0-preview.1', the one shape that *would* call Invoke-RestMethod.
+foreach ($exact in @('4.151.1', '4.151.1.1', '4.152.0-preview.1.26426.14', '4.152.0-rc.2.1.2')) {
+    Assert-Equal $exact (Resolve-NuGetPackageVersion 'SkiaSharp' $exact) `
+        "An exact version ($exact) was not passed through unchanged."
+}
+foreach ($invalid in @('4.152.0-preview.0', '4.152.0-rc.0', '4.152.0-beta.1', '4.152.0-preview')) {
+    Assert-Equal $invalid (Resolve-NuGetPackageVersion 'SkiaSharp' $invalid) `
+        "A non-resolvable version ($invalid) was not passed through unchanged."
+}
 $pages = @(
     @([pscustomobject] @{ number = 1 }, [pscustomobject] @{ number = 2 }),
     @([pscustomobject] @{ number = 3 })
@@ -204,6 +218,58 @@ try {
     Assert-True ($dryBranch -match 'requires -Push') 'A dry branch push did not explain its guard.'
     Assert-Equal $null (Get-RemoteBranchSha -Root $gitRoot -Remote $bareRoot -Branch release/dry) `
         'A dry branch push changed its remote.'
+
+    # --- Push-ReleaseTag: the irreversible path Finish uses to publish a release tag. ---
+    # A tag is immutable once consumed by a release, so the guarded behaviours below
+    # (dry-run refusal, create-and-verify, idempotent re-run, conflict rejection) are the
+    # ones worth pinning. Everything here runs against a local bare remote: no network.
+    $tagSha = (git -C $gitRoot rev-parse release/test).Trim()
+
+    $dryTag = @(Push-ReleaseTag `
+        -Root $gitRoot `
+        -Remote $bareRoot `
+        -Tag v9.9.9 `
+        -SourceCommit $tagSha 6>&1) -join "`n"
+    Assert-True ($dryTag -match 'requires -Push') 'A dry tag push did not explain its guard.'
+    Assert-Equal $null (Get-RemoteTagSha -Root $gitRoot -Remote $bareRoot -Tag v9.9.9) `
+        'A dry tag push created a remote tag.'
+
+    Push-ReleaseTag `
+        -Root $gitRoot `
+        -Remote $bareRoot `
+        -Tag v9.9.9 `
+        -SourceCommit $tagSha `
+        -Push
+    Assert-Equal $tagSha (Get-RemoteTagSha -Root $gitRoot -Remote $bareRoot -Tag v9.9.9) `
+        'A release tag was not created at its source commit.'
+
+    # Re-running Finish must be safe: the tag already points at the same commit.
+    $repeatTag = @(Push-ReleaseTag `
+        -Root $gitRoot `
+        -Remote $bareRoot `
+        -Tag v9.9.9 `
+        -SourceCommit $tagSha `
+        -Push 6>&1) -join "`n"
+    Assert-True ($repeatTag -match "points to $tagSha") `
+        'Re-pushing an identical tag was not reported as already ready.'
+
+    # A tag that already points somewhere else must NEVER be moved.
+    & git -C $gitRoot commit --quiet --allow-empty -m 'Second'
+    $otherSha = (git -C $gitRoot rev-parse HEAD).Trim()
+    Assert-Throws { Push-ReleaseTag `
+        -Root $gitRoot `
+        -Remote $bareRoot `
+        -Tag v9.9.9 `
+        -SourceCommit $otherSha `
+        -Push } 'expected' 'A conflicting release tag was silently accepted.'
+    Assert-Equal $tagSha (Get-RemoteTagSha -Root $gitRoot -Remote $bareRoot -Tag v9.9.9) `
+        'A conflicting tag push moved the remote tag.'
+    # The conflict must be detected before -Push is even considered.
+    Assert-Throws { Push-ReleaseTag `
+        -Root $gitRoot `
+        -Remote $bareRoot `
+        -Tag v9.9.9 `
+        -SourceCommit $otherSha } 'expected' 'A dry run ignored a conflicting release tag.'
 } finally {
     Remove-Item $gitRoot, $bareRoot -Recurse -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Description

Two gaps in the release tooling's safety net.

### 1. `Push-ReleaseTag` had no test coverage

It is the irreversible step `Finish` uses to publish a release tag. Once a GitHub Release consumes a tag it is effectively immutable, so the guards in it are the part that matters:

```powershell
$actual = Get-RemoteTagSha -Root $Root -Remote $Remote -Tag $Tag
if ($actual -and $actual -ne $SourceCommit) {
    throw "$Tag points to $actual, expected $SourceCommit."   # never move a published tag
}
if ($actual) { Write-ReleaseStatus ready ...; return }         # idempotent re-run
if (!$Push) { Write-ReleaseStatus skipped ...; return }        # dry-run refusal
...
if ((Get-RemoteTagSha ...) -ne $SourceCommit) { throw "$Tag creation could not be verified." }
```

All four behaviours are now pinned — dry-run refusal, create-and-verify, idempotent re-run, and conflict rejection in **both** the `-Push` and dry-run forms. That last pair matters because the conflict check sits *above* the `-Push` guard: a dry run must still refuse a conflicting tag rather than quietly reporting it would skip.

### 2. `Resolve-NuGetPackageVersion`'s offline branches

This decides whether `Finish` must disambiguate an abbreviated preview/rc against nuget.org. Only versions matching one specific shape may reach the network:

```powershell
if ($Version -notmatch '^\d+\.\d+\.\d+(?:\.\d+)?-(?:preview|rc)\.[1-9]\d*$') { return $Version }
```

The new assertions cover exactly the eight versions that must be returned untouched — already-exact versions and non-resolvable ones (`-preview.0`, `-rc.0`, `-beta.1`, bare `-preview`). `4.152.0-preview.1`, the one shape that *would* call `Invoke-RestMethod`, is deliberately excluded so the suite stays deterministic and offline. Everything drives a local bare git remote; no test makes a network call.

### 3. 137 release-notes tests that nothing ran

`scripts/infra/docs/release_notes/tests` contains 137 passing tests — including `test_update_github_summaries.py`, which covers the GitHub Release summary mutation `Finish` dispatches. No workflow executed them.

Worse, the `paths:` filters on `release-tooling-tests.yml` matched none of the release-note tooling, so that code could change with no gate running at all. I verified the gap by evaluating the old and new filters against representative files:

| Changed file | Before | After |
| --- | --- | --- |
| `scripts/infra/docs/release_notes/tests/test_shipments.py` | **MISSED** | trigger |
| `scripts/infra/docs/release_notes/render.py` | **MISSED** | trigger |
| `.agents/skills/release-notes/SKILL.md` | **MISSED** | trigger |
| `.github/workflows/update-github-release-summaries.yml` | **MISSED** | trigger |
| `scripts/infra/publishing/Publishing.Common.psm1` (control) | trigger | trigger |

Note `.github/workflows/release-*.yml` never matched `update-github-release-summaries.yml` — it starts with `update-`. The control confirms existing coverage is unchanged, not merely that the new globs are broad.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — test and CI coverage only. No production script was modified, so there is no public API or behavior change.

## Testing

**Publishing suite grew from 92 to 107 assertions**, all green:

```console
$ pwsh -NoLogo -NoProfile -File ./scripts/infra/publishing/tests/Test-PublishingScripts.ps1
[applied] Created v9.9.9 at 0ce13bab81510f75758e84c1b9b796779eee565d.
All 107 publishing script tests passed.
```

(92 is the count on current `main`; the 107 target came from the #4915 branch and the new assertions land exactly on it.)

**Mutation testing.** New assertions that pass prove nothing on their own, so I broke `Publishing.Common.psm1` three ways and confirmed each is caught:

| # | Mutation | Caught by |
| --- | --- | --- |
| 1 | Drop the conflicting-tag `throw` (let a published tag be moved) | `A conflicting release tag was silently accepted. No error was thrown.` |
| 2 | Drop the `if (!$Push)` guard (dry run creates the tag) | `A dry tag push did not explain its guard.` |
| 3 | Widen the resolver regex to `(?:preview\|rc\|beta)` | `Exception: SkiaSharp 4.152.0-beta.1 must match exactly one public NuGet version` |

Mutation 3 is the useful one: the `-beta.1` assertion only reaches nuget.org when the regex is *wrong*. That is positive evidence the new resolver assertions genuinely exercise the no-network path — the sole way to make them hit the network is to break the function under test. The module was restored and re-verified at 107 after each mutation.

**Every gate this workflow runs, executed locally:**

| Gate | Result |
| --- | --- |
| `Test-PublishingScripts.ps1` | `All 107 publishing script tests passed.` |
| `Test-ReleaseMilestones.ps1` | `All 25 publishing milestone tests passed.` |
| `release_notes/tests` (newly wired) | `Ran 137 tests … OK` |
| `.agents/skills/release-testing/scripts/tests` | `Ran 38 tests … OK` |
| `Test-PrepareTestRun.ps1` | exit 0 (silent success) |
| `python3 scripts/infra/caching/repo-deps.py validate` | `[PASS] All files covered!` |
| Parse every `.github/workflows/*.yml` with PyYAML | `parsed 28 workflow files, 0 failures` |

I ran the newly-wired release-notes suite before adding the step to confirm it was already green — this PR wires up passing tests, it does not fix failing ones. Its stdout includes lines like *"uses unsupported release data format 3"*; those are a test deliberately exercising a rejection path, not failures, which is why the summary line is the one quoted above.

Because `release-*.yml` is in its own `paths:` filter, this PR's edit to `release-tooling-tests.yml` triggers the workflow, so CI here exercises the change end to end.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated
