### PR TITLE
[migration] Make Docs, Pages, and Gallery identity portable

### DIFF
--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -96,6 +96,13 @@ jobs:
 
       - name: Validate Gallery repository metadata
         run: |
+          dotnet cake --target=samples-generate
+          for tree in samples samples-preview; do
+            repository_url="$(dotnet msbuild \
+              "output/${tree}/Gallery/Shared/SkiaSharpSample.Shared.csproj" \
+              -getProperty:SkiaSharpRepositoryUrl)"
+            test "$repository_url" = "https://github.com/mono/SkiaSharp"
+          done
           dotnet build samples/Gallery/Blazor/SkiaSharpSample.Blazor.csproj \
             -p:TargetFramework=net10.0 \
             -p:TargetFrameworks=net10.0 \

--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -16,7 +16,11 @@ on:
     paths:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
+      - "documentation/docfx/TOC.yml"
+      - "samples/Gallery/**"
       - ".github/scripts/**"
+      - "scripts/build-docs-site.py"
+      - "scripts/infra/tests/test_build_docs_site.py"
       # Any workflow edit, so the registry test re-checks its tracked list. '*.yml' already
       # covers the generated '*.lock.yml' files.
       - ".github/workflows/*.yml"
@@ -25,7 +29,11 @@ on:
     paths:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
+      - "documentation/docfx/TOC.yml"
+      - "samples/Gallery/**"
       - ".github/scripts/**"
+      - "scripts/build-docs-site.py"
+      - "scripts/infra/tests/test_build_docs_site.py"
       - ".github/workflows/*.yml"
   workflow_dispatch:
 
@@ -78,3 +86,26 @@ jobs:
 
       - name: Run skia-sync work detector tests
         run: bash .github/scripts/tests/skia-sync-detect.test.sh
+
+      - name: Run docs site tests
+        run: |
+          python3 -m unittest scripts/infra/tests/test_build_docs_site.py -v
+          python3 -m py_compile \
+            scripts/build-docs-site.py \
+            scripts/infra/tests/test_build_docs_site.py
+
+      - name: Validate Gallery repository metadata
+        run: |
+          dotnet build samples/Gallery/Blazor/SkiaSharpSample.Blazor.csproj \
+            -p:TargetFramework=net10.0 \
+            -p:TargetFrameworks=net10.0 \
+            -p:SkiaSharpRepositoryUrl=https://github.com/dotnet/SkiaSharp \
+            -p:WasmBuildNative=false \
+            -p:WasmNativeStrip=true \
+            -v:minimal
+          strings samples/Gallery/Shared/bin/Debug/net10.0/SkiaSharpSample.Shared.dll \
+            | grep -F 'RepositoryUrl#https://github.com/dotnet/SkiaSharp' \
+            > /dev/null
+      - name: Validate cache dependency coverage
+        run: python3 scripts/infra/caching/repo-deps.py validate
+        run: python3 scripts/infra/caching/repo-deps.py validate

--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -96,6 +96,7 @@ jobs:
 
       - name: Validate Gallery repository metadata
         run: |
+          dotnet tool restore
           dotnet cake --target=samples-generate
           for tree in samples samples-preview; do
             repository_url="$(dotnet msbuild \

--- a/.github/workflows/automation-tooling-tests.yml
+++ b/.github/workflows/automation-tooling-tests.yml
@@ -17,9 +17,11 @@ on:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
       - "documentation/docfx/TOC.yml"
+      - "documentation/docfx/docfx.json"
       - "samples/Gallery/**"
       - ".github/scripts/**"
       - "scripts/build-docs-site.py"
+      - "scripts/infra/caching/**"
       - "scripts/infra/tests/test_build_docs_site.py"
       # Any workflow edit, so the registry test re-checks its tracked list. '*.yml' already
       # covers the generated '*.lock.yml' files.
@@ -30,9 +32,11 @@ on:
       - ".agents/skills/ci-status/**"
       - ".agents/skills/update-skia/**"
       - "documentation/docfx/TOC.yml"
+      - "documentation/docfx/docfx.json"
       - "samples/Gallery/**"
       - ".github/scripts/**"
       - "scripts/build-docs-site.py"
+      - "scripts/infra/caching/**"
       - "scripts/infra/tests/test_build_docs_site.py"
       - ".github/workflows/*.yml"
   workflow_dispatch:
@@ -115,5 +119,4 @@ jobs:
             | grep -F 'RepositoryUrl#https://github.com/dotnet/SkiaSharp' \
             > /dev/null
       - name: Validate cache dependency coverage
-        run: python3 scripts/infra/caching/repo-deps.py validate
         run: python3 scripts/infra/caching/repo-deps.py validate

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -97,6 +97,7 @@ jobs:
             BRANCH_NAME="${GITHUB_REF_NAME}"
           fi
 
+          REPOSITORY_NAME="${GITHUB_REPOSITORY#*/}"
           if [ -n "$PR_NUMBER" ]; then
             # Validate PR_NUMBER is a positive integer
             if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
@@ -104,9 +105,9 @@ jobs:
               exit 1
             fi
             echo "artifact_name=staging-site-${PR_NUMBER}" >> $GITHUB_OUTPUT
-            echo "gallery_base_href=/SkiaSharp/staging/${PR_NUMBER}/gallery/" >> $GITHUB_OUTPUT
-            echo "uno_gallery_base_href=/SkiaSharp/staging/${PR_NUMBER}/gallery-uno/" >> $GITHUB_OUTPUT
-            echo "fiddle_base_href=/SkiaSharp/staging/${PR_NUMBER}/fiddle/" >> $GITHUB_OUTPUT
+            echo "gallery_base_href=/${REPOSITORY_NAME}/staging/${PR_NUMBER}/gallery/" >> $GITHUB_OUTPUT
+            echo "uno_gallery_base_href=/${REPOSITORY_NAME}/staging/${PR_NUMBER}/gallery-uno/" >> $GITHUB_OUTPUT
+            echo "fiddle_base_href=/${REPOSITORY_NAME}/staging/${PR_NUMBER}/fiddle/" >> $GITHUB_OUTPUT
             echo "is_staging=true" >> $GITHUB_OUTPUT
             echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
             echo "checkout_ref=${CHECKOUT_REF}" >> $GITHUB_OUTPUT
@@ -114,9 +115,9 @@ jobs:
             echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
           else
             echo "artifact_name=main-site" >> $GITHUB_OUTPUT
-            echo "gallery_base_href=/SkiaSharp/gallery/" >> $GITHUB_OUTPUT
-            echo "uno_gallery_base_href=/SkiaSharp/gallery-uno/" >> $GITHUB_OUTPUT
-            echo "fiddle_base_href=/SkiaSharp/fiddle/" >> $GITHUB_OUTPUT
+            echo "gallery_base_href=/${REPOSITORY_NAME}/gallery/" >> $GITHUB_OUTPUT
+            echo "uno_gallery_base_href=/${REPOSITORY_NAME}/gallery-uno/" >> $GITHUB_OUTPUT
+            echo "fiddle_base_href=/${REPOSITORY_NAME}/fiddle/" >> $GITHUB_OUTPUT
             echo "is_staging=false" >> $GITHUB_OUTPUT
             echo "pr_number=" >> $GITHUB_OUTPUT
             echo "checkout_ref=${CHECKOUT_REF}" >> $GITHUB_OUTPUT
@@ -146,13 +147,18 @@ jobs:
         env:
           SOURCE_LABEL: ${{ steps.vars.outputs.source_label }}
           BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
+          IS_STAGING: ${{ steps.vars.outputs.is_staging }}
+          PR_NUMBER: ${{ steps.vars.outputs.pr_number }}
         run: |
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
           APP_FOOTER="${SOURCE_LABEL} · ${BRANCH_NAME} · ${COMMIT_SHORT}"
-          jq --arg footer "$APP_FOOTER" \
-            '.build.globalMetadata._appFooter = $footer' \
-            documentation/docfx/docfx.json > documentation/docfx/docfx-build.json
-          dotnet docfx documentation/docfx/docfx-build.json
+          DOCFX_ARGS=(--app-footer "$APP_FOOTER")
+          if [ "$IS_STAGING" == "true" ]; then
+            REPOSITORY_NAME="${GITHUB_REPOSITORY#*/}"
+            STAGING_BASE_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPOSITORY_NAME}/staging/${PR_NUMBER}"
+            DOCFX_ARGS+=(--public-site-base-url "$STAGING_BASE_URL")
+          fi
+          python3 scripts/build-docs-site.py "${DOCFX_ARGS[@]}"
 
       # ── Build Gallery Blazor WASM app ──────────────────────────
       - name: Build WASM native libraries
@@ -167,11 +173,13 @@ jobs:
         run: |
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
           BUILD_FOOTER="${SOURCE_LABEL} · ${BRANCH_NAME} · ${COMMIT_SHORT}"
+          REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           dotnet publish "samples/Gallery/Blazor/SkiaSharpSample.Blazor.csproj" \
             -c Release \
             -o output/gallery-publish \
             -p:PlatformTargetFrameworks="" \
-            -p:BuildFooter="$BUILD_FOOTER"
+            -p:BuildFooter="$BUILD_FOOTER" \
+            -p:SkiaSharpRepositoryUrl="$REPOSITORY_URL"
 
       # ── Build Gallery Uno Platform WASM app ──────────────────────
       - name: Publish Gallery Uno WASM
@@ -181,13 +189,15 @@ jobs:
         run: |
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
           BUILD_FOOTER="${SOURCE_LABEL} · ${BRANCH_NAME} · ${COMMIT_SHORT}"
+          REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           dotnet publish "samples/Gallery/Uno/SkiaSharpSample.Uno.csproj" \
             -c Release \
             -f net10.0-browserwasm \
             -o output/gallery-uno-publish \
             -p:PlatformTargetFrameworks="" \
             -p:WasmEnableSIMD=false \
-            -p:BuildFooter="$BUILD_FOOTER"
+            -p:BuildFooter="$BUILD_FOOTER" \
+            -p:SkiaSharpRepositoryUrl="$REPOSITORY_URL"
 
       - name: Smoke test Gallery Uno WASM
         run: |
@@ -211,13 +221,15 @@ jobs:
         run: |
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
           BUILD_FOOTER="${SOURCE_LABEL} · ${BRANCH_NAME} · ${COMMIT_SHORT}"
+          REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           dotnet publish "samples/SkiaFiddle/SkiaFiddle.csproj" \
             -c Release \
             -f net10.0-browserwasm \
             -o output/skia-fiddle-publish \
             -p:PlatformTargetFrameworks="" \
             -p:WasmEnableSIMD=false \
-            -p:BuildFooter="$BUILD_FOOTER"
+            -p:BuildFooter="$BUILD_FOOTER" \
+            -p:SkiaSharpRepositoryUrl="$REPOSITORY_URL"
 
       - name: Smoke test SkiaFiddle WASM
         run: |
@@ -360,6 +372,26 @@ jobs:
           # SkiaFiddle (Uno Platform) → /fiddle/
           cp -r output/skia-fiddle-publish/wwwroot site/fiddle
           uno_rewrite_dir site/fiddle "${FIDDLE_BASE_HREF%/}"
+
+          # Render only the landing and current DocFX identities. The helper
+          # deliberately excludes historical releases plus /ai/ and /perf/.
+          find site/gallery site/gallery-uno site/fiddle -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > "$RUNNER_TEMP/wasm-assets-before.sha256"
+          python3 scripts/infra/repository_identity.py \
+            --repository "$GITHUB_REPOSITORY" render-site site
+          find site/gallery site/gallery-uno site/fiddle -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > "$RUNNER_TEMP/wasm-assets-after.sha256"
+          diff -u \
+            "$RUNNER_TEMP/wasm-assets-before.sha256" \
+            "$RUNNER_TEMP/wasm-assets-after.sha256"
+          if grep -R -nE --exclude-dir=releases \
+              '\{\{(Repository|SkiaRepository|DocsRepository|PublicSiteBaseUrl)\}\}' \
+              site/index.html site/docs site/gallery site/gallery-uno site/fiddle; then
+            echo "::error::Unresolved repository identity placeholder in assembled site."
+            exit 1
+          fi
 
           echo "=== Site layout ==="
           find site -maxdepth 2 -type f | head -30
@@ -540,11 +572,12 @@ jobs:
         with:
           script: |
             const prNumber = ${{ needs.build.outputs.pr_number }};
-            const stagingUrl = `https://mono.github.io/SkiaSharp/staging/${prNumber}/`;
-            const docsUrl = `https://mono.github.io/SkiaSharp/staging/${prNumber}/docs/`;
-            const galleryUrl = `https://mono.github.io/SkiaSharp/staging/${prNumber}/gallery/`;
-            const unoGalleryUrl = `https://mono.github.io/SkiaSharp/staging/${prNumber}/gallery-uno/`;
-            const fiddleUrl = `https://mono.github.io/SkiaSharp/staging/${prNumber}/fiddle/`;
+            const pagesBase = `https://${context.repo.owner}.github.io/${context.repo.repo}`;
+            const stagingUrl = `${pagesBase}/staging/${prNumber}/`;
+            const docsUrl = `${pagesBase}/staging/${prNumber}/docs/`;
+            const galleryUrl = `${pagesBase}/staging/${prNumber}/gallery/`;
+            const unoGalleryUrl = `${pagesBase}/staging/${prNumber}/gallery-uno/`;
+            const fiddleUrl = `${pagesBase}/staging/${prNumber}/fiddle/`;
 
             // Hidden marker to uniquely identify this workflow's comment
             const marker = '<!-- skiasharp-docs-staging-preview -->';

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -152,7 +152,11 @@ jobs:
         run: |
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
           APP_FOOTER="${SOURCE_LABEL} · ${BRANCH_NAME} · ${COMMIT_SHORT}"
-          DOCFX_ARGS=(--app-footer "$APP_FOOTER")
+          REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          DOCFX_ARGS=(
+            --app-footer "$APP_FOOTER"
+            --repository-url "$REPOSITORY_URL"
+          )
           if [ "$IS_STAGING" == "true" ]; then
             REPOSITORY_NAME="${GITHUB_REPOSITORY#*/}"
             STAGING_BASE_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPOSITORY_NAME}/staging/${PR_NUMBER}"
@@ -221,15 +225,13 @@ jobs:
         run: |
           COMMIT_SHORT="${GITHUB_SHA:0:7}"
           BUILD_FOOTER="${SOURCE_LABEL} · ${BRANCH_NAME} · ${COMMIT_SHORT}"
-          REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           dotnet publish "samples/SkiaFiddle/SkiaFiddle.csproj" \
             -c Release \
             -f net10.0-browserwasm \
             -o output/skia-fiddle-publish \
             -p:PlatformTargetFrameworks="" \
             -p:WasmEnableSIMD=false \
-            -p:BuildFooter="$BUILD_FOOTER" \
-            -p:SkiaSharpRepositoryUrl="$REPOSITORY_URL"
+            -p:BuildFooter="$BUILD_FOOTER"
 
       - name: Smoke test SkiaFiddle WASM
         run: |
@@ -373,23 +375,9 @@ jobs:
           cp -r output/skia-fiddle-publish/wwwroot site/fiddle
           uno_rewrite_dir site/fiddle "${FIDDLE_BASE_HREF%/}"
 
-          # Render only the landing and current DocFX identities. The helper
-          # deliberately excludes historical releases plus /ai/ and /perf/.
-          find site/gallery site/gallery-uno site/fiddle -type f -print0 \
-            | sort -z \
-            | xargs -0 sha256sum > "$RUNNER_TEMP/wasm-assets-before.sha256"
-          python3 scripts/infra/repository_identity.py \
-            --repository "$GITHUB_REPOSITORY" render-site site
-          find site/gallery site/gallery-uno site/fiddle -type f -print0 \
-            | sort -z \
-            | xargs -0 sha256sum > "$RUNNER_TEMP/wasm-assets-after.sha256"
-          diff -u \
-            "$RUNNER_TEMP/wasm-assets-before.sha256" \
-            "$RUNNER_TEMP/wasm-assets-after.sha256"
           if grep -R -nE --exclude-dir=releases \
-              '\{\{(Repository|SkiaRepository|DocsRepository|PublicSiteBaseUrl)\}\}' \
-              site/index.html site/docs site/gallery site/gallery-uno site/fiddle; then
-            echo "::error::Unresolved repository identity placeholder in assembled site."
+              '\{\{PublicSiteBaseUrl\}\}' site/docs; then
+            echo "::error::Unresolved public site placeholder in assembled docs."
             exit 1
           fi
 

--- a/documentation/dev/site.md
+++ b/documentation/dev/site.md
@@ -1,6 +1,8 @@
 # Building the Website
 
-This guide covers how to build, preview, and iterate on the SkiaSharp documentation site at [mono.github.io/SkiaSharp](https://mono.github.io/SkiaSharp/).
+This guide covers how to build, preview, and iterate on the SkiaSharp documentation site. The
+current public URL is the `publicSiteBaseUrl` in
+[`repository-identity.json`](../../scripts/infra/repository-identity.json).
 
 ## Site Structure
 
@@ -20,7 +22,7 @@ The CI workflow (`build-site.yml`) builds all three in parallel, then assembles 
 dotnet tool restore   # installs DocFX and other tools
 ```
 
-You also need `python3` if you want to use the preview server script.
+You also need `python3` for the identity-aware DocFX builder and preview scripts.
 
 ## Building Locally
 
@@ -39,21 +41,27 @@ To preview in a browser, open `documentation/site/index.html` directly. Note tha
 Build the DocFX site locally to iterate on content, styling, templates, or configuration:
 
 ```bash
-dotnet docfx documentation/docfx/docfx.json
+python3 scripts/build-docs-site.py
 ```
 
 This outputs to `output/site/docs/`. To preview with live rebuild on changes:
 
 ```bash
-dotnet docfx documentation/docfx/docfx.json --serve
+python3 scripts/build-docs-site.py --serve
 ```
 
-This starts a local server (typically at `http://localhost:8080`) and watches for file changes. This is the fastest way to iterate on:
+This starts a local server (typically at `http://localhost:8080`) and watches content and resource
+files for changes. Restart it after changing `TOC.yml` or `docfx.json`; those identity-bearing
+inputs are rendered into clean temporary snapshots when the command starts. This is the fastest
+way to iterate on:
 
 - Markdown content (`documentation/docfx/basics/`, `paths/`, etc.)
 - Table of contents (`documentation/docfx/TOC.yml`)
 - DocFX configuration (`documentation/docfx/docfx.json`)
 - Templates and styling (see [Customizing DocFX](#customizing-docfx) below)
+
+CI supplies `--public-site-base-url` for PR builds so Home and Gallery links stay inside the
+staging preview. Local and main builds use the centralized live URL unchanged.
 
 ### Gallery (Blazor WASM)
 
@@ -148,7 +156,7 @@ To customize the look of the DocFX site beyond what configuration offers, you ca
    ```json
    "template": ["default", "modern", "template"]
    ```
-4. Rebuild: `dotnet docfx documentation/docfx/docfx.json --serve`
+4. Rebuild: `python3 scripts/build-docs-site.py --serve`
 
 Common customizations:
 - **Styles:** Override CSS in `template/public/main.css`
@@ -185,5 +193,3 @@ scripts/
 .github/workflows/
   build-site.yml            # Unified build + deploy workflow
 ```
-
-

--- a/documentation/dev/site.md
+++ b/documentation/dev/site.md
@@ -1,8 +1,8 @@
 # Building the Website
 
 This guide covers how to build, preview, and iterate on the SkiaSharp documentation site. The
-current public URL is the `publicSiteBaseUrl` in
-[`repository-identity.json`](../../scripts/infra/repository-identity.json).
+current public URL is `_publicSiteBaseUrl` in
+[`docfx.json`](../docfx/docfx.json).
 
 ## Site Structure
 
@@ -22,7 +22,7 @@ The CI workflow (`build-site.yml`) builds all three in parallel, then assembles 
 dotnet tool restore   # installs DocFX and other tools
 ```
 
-You also need `python3` for the identity-aware DocFX builder and preview scripts.
+You also need `python3` for the repository-aware DocFX builder and preview scripts.
 
 ## Building Locally
 

--- a/documentation/dev/writing-docs.md
+++ b/documentation/dev/writing-docs.md
@@ -11,9 +11,9 @@ SkiaSharp provides two types of documentation: concept docs and API docs.
 
 ## Concept Docs
 
-The conceptual docs live on the `main` branch under `documentation/docfx/guides/` and are published to:
-
-- https://mono.github.io/SkiaSharp/docs/
+The conceptual docs live on the `main` branch under `documentation/docfx/guides/`. Their current
+public URL is the `publicSiteBaseUrl` in
+[`repository-identity.json`](../../scripts/infra/repository-identity.json), under `/docs/`.
 
 See [site.md](site.md) for how to build, preview, and customize the docs site.
 

--- a/documentation/dev/writing-docs.md
+++ b/documentation/dev/writing-docs.md
@@ -12,8 +12,8 @@ SkiaSharp provides two types of documentation: concept docs and API docs.
 ## Concept Docs
 
 The conceptual docs live on the `main` branch under `documentation/docfx/guides/`. Their current
-public URL is the `publicSiteBaseUrl` in
-[`repository-identity.json`](../../scripts/infra/repository-identity.json), under `/docs/`.
+public URL is `_publicSiteBaseUrl` in
+[`docfx.json`](../docfx/docfx.json), under `/docs/`.
 
 See [site.md](site.md) for how to build, preview, and customize the docs site.
 

--- a/documentation/docfx/TOC.yml
+++ b/documentation/docfx/TOC.yml
@@ -1,5 +1,5 @@
 - name: Home
-  href: https://mono.github.io/SkiaSharp/
+  href: "{{PublicSiteBaseUrl}}/"
 - name: Guides
   href: guides/
 - name: Release Notes
@@ -7,4 +7,4 @@
 - name: API Reference
   href: https://learn.microsoft.com/dotnet/api/skiasharp
 - name: Gallery
-  href: https://mono.github.io/SkiaSharp/gallery/
+  href: "{{PublicSiteBaseUrl}}/gallery/"

--- a/documentation/docfx/docfx.json
+++ b/documentation/docfx/docfx.json
@@ -39,6 +39,7 @@
       "_enableSearch": true,
       "_appLogoPath": "images/logo.png",
       "_appFaviconPath": "images/favicon.ico",
+      "_publicSiteBaseUrl": "https://mono.github.io/SkiaSharp",
       "_gitContribute": {
         "repo": "https://github.com/mono/SkiaSharp"
       },

--- a/samples/Gallery/Blazor/Layout/MainLayout.razor
+++ b/samples/Gallery/Blazor/Layout/MainLayout.razor
@@ -13,7 +13,7 @@
                 <button class="btn btn-sm btn-outline-light" @onclick="ToggleDarkMode" title="Toggle dark mode">
                     @(darkMode ? "☀️" : "🌙")
                 </button>
-                <a href="https://github.com/mono/SkiaSharp" target="_blank" title="GitHub" class="d-none d-sm-inline">GitHub</a>
+                <a href="@SampleService.RepositoryUrl" target="_blank" title="GitHub" class="d-none d-sm-inline">GitHub</a>
             </div>
         </div>
         <article class="content px-4">

--- a/samples/Gallery/Shared/Samples/PdfComposerSample.cs
+++ b/samples/Gallery/Shared/Samples/PdfComposerSample.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using SkiaSharp;
 using SkiaSharpSample.Controls;
+using SkiaSharpSample.Services;
 
 namespace SkiaSharpSample.Samples;
 
@@ -214,7 +215,7 @@ public class PdfComposerSample : DocumentSampleBase
 		// Footer URL
 		using var footerFont = new SKFont(SampleMedia.Fonts.Default, 11);
 		using var footerPaint = new SKPaint { IsAntialias = true, Color = LinkColor };
-		var url = "https://github.com/mono/SkiaSharp";
+		var url = SampleService.RepositoryUrl;
 		var urlW = footerFont.MeasureText(url);
 		var urlX = (pageWidth - urlW) / 2;
 		var urlY = pageHeight - 50;

--- a/samples/Gallery/Shared/Services/SampleService.cs
+++ b/samples/Gallery/Shared/Services/SampleService.cs
@@ -4,6 +4,10 @@ namespace SkiaSharpSample.Services;
 
 public class SampleService 
 {
+	public static string RepositoryUrl { get; } =
+		GetAssemblyMetadata("RepositoryUrl") ??
+		throw new InvalidOperationException("RepositoryUrl build metadata is missing.");
+
 	private readonly SampleBase[] samples;
 	private readonly SampleBase[] allSamples;
 

--- a/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
+++ b/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
@@ -24,6 +24,9 @@
   <!-- Stamp build metadata into assembly attributes -->
   <PropertyGroup>
     <BuildFooter></BuildFooter>
+    <_RepositoryIdentityJson>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\..\scripts\infra\repository-identity.json'))</_RepositoryIdentityJson>
+    <_RepositoryIdentitySlug>$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;offlineRepository&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value)</_RepositoryIdentitySlug>
+    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == ''">https://github.com/$(_RepositoryIdentitySlug)</SkiaSharpRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
@@ -33,6 +36,10 @@
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>BuildFooter</_Parameter1>
       <_Parameter2>$(BuildFooter)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>RepositoryUrl</_Parameter1>
+      <_Parameter2>$(SkiaSharpRepositoryUrl)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
+++ b/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
@@ -24,9 +24,10 @@
   <!-- Stamp build metadata into assembly attributes -->
   <PropertyGroup>
     <BuildFooter></BuildFooter>
-    <_RepositoryIdentityJson>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\..\scripts\infra\repository-identity.json'))</_RepositoryIdentityJson>
-    <_RepositoryIdentitySlug>$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;offlineRepository&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value)</_RepositoryIdentitySlug>
-    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == ''">https://github.com/$(_RepositoryIdentitySlug)</SkiaSharpRepositoryUrl>
+    <_RepositoryIdentityPath>$(MSBuildThisFileDirectory)..\..\..\scripts\infra\repository-identity.json</_RepositoryIdentityPath>
+    <_RepositoryIdentityJson Condition="'$(SkiaSharpRepositoryUrl)' == '' and Exists('$(_RepositoryIdentityPath)')">$([System.IO.File]::ReadAllText('$(_RepositoryIdentityPath)'))</_RepositoryIdentityJson>
+    <_RepositoryIdentitySlug Condition="'$(_RepositoryIdentityJson)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;offlineRepository&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value)</_RepositoryIdentitySlug>
+    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == '' and '$(_RepositoryIdentitySlug)' != ''">https://github.com/$(_RepositoryIdentitySlug)</SkiaSharpRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">

--- a/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
+++ b/samples/Gallery/Shared/SkiaSharpSample.Shared.csproj
@@ -24,10 +24,7 @@
   <!-- Stamp build metadata into assembly attributes -->
   <PropertyGroup>
     <BuildFooter></BuildFooter>
-    <_RepositoryIdentityPath>$(MSBuildThisFileDirectory)..\..\..\scripts\infra\repository-identity.json</_RepositoryIdentityPath>
-    <_RepositoryIdentityJson Condition="'$(SkiaSharpRepositoryUrl)' == '' and Exists('$(_RepositoryIdentityPath)')">$([System.IO.File]::ReadAllText('$(_RepositoryIdentityPath)'))</_RepositoryIdentityJson>
-    <_RepositoryIdentitySlug Condition="'$(_RepositoryIdentityJson)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(_RepositoryIdentityJson)', '&quot;offlineRepository&quot;\s*:\s*&quot;(?&lt;value&gt;[^&quot;]+)&quot;').Groups['value'].Value)</_RepositoryIdentitySlug>
-    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == '' and '$(_RepositoryIdentitySlug)' != ''">https://github.com/$(_RepositoryIdentitySlug)</SkiaSharpRepositoryUrl>
+    <SkiaSharpRepositoryUrl Condition="'$(SkiaSharpRepositoryUrl)' == ''">https://github.com/mono/SkiaSharp</SkiaSharpRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">

--- a/samples/Gallery/Uno/MainPage.xaml
+++ b/samples/Gallery/Uno/MainPage.xaml
@@ -62,7 +62,7 @@
                                    Foreground="White"
                                    FontSize="14" />
                     </Button>
-                    <HyperlinkButton NavigateUri="https://github.com/mono/SkiaSharp">
+                    <HyperlinkButton x:Name="RepositoryLink">
                         <TextBlock Text="GitHub" Foreground="White" />
                     </HyperlinkButton>
                 </StackPanel>

--- a/samples/Gallery/Uno/MainPage.xaml.cs
+++ b/samples/Gallery/Uno/MainPage.xaml.cs
@@ -11,6 +11,7 @@ public sealed partial class MainPage : Page
     public MainPage()
     {
         this.InitializeComponent();
+        RepositoryLink.NavigateUri = new Uri(SampleService.RepositoryUrl);
         Current = this;
         // ActualTheme is unreliable before the visual tree is loaded.
         Loaded += (_, _) =>

--- a/samples/Gallery/Uno/README.md
+++ b/samples/Gallery/Uno/README.md
@@ -4,7 +4,7 @@ Uno Platform host for the shared SkiaSharp gallery catalog
 (`samples/Gallery/Shared/`), alongside the existing Blazor gallery at
 `samples/Gallery/Blazor/`.
 
-**Hosted gallery (WebAssembly)**: https://mono.github.io/SkiaSharp/gallery-uno/ *(live after this feature merges)*
+**Hosted gallery (WebAssembly)**: published with the SkiaSharp project website.
 
 ## Target matrix
 

--- a/scripts/build-docs-site.py
+++ b/scripts/build-docs-site.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Build DocFX from temporary repository-identity-aware inputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCFX_DIR = ROOT / "documentation" / "docfx"
+IDENTITY_DIR = ROOT / "scripts" / "infra"
+PLACEHOLDERS = (
+    "{{Repository}}",
+    "{{SkiaRepository}}",
+    "{{DocsRepository}}",
+    "{{PublicSiteBaseUrl}}",
+)
+_TOC_HREF_RE = re.compile(
+    r"^(?P<prefix>\s*href:\s*)(?P<quote>['\"]?)"
+    r"(?P<href>[^'\"]+?)(?P=quote)(?P<ending>\s*)$"
+)
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(
+        description="Build DocFX without modifying tracked identity templates.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DOCFX_DIR / "docfx.json",
+        help="DocFX config path, relative to the repository root.",
+    )
+    parser.add_argument(
+        "--app-footer",
+        help="Optional DocFX _appFooter value for CI builds.",
+    )
+    parser.add_argument(
+        "--public-site-base-url",
+        help="Override the public site base for a staging build.",
+    )
+    return parser.parse_known_args()
+
+
+def load_docfx_config(path: Path) -> dict:
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Unable to read DocFX config {path}: {exc}") from exc
+    if not isinstance(config, dict) or not isinstance(config.get("build"), dict):
+        raise ValueError(f"DocFX config {path} must contain a build object.")
+    return config
+
+
+def normalize_public_site_base_url(value: str) -> str:
+    if value != value.strip():
+        raise ValueError("Public site base URL must not contain outer whitespace.")
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "Public site base URL must be HTTPS without a query or fragment."
+        )
+    return value.rstrip("/")
+
+
+def prepare_config(config: dict, temporary_source: Path, identity: dict) -> None:
+    build = config["build"]
+    content = build.get("content")
+    if (
+        not isinstance(content, list)
+        or not content
+        or not isinstance(content[0], dict)
+    ):
+        raise ValueError("DocFX build.content must contain a primary source object.")
+
+    exclusions = content[0].setdefault("exclude", [])
+    if not isinstance(exclusions, list):
+        raise ValueError("DocFX build.content[0].exclude must be a list.")
+    exclusions.extend(["TOC.yml", ".identity-preview.*/**"])
+    content.append(
+        {
+            "src": temporary_source.name,
+            "files": ["TOC.yml"],
+        }
+    )
+
+    metadata = build.setdefault("globalMetadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError("DocFX build.globalMetadata must be an object.")
+    contribution = metadata.setdefault("_gitContribute", {})
+    if not isinstance(contribution, dict):
+        raise ValueError(
+            "DocFX build.globalMetadata._gitContribute must be an object."
+        )
+    contribution["repo"] = identity["repositoryUrl"]
+
+
+def rebase_toc_relative_links(path: Path) -> None:
+    lines = []
+    for line in path.read_text(encoding="utf-8").splitlines(keepends=True):
+        newline = "\n" if line.endswith("\n") else ""
+        content = line.removesuffix("\n")
+        match = _TOC_HREF_RE.fullmatch(content)
+        if not match:
+            lines.append(line)
+            continue
+        href = match.group("href")
+        if (
+            "://" in href
+            or href.startswith(("/", "~", "#"))
+        ):
+            lines.append(line)
+            continue
+        lines.append(
+            f"{match.group('prefix')}{match.group('quote')}../{href}"
+            f"{match.group('quote')}{match.group('ending')}{newline}"
+        )
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def find_unresolved_placeholders(destination: Path) -> list[Path]:
+    unresolved = []
+    for path in destination.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if any(placeholder in text for placeholder in PLACEHOLDERS):
+            unresolved.append(path)
+    return unresolved
+
+
+def main() -> int:
+    args, docfx_args = parse_args()
+    config_path = args.config
+    if not config_path.is_absolute():
+        config_path = ROOT / config_path
+    config_path = config_path.resolve()
+    config_directory = config_path.parent
+    toc_source = config_directory / "TOC.yml"
+
+    sys.path.insert(0, str(IDENTITY_DIR))
+    import repository_identity
+
+    try:
+        config = load_docfx_config(config_path)
+        identity = repository_identity.resolve_identity(ROOT)
+        if args.public_site_base_url is not None:
+            identity = dict(identity)
+            identity["publicSiteBaseUrl"] = normalize_public_site_base_url(
+                args.public_site_base_url
+            )
+        destination = Path(config["build"]["dest"])
+        if not destination.is_absolute():
+            destination = (config_directory / destination).resolve()
+        if not toc_source.is_file():
+            raise ValueError(f"DocFX TOC not found: {toc_source}")
+    except (KeyError, TypeError, ValueError, repository_identity.IdentityError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(
+        prefix=".identity-preview.",
+        dir=config_directory,
+    ) as temporary_source:
+        temporary_source_path = Path(temporary_source)
+        temporary_toc = temporary_source_path / "TOC.yml"
+        temporary_toc.write_bytes(toc_source.read_bytes())
+        try:
+            repository_identity.render_identity_file(temporary_toc, identity)
+            rebase_toc_relative_links(temporary_toc)
+            prepare_config(config, temporary_source_path, identity)
+            if args.app_footer is not None:
+                config["build"]["globalMetadata"]["_appFooter"] = args.app_footer
+        except (ValueError, repository_identity.IdentityError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+        descriptor, temporary_config = tempfile.mkstemp(
+            prefix=".docfx-preview.",
+            suffix=".json",
+            dir=config_directory,
+        )
+        os.close(descriptor)
+        temporary_config_path = Path(temporary_config)
+        try:
+            temporary_config_path.write_text(
+                json.dumps(config, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                ["dotnet", "docfx", str(temporary_config_path), *docfx_args],
+                cwd=ROOT,
+                check=False,
+            )
+        finally:
+            temporary_config_path.unlink(missing_ok=True)
+
+    if result.returncode:
+        return result.returncode
+
+    unresolved = find_unresolved_placeholders(destination)
+    if unresolved:
+        print(
+            "ERROR: Unresolved repository identity placeholder in DocFX output:\n"
+            + "\n".join(str(path) for path in unresolved),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-docs-site.py
+++ b/scripts/build-docs-site.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build DocFX from temporary repository-identity-aware inputs."""
+"""Build DocFX from temporary repository-aware inputs."""
 
 from __future__ import annotations
 
@@ -16,22 +16,39 @@ from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCFX_DIR = ROOT / "documentation" / "docfx"
-IDENTITY_DIR = ROOT / "scripts" / "infra"
-PLACEHOLDERS = (
-    "{{Repository}}",
-    "{{SkiaRepository}}",
-    "{{DocsRepository}}",
-    "{{PublicSiteBaseUrl}}",
-)
+PUBLIC_SITE_METADATA = "_publicSiteBaseUrl"
+PLACEHOLDER = "{{PublicSiteBaseUrl}}"
 _TOC_HREF_RE = re.compile(
     r"^(?P<prefix>\s*href:\s*)(?P<quote>['\"]?)"
     r"(?P<href>[^'\"]+?)(?P=quote)(?P<ending>\s*)$"
+)
+_GITHUB_REMOTE_PATTERNS = (
+    re.compile(
+        r"https://github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"git://github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"git@github\.com:(?P<slug>[^/]+/[^/]+?)(?:\.git)?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"ssh://git@github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?",
+        re.IGNORECASE,
+    ),
+)
+_GITHUB_SLUG_RE = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?"
+    r"/[A-Za-z0-9._-]{1,100}"
 )
 
 
 def parse_args() -> tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser(
-        description="Build DocFX without modifying tracked identity templates.",
+        description="Build DocFX without modifying tracked templates.",
     )
     parser.add_argument(
         "--config",
@@ -40,12 +57,16 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
         help="DocFX config path, relative to the repository root.",
     )
     parser.add_argument(
-        "--app-footer",
-        help="Optional DocFX _appFooter value for CI builds.",
+        "--repository-url",
+        help="Current GitHub repository URL; defaults to the validated origin remote.",
     )
     parser.add_argument(
         "--public-site-base-url",
-        help="Override the public site base for a staging build.",
+        help="Override the configured public site base for a staging build.",
+    )
+    parser.add_argument(
+        "--app-footer",
+        help="Optional DocFX _appFooter value for CI builds.",
     )
     return parser.parse_known_args()
 
@@ -58,6 +79,42 @@ def load_docfx_config(path: Path) -> dict:
     if not isinstance(config, dict) or not isinstance(config.get("build"), dict):
         raise ValueError(f"DocFX config {path} must contain a build object.")
     return config
+
+
+def normalize_github_repository_url(value: str) -> str:
+    if value != value.strip() or any(
+        character.isspace()
+        or ord(character) < 32
+        or ord(character) == 127
+        for character in value
+    ):
+        raise ValueError(f"Unsupported GitHub repository URL: {value!r}")
+    for pattern in _GITHUB_REMOTE_PATTERNS:
+        match = pattern.fullmatch(value)
+        if not match:
+            continue
+        slug = match.group("slug").removesuffix(".git")
+        if (
+            _GITHUB_SLUG_RE.fullmatch(slug)
+            and "--" not in slug.split("/", 1)[0]
+            and slug.split("/", 1)[1] not in {".", ".."}
+        ):
+            return f"https://github.com/{slug}"
+    raise ValueError(f"Unsupported GitHub repository URL: {value!r}")
+
+
+def repository_url_from_remote(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        message = result.stderr.strip() or "origin remote is unavailable"
+        raise ValueError(f"Unable to resolve local repository URL: {message}")
+    return normalize_github_repository_url(result.stdout.rstrip("\n"))
 
 
 def normalize_public_site_base_url(value: str) -> str:
@@ -76,7 +133,23 @@ def normalize_public_site_base_url(value: str) -> str:
     return value.rstrip("/")
 
 
-def prepare_config(config: dict, temporary_source: Path, identity: dict) -> None:
+def configured_public_site_base_url(config: dict) -> str:
+    metadata = config["build"].get("globalMetadata")
+    if not isinstance(metadata, dict):
+        raise ValueError("DocFX build.globalMetadata must be an object.")
+    value = metadata.get(PUBLIC_SITE_METADATA)
+    if not isinstance(value, str):
+        raise ValueError(
+            f"DocFX global metadata must contain {PUBLIC_SITE_METADATA!r}."
+        )
+    return normalize_public_site_base_url(value)
+
+
+def prepare_config(
+    config: dict,
+    temporary_source: Path,
+    repository_url: str,
+) -> None:
     build = config["build"]
     content = build.get("content")
     if (
@@ -89,7 +162,7 @@ def prepare_config(config: dict, temporary_source: Path, identity: dict) -> None
     exclusions = content[0].setdefault("exclude", [])
     if not isinstance(exclusions, list):
         raise ValueError("DocFX build.content[0].exclude must be a list.")
-    exclusions.extend(["TOC.yml", ".identity-preview.*/**"])
+    exclusions.extend(["TOC.yml", ".docfx-preview.*/**"])
     content.append(
         {
             "src": temporary_source.name,
@@ -105,7 +178,15 @@ def prepare_config(config: dict, temporary_source: Path, identity: dict) -> None
         raise ValueError(
             "DocFX build.globalMetadata._gitContribute must be an object."
         )
-    contribution["repo"] = identity["repositoryUrl"]
+    contribution["repo"] = repository_url
+
+
+def render_toc(path: Path, public_site_base_url: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    path.write_text(
+        text.replace(PLACEHOLDER, public_site_base_url),
+        encoding="utf-8",
+    )
 
 
 def rebase_toc_relative_links(path: Path) -> None:
@@ -118,10 +199,7 @@ def rebase_toc_relative_links(path: Path) -> None:
             lines.append(line)
             continue
         href = match.group("href")
-        if (
-            "://" in href
-            or href.startswith(("/", "~", "#"))
-        ):
+        if "://" in href or href.startswith(("/", "~", "#")):
             lines.append(line)
             continue
         lines.append(
@@ -140,7 +218,7 @@ def find_unresolved_placeholders(destination: Path) -> list[Path]:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if any(placeholder in text for placeholder in PLACEHOLDERS):
+        if PLACEHOLDER in text:
             unresolved.append(path)
     return unresolved
 
@@ -154,40 +232,41 @@ def main() -> int:
     config_directory = config_path.parent
     toc_source = config_directory / "TOC.yml"
 
-    sys.path.insert(0, str(IDENTITY_DIR))
-    import repository_identity
-
     try:
         config = load_docfx_config(config_path)
-        identity = repository_identity.resolve_identity(ROOT)
-        if args.public_site_base_url is not None:
-            identity = dict(identity)
-            identity["publicSiteBaseUrl"] = normalize_public_site_base_url(
-                args.public_site_base_url
-            )
+        repository_url = (
+            normalize_github_repository_url(args.repository_url)
+            if args.repository_url is not None
+            else repository_url_from_remote(ROOT)
+        )
+        public_site_base_url = (
+            normalize_public_site_base_url(args.public_site_base_url)
+            if args.public_site_base_url is not None
+            else configured_public_site_base_url(config)
+        )
         destination = Path(config["build"]["dest"])
         if not destination.is_absolute():
             destination = (config_directory / destination).resolve()
         if not toc_source.is_file():
             raise ValueError(f"DocFX TOC not found: {toc_source}")
-    except (KeyError, TypeError, ValueError, repository_identity.IdentityError) as exc:
+    except (KeyError, TypeError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
     with tempfile.TemporaryDirectory(
-        prefix=".identity-preview.",
+        prefix=".docfx-preview.",
         dir=config_directory,
     ) as temporary_source:
         temporary_source_path = Path(temporary_source)
         temporary_toc = temporary_source_path / "TOC.yml"
         temporary_toc.write_bytes(toc_source.read_bytes())
         try:
-            repository_identity.render_identity_file(temporary_toc, identity)
+            render_toc(temporary_toc, public_site_base_url)
             rebase_toc_relative_links(temporary_toc)
-            prepare_config(config, temporary_source_path, identity)
+            prepare_config(config, temporary_source_path, repository_url)
             if args.app_footer is not None:
                 config["build"]["globalMetadata"]["_appFooter"] = args.app_footer
-        except (ValueError, repository_identity.IdentityError) as exc:
+        except (OSError, ValueError) as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
 
@@ -217,7 +296,7 @@ def main() -> int:
     unresolved = find_unresolved_placeholders(destination)
     if unresolved:
         print(
-            "ERROR: Unresolved repository identity placeholder in DocFX output:\n"
+            "ERROR: Unresolved public site placeholder in DocFX output:\n"
             + "\n".join(str(path) for path in unresolved),
             file=sys.stderr,
         )

--- a/scripts/infra/caching/repo-deps.json
+++ b/scripts/infra/caching/repo-deps.json
@@ -25,6 +25,7 @@
     "externals/.gitignore",
     "native/.gitignore",
     "scripts/get-skiasharp-pr.*",
+    "scripts/build-docs-site.py",
     "scripts/infra/caching/**",
     "scripts/infra/publishing/**",
     "scripts/infra/perf/**",

--- a/scripts/infra/samples/samples.cake
+++ b/scripts/infra/samples/samples.cake
@@ -1,6 +1,15 @@
 #addin nuget:?package=Cake.FileHelpers&version=4.0.1
 
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../../.."));
+FilePath REPOSITORY_IDENTITY_PATH = ROOT_PATH.CombineWithFilePath("scripts/infra/repository-identity.json");
+
+var repositoryIdentityJson = FileReadText(REPOSITORY_IDENTITY_PATH);
+var repositoryIdentityMatch = Regex.Match(
+    repositoryIdentityJson,
+    @"""offlineRepository""\s*:\s*""(?<value>[^""]+)""");
+if (!repositoryIdentityMatch.Success)
+    throw new Exception($"Unable to read offlineRepository from {REPOSITORY_IDENTITY_PATH}.");
+var SKIASHARP_REPOSITORY_URL = $"https://github.com/{repositoryIdentityMatch.Groups["value"].Value}";
 
 #load "../shared/shared.cake"
 #load "../shared/msbuild.cake"
@@ -432,6 +441,20 @@ void CreateSamplesDirectory(DirectoryPath samplesDirPath, DirectoryPath outputDi
                     Debug($"Substituting SkiaSharpVersion for {skiaVersion}.");
                     ve.Value = skiaVersion;
                 }
+            }
+
+            // Generated sample archives do not contain scripts/infra. Resolve the
+            // centralized repository identity now and remove source-tree-only helpers.
+            foreach (var identityElement in xdoc.Descendants().Where(e =>
+                e.Name.LocalName == "_RepositoryIdentityPath" ||
+                e.Name.LocalName == "_RepositoryIdentityJson" ||
+                e.Name.LocalName == "_RepositoryIdentitySlug").ToArray()) {
+                identityElement.Remove();
+            }
+            foreach (var repositoryUrl in xdoc.Descendants().Where(e =>
+                e.Name.LocalName == "SkiaSharpRepositoryUrl").ToArray()) {
+                repositoryUrl.Value = SKIASHARP_REPOSITORY_URL;
+                repositoryUrl.Attribute("Condition")?.Remove();
             }
 
             // save the project

--- a/scripts/infra/samples/samples.cake
+++ b/scripts/infra/samples/samples.cake
@@ -1,15 +1,6 @@
 #addin nuget:?package=Cake.FileHelpers&version=4.0.1
 
 DirectoryPath ROOT_PATH = MakeAbsolute(Directory("../../.."));
-FilePath REPOSITORY_IDENTITY_PATH = ROOT_PATH.CombineWithFilePath("scripts/infra/repository-identity.json");
-
-var repositoryIdentityJson = FileReadText(REPOSITORY_IDENTITY_PATH);
-var repositoryIdentityMatch = Regex.Match(
-    repositoryIdentityJson,
-    @"""offlineRepository""\s*:\s*""(?<value>[^""]+)""");
-if (!repositoryIdentityMatch.Success)
-    throw new Exception($"Unable to read offlineRepository from {REPOSITORY_IDENTITY_PATH}.");
-var SKIASHARP_REPOSITORY_URL = $"https://github.com/{repositoryIdentityMatch.Groups["value"].Value}";
 
 #load "../shared/shared.cake"
 #load "../shared/msbuild.cake"
@@ -441,20 +432,6 @@ void CreateSamplesDirectory(DirectoryPath samplesDirPath, DirectoryPath outputDi
                     Debug($"Substituting SkiaSharpVersion for {skiaVersion}.");
                     ve.Value = skiaVersion;
                 }
-            }
-
-            // Generated sample archives do not contain scripts/infra. Resolve the
-            // centralized repository identity now and remove source-tree-only helpers.
-            foreach (var identityElement in xdoc.Descendants().Where(e =>
-                e.Name.LocalName == "_RepositoryIdentityPath" ||
-                e.Name.LocalName == "_RepositoryIdentityJson" ||
-                e.Name.LocalName == "_RepositoryIdentitySlug").ToArray()) {
-                identityElement.Remove();
-            }
-            foreach (var repositoryUrl in xdoc.Descendants().Where(e =>
-                e.Name.LocalName == "SkiaSharpRepositoryUrl").ToArray()) {
-                repositoryUrl.Value = SKIASHARP_REPOSITORY_URL;
-                repositoryUrl.Attribute("Condition")?.Remove();
             }
 
             // save the project

--- a/scripts/infra/tests/test_build_docs_site.py
+++ b/scripts/infra/tests/test_build_docs_site.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "scripts" / "build-docs-site.py"
+SPEC = importlib.util.spec_from_file_location("build_docs_site", MODULE_PATH)
+BUILD_DOCS = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(BUILD_DOCS)
+
+
+class BuildDocsSiteTests(unittest.TestCase):
+    def test_normalizes_staging_site_base_url(self) -> None:
+        self.assertEqual(
+            "https://dotnet.github.io/SkiaSharp/staging/4988",
+            BUILD_DOCS.normalize_public_site_base_url(
+                "https://dotnet.github.io/SkiaSharp/staging/4988/"
+            ),
+        )
+        for value in (
+            "http://dotnet.github.io/SkiaSharp",
+            "https://dotnet.github.io/SkiaSharp?preview=1",
+            " https://dotnet.github.io/SkiaSharp",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    BUILD_DOCS.normalize_public_site_base_url(value)
+
+    def test_prepares_temporary_content_and_contribution_metadata(self) -> None:
+        config = {
+            "build": {
+                "content": [
+                    {
+                        "files": ["**/*.md", "**/*.yml"],
+                        "exclude": ["**/*.notes.md"],
+                    }
+                ],
+                "globalMetadata": {
+                    "_gitContribute": {
+                        "repo": "https://github.com/mono/SkiaSharp",
+                    }
+                },
+            }
+        }
+        temporary_source = Path(".identity-preview.test")
+
+        BUILD_DOCS.prepare_config(
+            config,
+            temporary_source,
+            {"repositoryUrl": "https://github.com/dotnet/SkiaSharp"},
+        )
+
+        self.assertEqual(
+            "https://github.com/dotnet/SkiaSharp",
+            config["build"]["globalMetadata"]["_gitContribute"]["repo"],
+        )
+        self.assertEqual(
+            {
+                "src": ".identity-preview.test",
+                "files": ["TOC.yml"],
+            },
+            config["build"]["content"][1],
+        )
+        self.assertIn("TOC.yml", config["build"]["content"][0]["exclude"])
+        self.assertIn(
+            ".identity-preview.*/**",
+            config["build"]["content"][0]["exclude"],
+        )
+
+    def test_rebases_only_relative_toc_links(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "TOC.yml"
+            path.write_text(
+                "- name: Guides\n"
+                "  href: guides/\n"
+                "- name: Home\n"
+                '  href: "https://docs.example/SkiaSharp/"\n'
+                "- name: Root\n"
+                "  href: ~/index.md\n",
+                encoding="utf-8",
+            )
+
+            BUILD_DOCS.rebase_toc_relative_links(path)
+
+            self.assertEqual(
+                "- name: Guides\n"
+                "  href: ../guides/\n"
+                "- name: Home\n"
+                '  href: "https://docs.example/SkiaSharp/"\n'
+                "- name: Root\n"
+                "  href: ~/index.md\n",
+                path.read_text(encoding="utf-8"),
+            )
+
+    def test_finds_unresolved_placeholders_in_text_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            clean = root / "clean.html"
+            unresolved = root / "unresolved.js"
+            binary = root / "assembly.dll"
+            clean.write_text("dotnet/SkiaSharp", encoding="utf-8")
+            unresolved.write_text("{{Repository}}", encoding="utf-8")
+            binary.write_bytes(b"\xff{{Repository}}")
+
+            self.assertEqual(
+                [unresolved],
+                BUILD_DOCS.find_unresolved_placeholders(root),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/infra/tests/test_build_docs_site.py
+++ b/scripts/infra/tests/test_build_docs_site.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -15,6 +17,45 @@ SPEC.loader.exec_module(BUILD_DOCS)
 
 
 class BuildDocsSiteTests(unittest.TestCase):
+    def test_normalizes_supported_github_repository_urls(self) -> None:
+        for value in (
+            "https://github.com/dotnet/SkiaSharp",
+            "https://github.com/dotnet/SkiaSharp.git",
+            "git://github.com/dotnet/SkiaSharp.git",
+            "git@github.com:dotnet/SkiaSharp.git",
+            "ssh://git@github.com/dotnet/SkiaSharp.git",
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    "https://github.com/dotnet/SkiaSharp",
+                    BUILD_DOCS.normalize_github_repository_url(value),
+                )
+
+    def test_rejects_unsupported_github_repository_urls(self) -> None:
+        for value in (
+            "dotnet/SkiaSharp",
+            " https://github.com/dotnet/SkiaSharp",
+            "https://example.test/dotnet/SkiaSharp",
+            "https://github.com/dotnet/SkiaSharp/issues/1",
+            "https://github.com/dotnet/SkiaSharp?ref=main",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    BUILD_DOCS.normalize_github_repository_url(value)
+
+    def test_resolves_and_validates_origin_remote(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["git"],
+            returncode=0,
+            stdout="git@github.com:dotnet/SkiaSharp.git\n",
+            stderr="",
+        )
+        with patch.object(BUILD_DOCS.subprocess, "run", return_value=completed):
+            self.assertEqual(
+                "https://github.com/dotnet/SkiaSharp",
+                BUILD_DOCS.repository_url_from_remote(ROOT),
+            )
+
     def test_normalizes_staging_site_base_url(self) -> None:
         self.assertEqual(
             "https://dotnet.github.io/SkiaSharp/staging/4988",
@@ -30,6 +71,19 @@ class BuildDocsSiteTests(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(ValueError):
                     BUILD_DOCS.normalize_public_site_base_url(value)
+
+    def test_reads_current_site_default_from_docfx_config(self) -> None:
+        config = {
+            "build": {
+                "globalMetadata": {
+                    "_publicSiteBaseUrl": "https://mono.github.io/SkiaSharp/",
+                }
+            }
+        }
+        self.assertEqual(
+            "https://mono.github.io/SkiaSharp",
+            BUILD_DOCS.configured_public_site_base_url(config),
+        )
 
     def test_prepares_temporary_content_and_contribution_metadata(self) -> None:
         config = {
@@ -47,12 +101,12 @@ class BuildDocsSiteTests(unittest.TestCase):
                 },
             }
         }
-        temporary_source = Path(".identity-preview.test")
+        temporary_source = Path(".docfx-preview.test")
 
         BUILD_DOCS.prepare_config(
             config,
             temporary_source,
-            {"repositoryUrl": "https://github.com/dotnet/SkiaSharp"},
+            "https://github.com/dotnet/SkiaSharp",
         )
 
         self.assertEqual(
@@ -61,37 +115,41 @@ class BuildDocsSiteTests(unittest.TestCase):
         )
         self.assertEqual(
             {
-                "src": ".identity-preview.test",
+                "src": ".docfx-preview.test",
                 "files": ["TOC.yml"],
             },
             config["build"]["content"][1],
         )
         self.assertIn("TOC.yml", config["build"]["content"][0]["exclude"])
         self.assertIn(
-            ".identity-preview.*/**",
+            ".docfx-preview.*/**",
             config["build"]["content"][0]["exclude"],
         )
 
-    def test_rebases_only_relative_toc_links(self) -> None:
+    def test_renders_site_base_and_rebases_only_relative_toc_links(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "TOC.yml"
             path.write_text(
                 "- name: Guides\n"
                 "  href: guides/\n"
                 "- name: Home\n"
-                '  href: "https://docs.example/SkiaSharp/"\n'
+                f'  href: "{BUILD_DOCS.PLACEHOLDER}/"\n'
                 "- name: Root\n"
                 "  href: ~/index.md\n",
                 encoding="utf-8",
             )
 
+            BUILD_DOCS.render_toc(
+                path,
+                "https://dotnet.github.io/SkiaSharp/staging/4988",
+            )
             BUILD_DOCS.rebase_toc_relative_links(path)
 
             self.assertEqual(
                 "- name: Guides\n"
                 "  href: ../guides/\n"
                 "- name: Home\n"
-                '  href: "https://docs.example/SkiaSharp/"\n'
+                '  href: "https://dotnet.github.io/SkiaSharp/staging/4988/"\n'
                 "- name: Root\n"
                 "  href: ~/index.md\n",
                 path.read_text(encoding="utf-8"),
@@ -103,9 +161,9 @@ class BuildDocsSiteTests(unittest.TestCase):
             clean = root / "clean.html"
             unresolved = root / "unresolved.js"
             binary = root / "assembly.dll"
-            clean.write_text("dotnet/SkiaSharp", encoding="utf-8")
-            unresolved.write_text("{{Repository}}", encoding="utf-8")
-            binary.write_bytes(b"\xff{{Repository}}")
+            clean.write_text("https://dotnet.github.io", encoding="utf-8")
+            unresolved.write_text(BUILD_DOCS.PLACEHOLDER, encoding="utf-8")
+            binary.write_bytes(b"\xff{{PublicSiteBaseUrl}}")
 
             self.assertEqual(
                 [unresolved],


### PR DESCRIPTION
## Description

Makes the Docs, Pages, DocFX, and Gallery surfaces portable for the planned repository transfer, directly on `main` and without a shared repository-identity foundation.

DocFX now builds through a small wrapper that renders only its owned `TOC.yml` into a temporary source, writes a temporary config, and supplies contribution metadata from an explicit workflow repository URL or a strictly validated local `origin` remote. The current live Pages default remains in `documentation/docfx/docfx.json`; PR builds override it with the staging URL. Tracked inputs are never mutated.

Gallery repository links are compiled from the `SkiaSharpRepositoryUrl` MSBuild property. CI passes the current GitHub repository explicitly, while local and generated samples retain the current `mono/SkiaSharp` domain-local default. Pages staging paths and preview comments derive from GitHub workflow context.

There is no generic site renderer and no post-assembly rewriting. Gallery, Uno, Fiddle, WASM, `_framework`, `_content`, assembly, NuGet, Learn, API, NativeAssets, Extended, and relative paths remain untouched. `/ai` and `/perf` remain outside this PR, and the live Pages URL is not pre-flipped.

This intentionally excludes AI/performance dashboard identity (#4985), package READMEs (#4989), release summaries (#4980), sync/release/agent workflows, issue skills, Backport, native/generated sources, and submodule changes.

**Related issues**

Fixes #4988

Related to #4960

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [x] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — site tooling, navigation, and Gallery repository metadata only; no public API or rendering behavior changes.

## Testing

- `python3 -m unittest scripts/infra/tests/test_build_docs_site.py -v` — 8 passed
- `python3 scripts/build-docs-site.py` — local DocFX build via validated `origin`
- Destination simulation with explicit `--repository-url https://github.com/dotnet/SkiaSharp` and staging `--public-site-base-url`; generated TOC stayed in staging with no unresolved placeholder
- `dotnet cake --target=samples-generate`; stable and preview Gallery archives retain the local `https://github.com/mono/SkiaSharp` default without repository-internal dependencies
- Destination-owner Blazor metadata build; `RepositoryUrl#https://github.com/dotnet/SkiaSharp` verified in `SkiaSharpSample.Shared.dll`
- `python3 scripts/infra/caching/repo-deps.py validate` — zero uncovered files
- YAML parsing, Python compilation, `git diff --check`, and a no-reference audit for `repository_identity`, `repository-identity`, `render-site`, and post-assembly hash traversal
- Previous visual validation screenshots remain representative of the unchanged Gallery rendering; final GitHub Build Site validation is pending after the direct-to-main force update

Validated locally on macOS arm64. No native, generated, package README, release-summary, dashboard, or submodule content changed.

<details>
<summary>Visual validation</summary>

| Blazor Gallery | Uno Gallery | SkiaFiddle |
| --- | --- | --- |
| ![Blazor Gallery](https://github.com/user-attachments/assets/0491e238-bd85-4546-a46d-beb121ab258e) | ![Uno Gallery](https://github.com/user-attachments/assets/0abaf5de-88d0-4399-9a65-b93917fa0e53) | ![SkiaFiddle](https://github.com/user-attachments/assets/29dd6b48-bcf4-4c83-8203-433c76d2df1b) |

</details>

## Checklist

- [x] Tests added or updated
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A — no public API changes
- [x] Native change? N/A — no native change or companion PR required