### PR TITLE
test: mirror #4956 M154 regression tests atop M154 bump (test-only)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "542baf750bd76e11a7b334fd0a7becc20de52352"
+          "commitHash": "4f282dedc68bbaaa9f9786684ba3c996e6110f8c"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "92dc1a61df70e9238e7efe435f40a4136e887df8"
+          "commitHash": "542baf750bd76e11a7b334fd0a7becc20de52352"
         }
       }
     },
@@ -318,13 +318,13 @@
         "type": "other",
         "other": {
           "name": "skia",
-          "version": "chrome/m153",
+          "version": "chrome/m154",
           "downloadUrl": "https://github.com/google/skia"
         }
       },
-      "chrome_milestone": 153,
-      "upstream_merge_commit": "4f574af2444846ceca4d277a8095c5d4229d175f",
-      "upstream_ref": "chrome/m153"
+      "chrome_milestone": 154,
+      "upstream_merge_commit": "7b950f0d8ed1028a75248ea69813ae6054ca65f8",
+      "upstream_ref": "chrome/m154"
     }
   ]
 }

--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -1,6 +1,6 @@
 # native sources
 harfbuzz                                        release     14.2.1
-skia                                            release     m153
+skia                                            release     m154
 ANGLE                                           release     chromium/6275
 
 # product dependencies
@@ -66,68 +66,68 @@ xunit.runner.console                            release     2.4.2
 # this is related to the API versions, not the library versions
 #  - milestone: the skia milestone determined by Google/Chromium
 #  - increment: the C API version increment caused by new APIs (externals\skia\include\c\sk_types.h)
-libSkiaSharp            milestone   153
+libSkiaSharp            milestone   154
 libSkiaSharp            increment   0
 
 # native sonames
 # <milestone>.<increment>.0
-libSkiaSharp            soname      153.0.0
+libSkiaSharp            soname      154.0.0
 # 0.<60000 + major*100 + minor*10 + micro>.0
 HarfBuzz                soname      0.61421.0
 
 # SkiaSharp.dll
 # SkiaSharp.dll
-SkiaSharp               assembly    4.153.0.0
-SkiaSharp               file        4.153.0.0
+SkiaSharp               assembly    4.154.0.0
+SkiaSharp               file        4.154.0.0
 
 # HarfBuzzSharp package revision N reserves 100 values per Skia milestone.
 # The milestone adopting native X.Y.Z uses 0-99; later milestones add 100.
 # Native HarfBuzz upgrades reset N to 0 and establish a new base milestone.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.1.300
+HarfBuzzSharp           file        14.2.1.400
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.153.0
-SkiaSharp.NativeAssets.Linux                    nuget       4.153.0
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.153.0
-SkiaSharp.NativeAssets.NanoServer               nuget       4.153.0
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.153.0
-SkiaSharp.NativeAssets.Android                  nuget       4.153.0
-SkiaSharp.NativeAssets.iOS                      nuget       4.153.0
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.153.0
-SkiaSharp.NativeAssets.macOS                    nuget       4.153.0
-SkiaSharp.NativeAssets.Tizen                    nuget       4.153.0
-SkiaSharp.NativeAssets.tvOS                     nuget       4.153.0
-SkiaSharp.NativeAssets.Win32                    nuget       4.153.0
-SkiaSharp.NativeAssets.WinUI                    nuget       4.153.0
-SkiaSharp.Views                                 nuget       4.153.0
-SkiaSharp.Views.Desktop.Common                  nuget       4.153.0
-SkiaSharp.Views.Gtk3                            nuget       4.153.0
-SkiaSharp.Views.Gtk4                            nuget       4.153.0
-SkiaSharp.Views.WindowsForms                    nuget       4.153.0
-SkiaSharp.Views.WPF                             nuget       4.153.0
-SkiaSharp.Views.Uno.WinUI                       nuget       4.153.0
-SkiaSharp.Views.WinUI                           nuget       4.153.0
-SkiaSharp.Views.Maui.Core                       nuget       4.153.0
-SkiaSharp.Views.Maui.Controls                   nuget       4.153.0
-SkiaSharp.Views.Blazor                          nuget       4.153.0
-SkiaSharp.HarfBuzz                              nuget       4.153.0
-SkiaSharp.Skottie                               nuget       4.153.0
-SkiaSharp.SceneGraph                            nuget       4.153.0
-SkiaSharp.Resources                             nuget       4.153.0
-SkiaSharp.Vulkan.SharpVk                        nuget       4.153.0
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.153.0
-SkiaSharp.Direct3D.Vortice                      nuget       4.153.0
+SkiaSharp                                       nuget       4.154.0
+SkiaSharp.NativeAssets.Linux                    nuget       4.154.0
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.154.0
+SkiaSharp.NativeAssets.NanoServer               nuget       4.154.0
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.154.0
+SkiaSharp.NativeAssets.Android                  nuget       4.154.0
+SkiaSharp.NativeAssets.iOS                      nuget       4.154.0
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.154.0
+SkiaSharp.NativeAssets.macOS                    nuget       4.154.0
+SkiaSharp.NativeAssets.Tizen                    nuget       4.154.0
+SkiaSharp.NativeAssets.tvOS                     nuget       4.154.0
+SkiaSharp.NativeAssets.Win32                    nuget       4.154.0
+SkiaSharp.NativeAssets.WinUI                    nuget       4.154.0
+SkiaSharp.Views                                 nuget       4.154.0
+SkiaSharp.Views.Desktop.Common                  nuget       4.154.0
+SkiaSharp.Views.Gtk3                            nuget       4.154.0
+SkiaSharp.Views.Gtk4                            nuget       4.154.0
+SkiaSharp.Views.WindowsForms                    nuget       4.154.0
+SkiaSharp.Views.WPF                             nuget       4.154.0
+SkiaSharp.Views.Uno.WinUI                       nuget       4.154.0
+SkiaSharp.Views.WinUI                           nuget       4.154.0
+SkiaSharp.Views.Maui.Core                       nuget       4.154.0
+SkiaSharp.Views.Maui.Controls                   nuget       4.154.0
+SkiaSharp.Views.Blazor                          nuget       4.154.0
+SkiaSharp.HarfBuzz                              nuget       4.154.0
+SkiaSharp.Skottie                               nuget       4.154.0
+SkiaSharp.SceneGraph                            nuget       4.154.0
+SkiaSharp.Resources                             nuget       4.154.0
+SkiaSharp.Vulkan.SharpVk                        nuget       4.154.0
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.154.0
+SkiaSharp.Direct3D.Vortice                      nuget       4.154.0
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.300
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.300
+HarfBuzzSharp                                   nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.400
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.400

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -1,7 +1,7 @@
 variables:
   # NOTE: Update this value when bumping the SkiaSharp version. It must match
   # the SkiaSharp NuGet version in scripts/VERSIONS.txt.
-  SKIASHARP_VERSION: 4.153.0
+  SKIASHARP_VERSION: 4.154.0
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranch)

--- a/tests/Tests/SkiaSharp/SKCanvasTest.cs
+++ b/tests/Tests/SkiaSharp/SKCanvasTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
@@ -467,6 +468,75 @@ namespace SkiaSharp.Tests
 				Assert.Equal("80", rect.Attribute("width")?.Value);
 				Assert.Equal("80", rect.Attribute("height")?.Value);
 			}
+		}
+
+		[Fact]
+		public void SvgCanvasEmitsFilterDefinitionForSrcInColorFilter()
+		{
+			// Guards against structural regressions in the SVG filter DAG emitted by
+			// SKSvgCanvas when a SrcIn blend-mode SKColorFilter is applied to a paint.
+			// This is the M153/M154 shared invariant for the SVG filter-emission code path
+			// touched by upstream 7788196ddd and 15db98a90b: assert only that the
+			// filter definition + reference wiring are structurally correct on BOTH
+			// milestones. Do NOT assert in2="SourceGraphic" (M154 fix), the specific
+			// set of feBlend elements (M154-only expansion), or exact XML text/order.
+
+			var stream = new MemoryStream();
+
+			using (var svg = SKSvgCanvas.Create(SKRect.Create(100, 100), stream))
+			using (var colorFilter = SKColorFilter.CreateBlendMode(SKColors.Red, SKBlendMode.SrcIn))
+			using (var paint = new SKPaint
+			{
+				Color = SKColors.Blue,
+				Style = SKPaintStyle.Fill,
+				ColorFilter = colorFilter,
+			})
+			{
+				svg.DrawRect(SKRect.Create(10, 10, 80, 80), paint);
+			}
+
+			stream.Position = 0;
+
+			using var reader = new StreamReader(stream);
+			var xml = reader.ReadToEnd();
+			var xdoc = XDocument.Parse(xml);
+
+			var svgRoot = xdoc.Root;
+			var ns = svgRoot.Name.Namespace;
+
+			// (1) Exactly one <filter> element with a non-empty id.
+			var filters = xdoc.Descendants(ns + "filter").ToList();
+			Assert.Single(filters);
+
+			var filter = filters[0];
+			var filterId = filter.Attribute("id")?.Value;
+			Assert.False(string.IsNullOrEmpty(filterId));
+
+			// (2) Inside the filter, an <feFlood> primitive with flood-color and
+			// flood-opacity attributes.
+			var feFloods = filter.Descendants(ns + "feFlood").ToList();
+			Assert.NotEmpty(feFloods);
+
+			var feFlood = feFloods[0];
+			Assert.False(string.IsNullOrEmpty(feFlood.Attribute("flood-color")?.Value));
+			Assert.False(string.IsNullOrEmpty(feFlood.Attribute("flood-opacity")?.Value));
+
+			// (3) An <feComposite> primitive with operator="in" and in="flood".
+			// This is the shape of the SrcIn masking primitive on both M153 and M154.
+			// (M154 additionally sets in2="SourceGraphic"; we do not assert that.)
+			var feComposites = filter.Descendants(ns + "feComposite").ToList();
+			var srcInComposite = feComposites.FirstOrDefault(e =>
+				e.Attribute("operator")?.Value == "in" &&
+				e.Attribute("in")?.Value == "flood");
+			Assert.NotNull(srcInComposite);
+
+			// (4) The painted <rect> references the filter via filter="url(#{filterId})".
+			var rect = xdoc.Descendants(ns + "rect")
+				.FirstOrDefault(e => e.Attribute("filter") != null);
+			Assert.NotNull(rect);
+
+			var filterAttr = rect.Attribute("filter").Value;
+			Assert.Equal($"url(#{filterId})", filterAttr);
 		}
 
 		[Theory]

--- a/tests/Tests/SkiaSharp/SKPictureRecorderTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureRecorderTest.cs
@@ -81,5 +81,55 @@ namespace SkiaSharp.Tests
 
 			Assert.Equal(SKRect.Create(x, y, w, h), picture.CullRect);
 		}
+
+		[Fact]
+		public void DrawableFromRecorderReproducesGeometryOnPlayback()
+		{
+			// Guards against regressions from the M154 SkBigPicture -> SkPicture refactor
+			// (upstream b392fb672d). Ensures that a picture recorded through
+			// EndRecordingAsDrawable reproduces its recorded geometry and colors when
+			// played back through both SKDrawable.Draw and SKDrawable.Snapshot -> Playback.
+			// Uses only stable, cross-platform, CPU-deterministic APIs.
+
+			var cullRect = SKRect.Create(0, 0, 40, 40);
+
+			using var recorder = new SKPictureRecorder();
+			var recCanvas = recorder.BeginRecording(cullRect);
+			DrawTestBitmap(recCanvas, 40, 40);
+
+			using var drawable = recorder.EndRecordingAsDrawable();
+			Assert.NotNull(drawable);
+			Assert.Equal(cullRect, drawable.Bounds);
+
+			// Path 1: Draw the drawable directly onto a fresh canvas and confirm the
+			// four quadrant colors of the recorded geometry survive the drawable playback.
+			using (var bmp = new SKBitmap(40, 40))
+			using (var cnv = new SKCanvas(bmp))
+			{
+				drawable.Draw(cnv, 0, 0);
+				ValidateTestBitmap(bmp);
+			}
+
+			// Path 2: Snapshot the drawable into an SKPicture and validate that both
+			// Playback and DrawPicture reproduce the same recorded geometry.
+			using var snapshot = drawable.Snapshot();
+			Assert.NotNull(snapshot);
+			Assert.Equal(cullRect, snapshot.CullRect);
+			Assert.True(snapshot.ApproximateBytesUsed > 0);
+
+			using (var bmp = new SKBitmap(40, 40))
+			using (var cnv = new SKCanvas(bmp))
+			{
+				snapshot.Playback(cnv);
+				ValidateTestBitmap(bmp);
+			}
+
+			using (var bmp = new SKBitmap(40, 40))
+			using (var cnv = new SKCanvas(bmp))
+			{
+				cnv.DrawPicture(snapshot);
+				ValidateTestBitmap(bmp);
+			}
+		}
 	}
 }

--- a/tests/Tests/SkiaSharp/SKPictureTest.cs
+++ b/tests/Tests/SkiaSharp/SKPictureTest.cs
@@ -112,6 +112,59 @@ namespace SkiaSharp.Tests
 		}
 
 		[Fact]
+		public void CanRoundtripNestedPictureThroughSerialization()
+		{
+			// Guards against regressions from the M154 SkBigPicture -> SkPicture refactor
+			// (upstream b392fb672d). Records an outer picture that draws a nested SKPicture,
+			// serializes / deserializes it through the stable C API, and asserts observable
+			// contract parity + raster playback fidelity. Uses only stable public APIs and
+			// avoids byte-exact serialization or exact byte-count assertions.
+
+			var cullRect = SKRect.Create(0, 0, 40, 40);
+
+			using var nested = CreateTestPicture();
+
+			using var recorder = new SKPictureRecorder();
+			var recCanvas = recorder.BeginRecording(cullRect);
+			recCanvas.DrawPicture(nested);
+			using var original = recorder.EndRecording();
+
+			var originalOpCount = original.ApproximateOperationCount;
+			var originalOpCountWithNested = original.GetApproximateOperationCount(true);
+
+			using var data = original.Serialize();
+			Assert.NotNull(data);
+
+			using var deserialized = SKPicture.Deserialize(data);
+			Assert.NotNull(deserialized);
+
+			// CullRect parity (exact — CullRect is round-tripped through the format).
+			Assert.Equal(original.CullRect, deserialized.CullRect);
+			Assert.Equal(cullRect, deserialized.CullRect);
+
+			// Approximate operation-count parity for both the shallow and nested variants.
+			// Cross-milestone-safe: assert equality between original and deserialized,
+			// not a specific magic number that could shift with internal storage changes.
+			Assert.Equal(originalOpCount, deserialized.ApproximateOperationCount);
+			Assert.Equal(originalOpCountWithNested, deserialized.GetApproximateOperationCount(true));
+
+			// The nested variant must not be smaller than the shallow variant.
+			Assert.True(deserialized.GetApproximateOperationCount(true) >= deserialized.ApproximateOperationCount);
+
+			// ApproximateBytesUsed is internal storage — only assert positivity, never an
+			// exact value: the M154 refactor may shift internal byte accounting.
+			Assert.True(deserialized.ApproximateBytesUsed > 0);
+
+			// Raster playback parity: the deserialized picture must reproduce the same
+			// pixels as the nested test bitmap.
+			using var bmp = new SKBitmap(40, 40);
+			using var cnv = new SKCanvas(bmp);
+			deserialized.Playback(cnv);
+
+			ValidateTestBitmap(bmp);
+		}
+
+		[Fact]
 		public void EncodesImageIntoPicture()
 		{
 			// create an image


### PR DESCRIPTION
## Description

This PR **mirrors the regression-test PR #4956 directly on top of the M154 bump PR #4945**, so the same three new tests can be evaluated against the actual M154 native/submodule world instead of `main`. It carries only #4956's tests unchanged — no other differences from `skia-sync/m154`.

- Sits **above** #4945 in a native stack: base = `skia-sync/m154`, head = `mattleibow-m154-regression-mirror`.
- Cherry-pick of `mattleibow-m154-regression-tests@e348b2c4899e83001314b952da06904876aec9ac` onto `skia-sync/m154@e68d4489f809357526e178d806881c6e4d7e4820`.
- Test-only. No `binding/` changes, no `externals/skia` changes, no generated bindings, no goldens.

Patch equivalence proof:

- Local diff vs `origin/skia-sync/m154` matches source commit's three files with identical line counts (+173).
- `git patch-id --stable` of our diff vs `origin/skia-sync/m154..HEAD`: `e56bbc83cdafe54cb2adb1d78deb43b68dfab8d2`
- `git patch-id --stable` of source commit `e348b2c^..e348b2c`: `e56bbc83cdafe54cb2adb1d78deb43b68dfab8d2`
- ⇒ **bit-for-bit patch-equivalent**.

**Related issues**

Related to #4945 (M154 bump this stacks above).
Mirror of #4956 (upstream tests against `main`).

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — test-only. No public API or behavioral change.

The three cherry-picked tests are:

- `tests/Tests/SkiaSharp/SKPictureTest.cs` — **`CanRoundtripNestedPictureThroughSerialization`** — guards the M154 `SkBigPicture` → `SkPicture` refactor by serializing a nested picture and re-drawing it via `SKPicture.Deserialize`.
- `tests/Tests/SkiaSharp/SKPictureRecorderTest.cs` — **`DrawableFromRecorderReproducesGeometryOnPlayback`** — CPU-deterministic playback-fidelity check for `EndRecordingAsDrawable`.
- `tests/Tests/SkiaSharp/SKCanvasTest.cs` — **`SvgCanvasEmitsFilterDefinitionForSrcInColorFilter`** — structural SVG-filter DAG test guarding `SrcIn` blend-mode emission touched by upstream `7788196ddd` / `15db98a90b`.

All three use stable public SkiaSharp APIs; no P/Invoke additions.

## Testing

**Patch structure verified against source** — see equivalence proof above.

**Full test suite `dotnet test tests/SkiaSharp.Tests.Console.slnx …` was NOT executed on this host.** The native gate could not be crossed on this session because the M154 native build stalls before compilation on this macOS ARM64 machine. Per repository policy this is reported precisely rather than worked around with `externals-download` (which is forbidden on a branch containing native/submodule changes):

- Host: macOS 26.6.2 (25G83), Xcode 26.6 (17F113), Apple clang 21.0.0, SDKROOT = `macosx26.5`.
- Command run: `dotnet cake --target=externals-macos --arch=arm64` (both submodules pre-initialized: `externals/skia@4f282dedc68bbaaa9f9786684ba3c996e6110f8c`, `externals/depot_tools@8fecc592a290769242d5098666cee8d29b7f0523`).
- Cake chain reaches `xcodebuild archive` on `native/macos/libSkiaSharp/libSkiaSharp.xcodeproj`. `xcodebuild` reaches the SwiftBuild `ExecuteExternalTool` preflight for `clang -v -E -dM -isysroot .../MacOSX26.5.sdk -x c -c /dev/null` and then sits at 0% CPU indefinitely. Both `xcodebuild` and its two `clang` preflight children remain at 0% CPU; no `libSkiaSharp` sources are ever compiled. Reproduced three times.
- The same clang preflight command run standalone completes in ~2 s with sane output — the hang is inside `SWBBuildService`, not clang.
- Direct `xcodebuild` invocation with the same arguments (bypassing Cake) reproduces the identical stall, so this is not a Cake-driver bug.

Because the cherry-pick is proven patch-identical to #4956 and touches only C# test code using stable public APIs, the mirror content is complete and correct even without local test execution. Once M154 natives are available on CI (or on a host without this Xcode 26.6 / SDK 26.5 stall), the three new tests will run against M154 natives from #4945.

Backends / platforms exercised locally by this PR: none — see above.

## Checklist

- [x] Tests added or updated (this PR *is* the tests)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later — N/A, no API changes.
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated — N/A, no native change in this PR (M154 natives come from #4945 below).