### PR TITLE
Update 4.151 release support tier

### DIFF
--- a/scripts/infra/docs/versions.json
+++ b/scripts/infra/docs/versions.json
@@ -3,11 +3,10 @@
   "support": {
     "$comment": "SkiaSharp's SUPPORTED release paths, used only by the release-notes TOC/index grouping. SkiaSharp ships NuGet packages on two paths (it is NOT a multi-tier channel product), so this is two lists of 'major.minor' lines (the SkiaSharp MINOR number IS the Chrome/Skia milestone). 'stable' = the supported stable line(s): normally the current Chrome Stable milestone, or the Chrome Extended-stable milestone during the promotion gap (when a preview is about to go stable). 'preview' = the in-flight preview/RC line(s): normally the Chrome Beta milestone, or newer when previewing ahead in Dev/Canary. Release Finish proposes additions and same-line preview-to-stable promotions from the exact public SkiaSharp package version; it never infers membership from Chromium Dash and never removes any other line. Maintainers explicitly remove lines when support ends. The security audit's heads-up check (.agents/skills/security-audit/scripts/query-milestone-schedule.py) compares these lists to live Chrome channels and reports drift for review. Every other 3.x+ line is OUT OF SUPPORT; 1.x/2.x lines are OBSOLETE. Empty/absent block => every 3.x+ line is treated as supported (legacy behavior).",
     "stable": [
-      "4.150"
-    ],
-    "preview": [
+      "4.150",
       "4.151"
-    ]
+    ],
+    "preview": []
   },
   "history_floor": {
     "$comment": "PERFORMANCE floor (spec §1.4), read by BOTH engines. A per-family minimum line core BELOW which no page is regenerated and no API diff is emitted, so a full '--all' run skips the obsolete back-catalogue it would otherwise rebuild from the NuGet feed every run. It is NOT a delete: pages and API-diff folders already committed below the floor are left exactly as they are (the Cake engine also skips CLEARING them), so history stays intact — it is simply not rebuilt. Baselines are unaffected: a floored line can still be downloaded as a baseline (e.g. 3.116.0 still diffs against 2.88.9) — both via an explicit compare_to override AND as the implicit predecessor of the lowest emitted line (the floor line resolves its below-floor baseline from the pre-floor emittable set and downloads it for comparison only, so it never regenerates against an empty 0.0.0.0 assembly). Absent/empty => no floor (legacy: every line is regenerated). Raise it over time as old lines stop needing refreshes; lower or remove it to rebuild history.",


### PR DESCRIPTION
## Description

Promote 4.151 to the stable support tier after publishing its stable release. Existing supported lines are retained because ending support remains an explicit maintainer decision.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None - release support metadata only.

## Testing

The publishing tests cover preview, RC, stable promotion, idempotency, multiple supported lines, and preservation of unrelated configuration.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A