### PR TITLE
[migration] Make package README links portable

### DIFF
--- a/binding/Directory.Build.targets
+++ b/binding/Directory.Build.targets
@@ -28,7 +28,7 @@ It provides a comprehensive 2D API that can be used across mobile, server and de
     <PackageReadmeResourceLinks>- [HarfBuzzSharp API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/harfbuzzsharp)
 - [HarfBuzz documentation](https://harfbuzz.github.io/)
 - [SkiaSharp.HarfBuzz integration package](https://www.nuget.org/packages/SkiaSharp.HarfBuzz)
-- [Package selection and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)</PackageReadmeResourceLinks>
+- [Package selection and deployment guide]($(SkiaSharpRepositoryUrl)/blob/main/documentation/dev/packages.md)</PackageReadmeResourceLinks>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)NativeAssets.Build.targets" Condition="$(MSBuildProjectName.Contains('.NativeAssets.'))" />

--- a/binding/HarfBuzzSharp/PACKAGE-README.md
+++ b/binding/HarfBuzzSharp/PACKAGE-README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/HarfBuzzSharp?style=flat-square&label=NuGet)](https://www.nuget.org/packages/HarfBuzzSharp)
 [![NuGet downloads](https://img.shields.io/nuget/dt/HarfBuzzSharp?style=flat-square&label=Downloads)](https://www.nuget.org/packages/HarfBuzzSharp)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)]({{RepositoryUrl}}/blob/main/LICENSE.md)
 
 **HarfBuzzSharp** provides .NET bindings for the [HarfBuzz](https://harfbuzz.github.io/) OpenType text shaping engine. It converts Unicode text into correctly selected and positioned glyphs for complex scripts, ligatures, kerning, variable fonts, bidirectional text, and advanced typographic features.
 
@@ -49,18 +49,18 @@ For drawing shaped text with SkiaSharp, install `SkiaSharp.HarfBuzz` and use `SK
 dotnet add package SkiaSharp.HarfBuzz
 ```
 
-> **Linux and WebAssembly:** add the matching `HarfBuzzSharp.NativeAssets.*` package directly to the application project when the target does not receive native assets transitively. See the [package deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md).
+> **Linux and WebAssembly:** add the matching `HarfBuzzSharp.NativeAssets.*` package directly to the application project when the target does not receive native assets transitively. See the [package deployment guide]({{RepositoryUrl}}/blob/main/documentation/dev/packages.md).
 
 ## Documentation and resources
 
 - [HarfBuzzSharp API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/harfbuzzsharp)
 - [SkiaSharp.HarfBuzz API reference](https://learn.microsoft.com/dotnet/api/skiasharp.harfbuzz)
 - [HarfBuzz documentation](https://harfbuzz.github.io/)
-- [SkiaSharp package and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
-- [SkiaSharp samples](https://github.com/mono/SkiaSharp/tree/main/samples)
+- [SkiaSharp package and deployment guide]({{RepositoryUrl}}/blob/main/documentation/dev/packages.md)
+- [SkiaSharp samples]({{RepositoryUrl}}/tree/main/samples)
 
 ## Feedback and contributing
 
-HarfBuzzSharp is part of the open-source SkiaSharp project from Microsoft. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+HarfBuzzSharp is part of the open-source SkiaSharp project from Microsoft. Use [GitHub Discussions]({{RepositoryUrl}}/discussions) for questions, file bugs and feature requests in the [issue tracker]({{RepositoryUrl}}/issues), and read the [contributing guide]({{RepositoryUrl}}/blob/main/CONTRIBUTING.md) to get involved.
 
-HarfBuzzSharp is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).
+HarfBuzzSharp is released under the [MIT license]({{RepositoryUrl}}/blob/main/LICENSE.md).

--- a/binding/SkiaSharp/PACKAGE-README.md
+++ b/binding/SkiaSharp/PACKAGE-README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/SkiaSharp?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp)
 [![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)]({{RepositoryUrl}}/blob/main/LICENSE.md)
 
 **SkiaSharp** is a cross-platform 2D graphics API for .NET powered by Google's [Skia](https://skia.org/) graphics engine. Draw vector graphics, render text, process images, apply shaders and filters, and produce consistent output across mobile, desktop, server, and WebAssembly applications.
 
@@ -53,7 +53,7 @@ using var output = File.Create("hello-skiasharp.png");
 data.SaveTo(output);
 ```
 
-> **Linux:** add [SkiaSharp.NativeAssets.Linux](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux) to the application project for fontconfig integration, or [SkiaSharp.NativeAssets.Linux.NoDependencies](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux.NoDependencies) for minimal containers and explicit font loading. See the [package deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md) for details.
+> **Linux:** add [SkiaSharp.NativeAssets.Linux](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux) to the application project for fontconfig integration, or [SkiaSharp.NativeAssets.Linux.NoDependencies](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux.NoDependencies) for minimal containers and explicit font loading. See the [package deployment guide]({{RepositoryUrl}}/blob/main/documentation/dev/packages.md) for details.
 
 ## Choose the right integration
 
@@ -69,15 +69,15 @@ data.SaveTo(output);
 
 ## Learn and explore
 
-- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/) - conceptual guides and tutorials
+- [SkiaSharp documentation]({{DocumentationUrl}}/docs/) - conceptual guides and tutorials
 - [API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/skiasharp)
-- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/) - interactive samples running in Blazor WebAssembly
-- [SkiaFiddle](https://mono.github.io/SkiaSharp/fiddle/) - experiment with SkiaSharp in your browser
-- [Samples](https://github.com/mono/SkiaSharp/tree/main/samples) - buildable console, mobile, desktop, web, and UI examples
-- [Release notes](https://mono.github.io/SkiaSharp/docs/releases/) - new features and API changes
+- [Live SkiaSharp Gallery]({{DocumentationUrl}}/gallery/) - interactive samples running in Blazor WebAssembly
+- [SkiaFiddle]({{DocumentationUrl}}/fiddle/) - experiment with SkiaSharp in your browser
+- [Samples]({{RepositoryUrl}}/tree/main/samples) - buildable console, mobile, desktop, web, and UI examples
+- [Release notes]({{DocumentationUrl}}/docs/releases/) - new features and API changes
 
 ## Feedback and contributing
 
-SkiaSharp is built in the open. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to help improve the project.
+SkiaSharp is built in the open. Use [GitHub Discussions]({{RepositoryUrl}}/discussions) for questions, file bugs and feature requests in the [issue tracker]({{RepositoryUrl}}/issues), and read the [contributing guide]({{RepositoryUrl}}/blob/main/CONTRIBUTING.md) to help improve the project.
 
-SkiaSharp is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).
+SkiaSharp is released under the [MIT license]({{RepositoryUrl}}/blob/main/LICENSE.md).

--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -159,8 +159,7 @@
         "libs": {},
         "package": {
           "include": [
-            "scripts/infra/package/**",
-            "scripts/infra/repository-identity.json"
+            "scripts/infra/package/**"
           ],
           "children": {
             "api_diff": {

--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -159,7 +159,8 @@
         "libs": {},
         "package": {
           "include": [
-            "scripts/infra/package/**"
+            "scripts/infra/package/**",
+            "scripts/infra/repository-identity.json"
           ],
           "children": {
             "api_diff": {

--- a/scripts/infra/package/tests/test_package_readmes.py
+++ b/scripts/infra/package/tests/test_package_readmes.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from html import escape
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[4]
+NUGET_PROPS = ROOT / "source" / "SkiaSharp.NuGet.props"
+NUGET_TARGETS = ROOT / "source" / "SkiaSharp.NuGet.targets"
+BINDING_TARGETS = ROOT / "binding" / "Directory.Build.targets"
+
+CURRENT_REPOSITORY_URL = "https://github.com/mono/SkiaSharp"
+CURRENT_DOCUMENTATION_URL = "https://mono.github.io/SkiaSharp"
+DESTINATION_REPOSITORY_URL = "https://github.com/dotnet/SkiaSharp"
+DESTINATION_DOCUMENTATION_URL = "https://dotnet.github.io/SkiaSharp"
+
+CUSTOM_TEMPLATES = (
+    ("SkiaSharp", ROOT / "binding" / "SkiaSharp" / "PACKAGE-README.md"),
+    (
+        "HarfBuzzSharp",
+        ROOT / "binding" / "HarfBuzzSharp" / "PACKAGE-README.md",
+    ),
+    (
+        "SkiaSharp.Views",
+        ROOT
+        / "source"
+        / "SkiaSharp.Views"
+        / "SkiaSharp.Views"
+        / "PACKAGE-README.md",
+    ),
+    (
+        "SkiaSharp.Views.Blazor",
+        ROOT
+        / "source"
+        / "SkiaSharp.Views"
+        / "SkiaSharp.Views.Blazor"
+        / "PACKAGE-README.md",
+    ),
+    (
+        "SkiaSharp.Views.Maui.Controls",
+        ROOT
+        / "source"
+        / "SkiaSharp.Views.Maui"
+        / "SkiaSharp.Views.Maui.Controls"
+        / "PACKAGE-README.md",
+    ),
+)
+
+
+def xml_text(value: object) -> str:
+    return escape(str(value), quote=False)
+
+
+def xml_attribute(value: object) -> str:
+    return escape(str(value), quote=True)
+
+
+class PackageReadmeTests(unittest.TestCase):
+    def render_readme(
+        self,
+        package_id: str,
+        *,
+        template: Path | None = None,
+        properties: dict[str, str] | None = None,
+        use_binding_targets: bool = False,
+    ) -> tuple[str, dict[str, str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            output = temp / "obj"
+            output.mkdir()
+            values = {
+                "PackagingGroup": "SkiaSharp",
+                "PackageId": package_id,
+                "PackageDescription": "Generated package summary.",
+                "IntermediateOutputPath": f"{output}{os.sep}",
+                "TargetFramework": "net10.0",
+                "IsWindows": "false",
+                "IsMacOS": "false",
+                "IsLinux": "true",
+                "IsNetTizenSupported": "false",
+                "IsNetTVOSSupported": "false",
+                "IsNetMacOSSupported": "false",
+                "SignAssembly": "false",
+                "ProduceReferenceAssembly": "false",
+            }
+            if template is not None:
+                values["PackageReadmeSource"] = str(template)
+            values.update(properties or {})
+
+            property_xml = "\n".join(
+                f"    <{name}>{xml_text(value)}</{name}>"
+                for name, value in values.items()
+            )
+            targets = BINDING_TARGETS if use_binding_targets else NUGET_TARGETS
+            project = temp / "PackageReadme.Tests.proj"
+            project.write_text(
+                f"""<Project>
+  <PropertyGroup>
+{property_xml}
+  </PropertyGroup>
+  <Import Project="{xml_attribute(NUGET_PROPS)}" />
+  <Import Project="{xml_attribute(targets)}" />
+  <Target Name="CapturePackageMetadata">
+    <ItemGroup>
+      <_PackageMetadata Include="PackageProjectUrl=$(PackageProjectUrl)" />
+      <_PackageMetadata Include="PackageReleaseNotes=$(PackageReleaseNotes)" />
+      <_PackageMetadata Include="PackageReadmeFile=$(PackageReadmeFile)" />
+      <_PackageMetadata Include="RepositoryUrl=$(RepositoryUrl)" />
+      <_PackageMetadata Include="RepositoryType=$(RepositoryType)" />
+    </ItemGroup>
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)metadata.txt"
+      Lines="@(_PackageMetadata)"
+      Encoding="UTF-8"
+      Overwrite="True" />
+  </Target>
+</Project>
+""",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    "dotnet",
+                    "msbuild",
+                    str(project),
+                    "/nologo",
+                    "/verbosity:minimal",
+                    "/target:_GeneratePackageReadmeFile;CapturePackageMetadata",
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                0,
+                result.returncode,
+                f"MSBuild failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+            )
+
+            readme = (output / "README.md").read_text(encoding="utf-8-sig")
+            metadata = {}
+            for line in (output / "metadata.txt").read_text(
+                encoding="utf-8-sig"
+            ).splitlines():
+                key, value = line.split("=", 1)
+                metadata[key] = value
+            return readme, metadata
+
+    def assert_template_rendered(
+        self,
+        package_id: str,
+        template: Path,
+        repository_url: str,
+        documentation_url: str,
+        *,
+        explicit: bool,
+    ) -> None:
+        properties = {}
+        if explicit:
+            properties = {
+                "SkiaSharpRepositoryUrl": repository_url,
+                "SkiaSharpDocumentationUrl": documentation_url,
+                "_RepositoryIdentityConfig": str(
+                    template.parent / "missing-repository-identity.json"
+                ),
+            }
+
+        actual, _ = self.render_readme(
+            package_id,
+            template=template,
+            properties=properties,
+        )
+        expected = (
+            template.read_text(encoding="utf-8-sig")
+            .replace("{{RepositoryUrl}}", repository_url)
+            .replace("{{DocumentationUrl}}", documentation_url)
+        )
+
+        self.assertEqual(expected.splitlines(), actual.splitlines())
+        self.assertNotIn("{{RepositoryUrl}}", actual)
+        self.assertNotIn("{{DocumentationUrl}}", actual)
+        self.assertIn(repository_url, actual)
+        if "{{DocumentationUrl}}" in template.read_text(encoding="utf-8-sig"):
+            self.assertIn(documentation_url, actual)
+        if explicit:
+            self.assertNotIn(CURRENT_REPOSITORY_URL, actual)
+            self.assertNotIn(CURRENT_DOCUMENTATION_URL, actual)
+
+    def test_custom_templates_render_for_current_and_destination_identities(
+        self,
+    ) -> None:
+        scenarios = (
+            (
+                CURRENT_REPOSITORY_URL,
+                CURRENT_DOCUMENTATION_URL,
+                False,
+            ),
+            (
+                DESTINATION_REPOSITORY_URL,
+                DESTINATION_DOCUMENTATION_URL,
+                True,
+            ),
+        )
+        for package_id, template in CUSTOM_TEMPLATES:
+            for repository_url, documentation_url, explicit in scenarios:
+                with self.subTest(
+                    package_id=package_id,
+                    repository_url=repository_url,
+                ):
+                    self.assert_template_rendered(
+                        package_id,
+                        template,
+                        repository_url,
+                        documentation_url,
+                        explicit=explicit,
+                    )
+
+    def test_generated_readme_uses_defaults_and_preserves_metadata(self) -> None:
+        readme, metadata = self.render_readme("Test.Package")
+
+        self.assertIn("# Test.Package", readme)
+        self.assertIn(
+            "https://www.nuget.org/packages/Test.Package",
+            readme,
+        )
+        self.assertIn(CURRENT_REPOSITORY_URL, readme)
+        self.assertIn(CURRENT_DOCUMENTATION_URL, readme)
+        self.assertEqual(
+            {
+                "PackageProjectUrl": (
+                    "https://go.microsoft.com/fwlink/?linkid=868515"
+                ),
+                "PackageReleaseNotes": (
+                    "Please visit https://go.microsoft.com/fwlink/?linkid=868517 "
+                    "to view the release notes."
+                ),
+                "PackageReadmeFile": "README.md",
+                "RepositoryUrl": (
+                    "https://go.microsoft.com/fwlink/?linkid=868515"
+                ),
+                "RepositoryType": "git",
+            },
+            metadata,
+        )
+
+    def test_explicit_identity_overrides_do_not_require_offline_config(
+        self,
+    ) -> None:
+        readme, metadata = self.render_readme(
+            "Test.Package",
+            properties={
+                "SkiaSharpRepositoryUrl": DESTINATION_REPOSITORY_URL,
+                "SkiaSharpDocumentationUrl": DESTINATION_DOCUMENTATION_URL,
+                "_RepositoryIdentityConfig": str(
+                    ROOT / "does-not-exist" / "repository-identity.json"
+                ),
+            },
+        )
+
+        self.assertIn(DESTINATION_REPOSITORY_URL, readme)
+        self.assertIn(DESTINATION_DOCUMENTATION_URL, readme)
+        self.assertNotIn(CURRENT_REPOSITORY_URL, readme)
+        self.assertNotIn(CURRENT_DOCUMENTATION_URL, readme)
+        self.assertEqual(
+            "https://go.microsoft.com/fwlink/?linkid=868515",
+            metadata["PackageProjectUrl"],
+        )
+        self.assertEqual(
+            "https://go.microsoft.com/fwlink/?linkid=868515",
+            metadata["RepositoryUrl"],
+        )
+
+    def test_harfbuzz_generated_resources_use_repository_override(self) -> None:
+        for repository_url, documentation_url, explicit in (
+            (
+                CURRENT_REPOSITORY_URL,
+                CURRENT_DOCUMENTATION_URL,
+                False,
+            ),
+            (
+                DESTINATION_REPOSITORY_URL,
+                DESTINATION_DOCUMENTATION_URL,
+                True,
+            ),
+        ):
+            properties = {"PackagingGroup": "HarfBuzzSharp"}
+            if explicit:
+                properties.update(
+                    {
+                        "SkiaSharpRepositoryUrl": repository_url,
+                        "SkiaSharpDocumentationUrl": documentation_url,
+                        "_RepositoryIdentityConfig": str(
+                            ROOT / "missing-repository-identity.json"
+                        ),
+                    }
+                )
+            with self.subTest(repository_url=repository_url):
+                readme, _ = self.render_readme(
+                    "HarfBuzzSharp.NativeAssets.Linux",
+                    properties=properties,
+                    use_binding_targets=True,
+                )
+                self.assertIn(
+                    f"{repository_url}/blob/main/documentation/dev/packages.md",
+                    readme,
+                )
+                self.assertIn(
+                    "https://learn.microsoft.com/dotnet/api/harfbuzzsharp",
+                    readme,
+                )
+                self.assertIn("https://harfbuzz.github.io/", readme)
+                self.assertIn(
+                    "https://www.nuget.org/packages/SkiaSharp.HarfBuzz",
+                    readme,
+                )
+
+    def test_generated_readme_round_trips_special_characters(self) -> None:
+        summary = (
+            'Summary & details; 50% <span title="quoted">"value"</span> - مرحبا'
+        )
+        notice = (
+            '> Notice: A&B; 75% <tag data-value="1 & 2">"quoted"</tag>'
+        )
+        details = (
+            '## Details\n\nXML: `<node attr="A&B">100% complete;</node>`\n\n'
+            "Unicode: Καλημέρα κόσμε"
+        )
+        resources = (
+            "- [Docs](https://example.test/docs?a=1&b=2)\n"
+            "- Literal `<tag>`; 99% complete"
+        )
+
+        readme, _ = self.render_readme(
+            "Test.Package",
+            properties={
+                "PackageDescription": summary,
+                "PackageReadmeNotice": notice,
+                "PackageReadmeAdditionalDetails": details,
+                "PackageReadmeResourceLinks": resources,
+            },
+        )
+
+        for value in (summary, notice, details, resources):
+            with self.subTest(value=value):
+                self.assertIn(value, readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/infra/package/tests/test_package_readmes.py
+++ b/scripts/infra/package/tests/test_package_readmes.py
@@ -165,9 +165,6 @@ class PackageReadmeTests(unittest.TestCase):
             properties = {
                 "SkiaSharpRepositoryUrl": repository_url,
                 "SkiaSharpDocumentationUrl": documentation_url,
-                "_RepositoryIdentityConfig": str(
-                    template.parent / "missing-repository-identity.json"
-                ),
             }
 
         actual, _ = self.render_readme(
@@ -248,17 +245,12 @@ class PackageReadmeTests(unittest.TestCase):
             metadata,
         )
 
-    def test_explicit_identity_overrides_do_not_require_offline_config(
-        self,
-    ) -> None:
+    def test_explicit_identity_overrides_replace_package_defaults(self) -> None:
         readme, metadata = self.render_readme(
             "Test.Package",
             properties={
                 "SkiaSharpRepositoryUrl": DESTINATION_REPOSITORY_URL,
                 "SkiaSharpDocumentationUrl": DESTINATION_DOCUMENTATION_URL,
-                "_RepositoryIdentityConfig": str(
-                    ROOT / "does-not-exist" / "repository-identity.json"
-                ),
             },
         )
 
@@ -294,9 +286,6 @@ class PackageReadmeTests(unittest.TestCase):
                     {
                         "SkiaSharpRepositoryUrl": repository_url,
                         "SkiaSharpDocumentationUrl": documentation_url,
-                        "_RepositoryIdentityConfig": str(
-                            ROOT / "missing-repository-identity.json"
-                        ),
                     }
                 )
             with self.subTest(repository_url=repository_url):

--- a/source/SkiaSharp.NuGet.props
+++ b/source/SkiaSharp.NuGet.props
@@ -1,6 +1,12 @@
 <Project>
 
   <PropertyGroup>
+    <_RepositoryIdentityConfig Condition="'$(_RepositoryIdentityConfig)' == ''">$(MSBuildThisFileDirectory)..\scripts\infra\repository-identity.json</_RepositoryIdentityConfig>
+    <_RepositoryIdentityJson Condition="'$(SkiaSharpRepositoryUrl)' == '' or '$(SkiaSharpDocumentationUrl)' == ''">$([System.IO.File]::ReadAllText($(_RepositoryIdentityConfig)))</_RepositoryIdentityJson>
+    <_RepositoryIdentitySlug Condition="'$(SkiaSharpRepositoryUrl)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;offlineRepository&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value)</_RepositoryIdentitySlug>
+    <_RepositoryIdentitySite Condition="'$(SkiaSharpDocumentationUrl)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;publicSiteBaseUrl&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value.TrimEnd('/'))</_RepositoryIdentitySite>
+    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == '' and '$(_RepositoryIdentitySlug)' != ''">https://github.com/$(_RepositoryIdentitySlug)</SkiaSharpRepositoryUrl>
+    <SkiaSharpDocumentationUrl Condition="'$(SkiaSharpDocumentationUrl)' == ''">$(_RepositoryIdentitySite)</SkiaSharpDocumentationUrl>
     
     <!-- package -->
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=868515</PackageProjectUrl>

--- a/source/SkiaSharp.NuGet.props
+++ b/source/SkiaSharp.NuGet.props
@@ -1,12 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <_RepositoryIdentityConfig Condition="'$(_RepositoryIdentityConfig)' == ''">$(MSBuildThisFileDirectory)..\scripts\infra\repository-identity.json</_RepositoryIdentityConfig>
-    <_RepositoryIdentityJson Condition="'$(SkiaSharpRepositoryUrl)' == '' or '$(SkiaSharpDocumentationUrl)' == ''">$([System.IO.File]::ReadAllText($(_RepositoryIdentityConfig)))</_RepositoryIdentityJson>
-    <_RepositoryIdentitySlug Condition="'$(SkiaSharpRepositoryUrl)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;offlineRepository&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value)</_RepositoryIdentitySlug>
-    <_RepositoryIdentitySite Condition="'$(SkiaSharpDocumentationUrl)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;publicSiteBaseUrl&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value.TrimEnd('/'))</_RepositoryIdentitySite>
-    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == '' and '$(_RepositoryIdentitySlug)' != ''">https://github.com/$(_RepositoryIdentitySlug)</SkiaSharpRepositoryUrl>
-    <SkiaSharpDocumentationUrl Condition="'$(SkiaSharpDocumentationUrl)' == ''">$(_RepositoryIdentitySite)</SkiaSharpDocumentationUrl>
+    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == ''">https://github.com/mono/SkiaSharp</SkiaSharpRepositoryUrl>
+    <SkiaSharpDocumentationUrl Condition="'$(SkiaSharpDocumentationUrl)' == ''">https://mono.github.io/SkiaSharp</SkiaSharpDocumentationUrl>
     
     <!-- package -->
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=868515</PackageProjectUrl>

--- a/source/SkiaSharp.NuGet.targets
+++ b/source/SkiaSharp.NuGet.targets
@@ -38,6 +38,10 @@ $(PackageNotes)</PackageDescription>
   <Target Name="_GeneratePackageReadmeFile"
           BeforeTargets="_GetPackageFiles"
           Condition="'$(PackageDescription)' != ''">
+    <Error Text="SkiaSharpRepositoryUrl could not be resolved from an explicit override or the repository identity config."
+           Condition="'$(SkiaSharpRepositoryUrl)' == ''" />
+    <Error Text="SkiaSharpDocumentationUrl could not be resolved from an explicit override or the repository identity config."
+           Condition="'$(SkiaSharpDocumentationUrl)' == ''" />
     <PropertyGroup>
       <_PackageReadmeOutput>$(IntermediateOutputPath)$(PackageReadmeFile)</_PackageReadmeOutput>
       <_PackageReadmeSource Condition="'$(PackageReadmeSource)' != ''">$(PackageReadmeSource)</_PackageReadmeSource>
@@ -46,11 +50,11 @@ $(PackageNotes)</PackageDescription>
       <_PackageReadmeApiUrl>$(PackageReadmeApiUrl)</_PackageReadmeApiUrl>
       <_PackageReadmeApiUrl Condition="'$(_PackageReadmeApiUrl)' == ''">https://learn.microsoft.com/dotnet/api/skiasharp</_PackageReadmeApiUrl>
       <_PackageReadmeResourceLinks>$(PackageReadmeResourceLinks)</_PackageReadmeResourceLinks>
-      <_PackageReadmeResourceLinks Condition="'$(_PackageReadmeResourceLinks)' == ''">- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/)
+      <_PackageReadmeResourceLinks Condition="'$(_PackageReadmeResourceLinks)' == ''">- [SkiaSharp documentation]($(SkiaSharpDocumentationUrl)/docs/)
 - [API reference on Microsoft Learn]($(_PackageReadmeApiUrl))
-- [Package selection and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
-- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/)
-- [SkiaFiddle](https://mono.github.io/SkiaSharp/fiddle/) - experiment with SkiaSharp in your browser</_PackageReadmeResourceLinks>
+- [Package selection and deployment guide]($(SkiaSharpRepositoryUrl)/blob/main/documentation/dev/packages.md)
+- [Live SkiaSharp Gallery]($(SkiaSharpDocumentationUrl)/gallery/)
+- [SkiaFiddle]($(SkiaSharpDocumentationUrl)/fiddle/) - experiment with SkiaSharp in your browser</_PackageReadmeResourceLinks>
 
       <_PackageReadmeSummary>$(PackageReadmeSummary)</_PackageReadmeSummary>
       <_PackageReadmeSummary Condition="'$(_PackageReadmeSummary)' == ''">$(PackageDescription)</_PackageReadmeSummary>
@@ -67,7 +71,7 @@ $(PackageNotes)</PackageDescription>
 
 [![NuGet](https://img.shields.io/nuget/v/$(PackageId)?style=flat-square&amp;label=NuGet)](https://www.nuget.org/packages/$(PackageId))
 [![NuGet downloads](https://img.shields.io/nuget/dt/$(PackageId)?style=flat-square&amp;label=Downloads)](https://www.nuget.org/packages/$(PackageId))
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)]($(SkiaSharpRepositoryUrl)/blob/main/LICENSE.md)
 
 $(_PackageReadmeSummary)
 
@@ -83,17 +87,14 @@ $(_PackageReadmeResourceLinks)
 
 ## Feedback and contributing
 
-SkiaSharp is an open-source project from Microsoft, released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md). Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and see the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.</_PackageReadmeContents>
+SkiaSharp is an open-source project from Microsoft, released under the [MIT license]($(SkiaSharpRepositoryUrl)/blob/main/LICENSE.md). Use [GitHub Discussions]($(SkiaSharpRepositoryUrl)/discussions) for questions, file bugs and feature requests in the [issue tracker]($(SkiaSharpRepositoryUrl)/issues), and see the [contributing guide]($(SkiaSharpRepositoryUrl)/blob/main/CONTRIBUTING.md) to get involved.</_PackageReadmeContents>
+      <_PackageReadmeContents Condition="'$(_PackageReadmeSource)' != ''">$([System.IO.File]::ReadAllText($(_PackageReadmeSource)).Replace('{{RepositoryUrl}}', '$(SkiaSharpRepositoryUrl)').Replace('{{DocumentationUrl}}', '$(SkiaSharpDocumentationUrl)'))</_PackageReadmeContents>
     </PropertyGroup>
 
-    <Copy SourceFiles="$(_PackageReadmeSource)"
-          DestinationFiles="$(_PackageReadmeOutput)"
-          Condition="'$(_PackageReadmeSource)' != ''" />
     <WriteLinesToFile File="$(_PackageReadmeOutput)"
-                     Lines="$(_PackageReadmeContents)"
+                     Lines="$([MSBuild]::Escape('$(_PackageReadmeContents)'))"
                      Encoding="UTF-8"
-                     Overwrite="True"
-                     Condition="'$(_PackageReadmeSource)' == ''" />
+                     Overwrite="True" />
     <ItemGroup>
       <FileWrites Include="$(_PackageReadmeOutput)" />
       <None Include="$(_PackageReadmeOutput)" PackagePath="$(PackageReadmeFile)" Pack="True" />

--- a/source/SkiaSharp.NuGet.targets
+++ b/source/SkiaSharp.NuGet.targets
@@ -38,9 +38,9 @@ $(PackageNotes)</PackageDescription>
   <Target Name="_GeneratePackageReadmeFile"
           BeforeTargets="_GetPackageFiles"
           Condition="'$(PackageDescription)' != ''">
-    <Error Text="SkiaSharpRepositoryUrl could not be resolved from an explicit override or the repository identity config."
+    <Error Text="SkiaSharpRepositoryUrl could not be resolved from an explicit override or the package default."
            Condition="'$(SkiaSharpRepositoryUrl)' == ''" />
-    <Error Text="SkiaSharpDocumentationUrl could not be resolved from an explicit override or the repository identity config."
+    <Error Text="SkiaSharpDocumentationUrl could not be resolved from an explicit override or the package default."
            Condition="'$(SkiaSharpDocumentationUrl)' == ''" />
     <PropertyGroup>
       <_PackageReadmeOutput>$(IntermediateOutputPath)$(PackageReadmeFile)</_PackageReadmeOutput>

--- a/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/PACKAGE-README.md
+++ b/source/SkiaSharp.Views.Maui/SkiaSharp.Views.Maui.Controls/PACKAGE-README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/SkiaSharp.Views.Maui.Controls?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls)
 [![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp.Views.Maui.Controls?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp.Views.Maui.Controls)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)]({{RepositoryUrl}}/blob/main/LICENSE.md)
 
 **SkiaSharp.Views.Maui.Controls** adds SkiaSharp rendering controls and image sources to .NET MAUI applications. Put a CPU- or GPU-backed canvas alongside standard MAUI controls, draw with the full SkiaSharp API, and share the same rendering code across Android, iOS, Mac Catalyst, and Windows.
 
@@ -73,14 +73,14 @@ Call `InvalidateSurface()` whenever state changes and the view should redraw. Us
 
 ## Documentation and resources
 
-- [SkiaSharp .NET MAUI guides](https://mono.github.io/SkiaSharp/docs/guides/)
+- [SkiaSharp .NET MAUI guides]({{DocumentationUrl}}/docs/guides/)
 - [API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/skiasharp.views.maui.controls)
-- [Buildable .NET MAUI sample](https://github.com/mono/SkiaSharp/tree/main/samples/Basic/Maui)
-- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/) - explore the rendering API in your browser
-- [SkiaSharp package and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+- [Buildable .NET MAUI sample]({{RepositoryUrl}}/tree/main/samples/Basic/Maui)
+- [Live SkiaSharp Gallery]({{DocumentationUrl}}/gallery/) - explore the rendering API in your browser
+- [SkiaSharp package and deployment guide]({{RepositoryUrl}}/blob/main/documentation/dev/packages.md)
 
 ## Feedback and contributing
 
-SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions]({{RepositoryUrl}}/discussions) for questions, file bugs and feature requests in the [issue tracker]({{RepositoryUrl}}/issues), and read the [contributing guide]({{RepositoryUrl}}/blob/main/CONTRIBUTING.md) to get involved.
 
-This package is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).
+This package is released under the [MIT license]({{RepositoryUrl}}/blob/main/LICENSE.md).

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/PACKAGE-README.md
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/PACKAGE-README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/SkiaSharp.Views.Blazor?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp.Views.Blazor)
 [![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp.Views.Blazor?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp.Views.Blazor)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)]({{RepositoryUrl}}/blob/main/LICENSE.md)
 
 **SkiaSharp.Views.Blazor** brings SkiaSharp to Blazor WebAssembly with ready-to-use Razor components. Draw with the same SkiaSharp API used by native .NET applications while the package handles the browser canvas, JavaScript interop, input events, and WebAssembly native assets.
 
@@ -60,19 +60,19 @@ The package supplies its browser interop automatically. Use .NET 8 or later for 
 
 ## See it running
 
-- [Live Blazor WebAssembly Gallery](https://mono.github.io/SkiaSharp/gallery/) - interactive SkiaSharp examples with no installation
-- [Buildable Blazor WebAssembly sample](https://github.com/mono/SkiaSharp/tree/main/samples/Basic/BlazorWebAssembly)
-- [SkiaFiddle](https://mono.github.io/SkiaSharp/fiddle/) - experiment with drawing code in your browser
+- [Live Blazor WebAssembly Gallery]({{DocumentationUrl}}/gallery/) - interactive SkiaSharp examples with no installation
+- [Buildable Blazor WebAssembly sample]({{RepositoryUrl}}/tree/main/samples/Basic/BlazorWebAssembly)
+- [SkiaFiddle]({{DocumentationUrl}}/fiddle/) - experiment with drawing code in your browser
 
 ## Documentation and resources
 
-- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/)
+- [SkiaSharp documentation]({{DocumentationUrl}}/docs/)
 - [Blazor API reference on Microsoft Learn](https://learn.microsoft.com/dotnet/api/skiasharp.views.blazor)
 - [Core SkiaSharp API reference](https://learn.microsoft.com/dotnet/api/skiasharp)
-- [WebAssembly package guidance](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+- [WebAssembly package guidance]({{RepositoryUrl}}/blob/main/documentation/dev/packages.md)
 
 ## Feedback and contributing
 
-SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions]({{RepositoryUrl}}/discussions) for questions, file bugs and feature requests in the [issue tracker]({{RepositoryUrl}}/issues), and read the [contributing guide]({{RepositoryUrl}}/blob/main/CONTRIBUTING.md) to get involved.
 
-This package is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).
+This package is released under the [MIT license]({{RepositoryUrl}}/blob/main/LICENSE.md).

--- a/source/SkiaSharp.Views/SkiaSharp.Views/PACKAGE-README.md
+++ b/source/SkiaSharp.Views/SkiaSharp.Views/PACKAGE-README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/SkiaSharp.Views?style=flat-square&label=NuGet)](https://www.nuget.org/packages/SkiaSharp.Views)
 [![NuGet downloads](https://img.shields.io/nuget/dt/SkiaSharp.Views?style=flat-square&label=Downloads)](https://www.nuget.org/packages/SkiaSharp.Views)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)]({{RepositoryUrl}}/blob/main/LICENSE.md)
 
 **SkiaSharp.Views** provides native SkiaSharp drawing views for Android, iOS, Mac Catalyst, macOS, tvOS, and Tizen applications. Each view owns the platform rendering surface and raises a familiar `PaintSurface` event so application code can draw with `SKCanvas`.
 
@@ -65,14 +65,14 @@ Choose the package that matches the application framework:
 
 ## Documentation and resources
 
-- [SkiaSharp documentation](https://mono.github.io/SkiaSharp/docs/)
+- [SkiaSharp documentation]({{DocumentationUrl}}/docs/)
 - Platform API reference on Microsoft Learn: [Android](https://learn.microsoft.com/dotnet/api/skiasharp.views.android), [iOS and Mac Catalyst](https://learn.microsoft.com/dotnet/api/skiasharp.views.ios), [macOS](https://learn.microsoft.com/dotnet/api/skiasharp.views.mac), and [Tizen](https://learn.microsoft.com/dotnet/api/skiasharp.views.tizen)
-- [Platform samples](https://github.com/mono/SkiaSharp/tree/main/samples/Basic)
-- [Live SkiaSharp Gallery](https://mono.github.io/SkiaSharp/gallery/)
-- [Package selection and deployment guide](https://github.com/mono/SkiaSharp/blob/main/documentation/dev/packages.md)
+- [Platform samples]({{RepositoryUrl}}/tree/main/samples/Basic)
+- [Live SkiaSharp Gallery]({{DocumentationUrl}}/gallery/)
+- [Package selection and deployment guide]({{RepositoryUrl}}/blob/main/documentation/dev/packages.md)
 
 ## Feedback and contributing
 
-SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions](https://github.com/mono/SkiaSharp/discussions) for questions, file bugs and feature requests in the [issue tracker](https://github.com/mono/SkiaSharp/issues), and read the [contributing guide](https://github.com/mono/SkiaSharp/blob/main/CONTRIBUTING.md) to get involved.
+SkiaSharp is an open-source Microsoft project built with the .NET community. Use [GitHub Discussions]({{RepositoryUrl}}/discussions) for questions, file bugs and feature requests in the [issue tracker]({{RepositoryUrl}}/issues), and read the [contributing guide]({{RepositoryUrl}}/blob/main/CONTRIBUTING.md) to get involved.
 
-This package is released under the [MIT license](https://github.com/mono/SkiaSharp/blob/main/LICENSE.md).
+This package is released under the [MIT license]({{RepositoryUrl}}/blob/main/LICENSE.md).


### PR DESCRIPTION
## Description

Makes package metadata and README repository links portable before the planned `mono` to `dotnet` transfer. Two package-specific properties in `SkiaSharp.NuGet.props` own the current repository and documentation defaults while allowing explicit build-time overrides, and both generated and custom package README templates render from those properties.

All five custom SkiaSharp, HarfBuzzSharp, and Views package READMEs are parameterized, along with the generated README and HarfBuzz resource block. Focused MSBuild-backed tests render every path with current `mono` defaults and simulated `dotnet` overrides, and cover Markdown containing XML, HTML, Unicode, ampersands, semicolons, percent signs, and quotes.

Stable package IDs, public API, package/project/release-note fwlinks, NuGet and Microsoft Learn URLs, and current live site defaults are unchanged. This PR does not publish packages or flip any live destination.

**Related issues**

Fixes #4989

Related to #4960

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — package metadata and README generation only; no public API or runtime behavior changes.

## Testing

- `python3 -m unittest scripts/infra/package/tests/test_package_readmes.py -v`
  - generated README plus all five custom templates
  - current `mono` defaults and explicit simulated `dotnet` identities
  - XML/HTML/Unicode/special-character round trips
  - generated HarfBuzz resource links
  - stable package metadata assertions
- `python3 scripts/infra/caching/repo-deps.py validate`
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj`
- Packed `SkiaSharp.4.154.0.nupkg` with current and simulated destination overrides and inspected `README.md` plus `SkiaSharp.nuspec`
- `dotnet test tests/SkiaSharp.Tests.Console.slnx -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0`
  - 6,143 tests passed and 47 skipped across the core, singleton, Vulkan, and Direct3D hosts
  - one existing macOS `ganesh-gl/DiagonalLines` visual-golden mismatch remains; the identical 1,832-pixel mismatch reproduces on unchanged `origin/main` commit `655da2f1a0751420e81282a24e904efcd83bcb75`

Validated on macOS arm64. No native, generated, runtime, rendering, submodule, workflow-gate, DocFX/Gallery/build-site, release, sync, Backport, or shared repository-identity content changed.

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A