### PR TITLE
Name the tooling test jobs so their checks are distinguishable

### DIFF
--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -38,6 +38,9 @@ concurrency:
 
 jobs:
   test:
+    # Named so the check-run is distinguishable in the PR checks list — several workflows
+    # use the job id 'test', and GitHub surfaces the job name, not the workflow name.
+    name: Automation tooling tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release-tooling-tests.yml
+++ b/.github/workflows/release-tooling-tests.yml
@@ -39,6 +39,9 @@ concurrency:
 
 jobs:
   test:
+    # Named so the check-run is distinguishable in the PR checks list — several workflows
+    # use the job id 'test', and GitHub surfaces the job name, not the workflow name.
+    name: Release tooling tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Description

`automation-tooling-tests.yml` and `release-tooling-tests.yml` both declare a job with the id `test` and no display name. GitHub surfaces the **job** name in the checks list, not the workflow name — so both render as a row simply labelled `test`, with nothing to tell them apart.

This is already the state of `main`:

```console
$ gh api repos/mono/SkiaSharp/commits/<main HEAD>/check-runs \
    --jq '[.check_runs[] | select(.name=="test")] | length'
2
```

It isn't cosmetic. It is the reason *"did the tooling tests run on this PR?"* couldn't be answered by looking at the checks list — the run existed and had passed, but the row was an unlabelled `test` indistinguishable from the release one. I hit this myself: `gh pr checks 4929 | grep -i automation` returned nothing even though `Automation - Tooling Tests` had completed successfully, because the check-run is called `test`.

Adds a display name to each job. **Job ids are unchanged**, so nothing that references `jobs.test` (`needs:`, reruns, the concurrency group) is affected.

**Branch protection is unaffected** — `test` is not a required context; `main` requires only `license/cla` and `mono-SkiaSharp`:

```console
$ gh api repos/mono/SkiaSharp/branches/main/protection --jq '.required_status_checks.contexts[]'
license/cla
mono-SkiaSharp
```

### Scope — why only this pair

Auditing job names across all 29 workflows turned up two more hand-written duplicates. The criterion that matters is **whether both workflows can attach a check-run to the same PR head SHA** — which is *not* the same as "both have a `pull_request` trigger". Any event carrying a commit SHA attaches to it, so the full set is `pull_request`, `pull_request_target`, `check_run`, `workflow_run` and `check_suite`. Getting this rule wrong is how the `resolve` pair below reads as harmless on a `pull_request`-only reading.

| Duplicate | Workflows | PR-attaching trigger | Both attach? |
| --- | --- | --- | --- |
| **`test`** | `automation-tooling-tests.yml` | `pull_request` | **YES** |
| | `release-tooling-tests.yml` | `pull_request` | |
| `resolve` | `track-artifact-sizes.yml` | `check_run` | **YES**, historically |
| | `track-benchmarks.yml` | `pull_request` | |
| `sync` | `auto-docs-submodule-sync.yml` | — (`schedule`/`dispatch`) | no |
| | `auto-skia-submodule-sync.yml` | — (`schedule`/`dispatch`) | no |

**`resolve` was in fact the worse offender, and it is fixed elsewhere.** On `60579244c4f`, taken while its `check_run` trigger was live, a single commit carried:

```console
$ gh api repos/mono/SkiaSharp/commits/60579244c4f/check-runs --paginate --jq '.check_runs[].name' | sort | uniq -c | sort -rn
 477 resolve
 476 pr
 476 nightly
```

477 identical `resolve` rows on one commit, stacked alongside `track-benchmarks`'s own `resolve`. It reads as zero today only because `track-artifact-sizes.yml` is currently `state=disabled_manually`, and #4915 removes the `check_run` trigger outright and names all three of that workflow's jobs. So `resolve` is already handled — by the PR that caused it — and touching that file from this branch would only create a conflict.

That leaves **`test` as the only pair that can still collide going forward**, which is what this PR fixes. Both tooling workflows match `.github/workflows/**`, so they fire on the *same* PR, side by side — exactly when two rows labelled `test` are indistinguishable.

`sync` is genuinely inert: neither workflow attaches to a PR SHA at all. Worth naming for run-list readability someday, but there is nothing to disambiguate on a PR.

A further 6 duplicate names (`activation`, `agent`, `conclusion`, `detection`, `pre_activation`, `safe_outputs`) exist only among gh-aw generated `*.lock.yml` files. Two of those workflows — `memory-leak-fixer` and `performance-fixer` — do both carry `pull_request`, but their `paths:` filters are disjoint (each scoped to its own `.md`, `.lock.yml` and skill directory), so they only co-fire on a PR that touches both. They are compiler output in any case and not editable by hand.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — CI metadata only. No public API or behavior change. The only observable difference is that the two check-runs are now labelled `Automation tooling tests` and `Release tooling tests` instead of both being `test`.

## Testing

| Gate | Result |
| --- | --- |
| Parse every `.github/workflows/*.yml` with PyYAML | `parsed 29 workflow files, 0 failures` |
| Resulting job names unique across both files | `Automation tooling tests` / `Release tooling tests` — no remaining hand-written `test` duplicate |
| `test` is not a required status check | confirmed against branch protection (see above) |
| Job ids unchanged | diff is **6 added lines, 0 modified** — `name:` plus a two-line comment on each |

The diff adds only:

```yaml
  test:
    # Named so the check-run is distinguishable in the PR checks list — several workflows
    # use the job id 'test', and GitHub surfaces the job name, not the workflow name.
    name: Automation tooling tests
```

Both workflows will run on this PR (each `paths:` filter matches `.github/workflows/*.yml`), so CI here demonstrates the fix directly — the two rows should now be distinguishable by name.

No `*.lock.yml` was modified.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated



