### PR TITLE
[skia-sync] Merge upstream Skia main (tip)

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -221,15 +221,15 @@
         "type": "other",
         "other": {
           "name": "vulkan-headers",
-          "version": "1.4.345",
+          "version": "1.4.362",
           "downloadUrl": "https://github.com/KhronosGroup/Vulkan-Headers"
         }
       },
       "skia_dependency": {
         "name": "vulkan-headers",
-        "revision": "74d8a6cb930c68ef617b202c3ff3c59d919e086b",
-        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@74d8a6cb930c68ef617b202c3ff3c59d919e086b",
-        "version_source": "include/vulkan/vulkan_core.h: VK_HEADER_VERSION_COMPLETE = 1.4.345"
+        "revision": "ee2ec5fd83dafce291024683b50dc89219333076",
+        "version_reviewed_identity": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@ee2ec5fd83dafce291024683b50dc89219333076",
+        "version_source": "include/vulkan/vulkan_core.h: VK_HEADER_VERSION_COMPLETE = 1.4.362"
       }
     },
     {
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "cc43af052d3d98e605bee4ddc98671dafded1c57"
+          "commitHash": "20969ad8b51601bfc54890455a80248b1fd7a9d5"
         }
       }
     },
@@ -323,8 +323,8 @@
         }
       },
       "chrome_milestone": 154,
-      "upstream_merge_commit": "7b950f0d8ed1028a75248ea69813ae6054ca65f8",
-      "upstream_ref": "chrome/m154"
+      "upstream_merge_commit": "10652f9d64d664e3858ec9691f5963c339fc1499",
+      "upstream_ref": "main"
     }
   ]
 }


### PR DESCRIPTION
## Description

Automated bleeding-edge sync from the tip of upstream Skia (google/skia main).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/355

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

- Advanced the `externals/skia` gitlink from `cc43af052d3d98e605bee4ddc98671dafded1c57` to tested fork commit `20969ad8b51601bfc54890455a80248b1fd7a9d5`, containing upstream `main` through `10652f9d64d664e3858ec9691f5963c339fc1499`.
- Updated the Skia Component Governance registration to upstream `main` and Vulkan-Headers from 1.4.345 to source-verified 1.4.362 at `ee2ec5fd83dafce291024683b50dc89219333076`.
- Retained all m154 package, assembly, and native API versions. Regeneration found no binding changes or new native functions, so no managed wrappers or tests required modification.

## Testing

- Linux x64 native source build and `dotnet build binding/SkiaSharp/SkiaSharp.csproj` passed.
- Final `net10.0` solution results: Singleton 1 passed/0 skipped; Core 6127 passed/33 skipped; Direct3D 2 passed/3 skipped; Vulkan 23 passed/2 skipped. Zero tests failed, and no required backend was skipped.
- Deterministic version/registration validation and the final fork-patch audit passed against the exact committed gitlink.

## Human review

- Confirm the main-tip sync correctly retains the m154 release line and review the Vulkan-Headers manifest evidence.
- Linux x64 and Vulkan lavapipe were executed. Metal Graphite requires macOS/iOS CI; Dawn/WebGPU requires applicable Windows CI; Vulkan dependency rolls still require Android and Windows Vulkan CI.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-09-05T02:03:50Z_
