### PR TITLE
[migration] Make CI status and dashboard repository-portable

### DIFF
--- a/.agents/skills/ci-status/SKILL.md
+++ b/.agents/skills/ci-status/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Check the CI build health and automation status of SkiaSharp across main and
   recent release branches. Collects the last N builds from the AzDO pipeline chain
   (Public plus the combined Build and connected Tests) and all GitHub Actions workflows from
-  mono/SkiaSharp and mono/SkiaSharp-API-docs, providing a daily dashboard view
+  the current SkiaSharp and `.gitmodules`-resolved API-docs repositories, providing a daily dashboard view
   with AI-powered analysis of failures, regressions, and flakes.
 
   Use when user asks to:
@@ -39,7 +39,7 @@ including the current dnceng Build and Tests pipelines.
 
 The collector script requires:
 - **`az` CLI** — authenticated with access to `dnceng-public/public` and `dnceng/internal`
-- **`gh` CLI** — authenticated with read access to `mono/SkiaSharp` and `mono/SkiaSharp-API-docs`
+- **`gh` CLI** — authenticated with read access to the current and `.gitmodules`-resolved API-docs repositories
 - **Git remotes** — fetched recently so `git branch -r` returns up-to-date release branches
 
 ### Public CI (dnceng-public/public org — triggers on push/PR to main and release/*)
@@ -60,40 +60,44 @@ Tests consumes the folder-qualified pipeline resource
 managed compilation, real signing, BAR registration/validation, and Arcade's
 standard Darc/Maestro stages.
 
-### GitHub Actions (mono/SkiaSharp and mono/SkiaSharp-API-docs)
+### GitHub Actions
+
+`{current}` means the repository resolved from the explicit CLI option, GitHub
+context, or an unambiguous local GitHub remote. `{docs}` means the API-docs repository
+resolved from `.gitmodules`.
 
 | Workflow | Repository | Trigger | Why Track |
 |----------|------------|---------|-----------|
-| Pages - Deploy | mono/SkiaSharp | Push/PR to main | Docs site broken if failing |
-| Pages - Go Live! | mono/SkiaSharp | Workflow dispatch | Docs don't publish if failing |
-| Pages - PR Staging - Cleanup | mono/SkiaSharp | PR close events | Stale staging deploys accumulate |
-| Pages - PR Staging - Sweep Stale | mono/SkiaSharp | Daily (06:00 UTC) | Stale staging deploys accumulate |
-| Sync - Samples | mono/SkiaSharp | Push/PR to `samples/` | Sample projects broken if failing |
-| Tests - Binding Generation Determinism | mono/SkiaSharp | Push/PR | Generated bindings drift undetected |
-| Sync - Docs Submodule | mono/SkiaSharp | Daily (10:00 UTC) | API docs get out of sync |
-| Sync - Skia Submodule | mono/SkiaSharp | Daily (10:30 UTC) | Skia submodule pin goes stale |
-| Sync - Release Notes & API Diffs | mono/SkiaSharp | Push to main + daily | Release notes stop auto-updating |
-| Sync - Skia Upstream | mono/SkiaSharp | Every 6h | Upstream tracking breaks |
-| Fixer - Memory Leak | mono/SkiaSharp | Every 12h | Leak-hunting automation stops |
-| Fixer - Performance | mono/SkiaSharp | Every 12h | Perf-hunting automation stops |
-| Sync - Issue Triage | mono/SkiaSharp | Daily | Triage automation stops |
-| Sync - Issue Template Versions | mono/SkiaSharp | Daily (09:00 UTC) | Bug template advertises stale versions |
-| Sync - Agentic Data | mono/SkiaSharp | Workflow run events | AI workflow data lost |
-| Track - Artifact Sizes | mono/SkiaSharp | Nightly + PR sweep | Package size tracking/PR reports stop |
-| Track - Benchmarks | mono/SkiaSharp | Every 6h | Benchmark trend tracking stops |
-| Release - Prepare | mono/SkiaSharp | Workflow dispatch | Release branches cannot be cut |
-| Release - Finish | mono/SkiaSharp | Workflow dispatch | Releases cannot be finalized |
-| Release - Milestones | mono/SkiaSharp | Workflow dispatch | Milestone reconciliation stops |
-| Update GitHub Release summaries | mono/SkiaSharp | Workflow dispatch | Release bodies go stale |
-| Release - Tooling Tests | mono/SkiaSharp | Push/PR to release tooling | Release scripts regress unnoticed |
-| Automation - Tooling Tests | mono/SkiaSharp | Push/PR to automation tooling | Automation scripts regress unnoticed |
-| PR - Backport | mono/SkiaSharp | PR label/comment | Cherry-picks to release branches fail |
-| PR - Rebase | mono/SkiaSharp | PR comment | PR rebase automation broken |
-| PR - Artifacts Comment | mono/SkiaSharp | Workflow run events | Build links not posted to PRs |
-| Merge Message | mono/SkiaSharp | PR comment events | Merge commit messages not drafted |
-| Auto API Docs Writer | mono/SkiaSharp-API-docs | Scheduled/dispatch | XML docs stop being written |
-| Automerge Docs | mono/SkiaSharp-API-docs | PR events | Doc PRs won't auto-merge |
-| Go Live | mono/SkiaSharp-API-docs | Workflow dispatch | Docs don't publish to live |
+| Pages - Deploy | `{current}` | Push/PR to main | Docs site broken if failing |
+| Pages - Go Live! | `{current}` | Workflow dispatch | Docs don't publish if failing |
+| Pages - PR Staging - Cleanup | `{current}` | PR close events | Stale staging deploys accumulate |
+| Pages - PR Staging - Sweep Stale | `{current}` | Daily (06:00 UTC) | Stale staging deploys accumulate |
+| Sync - Samples | `{current}` | Push/PR to `samples/` | Sample projects broken if failing |
+| Tests - Binding Generation Determinism | `{current}` | Push/PR | Generated bindings drift undetected |
+| Sync - Docs Submodule | `{current}` | Daily (10:00 UTC) | API docs get out of sync |
+| Sync - Skia Submodule | `{current}` | Daily (10:30 UTC) | Skia submodule pin goes stale |
+| Sync - Release Notes & API Diffs | `{current}` | Push to main + daily | Release notes stop auto-updating |
+| Sync - Skia Upstream | `{current}` | Every 6h | Upstream tracking breaks |
+| Fixer - Memory Leak | `{current}` | Every 12h | Leak-hunting automation stops |
+| Fixer - Performance | `{current}` | Every 12h | Perf-hunting automation stops |
+| Sync - Issue Triage | `{current}` | Daily | Triage automation stops |
+| Sync - Issue Template Versions | `{current}` | Daily (09:00 UTC) | Bug template advertises stale versions |
+| Sync - Agentic Data | `{current}` | Workflow run events | AI workflow data lost |
+| Track - Artifact Sizes | `{current}` | Nightly + PR sweep | Package size tracking/PR reports stop |
+| Track - Benchmarks | `{current}` | Every 6h | Benchmark trend tracking stops |
+| Release - Prepare | `{current}` | Workflow dispatch | Release branches cannot be cut |
+| Release - Finish | `{current}` | Workflow dispatch | Releases cannot be finalized |
+| Release - Milestones | `{current}` | Workflow dispatch | Milestone reconciliation stops |
+| Update GitHub Release summaries | `{current}` | Workflow dispatch | Release bodies go stale |
+| Release - Tooling Tests | `{current}` | Push/PR to release tooling | Release scripts regress unnoticed |
+| Automation - Tooling Tests | `{current}` | Push/PR to automation tooling | Automation scripts regress unnoticed |
+| PR - Backport | `{current}` | PR label/comment | Cherry-picks to release branches fail |
+| PR - Rebase | `{current}` | PR comment | PR rebase automation broken |
+| PR - Artifacts Comment | `{current}` | Workflow run events | Build links not posted to PRs |
+| Merge Message | `{current}` | PR comment events | Merge commit messages not drafted |
+| Auto API Docs Writer | `{docs}` | Scheduled/dispatch | XML docs stop being written |
+| Automerge Docs | `{docs}` | PR events | Doc PRs won't auto-merge |
+| Go Live | `{docs}` | Workflow dispatch | Docs don't publish to live |
 
 > Schedules above are deliberately imprecise for gh-aw generated `*.lock.yml` workflows
 > ("Every 6h", "Daily"). The compiler re-jitters their cron on every upgrade, so a literal
@@ -123,6 +127,7 @@ summary for quick visual inspection.
 | `--builds N` | 5 | Number of recent builds to show per pipeline per branch |
 | `--no-issues` | off | Skip fetching errors/warnings (faster, less detail) |
 | `--json PATH` | none | Write raw structured JSON (for AI analysis) |
+| `--repository OWNER/REPO` | context or `origin` | Override the current GitHub repository |
 
 ### Examples
 

--- a/.agents/skills/ci-status/references/report-schema.md
+++ b/.agents/skills/ci-status/references/report-schema.md
@@ -167,7 +167,7 @@ Array of chain analysis verdicts. One entry per branch with ≥1 red internal pi
   "workflows": [
     {
       "name": "Pages - Deploy",
-      "repo": "mono/SkiaSharp",
+      "repo": "{current}",
       "trigger": "push",
       "scope": "branch",
       "severity": "high",
@@ -222,7 +222,7 @@ Array of chain analysis verdicts. One entry per branch with ≥1 red internal pi
     "name": "build-and-deploy",
     "failedSteps": ["Run build", "Deploy to Azure"],
     "runId": 26651087356,
-    "runUrl": "https://github.com/mono/SkiaSharp/actions/runs/..."
+    "runUrl": "https://github.com/{current}/actions/runs/..."
   }
 ]
 ```

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -2,14 +2,14 @@
 """Collect CI build status for SkiaSharp main and recent release branches.
 
 Usage:
-    ci-status.py [--branches N] [--builds N] [--output FILE] [--json FILE]
+    ci-status.py [--branches N] [--builds N] [--json FILE] [--repository OWNER/REPO]
 
 Options:
     --branches N    Number of most recent release branches to include (default: 3)
     --builds N      Number of recent builds per pipeline per branch (default: 5)
-    --output FILE   Write a formatted markdown report to FILE
     --json FILE     Write raw structured JSON data to FILE (for AI analysis)
     --no-issues     Skip fetching errors/warnings (faster)
+    --repository    Override the current GitHub repository
 
 Queries Azure DevOps for:
   Public CI:  mono-SkiaSharp — dnceng-public/public, def 345
@@ -17,13 +17,21 @@ Queries Azure DevOps for:
 """
 
 import argparse
+import configparser
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.request
 from datetime import datetime, timezone
 from collections import defaultdict
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+_OWNER_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?")
+_REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+")
 
 ORG_DNCENG = "https://dev.azure.com/dnceng"
 PROJECT_DNCENG = "internal"
@@ -60,46 +68,153 @@ ICONS = {
 # trigger: "push" = push/PR, "schedule" = cron, "dispatch" = manual, "event" = PR/issue events
 # branches: (optional) override which branches to query for branch-scoped workflows.
 #           If omitted, uses the full set (main + release/*).
-GITHUB_WORKFLOWS = [
-    # mono/SkiaSharp — Build & Docs (push-triggered, main + release/*)
-    {"repo": "mono/SkiaSharp", "workflow": "build-site.yml", "name": "Pages - Deploy", "scope": "branch", "trigger": "push"},
-    {"repo": "mono/SkiaSharp", "workflow": "samples.yml", "name": "Sync - Samples", "scope": "branch", "trigger": "push"},
-    {"repo": "mono/SkiaSharp", "workflow": "binding-generation-determinism.yml", "name": "Tests - Binding Generation Determinism", "scope": "branch", "trigger": "push"},
-    # mono/SkiaSharp — Release-path push workflow (main + release/*)
-    {"repo": "mono/SkiaSharp", "workflow": "update-release-notes.lock.yml", "name": "Sync - Release Notes & API Diffs", "scope": "branch", "trigger": "push"},
-    # mono/SkiaSharp — Automation & Sync (global: scheduled/dispatch, not branch-specific)
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-go-live.yml", "name": "Pages - Go Live!", "scope": "global", "trigger": "dispatch"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup.yml", "name": "Pages - PR Staging - Cleanup", "scope": "global", "trigger": "event"},
-    {"repo": "mono/SkiaSharp", "workflow": "build-site-cleanup-stale.yml", "name": "Pages - PR Staging - Sweep Stale", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-docs-submodule-sync.yml", "name": "Sync - Docs Submodule", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-submodule-sync.yml", "name": "Sync - Skia Submodule", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-skia-sync.lock.yml", "name": "Sync - Skia Upstream", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "memory-leak-fixer.lock.yml", "name": "Fixer - Memory Leak", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "performance-fixer.lock.yml", "name": "Fixer - Performance", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-triage.lock.yml", "name": "Sync - Issue Triage", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "auto-update-issue-template-versions.yml", "name": "Sync - Issue Template Versions", "scope": "global", "trigger": "schedule"},
+_GITHUB_WORKFLOWS = [
+    # Current repository — Build & Docs (push-triggered, main + release/*)
+    {"repo": "current", "workflow": "build-site.yml", "name": "Pages - Deploy", "scope": "branch", "trigger": "push"},
+    {"repo": "current", "workflow": "samples.yml", "name": "Sync - Samples", "scope": "branch", "trigger": "push"},
+    {"repo": "current", "workflow": "binding-generation-determinism.yml", "name": "Tests - Binding Generation Determinism", "scope": "branch", "trigger": "push"},
+    # Current repository — Release-path push workflow (main + release/*)
+    {"repo": "current", "workflow": "update-release-notes.lock.yml", "name": "Sync - Release Notes & API Diffs", "scope": "branch", "trigger": "push"},
+    # Current repository — Automation & Sync (global: scheduled/dispatch, not branch-specific)
+    {"repo": "current", "workflow": "build-site-go-live.yml", "name": "Pages - Go Live!", "scope": "global", "trigger": "dispatch"},
+    {"repo": "current", "workflow": "build-site-cleanup.yml", "name": "Pages - PR Staging - Cleanup", "scope": "global", "trigger": "event"},
+    {"repo": "current", "workflow": "build-site-cleanup-stale.yml", "name": "Pages - PR Staging - Sweep Stale", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "auto-docs-submodule-sync.yml", "name": "Sync - Docs Submodule", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "auto-skia-submodule-sync.yml", "name": "Sync - Skia Submodule", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "auto-skia-sync.lock.yml", "name": "Sync - Skia Upstream", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "memory-leak-fixer.lock.yml", "name": "Fixer - Memory Leak", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "performance-fixer.lock.yml", "name": "Fixer - Performance", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "auto-triage.lock.yml", "name": "Sync - Issue Triage", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "auto-update-issue-template-versions.yml", "name": "Sync - Issue Template Versions", "scope": "global", "trigger": "schedule"},
     # persist-aw-data runs off workflow_run, not push — see tests/test_workflow_registry.py
-    {"repo": "mono/SkiaSharp", "workflow": "persist-aw-data.yml", "name": "Sync - Agentic Data", "scope": "global", "trigger": "event"},
-    # mono/SkiaSharp — Tracking dashboards (global: scheduled)
-    {"repo": "mono/SkiaSharp", "workflow": "track-artifact-sizes.yml", "name": "Track - Artifact Sizes", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp", "workflow": "track-benchmarks.yml", "name": "Track - Benchmarks", "scope": "global", "trigger": "schedule"},
-    # mono/SkiaSharp — Release path (dispatch-driven, plus the tooling test gate)
-    {"repo": "mono/SkiaSharp", "workflow": "release-prepare.yml", "name": "Release - Prepare", "scope": "global", "trigger": "dispatch"},
-    {"repo": "mono/SkiaSharp", "workflow": "release-finish.yml", "name": "Release - Finish", "scope": "global", "trigger": "dispatch"},
-    {"repo": "mono/SkiaSharp", "workflow": "release-milestones.yml", "name": "Release - Milestones", "scope": "global", "trigger": "dispatch"},
-    {"repo": "mono/SkiaSharp", "workflow": "update-github-release-summaries.yml", "name": "Update GitHub Release summaries", "scope": "global", "trigger": "dispatch"},
-    {"repo": "mono/SkiaSharp", "workflow": "release-tooling-tests.yml", "name": "Release - Tooling Tests", "scope": "branch", "trigger": "push"},
-    {"repo": "mono/SkiaSharp", "workflow": "automation-tooling-tests.yml", "name": "Automation - Tooling Tests", "scope": "branch", "trigger": "push"},
-    # mono/SkiaSharp — PR Utilities (global: triggered by PR events, not branch-specific)
-    {"repo": "mono/SkiaSharp", "workflow": "backport.yml", "name": "PR - Backport", "scope": "global", "trigger": "event"},
-    {"repo": "mono/SkiaSharp", "workflow": "rebase.yml", "name": "PR - Rebase", "scope": "global", "trigger": "event"},
-    {"repo": "mono/SkiaSharp", "workflow": "pr-artifacts-comment.yml", "name": "PR - Artifacts Comment", "scope": "global", "trigger": "event"},
-    {"repo": "mono/SkiaSharp", "workflow": "merge-message.lock.yml", "name": "Merge Message", "scope": "global", "trigger": "event"},
-    # mono/SkiaSharp-API-docs (global: scheduled/dispatch/PR events)
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer", "scope": "global", "trigger": "schedule"},
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs", "scope": "global", "trigger": "event"},
-    {"repo": "mono/SkiaSharp-API-docs", "workflow": "go-live.yml", "name": "Go Live", "scope": "global", "trigger": "dispatch"},
+    {"repo": "current", "workflow": "persist-aw-data.yml", "name": "Sync - Agentic Data", "scope": "global", "trigger": "event"},
+    # Current repository — Tracking dashboards (global: scheduled)
+    {"repo": "current", "workflow": "track-artifact-sizes.yml", "name": "Track - Artifact Sizes", "scope": "global", "trigger": "schedule"},
+    {"repo": "current", "workflow": "track-benchmarks.yml", "name": "Track - Benchmarks", "scope": "global", "trigger": "schedule"},
+    # Current repository — Release path (dispatch-driven, plus the tooling test gate)
+    {"repo": "current", "workflow": "release-prepare.yml", "name": "Release - Prepare", "scope": "global", "trigger": "dispatch"},
+    {"repo": "current", "workflow": "release-finish.yml", "name": "Release - Finish", "scope": "global", "trigger": "dispatch"},
+    {"repo": "current", "workflow": "release-milestones.yml", "name": "Release - Milestones", "scope": "global", "trigger": "dispatch"},
+    {"repo": "current", "workflow": "update-github-release-summaries.yml", "name": "Update GitHub Release summaries", "scope": "global", "trigger": "dispatch"},
+    {"repo": "current", "workflow": "release-tooling-tests.yml", "name": "Release - Tooling Tests", "scope": "branch", "trigger": "push"},
+    {"repo": "current", "workflow": "automation-tooling-tests.yml", "name": "Automation - Tooling Tests", "scope": "branch", "trigger": "push"},
+    # Current repository — PR Utilities (global: triggered by PR events, not branch-specific)
+    {"repo": "current", "workflow": "backport.yml", "name": "PR - Backport", "scope": "global", "trigger": "event"},
+    {"repo": "current", "workflow": "rebase.yml", "name": "PR - Rebase", "scope": "global", "trigger": "event"},
+    {"repo": "current", "workflow": "pr-artifacts-comment.yml", "name": "PR - Artifacts Comment", "scope": "global", "trigger": "event"},
+    {"repo": "current", "workflow": "merge-message.lock.yml", "name": "Merge Message", "scope": "global", "trigger": "event"},
+    # API docs repository (global: scheduled/dispatch/PR events)
+    {"repo": "docs", "workflow": "auto-api-docs-writer.lock.yml", "name": "Auto API Docs Writer", "scope": "global", "trigger": "schedule"},
+    {"repo": "docs", "workflow": "automerge-docs.yml", "name": "Automerge Docs", "scope": "global", "trigger": "event"},
+    {"repo": "docs", "workflow": "go-live.yml", "name": "Go Live", "scope": "global", "trigger": "dispatch"},
 ]
+
+
+def normalize_repository(value: str) -> str:
+    """Return a validated GitHub owner/repository slug."""
+
+    candidate = value.strip()
+    if candidate.startswith("git@github.com:"):
+        candidate = candidate.removeprefix("git@github.com:")
+    elif "://" in candidate:
+        parsed = urlparse(candidate)
+        if (
+            parsed.hostname != "github.com"
+            or parsed.query
+            or parsed.fragment
+            or parsed.params
+        ):
+            raise ValueError(f"Unsupported GitHub repository: {value!r}")
+        candidate = parsed.path.lstrip("/")
+
+    candidate = candidate.removesuffix(".git").rstrip("/")
+    parts = candidate.split("/")
+    if (
+        len(parts) != 2
+        or not _OWNER_RE.fullmatch(parts[0])
+        or not _REPOSITORY_RE.fullmatch(parts[1])
+        or parts[1] in {".", ".."}
+    ):
+        raise ValueError(f"Unsupported GitHub repository: {value!r}")
+    return candidate
+
+
+def repository_from_git_remote(root: Path) -> str:
+    """Resolve one unambiguous GitHub repository from the checkout's origin."""
+
+    urls = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "--all", "origin"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    repositories = set()
+    for url in urls:
+        try:
+            repositories.add(normalize_repository(url))
+        except ValueError:
+            continue
+
+    if len(repositories) != 1:
+        raise RuntimeError(
+            "Unable to resolve one GitHub repository from the origin remote; "
+            "pass --repository explicitly."
+        )
+    return repositories.pop()
+
+
+def current_repository(
+    explicit: str | None = None,
+    *,
+    root: Path = REPO_ROOT,
+    environ: dict[str, str] | None = None,
+) -> str:
+    if explicit:
+        return normalize_repository(explicit)
+    runtime = (environ if environ is not None else os.environ).get("GITHUB_REPOSITORY")
+    if runtime:
+        return normalize_repository(runtime)
+    return repository_from_git_remote(root)
+
+
+def docs_repository(root: Path = REPO_ROOT) -> str:
+    parser = configparser.ConfigParser(interpolation=None)
+    gitmodules = root / ".gitmodules"
+    with gitmodules.open(encoding="utf-8") as stream:
+        parser.read_file(stream)
+    section = 'submodule "docs"'
+    if not parser.has_option(section, "url"):
+        raise RuntimeError(f"{gitmodules} has no URL for the docs submodule.")
+    return normalize_repository(parser.get(section, "url"))
+
+
+def workflow_registry(
+    repository: str | None = None,
+    docs: str | None = None,
+    *,
+    root: Path = REPO_ROOT,
+    environ: dict[str, str] | None = None,
+) -> list[dict]:
+    repositories = {
+        "current": current_repository(repository, root=root, environ=environ),
+        "docs": normalize_repository(docs) if docs else docs_repository(root),
+    }
+    return [
+        {**entry, "repo": repositories[entry["repo"]]}
+        for entry in _GITHUB_WORKFLOWS
+    ]
+
+
+CURRENT_REPOSITORY = current_repository()
+DOCS_REPOSITORY = docs_repository()
+GITHUB_WORKFLOWS = workflow_registry(CURRENT_REPOSITORY, DOCS_REPOSITORY)
+
+
+def configure_workflow_repository(repository: str | None = None) -> None:
+    """Apply an explicit current-repository override without changing the docs source."""
+
+    global GITHUB_WORKFLOWS
+    GITHUB_WORKFLOWS = workflow_registry(repository, DOCS_REPOSITORY)
 
 
 def az(args: list[str]) -> str:
@@ -801,7 +916,13 @@ def main():
         "--json", type=str, default=None, dest="json_output",
         help="Write raw structured JSON data to the specified file (for AI analysis)"
     )
+    parser.add_argument(
+        "--repository",
+        default=None,
+        help="Current GitHub repository override (default: context or origin remote)",
+    )
     args = parser.parse_args()
+    configure_workflow_repository(args.repository)
 
     # Collect branches to check
     branches = ["main"]

--- a/.agents/skills/ci-status/scripts/ci-status.py
+++ b/.agents/skills/ci-status/scripts/ci-status.py
@@ -205,16 +205,14 @@ def workflow_registry(
     ]
 
 
-CURRENT_REPOSITORY = current_repository()
-DOCS_REPOSITORY = docs_repository()
-GITHUB_WORKFLOWS = workflow_registry(CURRENT_REPOSITORY, DOCS_REPOSITORY)
+GITHUB_WORKFLOWS = []
 
 
 def configure_workflow_repository(repository: str | None = None) -> None:
     """Apply an explicit current-repository override without changing the docs source."""
 
     global GITHUB_WORKFLOWS
-    GITHUB_WORKFLOWS = workflow_registry(repository, DOCS_REPOSITORY)
+    GITHUB_WORKFLOWS = workflow_registry(repository)
 
 
 def az(args: list[str]) -> str:

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -52,7 +52,12 @@ def _load_collector():
 
 
 COLLECTOR = _load_collector()
-GITHUB_WORKFLOWS = COLLECTOR.GITHUB_WORKFLOWS
+CURRENT_REPOSITORY = COLLECTOR.current_repository()
+DOCS_REPOSITORY = COLLECTOR.docs_repository()
+GITHUB_WORKFLOWS = COLLECTOR.workflow_registry(
+    CURRENT_REPOSITORY,
+    DOCS_REPOSITORY,
+)
 
 EXPECTED_WORKFLOW_ROWS = (
     ("build-site.yml", "Pages - Deploy", "branch", "push", "current"),
@@ -235,7 +240,7 @@ TRIGGER_KEYS = {
 
 def local_workflows(registry=GITHUB_WORKFLOWS, repository=None):
     """Entries owned by this repository (the rest live in the docs repository)."""
-    repository = repository or COLLECTOR.CURRENT_REPOSITORY
+    repository = repository or CURRENT_REPOSITORY
     return [w for w in registry if w["repo"] == repository]
 
 
@@ -315,8 +320,8 @@ class RegistryTests(unittest.TestCase):
             EXPECTED_WORKFLOW_ROWS,
             registry_rows(
                 GITHUB_WORKFLOWS,
-                COLLECTOR.CURRENT_REPOSITORY,
-                COLLECTOR.DOCS_REPOSITORY,
+                CURRENT_REPOSITORY,
+                DOCS_REPOSITORY,
             ),
         )
 

--- a/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
+++ b/.agents/skills/ci-status/scripts/tests/test_workflow_registry.py
@@ -17,7 +17,7 @@ Two real examples this suite would have caught:
   removed 2026-06-18 when it was folded into "Sync - Release Notes & API Diffs"), so the
   row was a stale leftover quietly duplicating a workflow already listed below it.
 
-These tests assert that every ``mono/SkiaSharp`` entry names a file that exists on this
+These tests assert that every current-repository entry names a file that exists on this
 branch, that the declared ``trigger`` still matches that file's ``on:`` block, and that the
 display name matches. They parse the committed workflow YAML — including generated
 ``.lock.yml`` files, which carry their own ``on:`` block — so they never need the gh-aw
@@ -29,7 +29,10 @@ from __future__ import annotations
 import importlib.util
 import os
 import re
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 import yaml
 
@@ -51,6 +54,171 @@ def _load_collector():
 COLLECTOR = _load_collector()
 GITHUB_WORKFLOWS = COLLECTOR.GITHUB_WORKFLOWS
 
+EXPECTED_WORKFLOW_ROWS = (
+    ("build-site.yml", "Pages - Deploy", "branch", "push", "current"),
+    ("samples.yml", "Sync - Samples", "branch", "push", "current"),
+    (
+        "binding-generation-determinism.yml",
+        "Tests - Binding Generation Determinism",
+        "branch",
+        "push",
+        "current",
+    ),
+    (
+        "update-release-notes.lock.yml",
+        "Sync - Release Notes & API Diffs",
+        "branch",
+        "push",
+        "current",
+    ),
+    ("build-site-go-live.yml", "Pages - Go Live!", "global", "dispatch", "current"),
+    (
+        "build-site-cleanup.yml",
+        "Pages - PR Staging - Cleanup",
+        "global",
+        "event",
+        "current",
+    ),
+    (
+        "build-site-cleanup-stale.yml",
+        "Pages - PR Staging - Sweep Stale",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "auto-docs-submodule-sync.yml",
+        "Sync - Docs Submodule",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "auto-skia-submodule-sync.yml",
+        "Sync - Skia Submodule",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "auto-skia-sync.lock.yml",
+        "Sync - Skia Upstream",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "memory-leak-fixer.lock.yml",
+        "Fixer - Memory Leak",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "performance-fixer.lock.yml",
+        "Fixer - Performance",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "auto-triage.lock.yml",
+        "Sync - Issue Triage",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "auto-update-issue-template-versions.yml",
+        "Sync - Issue Template Versions",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "persist-aw-data.yml",
+        "Sync - Agentic Data",
+        "global",
+        "event",
+        "current",
+    ),
+    (
+        "track-artifact-sizes.yml",
+        "Track - Artifact Sizes",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "track-benchmarks.yml",
+        "Track - Benchmarks",
+        "global",
+        "schedule",
+        "current",
+    ),
+    (
+        "release-prepare.yml",
+        "Release - Prepare",
+        "global",
+        "dispatch",
+        "current",
+    ),
+    (
+        "release-finish.yml",
+        "Release - Finish",
+        "global",
+        "dispatch",
+        "current",
+    ),
+    (
+        "release-milestones.yml",
+        "Release - Milestones",
+        "global",
+        "dispatch",
+        "current",
+    ),
+    (
+        "update-github-release-summaries.yml",
+        "Update GitHub Release summaries",
+        "global",
+        "dispatch",
+        "current",
+    ),
+    (
+        "release-tooling-tests.yml",
+        "Release - Tooling Tests",
+        "branch",
+        "push",
+        "current",
+    ),
+    (
+        "automation-tooling-tests.yml",
+        "Automation - Tooling Tests",
+        "branch",
+        "push",
+        "current",
+    ),
+    ("backport.yml", "PR - Backport", "global", "event", "current"),
+    ("rebase.yml", "PR - Rebase", "global", "event", "current"),
+    (
+        "pr-artifacts-comment.yml",
+        "PR - Artifacts Comment",
+        "global",
+        "event",
+        "current",
+    ),
+    ("merge-message.lock.yml", "Merge Message", "global", "event", "current"),
+    (
+        "auto-api-docs-writer.lock.yml",
+        "Auto API Docs Writer",
+        "global",
+        "schedule",
+        "docs",
+    ),
+    ("automerge-docs.yml", "Automerge Docs", "global", "event", "docs"),
+    ("go-live.yml", "Go Live", "global", "dispatch", "docs"),
+)
+
 # `on:` keys that satisfy each declared trigger. A workflow may legitimately carry more
 # triggers than it is tracked for (most also allow workflow_dispatch), so this checks the
 # declared trigger is *present*, not that it is exclusive.
@@ -65,9 +233,50 @@ TRIGGER_KEYS = {
 }
 
 
-def local_workflows():
-    """Entries owned by this repository (the rest live in mono/SkiaSharp-API-docs)."""
-    return [w for w in GITHUB_WORKFLOWS if w["repo"] == "mono/SkiaSharp"]
+def local_workflows(registry=GITHUB_WORKFLOWS, repository=None):
+    """Entries owned by this repository (the rest live in the docs repository)."""
+    repository = repository or COLLECTOR.CURRENT_REPOSITORY
+    return [w for w in registry if w["repo"] == repository]
+
+
+def registry_rows(registry, repository, docs):
+    roles = {
+        repository: "current",
+        docs: "docs",
+    }
+    return tuple(
+        (
+            entry["workflow"],
+            entry["name"],
+            entry["scope"],
+            entry["trigger"],
+            roles[entry["repo"]],
+        )
+        for entry in registry
+    )
+
+
+def simulated_registry(owner):
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / ".gitmodules").write_text(
+            f"""[submodule "externals/skia"]
+\tpath = externals/skia
+\turl = https://github.com/{owner}/skia.git
+[submodule "docs"]
+\tpath = docs
+\turl = https://github.com/{owner}/SkiaSharp-API-docs.git
+""",
+            encoding="utf-8",
+        )
+        repository = f"{owner}/SkiaSharp"
+        docs = f"{owner}/SkiaSharp-API-docs"
+        registry = COLLECTOR.workflow_registry(
+            repository,
+            root=root,
+            environ={},
+        )
+        return repository, docs, registry
 
 
 def load_workflow(name):
@@ -99,7 +308,68 @@ def crons_for(workflow_file):
 
 class RegistryTests(unittest.TestCase):
     def test_registry_is_not_empty(self):
-        self.assertTrue(local_workflows(), "No mono/SkiaSharp workflows are tracked.")
+        self.assertTrue(local_workflows(), "No current-repository workflows are tracked.")
+
+    def test_registry_contains_every_expected_workflow(self):
+        self.assertEqual(
+            EXPECTED_WORKFLOW_ROWS,
+            registry_rows(
+                GITHUB_WORKFLOWS,
+                COLLECTOR.CURRENT_REPOSITORY,
+                COLLECTOR.DOCS_REPOSITORY,
+            ),
+        )
+
+    def test_registry_resolves_current_and_destination_repositories(self):
+        for owner in ("mono", "dotnet"):
+            with self.subTest(owner=owner):
+                repository, docs, registry = simulated_registry(owner)
+                self.assertEqual(
+                    EXPECTED_WORKFLOW_ROWS,
+                    registry_rows(registry, repository, docs),
+                )
+                self.assertEqual(
+                    {repository, docs},
+                    {entry["repo"] for entry in registry},
+                )
+
+    def test_repository_resolution_precedence_and_ambiguous_remote(self):
+        with mock.patch.object(
+            COLLECTOR,
+            "repository_from_git_remote",
+            return_value="remote/SkiaSharp",
+        ) as remote:
+            self.assertEqual(
+                "explicit/SkiaSharp",
+                COLLECTOR.current_repository(
+                    "explicit/SkiaSharp",
+                    environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                ),
+            )
+            self.assertEqual(
+                "runtime/SkiaSharp",
+                COLLECTOR.current_repository(
+                    environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                ),
+            )
+            self.assertEqual(
+                "remote/SkiaSharp",
+                COLLECTOR.current_repository(environ={}),
+            )
+            remote.assert_called_once()
+
+        with mock.patch.object(
+            COLLECTOR.subprocess,
+            "run",
+            return_value=mock.Mock(
+                stdout=(
+                    "https://github.com/mono/SkiaSharp.git\n"
+                    "git@github.com:dotnet/SkiaSharp.git\n"
+                )
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "pass --repository"):
+                COLLECTOR.repository_from_git_remote(Path(REPO_ROOT))
 
     def test_every_tracked_workflow_file_exists(self):
         missing = [w["workflow"] for w in local_workflows()
@@ -154,6 +424,46 @@ class SkillDocTests(unittest.TestCase):
         with open(os.path.join(SKILL_DIR, "SKILL.md"), encoding="utf-8") as fh:
             return fh.read()
 
+    def _workflow_rows(self):
+        rows = []
+        for line in self._skill_text().splitlines():
+            if not line.startswith("| "):
+                continue
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            if len(cells) >= 4 and cells[1] in ("`{current}`", "`{docs}`"):
+                rows.append(cells)
+        return rows
+
+    def test_every_documented_workflow_matches_the_registry(self):
+        rows = self._workflow_rows()
+        actual = {(cells[0], cells[1]) for cells in rows}
+        expected = {
+            (name, f"`{{{role}}}`")
+            for _, name, _, _, role in EXPECTED_WORKFLOW_ROWS
+        }
+        self.assertEqual(len(EXPECTED_WORKFLOW_ROWS), len(rows))
+        self.assertEqual(expected, actual)
+
+    def test_documented_workflows_resolve_in_both_repository_contexts(self):
+        rows = self._workflow_rows()
+        for owner in ("mono", "dotnet"):
+            with self.subTest(owner=owner):
+                repository, docs, registry = simulated_registry(owner)
+                repositories = {
+                    "`{current}`": repository,
+                    "`{docs}`": docs,
+                }
+                documented = {
+                    (cells[0], repositories[cells[1]])
+                    for cells in rows
+                }
+                expected = {
+                    (entry["name"], entry["repo"])
+                    for entry in registry
+                }
+                self.assertEqual(len(EXPECTED_WORKFLOW_ROWS), len(documented))
+                self.assertEqual(expected, documented)
+
     def test_skill_table_only_names_tracked_workflows(self):
         rows = [ln for ln in self._skill_text().splitlines() if ln.startswith("| ")]
         tracked = {w["name"] for w in GITHUB_WORKFLOWS}
@@ -178,7 +488,7 @@ class SkillDocTests(unittest.TestCase):
         unresolved = []
         for row in rows:
             cells = [c.strip() for c in row.strip().strip("|").split("|")]
-            if len(cells) < 3 or cells[1] != "mono/SkiaSharp":
+            if len(cells) < 3 or cells[1] != "`{current}`":
                 continue  # header, separator, or a row owned by another repository
             name = cells[0]
             if name not in by_name:

--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -17,6 +17,9 @@ on:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
       - ".github/scripts/**"
+      - "scripts/infra/docs/generate-ai-dashboard.py"
+      - "scripts/infra/docs/tests/test_generate_ai_dashboard.py"
+      - ".gitmodules"
       # Any workflow edit, so the registry test re-checks its tracked list. '*.yml' already
       # covers the generated '*.lock.yml' files.
       - ".github/workflows/*.yml"
@@ -26,6 +29,9 @@ on:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
       - ".github/scripts/**"
+      - "scripts/infra/docs/generate-ai-dashboard.py"
+      - "scripts/infra/docs/tests/test_generate_ai_dashboard.py"
+      - ".gitmodules"
       - ".github/workflows/*.yml"
   workflow_dispatch:
 
@@ -57,6 +63,13 @@ jobs:
           python3 -c "import yaml" 2>/dev/null \
             || python3 -m pip install --quiet --break-system-packages pyyaml
           python3 -m unittest discover -s .agents/skills/ci-status/scripts/tests -p "test_*.py" -v
+
+      - name: Run AI dashboard rendering tests
+        run: |
+          python3 -m unittest discover \
+            -s scripts/infra/docs/tests \
+            -p "test_*.py" \
+            -v
 
       - name: Run update-skia tooling tests
         # These import their module under test by name, so they must run from their own

--- a/.github/workflows/persist-aw-data.yml
+++ b/.github/workflows/persist-aw-data.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       run-url:
-        description: 'URL of the workflow run to persist (e.g. https://github.com/mono/SkiaSharp/actions/runs/12345)'
+        description: 'URL of the workflow run to persist (for example, https://github.com/owner/repo/actions/runs/12345)'
         required: true
         type: string
 

--- a/scripts/infra/docs/generate-ai-dashboard.py
+++ b/scripts/infra/docs/generate-ai-dashboard.py
@@ -39,11 +39,17 @@ import argparse
 import datetime
 import gzip
 import json
+import os
 import re
 import subprocess
 import sys
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_OWNER_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?")
+_REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+")
 
 # ── Paths & constants ────────────────────────────────────────────────────────
 
@@ -78,6 +84,67 @@ SKIASHARP_MAJOR = 4
 ADOPTION_LINE_COUNT = 5
 
 USER_AGENT = "SkiaSharp-ai-dashboard"
+
+
+def normalize_repository(value):
+    # type: (str) -> str
+    """Return a validated GitHub owner/repository slug."""
+    candidate = value.strip()
+    if candidate.startswith("git@github.com:"):
+        candidate = candidate.removeprefix("git@github.com:")
+    elif "://" in candidate:
+        parsed = urlparse(candidate)
+        if (
+            parsed.hostname != "github.com"
+            or parsed.query
+            or parsed.fragment
+            or parsed.params
+        ):
+            raise ValueError("Unsupported GitHub repository: {!r}".format(value))
+        candidate = parsed.path.lstrip("/")
+
+    candidate = candidate.removesuffix(".git").rstrip("/")
+    parts = candidate.split("/")
+    if (
+        len(parts) != 2
+        or not _OWNER_RE.fullmatch(parts[0])
+        or not _REPOSITORY_RE.fullmatch(parts[1])
+        or parts[1] in {".", ".."}
+    ):
+        raise ValueError("Unsupported GitHub repository: {!r}".format(value))
+    return candidate
+
+
+def repository_from_git_remote(root):
+    # type: (Path) -> str
+    urls = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "--all", "origin"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    repositories = set()
+    for url in urls:
+        try:
+            repositories.add(normalize_repository(url))
+        except ValueError:
+            continue
+    if len(repositories) != 1:
+        raise RuntimeError(
+            "Unable to resolve one GitHub repository from the origin remote; "
+            "pass --repository explicitly."
+        )
+    return repositories.pop()
+
+
+def current_repository(explicit=None, root=REPO_ROOT, environ=None):
+    # type: (str | None, Path, dict | None) -> str
+    if explicit:
+        return normalize_repository(explicit)
+    runtime = (environ if environ is not None else os.environ).get("GITHUB_REPOSITORY")
+    if runtime:
+        return normalize_repository(runtime)
+    return repository_from_git_remote(root)
 
 
 def log(*args):
@@ -397,9 +464,7 @@ def build_cadence(existing):
         "asOf": today_iso(),
         "scheduleUrl": prev_cadence.get(
             "scheduleUrl", "https://chromiumdash.appspot.com/schedule"),
-        "prsUrl": prev_cadence.get(
-            "prsUrl",
-            "https://github.com/mono/SkiaSharp/pulls?q=is%3Apr+milestone+in%3Atitle"),
+        "prsUrl": prev_cadence.get("prsUrl", ""),
         "caption": prev_cadence.get(
             "caption",
             "AI opens, tests, and lands the sync PR; humans review the API."),
@@ -436,6 +501,22 @@ def load_existing(path):
     return {}
 
 
+def build_dashboard(existing, repository=None):
+    repository = current_repository(repository)
+    repository_url = "https://github.com/{}".format(repository)
+    cadence = dict(build_cadence(existing))
+    cadence["prsUrl"] = (
+        "{}/pulls?q=is%3Apr+milestone+in%3Atitle".format(repository_url)
+    )
+    return {
+        "generatedAt": today_iso(),
+        "adoption": build_adoption(existing),
+        "cadence": cadence,
+        "cost": build_cost(existing),
+        "footerUrl": "{}/tree/main/.github/workflows".format(repository_url),
+    }
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -449,20 +530,14 @@ def main(argv=None):
     parser.add_argument(
         "--check", action="store_true",
         help="compute and print, but do not write the output file")
+    parser.add_argument(
+        "--repository",
+        help="current GitHub repository (default: context or unambiguous git remote)")
     args = parser.parse_args(argv)
 
     base_path = args.base or args.output
     existing = load_existing(base_path)
-
-    result = {
-        "generatedAt": today_iso(),
-        "adoption": build_adoption(existing),
-        "cadence": build_cadence(existing),
-        "cost": build_cost(existing),
-        "footerUrl": existing.get(
-            "footerUrl",
-            "https://github.com/mono/SkiaSharp/tree/main/.github/workflows"),
-    }
+    result = build_dashboard(existing, args.repository)
 
     text = json.dumps(result, indent=2, ensure_ascii=False) + "\n"
     if args.check:

--- a/scripts/infra/docs/tests/test_generate_ai_dashboard.py
+++ b/scripts/infra/docs/tests/test_generate_ai_dashboard.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "infra" / "docs" / "generate-ai-dashboard.py"
+
+
+def load_dashboard_module():
+    spec = importlib.util.spec_from_file_location("generate_ai_dashboard", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DASHBOARD = load_dashboard_module()
+
+
+class DashboardRenderingTests(unittest.TestCase):
+    def setUp(self):
+        self.existing = {
+            "generatedAt": "2026-08-01",
+            "adoption": {
+                "asOf": "2026-07-31",
+                "series": [{"version": "4.100", "downloads": 123}],
+            },
+            "cadence": {
+                "asOf": "2026-07-30",
+                "prsUrl": "https://github.com/mono/SkiaSharp/pulls?legacy=true",
+                "caption": "Historical cadence caption",
+                "milestones": [
+                    {
+                        "milestone": 150,
+                        "prNumber": 4900,
+                        "prOpened": "2026-07-01",
+                        "prMerged": "2026-07-02",
+                        "note": "Historical milestone note",
+                    }
+                ],
+            },
+            "cost": {
+                "asOf": "2026-07-29",
+                "runs": [{"workflow": "Skia Update", "tokens": 456}],
+            },
+            "footerUrl": "https://github.com/mono/SkiaSharp/tree/legacy/workflows",
+        }
+
+    def render(self, repository):
+        with (
+            mock.patch.object(
+                DASHBOARD,
+                "build_adoption",
+                return_value=copy.deepcopy(self.existing["adoption"]),
+            ),
+            mock.patch.object(
+                DASHBOARD,
+                "build_cadence",
+                return_value=copy.deepcopy(self.existing["cadence"]),
+            ),
+            mock.patch.object(
+                DASHBOARD,
+                "build_cost",
+                return_value=copy.deepcopy(self.existing["cost"]),
+            ),
+            mock.patch.object(DASHBOARD, "today_iso", return_value="2026-09-05"),
+        ):
+            return DASHBOARD.build_dashboard(
+                copy.deepcopy(self.existing),
+                repository,
+            )
+
+    def test_active_links_follow_current_repository(self):
+        for repository in ("mono/SkiaSharp", "dotnet/SkiaSharp"):
+            with self.subTest(repository=repository):
+                rendered = self.render(repository)
+                repository_url = f"https://github.com/{repository}"
+                self.assertEqual(
+                    f"{repository_url}/pulls?q=is%3Apr+milestone+in%3Atitle",
+                    rendered["cadence"]["prsUrl"],
+                )
+                self.assertEqual(
+                    f"{repository_url}/tree/main/.github/workflows",
+                    rendered["footerUrl"],
+                )
+
+    def test_historical_dashboard_data_is_preserved(self):
+        rendered = self.render("dotnet/SkiaSharp")
+        self.assertEqual(self.existing["adoption"], rendered["adoption"])
+        self.assertEqual(self.existing["cost"], rendered["cost"])
+
+        cadence = copy.deepcopy(rendered["cadence"])
+        cadence["prsUrl"] = self.existing["cadence"]["prsUrl"]
+        self.assertEqual(self.existing["cadence"], cadence)
+
+    def test_main_writes_portable_links_without_rewriting_history(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            base = root / "base.json"
+            output = root / "output.json"
+            base.write_text(json.dumps(self.existing), encoding="utf-8")
+
+            with (
+                mock.patch.object(
+                    DASHBOARD,
+                    "build_adoption",
+                    side_effect=lambda existing: copy.deepcopy(existing["adoption"]),
+                ),
+                mock.patch.object(
+                    DASHBOARD,
+                    "build_cadence",
+                    side_effect=lambda existing: copy.deepcopy(existing["cadence"]),
+                ),
+                mock.patch.object(
+                    DASHBOARD,
+                    "build_cost",
+                    side_effect=lambda existing: copy.deepcopy(existing["cost"]),
+                ),
+                mock.patch.object(DASHBOARD, "today_iso", return_value="2026-09-05"),
+            ):
+                result = DASHBOARD.main(
+                    [
+                        "--base",
+                        str(base),
+                        "--output",
+                        str(output),
+                        "--repository",
+                        "dotnet/SkiaSharp",
+                    ],
+                )
+
+            self.assertEqual(0, result)
+            rendered = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(self.existing["adoption"], rendered["adoption"])
+            self.assertEqual(self.existing["cost"], rendered["cost"])
+            self.assertEqual(
+                "Historical milestone note",
+                rendered["cadence"]["milestones"][0]["note"],
+            )
+            self.assertEqual(
+                "https://github.com/dotnet/SkiaSharp/tree/main/.github/workflows",
+                rendered["footerUrl"],
+            )
+
+    def test_repository_resolution_precedence_and_ambiguous_remote(self):
+        with mock.patch.object(
+            DASHBOARD,
+            "repository_from_git_remote",
+            return_value="remote/SkiaSharp",
+        ) as remote:
+            self.assertEqual(
+                "explicit/SkiaSharp",
+                DASHBOARD.current_repository(
+                    "explicit/SkiaSharp",
+                    environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                ),
+            )
+            self.assertEqual(
+                "runtime/SkiaSharp",
+                DASHBOARD.current_repository(
+                    environ={"GITHUB_REPOSITORY": "runtime/SkiaSharp"},
+                ),
+            )
+            self.assertEqual(
+                "remote/SkiaSharp",
+                DASHBOARD.current_repository(environ={}),
+            )
+            remote.assert_called_once()
+
+        with mock.patch.object(
+            DASHBOARD.subprocess,
+            "run",
+            return_value=mock.Mock(
+                stdout=(
+                    "https://github.com/mono/SkiaSharp.git\n"
+                    "git@github.com:dotnet/SkiaSharp.git\n"
+                )
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "pass --repository"):
+                DASHBOARD.repository_from_git_remote(REPO_ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Makes the CI-status registry, its documentation, and active AI dashboard links portable for the planned `mono` to `dotnet` transfer.

Each domain now resolves the current repository from explicit `--repository` input, then `GITHUB_REPOSITORY`, then one validated GitHub URL on the local `origin` remote. Ambiguous local origins fail with guidance to pass the repository explicitly. The CI registry resolves the API-docs repository directly from `.gitmodules`.

The complete workflow registry, trigger/name/scope semantics, collector/report shape, and permanent Azure identities such as definition `345` and `mono-SkiaSharp` remain unchanged. The AI dashboard renders only its active milestone-query and workflow-source links from current identity while preserving cached historical data.

Exact registry/documentation tests cover every row under both current `mono` and simulated `dotnet` contexts. Focused renderer tests prove active links move without rewriting historical adoption, cadence, or cost data. This PR intentionally does not change Azure bindings, DocFX/Gallery/build-site assets, release notes, workflow gates or locks, Backport, packages, agent/issue skills, native/generated files, or submodules.

**Related issues**

Fixes #4985

Related to #4960

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — repository tooling and operational documentation only; no public API or application behavior changes.

## Testing

- 13 CI-status registry/documentation tests, including exact mono/dotnet row coverage and explicit/context/origin precedence
- 4 AI dashboard renderer tests, including mono/dotnet links, ambiguous-origin failure, and historical payload preservation
- All `update-skia` Python tooling tests
- 146 release-note/GitHub-summary Python tests
- 38 release-testing Python tests
- 113 publishing PowerShell tests
- 26 release milestone PowerShell tests
- Release test-run PowerShell tests
- Cache dependency coverage: 4,851 tracked files, zero uncovered
- Python compilation and `git diff --check`

The unchanged Skia-sync detector shell harness was also attempted twice locally but hung without output; the GitHub `Automation - Tooling Tests` job remains the authoritative run for that suite.

Validated on macOS. No native, generated, managed-product, rendering, or submodule content changed.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A