### PR TITLE
[skia-sync] Update skia to milestone 154

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "542baf750bd76e11a7b334fd0a7becc20de52352"
+          "commitHash": "4f282dedc68bbaaa9f9786684ba3c996e6110f8c"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "92dc1a61df70e9238e7efe435f40a4136e887df8"
+          "commitHash": "542baf750bd76e11a7b334fd0a7becc20de52352"
         }
       }
     },
@@ -318,13 +318,13 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m153",
+          "version": "chrome/m154",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 153,
-      "upstream_merge_commit": "4f574af2444846ceca4d277a8095c5d4229d175f",
-      "upstream_ref": "chrome/m153"
+      "chrome_milestone": 154,
+      "upstream_merge_commit": "7b950f0d8ed1028a75248ea69813ae6054ca65f8",
+      "upstream_ref": "chrome/m154"
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "4f282dedc68bbaaa9f9786684ba3c996e6110f8c"
+          "commitHash": "cc43af052d3d98e605bee4ddc98671dafded1c57"
         }
       }
     },

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m153
+skia                                            release     m154
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,68 +66,68 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   153
+libSkiaSharp            milestone   154
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      153.0.0
+libSkiaSharp            soname      154.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.153.0.0
-SkiaSharp               file        4.153.0.0
+SkiaSharp               assembly    4.154.0.0
+SkiaSharp               file        4.154.0.0
 
 # HarfBuzzSharp package revision N reserves 100 values per Skia milestone.
 # The milestone adopting native X.Y.Z uses 0-99; later milestones add 100.
 # Native HarfBuzz upgrades reset N to 0 and establish a new base milestone.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.1.300
+HarfBuzzSharp           file        14.2.1.400
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.153.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.153.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.153.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.153.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.153.0
-SkiaSharp.NativeAssets.Android                  nuget       4.153.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.153.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.153.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.153.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.153.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.153.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.153.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.153.0
-SkiaSharp.Views                                 nuget       4.153.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.153.0
-SkiaSharp.Views.Gtk3                            nuget       4.153.0
-SkiaSharp.Views.Gtk4                            nuget       4.153.0
-SkiaSharp.Views.WindowsForms                    nuget       4.153.0
-SkiaSharp.Views.WPF                             nuget       4.153.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.153.0
-SkiaSharp.Views.WinUI                           nuget       4.153.0
-SkiaSharp.Views.Maui.Core                       nuget       4.153.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.153.0
-SkiaSharp.Views.Blazor                          nuget       4.153.0
-SkiaSharp.HarfBuzz                              nuget       4.153.0
-SkiaSharp.Skottie                               nuget       4.153.0
-SkiaSharp.SceneGraph                            nuget       4.153.0
-SkiaSharp.Resources                             nuget       4.153.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.153.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.153.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.153.0
+SkiaSharp                                       nuget       4.154.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.154.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.154.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.154.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.154.0
+SkiaSharp.NativeAssets.Android                  nuget       4.154.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.154.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.154.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.154.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.154.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.154.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.154.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.154.0
+SkiaSharp.Views                                 nuget       4.154.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.154.0
+SkiaSharp.Views.Gtk3                            nuget       4.154.0
+SkiaSharp.Views.Gtk4                            nuget       4.154.0
+SkiaSharp.Views.WindowsForms                    nuget       4.154.0
+SkiaSharp.Views.WPF                             nuget       4.154.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.154.0
+SkiaSharp.Views.WinUI                           nuget       4.154.0
+SkiaSharp.Views.Maui.Core                       nuget       4.154.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.154.0
+SkiaSharp.Views.Blazor                          nuget       4.154.0
+SkiaSharp.HarfBuzz                              nuget       4.154.0
+SkiaSharp.Skottie                               nuget       4.154.0
+SkiaSharp.SceneGraph                            nuget       4.154.0
+SkiaSharp.Resources                             nuget       4.154.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.154.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.154.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.154.0
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.300
+HarfBuzzSharp                                   nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.400

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -1,7 +1,7 @@
 variables:
   # NOTE: Update this value when bumping the SkiaSharp version. It must match
   # the SkiaSharp NuGet version in scripts/VERSIONS.txt.
-  SKIASHARP_VERSION: 4.153.0
+  SKIASHARP_VERSION: 4.154.0
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranch)


### PR DESCRIPTION
## Description

Automated Skia milestone bump from m153 to m154.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/351

**Areas affected**

- [ ] Managed API (`binding/`)
- [x] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Advance the Skia submodule from Chrome milestone m153 to m154 on branch `skia-sync/m154`.
Parent commit `093b35b46c` points the `externals/skia` gitlink at the exact tested mono/skia
commit `542baf750b` (merge of upstream `chrome/m154` @ `7b950f0d8ed`).

- `externals/skia` submodule pointer: `ca4e52cbb9` -> `542baf750b`.
- `scripts/VERSIONS.txt` — milestone 153 -> 154, `libSkiaSharp` soname `154.0.0`, `SkiaSharp`
  assembly/file `4.154.0.0`, all NuGet package versions `4.153.0` -> `4.154.0`, HarfBuzzSharp
  file version `14.2.1.300` -> `14.2.1.400`.
- `scripts/azure-templates-variables.yml` — Skia release channel `m153` -> `m154`.
- `cgmanifest.json` — Skia registration `chrome/m153` -> `chrome/m154` at commit `542baf750b`.
- Bindings regenerated (`regenerate_bindings.py`): **no binding changes** — m154 introduced no
  new C API surface in the fork shim. HarfBuzz generated binding reverted per policy. No
  `*.generated.cs` was hand-edited.

## Testing

Managed build `binding/SkiaSharp/SkiaSharp.csproj` succeeded (0 errors; only EOL-workload warnings).

Full unfiltered solution `tests/SkiaSharp.Tests.Console.slnx` (net10.0), exit code 0:

- SkiaSharp.Tests.dll — Passed 6127, Skipped 33, Failed 0
- SkiaSharp.Vulkan.Tests.dll — Passed 23, Skipped 2, Failed 0 (lavapipe ICD)
- SkiaSharp.Direct3D.Tests.dll — Passed 2, Skipped 3, Failed 0
- SkiaSharp.Tests.SingletonInit.dll — Passed 1, Skipped 0, Failed 0

No **required** `GpuPolicy` backend was skipped: the Vulkan backend (lavapipe) initialized and
executed successfully. Direct3D skips reflect the existing platform policy (D3D unavailable on Linux).

## Human review

- This parent PR must be merged after the paired mono/skia PR; update the submodule pointer to the
  merged `skiasharp` branch commit before merging (do not leave it on an orphaned PR-head commit).
- Non-Linux platforms (Windows, macOS, Android, iOS, tvOS, MacCatalyst, Tizen, WASM) were not built
  or tested locally and rely on CI.
- Confirm the version bumps match the intended milestone-release cadence (IS_RELEASE=false).


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-09-03T04:22:23Z_
