### PR TITLE
[migration] Adopt the Arcade backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,33 +1,25 @@
 name: PR - Backport
 
+# Comment `/backport to <branch>` or `/backport <branch>` on a merged pull request.
 on:
-  pull_request_target:
+  issue_comment:
     types:
-      - closed
-      - labeled
+      - created
+  schedule:
+    # Once a day at 13:00 UTC to clean up completed runs of this workflow.
+    - cron: '0 13 * * *'
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   backport:
-    name: Backport
-    runs-on: ubuntu-latest
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
-        )
-      )
-    steps:
-      - uses: tibdex/backport@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          body_template: >
-             Backport of <%= mergeCommitSha %> from #<%= number %>.
-          head_template: "backport/pr-<%= number %>-to-<%= base %>"
-          label_pattern: "^backport/(?<base>([^ ]+))$"
-          labels_template: "[ \"backport\" ]"
-          title_template: "[<%= base %>] <%= title %>"
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@306225d7029934938d109e18df390f04e366a68d # main as of 2026-08-31
+    with:
+      repository_owners: mono,dotnet # Remove mono after the repository transfer.
+      pr_title_template: '[%target_branch%] %source_pr_title%'
+      pr_description_template: 'Backport of #%source_pr_number% to %target_branch%'
+      pr_labels: backport


### PR DESCRIPTION
## Description

Replace the label-driven `tibdex/backport` action with the trusted standard .NET reusable workflow from `dotnet/arcade`, pinned to reviewed commit `306225d7029934938d109e18df390f04e366a68d`.

Maintainer UX intentionally changes from applying a `backport/<branch>` label to commenting `/backport to <branch>` or `/backport <branch>` on a merged pull request. Arcade verifies that the commenter has `write` or `admin` permission, confirms the target branch exists, and creates or updates the deterministic backport branch and pull request.

The caller preserves the `PR - Backport` display name used by CI-status tooling, configures the existing title and label conventions, and adds Arcade's daily cleanup schedule. `repository_owners: mono,dotnet` keeps the workflow usable through the organization transfer; the inline follow-up comment records that `mono` should be removed afterward.

`dotnet/arcade` and its trusted transitive workflow model are accepted .NET organization infrastructure, including the temporary-branch force update and scheduled cleanup behavior.

**Related issues**

Fixes #4965

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — workflow-only change; no public API or application behavior changes.

## Testing

- Parsed `.github/workflows/backport.yml` as YAML and asserted the exact name, triggers, daily schedule, permissions, pinned reusable-workflow SHA, migration owners, title/body templates, and label input.
- Inspected the pinned Arcade workflow to confirm the caller input names and comment-command behavior.
- Confirmed no executable `tibdex/backport` reference remains.
- Ran all 8 CI-status workflow registry tests, including display-name and trigger compatibility.
- Confirmed the diff contains only `.github/workflows/backport.yml` and passes `git diff --check`.
- No new test file was needed because the existing automation-tooling workflow already runs the registry suite for every workflow edit; the exact caller contract was validated directly.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated