### PR TITLE
[release-notes] Carry manual notes through cumulative rollups

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -95,10 +95,11 @@ section on the SkiaSharp page (see `harfbuzz_summary` below). For **each** page:
    `shipments` (format 4+; the exact git tag(s) this page rolls up — a preview,
    an rc, and/or the stable release itself, see `release_summaries` below), and
    the banner/link facts.
-2. Read the breaking sources it points at, if present: the version's
-   `*.breaking.md` API diff and any `_sources/<version>.notes.md` sidecar. These
-   are your material for the `breaking` slot — the API diff gives signature
-   removals, the notes sidecar gives *behavioural* breaks (same signature, new
+2. Read every breaking source named in `breaking_candidates`, if present: the
+   version's `*.breaking.md` API diffs and every referenced `_sources/*.notes.md`
+   sidecar. A cumulative page may reference notes from a skipped preview-only line.
+   These are your material for the `breaking` slot — API diffs give signature
+   removals, while notes sidecars give *behavioural* breaks (same signature, new
    runtime behaviour) that no diff can detect.
 3. Write `documentation/docfx/releases/_sources/<version>.prose.json`
    (schema: `scripts/infra/docs/release-notes-schema/prose.schema.json`).

--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -870,10 +870,13 @@ material to surface.
   (`**/*.notes.md`) so it never becomes its own published page.
 - **Read by `release-notes-data.py` (hash only), read by the AI (content).** `release-notes-data.py`
   records its page-relative path (`_sources/<stem>.notes.md`) plus a `sha256` of its
-  bytes in `breaking_candidates[]` (§4.3/§4.7), so editing it changes the
-  timestamp-free data sidecar (§4.6) and re-polishes exactly that page. `release-notes-data.py`
-  never parses its *content*. The Polish AI opens and reads it and summarizes / weaves
-  it into the prose (§4.7).
+  bytes in `breaking_candidates[]` (§4.3/§4.7). A rollup page also references notes
+  from skipped preview-only lines inside its cumulative diff window, so behavioral
+  changes are not lost merely because their original line never shipped stable.
+  Editing a sidecar changes every affected page's timestamp-free data sidecar (§4.6)
+  and re-polishes those pages. `release-notes-data.py` never parses its *content*. The
+  Polish AI opens and reads each referenced sidecar and summarizes / weaves it into
+  the prose (§4.7).
 - **Orphan handling.** A `_sources/<stem>.notes.md` with no matching SkiaSharp page one
   directory up (neither `<stem>.md` nor `<stem>-unreleased.md` exists for its stem) is a
   maintainer typo; `release-notes-data.py` **warns** and ignores it, writing nothing on its
@@ -1238,15 +1241,15 @@ For a given SkiaSharp release page, `release-notes-data.py` records whichever of
 
 | Companion source | Path (page-relative) | Owner | Present when |
 |---|---|---|---|
-| **Manual additions** (§3.7) | `_sources/<stem>.notes.md` | maintainer (freeform md) | a human wrote one |
+| **Manual additions** (§3.7) | `_sources/<stem>.notes.md` | maintainer (freeform md) | a human wrote one for this page or a skipped line in its cumulative diff window |
 | **API breaking diff** (§3.3) | `<line>/<pkg>/<assembly>.breaking.md` | Cake | **real breaking changes exist** (Cake deletes an empty one, §5.2) |
 
 The full SkiaSharp API diff folder and the co-shipped HarfBuzzSharp API diff folder are
 already linked from the page (§4.4). What §4.7 adds is: **(a)** the maintainer-authored
 manual additions companion (§3.7); **(b)** teaching the Polish AI to open and summarize
 the manual notes and every breaking diff named by `data.json`; **(c)** hashing those
-companions into `data.json` (§4.6) so a companion-only edit re-polishes exactly that
-page.
+companions into `data.json` (§4.6) so a companion-only edit re-polishes that page,
+plus any later rollup page whose cumulative window includes that sidecar.
 
 Because `.breaking.md` exists **only when real breaking changes exist** (§5.2), its
 mere presence in `breaking_candidates` is the signal that this line broke something,
@@ -1258,7 +1261,8 @@ For each present companion, `release-notes-data.py` writes an entry into
 `breaking_candidates[]`:
 
 - `{"source": "notes-sidecar", "path": "_sources/<stem>.notes.md", "sha256": …}`
-  for the manual additions sidecar.
+  for each applicable manual additions sidecar, including skipped preview-only lines
+  inside the page's cumulative diff window.
 - `{"source": "api-breaking-diff", "path": "<line>/<pkg>/<assembly>.breaking.md", "sha256": …}`
   for each breaking diff file.
 
@@ -1303,11 +1307,12 @@ sources for "what's new" and "what broke".
 
 Reading a companion does not by itself change the page; deterministic re-polish is
 preserved by the hashes in `data.json` (§4.6). Editing `_sources/<stem>.notes.md`
-flips the `notes-sidecar` candidate hash; a breaking change appearing, disappearing,
-or changing flips the `api-breaking-diff` candidate hash. Either re-polishes **only**
-the affected page. The full non-breaking API diff is deliberately **not**
-folder-hashed (§4.6): its change signal is already carried by the PR set and the
-`api_links` entry, so a routine diff refresh does not force a spurious re-polish.
+flips the `notes-sidecar` candidate hash on its own page and any cumulative successor
+that references it; a breaking change appearing, disappearing, or changing flips the
+`api-breaking-diff` candidate hash on its line. The full non-breaking API diff is
+deliberately **not** folder-hashed (§4.6): its change signal is already carried by the
+PR set and the `api_links` entry, so a routine diff refresh does not force a spurious
+re-polish.
 
 ---
 
@@ -1639,8 +1644,9 @@ HarfBuzzSharp API diff.
     `data.json` records each present companion (manual additions sidecar §3.7,
     breaking diff §3.3) in `breaking_candidates[]` as a page-relative **path +
     `sha256`**, never inlined content. Those hashes join the content key (§4.6) so a
-    companion-only edit re-polishes exactly that page; the full non-breaking diff is
-    linked but not folder-hashed. The `_sources/*.notes.md` sidecar is a
+    companion-only edit re-polishes its own page and every cumulative successor that
+    references it; the full non-breaking diff is linked but not folder-hashed. The
+    `_sources/*.notes.md` sidecar is a
     **maintainer-owned freeform-Markdown input**: never machine-written, renamed, or
     cleared; docfx-excluded; skipped by page discovery. The Polish AI may **read** the
     referenced companions (a bounded allow-list) and summarize them, but writes only

--- a/scripts/infra/docs/release-notes-data.py
+++ b/scripts/infra/docs/release-notes-data.py
@@ -320,6 +320,47 @@ def load_notes_sidecar(stem, base_dir):
             "sha256": _sha256_bytes(notes_path.read_bytes())}
 
 
+def _notes_sidecar_has_page(stem, base_dir):
+    # type: (str, Path) -> bool
+    """Whether a manual sidecar belongs to a released or in-flight page."""
+    if (base_dir / "{}.md".format(stem)).is_file():
+        return True
+    return (not stem.endswith("-unreleased")
+            and (base_dir / "{}-unreleased.md".format(stem)).is_file())
+
+
+def load_notes_sidecars(stem, base_version, version, base_dir):
+    # type: (str, Optional[str], str, Path) -> list[dict]
+    """Load current-page notes plus notes from its cumulative version window."""
+    current = load_notes_sidecar(stem, base_dir)
+    if not base_version or stem.endswith("-unreleased"):
+        return [current] if current else []
+
+    lower = _core_tuple(base_version)
+    upper = _core_tuple(version)
+    found = {}  # type: dict[str, tuple[tuple, dict]]
+    sources = base_dir / "_sources"
+    if sources.is_dir():
+        for notes_path in sources.glob("*.notes.md"):
+            note_stem = notes_path.name[:-len(".notes.md")]
+            if not re.fullmatch(r"\d+(?:\.\d+){2,3}", note_stem):
+                continue
+            note_version = _core_tuple(note_stem)
+            if not (lower < note_version <= upper):
+                continue
+            if note_stem != stem and not _notes_sidecar_has_page(note_stem, base_dir):
+                continue
+            companion = load_notes_sidecar(note_stem, base_dir)
+            if companion:
+                found[companion["path"]] = (note_version, companion)
+
+    if current:
+        found[current["path"]] = (_core_tuple(version), current)
+
+    ordered = sorted(found.values(), key=lambda item: (item[0], item[1]["path"]))
+    return [companion for _, companion in ordered]
+
+
 def load_breaking_companions(line, base_dir):
     # type: (str, Path) -> Optional[dict]
     """The API breaking-diff companions for a line (spec §3.3/§4.7).
@@ -1887,8 +1928,10 @@ def build_data_json(prs, metadata):
             breaking_candidates.append(
                 {"source": "api-breaking-diff", "path": p,
                  "sha256": bc.get("sha256", ""), "prs": []})
-    if companions.get("notes"):
-        nc = companions["notes"]
+    notes = companions.get("notes") or []
+    if isinstance(notes, dict):
+        notes = [notes]
+    for nc in notes:
         breaking_candidates.append(
             {"source": "notes-sidecar", "path": nc.get("path"),
              "sha256": nc.get("sha256", ""), "prs": []})
@@ -2208,10 +2251,10 @@ def warn_orphan_notes_sidecars():
             if not f.is_file() or not f.name.endswith(".notes.md"):
                 continue
             stem = f.name[:-len(".notes.md")]
-            if not (base_dir / "{}.md".format(stem)).is_file():
+            if not _notes_sidecar_has_page(stem, base_dir):
                 log("WARNING: orphan manual notes sidecar {} has no matching "
-                    "page {}.md — ignoring it (spec §3.7). Did you mean a "
-                    "different stem?".format(f.name, stem))
+                    "page {}.md or {}-unreleased.md — ignoring it (spec §3.7). "
+                    "Did you mean a different stem?".format(f.name, stem, stem))
                 orphans.append(str(f))
     return orphans
 
@@ -2353,6 +2396,18 @@ def _write_page(branch, all_branches, verbose=False, force=False,
         from_display = from_display[:12]
     diff_range_str = "{}..{}".format(from_display, to_display)
 
+    base_version = None
+    if from_display.startswith("release/"):
+        base_version = version_from_branch(from_display)
+    elif re.match(r"^\d+\.\d+\.\d+", from_display):
+        base_version = from_display
+    else:
+        # A bare commit SHA can come from a versions.json compare_to tag. Recover
+        # that core so cumulative manual notes use the same lower bound as git.
+        ce = _versions_config_lookup(version)
+        if ce and ce.get("compare_to"):
+            base_version = ce["compare_to"]
+
     status, superseded_by, supersedes = _compute_page_status(branch, version)
 
     if verbose:
@@ -2408,11 +2463,12 @@ def _write_page(branch, all_branches, verbose=False, force=False,
         }
 
     # Companion files (spec §3.7/§4.7): the manual additions sidecar (keyed by the
-    # page STEM) and the API breaking-diff (under the line's <version>/ folder).
-    # Their content hashes are folded into data.json (build_data_json), so a
-    # companion-only edit changes data.json and re-polishes just this page (§4.6).
+    # page STEM, plus any skipped lines in this cumulative window) and the API
+    # breaking-diff (under the line's <version>/ folder). Their content hashes are
+    # folded into data.json (build_data_json), so a companion-only edit changes
+    # every affected data.json and re-polishes those pages (§4.6).
     stem = _page_filename(branch, version)[:-len(".md")]
-    notes_comp = load_notes_sidecar(stem, RELEASES_DIR)
+    notes_comp = load_notes_sidecars(stem, base_version, version, RELEASES_DIR)
     breaking_comp = (load_breaking_companions(version, RELEASES_DIR)
                      if not is_head else None)
 
@@ -2430,19 +2486,6 @@ def _write_page(branch, all_branches, verbose=False, force=False,
     # the trailing "## Preview N (date)" sections render. The lower bound is the
     # diff base, so a page naturally includes a skipped predecessor minor's
     # previews (the 4.148 page lists the 4.147 previews).
-    base_version = None
-    if from_display.startswith("release/"):
-        base_version = version_from_branch(from_display)
-    elif re.match(r"^\d+\.\d+\.\d+", from_display):
-        base_version = from_display
-    else:
-        # from_display is a bare commit SHA — happens when versions.json
-        # compare_to resolved to a `v<compare_to>` TAG (no release/* branch). The
-        # base core is then exactly that compare_to value; recover it so the
-        # milestone window stays bounded.
-        ce = _versions_config_lookup(version)
-        if ce and ce.get("compare_to"):
-            base_version = ce["compare_to"]
     preview_milestones = collect_preview_milestones(version, base_version)
 
     metadata = {

--- a/scripts/infra/docs/release_notes/tests/test_common.py
+++ b/scripts/infra/docs/release_notes/tests/test_common.py
@@ -119,6 +119,138 @@ class CoreTupleTests(unittest.TestCase):
         self.assertEqual(common.core_tuple("3.119.0.1"), (3, 119, 0, 1))
 
 
+class NotesSidecarTests(unittest.TestCase):
+    def setUp(self):
+        self.module = _load_release_notes_data_module()
+
+    @staticmethod
+    def _write_page_and_notes(releases, version, text):
+        (releases / "{}.md".format(version)).write_text("# {}".format(version))
+        notes = releases / "_sources" / "{}.notes.md".format(version)
+        notes.parent.mkdir(exist_ok=True)
+        notes.write_text(text)
+
+    def test_cumulative_page_carries_notes_after_its_stable_base(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            releases = Path(tmp_dir)
+            self._write_page_and_notes(releases, "4.151.2", "Already shipped")
+            self._write_page_and_notes(releases, "4.153.0", "Behavior changed")
+            self._write_page_and_notes(releases, "4.154.0", "Current note")
+
+            notes = self.module.load_notes_sidecars(
+                "4.154.0", "4.151.2", "4.154.0", releases
+            )
+
+            self.assertEqual(
+                [note["path"] for note in notes],
+                [
+                    "_sources/4.153.0.notes.md",
+                    "_sources/4.154.0.notes.md",
+                ],
+            )
+
+    def test_stable_baseline_stops_carrying_prior_notes(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            releases = Path(tmp_dir)
+            self._write_page_and_notes(releases, "4.153.0", "Already shipped")
+            self._write_page_and_notes(releases, "4.154.0", "Current note")
+
+            notes = self.module.load_notes_sidecars(
+                "4.154.0", "4.153.0", "4.154.0", releases
+            )
+
+            self.assertEqual(
+                [note["path"] for note in notes],
+                ["_sources/4.154.0.notes.md"],
+            )
+
+    def test_orphan_notes_do_not_leak_into_a_cumulative_page(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            releases = Path(tmp_dir)
+            sources = releases / "_sources"
+            sources.mkdir()
+            (sources / "4.153.0.notes.md").write_text("Orphan note")
+            self._write_page_and_notes(releases, "4.154.0", "Current note")
+
+            notes = self.module.load_notes_sidecars(
+                "4.154.0", "4.151.2", "4.154.0", releases
+            )
+
+            self.assertEqual(
+                [note["path"] for note in notes],
+                ["_sources/4.154.0.notes.md"],
+            )
+
+    def test_unreleased_head_uses_only_its_own_notes(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            releases = Path(tmp_dir)
+            self._write_page_and_notes(releases, "4.153.0", "Prior line")
+            (releases / "4.154.0-unreleased.md").write_text("# Unreleased")
+            notes = releases / "_sources" / "4.154.0-unreleased.notes.md"
+            notes.write_text("Head delta")
+
+            loaded = self.module.load_notes_sidecars(
+                "4.154.0-unreleased", "4.153.0", "4.154.0", releases
+            )
+
+            self.assertEqual(
+                [note["path"] for note in loaded],
+                ["_sources/4.154.0-unreleased.notes.md"],
+            )
+
+    def test_build_data_json_emits_each_cumulative_notes_candidate(self):
+        notes = [
+            {"path": "_sources/4.153.0.notes.md", "sha256": "sha256:153"},
+            {"path": "_sources/4.154.0.notes.md", "sha256": "sha256:154"},
+        ]
+
+        data = self.module.build_data_json(
+            [],
+            {
+                "version": "4.154.0",
+                "status": "unreleased",
+                "companions": {"notes": notes},
+            },
+        )
+
+        self.assertEqual(
+            data["breaking_candidates"],
+            [
+                {
+                    "source": "notes-sidecar",
+                    "path": "_sources/4.153.0.notes.md",
+                    "sha256": "sha256:153",
+                    "prs": [],
+                },
+                {
+                    "source": "notes-sidecar",
+                    "path": "_sources/4.154.0.notes.md",
+                    "sha256": "sha256:154",
+                    "prs": [],
+                },
+            ],
+        )
+
+    def test_stable_named_sidecar_matches_an_unreleased_page(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            releases = Path(tmp_dir)
+            (releases / "4.154.0-unreleased.md").write_text("# Unreleased")
+
+            self.assertTrue(
+                self.module._notes_sidecar_has_page("4.154.0", releases)
+            )
+
+
 class ReleaseGithubTests(unittest.TestCase):
     def test_owns_the_managed_markers(self):
         self.assertEqual(github.SUMMARY_START_MARKER, "<!-- SKIASHARP:RELEASE-SUMMARY:START -->")


### PR DESCRIPTION
## Description

Carry eligible manual-notes sidecars from versions after a release page's stable comparison base through the target version. Previously, cumulative pages rolled forward PRs and preview milestones but loaded only the destination page's manual sidecar. As seen in #4969, 4.154 could therefore include the 4.153 changes while omitting its Linux font-fallback behavior warning, which managed API diffs cannot detect.

The generator now emits each applicable sidecar as a separate `breaking_candidates` entry, stops carrying notes once their version becomes the stable baseline, keeps unreleased head deltas isolated, and excludes genuine orphan sidecars. Stable-named notes are also recognized while the corresponding `-unreleased` page exists.

**Related issues**

Related to #4969.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — release-note generation only; no public API or shipped runtime behavior changes.

## Testing

- `python3 -m py_compile scripts/infra/docs/release-notes-data.py`
- `python3 -m unittest discover -s scripts/infra/docs/release_notes/tests -p 'test_*.py' -q` (146 tests)

Regression coverage verifies cumulative carry-forward, stable-baseline cutoff, orphan exclusion, unreleased-head isolation, stable-named sidecar discovery, and multiple `breaking_candidates` entries.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native changes