### PR TITLE
test: add M154 regression tests for SKPicture, SKDrawable, and SKSvgCanvas surfaces

### DIFF
--- a/tests/Tests/SkiaSharp/SKCanvasTest.cs
+++ b/tests/Tests/SkiaSharp/SKCanvasTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
@@ -467,6 +468,75 @@ namespace SkiaSharp.Tests
 				Assert.Equal("80", rect.Attribute("width")?.Value);
 				Assert.Equal("80", rect.Attribute("height")?.Value);
 			}
+		}
+
+		[Fact]
+		public void SvgCanvasEmitsFilterDefinitionForSrcInColorFilter()
+		{
+			// Guards against structural regressions in the SVG filter DAG emitted by
+			// SKSvgCanvas when a SrcIn blend-mode SKColorFilter is applied to a paint.
+			// This is the M153/M154 shared invariant for the SVG filter-emission code path
+			// touched by upstream 7788196ddd and 15db98a90b: assert only that the
+			// filter definition + reference wiring are structurally correct on BOTH
+			// milestones. Do NOT assert in2="SourceGraphic" (M154 fix), the specific
+			// set of feBlend elements (M154-only expansion), or exact XML text/order.
+
+			var stream = new MemoryStream();
+
+			using (var svg = SKSvgCanvas.Create(SKRect.Create(100, 100), stream))
+			using (var colorFilter = SKColorFilter.CreateBlendMode(SKColors.Red, SKBlendMode.SrcIn))
+			using (var paint = new SKPaint
+			{
+				Color = SKColors.Blue,
+				Style = SKPaintStyle.Fill,
+				ColorFilter = colorFilter,
+			})
+			{
+				svg.DrawRect(SKRect.Create(10, 10, 80, 80), paint);
+			}
+
+			stream.Position = 0;
+
+			using var reader = new StreamReader(stream);
+			var xml = reader.ReadToEnd();
+			var xdoc = XDocument.Parse(xml);
+
+			var svgRoot = xdoc.Root;
+			var ns = svgRoot.Name.Namespace;
+
+			// (1) Exactly one <filter> element with a non-empty id.
+			var filters = xdoc.Descendants(ns + "filter").ToList();
+			Assert.Single(filters);
+
+			var filter = filters[0];
+			var filterId = filter.Attribute("id")?.Value;
+			Assert.False(string.IsNullOrEmpty(filterId));
+
+			// (2) Inside the filter, an <feFlood> primitive with flood-color and
+			// flood-opacity attributes.
+			var feFloods = filter.Descendants(ns + "feFlood").ToList();
+			Assert.NotEmpty(feFloods);
+
+			var feFlood = feFloods[0];
+			Assert.False(string.IsNullOrEmpty(feFlood.Attribute("flood-color")?.Value));
+			Assert.False(string.IsNullOrEmpty(feFlood.Attribute("flood-opacity")?.Value));
+
+			// (3) An <feComposite> primitive with operator="in" and in="flood".
+			// This is the shape of the SrcIn masking primitive on both M153 and M154.
+			// (M154 additionally sets in2="SourceGraphic"; we do not assert that.)
+			var feComposites = filter.Descendants(ns + "feComposite").ToList();
+			var srcInComposite = feComposites.FirstOrDefault(e =>
+				e.Attribute("operator")?.Value == "in" &&
+				e.Attribute("in")?.Value == "flood");
+			Assert.NotNull(srcInComposite);
+
+			// (4) The painted <rect> references the filter via filter="url(#{filterId})".
+			var rect = xdoc.Descendants(ns + "rect")
+				.FirstOrDefault(e => e.Attribute("filter") != null);
+			Assert.NotNull(rect);
+
+			var filterAttr = rect.Attribute("filter").Value;
+			Assert.Equal($"url(#{filterId})", filterAttr);
 		}
 
 		[Theory]

--- a/tests/Tests/SkiaSharp/SKPictureRecorderTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureRecorderTest.cs
@@ -81,5 +81,55 @@ namespace SkiaSharp.Tests
 
 			Assert.Equal(SKRect.Create(x, y, w, h), picture.CullRect);
 		}
+
+		[Fact]
+		public void DrawableFromRecorderReproducesGeometryOnPlayback()
+		{
+			// Guards against regressions from the M154 SkBigPicture -> SkPicture refactor
+			// (upstream b392fb672d). Ensures that a picture recorded through
+			// EndRecordingAsDrawable reproduces its recorded geometry and colors when
+			// played back through both SKDrawable.Draw and SKDrawable.Snapshot -> Playback.
+			// Uses only stable, cross-platform, CPU-deterministic APIs.
+
+			var cullRect = SKRect.Create(0, 0, 40, 40);
+
+			using var recorder = new SKPictureRecorder();
+			var recCanvas = recorder.BeginRecording(cullRect);
+			DrawTestBitmap(recCanvas, 40, 40);
+
+			using var drawable = recorder.EndRecordingAsDrawable();
+			Assert.NotNull(drawable);
+			Assert.Equal(cullRect, drawable.Bounds);
+
+			// Path 1: Draw the drawable directly onto a fresh canvas and confirm the
+			// four quadrant colors of the recorded geometry survive the drawable playback.
+			using (var bmp = new SKBitmap(40, 40))
+			using (var cnv = new SKCanvas(bmp))
+			{
+				drawable.Draw(cnv, 0, 0);
+				ValidateTestBitmap(bmp);
+			}
+
+			// Path 2: Snapshot the drawable into an SKPicture and validate that both
+			// Playback and DrawPicture reproduce the same recorded geometry.
+			using var snapshot = drawable.Snapshot();
+			Assert.NotNull(snapshot);
+			Assert.Equal(cullRect, snapshot.CullRect);
+			Assert.True(snapshot.ApproximateBytesUsed > 0);
+
+			using (var bmp = new SKBitmap(40, 40))
+			using (var cnv = new SKCanvas(bmp))
+			{
+				snapshot.Playback(cnv);
+				ValidateTestBitmap(bmp);
+			}
+
+			using (var bmp = new SKBitmap(40, 40))
+			using (var cnv = new SKCanvas(bmp))
+			{
+				cnv.DrawPicture(snapshot);
+				ValidateTestBitmap(bmp);
+			}
+		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPictureTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureTest.cs
@@ -112,6 +112,59 @@ namespace SkiaSharp.Tests
 		}
 
 		[Fact]
+		public void CanRoundtripNestedPictureThroughSerialization()
+		{
+			// Guards against regressions from the M154 SkBigPicture -> SkPicture refactor
+			// (upstream b392fb672d). Records an outer picture that draws a nested SKPicture,
+			// serializes / deserializes it through the stable C API, and asserts observable
+			// contract parity + raster playback fidelity. Uses only stable public APIs and
+			// avoids byte-exact serialization or exact byte-count assertions.
+
+			var cullRect = SKRect.Create(0, 0, 40, 40);
+
+			using var nested = CreateTestPicture();
+
+			using var recorder = new SKPictureRecorder();
+			var recCanvas = recorder.BeginRecording(cullRect);
+			recCanvas.DrawPicture(nested);
+			using var original = recorder.EndRecording();
+
+			var originalOpCount = original.ApproximateOperationCount;
+			var originalOpCountWithNested = original.GetApproximateOperationCount(true);
+
+			using var data = original.Serialize();
+			Assert.NotNull(data);
+
+			using var deserialized = SKPicture.Deserialize(data);
+			Assert.NotNull(deserialized);
+
+			// CullRect parity (exact — CullRect is round-tripped through the format).
+			Assert.Equal(original.CullRect, deserialized.CullRect);
+			Assert.Equal(cullRect, deserialized.CullRect);
+
+			// Approximate operation-count parity for both the shallow and nested variants.
+			// Cross-milestone-safe: assert equality between original and deserialized,
+			// not a specific magic number that could shift with internal storage changes.
+			Assert.Equal(originalOpCount, deserialized.ApproximateOperationCount);
+			Assert.Equal(originalOpCountWithNested, deserialized.GetApproximateOperationCount(true));
+
+			// The nested variant must not be smaller than the shallow variant.
+			Assert.True(deserialized.GetApproximateOperationCount(true) >= deserialized.ApproximateOperationCount);
+
+			// ApproximateBytesUsed is internal storage — only assert positivity, never an
+			// exact value: the M154 refactor may shift internal byte accounting.
+			Assert.True(deserialized.ApproximateBytesUsed > 0);
+
+			// Raster playback parity: the deserialized picture must reproduce the same
+			// pixels as the nested test bitmap.
+			using var bmp = new SKBitmap(40, 40);
+			using var cnv = new SKCanvas(bmp);
+			deserialized.Playback(cnv);
+
+			ValidateTestBitmap(bmp);
+		}
+
+		[Fact]
 		public void EncodesImageIntoPicture()
 		{
 			// create an image


### PR DESCRIPTION
## Description

Adds three focused regression tests that guard the SkiaSharp surfaces most affected by the M154 update just landed on `main`. All three tests target only stable public APIs, are CPU-deterministic, cross-platform, use no goldens or external assets, and were engineered to pass on both the pre-M154 baseline and M154 itself so the same patch is safe on stacked branches and any future backports.

The three surfaces:

1. **`SKPicture` nested serialize/deserialize/playback** — guards the M154 `SkBigPicture` → `SkPicture` refactor (upstream [`b392fb672d`](https://skia.googlesource.com/skia/+/b392fb672d)), the largest structural change to the picture format in this milestone. Tests the observable round-trip contract without asserting internal storage.
2. **`SKPictureRecorder.EndRecordingAsDrawable` playback fidelity** — validates that drawables recorded through `SKPictureRecorder` still reproduce the recorded geometry after the same M154 refactor, across `SKDrawable.Draw`, `SKDrawable.Snapshot() → SKPicture.Playback`, and `SKCanvas.DrawPicture(snapshot)`.
3. **`SKSvgCanvas` SrcIn color-filter DAG structure** — guards the SVG filter-emission path touched by upstream [`7788196ddd`](https://skia.googlesource.com/skia/+/7788196ddd) and [`15db98a90b`](https://skia.googlesource.com/skia/+/15db98a90b). Asserts only structural invariants that hold on both the pre-M154 baseline and M154; deliberately does not assert the M154-only `in2="SourceGraphic"` fix, the M154 expanded blend-mode set, or `feBlend` presence, so the same test survives any future SVG emission tuning.

**Related issues**

None. Repository-hygiene regression tests requested by a skia-analyst review of the M154 delta.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — test-only. No public API changes. No native / C API changes. No generated file regeneration. No new external assets. Three new `[Fact]` methods added to existing test files.

**Public API**

None.

**Behavior**

None. This PR adds `[Fact]` tests only; production code is untouched.

## Testing

Three new `[Fact]` methods, all deterministic and CPU-only:

- **`SKPictureTest.CanRoundtripNestedPictureThroughSerialization`** — records an outer picture that `DrawPicture`s a nested `CreateTestPicture()`, calls `Serialize()` → `Deserialize(data)`, and asserts:
  - `CullRect` parity (original vs deserialized, and equal to the recorded `(0,0,40,40)`).
  - `ApproximateOperationCount` (shallow) parity between original and deserialized.
  - `GetApproximateOperationCount(true)` (nested) parity between original and deserialized.
  - Nested op-count `>=` shallow op-count on the deserialized picture.
  - `ApproximateBytesUsed > 0` (never exact — resilient across the M154 storage refactor).
  - Raster playback parity via the existing `ValidateTestBitmap` four-quadrant pixel helper.
  - Does **not** assert byte-for-byte serialized equality.

- **`SKPictureRecorderTest.DrawableFromRecorderReproducesGeometryOnPlayback`** — records `DrawTestBitmap(canvas, 40, 40)` into a drawable via `EndRecordingAsDrawable()`, then validates the four-quadrant recorded geometry survives three playback paths:
  1. `drawable.Draw(canvas, 0, 0)` → `ValidateTestBitmap`.
  2. `drawable.Snapshot().Playback(canvas)` → `ValidateTestBitmap`.
  3. `canvas.DrawPicture(snapshot)` → `ValidateTestBitmap`.
  - Asserts `drawable.Bounds == cullRect`, `snapshot.CullRect == cullRect`, `snapshot.ApproximateBytesUsed > 0`.

- **`SKCanvasTest.SvgCanvasEmitsFilterDefinitionForSrcInColorFilter`** — draws a filled rect through `SKSvgCanvas.Create(...)` with a `SKColorFilter.CreateBlendMode(SKColors.Red, SKBlendMode.SrcIn)` applied to the paint, then parses the emitted SVG with `XDocument.Parse` and asserts M154-safe structural invariants only:
  - Exactly one `<filter>` element with a non-empty `id`.
  - An `<feFlood>` primitive inside the filter with non-empty `flood-color` and `flood-opacity`.
  - An `<feComposite>` primitive with `operator="in"` and `in="flood"` (the SrcIn masking shape).
  - The painted `<rect>` references the filter via `filter="url(#<id>)"` matching the same `<filter>` id.
  - Deliberately does **not** assert `in2="SourceGraphic"` (the M154-only fix), the M154 expanded blend-mode set, `feBlend` presence/absence, exact XML text/order, or any pixel/golden data.

**Verification**

- Build: `dotnet build tests/SkiaSharp.Tests.Console/SkiaSharp.Tests.Console.csproj -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0` → **0 Errors, 58 pre-existing Warnings**.
- Bootstrapped with `dotnet cake --target=externals-download` (per AGENTS.md for C#-only work).
- Rebased onto the M154 tip of `main` so this PR's CI validates the tests against the M154 native library across the full CI matrix (Windows / macOS / Ubuntu, all supported target frameworks); local execution against M154 native binaries is deferred to CI.

**Cross-milestone safety review**

Every assertion in this PR was chosen so both the pre-M154 baseline and M154 pass; this keeps the same patch valid on stacked branches and any future backports:

| Concern | Never asserted | Asserted instead |
| --- | --- | --- |
| SkBigPicture → SkPicture internal storage | exact `ApproximateBytesUsed` | `> 0` |
| Serialization format | byte-for-byte equality | round-trip contract parity |
| Op-count magic numbers | fixed integers | equality between original and deserialized |
| M154 SVG SrcIn fix | `in2="SourceGraphic"` | `operator="in"` + `in="flood"` |
| M154 expanded SVG blend modes | `feBlend` presence / mode names | absent from assertions |
| SVG text | exact XML text or element order | parsed-DOM structural queries |
| Rendering | pixel goldens | four-quadrant `ValidateTestBitmap` |

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later — **N/A, no public API changes**
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated — **N/A, no native changes**