### PR TITLE
Run the automation tooling tests in CI

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -86,6 +86,7 @@ standard Darc/Maestro stages.
 | Release - Milestones | mono/SkiaSharp | Workflow dispatch | Milestone reconciliation stops |
 | Update GitHub Release summaries | mono/SkiaSharp | Workflow dispatch | Release bodies go stale |
 | Release - Tooling Tests | mono/SkiaSharp | Push/PR to release tooling | Release scripts regress unnoticed |
+| Automation - Tooling Tests | mono/SkiaSharp | Push/PR to automation tooling | Automation scripts regress unnoticed |
 | PR - Backport | mono/SkiaSharp | PR label/comment | Cherry-picks to release branches fail |
 | PR - Rebase | mono/SkiaSharp | PR comment | PR rebase automation broken |
 | PR - Artifacts Comment | mono/SkiaSharp | Workflow run events | Build links not posted to PRs |
@@ -247,7 +248,7 @@ For each tracked GitHub Actions workflow:
     (broken = user-facing impact or release process blocked)
   - **Medium**: Sync - Docs Submodule, Sync - Skia Submodule, Fixer - Memory Leak, Fixer - Performance,
     Sync - Issue Triage, Sync - Issue Template Versions, Tests - Binding Generation Determinism,
-    Release - Milestones, Update GitHub Release summaries,
+    Automation - Tooling Tests, Release - Milestones, Update GitHub Release summaries,
     PR - Backport, Pages - Go Live! (broken = automation degraded, manual workaround exists)
   - **Low**: Pages - PR Staging - Cleanup, Pages - PR Staging - Sweep Stale, PR - Rebase, PR - Artifacts Comment,
     Merge Message, Track - Artifact Sizes, Track - Benchmarks,

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -89,6 +89,7 @@ GITHUB_WORKFLOWS = [
     {"repo": "mono/SkiaSharp", "workflow": "release-milestones.yml", "name": "Release - Milestones", "scope": "global", "trigger": "dispatch"},
     {"repo": "mono/SkiaSharp", "workflow": "update-github-release-summaries.yml", "name": "Update GitHub Release summaries", "scope": "global", "trigger": "dispatch"},
     {"repo": "mono/SkiaSharp", "workflow": "release-tooling-tests.yml", "name": "Release - Tooling Tests", "scope": "branch", "trigger": "push"},
+    {"repo": "mono/SkiaSharp", "workflow": "automation-tooling-tests.yml", "name": "Automation - Tooling Tests", "scope": "branch", "trigger": "push"},
     # mono/SkiaSharp — PR Utilities (global: triggered by PR events, not branch-specific)
     {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "PR - Backport", "scope": "global", "trigger": "event"},
     {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "PR - Rebase", "scope": "global", "trigger": "event"},

--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -1,0 +1,80 @@
+name: Automation - Tooling Tests
+
+# Runs the repository's non-release automation test suites. These all existed and passed
+# locally but were wired to no workflow, so a regression in them could reach `main`
+# silently:
+#
+#   * .agents/skills/ci-status/scripts/tests/       — the CI dashboard's workflow registry
+#   * .agents/skills/update-skia/scripts/*_test.py  — Skia milestone update tooling
+#   * .github/scripts/tests/skia-sync-detect.test.sh — the auto-skia-sync work detector
+#
+# Release publishing tooling is covered separately by release-tooling-tests.yml. Paths are
+# kept tight on purpose: this must not become a catch-all that runs on every change.
+
+on:
+  pull_request:
+    paths:
+      - ".agents/skills/ci-status/**"
+      - ".agents/skills/update-skia/**"
+      - ".github/scripts/**"
+      # Any workflow edit, so the registry test re-checks its tracked list. '*.yml' already
+      # covers the generated '*.lock.yml' files.
+      - ".github/workflows/*.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".agents/skills/ci-status/**"
+      - ".agents/skills/update-skia/**"
+      - ".github/scripts/**"
+      - ".github/workflows/*.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: automation-tooling-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run ci-status workflow registry tests
+        # Guards the CI dashboard against tracking workflows that no longer exist — a stale
+        # entry does not error, it renders a GREEN row for a workflow that is not there.
+        #
+        # Called directly rather than behind an existence check: on the runner's Python
+        # (3.12+) `unittest discover` fails loudly in both degenerate cases — exit 1
+        # (ImportError) if the directory is gone, exit 5 ("NO TESTS RAN") if it is empty.
+        # A guard here would only be able to turn those into a silent pass.
+        run: |
+          set -euo pipefail
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --quiet --break-system-packages pyyaml
+          python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py" -v
+
+      - name: Run update-skia tooling tests
+        # These import their module under test by name, so they must run from their own
+        # directory rather than through a repository-root discovery run.
+        working-directory: .agents/skills/update-skia/scripts
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(*_test.py)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "::error::No *_test.py found — the update-skia tests moved or were renamed."
+            exit 1
+          fi
+          for test in "${tests[@]}"; do
+            echo "::group::$test"
+            python3 -m unittest "${test%.py}"
+            echo "::endgroup::"
+          done
+
+      - name: Run skia-sync work detector tests
+        run: bash .github/scripts/tests/skia-sync-detect.test.sh


### PR DESCRIPTION
## Description

Three test suites live in this repository, pass today, and are wired to **no workflow at all** — so a regression in any of them reaches `main` silently:

| Suite | Size |
| --- | --- |
| `.agents/skills/ci-status/scripts/tests/` | 8 tests |
| `.agents/skills/update-skia/scripts/*_test.py` | 4 modules |
| `.github/scripts/tests/skia-sync-detect.test.sh` | shell suite |

The ci-status one is the sharpest example. It landed in #4932 specifically to catch a dashboard that reports a workflow which isn't there — but nothing ran it, so **the guard was itself unguarded**. Confirmed on `main`: `grep -rl ci-status .github/workflows/*.yml` returns nothing.

This adds `Automation - Tooling Tests` covering all three, scoped tightly to the paths that feed them plus **any** `.github/workflows/*.yml` edit — that last one is what makes the registry suite re-check its tracked list whenever a workflow is added, renamed or deleted, which is exactly when it can go stale.

### Extracted from #4915

This workflow originated in #4915. That PR is scoped to artifact-size tracking and carries two further steps for `scripts/infra/perf/**`, which does not exist on `main` yet. Rather than block three ready PRs behind it, this lands the portion that works on `main` today; **#4915 keeps its two perf steps and adds them back on top** (`Run artifact-size intake tests`, `Run perf HTTP contract tests`), along with the `scripts/infra/perf/**` path filter. Nothing is lost, and #4915 shrinks to just its own steps.

Two simplifications the extraction allowed, both because #4932 has now merged:

- **Dropped the "suite not present yet" tolerance.** It existed only so #4915 and #4932 could merge in either order. `.agents/skills/ci-status/scripts/tests/` is on `main` now, so that branch is unreachable dead code — and a step that can pass while testing nothing is precisely the failure this suite exists to catch.
- **Dropped the surrounding `NO TESTS RAN` wrapper too**, because on the runner's Python it cannot help. Measured on 3.13.5 (`ubuntu-latest` ships 3.12+, and exit-5-on-no-tests landed in [3.12](https://github.com/python/cpython/issues/106584)):

  ```console
  $ python3 -m unittest discover -s /tmp/nope  -p "test_*.py"; echo $?
  ImportError: Start directory is not importable: '/tmp/nope'
  1
  $ python3 -m unittest discover -s /tmp/empty -p "test_*.py"; echo $?
  NO TESTS RAN
  5
  ```

  Both degenerate cases already fail loudly, so a wrapper could only ever convert them into a silent pass. The comment in the workflow records this so nobody "hardens" it back.

The `update-skia` loop **does** still need an explicit guard, and keeps one — it globs `*_test.py`, and a glob matching nothing iterates zero times and succeeds. That is a real silent-pass path with no interpreter-level backstop.

Also registers the new workflow with the ci-status dashboard that it runs, keeping coverage honest at **27 of 29** (`copilot-setup-steps.yml` is agent setup, not CI health; `manage-nuget-feed.yml` is deleted by #4929).

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — CI and skill documentation only. No production code, no public API or behavior change. The observable effect is that three existing suites now gate PRs instead of never running.

## Testing

**All three suites verified green on current `main` before wiring them** — this PR wires up passing tests, it does not fix failing ones:

```console
--- ci-status registry ---   Ran 8 tests ... OK
--- update-skia ---
  audit_fork_patches_test.py       OK
  prepare_branches_test.py         OK
  regenerate_bindings_test.py      OK
  update_versions_test.py          OK
--- skia-sync detector ---   PASS: compare-api-failure
                             All skia-sync detector tests passed.   (exit 0)
```

**Trigger simulation** — the point of the PR is that these run on the PRs currently in flight, so I evaluated the new `paths:` filters against each open branch's real changed-file list:

| PR | Result |
| --- | --- |
| #4929 retire manage-nuget-feed | **TRIGGERS** via `.github/workflows/manage-nuget-feed.yml` |
| #4930 docs-sync lease | **TRIGGERS** via `.github/workflows/auto-docs-submodule-sync.yml` |
| #4933 release tag coverage | **TRIGGERS** via `.github/workflows/release-tooling-tests.yml` |

**Gates run:**

| Gate | Result |
| --- | --- |
| Parse every `.github/workflows/*.yml` with PyYAML | `parsed 29 workflow files, 0 failures` |
| `bash -n` on all three `run:` blocks | OK / OK / OK |
| ci-status registry suite, with this workflow added *and* tracked | `Ran 8 tests … OK` |
| Registry coverage | 27 of 29 tracked, **0 tracked-but-missing** |

That last row matters: adding a workflow and registering it in the same PR is what keeps the registry test meaningful — the suite asserts every tracked file exists, so a registry entry for a workflow that failed to land would fail immediately.

No `*.lock.yml` was modified.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated
