### PR TITLE
[memory-leak] Generalize disposed-field ownership guidance

### DIFF
--- a/.agents/skills/memory-leak-fixer/references/leaks/field-not-nulled-on-dispose.md
+++ b/.agents/skills/memory-leak-fixer/references/leaks/field-not-nulled-on-dispose.md
@@ -1,21 +1,24 @@
 # 8 — Field not nulled on dispose
 
-**Where to look.** `binding/SkiaSharp/**`. `grep -rnE "DisposeManaged|= null;" binding/SkiaSharp` — a freed native child field that isn't cleared afterwards.
+**Where to look.** `binding/SkiaSharp/**`. `grep -rnE "DisposeManaged|= null;" binding/SkiaSharp` — a managed field that remains after the wrapper/native teardown, whether it held an owned child or a borrowed dependency.
 
-**What it is.** A `Dispose`/`DisposeManaged` frees a cached native child (a canvas, a
-sub-object) but leaves the managed field still pointing at the now-dead wrapper.
+**What it is.** A `Dispose`/`DisposeManaged` completes wrapper/native teardown but leaves
+a managed field rooted even though it is no longer needed. This can be a cached native child
+that the wrapper owns, or a caller-owned dependency that the wrapper merely borrows.
 
-**Why it's bad.** A later `Dispose` (or a caller re-reading the field) hits the freed object →
-**double-dispose / `AccessViolationException`**; or the stale reference keeps a whole native
-graph rooted → leak.
+**Why it's bad.** An owned child left pointing at a disposed wrapper can be disposed again or
+read after disposal → **double-dispose / `AccessViolationException`**. A borrowed dependency
+must not be disposed by this wrapper, but retaining its stale field still keeps the caller's
+object graph rooted for as long as the disposed wrapper remains reachable.
 
 **Leak (❌):**
 ```csharp
 protected override void DisposeManaged()
 {
-    _canvas?.Dispose();
-    // ❌ _canvas still references the disposed wrapper; a second Dispose double-frees.
-    base.DisposeManaged();
+    TearDownNativeUsage();
+    if (ownsDependency)
+        dependency?.Dispose();
+    // ❌ `dependency` stays rooted when it was borrowed.
 }
 ```
 
@@ -23,14 +26,18 @@ protected override void DisposeManaged()
 ```csharp
 protected override void DisposeManaged()
 {
-    _canvas?.Dispose();
-    _canvas = null;               // clear the link → second dispose is a no-op
-    base.DisposeManaged();
+    TearDownNativeUsage();         // native callbacks can no longer use `dependency`
+    if (ownsDependency)
+        dependency?.Dispose();     // dispose only what this wrapper owns
+    dependency = null;             // clear owned and borrowed dependencies after teardown
 }
 ```
 
-**Watch out (❌ don't):** don't null the field *before* disposing the child — you'd drop the
-only reference and leak the native object instead. The order is fixed: **dispose, then null.**
+**Watch out (❌ don't):** don't clear a field while callbacks or native teardown can still use
+it, and never dispose a caller-owned resource. Once teardown no longer needs the field, the
+order for an owned resource is **dispose, then null**; for a borrowed resource, **do not
+dispose, but null**. The abbreviated example shows the required lifetime rule, not a claim
+that every wrapper with a similarly shaped field is defective.
 
 **Real cases:** #1256, #1344. `SKSurface` (nulls its cached `SKCanvas`) and `SKPixmap` (nulls
 `pixelSource`) are the correct patterns.


### PR DESCRIPTION
## Description

Generalize memory-leak-fixer focus-area 8 from historical disposal fixes [#1256](https://github.com/mono/SkiaSharp/pull/1256) and [#1344](https://github.com/mono/SkiaSharp/pull/1344).

PR #1256 established that a disposed cached field must be nulled so later access cannot reuse a dead wrapper. PR #1344 established that cleanup order depends on ownership across managed/native object pairs: reference-only children may require managed cleanup before native teardown, while native-owned managed dependencies can remain live until native teardown finishes.

Focus 8 now expresses the general rule derived from those cases:

- after wrapper/native teardown, clear managed fields that are no longer needed;
- owned resources are disposed and then nulled;
- borrowed resources are not disposed, but their stale fields are nulled after teardown;
- fields remain rooted while native teardown or callbacks can still use them.

The example remains generalized and explicitly does not classify every similarly shaped wrapper as defective. One-leak-per-run, empirical-proof, and open-item deduplication gates remain unchanged.

**Related issues**

Context: https://github.com/mono/SkiaSharp/pull/1256  
Context: https://github.com/mono/SkiaSharp/pull/1344

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — agent guidance only; no public API or runtime behavior changes.

## Testing

- Verified the historical ownership and cleanup rules against merged PRs #1256 and #1344.
- Verified every focus reference link exists.
- A clean, de-biased focus-8 dry run ([33936785050](https://github.com/mono/SkiaSharp/actions/runs/33936785050)) using GPT-5.6 Terra independently applied the corrected ownership/retention distinction and produced both a shipped-package `WeakReference` probe and in-repository red→green validation. This confirms the revised guidance directs Terra to the intended analysis without broadening it into a claim about every similarly shaped wrapper.
- Independent GPT-5.6 Sol code review reported no significant issues.
- `git diff --check` passed.

No workflow source changed, so lock recompilation was not required.

## Checklist

- [x] Tests added or updated (not applicable; one-file guidance change grounded in historical merged fixes and independent review)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later (not applicable)
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated (not applicable)