### PR TITLE
Fail the ci-status schedule check when it compares nothing

### DIFF
--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -305,5 +305,56 @@ class CollectorWiringTests(unittest.TestCase):
             "The report's github_workflows payload is not the tracked registry.")
 
 
+class WorkflowInvokesWhatItGuardsTests(unittest.TestCase):
+    """The workflow that runs these suites must also trigger on what they cover.
+
+    Everything above tests the suite. Nothing tested the layer that *invokes* it, and
+    that layer has a silent failure of its own: delete an entry from the workflow's
+    `paths:` filter and the suite simply stops running for changes in that area. No
+    test fails, no run goes red — the guard is gone and CI stays green, which is the
+    same "healthy-looking but absent" shape this whole suite exists to catch.
+    """
+
+    WORKFLOW = "automation-tooling-tests.yml"
+
+    def _workflow(self):
+        path = os.path.join(WORKFLOW_DIR, self.WORKFLOW)
+        if not os.path.isfile(path):
+            self.skipTest(f"{self.WORKFLOW} is not present on this branch")
+        return load_workflow(self.WORKFLOW)
+
+    @staticmethod
+    def _suite_roots(workflow):
+        """Directories the workflow's steps actually execute tests from."""
+        roots = set()
+        for step in workflow["jobs"]["test"]["steps"]:
+            run = step.get("run", "")
+            if step.get("working-directory"):
+                roots.add(step["working-directory"].strip("/"))
+            # Anchored on `unittest discover` rather than a bare `-s`, which would also
+            # match unrelated shell options such as `shopt -s nullglob`.
+            for m in re.finditer(r"unittest\s+discover\s+-s\s+(\S+)", run):
+                roots.add(m.group(1).strip("/"))
+            for m in re.finditer(r"bash\s+(\S+\.sh)", run):
+                roots.add(os.path.dirname(m.group(1).strip("/")))
+        return {r for r in roots if r}
+
+    def test_every_suite_it_runs_is_in_its_own_paths_filter(self):
+        workflow = self._workflow()
+        block = on_block(workflow)
+        roots = self._suite_roots(workflow)
+        self.assertTrue(roots, "Found no test directories in the workflow's steps.")
+
+        for event in ("pull_request", "push"):
+            patterns = [p.rstrip("*").rstrip("/") for p in (block[event]["paths"] or [])]
+            uncovered = [r for r in roots
+                         if not any(r == p or r.startswith(p + "/") for p in patterns)]
+            self.assertEqual(
+                [], uncovered,
+                f"{self.WORKFLOW} runs suites under {uncovered} but its {event} "
+                f"paths filter does not cover them — a change there would not run "
+                f"them, and nothing would report that.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -228,5 +228,48 @@ class SkillDocTests(unittest.TestCase):
             "for a hand-written (non-lock) workflow.")
 
 
+class CollectorWiringTests(unittest.TestCase):
+    """The registry is only worth validating if the collector actually reads it.
+
+    Every other test here checks the *contents* of GITHUB_WORKFLOWS. None of them
+    execute ``collect_github_data``, so the line joining the registry to the collector
+    is untested: point that loop at an empty list, or at a hardcoded entry, and the
+    whole suite still passes while the dashboard reports nothing — or reports a
+    workflow that was never tracked, which is the exact failure this suite exists to
+    catch. This test covers the wiring rather than the parts.
+    """
+
+    def _collect_with_stubs(self):
+        """Run the collector with every network call replaced by a recorder."""
+        requested = []
+
+        def fake_runs(repo, workflow, branch, top=5):
+            requested.append((repo, workflow))
+            return []
+
+        original_runs = COLLECTOR.get_github_workflow_runs
+        original_enrich = COLLECTOR._enrich_failed_runs
+        COLLECTOR.get_github_workflow_runs = fake_runs
+        COLLECTOR._enrich_failed_runs = lambda wf_data: None
+        try:
+            collected = COLLECTOR.collect_github_data(["main"], 1)
+        finally:
+            COLLECTOR.get_github_workflow_runs = original_runs
+            COLLECTOR._enrich_failed_runs = original_enrich
+        return requested, collected
+
+    def test_collector_queries_exactly_the_tracked_workflows(self):
+        requested, collected = self._collect_with_stubs()
+        self.assertTrue(requested, "collect_github_data queried nothing at all.")
+        self.assertEqual(
+            {(w["repo"], w["workflow"]) for w in GITHUB_WORKFLOWS},
+            set(requested),
+            "collect_github_data did not query exactly the tracked workflows — the "
+            "registry and the collector have come apart.")
+        self.assertEqual(
+            len(GITHUB_WORKFLOWS), len(collected),
+            "collect_github_data returned a different number of entries than it tracks.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -176,6 +176,7 @@ class SkillDocTests(unittest.TestCase):
         by_name = {w["name"]: w["workflow"] for w in local_workflows()}
         stale = []
         unresolved = []
+        compared = 0
         for row in rows:
             cells = [c.strip() for c in row.strip().strip("|").split("|")]
             if len(cells) < 3 or cells[1] != "mono/SkiaSharp":
@@ -192,10 +193,12 @@ class SkillDocTests(unittest.TestCase):
             trigger_cell = cells[2]
 
             for literal in re.findall(r"`([^`]*\*[^`]*)`", trigger_cell):
+                compared += 1
                 if literal not in crons:
                     stale.append(f"{name}: documents cron {literal!r}, file has {crons}")
 
             for hh, mm in re.findall(r"\b(\d{1,2}):(\d{2}) UTC", trigger_cell):
+                compared += 1
                 actual = {(c.split()[1], c.split()[0]) for c in crons if len(c.split()) >= 2}
                 if (str(int(hh)), str(int(mm))) not in actual:
                     stale.append(f"{name}: documents {hh}:{mm} UTC, file has {crons}")
@@ -203,6 +206,16 @@ class SkillDocTests(unittest.TestCase):
         self.assertEqual([], stale, "; ".join(stale))
         self.assertEqual([], unresolved,
                          f"SKILL.md rows name untracked workflows: {unresolved}")
+        # A pass here means nothing unless at least one schedule was actually compared.
+        # Strip every documented time from the table and the loops above simply never run,
+        # leaving a green test that checks nothing — the same silent-pass shape this suite
+        # exists to catch. Hand-written workflows must keep their exact time documented;
+        # only gh-aw locks are allowed to be imprecise.
+        self.assertGreater(
+            compared, 0,
+            "No documented schedule was compared, so this test asserted nothing. "
+            "At least one SKILL.md row must state an exact 'HH:MM UTC' or literal cron "
+            "for a hand-written (non-lock) workflow.")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -270,6 +270,40 @@ class CollectorWiringTests(unittest.TestCase):
             len(GITHUB_WORKFLOWS), len(collected),
             "collect_github_data returned a different number of entries than it tracks.")
 
+    def test_report_carries_the_collected_workflows_through_unchanged(self):
+        """The assembly layer must not drop or filter what the collector returned.
+
+        Covering collect_github_data is not enough: the payload is assembled a layer up,
+        and that join can silently narrow the result. Replacing the assignment with a
+        filtered comprehension — the same 'drop the branch-scoped entries' mistake this
+        suite catches one level down — leaves a report that still looks complete.
+        `branches=[]` skips the Azure DevOps loop entirely, so this needs no `az`.
+        """
+        # Shaped like a real entry so a filtering mutation fails on the assertion below
+        # rather than incidentally raising KeyError on a missing field.
+        sentinel = [
+            {"repo": "mono/SkiaSharp", "workflow": "sentinel-a.yml", "name": "Sentinel A",
+             "scope": "branch", "trigger": "push", "branches": [], "runs": [],
+             "stats": None, "error": None},
+            {"repo": "mono/SkiaSharp", "workflow": "sentinel-b.yml", "name": "Sentinel B",
+             "scope": "global", "trigger": "schedule", "branches": [], "runs": [],
+             "stats": None, "error": None},
+        ]
+        original = COLLECTOR.collect_github_data
+        COLLECTOR.collect_github_data = lambda branches, top_builds: list(sentinel)
+        try:
+            data = COLLECTOR.collect_data([], 1, False)
+        finally:
+            COLLECTOR.collect_github_data = original
+
+        self.assertEqual(
+            sentinel, data["github_actions"],
+            "The report did not carry through what collect_github_data returned — the "
+            "assembly layer dropped, filtered or replaced it.")
+        self.assertEqual(
+            GITHUB_WORKFLOWS, data["github_workflows"],
+            "The report's github_workflows payload is not the tracked registry.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -137,14 +137,24 @@ class RegistryTests(unittest.TestCase):
     def test_scheduled_workflows_really_have_a_cron(self):
         """A workflow tracked as scheduled but with no cron would always look idle."""
         missing = []
+        checked = 0
         for entry in local_workflows():
             if entry["trigger"] != "schedule":
                 continue
             if not os.path.isfile(os.path.join(WORKFLOW_DIR, entry["workflow"])):
                 continue
+            checked += 1
             if not crons_for(entry["workflow"]):
                 missing.append(entry["workflow"])
         self.assertEqual([], missing, f"Tracked as scheduled but define no cron: {missing}")
+        # `missing` is also empty when nothing was examined at all. Re-typing the tracked
+        # schedule entries to another trigger empties this loop while leaving the registry
+        # full, and it does not trip the trigger test either, because a scheduled workflow
+        # almost always declares workflow_dispatch as well. Assert the loop did work.
+        self.assertGreater(
+            checked, 0,
+            "No scheduled workflow was examined, so this test asserted nothing — "
+            "the registry has no entry with trigger='schedule'.")
 
 
 class SkillDocTests(unittest.TestCase):


### PR DESCRIPTION
## Description

`test_workflow_registry.py` (added in #4932) exists to catch a CI dashboard that reports a workflow which isn't there — a guard against silent passes. One of its own assertions had exactly that defect.

`test_documented_schedules_match_the_workflow` only inspects rows that state an exact time or literal cron:

```python
for literal in re.findall(r"`([^`]*\*[^`]*)`", trigger_cell):   # documented cron
for hh, mm in re.findall(r"\b(\d{1,2}):(\d{2}) UTC", trigger_cell):  # documented time
```

If `SKILL.md` stops documenting any, **both loops never execute** and the test reports `OK` having compared nothing.

**This is reachable, not theoretical.** The rule the suite itself enforces is that gh-aw lock schedules must stay *imprecise*, because the compiler re-jitters their cron on every upgrade. Applying that rule one row too broadly — a plausible tidy-up — silently disables the guard. Verified by stripping every `(HH:MM UTC)` from the table on `main`:

```console
$ python3 -c "...strip every '(HH:MM UTC)' from SKILL.md..."
  removed: 4
$ python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py"
Ran 8 tests in 2.036s
OK          # <-- green, asserting nothing
```

This counts the comparisons actually performed and requires at least one, so a table with no precise schedule fails loudly:

```
AssertionError: 0 not greater than 0 : No documented schedule was compared, so this
test asserted nothing. At least one SKILL.md row must state an exact 'HH:MM UTC' or
literal cron for a hand-written (non-lock) workflow.
```

I chose a comparison counter over asserting a fixed list of workflows-that-must-document-a-time, because the latter would be wrong for the legitimately imprecise rows: `Track - Benchmarks` runs on `0 */6` (no fixed daily time) and `Track - Artifact Sizes` is deliberately vague while #4915 rewrites it. The counter encodes the real invariant — *this test must have checked something* — without freezing a per-workflow policy that has valid exceptions.

### A second instance, found by auditing the rest of the suite

The same question — *can this assertion pass having examined nothing?* — turned out to apply to `test_scheduled_workflows_really_have_a_cron` as well. It uses the accumulate-then-assert shape:

```python
for entry in local_workflows():
    if entry["trigger"] != "schedule": continue
    ...
    if not crons_for(entry["workflow"]): missing.append(...)
self.assertEqual([], missing, ...)
```

`missing` is empty when every scheduled workflow has a cron — and equally empty when the loop never ran.

Two existing guards *look* like they cover this and do not:

- `test_registry_is_not_empty` doesn't, because the loop filters to `trigger == "schedule"`. Retyping those entries empties the loop while leaving the registry full.
- `test_declared_trigger_matches_the_workflow` doesn't, because a scheduled workflow almost always declares `workflow_dispatch` too — so reclassifying `schedule` → `dispatch` still satisfies it.

Measured, rather than argued:

```console
schedule entries now: 0 | registry size: 30
Ran 8 tests in 1.705s
OK          # <-- green, the cron guard silently disabled
```

That is reachable by ordinary maintenance: `trigger` is hand-edited whenever workflows change, and it is the exact field that was already wrong once — `persist-aw-data` was tracked as `push` when it runs on `workflow_run`, which #4932 fixed. A partial mis-classification has already happened here; a wholesale one would be silent.

Same instrument applied: count what was examined, require at least one.

Filed as a separate PR because #4932 is already merged.


**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

### What these guards are actually holding up

Both fixes are counters, which reads like hygiene. It isn't — I measured which tests catch a globally broken helper by mutating the helpers themselves and recording what failed:

| Break | Caught by |
| --- | --- |
| `load_workflow()` returns `{}` | `declared_trigger`, `scheduled_cron`, `documented_schedules` (3) |
| `os.path.isfile` always `False` | `file_exists`, `scheduled_cron`, `documented_schedules` (3) |
| **`crons_for()` returns a fixed wrong cron** | **`documented_schedules` — 1 test, nothing else** |

A cron reader that silently returns the wrong value is caught by exactly **one** assertion in the suite — and that assertion is the one this PR found could be emptied. Combine the two and `main` has a real blind spot:

```console
# on main: strip documented times AND break crons_for()
Ran 8 tests in 1.799s
OK          # <-- cron reader globally broken, nothing notices

# same two mutations on this branch
AssertionError: 0 not greater than 0 : No documented schedule was compared...
FAILED (failures=1)
```

So the counter is not protecting the schedule text — it is protecting the sole detector of a broken cron reader from being silently switched off. The other two breaks have redundant coverage; this one has none.

### The larger gap: the registry was validated, but nothing read it

Every test in this suite checks the *contents* of `GITHUB_WORKFLOWS`. None of them executed `collect_github_data`. So the line joining the registry to the collector had no test at all — and a correct registry is worth nothing if the collector doesn't consume it.

Mutating the wiring rather than the parts:

| Mutation to `collect_github_data` | Suite result before |
| --- | --- |
| `for wf in []:` — query nothing | **OK (8/8)** — dashboard reports no workflows |
| `for wf in [{...hardcoded "nope.yml"...}]:` | **OK (8/8)** — dashboard reports a workflow never tracked |
| `for wf in [w for w in GITHUB_WORKFLOWS if w["scope"] != "branch"]:` | **OK (8/8)** — silently under-reports |

That third one is the original `nightly-fix-finder` failure in a new place: the dashboard looks healthy while covering less than it claims.

Adds `CollectorWiringTests`, which runs the collector with `get_github_workflow_runs` and `_enrich_failed_runs` replaced by a recorder and asserts it queried *exactly* the tracked set. All three mutations now fail:

```console
W1 empty list       -> AssertionError: [] is not true : collect_github_data queried nothing at all.
W2 hardcoded entry  -> AssertionError: Items in the first set but not the second: ...
W3 drops branch     -> AssertionError: Items in the first set but not the second: ...
restored            -> Ran 9 tests ... OK
```

The stubs keep it offline. Confirmed by re-running the suite with `gh`, `az` and `curl` shadowed by stubs that print and exit 97 — no interception fired, `Ran 9 tests … OK`. Deterministic across three consecutive runs (~2.0s each).

### Where this stops — and a boundary I had to move twice

I first drew the line at `collect_github_data`, arguing the layer above was safe because breaking it would "fail visibly". **That was reasoning, not measurement, and it was wrong:**

| Mutation to `collect_data` | Suite result |
| --- | --- |
| `data["github_actions"] = []` | **OK (9/9)** |
| `= [w for w in collect_github_data(...) if w["scope"] != "branch"]` | **OK (9/9)** — looks complete, under-reports |
| `"github_workflows": []` | **OK (9/9)** |

The second is the same "drop the branch-scoped entries" defect this suite catches one level down, reappearing one layer up where nothing was watching.

Then the same question applied to the layer that *invokes* the suite — the workflow's `paths:` filter — and it failed too:

| Mutation to `automation-tooling-tests.yml` | Suite result |
| --- | --- |
| drop `.agents/skills/ci-status/**` from both filters | **OK (10/10)** |
| drop it from **only** `pull_request` | **OK (10/10)** |
| point a step at a directory no filter covers | **OK (10/10)** |

That one is worse than a wrong result: the suite doesn't run at all, and CI is green *because* it didn't run. Exactly the "healthy-looking but absent" failure the whole suite was written for.

Both layers are now covered. `test_every_suite_it_runs_is_in_its_own_paths_filter` asserts **per event**, not by counting occurrences across the file, because a total would accept the single-filter case above.

Two method notes, both found by running rather than reading:
- The sentinel in the assembly test is shaped like a real entry on purpose. A minimal `{"repo","workflow"}` stub made the filtering mutation fail with `KeyError` — caught by accident, and a filter keying on a field the stub happened to have would have slipped through. Verified against `if w["trigger"] != "schedule"`, which now fails on the assertion.
- Extraction of the suite directories is anchored on `unittest discover -s`, not a bare `-s`, which captured `shopt -s nullglob` and failed the test on an unmodified tree.

The line now sits at the runner actually executing these steps. That is a cost/benefit call, not a safety claim — and after moving this boundary twice, I'd treat it as **untested rather than safe**.

### The invocation guard is generic, not scoped to what exists today

`test_every_suite_it_runs_is_in_its_own_paths_filter` derives the suite directories from the workflow's own steps, so it covers whatever that workflow runs — including suites added later by someone else. Verified against #4915's version of `automation-tooling-tests.yml`, which adds two perf suites that do not exist on this branch:

```console
roots found in #4915's workflow:
  .agents/skills/ci-status/scripts/tests
  .agents/skills/update-skia/scripts
  .github/scripts/tests
  scripts/infra/perf/sizes/tests      <- added by #4915
  scripts/infra/perf/tests            <- added by #4915

# with 'scripts/infra/perf/**' dropped from that workflow:
pull_request: WOULD FAIL -> uncovered=['scripts/infra/perf/sizes/tests', 'scripts/infra/perf/tests']
push:         WOULD FAIL -> uncovered=[...]

# dropped from only pull_request:
pull_request: WOULD FAIL     push: covered
```

So the guard names directories it has no knowledge of, and catches the single-filter case there too. #4915 has the same `paths:` exposure on its own branch and is deliberately *not* adding a duplicate test for it — a second guard on the same property would be free to drift from this one, which is the failure this PR is about. That exposure closes when this merges.

## Changes

None — test-only. No production code, no public API or behavior change.

## Testing

| Scenario | Before this PR | After |
| --- | --- | --- |
| Table unchanged (4 documented times) | `Ran 8 … OK` | `Ran 8 … OK` |
| **Every documented time stripped** | **`OK` — vacuous pass** | **`FAILED` — `0 not greater than 0`** |
| A documented time made wrong (`10:00`→`23:00 UTC`) | `FAILED` | `FAILED` — unchanged |

```console
=== RED: strip every documented time ===
AssertionError: 0 not greater than 0 : No documented schedule was compared...
FAILED (failures=1)

=== RED: a documented time that is WRONG (regression check) ===
AssertionError: Lists differ: [] != ["Sync - Docs Submodule: documents 23:00 UTC, file has ['0 10 * * *']"]
FAILED (failures=1)

=== restored ===
Ran 8 tests in 1.706s
OK
```

The third row matters: the new assertion must not mask the original one. Both fire independently, and the pre-existing staleness check still catches a wrong time exactly as before.

This suite runs in CI via `Automation - Tooling Tests` (#4939), and `.agents/skills/ci-status/**` is in that workflow's `paths:` filter, so this PR exercises the change directly.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated







