### PR TITLE
Capture source repositories used by CI

### DIFF
--- a/documentation/dev/dependencies.md
+++ b/documentation/dev/dependencies.md
@@ -63,8 +63,8 @@ The report combines three sources so it does not depend on one manifest being co
 1. Runtime Git events, including Git processes started indirectly by Cake, `git-sync-deps`, and
    `gclient`.
 2. Remotes and exact revisions from checked-out repositories that remain in the workspace.
-3. Declared repository URLs from `.gitmodules`, `DEPS`, `cgmanifest.json`, Cake files, build
-   scripts, Dockerfiles, and pipeline YAML.
+3. Declared repository URLs from `.gitmodules`, pinned Skia DEPS identities in
+   `cgmanifest.json`, Cake files, build scripts, Dockerfiles, and pipeline YAML.
 
 Runtime events are marked `observed`; static-only entries are marked `declared`. The latter expose
 source paths that exist in another platform or target but were not exercised by the current job.

--- a/documentation/dev/dependencies.md
+++ b/documentation/dev/dependencies.md
@@ -5,6 +5,7 @@ Single source of truth for native dependencies: what's used, what's not, and how
 ## Contents
 
 - [Active Dependencies](#active-dependencies) — What SkiaSharp actually compiles
+- [Build Source Reports](#build-source-reports) — Runtime evidence for compliance review
 - [cgmanifest.json](#cgmanifestjson) — CVE detection setup
 - [Known False Positives](#known-false-positives) — CVEs that don't affect SkiaSharp
 
@@ -45,6 +46,38 @@ SkiaSharp uses only a subset of Skia's dependencies. Unused dependencies are com
 |------------|---------|-----------|
 | **piex** | RAW preview | All except Windows, WASM |
 | **buildtools** | Compiler toolchain | All |
+
+---
+
+## Build Source Reports
+
+Every SkiaSharp build, test, package, signing, and analysis job in Azure Pipelines enables Git
+Trace2 before checkout and publishes a `source_dependencies_<job>_<attempt>` artifact at the end
+of the job, including failed jobs. The artifact contains:
+
+- `source-dependencies.json` for aggregation and compliance tooling.
+- `source-dependencies.md` for human review.
+
+The report combines three sources so it does not depend on one manifest being complete:
+
+1. Runtime Git events, including Git processes started indirectly by Cake, `git-sync-deps`, and
+   `gclient`.
+2. Remotes and exact revisions from checked-out repositories that remain in the workspace.
+3. Declared repository URLs from `.gitmodules`, `DEPS`, `cgmanifest.json`, Cake files, build
+   scripts, Dockerfiles, and pipeline YAML.
+
+Runtime events are marked `observed`; static-only entries are marked `declared`. The latter expose
+source paths that exist in another platform or target but were not exercised by the current job.
+Container bootstrapper runs write Trace2 data into the mounted workspace so they are included in
+the same report.
+
+The raw Trace2 events can contain command-line details, so they remain in the agent temporary
+directory and are deleted after the sanitized report is generated. Credentials, URL user info,
+queries, and fragments are never copied to the report.
+
+This report intentionally covers source repositories and repository-backed source downloads. It
+does not inventory package feeds, SDK installers, operating-system packages, or arbitrary tool
+downloads; those need a separate software-bill-of-materials or network-egress report.
 
 ---
 

--- a/documentation/dev/dependencies.md
+++ b/documentation/dev/dependencies.md
@@ -63,8 +63,9 @@ The report combines three sources so it does not depend on one manifest being co
 1. Runtime Git events, including Git processes started indirectly by Cake, `git-sync-deps`, and
    `gclient`.
 2. Remotes and exact revisions from checked-out repositories that remain in the workspace.
-3. Declared repository URLs from `.gitmodules`, pinned Skia DEPS identities in
-   `cgmanifest.json`, Cake files, build scripts, Dockerfiles, and pipeline YAML.
+3. Declared repository URLs and revisions from `.gitmodules`, active direct entries in the
+   checked-out Skia `DEPS`, pinned identities in `cgmanifest.json`, Cake files, build scripts,
+   Dockerfiles, and pipeline YAML.
 
 Runtime events are marked `observed`; static-only entries are marked `declared`. The latter expose
 source paths that exist in another platform or target but were not exercised by the current job.

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -527,3 +527,4 @@ jobs:
       - template: /scripts/azure-templates-steps-source-dependencies.yml@self
         parameters:
           mode: finish
+          reportName: ${{ parameters.name }}

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -71,6 +71,12 @@ jobs:
           condition: failed()
           artifactName: ${{ parameters.name }}_failed_$(System.JobAttempt)
           targetPath: 'output'
+        - output: pipelineArtifact
+          displayName: 'Publish the ${{ parameters.name }} source dependency report'
+          condition: always()
+          artifactName: source_dependencies_${{ parameters.name }}_$(System.JobAttempt)
+          targetPath: 'output/source-dependencies/${{ parameters.name }}'
+          isProduction: false
         - ${{ each additionalArtifact in parameters.publishArtifacts }}:
           - output: pipelineArtifact
             displayName: 'Publish the ${{ additionalArtifact.name }} artifacts'
@@ -86,6 +92,10 @@ jobs:
               targetPath: ${{ additionalArtifact.path }}
 
     steps:
+      - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+        parameters:
+          mode: start
+
       - pwsh: if ($IsLinux -or $IsMacOS) { df -h } else { Get-Volume }
         displayName: Get the volume information before the run
         condition: always()
@@ -450,7 +460,8 @@ jobs:
                 echo dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }} >> cmd.sh
                 sed -i 's/--gnArgs=\" \"//' cmd.sh
                 cat cmd.sh
-                : > docker.env
+                mkdir -p .source-dependency-trace
+                printf 'GIT_TRACE2_EVENT=/work/.source-dependency-trace\nGIT_TRACE_REDACT=1\n' > docker.env
               displayName: Generate the script for the Docker image
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - ${{ each pair in parameters.env }}:
@@ -477,7 +488,10 @@ jobs:
                 'dotnet cake --target=${{ parameters.target }} --verbosity=${{ parameters.verbosity }} --configuration=${{ coalesce(parameters.configuration, 'Release') }} ${{ parameters.additionalArgs }}' | Add-Content cmd.cmd -Encoding ascii
                 Get-Content cmd.cmd
                 # Docker's env-file parser keeps a trailing CR as part of the value, so write LF only.
-                [IO.File]::WriteAllText("$PWD/docker.env", "")
+                [IO.Directory]::CreateDirectory("$PWD/.source-dependency-trace") | Out-Null
+                [IO.File]::WriteAllText(
+                  "$PWD/docker.env",
+                  "GIT_TRACE2_EVENT=C:\work\.source-dependency-trace`nGIT_TRACE_REDACT=1`n")
               displayName: Generate the script for the Docker image
               condition: and(succeeded(), ne(variables['CACHE_SKIP'], 'true'))
             - ${{ each pair in parameters.env }}:
@@ -509,3 +523,7 @@ jobs:
       - pwsh: .\scripts\infra\native\shared\get-free-space.ps1
         displayName: Get the volume information after the entire run
         condition: always()
+
+      - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+        parameters:
+          mode: finish

--- a/scripts/azure-templates-jobs-bootstrapper.yml
+++ b/scripts/azure-templates-jobs-bootstrapper.yml
@@ -146,6 +146,11 @@ jobs:
         - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
           displayName: Configure build variables
 
+      # Create this on the host before a root container creates output/ with restrictive ownership.
+      - pwsh: New-Item 'output/source-dependencies/${{ parameters.name }}' -ItemType Directory -Force | Out-Null
+        displayName: Prepare source dependency report directory
+        condition: always()
+
       # Native source builds only use Skia and depot_tools. Merge-only jobs use no submodules.
       - ${{ if and(startsWith(parameters.name, 'native_'), ne(parameters.skipSteps, 'true')) }}:
         - pwsh: git submodule update --init --recursive externals/skia externals/depot_tools

--- a/scripts/azure-templates-stages-apiscan.yml
+++ b/scripts/azure-templates-stages-apiscan.yml
@@ -142,3 +142,4 @@ stages:
           - template: /scripts/azure-templates-steps-source-dependencies.yml@self
             parameters:
               mode: finish
+              reportName: api_scan

--- a/scripts/azure-templates-stages-apiscan.yml
+++ b/scripts/azure-templates-stages-apiscan.yml
@@ -13,7 +13,18 @@ stages:
         pool: ${{ parameters.buildAgentWindows.pool }}
         workspace:
           clean: all
+        templateContext:
+          outputs:
+            - output: pipelineArtifact
+              displayName: Publish API Scan source dependency report
+              artifactName: source_dependencies_api_scan_$(System.JobAttempt)
+              targetPath: output/source-dependencies/api_scan
+              condition: always()
+              isProduction: false
         steps:
+          - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+            parameters:
+              mode: start
           - checkout: self
             submodules: false
             fetchDepth: 1
@@ -127,3 +138,7 @@ stages:
               GdnBreakPolicyMinSev: Note
               GdnBreakSuppressionFiles: $(Build.SourcesDirectory)\scripts\infra\security\source.gdnsuppress
               GdnBreakSuppressionSets: default
+
+          - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+            parameters:
+              mode: finish

--- a/scripts/azure-templates-stages-prepare.yml
+++ b/scripts/azure-templates-stages-prepare.yml
@@ -9,7 +9,18 @@ stages:
       - job: prepare
         displayName: Prepare Build
         pool: ${{ parameters.buildAgentHost.pool }}
+        templateContext:
+          outputs:
+            - output: pipelineArtifact
+              displayName: Publish prepare source dependency report
+              artifactName: source_dependencies_prepare_$(System.JobAttempt)
+              targetPath: output/source-dependencies/prepare
+              condition: always()
+              isProduction: false
         steps:
+          - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+            parameters:
+              mode: start
           - checkout: self
             submodules: false
             fetchDepth: 1
@@ -19,6 +30,8 @@ stages:
             displayName: Validate build identity rules
           - pwsh: ./scripts/infra/security/tests/PrepareApiScanInputs.Tests.ps1
             displayName: Validate API Scan input preparation
+          - pwsh: ./scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
+            displayName: Validate source dependency reporting
           - bash: python3 scripts/infra/caching/repo-deps.py validate
             displayName: Validate cache config coverage
           - bash: |
@@ -31,3 +44,6 @@ stages:
               python3 scripts/infra/caching/repo-deps.py cache-key \
                 --job all --name prepare ${BASE:+--base "$BASE"}
             displayName: Show dependency tree
+          - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+            parameters:
+              mode: finish

--- a/scripts/azure-templates-stages-prepare.yml
+++ b/scripts/azure-templates-stages-prepare.yml
@@ -47,3 +47,4 @@ stages:
           - template: /scripts/azure-templates-steps-source-dependencies.yml@self
             parameters:
               mode: finish
+              reportName: prepare

--- a/scripts/azure-templates-stages-signing.yml
+++ b/scripts/azure-templates-stages-signing.yml
@@ -92,6 +92,7 @@ stages:
             - template: /scripts/azure-templates-steps-source-dependencies.yml@self
               parameters:
                 mode: finish
+                reportName: sign_nugets
 
   - ${{ if eq(parameters.publishAssets, true) }}:
     - stage: publish_assets
@@ -160,6 +161,7 @@ stages:
               - template: /scripts/azure-templates-steps-source-dependencies.yml@self
                 parameters:
                   mode: finish
+                  reportName: generate_arcade_manifest
 
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:

--- a/scripts/azure-templates-stages-signing.yml
+++ b/scripts/azure-templates-stages-signing.yml
@@ -48,7 +48,16 @@ stages:
                 artifactName: arcade_shipping_signed
                 targetPath: '$(Build.SourcesDirectory)\artifacts\packages\Release\Shipping'
                 condition: succeeded()
+              - output: pipelineArtifact
+                displayName: Publish signing source dependency report
+                artifactName: source_dependencies_sign_nugets_$(System.JobAttempt)
+                targetPath: '$(Build.SourcesDirectory)\output\source-dependencies\sign_nugets'
+                condition: always()
+                isProduction: false
           preSteps:
+            - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+              parameters:
+                mode: start
             - checkout: self
               clean: true
               fetchDepth: 1
@@ -80,6 +89,10 @@ stages:
               env:
                 SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+            - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+              parameters:
+                mode: finish
+
   - ${{ if eq(parameters.publishAssets, true) }}:
     - stage: publish_assets
       displayName: Register Arcade assets
@@ -98,7 +111,18 @@ stages:
               publish:
                 logs:
                   name: arcade_publish_logs
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  displayName: Publish Arcade manifest source dependency report
+                  artifactName: source_dependencies_generate_arcade_manifest_$(System.JobAttempt)
+                  targetPath: '$(Build.SourcesDirectory)\output\source-dependencies\generate_arcade_manifest'
+                  condition: always()
+                  isProduction: false
             preSteps:
+              - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+                parameters:
+                  mode: start
               - checkout: self
                 clean: true
                 fetchDepth: 1
@@ -132,6 +156,10 @@ stages:
                 displayName: Generate Arcade V3 asset manifest
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+              - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+                parameters:
+                  mode: finish
 
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -668,6 +668,7 @@ stages:
             - template: /scripts/azure-templates-steps-source-dependencies.yml@self
               parameters:
                 mode: finish
+                reportName: coverage_reports
 
     - stage: samples
       displayName: Samples

--- a/scripts/azure-templates-stages-test.yml
+++ b/scripts/azure-templates-stages-test.yml
@@ -630,7 +630,18 @@ stages:
             - tests_netcore_windows
             - tests_netcore_macos
             - tests_netcore_linux
+          templateContext:
+            outputs:
+              - output: pipelineArtifact
+                displayName: Publish coverage source dependency report
+                artifactName: source_dependencies_coverage_reports_$(System.JobAttempt)
+                targetPath: output/source-dependencies/coverage_reports
+                condition: always()
+                isProduction: false
           steps:
+            - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+              parameters:
+                mode: start
             - checkout: self
             - pwsh: ./scripts/infra/native/shared/set-build-variables.ps1
               displayName: Configure build variables
@@ -654,6 +665,9 @@ stages:
               inputs:
                 codeCoverageTool: Cobertura
                 summaryFileLocation: 'output/**/Cobertura.xml'
+            - template: /scripts/azure-templates-steps-source-dependencies.yml@self
+              parameters:
+                mode: finish
 
     - stage: samples
       displayName: Samples

--- a/scripts/azure-templates-steps-source-dependencies.yml
+++ b/scripts/azure-templates-steps-source-dependencies.yml
@@ -4,6 +4,9 @@ parameters:
     values:
       - start
       - finish
+  - name: reportName
+    type: string
+    default: ''
 
 steps:
   - ${{ if eq(parameters.mode, 'start') }}:
@@ -24,7 +27,8 @@ steps:
         -Finish
         -TraceDirectory "$(SOURCE_DEPENDENCY_TRACE_DIRECTORY)"
         -RepositoryRoot "$(Build.SourcesDirectory)"
-        -ReportDirectory "$(Build.SourcesDirectory)/output/source-dependencies/$(System.JobName)"
+        -ReportDirectory "$(Build.SourcesDirectory)/output/source-dependencies/${{ parameters.reportName }}"
+        -JobName "${{ parameters.reportName }}"
         -RequireTrace
       displayName: Create source dependency report
       condition: always()

--- a/scripts/azure-templates-steps-source-dependencies.yml
+++ b/scripts/azure-templates-steps-source-dependencies.yml
@@ -1,0 +1,30 @@
+parameters:
+  - name: mode
+    type: string
+    values:
+      - start
+      - finish
+
+steps:
+  - ${{ if eq(parameters.mode, 'start') }}:
+    - pwsh: |
+        $traceDirectory = Join-Path `
+          $env:AGENT_TEMPDIRECTORY `
+          "skiasharp-source-dependencies-$env:SYSTEM_JOBID-$env:SYSTEM_JOBATTEMPT"
+        New-Item $traceDirectory -ItemType Directory -Force | Out-Null
+        Write-Host "##vso[task.setvariable variable=SOURCE_DEPENDENCY_TRACE_DIRECTORY]$traceDirectory"
+        Write-Host "##vso[task.setvariable variable=GIT_TRACE2_EVENT]$traceDirectory"
+        Write-Host "##vso[task.setvariable variable=GIT_TRACE_REDACT]1"
+        Write-Host "Git source dependency tracing enabled at '$traceDirectory'."
+      displayName: Start source dependency capture
+
+  - ${{ if eq(parameters.mode, 'finish') }}:
+    - pwsh: >
+        ./scripts/infra/security/source-dependency-report.ps1
+        -Finish
+        -TraceDirectory "$(SOURCE_DEPENDENCY_TRACE_DIRECTORY)"
+        -RepositoryRoot "$(Build.SourcesDirectory)"
+        -ReportDirectory "$(Build.SourcesDirectory)/output/source-dependencies/$(System.JobName)"
+        -RequireTrace
+      displayName: Create source dependency report
+      condition: always()

--- a/scripts/infra/security/source-dependency-report.ps1
+++ b/scripts/infra/security/source-dependency-report.ps1
@@ -332,6 +332,25 @@ $sessionOperations = @{}
 $traceWorktrees = [Collections.Generic.HashSet[string]]::new(
     [StringComparer]::OrdinalIgnoreCase)
 
+function ConvertTo-HostWorktreePath {
+    param([Parameter(Mandatory)][string] $Path)
+
+    if ($Path -eq '/work') {
+        return $RepositoryRoot
+    }
+    if ($Path.StartsWith('/work/', [StringComparison]::Ordinal)) {
+        return [IO.Path]::GetFullPath(
+            (Join-Path $RepositoryRoot $Path.Substring('/work/'.Length)))
+    }
+    if ($Path -match '^[A-Za-z]:[\\/]work(?:[\\/](?<relative>.*))?$') {
+        if ([string]::IsNullOrWhiteSpace($Matches.relative)) {
+            return $RepositoryRoot
+        }
+        return [IO.Path]::GetFullPath((Join-Path $RepositoryRoot $Matches.relative))
+    }
+    return [IO.Path]::GetFullPath($Path)
+}
+
 foreach ($directory in @($traceDirectories | Select-Object -Unique)) {
     if (-not (Test-Path $directory -PathType Container)) {
         continue
@@ -354,7 +373,7 @@ foreach ($directory in @($traceDirectories | Select-Object -Unique)) {
             if ($event.event -eq 'def_repo' -and
                 $event.PSObject.Properties.Name -contains 'worktree' -and
                 -not [string]::IsNullOrWhiteSpace($event.worktree)) {
-                $traceWorktrees.Add([IO.Path]::GetFullPath($event.worktree)) | Out-Null
+                $traceWorktrees.Add((ConvertTo-HostWorktreePath $event.worktree)) | Out-Null
                 continue
             }
 
@@ -444,6 +463,7 @@ foreach ($worktree in $traceWorktrees) {
 Add-GitWorktreeChildren (Join-Path $RepositoryRoot 'externals')
 Add-GitWorktreeChildren (Join-Path $RepositoryRoot 'externals/skia/third_party/externals')
 Add-GitWorktreeCandidate (Join-Path $RepositoryRoot 'externals/skia/buildtools')
+Add-GitWorktreeChildren (Join-Path $RepositoryRoot 'externals/skia/buildtools')
 
 foreach ($line in Invoke-Git $RepositoryRoot @('submodule', 'status', '--recursive')) {
     if ($line -match '^.?[0-9a-f]{40}\s+(?<path>.+?)(?:\s+\(.+\))?$') {

--- a/scripts/infra/security/source-dependency-report.ps1
+++ b/scripts/infra/security/source-dependency-report.ps1
@@ -1,0 +1,652 @@
+[CmdletBinding(DefaultParameterSetName = 'Finish')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Start')]
+    [switch] $Start,
+
+    [Parameter(Mandatory, ParameterSetName = 'Finish')]
+    [switch] $Finish,
+
+    [Parameter(ParameterSetName = 'Start')]
+    [Parameter(ParameterSetName = 'Finish')]
+    [string[]] $TraceDirectory,
+
+    [Parameter(ParameterSetName = 'Finish')]
+    [string] $RepositoryRoot,
+
+    [Parameter(ParameterSetName = 'Finish')]
+    [string] $ReportDirectory,
+
+    [Parameter(ParameterSetName = 'Finish')]
+    [switch] $RequireTrace,
+
+    [Parameter(ParameterSetName = 'Finish')]
+    [switch] $KeepTrace
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function ConvertTo-AzurePipelinesValue {
+    param([Parameter(Mandatory)][string] $Value)
+
+    return $Value.
+        Replace('%', '%AZP25').
+        Replace("`r", '%0D').
+        Replace("`n", '%0A').
+        Replace(']', '%5D')
+}
+
+function Get-DefaultTraceDirectory {
+    $tempDirectory = $env:AGENT_TEMPDIRECTORY
+    if ([string]::IsNullOrWhiteSpace($tempDirectory)) {
+        $tempDirectory = [IO.Path]::GetTempPath()
+    }
+
+    $jobId = if ([string]::IsNullOrWhiteSpace($env:SYSTEM_JOBID)) {
+        [Guid]::NewGuid().ToString('N')
+    } else {
+        $env:SYSTEM_JOBID
+    }
+    $attempt = if ([string]::IsNullOrWhiteSpace($env:SYSTEM_JOBATTEMPT)) {
+        '1'
+    } else {
+        $env:SYSTEM_JOBATTEMPT
+    }
+
+    return Join-Path $tempDirectory "skiasharp-source-dependencies-$jobId-$attempt"
+}
+
+if ($Start) {
+    $tracePath = if ($TraceDirectory.Count -gt 0) {
+        $TraceDirectory[0]
+    } else {
+        Get-DefaultTraceDirectory
+    }
+    $tracePath = [IO.Path]::GetFullPath($tracePath)
+    New-Item $tracePath -ItemType Directory -Force | Out-Null
+
+    $escapedPath = ConvertTo-AzurePipelinesValue $tracePath
+    Write-Host "##vso[task.setvariable variable=SOURCE_DEPENDENCY_TRACE_DIRECTORY]$escapedPath"
+    Write-Host "##vso[task.setvariable variable=GIT_TRACE2_EVENT]$escapedPath"
+    Write-Host '##vso[task.setvariable variable=GIT_TRACE_REDACT]1'
+    Write-Host "Git source dependency tracing enabled at '$tracePath'."
+    return
+}
+
+function Get-EnvironmentValue {
+    param([Parameter(Mandatory)][string] $Name)
+
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ($null -eq $value) {
+        return ''
+    }
+    return $value
+}
+
+function Get-SourceUrlCandidates {
+    param([Parameter(Mandatory)][AllowEmptyString()][string] $Text)
+
+    $pattern = '(?i)(?:https?|ssh|git)://[^\s''"`<>]+|[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:[^\s''"`<>]+'
+    foreach ($match in [regex]::Matches($Text, $pattern)) {
+        $match.Value.TrimEnd('.', ',', ';', ':', ')', ']', '}')
+    }
+}
+
+function ConvertTo-CanonicalSourceUrl {
+    param(
+        [Parameter(Mandatory)][string] $Candidate,
+        [switch] $FromGit
+    )
+
+    $value = $Candidate.Trim().Trim("'`"")
+    if ($value -match '^(?<user>[A-Za-z0-9._-]+)@(?<host>[A-Za-z0-9.-]+):(?<path>.+)$') {
+        $value = "ssh://$($Matches.user)@$($Matches.host)/$($Matches.path)"
+    }
+
+    if ($value -notmatch '^(?<scheme>https?|ssh|git)://(?<remainder>.+)$') {
+        return $null
+    }
+
+    $scheme = $Matches.scheme.ToLowerInvariant()
+    $remainder = $Matches.remainder
+    $slash = $remainder.IndexOf('/')
+    if ($slash -lt 0) {
+        return $null
+    }
+
+    $authority = $remainder.Substring(0, $slash)
+    $path = ($remainder.Substring($slash) -split '[?#]', 2)[0].TrimEnd('/')
+    if ($authority.Contains('@')) {
+        $authority = $authority.Substring($authority.LastIndexOf('@') + 1)
+    }
+    $sourceHost = $authority.Split(':')[0].ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($sourceHost) -or [string]::IsNullOrWhiteSpace($path)) {
+        return $null
+    }
+
+    $sourceHosts = @(
+        'bitbucket.org',
+        'codeload.github.com',
+        'github.com',
+        'gitlab.com',
+        'raw.githubusercontent.com',
+        'ssh.dev.azure.com'
+    )
+    $isSourceHost =
+        $sourceHosts -contains $sourceHost -or
+        $sourceHost.EndsWith('.googlesource.com', [StringComparison]::OrdinalIgnoreCase) -or
+        $sourceHost.EndsWith('.visualstudio.com', [StringComparison]::OrdinalIgnoreCase) -or
+        $sourceHost -eq 'dev.azure.com'
+    if (-not $FromGit -and -not $isSourceHost) {
+        return $null
+    }
+
+    $segments = @($path.Trim('/').Split('/', [StringSplitOptions]::RemoveEmptyEntries))
+    if ($sourceHost -in @('github.com', 'raw.githubusercontent.com', 'codeload.github.com')) {
+        if ($segments.Count -lt 2) {
+            return $null
+        }
+        $owner = $segments[0]
+        $repository = $segments[1].Split('@')[0] -replace '\.git$', ''
+        if ($owner -match '[$\{\}]' -or $repository -match '[$\{\}]') {
+            return $null
+        }
+        return "https://github.com/$owner/$repository"
+    }
+
+    if ($sourceHost -eq 'bitbucket.org') {
+        if ($segments.Count -lt 2) {
+            return $null
+        }
+        $repository = $segments[1].Split('@')[0] -replace '\.git$', ''
+        return "https://bitbucket.org/$($segments[0])/$repository"
+    }
+
+    if ($sourceHost -eq 'gitlab.com') {
+        $marker = [Array]::IndexOf($segments, '-')
+        if ($marker -gt 0) {
+            $segments = @($segments[0..($marker - 1)])
+        }
+        if ($segments.Count -lt 2) {
+            return $null
+        }
+        $segments[$segments.Count - 1] =
+            $segments[$segments.Count - 1].Split('@')[0] -replace '\.git$', ''
+        return "https://gitlab.com/$($segments -join '/')"
+    }
+
+    if ($sourceHost -eq 'dev.azure.com' -and
+        $path -match '^/(?<org>[^/]+)/(?<project>[^/]+)/_git/(?<repo>[^/]+)') {
+        $repo = $Matches.repo.Split('@')[0] -replace '\.git$', ''
+        return "https://dev.azure.com/$($Matches.org)/$($Matches.project)/_git/$repo"
+    }
+    if ($sourceHost -eq 'dev.azure.com') {
+        return $null
+    }
+
+    if ($sourceHost -eq 'ssh.dev.azure.com' -and
+        $path -match '^/v3/(?<org>[^/]+)/(?<project>[^/]+)/(?<repo>[^/]+)') {
+        $repo = $Matches.repo.Split('@')[0] -replace '\.git$', ''
+        return "https://dev.azure.com/$($Matches.org)/$($Matches.project)/_git/$repo"
+    }
+
+    if ($sourceHost.EndsWith('.googlesource.com', [StringComparison]::OrdinalIgnoreCase)) {
+        $path = $path.Split('@')[0]
+        $plus = $path.IndexOf('/+')
+        if ($plus -ge 0) {
+            $path = $path.Substring(0, $plus)
+        }
+        $path = $path -replace '\.git$', ''
+        return "https://$sourceHost$path"
+    }
+
+    $path = $path.Split('@')[0] -replace '\.git$', ''
+    return "${scheme}://$sourceHost$path"
+}
+
+function Get-SourceHost {
+    param([Parameter(Mandatory)][string] $Url)
+
+    if ($Url -match '^[a-z]+://(?<host>[^/]+)') {
+        return $Matches.host
+    }
+    return ''
+}
+
+$records = @{}
+
+function Add-SourceRecord {
+    param(
+        [Parameter(Mandatory)][string] $Url,
+        [Parameter(Mandatory)][ValidateSet('observed', 'declared')][string] $Detection,
+        [Parameter(Mandatory)][string] $Kind,
+        [string] $Operation,
+        [string] $Path,
+        [int] $Line,
+        [string] $Revision
+    )
+
+    if (-not $records.ContainsKey($Url)) {
+        $records[$Url] = @{
+            Url = $Url
+            Host = Get-SourceHost $Url
+            Observed = $false
+            Declared = $false
+            Operations = [Collections.Generic.HashSet[string]]::new(
+                [StringComparer]::OrdinalIgnoreCase)
+            Revisions = [Collections.Generic.HashSet[string]]::new(
+                [StringComparer]::OrdinalIgnoreCase)
+            Evidence = @{}
+        }
+    }
+
+    $record = $records[$Url]
+    if ($Detection -eq 'observed') {
+        $record.Observed = $true
+    } else {
+        $record.Declared = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Operation)) {
+        $record.Operations.Add($Operation) | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Revision)) {
+        $record.Revisions.Add($Revision) | Out-Null
+    }
+
+    $evidenceKey = "$Kind|$Operation|$Path|$Line"
+    if (-not $record.Evidence.ContainsKey($evidenceKey)) {
+        $evidence = [ordered]@{ kind = $Kind }
+        if (-not [string]::IsNullOrWhiteSpace($Operation)) {
+            $evidence.operation = $Operation
+        }
+        if (-not [string]::IsNullOrWhiteSpace($Path)) {
+            $evidence.path = $Path
+        }
+        if ($Line -gt 0) {
+            $evidence.line = $Line
+        }
+        $record.Evidence[$evidenceKey] = $evidence
+    }
+}
+
+function Get-GitOperation {
+    param([Parameter(Mandatory)][string] $Command)
+
+    foreach ($operation in @('clone', 'fetch', 'pull', 'submodule', 'ls-remote')) {
+        if ($Command -match "(?i)(?:^|\s)$([regex]::Escape($operation))(?:\s|$)") {
+            return $operation
+        }
+    }
+    return 'transport'
+}
+
+if ([string]::IsNullOrWhiteSpace($RepositoryRoot)) {
+    $RepositoryRoot = Get-EnvironmentValue 'BUILD_SOURCESDIRECTORY'
+}
+if ([string]::IsNullOrWhiteSpace($RepositoryRoot)) {
+    $RepositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../../..'))
+} else {
+    $RepositoryRoot = [IO.Path]::GetFullPath($RepositoryRoot)
+}
+
+if ([string]::IsNullOrWhiteSpace($ReportDirectory)) {
+    $ReportDirectory = Join-Path $RepositoryRoot 'output/source-dependencies'
+}
+$ReportDirectory = [IO.Path]::GetFullPath($ReportDirectory)
+
+$traceDirectories = [Collections.Generic.List[string]]::new()
+foreach ($directory in @($TraceDirectory)) {
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        $traceDirectories.Add([IO.Path]::GetFullPath($directory))
+    }
+}
+if ($traceDirectories.Count -eq 0) {
+    $environmentTrace = Get-EnvironmentValue 'SOURCE_DEPENDENCY_TRACE_DIRECTORY'
+    if (-not [string]::IsNullOrWhiteSpace($environmentTrace)) {
+        $traceDirectories.Add([IO.Path]::GetFullPath($environmentTrace))
+    }
+}
+$containerTrace = Join-Path $RepositoryRoot '.source-dependency-trace'
+if (Test-Path $containerTrace -PathType Container) {
+    $traceDirectories.Add([IO.Path]::GetFullPath($containerTrace))
+}
+
+$traceFileCount = 0
+$traceEventCount = 0
+$malformedTraceLineCount = 0
+$sessionOperations = @{}
+$traceWorktrees = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase)
+
+foreach ($directory in @($traceDirectories | Select-Object -Unique)) {
+    if (-not (Test-Path $directory -PathType Container)) {
+        continue
+    }
+
+    foreach ($file in Get-ChildItem $directory -File -Recurse -Force -ErrorAction SilentlyContinue) {
+        $traceFileCount++
+        foreach ($line in [IO.File]::ReadLines($file.FullName)) {
+            if ([string]::IsNullOrWhiteSpace($line)) {
+                continue
+            }
+            try {
+                $event = $line | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                $malformedTraceLineCount++
+                continue
+            }
+            $traceEventCount++
+
+            if ($event.event -eq 'def_repo' -and
+                $event.PSObject.Properties.Name -contains 'worktree' -and
+                -not [string]::IsNullOrWhiteSpace($event.worktree)) {
+                $traceWorktrees.Add([IO.Path]::GetFullPath($event.worktree)) | Out-Null
+                continue
+            }
+
+            if ($event.event -notin @('start', 'child_start', 'exec')) {
+                continue
+            }
+
+            $arguments = @($event.argv)
+            if ($arguments.Count -eq 0) {
+                continue
+            }
+            $command = $arguments -join ' '
+            $operation = Get-GitOperation $command
+            if ($event.PSObject.Properties.Name -contains 'sid' -and
+                -not [string]::IsNullOrWhiteSpace($event.sid)) {
+                if ($event.event -eq 'start') {
+                    $sessionOperations[$event.sid] = $operation
+                } elseif ($sessionOperations.ContainsKey($event.sid)) {
+                    $operation = $sessionOperations[$event.sid]
+                }
+            }
+
+            foreach ($candidate in Get-SourceUrlCandidates $command) {
+                $url = ConvertTo-CanonicalSourceUrl $candidate -FromGit
+                if ($null -ne $url) {
+                    Add-SourceRecord $url observed 'git-trace' $operation
+                }
+            }
+        }
+    }
+}
+
+foreach ($variable in @('BUILD_REPOSITORY_URI', 'SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI')) {
+    $candidate = Get-EnvironmentValue $variable
+    if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+        $url = ConvertTo-CanonicalSourceUrl $candidate -FromGit
+        if ($null -ne $url) {
+            Add-SourceRecord $url observed 'pipeline' 'checkout'
+        }
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory)][string] $WorkingDirectory,
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $output = @(& git -C $WorkingDirectory @Arguments 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return @()
+    }
+    return $output
+}
+
+$worktreeSet = [Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase)
+$worktreeSet.Add($RepositoryRoot) | Out-Null
+foreach ($worktree in $traceWorktrees) {
+    if ($worktree.StartsWith($RepositoryRoot, [StringComparison]::OrdinalIgnoreCase) -and
+        (Test-Path (Join-Path $worktree '.git'))) {
+        $worktreeSet.Add($worktree) | Out-Null
+    }
+}
+foreach ($line in Invoke-Git $RepositoryRoot @('submodule', 'status', '--recursive')) {
+    if ($line -match '^.?[0-9a-f]{40}\s+(?<path>.+?)(?:\s+\(.+\))?$') {
+        $worktree = [IO.Path]::GetFullPath((Join-Path $RepositoryRoot $Matches.path))
+        if (Test-Path (Join-Path $worktree '.git')) {
+            $worktreeSet.Add($worktree) | Out-Null
+        }
+    }
+}
+
+$worktrees = @($worktreeSet | Sort-Object)
+foreach ($worktree in $worktrees) {
+    $relativePath = [IO.Path]::GetRelativePath($RepositoryRoot, $worktree).
+        Replace('\', '/')
+    if ($relativePath -eq '.') {
+        $relativePath = '.'
+    }
+    $revision = (Invoke-Git $worktree @('rev-parse', 'HEAD') | Select-Object -First 1)
+    foreach ($remote in Invoke-Git $worktree @('config', '--get', 'remote.origin.url')) {
+        $url = ConvertTo-CanonicalSourceUrl $remote -FromGit
+        if ($null -ne $url) {
+            Add-SourceRecord $url observed 'workspace' 'present' $relativePath 0 $revision
+        }
+    }
+}
+
+function Add-DeclarationsFromFile {
+    param(
+        [Parameter(Mandatory)][string] $File,
+        [Parameter(Mandatory)][string] $DisplayPath
+    )
+
+    $lineNumber = 0
+    foreach ($line in [IO.File]::ReadLines($File)) {
+        $lineNumber++
+        foreach ($candidate in Get-SourceUrlCandidates $line) {
+            $url = ConvertTo-CanonicalSourceUrl $candidate
+            if ($null -ne $url) {
+                Add-SourceRecord $url declared 'declaration' '' $DisplayPath $lineNumber
+            }
+        }
+    }
+}
+
+$declarationFiles = @{}
+foreach ($worktree in $worktrees) {
+    foreach ($name in @('.gitmodules', 'DEPS')) {
+        $path = Join-Path $worktree $name
+        if (Test-Path $path -PathType Leaf) {
+            $displayPath = [IO.Path]::GetRelativePath($RepositoryRoot, $path).
+                Replace('\', '/')
+            $declarationFiles[$path] = $displayPath
+        }
+    }
+}
+
+foreach ($trackedFile in Invoke-Git $RepositoryRoot @('ls-files')) {
+    $normalized = $trackedFile.Replace('\', '/')
+    $extension = [IO.Path]::GetExtension($normalized)
+    $isBuildFile =
+        $normalized -eq 'build.cake' -or
+        $normalized.StartsWith('native/', [StringComparison]::Ordinal) -or
+        $normalized.StartsWith('scripts/', [StringComparison]::Ordinal)
+    $isTestFixture =
+        $normalized.Contains('/tests/', [StringComparison]::OrdinalIgnoreCase) -or
+        [IO.Path]::GetFileName($normalized).Contains('.Tests.', [StringComparison]::OrdinalIgnoreCase)
+    $isScannable =
+        $extension -in @('.cake', '.ps1', '.py', '.sh', '.yaml', '.yml') -or
+        [IO.Path]::GetFileName($normalized) -eq 'Dockerfile'
+    if ($isBuildFile -and $isScannable -and -not $isTestFixture) {
+        $path = Join-Path $RepositoryRoot $trackedFile
+        if (Test-Path $path -PathType Leaf) {
+            $declarationFiles[$path] = $normalized
+        }
+    }
+}
+
+foreach ($entry in $declarationFiles.GetEnumerator()) {
+    Add-DeclarationsFromFile $entry.Key $entry.Value
+}
+
+$componentManifestPath = Join-Path $RepositoryRoot 'cgmanifest.json'
+if (Test-Path $componentManifestPath -PathType Leaf) {
+    $componentManifest = Get-Content $componentManifestPath -Raw | ConvertFrom-Json
+    foreach ($registration in @($componentManifest.registrations)) {
+        $identity = $null
+        $revision = $null
+        if ($registration.PSObject.Properties.Name -contains 'skia_dependency') {
+            $identity = $registration.skia_dependency.version_reviewed_identity
+            $revision = $registration.skia_dependency.revision
+        }
+        if (-not [string]::IsNullOrWhiteSpace($identity)) {
+            $url = ConvertTo-CanonicalSourceUrl $identity
+            if ($null -ne $url) {
+                Add-SourceRecord `
+                    $url `
+                    declared `
+                    'component-manifest' `
+                    '' `
+                    'cgmanifest.json' `
+                    0 `
+                    $revision
+            }
+        }
+
+        if ($registration.component.type -eq 'git') {
+            $url = ConvertTo-CanonicalSourceUrl $registration.component.git.repositoryUrl
+            if ($null -ne $url) {
+                Add-SourceRecord `
+                    $url `
+                    declared `
+                    'component-manifest' `
+                    '' `
+                    'cgmanifest.json' `
+                    0 `
+                    $registration.component.git.commitHash
+            }
+        }
+    }
+}
+
+if ($RequireTrace -and $traceFileCount -eq 0) {
+    throw 'Git Trace2 did not produce any files. The source dependency report would be incomplete.'
+}
+
+$repositoryOutput = @(
+    foreach ($record in @($records.Values | Sort-Object Url)) {
+        [ordered]@{
+            url = $record.Url
+            host = $record.Host
+            status = if ($record.Observed) {
+                if ($record.Declared) { 'observed-and-declared' } else { 'observed' }
+            } else {
+                'declared'
+            }
+            observed = $record.Observed
+            declared = $record.Declared
+            operations = @($record.Operations | Sort-Object)
+            revisions = @($record.Revisions | Sort-Object)
+            evidence = @($record.Evidence.Values | Sort-Object kind, path, line, operation)
+        }
+    }
+)
+
+$observedCount = @($repositoryOutput | Where-Object observed).Count
+$declaredOnlyCount = @($repositoryOutput | Where-Object { -not $_.observed }).Count
+$report = [ordered]@{
+    schemaVersion = 1
+    generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+    scope = 'Git repositories and repository-backed source downloads used or declared by this job'
+    build = [ordered]@{
+        buildId = Get-EnvironmentValue 'BUILD_BUILDID'
+        buildNumber = Get-EnvironmentValue 'BUILD_BUILDNUMBER'
+        jobName = Get-EnvironmentValue 'SYSTEM_JOBNAME'
+        jobAttempt = Get-EnvironmentValue 'SYSTEM_JOBATTEMPT'
+        repository = Get-EnvironmentValue 'BUILD_REPOSITORY_URI'
+        commit = Get-EnvironmentValue 'BUILD_SOURCEVERSION'
+    }
+    coverage = [ordered]@{
+        gitTrace2 = [ordered]@{
+            traceDirectories = $traceDirectories.Count
+            traceFiles = $traceFileCount
+            events = $traceEventCount
+            malformedLines = $malformedTraceLineCount
+        }
+        workspaceRepositories = $worktrees.Count
+        declarationFiles = $declarationFiles.Count
+        observedRepositories = $observedCount
+        declaredOnlyRepositories = $declaredOnlyCount
+        methods = @(
+            'Git Trace2 process events, including indirect Git calls from gclient and build scripts'
+            'Git remotes and exact revisions from repositories remaining in the workspace'
+            'Repository URLs declared in .gitmodules, DEPS, Cake, scripts, Dockerfiles, and pipeline YAML'
+            'Pinned source identities from cgmanifest.json, excluding canonical upstream CVE aliases'
+        )
+        limitations = @(
+            'Package feeds, SDK/tool installers, and arbitrary non-repository HTTP downloads are outside this source-repository report.'
+            'A declared-only repository may belong to a build path that this job did not execute.'
+            'A source URL assembled entirely at runtime is reported when Git observes it; it cannot be recovered statically from an unexecuted path.'
+        )
+    }
+    repositories = $repositoryOutput
+}
+
+New-Item $ReportDirectory -ItemType Directory -Force | Out-Null
+$jsonPath = Join-Path $ReportDirectory 'source-dependencies.json'
+$markdownPath = Join-Path $ReportDirectory 'source-dependencies.md'
+$report | ConvertTo-Json -Depth 8 | Set-Content $jsonPath -Encoding utf8NoBOM
+
+$markdown = [Collections.Generic.List[string]]::new()
+$markdown.Add('# Source dependency report')
+$markdown.Add('')
+$markdown.Add("Job: ``$($report.build.jobName)``; build: ``$($report.build.buildNumber)``; commit: ``$($report.build.commit)``")
+$markdown.Add('')
+$markdown.Add(
+    "Found **$observedCount observed** source repositories and **$declaredOnlyCount declared-only** repositories.")
+$markdown.Add('')
+$markdown.Add('| Repository | Detection | Revision | Evidence |')
+$markdown.Add('|---|---|---|---|')
+foreach ($repository in $repositoryOutput) {
+    $revision = if ($repository.revisions.Count -eq 0) {
+        ''
+    } else {
+        (@($repository.revisions | ForEach-Object {
+            if ($_.Length -gt 12) { $_.Substring(0, 12) } else { $_ }
+        }) -join ', ')
+    }
+    $evidence = @(
+        $repository.evidence | Select-Object -First 6 | ForEach-Object {
+            if ($_.kind -eq 'declaration') {
+                "$($_.path):$($_.line)"
+            } elseif ($_.kind -eq 'workspace') {
+                "workspace:$($_.path)"
+            } elseif ($_.PSObject.Properties.Name -contains 'operation') {
+                "$($_.kind):$($_.operation)"
+            } else {
+                $_.kind
+            }
+        }
+    ) -join ', '
+    $markdown.Add(
+        "| $($repository.url.Replace('|', '\|')) | $($repository.status) | $revision | $($evidence.Replace('|', '\|')) |")
+}
+$markdown.Add('')
+$markdown.Add('## Coverage and limitations')
+$markdown.Add('')
+foreach ($method in $report.coverage.methods) {
+    $markdown.Add("- $method")
+}
+$markdown.Add('')
+foreach ($limitation in $report.coverage.limitations) {
+    $markdown.Add("- $limitation")
+}
+$markdown | Set-Content $markdownPath -Encoding utf8NoBOM
+
+Write-Host "##[section]Source dependency report: $observedCount observed, $declaredOnlyCount declared-only"
+foreach ($repository in $repositoryOutput) {
+    Write-Host "[$($repository.status)] $($repository.url)"
+}
+Write-Host "Reports written to '$ReportDirectory'."
+
+if (-not $KeepTrace) {
+    foreach ($directory in @($traceDirectories | Select-Object -Unique)) {
+        Remove-Item $directory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/infra/security/source-dependency-report.ps1
+++ b/scripts/infra/security/source-dependency-report.ps1
@@ -205,7 +205,7 @@ function ConvertTo-CanonicalSourceUrl {
     }
 
     if ($sourceHost.EndsWith('.googlesource.com', [StringComparison]::OrdinalIgnoreCase)) {
-        $path = $path.Split('@')[0]
+        $path = $path.Split('@')[0].TrimEnd('/')
         $plus = $path.IndexOf('/+')
         if ($plus -ge 0) {
             $path = $path.Substring(0, $plus)
@@ -214,7 +214,7 @@ function ConvertTo-CanonicalSourceUrl {
         return "https://$sourceHost$path"
     }
 
-    $path = $path.Split('@')[0] -replace '\.git$', ''
+    $path = $path.Split('@')[0].TrimEnd('/') -replace '\.git$', ''
     return "${scheme}://$sourceHost$path"
 }
 
@@ -514,6 +514,48 @@ function Add-DeclarationsFromFile {
     }
 }
 
+function Add-ActiveDepsDeclarations {
+    param(
+        [Parameter(Mandatory)][string] $File,
+        [Parameter(Mandatory)][string] $DisplayPath
+    )
+
+    $lineNumber = 0
+    foreach ($line in [IO.File]::ReadLines($File)) {
+        $lineNumber++
+        $trimmed = $line.TrimStart()
+        if ($trimmed.StartsWith('#', [StringComparison]::Ordinal)) {
+            continue
+        }
+
+        $keyMatch = [regex]::Match(
+            $line,
+            '^\s*["'']?(?<key>[^"'':]+)["'']?\s*:')
+        if (-not $keyMatch.Success -or
+            $keyMatch.Groups['key'].Value.Trim() -in @('url', 'condition')) {
+            continue
+        }
+
+        foreach ($candidate in Get-SourceUrlCandidates $line) {
+            if ($candidate -notmatch '@(?<revision>[0-9a-fA-F]{40})(?:$|[/?#])') {
+                continue
+            }
+            $revision = $Matches.revision
+            $url = ConvertTo-CanonicalSourceUrl $candidate
+            if ($null -ne $url) {
+                Add-SourceRecord `
+                    $url `
+                    declared `
+                    'deps-manifest' `
+                    '' `
+                    $DisplayPath `
+                    $lineNumber `
+                    $revision
+            }
+        }
+    }
+}
+
 $declarationFiles = @{}
 foreach ($worktree in $worktrees) {
     foreach ($name in @('.gitmodules')) {
@@ -550,6 +592,11 @@ foreach ($trackedFile in Invoke-Git $RepositoryRoot @('ls-files')) {
 
 foreach ($entry in $declarationFiles.GetEnumerator()) {
     Add-DeclarationsFromFile $entry.Key $entry.Value
+}
+
+$skiaDepsPath = Join-Path $RepositoryRoot 'externals/skia/DEPS'
+if (Test-Path $skiaDepsPath -PathType Leaf) {
+    Add-ActiveDepsDeclarations $skiaDepsPath 'externals/skia/DEPS'
 }
 
 $componentManifestPath = Join-Path $RepositoryRoot 'cgmanifest.json'
@@ -648,7 +695,7 @@ $report = [ordered]@{
         methods = @(
             'Git Trace2 process events, including indirect Git calls from gclient and build scripts'
             'Git remotes and exact revisions from repositories remaining in the workspace'
-            'Repository URLs declared in .gitmodules, Cake, scripts, Dockerfiles, and pipeline YAML'
+            'Repository URLs declared in .gitmodules, active Skia DEPS entries, Cake, scripts, Dockerfiles, and pipeline YAML'
             'Pinned source identities from cgmanifest.json, excluding canonical upstream CVE aliases'
         )
         limitations = @(

--- a/scripts/infra/security/source-dependency-report.ps1
+++ b/scripts/infra/security/source-dependency-report.ps1
@@ -17,6 +17,9 @@ param(
     [string] $ReportDirectory,
 
     [Parameter(ParameterSetName = 'Finish')]
+    [string] $JobName,
+
+    [Parameter(ParameterSetName = 'Finish')]
     [switch] $RequireTrace,
 
     [Parameter(ParameterSetName = 'Finish')]
@@ -88,6 +91,9 @@ function Get-SourceUrlCandidates {
 
     $pattern = '(?i)(?:https?|ssh|git)://[^\s''"`<>]+|[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:[^\s''"`<>]+'
     foreach ($match in [regex]::Matches($Text, $pattern)) {
+        if ($match.Value -match '(?i)\.extraheader(?:=|$)') {
+            continue
+        }
         $match.Value.TrimEnd('.', ',', ';', ':', ')', ']', '}')
     }
 }
@@ -158,6 +164,9 @@ function ConvertTo-CanonicalSourceUrl {
         if ($segments.Count -lt 2) {
             return $null
         }
+        if ($segments[0] -match '[$\{\}]' -or $segments[1] -match '[$\{\}]') {
+            return $null
+        }
         $repository = $segments[1].Split('@')[0] -replace '\.git$', ''
         return "https://bitbucket.org/$($segments[0])/$repository"
     }
@@ -177,6 +186,11 @@ function ConvertTo-CanonicalSourceUrl {
 
     if ($sourceHost -eq 'dev.azure.com' -and
         $path -match '^/(?<org>[^/]+)/(?<project>[^/]+)/_git/(?<repo>[^/]+)') {
+        if ($Matches.org -match '[$\{\}]' -or
+            $Matches.project -match '[$\{\}]' -or
+            $Matches.repo -match '[$\{\}]') {
+            return $null
+        }
         $repo = $Matches.repo.Split('@')[0] -replace '\.git$', ''
         return "https://dev.azure.com/$($Matches.org)/$($Matches.project)/_git/$repo"
     }
@@ -470,10 +484,11 @@ foreach ($trackedFile in Invoke-Git $RepositoryRoot @('ls-files')) {
     $isTestFixture =
         $normalized.Contains('/tests/', [StringComparison]::OrdinalIgnoreCase) -or
         [IO.Path]::GetFileName($normalized).Contains('.Tests.', [StringComparison]::OrdinalIgnoreCase)
+    $isReporter = $normalized -eq 'scripts/infra/security/source-dependency-report.ps1'
     $isScannable =
         $extension -in @('.cake', '.ps1', '.py', '.sh', '.yaml', '.yml') -or
         [IO.Path]::GetFileName($normalized) -eq 'Dockerfile'
-    if ($isBuildFile -and $isScannable -and -not $isTestFixture) {
+    if ($isBuildFile -and $isScannable -and -not $isTestFixture -and -not $isReporter) {
         $path = Join-Path $RepositoryRoot $trackedFile
         if (Test-Path $path -PathType Leaf) {
             $declarationFiles[$path] = $normalized
@@ -550,6 +565,11 @@ $repositoryOutput = @(
 
 $observedCount = @($repositoryOutput | Where-Object observed).Count
 $declaredOnlyCount = @($repositoryOutput | Where-Object { -not $_.observed }).Count
+$effectiveJobName = if ([string]::IsNullOrWhiteSpace($JobName)) {
+    Get-EnvironmentValue 'SYSTEM_JOBNAME'
+} else {
+    $JobName
+}
 $report = [ordered]@{
     schemaVersion = 1
     generatedAtUtc = [DateTime]::UtcNow.ToString('o')
@@ -557,7 +577,7 @@ $report = [ordered]@{
     build = [ordered]@{
         buildId = Get-EnvironmentValue 'BUILD_BUILDID'
         buildNumber = Get-EnvironmentValue 'BUILD_BUILDNUMBER'
-        jobName = Get-EnvironmentValue 'SYSTEM_JOBNAME'
+        jobName = $effectiveJobName
         jobAttempt = Get-EnvironmentValue 'SYSTEM_JOBATTEMPT'
         repository = Get-EnvironmentValue 'BUILD_REPOSITORY_URI'
         commit = Get-EnvironmentValue 'BUILD_SOURCEVERSION'

--- a/scripts/infra/security/source-dependency-report.ps1
+++ b/scripts/infra/security/source-dependency-report.ps1
@@ -412,18 +412,50 @@ function Invoke-Git {
 
 $worktreeSet = [Collections.Generic.HashSet[string]]::new(
     [StringComparer]::OrdinalIgnoreCase)
-$worktreeSet.Add($RepositoryRoot) | Out-Null
+
+function Add-GitWorktreeCandidate {
+    param([Parameter(Mandatory)][string] $Path)
+
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    if (Test-Path (Join-Path $fullPath '.git')) {
+        $worktreeSet.Add($fullPath) | Out-Null
+    }
+}
+
+function Add-GitWorktreeChildren {
+    param([Parameter(Mandatory)][string] $Path)
+
+    if (-not (Test-Path $Path -PathType Container)) {
+        return
+    }
+    foreach ($child in [IO.Directory]::EnumerateDirectories($Path)) {
+        Add-GitWorktreeCandidate $child
+    }
+}
+
+Add-GitWorktreeCandidate $RepositoryRoot
 foreach ($worktree in $traceWorktrees) {
     if ($worktree.StartsWith($RepositoryRoot, [StringComparison]::OrdinalIgnoreCase) -and
         (Test-Path (Join-Path $worktree '.git'))) {
-        $worktreeSet.Add($worktree) | Out-Null
+        Add-GitWorktreeCandidate $worktree
     }
 }
+
+Add-GitWorktreeChildren (Join-Path $RepositoryRoot 'externals')
+Add-GitWorktreeChildren (Join-Path $RepositoryRoot 'externals/skia/third_party/externals')
+Add-GitWorktreeCandidate (Join-Path $RepositoryRoot 'externals/skia/buildtools')
+
 foreach ($line in Invoke-Git $RepositoryRoot @('submodule', 'status', '--recursive')) {
     if ($line -match '^.?[0-9a-f]{40}\s+(?<path>.+?)(?:\s+\(.+\))?$') {
         $worktree = [IO.Path]::GetFullPath((Join-Path $RepositoryRoot $Matches.path))
-        if (Test-Path (Join-Path $worktree '.git')) {
-            $worktreeSet.Add($worktree) | Out-Null
+        Add-GitWorktreeCandidate $worktree
+    }
+}
+foreach ($parentWorktree in @($worktreeSet)) {
+    foreach ($line in Invoke-Git $parentWorktree @('submodule', 'status', '--recursive')) {
+        if ($line -match '^.?[0-9a-f]{40}\s+(?<path>.+?)(?:\s+\(.+\))?$') {
+            $worktree = [IO.Path]::GetFullPath((Join-Path $parentWorktree $Matches.path))
+            Add-GitWorktreeCandidate $worktree
         }
     }
 }
@@ -464,7 +496,7 @@ function Add-DeclarationsFromFile {
 
 $declarationFiles = @{}
 foreach ($worktree in $worktrees) {
-    foreach ($name in @('.gitmodules', 'DEPS')) {
+    foreach ($name in @('.gitmodules')) {
         $path = Join-Path $worktree $name
         if (Test-Path $path -PathType Leaf) {
             $displayPath = [IO.Path]::GetRelativePath($RepositoryRoot, $path).
@@ -596,7 +628,7 @@ $report = [ordered]@{
         methods = @(
             'Git Trace2 process events, including indirect Git calls from gclient and build scripts'
             'Git remotes and exact revisions from repositories remaining in the workspace'
-            'Repository URLs declared in .gitmodules, DEPS, Cake, scripts, Dockerfiles, and pipeline YAML'
+            'Repository URLs declared in .gitmodules, Cake, scripts, Dockerfiles, and pipeline YAML'
             'Pinned source identities from cgmanifest.json, excluding canonical upstream CVE aliases'
         )
         limitations = @(

--- a/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
+++ b/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
@@ -1,0 +1,155 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../../../..'))
+$scriptPath = Join-Path $repoRoot 'scripts/infra/security/source-dependency-report.ps1'
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) "skiasharp-source-report-tests-$([Guid]::NewGuid().ToString('N'))"
+$sourceRoot = Join-Path $testRoot 'source'
+$traceRoot = Join-Path $testRoot 'trace'
+$reportRoot = Join-Path $testRoot 'report'
+
+function Assert-Repository {
+    param(
+        [Parameter(Mandatory)] $Report,
+        [Parameter(Mandatory)][string] $Url,
+        [switch] $Observed,
+        [switch] $Declared
+    )
+
+    $repository = @($Report.repositories | Where-Object url -eq $Url)
+    if ($repository.Count -ne 1) {
+        throw "Expected one '$Url' repository, found $($repository.Count)."
+    }
+    if ($Observed -and -not $repository[0].observed) {
+        throw "Expected '$Url' to be observed."
+    }
+    if ($Declared -and -not $repository[0].declared) {
+        throw "Expected '$Url' to be declared."
+    }
+}
+
+try {
+    New-Item $sourceRoot, $traceRoot -ItemType Directory -Force | Out-Null
+    & git -C $sourceRoot init --quiet
+    & git -C $sourceRoot config user.email source-report@example.invalid
+    & git -C $sourceRoot config user.name 'Source Report Tests'
+    & git -C $sourceRoot remote add origin `
+        'https://build-user:super-secret@github.com/mono/SkiaSharp.git?access_token=do-not-publish'
+
+    @'
+[submodule "depot_tools"]
+    path = externals/depot_tools
+    url = https://chromium.googlesource.com/chromium/tools/depot_tools.git
+'@ | Set-Content (Join-Path $sourceRoot '.gitmodules')
+    @'
+var dawn = "https://github.com/google/dawn/releases/download/{TAG}/source.zip";
+'@ | Set-Content (Join-Path $sourceRoot 'build.cake')
+    $fixtureDirectory = Join-Path $sourceRoot 'scripts/infra/security/tests'
+    New-Item $fixtureDirectory -ItemType Directory -Force | Out-Null
+    'https://dev.azure.com/example/project/_git/test-fixture' |
+        Set-Content (Join-Path $fixtureDirectory 'Fake.Tests.ps1')
+    @'
+{
+  "registrations": [
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "example",
+          "version": "1.0",
+          "downloadUrl": "https://github.com/upstream/not-actually-downloaded"
+        }
+      },
+      "skia_dependency": {
+        "revision": "0123456789abcdef0123456789abcdef01234567",
+        "version_reviewed_identity": "https://skia.googlesource.com/example/source.git@0123456789abcdef0123456789abcdef01234567"
+      }
+    }
+  ]
+}
+'@ | Set-Content (Join-Path $sourceRoot 'cgmanifest.json')
+    & git -C $sourceRoot add .
+    & git -C $sourceRoot commit --quiet -m initial
+
+    @'
+{"event":"start","sid":"clone-session","argv":["git","clone","https://trace-user:trace-password@github.com/google/angle.git?token=hidden","externals/angle"]}
+{"event":"child_start","sid":"fetch-session","child_class":"transport/https","argv":["git","remote-https","origin","https://github.com/emscripten-core/emsdk.git"]}
+not-json
+'@ | Set-Content (Join-Path $traceRoot 'trace-event')
+
+    $startTrace = Join-Path $testRoot 'start-trace'
+    $startOutput = & $scriptPath -Start -TraceDirectory $startTrace 6>&1 | Out-String
+    if ($startOutput -notmatch 'variable=GIT_TRACE2_EVENT') {
+        throw 'Start mode did not configure Git Trace2.'
+    }
+    if (-not (Test-Path $startTrace -PathType Container)) {
+        throw 'Start mode did not create the trace directory.'
+    }
+
+    & $scriptPath `
+        -Finish `
+        -TraceDirectory $traceRoot `
+        -RepositoryRoot $sourceRoot `
+        -ReportDirectory $reportRoot `
+        -RequireTrace
+
+    $jsonPath = Join-Path $reportRoot 'source-dependencies.json'
+    $markdownPath = Join-Path $reportRoot 'source-dependencies.md'
+    if (-not (Test-Path $jsonPath -PathType Leaf) -or
+        -not (Test-Path $markdownPath -PathType Leaf)) {
+        throw 'The JSON and Markdown reports were not both created.'
+    }
+
+    $json = Get-Content $jsonPath -Raw
+    if ($json -match 'super-secret|trace-password|access_token|token=hidden') {
+        throw 'The report leaked credentials or URL query parameters.'
+    }
+    $report = $json | ConvertFrom-Json
+    if ($report.schemaVersion -ne 1) {
+        throw "Unexpected schema version '$($report.schemaVersion)'."
+    }
+    if ($report.coverage.gitTrace2.traceFiles -ne 1 -or
+        $report.coverage.gitTrace2.malformedLines -ne 1) {
+        throw 'Trace coverage counters are incorrect.'
+    }
+
+    Assert-Repository $report 'https://github.com/mono/SkiaSharp' -Observed
+    Assert-Repository $report 'https://github.com/google/angle' -Observed
+    Assert-Repository $report 'https://github.com/emscripten-core/emsdk' -Observed
+    Assert-Repository $report 'https://github.com/google/dawn' -Declared
+    Assert-Repository $report `
+        'https://chromium.googlesource.com/chromium/tools/depot_tools' `
+        -Declared
+    Assert-Repository $report 'https://skia.googlesource.com/example/source' -Declared
+    if (@($report.repositories | Where-Object {
+        $_.url -in @(
+            'https://dev.azure.com/example/project/_git/test-fixture'
+            'https://github.com/upstream/not-actually-downloaded'
+        )
+    }).Count -ne 0) {
+        throw 'Test fixtures or canonical CVE aliases leaked into source declarations.'
+    }
+
+    if (Test-Path $traceRoot) {
+        throw 'Raw Trace2 data was not removed after report generation.'
+    }
+
+    $missingTraceRejected = $false
+    try {
+        & $scriptPath `
+            -Finish `
+            -TraceDirectory (Join-Path $testRoot 'missing') `
+            -RepositoryRoot $sourceRoot `
+            -ReportDirectory (Join-Path $testRoot 'missing-report') `
+            -RequireTrace
+    } catch {
+        $missingTraceRejected = $_.Exception.Message -like '*Trace2 did not produce any files*'
+    }
+    if (-not $missingTraceRejected) {
+        throw 'Required Trace2 coverage accepted a missing trace.'
+    }
+
+    Write-Host 'Source dependency report tests passed.'
+} finally {
+    Remove-Item $testRoot -Recurse -Force -ErrorAction Ignore
+}

--- a/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
+++ b/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
@@ -86,6 +86,7 @@ var dawn = "https://github.com/google/dawn/releases/download/{TAG}/source.zip";
 {"event":"start","sid":"clone-session","argv":["git","clone","https://trace-user:trace-password@github.com/google/angle.git?token=hidden","externals/angle"]}
 {"event":"child_start","sid":"fetch-session","child_class":"transport/https","argv":["git","remote-https","origin","https://github.com/emscripten-core/emsdk.git"]}
 {"event":"start","sid":"checkout-session","argv":["git","-c","http.https://github.com/mono/SkiaSharp.extraheader=AUTHORIZATION: bearer secret","fetch","origin"]}
+{"event":"def_repo","sid":"container-session","worktree":"/work/externals/skia/third_party/externals/zlib"}
 not-json
 '@ | Set-Content (Join-Path $traceRoot 'trace-event')
 
@@ -137,6 +138,11 @@ not-json
         $report `
         'https://chromium.googlesource.com/chromium/src/third_party/zlib' `
         -Observed
+    $zlib = @($report.repositories | Where-Object url -eq `
+        'https://chromium.googlesource.com/chromium/src/third_party/zlib')[0]
+    if ($zlib.revisions.Count -ne 1) {
+        throw 'The mapped container worktree did not contribute its exact revision.'
+    }
     Assert-Repository $report `
         'https://chromium.googlesource.com/chromium/tools/depot_tools' `
         -Declared

--- a/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
+++ b/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
@@ -74,6 +74,7 @@ var dawn = "https://github.com/google/dawn/releases/download/{TAG}/source.zip";
     @'
 {"event":"start","sid":"clone-session","argv":["git","clone","https://trace-user:trace-password@github.com/google/angle.git?token=hidden","externals/angle"]}
 {"event":"child_start","sid":"fetch-session","child_class":"transport/https","argv":["git","remote-https","origin","https://github.com/emscripten-core/emsdk.git"]}
+{"event":"start","sid":"checkout-session","argv":["git","-c","http.https://github.com/mono/SkiaSharp.extraheader=AUTHORIZATION: bearer secret","fetch","origin"]}
 not-json
 '@ | Set-Content (Join-Path $traceRoot 'trace-event')
 
@@ -91,6 +92,7 @@ not-json
         -TraceDirectory $traceRoot `
         -RepositoryRoot $sourceRoot `
         -ReportDirectory $reportRoot `
+        -JobName test_job `
         -RequireTrace
 
     $jsonPath = Join-Path $reportRoot 'source-dependencies.json'
@@ -107,6 +109,9 @@ not-json
     $report = $json | ConvertFrom-Json
     if ($report.schemaVersion -ne 1) {
         throw "Unexpected schema version '$($report.schemaVersion)'."
+    }
+    if ($report.build.jobName -ne 'test_job') {
+        throw "Unexpected report job name '$($report.build.jobName)'."
     }
     if ($report.coverage.gitTrace2.traceFiles -ne 1 -or
         $report.coverage.gitTrace2.malformedLines -ne 1) {
@@ -126,8 +131,8 @@ not-json
             'https://dev.azure.com/example/project/_git/test-fixture'
             'https://github.com/upstream/not-actually-downloaded'
         )
-    }).Count -ne 0) {
-        throw 'Test fixtures or canonical CVE aliases leaked into source declarations.'
+    }).Count -ne 0 -or $json -match 'SkiaSharp\.extraheader') {
+        throw 'Test fixtures, Git auth config, or canonical CVE aliases leaked into the report.'
     }
 
     if (Test-Path $traceRoot) {

--- a/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
+++ b/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
@@ -81,6 +81,16 @@ var dawn = "https://github.com/google/dawn/releases/download/{TAG}/source.zip";
     & git -C $existingDependency commit --quiet -m dependency
     & git -C $existingDependency remote add origin `
         'https://chromium.googlesource.com/chromium/src/third_party/zlib'
+    @'
+deps = {
+  "buildtools": "https://chromium.googlesource.com/chromium/src/buildtools.git@729495f2ffa69080907780591fa2a630b2556e98",
+  "agents/shared": "https://chromium.googlesource.com/chromium/agents/@e75efa515896f6bf1dea92eaffbcf8ee711a65d8",
+  "inactive": {
+    "url": "https://example.googlesource.com/inactive.git@1111111111111111111111111111111111111111",
+    "condition": "False",
+  },
+}
+'@ | Set-Content (Join-Path $sourceRoot 'externals/skia/DEPS')
 
     @'
 {"event":"start","sid":"clone-session","argv":["git","clone","https://trace-user:trace-password@github.com/google/angle.git?token=hidden","externals/angle"]}
@@ -138,6 +148,27 @@ not-json
         $report `
         'https://chromium.googlesource.com/chromium/src/third_party/zlib' `
         -Observed
+    Assert-Repository `
+        $report `
+        'https://chromium.googlesource.com/chromium/src/buildtools' `
+        -Declared
+    Assert-Repository `
+        $report `
+        'https://chromium.googlesource.com/chromium/agents' `
+        -Declared
+    $depsRevisions = @{
+        'https://chromium.googlesource.com/chromium/src/buildtools' =
+            '729495f2ffa69080907780591fa2a630b2556e98'
+        'https://chromium.googlesource.com/chromium/agents' =
+            'e75efa515896f6bf1dea92eaffbcf8ee711a65d8'
+    }
+    foreach ($entry in $depsRevisions.GetEnumerator()) {
+        $repository = @($report.repositories | Where-Object url -eq $entry.Key)[0]
+        if ($repository.revisions.Count -ne 1 -or
+            $repository.revisions[0] -ne $entry.Value) {
+            throw "DEPS revision for '$($entry.Key)' was not preserved."
+        }
+    }
     $zlib = @($report.repositories | Where-Object url -eq `
         'https://chromium.googlesource.com/chromium/src/third_party/zlib')[0]
     if ($zlib.revisions.Count -ne 1) {
@@ -151,6 +182,7 @@ not-json
         $_.url -in @(
             'https://dev.azure.com/example/project/_git/test-fixture'
             'https://github.com/upstream/not-actually-downloaded'
+            'https://example.googlesource.com/inactive'
         )
     }).Count -ne 0 -or $json -match 'SkiaSharp\.extraheader') {
         throw 'Test fixtures, Git auth config, or canonical CVE aliases leaked into the report.'

--- a/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
+++ b/scripts/infra/security/tests/SourceDependencyReport.Tests.ps1
@@ -71,6 +71,17 @@ var dawn = "https://github.com/google/dawn/releases/download/{TAG}/source.zip";
     & git -C $sourceRoot add .
     & git -C $sourceRoot commit --quiet -m initial
 
+    $existingDependency = Join-Path $sourceRoot 'externals/skia/third_party/externals/zlib'
+    New-Item $existingDependency -ItemType Directory -Force | Out-Null
+    & git -C $existingDependency init --quiet
+    & git -C $existingDependency config user.email source-report@example.invalid
+    & git -C $existingDependency config user.name 'Source Report Tests'
+    'dependency' | Set-Content (Join-Path $existingDependency 'source.txt')
+    & git -C $existingDependency add source.txt
+    & git -C $existingDependency commit --quiet -m dependency
+    & git -C $existingDependency remote add origin `
+        'https://chromium.googlesource.com/chromium/src/third_party/zlib'
+
     @'
 {"event":"start","sid":"clone-session","argv":["git","clone","https://trace-user:trace-password@github.com/google/angle.git?token=hidden","externals/angle"]}
 {"event":"child_start","sid":"fetch-session","child_class":"transport/https","argv":["git","remote-https","origin","https://github.com/emscripten-core/emsdk.git"]}
@@ -122,6 +133,10 @@ not-json
     Assert-Repository $report 'https://github.com/google/angle' -Observed
     Assert-Repository $report 'https://github.com/emscripten-core/emsdk' -Observed
     Assert-Repository $report 'https://github.com/google/dawn' -Declared
+    Assert-Repository `
+        $report `
+        'https://chromium.googlesource.com/chromium/src/third_party/zlib' `
+        -Observed
     Assert-Repository $report `
         'https://chromium.googlesource.com/chromium/tools/depot_tools' `
         -Declared


### PR DESCRIPTION
## Description

Capture the source repositories used by SkiaSharp builds for compliance review instead of relying on any single manifest.

Each SkiaSharp Azure Pipelines job enables Git Trace2 before checkout, combines observed Git traffic with checked-out repository revisions and declared build sources, and publishes sanitized JSON and Markdown reports even when the job fails. This covers indirect clones from `git-sync-deps`/gclient, Cake, submodules, and mounted Linux/Windows build containers. Static discovery records source paths in `.gitmodules`, active Skia `DEPS`, `cgmanifest.json`, Cake/scripts, Dockerfiles, and pipeline YAML.

Raw Trace2 events remain in agent temporary storage and are deleted after report generation. Published reports strip URL credentials, user info, queries, and fragments. Package feeds, SDK installers, OS packages, and arbitrary non-repository downloads are explicitly out of scope.

### Collected source repositories

The exercised Windows ANGLE, Windows Skia, Linux container, and macOS jobs produced this 96-repository union. **Observed** means the source was seen in a checked-out worktree or Git traffic; **declared-only** means the job found the source in a relevant manifest/script but did not execute that path.

<details>
<summary>Observed in CI (35)</summary>

- `https://android.googlesource.com/platform/external/dng_sdk`
- `https://android.googlesource.com/platform/external/piex`
- `https://chromium.googlesource.com/chromium/agents`
- `https://chromium.googlesource.com/chromium/src/build`
- `https://chromium.googlesource.com/chromium/src/buildtools`
- `https://chromium.googlesource.com/chromium/src/testing`
- `https://chromium.googlesource.com/chromium/src/third_party/freetype2`
- `https://chromium.googlesource.com/chromium/src/third_party/jsoncpp`
- `https://chromium.googlesource.com/chromium/src/third_party/zlib`
- `https://chromium.googlesource.com/chromium/src/tools/clang`
- `https://chromium.googlesource.com/chromium/tools/depot_tools`
- `https://chromium.googlesource.com/external/github.com/ARM-software/astc-encoder`
- `https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang`
- `https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz`
- `https://chromium.googlesource.com/external/github.com/libexpat/libexpat`
- `https://chromium.googlesource.com/vulkan-deps`
- `https://chromium.googlesource.com/webm/libwebp`
- `https://github.com/google/angle`
- `https://github.com/google/googletest`
- `https://github.com/libjpeg-turbo/libjpeg-turbo`
- `https://github.com/mono/SkiaSharp`
- `https://github.com/mono/skia`
- `https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator`
- `https://skia.googlesource.com/external/github.com/google/brotli`
- `https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c`
- `https://skia.googlesource.com/third_party/libpng`

</details>

<details>
<summary>Declared-only in the exercised jobs (61)</summary>

- `https://android.googlesource.com/platform/external/cherry`
- `https://android.googlesource.com/platform/external/libpng`
- `https://chrome-internal.googlesource.com/angle/es-cts`
- `https://chromium.googlesource.com/catapult`
- `https://chromium.googlesource.com/chromium/deps/libjpeg_turbo`
- `https://chromium.googlesource.com/chromium/deps/nasm`
- `https://chromium.googlesource.com/chromium/src/third_party/Python-Markdown`
- `https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp`
- `https://chromium.googlesource.com/chromium/src/third_party/android_build_tools`
- `https://chromium.googlesource.com/chromium/src/third_party/android_deps`
- `https://chromium.googlesource.com/chromium/src/third_party/android_platform`
- `https://chromium.googlesource.com/chromium/src/third_party/android_sdk`
- `https://chromium.googlesource.com/chromium/src/third_party/googletest`
- `https://chromium.googlesource.com/chromium/src/third_party/ijar`
- `https://chromium.googlesource.com/chromium/src/third_party/jinja2`
- `https://chromium.googlesource.com/chromium/src/third_party/markupsafe`
- `https://chromium.googlesource.com/chromium/src/third_party/protobuf`
- `https://chromium.googlesource.com/chromium/src/third_party/six`
- `https://chromium.googlesource.com/chromium/src/tools/android`
- `https://chromium.googlesource.com/chromium/src/tools/mb`
- `https://chromium.googlesource.com/chromium/src/tools/md_browser`
- `https://chromium.googlesource.com/chromium/src/tools/memory`
- `https://chromium.googlesource.com/chromium/src/tools/perf`
- `https://chromium.googlesource.com/chromium/src/tools/protoc_wrapper`
- `https://chromium.googlesource.com/chromium/src/tools/python`
- `https://chromium.googlesource.com/chromium/src/tools/valgrind`
- `https://chromium.googlesource.com/chromiumos/third_party/libdrm`
- `https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland`
- `https://chromium.googlesource.com/external/colorama`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenCL-Docs`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenCL-ICD-Loader`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry`
- `https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS`
- `https://chromium.googlesource.com/external/github.com/Mesa3D/mesa`
- `https://chromium.googlesource.com/external/github.com/Tencent/rapidjson`
- `https://chromium.googlesource.com/external/github.com/glmark2/glmark2`
- `https://chromium.googlesource.com/external/github.com/google/clspv`
- `https://chromium.googlesource.com/external/github.com/google/cpu_features`
- `https://chromium.googlesource.com/external/github.com/google/flatbuffers`
- `https://chromium.googlesource.com/external/github.com/kennethreitz/requests`
- `https://chromium.googlesource.com/external/github.com/llvm/llvm-project`
- `https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format`
- `https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx`
- `https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi`
- `https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind`
- `https://chromium.googlesource.com/external/github.com/mesonbuild/meson`
- `https://dawn.googlesource.com/dawn`
- `https://github.com/dotnet/dotnet-buildtools-prereqs-docker`
- `https://github.com/emscripten-core/emsdk`
- `https://github.com/google/dawn`
- `https://github.com/google/skia`
- `https://github.com/ip7z/7zip`
- `https://github.com/llvm/llvm-project`
- `https://github.com/microsoft/azure-pipelines-tasks`
- `https://github.com/mono/SkiaSharp-API-docs`
- `https://github.com/mono/api-doc-tools`
- `https://github.com/mono/gtk-sharp`
- `https://github.com/nyorain/dlg`
- `https://github.com/pal1000/mesa-dist-win`
- `https://swiftshader.googlesource.com/SwiftShader`

</details>

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — CI-only reporting; no public API or product behavior change.

## Testing

- Source-report tests and cache coverage validation pass locally.
- Azure build 1582945 published a Linux-container report with 20/20 observed repositories carrying exact 40-character commits; 335 Trace2 files yielded 3,766 events.
- Azure build 1582807 published macOS (20/20 exact) and procedural Windows ANGLE (35/35 exact) reports.
- Downloaded JSON/Markdown artifacts parse at schema version 1 and contain no authorization headers, bearer values, Git extraheaders, access tokens, or passwords.
- Reports are created and published on failed build legs as designed.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native or C API changes