### PR TITLE
Fix release notes versions JSON

### DIFF
--- a/scripts/infra/docs/versions.json
+++ b/scripts/infra/docs/versions.json
@@ -8,7 +8,7 @@
     ],
     "preview": [
       "4.152"
-    ],
+    ]
   },
   "history_floor": {
     "$comment": "PERFORMANCE floor (spec §1.4), read by BOTH engines. A per-family minimum line core BELOW which no page is regenerated and no API diff is emitted, so a full '--all' run skips the obsolete back-catalogue it would otherwise rebuild from the NuGet feed every run. It is NOT a delete: pages and API-diff folders already committed below the floor are left exactly as they are (the Cake engine also skips CLEARING them), so history stays intact — it is simply not rebuilt. Baselines are unaffected: a floored line can still be downloaded as a baseline (e.g. 3.116.0 still diffs against 2.88.9) — both via an explicit compare_to override AND as the implicit predecessor of the lowest emitted line (the floor line resolves its below-floor baseline from the pre-floor emittable set and downloads it for comparison only, so it never regenerates against an empty 0.0.0.0 assembly). Absent/empty => no floor (legacy: every line is regenerated). Raise it over time as old lines stop needing refreshes; lower or remove it to rebuild history.",


### PR DESCRIPTION
## Description

Remove the trailing comma from the `support.preview` array in `scripts/infra/docs/versions.json`. The malformed JSON caused the release-notes preparation workflow to fail in `release-notes-data.py` with `JSONDecodeError` after API diff generation completed.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — metadata syntax fix only; no public API or behavioral changes.

## Testing

Validated `scripts/infra/docs/versions.json` with `python3 -m json.tool` and checked the patch with `git diff --check`.

## Checklist

- [x] Tests added or updated (not applicable; one-character JSON syntax correction)
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A