### PR TITLE
[skia-sync] Use shared task for Phase 03 review

### DIFF
--- a/.agents/skills/update-skia/references/phases/01-03-research.md
+++ b/.agents/skills/update-skia/references/phases/01-03-research.md
@@ -97,7 +97,7 @@ Launch one synchronous, read-only validator using
 [../validation-prompt.md](../validation-prompt.md), substituting the exact range,
 `$ARTIFACT_DIR/skia-breaking-change-analysis.md`, and
 `$ARTIFACT_DIR/skia-dependency-decisions.md`. When the `task` tool is available, use
-`agent_type="explore"`, `model="gpt-5.6-terra"`, and `mode="sync"`. Locally, use an independent
+`agent_type="task"`, `model="gpt-5.6-terra"`, and `mode="sync"`. Locally, use an independent
 reviewer if available; otherwise perform a distinct second pass and record that limitation.
 
 The review reports only missed items, incorrect classifications, unsafe dependency decisions, and


### PR DESCRIPTION
## Description

Fix the independent Phase 03 validator handoff exposed by [run 33924393336](https://github.com/mono/SkiaSharp/actions/runs/33924393336). The parent agent could read the prepared checkout and `/tmp/gh-aw/agent` reports, but the delegated `explore` agent ran behind an isolated filesystem/repository boundary and could not inspect either source of evidence.

This changes only the validator agent type from `explore` to synchronous `task`. The existing GPT-5.6 Terra model, synchronous execution, read-only instructions, artifact paths, and review gate remain unchanged. A `task` agent shares the prepared checkout and `/tmp/gh-aw` scope required by the validator.

[Run 33936493725](https://github.com/mono/SkiaSharp/actions/runs/33936493725) validated the fix before the history-only squash. One synchronous GPT-5.6 Terra task read both prepared reports, inspected the exact `externals/skia` revisions, returned discrepancies directly to the parent, and completed in 87 seconds. The parent continued through the remaining phases, wrote both repository summaries, emitted the staged `create_pull_request` output, and shut down in about 118 ms without a pending-task timeout or orphan cleanup.

**Related issues**

Related to #4977.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — automation-only; no public API or SkiaSharp runtime behavior changes.

## Testing

- `gh aw compile auto-skia-sync --strict` passed.
- Run 33936493725 completed successfully from the pre-squash tree-equivalent commit `934261cf0dcbbcf2c7c2b28e415a9305ee2bf903`.
- The Phase 03 task accessed the prepared checkout and both `/tmp/gh-aw/agent` inputs, returned independent discrepancies, and allowed the parent to continue without `list_agents` or `write_agent` recovery.
- Linux x64 native build, binding regeneration, and managed build passed.
- Full unfiltered results: Singleton 1 passed/0 skipped; Core 6127 passed/33 skipped; Direct3D 2 passed/3 skipped; Vulkan 23 passed/2 skipped. Zero tests failed.
- Delivery created draft PRs [mono/skia#355](https://github.com/mono/skia/pull/355) and [mono/SkiaSharp#5006](https://github.com/mono/SkiaSharp/pull/5006).

## Checklist

- [x] Tests added or updated (validated by the live end-to-end workflow run; no deterministic unit seam exists for the task-agent filesystem boundary)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later (not applicable)
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated (not applicable; this PR does not change native source)