### PR TITLE
[release] Fix milestone due-date normalization

### DIFF
--- a/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
+++ b/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
@@ -130,11 +130,11 @@ Assert-Equal @(
     '4.152.0'
 ) @($desired.Title) 'Chromium stages were not mapped to release milestones.'
 Assert-Equal @(
-    '2026-08-04T00:00:00Z',
-    '2026-08-12T00:00:00Z',
-    '2026-08-18T00:00:00Z',
-    '2026-08-25T00:00:00Z'
-) @($desired.DueOn) 'Chromium schedule dates were not mapped to the expected stages.'
+    '2026-08-04T23:59:59Z',
+    '2026-08-12T23:59:59Z',
+    '2026-08-18T23:59:59Z',
+    '2026-08-25T23:59:59Z'
+) @($desired.DueOn) 'Chromium schedule dates were not mapped to end-of-day GitHub deadlines.'
 Assert-True ($desired[0].Description.Contains([char] 0x00b7)) 'Milestone descriptions lost their separators.'
 
 $matchingSchedule = @{

--- a/scripts/infra/publishing/update-release-milestones.ps1
+++ b/scripts/infra/publishing/update-release-milestones.ps1
@@ -78,6 +78,11 @@ function Format-ScheduleDate([datetime] $Date) {
     return $Date.ToString('ddd, MMM dd, yyyy', [Globalization.CultureInfo]::InvariantCulture)
 }
 
+# Uses end-of-day UTC so GitHub preserves the intended calendar date when normalizing milestone deadlines.
+function Format-GitHubDueOn([datetime] $Date) {
+    return $Date.ToString('yyyy-MM-dd', [Globalization.CultureInfo]::InvariantCulture) + 'T23:59:59Z'
+}
+
 # Normalizes GitHub string or DateTime values to an ISO calendar date.
 function ConvertTo-IsoDate([object] $Value) {
     if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string] $Value)) {
@@ -134,7 +139,7 @@ function New-DesiredReleaseMilestones([object] $Schedule, [int] $Milestone, [int
         [pscustomobject] @{
             Title = "$base-preview.1"
             Due = $beta
-            DueOn = $beta.ToString('yyyy-MM-dd') + 'T00:00:00Z'
+            DueOn = Format-GitHubDueOn $beta
             Description = (
                 "Skia m$Milestone preview.1 $separator Start $(Format-ScheduleDate $branch) $separator " +
                 'Merge Skia sync PR and ship preview.')
@@ -142,7 +147,7 @@ function New-DesiredReleaseMilestones([object] $Schedule, [int] $Milestone, [int
         [pscustomobject] @{
             Title = "$base-preview.2"
             Due = $earlyStable
-            DueOn = $earlyStable.ToString('yyyy-MM-dd') + 'T00:00:00Z'
+            DueOn = Format-GitHubDueOn $earlyStable
             Description = (
                 "Skia m$Milestone preview.2 $separator Start $(Format-ScheduleDate $earlyCut) $separator " +
                 'Bug fixes and API additions from preview.1 feedback.')
@@ -150,7 +155,7 @@ function New-DesiredReleaseMilestones([object] $Schedule, [int] $Milestone, [int
         [pscustomobject] @{
             Title = "$base-rc.1"
             Due = $stableCut
-            DueOn = $stableCut.ToString('yyyy-MM-dd') + 'T00:00:00Z'
+            DueOn = Format-GitHubDueOn $stableCut
             Description = (
                 "Skia m$Milestone RC $separator Start $(Format-ScheduleDate $earlyStable) $separator " +
                 'Critical bug fixes only, no new features.')
@@ -158,7 +163,7 @@ function New-DesiredReleaseMilestones([object] $Schedule, [int] $Milestone, [int
         [pscustomobject] @{
             Title = $base
             Due = $stable
-            DueOn = $stable.ToString('yyyy-MM-dd') + 'T00:00:00Z'
+            DueOn = Format-GitHubDueOn $stable
             Description = (
                 "Skia m$Milestone stable $separator Start $(Format-ScheduleDate $stableCut) $separator " +
                 'Ship to NuGet.org, tag and create GitHub Release.')


### PR DESCRIPTION
## Description

Write GitHub milestone deadlines at the end of the intended UTC day rather than midnight. GitHub normalized the midnight deadline for `4.155.0-preview.1` to the previous calendar date, causing `Release - Milestones` run 33713871430 to fail strict post-write verification after creating the milestone.

Date comparisons remain calendar-date based. The next workflow run will therefore repair the partially created milestone, create the remaining planned milestones, and continue normal closure processing.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — release-maintenance automation only; no public API or runtime behavior changes.

## Testing

- `Test-ReleaseMilestones.ps1`: 25 passed
- `Test-PublishingScripts.ps1`: 107 passed
- Live read-only milestone update planned one repair, three creates, and one closure without mutations
- `git diff --check`

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A