### PR TITLE
Bump playwright from 1.49.0 to 1.55.1 in the WASM smoke harnesses

### DIFF
--- a/samples/Gallery/Uno/scripts/package.json
+++ b/samples/Gallery/Uno/scripts/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Headless smoke test harness for the SkiaSharp Uno WASM gallery. See specs/001-uno-wasm-sample/contracts/smoke-test.md.",
   "dependencies": {
-    "playwright": "1.49.0"
+    "playwright": "1.55.1"
   }
 }

--- a/samples/Gallery/Uno/scripts/smoke.sh
+++ b/samples/Gallery/Uno/scripts/smoke.sh
@@ -62,18 +62,12 @@ command -v python3 >/dev/null 2>&1 || { echo "smoke.sh: python3 not found" >&2; 
 command -v node    >/dev/null 2>&1 || { echo "smoke.sh: node not found" >&2; exit 1; }
 command -v npm     >/dev/null 2>&1 || { echo "smoke.sh: npm not found" >&2; exit 1; }
 
-# Ensure Playwright is installed in scripts/node_modules
-if [[ ! -d "$SCRIPT_DIR/node_modules/playwright" ]]; then
-    echo "smoke.sh: installing Playwright (first run) ..." >&2
-    (cd "$SCRIPT_DIR" && npm install --silent --no-audit --no-fund) >&2
-fi
+# Ensure Playwright matches package.json
+(cd "$SCRIPT_DIR" && npm install --silent --no-audit --no-fund) >&2
 
-# Ensure Chromium binary is present
+# Ensure the matching Chromium binary is present
 export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
-if ! ls "$PLAYWRIGHT_BROWSERS_PATH"/chromium-* >/dev/null 2>&1; then
-    echo "smoke.sh: installing Playwright Chromium (first run) ..." >&2
-    (cd "$SCRIPT_DIR" && node_modules/.bin/playwright install chromium) >&2
-fi
+(cd "$SCRIPT_DIR" && node_modules/.bin/playwright install chromium) >&2
 
 # Pick a free port if not provided
 if [[ -z "$PORT" ]]; then

--- a/samples/SkiaFiddle/scripts/package.json
+++ b/samples/SkiaFiddle/scripts/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Headless smoke test harness for the SkiaFiddle Uno Platform WASM sample.",
   "dependencies": {
-    "playwright": "1.49.0"
+    "playwright": "1.55.1"
   }
 }

--- a/samples/SkiaFiddle/scripts/smoke.sh
+++ b/samples/SkiaFiddle/scripts/smoke.sh
@@ -59,18 +59,12 @@ command -v python3 >/dev/null 2>&1 || { echo "smoke.sh: python3 not found" >&2; 
 command -v node    >/dev/null 2>&1 || { echo "smoke.sh: node not found" >&2; exit 1; }
 command -v npm     >/dev/null 2>&1 || { echo "smoke.sh: npm not found" >&2; exit 1; }
 
-# Ensure Playwright is installed in scripts/node_modules
-if [[ ! -d "$SCRIPT_DIR/node_modules/playwright" ]]; then
-    echo "smoke.sh: installing Playwright (first run) ..." >&2
-    (cd "$SCRIPT_DIR" && npm install --silent --no-audit --no-fund) >&2
-fi
+# Ensure Playwright matches package.json
+(cd "$SCRIPT_DIR" && npm install --silent --no-audit --no-fund) >&2
 
-# Ensure Chromium binary is present
+# Ensure the matching Chromium binary is present
 export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
-if ! ls "$PLAYWRIGHT_BROWSERS_PATH"/chromium-* >/dev/null 2>&1; then
-    echo "smoke.sh: installing Playwright Chromium (first run) ..." >&2
-    (cd "$SCRIPT_DIR" && node_modules/.bin/playwright install chromium) >&2
-fi
+(cd "$SCRIPT_DIR" && node_modules/.bin/playwright install chromium) >&2
 
 # Pick a free port if not provided
 if [[ -z "$PORT" ]]; then


### PR DESCRIPTION
## Description

Updates the Gallery Uno and SkiaFiddle WASM smoke harnesses from Playwright 1.49.0 to 1.55.1. Both harnesses now run the idempotent package and Chromium installers on each invocation so an existing node_modules directory or browser cache cannot retain a mismatched version.

This consolidates the two related Dependabot updates so the Pages - Deploy workflow validates both harnesses together. It replaces #3766, which GitHub marked as merged during restacking without landing its commits on main, and supersedes #3759.

**Related issues**

Supersedes #3759 and #3766.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [x] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — sample smoke-test tooling only; no public API or product behavior changes.

## Testing

Validated both shell scripts, resolved Playwright 1.55.1 with npm, and confirmed the Playwright installer selects Chromium 140.0.7339.186 revision 1193. No new test was added because the existing Pages - Deploy workflow directly runs both WASM smoke harnesses.

## Checklist

- [ ] Tests added or updated (covered by the existing Pages - Deploy smoke tests)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated