### PR TITLE
[migration] Add the portable repository identity foundation

### DIFF
--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -21,6 +21,8 @@ on:
       - "scripts/infra/repository_identity.py"
       - "scripts/infra/tests/test_repository_identity.py"
       - "scripts/infra/caching/repo-deps.json"
+      - ".gitmodules"
+      - "cgmanifest.json"
       # Any workflow edit, so the registry test re-checks its tracked list. '*.yml' already
       # covers the generated '*.lock.yml' files.
       - ".github/workflows/*.yml"
@@ -34,6 +36,8 @@ on:
       - "scripts/infra/repository_identity.py"
       - "scripts/infra/tests/test_repository_identity.py"
       - "scripts/infra/caching/repo-deps.json"
+      - ".gitmodules"
+      - "cgmanifest.json"
       - ".github/workflows/*.yml"
   workflow_dispatch:
 

--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -17,6 +17,10 @@ on:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
       - ".github/scripts/**"
+      - "scripts/infra/repository-identity.json"
+      - "scripts/infra/repository_identity.py"
+      - "scripts/infra/tests/test_repository_identity.py"
+      - "scripts/infra/caching/repo-deps.json"
       # Any workflow edit, so the registry test re-checks its tracked list. '*.yml' already
       # covers the generated '*.lock.yml' files.
       - ".github/workflows/*.yml"
@@ -26,6 +30,10 @@ on:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
       - ".github/scripts/**"
+      - "scripts/infra/repository-identity.json"
+      - "scripts/infra/repository_identity.py"
+      - "scripts/infra/tests/test_repository_identity.py"
+      - "scripts/infra/caching/repo-deps.json"
       - ".github/workflows/*.yml"
   workflow_dispatch:
 
@@ -78,3 +86,11 @@ jobs:
 
       - name: Run skia-sync work detector tests
         run: bash .github/scripts/tests/skia-sync-detect.test.sh
+
+      - name: Run repository identity tests
+        run: |
+          python3 -m unittest scripts/infra/tests/test_repository_identity.py -v
+          python3 scripts/infra/repository_identity.py validate
+
+      - name: Validate cache dependency coverage
+        run: python3 scripts/infra/caching/repo-deps.py validate

--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -159,12 +159,14 @@
         "libs": {},
         "package": {
           "include": [
-            "scripts/infra/package/**"
+            "scripts/infra/package/**",
+            "scripts/infra/repository-identity.json"
           ],
           "children": {
             "api_diff": {
               "include": [
                 "scripts/infra/docs/**",
+                "scripts/infra/repository_identity.py",
                 "documentation/docfx/releases/**"
               ]
             },

--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -29,6 +29,9 @@
     "scripts/infra/publishing/**",
     "scripts/infra/perf/**",
     "cgmanifest.json",
+    "# Inert identity files; consumer PRs must add them to cache inputs when used.",
+    "scripts/infra/repository-identity.json",
+    "scripts/infra/repository_identity.py",
     "utils/SkiaSharpGenerator/**",
     "utils/Utils.slnx",
     "utils/generate.ps1",
@@ -159,14 +162,12 @@
         "libs": {},
         "package": {
           "include": [
-            "scripts/infra/package/**",
-            "scripts/infra/repository-identity.json"
+            "scripts/infra/package/**"
           ],
           "children": {
             "api_diff": {
               "include": [
                 "scripts/infra/docs/**",
-                "scripts/infra/repository_identity.py",
                 "documentation/docfx/releases/**"
               ]
             },

--- a/scripts/infra/repository-identity.json
+++ b/scripts/infra/repository-identity.json
@@ -3,10 +3,6 @@
   "offlineRepository": "mono/SkiaSharp",
   "upstreamSkiaRepository": "google/skia",
   "publicSiteBaseUrl": "https://mono.github.io/SkiaSharp",
-  "repositoryKey": "github-52293126",
-  "legacyRepositoryKeys": [
-    "mono-SkiaSharp"
-  ],
   "skiaRepositoryKey": "github-52292286",
   "legacySkiaRepositoryKeys": [
     "mono-skia"

--- a/scripts/infra/repository-identity.json
+++ b/scripts/infra/repository-identity.json
@@ -1,0 +1,14 @@
+{
+  "canonicalRepositoryId": 52293126,
+  "offlineRepository": "mono/SkiaSharp",
+  "upstreamSkiaRepository": "google/skia",
+  "publicSiteBaseUrl": "https://mono.github.io/SkiaSharp",
+  "repositoryKey": "github-52293126",
+  "legacyRepositoryKeys": [
+    "mono-SkiaSharp"
+  ],
+  "skiaRepositoryKey": "github-52292286",
+  "legacySkiaRepositoryKeys": [
+    "mono-skia"
+  ]
+}

--- a/scripts/infra/repository_identity.py
+++ b/scripts/infra/repository_identity.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Resolve the portable repository identities used by SkiaSharp automation."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlsplit
+
+
+THIS_DIR = Path(__file__).resolve().parent
+DEFAULT_ROOT = THIS_DIR.parents[1]
+CONFIG_PATH = THIS_DIR / "repository-identity.json"
+_SLUG_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_URL_PATTERNS = (
+    re.compile(
+        r"https://github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"git://github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"git@github\.com:(?P<slug>[^/]+/[^/]+?)(?:\.git)?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"ssh://git@github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
+        re.IGNORECASE,
+    ),
+)
+_CONFIG_FIELDS = {
+    "canonicalRepositoryId": int,
+    "offlineRepository": str,
+    "upstreamSkiaRepository": str,
+    "publicSiteBaseUrl": str,
+    "repositoryKey": str,
+    "legacyRepositoryKeys": list,
+    "skiaRepositoryKey": str,
+    "legacySkiaRepositoryKeys": list,
+}
+
+
+class IdentityError(RuntimeError):
+    """A required repository identity could not be resolved safely."""
+
+
+def _normalize_slug(value: str) -> str:
+    slug = value.removesuffix(".git")
+    if not _SLUG_RE.fullmatch(slug):
+        raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
+    return slug
+
+
+def normalize_github_repository(value: str) -> str:
+    """Return an owner/repository slug for a supported GitHub URL or slug."""
+
+    candidate = (value or "").strip()
+    if _SLUG_RE.fullmatch(candidate):
+        return _normalize_slug(candidate)
+    for pattern in _URL_PATTERNS:
+        match = pattern.fullmatch(candidate)
+        if match:
+            return _normalize_slug(match.group("slug"))
+    raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
+
+
+def github_url(repository: str, *, git: bool = False) -> str:
+    suffix = ".git" if git else ""
+    return f"https://github.com/{normalize_github_repository(repository)}{suffix}"
+
+
+def _require_nonempty_string(config: dict, key: str) -> None:
+    if not config[key].strip():
+        raise IdentityError(
+            f"Repository identity config field {key!r} must not be empty."
+        )
+
+
+def load_config(path: Path | None = None) -> dict:
+    path = path or CONFIG_PATH
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise IdentityError(
+            f"Unable to read repository identity config {path}: {exc}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise IdentityError(
+            f"Repository identity config {path} must contain an object."
+        )
+
+    for key, expected_type in _CONFIG_FIELDS.items():
+        if type(value.get(key)) is not expected_type:
+            raise IdentityError(
+                f"Repository identity config field {key!r} must be "
+                f"{expected_type.__name__}."
+            )
+
+    if value["canonicalRepositoryId"] <= 0:
+        raise IdentityError(
+            "Repository identity config field 'canonicalRepositoryId' "
+            "must be positive."
+        )
+    for key in (
+        "offlineRepository",
+        "upstreamSkiaRepository",
+        "publicSiteBaseUrl",
+        "repositoryKey",
+        "skiaRepositoryKey",
+    ):
+        _require_nonempty_string(value, key)
+    for key in ("legacyRepositoryKeys", "legacySkiaRepositoryKeys"):
+        entries = value[key]
+        if not entries or any(
+            not isinstance(entry, str) or not entry.strip() for entry in entries
+        ):
+            raise IdentityError(
+                f"Repository identity config field {key!r} must contain "
+                "non-empty strings."
+            )
+
+    normalize_github_repository(value["offlineRepository"])
+    normalize_github_repository(value["upstreamSkiaRepository"])
+    site = urlsplit(value["publicSiteBaseUrl"])
+    if (
+        site.scheme != "https"
+        or not site.netloc
+        or site.query
+        or site.fragment
+    ):
+        raise IdentityError(
+            "Repository identity config field 'publicSiteBaseUrl' must be "
+            "an HTTPS URL without a query or fragment."
+        )
+    return value
+
+
+def resolve_current_repository(
+    explicit: str | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    config: dict | None = None,
+) -> str:
+    if explicit is not None:
+        return normalize_github_repository(explicit)
+
+    values = environ if environ is not None else os.environ
+    runtime = values.get("GITHUB_REPOSITORY")
+    if runtime:
+        return normalize_github_repository(runtime)
+
+    return normalize_github_repository(
+        (config or load_config())["offlineRepository"]
+    )
+
+
+def read_submodule_repository(root: Path, path: str) -> str:
+    gitmodules = root / ".gitmodules"
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        with gitmodules.open(encoding="utf-8") as stream:
+            parser.read_file(stream)
+    except (OSError, configparser.Error) as exc:
+        raise IdentityError(f"Unable to read {gitmodules}: {exc}") from exc
+
+    section = f'submodule "{path}"'
+    if not parser.has_option(section, "url"):
+        raise IdentityError(
+            f"{gitmodules} has no URL for submodule {path!r}."
+        )
+    return normalize_github_repository(parser.get(section, "url"))
+
+
+def resolve_identity(
+    root: Path | None = None,
+    *,
+    repository: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    config_path: Path | None = None,
+) -> dict:
+    root = (root or DEFAULT_ROOT).resolve()
+    config = load_config(config_path)
+    current = resolve_current_repository(
+        repository,
+        environ=environ,
+        config=config,
+    )
+    skia = read_submodule_repository(root, "externals/skia")
+    docs = read_submodule_repository(root, "docs")
+    upstream = normalize_github_repository(config["upstreamSkiaRepository"])
+
+    return {
+        "canonicalRepositoryId": config["canonicalRepositoryId"],
+        "repository": current,
+        "repositoryUrl": github_url(current),
+        "repositoryGitUrl": github_url(current, git=True),
+        "repositoryKey": config["repositoryKey"],
+        "legacyRepositoryKeys": list(config["legacyRepositoryKeys"]),
+        "skiaRepository": skia,
+        "skiaUrl": github_url(skia),
+        "skiaGitUrl": github_url(skia, git=True),
+        "skiaRepositoryKey": config["skiaRepositoryKey"],
+        "legacySkiaRepositoryKeys": list(config["legacySkiaRepositoryKeys"]),
+        "docsRepository": docs,
+        "docsUrl": github_url(docs),
+        "docsGitUrl": github_url(docs, git=True),
+        "upstreamSkiaRepository": upstream,
+        "upstreamSkiaGitUrl": github_url(upstream, git=True),
+        "publicSiteBaseUrl": config["publicSiteBaseUrl"].rstrip("/"),
+    }
+
+
+def validate_manifest(root: Path, identity: dict) -> None:
+    manifest_path = root / "cgmanifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise IdentityError(f"Unable to read {manifest_path}: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise IdentityError(f"{manifest_path} must contain an object.")
+
+    registrations = manifest.get("registrations")
+    if not isinstance(registrations, list):
+        raise IdentityError(
+            f"{manifest_path} field 'registrations' must contain a list."
+        )
+
+    expected_url = identity["skiaGitUrl"]
+    matches = []
+    for index, registration in enumerate(registrations):
+        if not isinstance(registration, dict):
+            raise IdentityError(
+                f"{manifest_path} registration {index} must contain an object."
+            )
+        component = registration.get("component")
+        if not isinstance(component, dict):
+            continue
+        git = component.get("git")
+        if git is not None and not isinstance(git, dict):
+            raise IdentityError(
+                f"{manifest_path} registration {index} git component must "
+                "contain an object."
+            )
+        if isinstance(git, dict) and git.get("repositoryUrl") == expected_url:
+            matches.append(registration)
+
+    if len(matches) != 1:
+        raise IdentityError(
+            f"{manifest_path} must contain exactly one git registration for "
+            f"{expected_url}; found {len(matches)}."
+        )
+
+
+def _lookup(value: object, dotted_key: str) -> object:
+    current = value
+    for part in dotted_key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise IdentityError(
+                f"Unknown repository identity field: {dotted_key}"
+            )
+        current = current[part]
+    return current
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--repository")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("json")
+    get_parser = subparsers.add_parser("get")
+    get_parser.add_argument("field")
+    subparsers.add_parser("validate")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = create_parser().parse_args(argv)
+    root = (args.root or DEFAULT_ROOT).resolve()
+    try:
+        identity = resolve_identity(
+            root,
+            repository=args.repository,
+            config_path=args.config,
+        )
+        if args.command == "json":
+            print(json.dumps(identity, sort_keys=True))
+        elif args.command == "get":
+            value = _lookup(identity, args.field)
+            if isinstance(value, (dict, list)):
+                print(json.dumps(value, sort_keys=True))
+            else:
+                print(value)
+        elif args.command == "validate":
+            validate_manifest(root, identity)
+            print(
+                f"Repository identity is valid: {identity['repository']} "
+                f"(ID {identity['canonicalRepositoryId']}), "
+                f"Skia {identity['skiaRepository']}, "
+                f"docs {identity['docsRepository']}."
+            )
+        return 0
+    except IdentityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/infra/repository_identity.py
+++ b/scripts/infra/repository_identity.py
@@ -17,7 +17,11 @@ from urllib.parse import urlsplit
 THIS_DIR = Path(__file__).resolve().parent
 DEFAULT_ROOT = THIS_DIR.parents[1]
 CONFIG_PATH = THIS_DIR / "repository-identity.json"
-_SLUG_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_SLUG_RE = re.compile(r"[^/]+/[^/]+")
+_OWNER_RE = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?"
+)
+_REPOSITORY_RE = re.compile(r"[A-Za-z0-9._-]{1,100}")
 _URL_PATTERNS = (
     re.compile(
         r"https://github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
@@ -56,20 +60,36 @@ def _normalize_slug(value: str) -> str:
     slug = value.removesuffix(".git")
     if not _SLUG_RE.fullmatch(slug):
         raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
+
+    owner, repository = slug.split("/", 1)
+    if (
+        not _OWNER_RE.fullmatch(owner)
+        or "--" in owner
+        or not _REPOSITORY_RE.fullmatch(repository)
+        or repository in {".", ".."}
+    ):
+        raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
     return slug
 
 
 def normalize_github_repository(value: str) -> str:
     """Return an owner/repository slug for a supported GitHub URL or slug."""
 
-    candidate = (value or "").strip()
-    if _SLUG_RE.fullmatch(candidate):
-        return _normalize_slug(candidate)
+    if not isinstance(value, str):
+        raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
+    candidate = value
+    if candidate != candidate.strip() or any(
+        character.isspace()
+        or ord(character) < 32
+        or ord(character) == 127
+        for character in candidate
+    ):
+        raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
     for pattern in _URL_PATTERNS:
         match = pattern.fullmatch(candidate)
         if match:
             return _normalize_slug(match.group("slug"))
-    raise IdentityError(f"Unsupported GitHub repository identity: {value!r}")
+    return _normalize_slug(candidate)
 
 
 def github_url(repository: str, *, git: bool = False) -> str:
@@ -242,14 +262,32 @@ def validate_manifest(root: Path, identity: dict) -> None:
             )
         component = registration.get("component")
         if not isinstance(component, dict):
+            raise IdentityError(
+                f"{manifest_path} registration {index} component must "
+                "contain an object."
+            )
+        component_type = component.get("type")
+        if not isinstance(component_type, str) or not component_type:
+            raise IdentityError(
+                f"{manifest_path} registration {index} component type must "
+                "contain a string."
+            )
+        if component_type != "git":
             continue
+
         git = component.get("git")
-        if git is not None and not isinstance(git, dict):
+        if not isinstance(git, dict):
             raise IdentityError(
                 f"{manifest_path} registration {index} git component must "
                 "contain an object."
             )
-        if isinstance(git, dict) and git.get("repositoryUrl") == expected_url:
+        repository_url = git.get("repositoryUrl")
+        if not isinstance(repository_url, str) or not repository_url:
+            raise IdentityError(
+                f"{manifest_path} registration {index} repositoryUrl must "
+                "contain a string."
+            )
+        if repository_url == expected_url:
             matches.append(registration)
 
     if len(matches) != 1:

--- a/scripts/infra/repository_identity.py
+++ b/scripts/infra/repository_identity.py
@@ -45,8 +45,6 @@ _CONFIG_FIELDS = {
     "offlineRepository": str,
     "upstreamSkiaRepository": str,
     "publicSiteBaseUrl": str,
-    "repositoryKey": str,
-    "legacyRepositoryKeys": list,
     "skiaRepositoryKey": str,
     "legacySkiaRepositoryKeys": list,
 }
@@ -133,19 +131,17 @@ def load_config(path: Path | None = None) -> dict:
         "offlineRepository",
         "upstreamSkiaRepository",
         "publicSiteBaseUrl",
-        "repositoryKey",
         "skiaRepositoryKey",
     ):
         _require_nonempty_string(value, key)
-    for key in ("legacyRepositoryKeys", "legacySkiaRepositoryKeys"):
-        entries = value[key]
-        if not entries or any(
-            not isinstance(entry, str) or not entry.strip() for entry in entries
-        ):
-            raise IdentityError(
-                f"Repository identity config field {key!r} must contain "
-                "non-empty strings."
-            )
+    entries = value["legacySkiaRepositoryKeys"]
+    if not entries or any(
+        not isinstance(entry, str) or not entry.strip() for entry in entries
+    ):
+        raise IdentityError(
+            "Repository identity config field 'legacySkiaRepositoryKeys' "
+            "must contain non-empty strings."
+        )
 
     normalize_github_repository(value["offlineRepository"])
     normalize_github_repository(value["upstreamSkiaRepository"])
@@ -222,8 +218,6 @@ def resolve_identity(
         "repository": current,
         "repositoryUrl": github_url(current),
         "repositoryGitUrl": github_url(current, git=True),
-        "repositoryKey": config["repositoryKey"],
-        "legacyRepositoryKeys": list(config["legacyRepositoryKeys"]),
         "skiaRepository": skia,
         "skiaUrl": github_url(skia),
         "skiaGitUrl": github_url(skia, git=True),

--- a/scripts/infra/tests/test_repository_identity.py
+++ b/scripts/infra/tests/test_repository_identity.py
@@ -83,19 +83,30 @@ class RepositoryIdentityTests(unittest.TestCase):
         )
 
     def test_normalizes_supported_github_identities(self) -> None:
-        for value in (
-            "dotnet/SkiaSharp",
-            "dotnet/SkiaSharp.git",
-            " https://github.com/dotnet/SkiaSharp ",
-            "https://github.com/dotnet/SkiaSharp.git",
-            "https://github.com/dotnet/SkiaSharp/",
-            "git://github.com/dotnet/SkiaSharp.git",
-            "git@github.com:dotnet/SkiaSharp.git",
-            "ssh://git@github.com/dotnet/SkiaSharp.git",
+        for value, expected in (
+            ("dotnet/SkiaSharp", "dotnet/SkiaSharp"),
+            ("dotnet/SkiaSharp.git", "dotnet/SkiaSharp"),
+            (
+                "https://github.com/dotnet/SkiaSharp.git",
+                "dotnet/SkiaSharp",
+            ),
+            ("https://github.com/dotnet/SkiaSharp/", "dotnet/SkiaSharp"),
+            (
+                "git://github.com/dotnet/SkiaSharp.git",
+                "dotnet/SkiaSharp",
+            ),
+            ("git@github.com:dotnet/SkiaSharp.git", "dotnet/SkiaSharp"),
+            (
+                "ssh://git@github.com/dotnet/SkiaSharp.git",
+                "dotnet/SkiaSharp",
+            ),
+            ("owner-name/repo.name_with-dots", "owner-name/repo.name_with-dots"),
+            ("owner/.github", "owner/.github"),
+            ("owner/_private", "owner/_private"),
         ):
             with self.subTest(value=value):
                 self.assertEqual(
-                    "dotnet/SkiaSharp",
+                    expected,
                     IDENTITY.normalize_github_repository(value),
                 )
 
@@ -109,10 +120,22 @@ class RepositoryIdentityTests(unittest.TestCase):
     def test_rejects_non_github_and_ambiguous_identities(self) -> None:
         for value in (
             "",
+            " dotnet/SkiaSharp ",
             "SkiaSharp",
+            "./repo",
+            "../repo",
+            "owner/.",
+            "owner/..",
             "dotnet/",
             "dotnet/.git",
             "/SkiaSharp",
+            "-owner/repo",
+            "owner-/repo",
+            "owner--name/repo",
+            "owner_name/repo",
+            "owner/repo name",
+            "owner/repo\tname",
+            "owner/repo\x00name",
             "https://example.test/dotnet/SkiaSharp",
             "https://github.com/dotnet",
             "https://github.com/dotnet/SkiaSharp/issues/1",
@@ -297,6 +320,24 @@ class RepositoryIdentityTests(unittest.TestCase):
                     with self.assertRaises(IDENTITY.IdentityError):
                         IDENTITY.validate_manifest(root, identity)
 
+            (root / "cgmanifest.json").write_text(
+                json.dumps(
+                    {
+                        "registrations": [
+                            {
+                                "component": {
+                                    "type": "other",
+                                    "git": {"repositoryUrl": expected},
+                                }
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.validate_manifest(root, identity)
+
     def test_rejects_malformed_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -307,9 +348,28 @@ class RepositoryIdentityTests(unittest.TestCase):
                 {},
                 {"registrations": {}},
                 {"registrations": ["invalid"]},
+                {"registrations": [{}]},
+                {"registrations": [{"component": "invalid"}]},
+                {"registrations": [{"component": {}}]},
+                {"registrations": [{"component": {"type": "git"}}]},
                 {
                     "registrations": [
-                        {"component": {"git": "invalid"}}
+                        {"component": {"type": "git", "git": "invalid"}}
+                    ]
+                },
+                {
+                    "registrations": [
+                        {"component": {"type": "git", "git": {}}}
+                    ]
+                },
+                {
+                    "registrations": [
+                        {
+                            "component": {
+                                "type": "git",
+                                "git": {"repositoryUrl": None},
+                            }
+                        }
                     ]
                 },
             )

--- a/scripts/infra/tests/test_repository_identity.py
+++ b/scripts/infra/tests/test_repository_identity.py
@@ -21,8 +21,6 @@ BASE_CONFIG = {
     "offlineRepository": "mono/SkiaSharp",
     "upstreamSkiaRepository": "google/skia",
     "publicSiteBaseUrl": "https://mono.github.io/SkiaSharp",
-    "repositoryKey": "github-52293126",
-    "legacyRepositoryKeys": ["mono-SkiaSharp"],
     "skiaRepositoryKey": "github-52292286",
     "legacySkiaRepositoryKeys": ["mono-skia"],
 }
@@ -152,8 +150,6 @@ class RepositoryIdentityTests(unittest.TestCase):
         self.assertEqual(52293126, config["canonicalRepositoryId"])
         self.assertEqual("mono/SkiaSharp", config["offlineRepository"])
         self.assertEqual("google/skia", config["upstreamSkiaRepository"])
-        self.assertEqual("github-52293126", config["repositoryKey"])
-        self.assertEqual(["mono-SkiaSharp"], config["legacyRepositoryKeys"])
         self.assertEqual("github-52292286", config["skiaRepositoryKey"])
         self.assertEqual(["mono-skia"], config["legacySkiaRepositoryKeys"])
 
@@ -170,8 +166,8 @@ class RepositoryIdentityTests(unittest.TestCase):
                 {**BASE_CONFIG, "canonicalRepositoryId": True},
                 {**BASE_CONFIG, "offlineRepository": ""},
                 {**BASE_CONFIG, "offlineRepository": "SkiaSharp"},
-                {**BASE_CONFIG, "legacyRepositoryKeys": []},
-                {**BASE_CONFIG, "legacyRepositoryKeys": [1]},
+                {**BASE_CONFIG, "legacySkiaRepositoryKeys": []},
+                {**BASE_CONFIG, "legacySkiaRepositoryKeys": [1]},
                 {**BASE_CONFIG, "publicSiteBaseUrl": "http://example.test"},
                 {
                     **BASE_CONFIG,
@@ -254,14 +250,6 @@ class RepositoryIdentityTests(unittest.TestCase):
                 self.assertEqual(
                     "google/skia",
                     identity["upstreamSkiaRepository"],
-                )
-                self.assertEqual(
-                    "github-52293126",
-                    identity["repositoryKey"],
-                )
-                self.assertEqual(
-                    ["mono-SkiaSharp"],
-                    identity["legacyRepositoryKeys"],
                 )
                 self.assertEqual(
                     "github-52292286",
@@ -419,12 +407,7 @@ class RepositoryIdentityTests(unittest.TestCase):
                 identity["publicSiteBaseUrl"],
             )
             self.assertEqual(52293126, identity["canonicalRepositoryId"])
-            self.assertEqual("github-52293126", identity["repositoryKey"])
             self.assertEqual("github-52292286", identity["skiaRepositoryKey"])
-            self.assertEqual(
-                ["mono-SkiaSharp"],
-                identity["legacyRepositoryKeys"],
-            )
             self.assertEqual(
                 ["mono-skia"],
                 identity["legacySkiaRepositoryKeys"],
@@ -462,9 +445,9 @@ class RepositoryIdentityTests(unittest.TestCase):
             with redirect_stdout(stdout):
                 self.assertEqual(
                     0,
-                    IDENTITY.main([*common, "get", "legacyRepositoryKeys"]),
+                    IDENTITY.main([*common, "get", "legacySkiaRepositoryKeys"]),
                 )
-            self.assertEqual('["mono-SkiaSharp"]\n', stdout.getvalue())
+            self.assertEqual('["mono-skia"]\n', stdout.getvalue())
 
             stdout = io.StringIO()
             with redirect_stdout(stdout):

--- a/scripts/infra/tests/test_repository_identity.py
+++ b/scripts/infra/tests/test_repository_identity.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "scripts" / "infra" / "repository_identity.py"
+SPEC = importlib.util.spec_from_file_location("repository_identity", MODULE_PATH)
+IDENTITY = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(IDENTITY)
+
+BASE_CONFIG = {
+    "canonicalRepositoryId": 52293126,
+    "offlineRepository": "mono/SkiaSharp",
+    "upstreamSkiaRepository": "google/skia",
+    "publicSiteBaseUrl": "https://mono.github.io/SkiaSharp",
+    "repositoryKey": "github-52293126",
+    "legacyRepositoryKeys": ["mono-SkiaSharp"],
+    "skiaRepositoryKey": "github-52292286",
+    "legacySkiaRepositoryKeys": ["mono-skia"],
+}
+
+
+class RepositoryIdentityTests(unittest.TestCase):
+    def write_config(self, root: Path, **updates: object) -> Path:
+        config = dict(BASE_CONFIG)
+        config.update(updates)
+        path = root / "repository-identity.json"
+        path.write_text(json.dumps(config), encoding="utf-8")
+        return path
+
+    def write_gitmodules(
+        self,
+        root: Path,
+        *,
+        skia_url: str = "https://github.com/mono/skia.git",
+        docs_url: str = "https://github.com/mono/SkiaSharp-API-docs",
+    ) -> None:
+        (root / ".gitmodules").write_text(
+            '[submodule "externals/skia"]\n'
+            "\tpath = externals/skia\n"
+            f"\turl = {skia_url}\n"
+            '[submodule "docs"]\n'
+            "\tpath = docs\n"
+            f"\turl = {docs_url}\n",
+            encoding="utf-8",
+        )
+
+    def write_manifest(self, root: Path, *repository_urls: str) -> None:
+        registrations = [
+            {
+                "component": {
+                    "type": "git",
+                    "git": {
+                        "repositoryUrl": repository_url,
+                        "commitHash": "0" * 40,
+                    },
+                }
+            }
+            for repository_url in repository_urls
+        ]
+        registrations.append(
+            {
+                "component": {
+                    "type": "other",
+                    "other": {
+                        "name": "libpng",
+                        "version": "1.0",
+                    },
+                }
+            }
+        )
+        (root / "cgmanifest.json").write_text(
+            json.dumps({"registrations": registrations}),
+            encoding="utf-8",
+        )
+
+    def test_normalizes_supported_github_identities(self) -> None:
+        for value in (
+            "dotnet/SkiaSharp",
+            "dotnet/SkiaSharp.git",
+            " https://github.com/dotnet/SkiaSharp ",
+            "https://github.com/dotnet/SkiaSharp.git",
+            "https://github.com/dotnet/SkiaSharp/",
+            "git://github.com/dotnet/SkiaSharp.git",
+            "git@github.com:dotnet/SkiaSharp.git",
+            "ssh://git@github.com/dotnet/SkiaSharp.git",
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    "dotnet/SkiaSharp",
+                    IDENTITY.normalize_github_repository(value),
+                )
+
+        self.assertEqual(
+            "DoTnEt/SkIaShArP",
+            IDENTITY.normalize_github_repository(
+                "HTTPS://GITHUB.COM/DoTnEt/SkIaShArP.git"
+            ),
+        )
+
+    def test_rejects_non_github_and_ambiguous_identities(self) -> None:
+        for value in (
+            "",
+            "SkiaSharp",
+            "dotnet/",
+            "dotnet/.git",
+            "/SkiaSharp",
+            "https://example.test/dotnet/SkiaSharp",
+            "https://github.com/dotnet",
+            "https://github.com/dotnet/SkiaSharp/issues/1",
+            "https://github.com/dotnet/SkiaSharp?ref=main",
+            "https://github.com/dotnet/SkiaSharp#readme",
+            "https://api.github.com/repos/dotnet/SkiaSharp",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(IDENTITY.IdentityError):
+                    IDENTITY.normalize_github_repository(value)
+
+    def test_loads_committed_config(self) -> None:
+        config = IDENTITY.load_config()
+        self.assertEqual(52293126, config["canonicalRepositoryId"])
+        self.assertEqual("mono/SkiaSharp", config["offlineRepository"])
+        self.assertEqual("google/skia", config["upstreamSkiaRepository"])
+        self.assertEqual("github-52293126", config["repositoryKey"])
+        self.assertEqual(["mono-SkiaSharp"], config["legacyRepositoryKeys"])
+        self.assertEqual("github-52292286", config["skiaRepositoryKey"])
+        self.assertEqual(["mono-skia"], config["legacySkiaRepositoryKeys"])
+
+    def test_rejects_missing_and_malformed_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.load_config(root / "missing.json")
+
+            invalid_configs = (
+                [],
+                {key: value for key, value in BASE_CONFIG.items()
+                 if key != "canonicalRepositoryId"},
+                {**BASE_CONFIG, "canonicalRepositoryId": True},
+                {**BASE_CONFIG, "offlineRepository": ""},
+                {**BASE_CONFIG, "offlineRepository": "SkiaSharp"},
+                {**BASE_CONFIG, "legacyRepositoryKeys": []},
+                {**BASE_CONFIG, "legacyRepositoryKeys": [1]},
+                {**BASE_CONFIG, "publicSiteBaseUrl": "http://example.test"},
+                {
+                    **BASE_CONFIG,
+                    "publicSiteBaseUrl": "https://example.test/?preview=1",
+                },
+            )
+            path = root / "identity.json"
+            for config in invalid_configs:
+                with self.subTest(config=config):
+                    path.write_text(json.dumps(config), encoding="utf-8")
+                    with self.assertRaises(IDENTITY.IdentityError):
+                        IDENTITY.load_config(path)
+
+            path.write_text("{", encoding="utf-8")
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.load_config(path)
+
+    def test_current_repository_precedence(self) -> None:
+        config = {"offlineRepository": "fallback/SkiaSharp"}
+        self.assertEqual(
+            "explicit/SkiaSharp",
+            IDENTITY.resolve_current_repository(
+                "explicit/SkiaSharp",
+                environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                config=config,
+            ),
+        )
+        self.assertEqual(
+            "runtime/SkiaSharp",
+            IDENTITY.resolve_current_repository(
+                environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                config=config,
+            ),
+        )
+        self.assertEqual(
+            "fallback/SkiaSharp",
+            IDENTITY.resolve_current_repository(environ={}, config=config),
+        )
+        with self.assertRaises(IDENTITY.IdentityError):
+            IDENTITY.resolve_current_repository(
+                "",
+                environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                config=config,
+            )
+        with self.assertRaises(IDENTITY.IdentityError):
+            IDENTITY.resolve_current_repository(
+                environ={"GITHUB_REPOSITORY": "not-a-repository"},
+                config=config,
+            )
+
+    def test_resolves_paired_repositories_for_both_organizations(self) -> None:
+        for owner in ("mono", "dotnet"):
+            with self.subTest(owner=owner), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                self.write_gitmodules(
+                    root,
+                    skia_url=f"git@github.com:{owner}/skia.git",
+                    docs_url=(
+                        f"ssh://git@github.com/{owner}/"
+                        "SkiaSharp-API-docs.git"
+                    ),
+                )
+                config_path = self.write_config(root)
+                identity = IDENTITY.resolve_identity(
+                    root,
+                    repository=f"https://github.com/{owner}/SkiaSharp.git",
+                    config_path=config_path,
+                )
+
+                self.assertEqual(f"{owner}/SkiaSharp", identity["repository"])
+                self.assertEqual(f"{owner}/skia", identity["skiaRepository"])
+                self.assertEqual(
+                    f"https://github.com/{owner}/skia.git",
+                    identity["skiaGitUrl"],
+                )
+                self.assertEqual(
+                    f"{owner}/SkiaSharp-API-docs",
+                    identity["docsRepository"],
+                )
+                self.assertEqual(
+                    "google/skia",
+                    identity["upstreamSkiaRepository"],
+                )
+                self.assertEqual(
+                    "github-52293126",
+                    identity["repositoryKey"],
+                )
+                self.assertEqual(
+                    ["mono-SkiaSharp"],
+                    identity["legacyRepositoryKeys"],
+                )
+                self.assertEqual(
+                    "github-52292286",
+                    identity["skiaRepositoryKey"],
+                )
+                self.assertEqual(
+                    ["mono-skia"],
+                    identity["legacySkiaRepositoryKeys"],
+                )
+
+    def test_rejects_missing_and_malformed_submodule_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.read_submodule_repository(root, "externals/skia")
+
+            gitmodules = root / ".gitmodules"
+            gitmodules.write_text("not a config file", encoding="utf-8")
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.read_submodule_repository(root, "externals/skia")
+
+            gitmodules.write_text(
+                '[submodule "docs"]\n\tpath = docs\n',
+                encoding="utf-8",
+            )
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.read_submodule_repository(root, "docs")
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.read_submodule_repository(root, "externals/skia")
+
+            gitmodules.write_text(
+                '[submodule "externals/skia"]\n'
+                "\turl = https://example.test/mono/skia.git\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.read_submodule_repository(root, "externals/skia")
+
+    def test_manifest_requires_exactly_one_exact_skia_registration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = "https://github.com/dotnet/skia.git"
+            identity = {"skiaGitUrl": expected}
+
+            self.write_manifest(root, expected)
+            IDENTITY.validate_manifest(root, identity)
+
+            for urls in (
+                (),
+                (expected, expected),
+                ("https://github.com/dotnet/skia",),
+                ("https://github.com/mono/skia.git",),
+            ):
+                with self.subTest(urls=urls):
+                    self.write_manifest(root, *urls)
+                    with self.assertRaises(IDENTITY.IdentityError):
+                        IDENTITY.validate_manifest(root, identity)
+
+    def test_rejects_malformed_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            identity = {"skiaGitUrl": "https://github.com/mono/skia.git"}
+            path = root / "cgmanifest.json"
+            invalid_manifests = (
+                [],
+                {},
+                {"registrations": {}},
+                {"registrations": ["invalid"]},
+                {
+                    "registrations": [
+                        {"component": {"git": "invalid"}}
+                    ]
+                },
+            )
+            for manifest in invalid_manifests:
+                with self.subTest(manifest=manifest):
+                    path.write_text(json.dumps(manifest), encoding="utf-8")
+                    with self.assertRaises(IDENTITY.IdentityError):
+                        IDENTITY.validate_manifest(root, identity)
+
+            path.write_text("{", encoding="utf-8")
+            with self.assertRaises(IDENTITY.IdentityError):
+                IDENTITY.validate_manifest(root, identity)
+
+    def test_complete_destination_identity_flip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = self.write_config(
+                root,
+                offlineRepository="dotnet/SkiaSharp",
+                publicSiteBaseUrl="https://docs.example/SkiaSharp/",
+            )
+            self.write_gitmodules(
+                root,
+                skia_url="https://github.com/dotnet/skia.git",
+                docs_url="https://github.com/dotnet/SkiaSharp-API-docs.git",
+            )
+            self.write_manifest(
+                root,
+                "https://github.com/dotnet/skia.git",
+            )
+
+            identity = IDENTITY.resolve_identity(
+                root,
+                environ={},
+                config_path=config_path,
+            )
+            IDENTITY.validate_manifest(root, identity)
+
+            self.assertEqual("dotnet/SkiaSharp", identity["repository"])
+            self.assertEqual("dotnet/skia", identity["skiaRepository"])
+            self.assertEqual(
+                "dotnet/SkiaSharp-API-docs",
+                identity["docsRepository"],
+            )
+            self.assertEqual(
+                "https://docs.example/SkiaSharp",
+                identity["publicSiteBaseUrl"],
+            )
+            self.assertEqual(52293126, identity["canonicalRepositoryId"])
+            self.assertEqual("github-52293126", identity["repositoryKey"])
+            self.assertEqual("github-52292286", identity["skiaRepositoryKey"])
+            self.assertEqual(
+                ["mono-SkiaSharp"],
+                identity["legacyRepositoryKeys"],
+            )
+            self.assertEqual(
+                ["mono-skia"],
+                identity["legacySkiaRepositoryKeys"],
+            )
+
+    def test_cli_json_get_validate_and_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = self.write_config(root)
+            self.write_gitmodules(root)
+            self.write_manifest(root, "https://github.com/mono/skia.git")
+            common = [
+                "--root",
+                str(root),
+                "--config",
+                str(config_path),
+                "--repository",
+                "https://github.com/dotnet/SkiaSharp.git",
+            ]
+            identity = IDENTITY.resolve_identity(
+                root,
+                repository="dotnet/SkiaSharp",
+                config_path=config_path,
+            )
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                self.assertEqual(0, IDENTITY.main([*common, "json"]))
+            self.assertEqual(
+                json.dumps(identity, sort_keys=True) + "\n",
+                stdout.getvalue(),
+            )
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                self.assertEqual(
+                    0,
+                    IDENTITY.main([*common, "get", "legacyRepositoryKeys"]),
+                )
+            self.assertEqual('["mono-SkiaSharp"]\n', stdout.getvalue())
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                self.assertEqual(0, IDENTITY.main([*common, "validate"]))
+            self.assertIn(
+                "Repository identity is valid: dotnet/SkiaSharp",
+                stdout.getvalue(),
+            )
+
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                self.assertEqual(
+                    1,
+                    IDENTITY.main([*common, "get", "missing"]),
+                )
+            self.assertIn(
+                "Unknown repository identity field: missing",
+                stderr.getvalue(),
+            )
+
+    def test_current_checkout_identity_and_manifest_are_consistent(self) -> None:
+        identity = IDENTITY.resolve_identity(ROOT, environ={})
+        self.assertEqual("mono/SkiaSharp", identity["repository"])
+        self.assertEqual("mono/skia", identity["skiaRepository"])
+        self.assertEqual(
+            "mono/SkiaSharp-API-docs",
+            identity["docsRepository"],
+        )
+        IDENTITY.validate_manifest(ROOT, identity)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds the small, inert repository identity foundation needed for the planned
`mono` to `dotnet` transfer without migrating any consumers yet.

The committed identity contract owns the stable SkiaSharp repository ID,
stable/legacy Skia cache keys, the single offline SkiaSharp fallback, explicit
upstream Skia identity, and current public-site base. A network-free Python
standard-library helper resolves the current repository from an explicit
value, GitHub Actions context, or the offline fallback; reads the paired Skia
and API-docs identities from `.gitmodules`; and exposes the resolved values
through importable helpers plus `json`, `get`, and `validate` CLI commands for
Python, shell, and PowerShell consumers. It intentionally does not expose
SkiaSharp cache keys used only by deferred `issue-*` tooling.

Normalization accepts only complete GitHub repository slugs and supported clone
URL forms. Manifest validation requires exactly one `cgmanifest.json` Git
registration whose URL exactly matches the canonical Skia clone URL derived
from `.gitmodules`. Focused tests cover current and destination identities,
strict URL boundaries, malformed inputs, stable/legacy keys, CLI output, and a
complete transfer simulation.

This PR intentionally does not migrate consumers or change `.gitmodules`,
`cgmanifest.json`, live URLs, workflows gates, synchronization, publishing,
release tooling, packages, DocFX/Gallery, generated/native files, or submodule
SHAs.

**Related issues**

Fixes #4986

Related to #4960

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — repository tooling only; no public API or application behavior changes.

## Testing

- `python3 -m unittest scripts/infra/tests/test_repository_identity.py -v`
- Strict normalization cases for trim-changing input, dot segments, whitespace/control
  characters, GitHub owner rules, and valid dotted/underscored repository names
- Exact manifest cases for typed Git components, malformed structures, non-Git components,
  missing fields, zero matches, duplicate matches, and mismatched URLs
- `python3 scripts/infra/repository_identity.py validate`
- `python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py" -v`
- All `.agents/skills/update-skia/scripts/*_test.py` suites
- `/bin/bash .github/scripts/tests/skia-sync-detect.test.sh`
- Automation workflow filters cover identity source, `.gitmodules`, and `cgmanifest.json`
- `python3 scripts/infra/caching/repo-deps.py validate` with the inert identity files excluded
  from product cache inputs, 4,853 tracked files, and zero uncovered
- `python3 -m py_compile scripts/infra/repository_identity.py scripts/infra/tests/test_repository_identity.py`

Validated on macOS. No native, generated, managed-product, rendering, or
submodule content changed.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A
