### PR TITLE
Fix release milestone reconciliation across parallel release lines

### DIFF
--- a/scripts/infra/publishing/reconcile-release-assignments.ps1
+++ b/scripts/infra/publishing/reconcile-release-assignments.ps1
@@ -46,11 +46,15 @@ function Get-GitHubPullRequest([string] $Repository, [int] $Number) {
 function Get-GitHubClosingIssues([string] $Repository, [int] $PullRequest) {
     $owner, $name = $Repository.Split('/', 2)
     $query = @'
-query($owner: String!, $name: String!, $number: Int!) {
+query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      closingIssuesReferences(first: 50) {
-        nodes { number }
+      closingIssuesReferences(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          number
+          repository { nameWithOwner }
+        }
       }
     }
   }
@@ -58,17 +62,91 @@ query($owner: String!, $name: String!, $number: Int!) {
 '@
     $data = Invoke-GitHubJsonWithRetry -Arguments @(
         'api', 'graphql',
+        '--paginate',
+        '--slurp',
         '-f', "query=$query",
         '-F', "owner=$owner",
         '-F', "name=$name",
         '-F', "number=$PullRequest"
     )
-    $nodes = @($data.data.repository.pullRequest.closingIssuesReferences.nodes)
-    return @($nodes | ForEach-Object { [int] $_.number })
+    $numbers = foreach ($page in @($data)) {
+        foreach ($node in @($page.data.repository.pullRequest.closingIssuesReferences.nodes)) {
+            if ([string] $node.repository.nameWithOwner -eq $Repository) {
+                [int] $node.number
+            }
+        }
+    }
+    return @($numbers | Sort-Object -Unique)
 }
 
-# Enumerates release branches and selects those in one numeric release line.
-function Get-ReleaseBranches([string] $Root, [string] $Version) {
+# Reads local pull requests that GitHub records as closing one issue.
+function Get-GitHubClosingPullRequests([string] $Repository, [int] $Issue) {
+    $owner, $name = $Repository.Split('/', 2)
+    $query = @'
+query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      closedByPullRequestsReferences(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          number
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+}
+'@
+    $data = Invoke-GitHubJsonWithRetry -Arguments @(
+        'api', 'graphql',
+        '--paginate',
+        '--slurp',
+        '-f', "query=$query",
+        '-F', "owner=$owner",
+        '-F', "name=$name",
+        '-F', "number=$Issue"
+    )
+    $numbers = foreach ($page in @($data)) {
+        foreach ($node in @($page.data.repository.issue.closedByPullRequestsReferences.nodes)) {
+            if ([string] $node.repository.nameWithOwner -eq $Repository) {
+                [int] $node.number
+            }
+        }
+    }
+    return @($numbers | Sort-Object -Unique)
+}
+
+# Parses every exact shipped tag into its release identity.
+function Get-ShippedReleases([string[]] $Tags) {
+    $result = foreach ($tag in $Tags) {
+        $match = [regex]::Match(
+            $tag,
+            '^v(?<title>\d+\.\d+\.\d+(?:\.\d+)?-(?:preview|rc)\.\d+)\.\d+(?:\.\d+)?$')
+        if (!$match.Success) {
+            $match = [regex]::Match($tag, '^v(?<title>\d+\.\d+\.\d+(?:\.\d+)?)$')
+        }
+        if (!$match.Success) {
+            continue
+        }
+        $release = ConvertTo-ReleaseMilestone $match.Groups['title'].Value
+        if ($release) {
+            [pscustomobject] @{
+                Title = $release.Title
+                Tag = $tag
+                NumericKey = $release.NumericKey
+                SortKey = $release.SortKey
+            }
+        }
+    }
+    return @($result | Sort-Object SortKey, Tag)
+}
+
+# Combines immutable shipped identities and extant release branches for one numeric line.
+function Get-ReleaseMilestones(
+    [string] $Root,
+    [string] $Version,
+    [object[]] $ShippedReleases
+) {
     $output = (Invoke-Git -Root $Root -Arguments @(
         'for-each-ref',
         '--format=%(refname:strip=3)',
@@ -84,34 +162,29 @@ function Get-ReleaseBranches([string] $Root, [string] $Version) {
             }
         }
     )
-    $selected = @($all | Where-Object {
+    $byTitle = @{}
+    foreach ($release in @($all) + @($ShippedReleases)) {
+        if (!$byTitle.ContainsKey($release.Title)) {
+            $byTitle[$release.Title] = ConvertTo-ReleaseMilestone $release.Title
+        }
+    }
+    $selected = @($byTitle.Values | Where-Object {
         $_.Title -eq $Version -or $_.Title.StartsWith("$Version-") -or $_.Title.StartsWith("$Version.")
     } | Sort-Object SortKey)
     if ($selected.Count -eq 0) {
-        throw "No release branches match $Version."
+        throw "No release branches or shipped tags match $Version."
     }
-    return [pscustomobject] @{ Selected = $selected; All = $all }
-}
-
-# Combines release identities with their exact shipped tags.
-function Get-ShippedReleases([object[]] $Branches, [string[]] $Tags) {
-    $result = foreach ($branch in $Branches) {
-        $tag = Get-ShippedTag -Title $branch.Title -Tags $Tags
-        if ($tag) {
-            [pscustomobject] @{
-                Title = $branch.Title
-                Tag = $tag
-                NumericKey = $branch.NumericKey
-                SortKey = $branch.SortKey
-            }
-        }
-    }
-    return @($result | Sort-Object SortKey, Tag)
+    return $selected
 }
 
 # Refreshes remote release tags immediately before a write.
 function Get-CurrentRemoteReleaseTags([string] $Root) {
     return Get-RemoteReleaseTags -Root $Root
+}
+
+# Tests whether two remote tag snapshots contain the same release tags.
+function Test-ReleaseTagsEqual([string[]] $Left, [string[]] $Right) {
+    return @(Compare-Object @($Left) @($Right)).Count -eq 0
 }
 
 # Finds the nearest branch commit shared with a semantically earlier shipped release.
@@ -175,21 +248,106 @@ function Get-EffectiveMilestoneTitles([object[]] $Branches, [string[]] $Tags) {
     return $result.ToArray()
 }
 
-# Extracts merged pull request numbers from one first-parent release range.
-function Get-ReleasePullRequests([string] $Root, [string] $Start, [string] $End) {
-    $output = (Invoke-Git -Root $Root -Arguments @(
+# Extracts pull requests reachable from this tag but no semantically earlier shipped tag.
+function Get-ReleasePullRequests(
+    [string] $Root,
+    [object[]] $Releases,
+    [object] $CurrentRelease
+) {
+    $arguments = @(
         'log',
         '--format=%s',
-        '--first-parent',
-        "$Start..$End"
-    )).Output
+        "refs/tags/$($CurrentRelease.Tag)"
+    )
+    $earlier = @($Releases | Where-Object SortKey -lt $CurrentRelease.SortKey)
+    if ($earlier.Count -gt 0) {
+        $arguments += '--not'
+        $arguments += @($earlier | ForEach-Object { "refs/tags/$($_.Tag)" })
+    }
+    $output = (Invoke-Git -Root $Root -Arguments $arguments).Output
     $numbers = foreach ($subject in @($output -split "`r?`n")) {
         $match = [regex]::Match($subject, '\(#(?<number>\d+)\)$')
+        if (!$match.Success) {
+            $match = [regex]::Match($subject, '^Merge pull request #(?<number>\d+)\b')
+        }
         if ($match.Success) {
             [int] $match.Groups['number'].Value
         }
     }
     return @($numbers | Sort-Object -Unique)
+}
+
+# Maps every shipped pull request to its lowest semantic release identity.
+function Get-ReleasePullRequestOwners([string] $Root, [object[]] $Releases) {
+    $result = @{}
+    $seenIdentities = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($release in @($Releases | Sort-Object SortKey, Tag)) {
+        if (!$seenIdentities.Add($release.Title)) {
+            continue
+        }
+        $identityReleases = @($Releases |
+            Where-Object Title -eq $release.Title |
+            Sort-Object SortKey, Tag)
+        $ownerRelease = $identityReleases | Select-Object -First 1
+        foreach ($exactRelease in $identityReleases) {
+            foreach ($pullRequest in Get-ReleasePullRequests `
+                -Root $Root `
+                -Releases $Releases `
+                -CurrentRelease $exactRelease) {
+                if (!$result.ContainsKey($pullRequest)) {
+                    $result[$pullRequest] = $ownerRelease
+                }
+            }
+        }
+    }
+    return $result
+}
+
+# Selects the lowest semantic release among all shipped PRs that close one issue.
+function Get-LinkedIssueOwner(
+    [string] $Repository,
+    [int] $Issue,
+    [int] $ViaPullRequest,
+    [hashtable] $PullRequestOwners
+) {
+    $closingPullRequests = [System.Collections.Generic.HashSet[int]]::new()
+    $null = $closingPullRequests.Add($ViaPullRequest)
+    foreach ($pullRequest in Get-GitHubClosingPullRequests -Repository $Repository -Issue $Issue) {
+        $null = $closingPullRequests.Add($pullRequest)
+    }
+    return @(
+        $closingPullRequests |
+            Where-Object { $PullRequestOwners.ContainsKey($_) } |
+            ForEach-Object { $PullRequestOwners[$_] } |
+            Sort-Object SortKey, Tag
+    ) | Select-Object -First 1
+}
+
+# Re-fetches changed tags and verifies that a target still owns one item.
+function Test-LiveReleaseAssignmentOwnership(
+    [string] $Root,
+    [string] $Repository,
+    [string[]] $Tags,
+    [string] $TargetMilestone,
+    [string] $Kind,
+    [int] $Number,
+    [object] $ViaPullRequest
+) {
+    $null = Invoke-Git -Root $Root -Arguments @('fetch', 'origin', '--prune', '--tags')
+    $releases = @(Get-ShippedReleases -Tags $Tags)
+    $pullRequestOwners = Get-ReleasePullRequestOwners -Root $Root -Releases $releases
+    if ($Kind -eq 'issue') {
+        $owner = Get-LinkedIssueOwner `
+            -Repository $Repository `
+            -Issue $Number `
+            -ViaPullRequest ([int] $ViaPullRequest) `
+            -PullRequestOwners $pullRequestOwners
+        return $owner -and $owner.Title -eq $TargetMilestone
+    }
+    return (
+        $pullRequestOwners.ContainsKey($Number) -and
+        $pullRequestOwners[$Number].Title -eq $TargetMilestone
+    )
 }
 
 # Combines GitHub closing references with closing keywords in the pull request body.
@@ -264,17 +422,72 @@ function Get-ReleaseAssignmentPlan(
     }
 }
 
+# Restores the live assignment that was observed immediately before a mutation.
+function Restore-PlannedReleaseAssignment([string] $Repository, [object] $Item) {
+    $description = "Restore $($Item.Kind) #$($Item.Number)"
+    if ($Item.FromMilestoneNumber) {
+        Set-GitHubItemMilestone `
+            -Repository $Repository `
+            -Number $Item.Number `
+            -MilestoneNumber $Item.FromMilestoneNumber `
+            -MilestoneTitle $Item.FromMilestone `
+            -Description "$description to $($Item.FromMilestone)" `
+            -Push
+        return
+    }
+
+    $null = Invoke-GitHubMutation `
+        -Arguments @(
+            'api',
+            "repos/$Repository/issues/$($Item.Number)",
+            '-X',
+            'PATCH',
+            '-F',
+            'milestone=null'
+        ) `
+        -Description "$description to no milestone" `
+        -Push
+    $actual = Get-GitHubIssue -Repository $Repository -Number $Item.Number
+    if ($actual.milestone) {
+        throw "GitHub item #$($Item.Number) milestone restoration could not be verified."
+    }
+    Write-ReleaseStatus applied "$description to no milestone verified."
+}
+
 # Revalidates a planned assignment immediately before a remote mutation.
 function Set-PlannedReleaseAssignment(
     [string] $Root,
     [string] $Repository,
     [object] $Item,
     [hashtable] $Milestones,
+    [string[]] $PlanningTags,
     [switch] $Push
 ) {
+    $ownershipPullRequest = if ($Item.ViaPullRequest) { [int] $Item.ViaPullRequest } else { [int] $Item.Number }
+    $ownershipDescription = if ($Item.Kind -eq 'issue') {
+        "issue #$($Item.Number) across its shipped closing pull requests"
+    } else {
+        "pull request #$ownershipPullRequest"
+    }
+    $liveTags = $PlanningTags
     if ($Push) {
         $live = Get-GitHubIssue -Repository $Repository -Number $Item.Number
         $liveTags = Get-CurrentRemoteReleaseTags -Root $Root
+        if (
+            !(Test-ReleaseTagsEqual -Left $PlanningTags -Right $liveTags) -and
+            !(Test-LiveReleaseAssignmentOwnership `
+                -Root $Root `
+                -Repository $Repository `
+                -Tags $liveTags `
+                -TargetMilestone $Item.ToMilestone `
+                -Kind $Item.Kind `
+                -Number $Item.Number `
+                -ViaPullRequest $Item.ViaPullRequest)
+        ) {
+            throw (
+                "Release ownership changed after planning: $($Item.ToMilestone) no longer owns " +
+                "$ownershipDescription.")
+        }
         $liveMilestones = $Milestones.Clone()
         $liveMilestoneTitle = [string] $live.milestone.title
         if ($liveMilestoneTitle) {
@@ -310,9 +523,32 @@ function Set-PlannedReleaseAssignment(
 
     $sourceRelease = ConvertTo-ReleaseMilestone $Item.FromMilestone
     $targetRelease = ConvertTo-ReleaseMilestone $Item.ToMilestone
+    $postWriteTags = if ($Push) { Get-CurrentRemoteReleaseTags -Root $Root } else { $liveTags }
+    if (
+        $Push -and
+        !(Test-ReleaseTagsEqual -Left $liveTags -Right $postWriteTags) -and
+        !(Test-LiveReleaseAssignmentOwnership `
+            -Root $Root `
+            -Repository $Repository `
+            -Tags $postWriteTags `
+            -TargetMilestone $Item.ToMilestone `
+            -Kind $Item.Kind `
+            -Number $Item.Number `
+            -ViaPullRequest $Item.ViaPullRequest)
+    ) {
+        $postWriteItem = Get-GitHubIssue -Repository $Repository -Number $Item.Number
+        if ([string] $postWriteItem.milestone.title -ne $Item.ToMilestone) {
+            throw (
+                "Release ownership changed during mutation, but $($Item.Kind) #$($Item.Number) " +
+                'also changed again; no automatic restoration was attempted.')
+        }
+        Restore-PlannedReleaseAssignment -Repository $Repository -Item $Item
+        throw (
+            "Release ownership changed during mutation: $($Item.ToMilestone) no longer owns " +
+            "$ownershipDescription. The assignment was restored.")
+    }
     if ($Push -and $sourceRelease -and $targetRelease -and $sourceRelease.SortKey -lt $targetRelease.SortKey) {
         $postWriteMilestones = Get-GitHubMilestoneMap -Repository $Repository
-        $postWriteTags = Get-CurrentRemoteReleaseTags -Root $Root
         $postWritePlan = Get-ReleaseAssignmentPlan `
             -Kind $Item.Kind `
             -Number $Item.Number `
@@ -322,22 +558,13 @@ function Set-PlannedReleaseAssignment(
             -Milestones $postWriteMilestones `
             -Tags $postWriteTags
         if ($postWritePlan.Status -eq 'blocked') {
-            if (!$Item.FromMilestoneNumber) {
-                throw "$($postWritePlan.Warning) The assignment changed before it could be restored."
-            }
             $postWriteItem = Get-GitHubIssue -Repository $Repository -Number $Item.Number
             if ([string] $postWriteItem.milestone.title -ne $Item.ToMilestone) {
                 throw (
                     "$($postWritePlan.Warning) The item changed again after mutation; " +
                     'no automatic restoration was attempted.')
             }
-            Set-GitHubItemMilestone `
-                -Repository $Repository `
-                -Number $Item.Number `
-                -MilestoneNumber $Item.FromMilestoneNumber `
-                -MilestoneTitle $Item.FromMilestone `
-                -Description "Restore $($Item.Kind) #$($Item.Number) to $($Item.FromMilestone)" `
-                -Push
+            Restore-PlannedReleaseAssignment -Repository $Repository -Item $Item
             throw "$($postWritePlan.Warning) The concurrent change was detected after mutation and the assignment was restored."
         }
     }
@@ -349,12 +576,13 @@ Write-ReleaseStatus start "Release assignment reconciliation for $Version ($mode
 # 1.1 Refresh release refs and identify shipped milestones in release order.
 $null = Invoke-Git -Root $root -Arguments @('fetch', 'origin', '--prune', '--tags')
 $tags = Get-RemoteReleaseTags -Root $root
-$branchSet = Get-ReleaseBranches -Root $root -Version $Version
-$branches = @($branchSet.Selected)
 $warnings = [System.Collections.Generic.List[string]]::new()
-$shippedReleases = @(Get-ShippedReleases `
-    -Branches $branchSet.All `
-    -Tags $tags)
+$shippedReleases = @(Get-ShippedReleases -Tags $tags)
+$pullRequestOwners = Get-ReleasePullRequestOwners -Root $root -Releases $shippedReleases
+$branches = @(Get-ReleaseMilestones `
+    -Root $root `
+    -Version $Version `
+    -ShippedReleases $shippedReleases)
 
 # 1.2 Roll unshipped milestones forward and inspect each shipped tag range once.
 $effective = @(Get-EffectiveMilestoneTitles -Branches $branches -Tags $tags)
@@ -387,10 +615,11 @@ foreach ($targetTitle in $targetTitles) {
         $warnings.Add("Release boundary before $targetTitle is missing.")
         continue
     }
-    foreach ($pullRequest in Get-ReleasePullRequests `
-        -Root $root `
-        -Start $boundary.Start `
-        -End $boundary.End) {
+    foreach ($pullRequest in @(
+        $pullRequestOwners.Keys |
+            Where-Object { $pullRequestOwners[$_].Title -eq $targetTitle } |
+            Sort-Object
+    )) {
         if (!$seenPullRequests.Add($pullRequest)) {
             continue
         }
@@ -413,6 +642,14 @@ foreach ($targetTitle in $targetTitles) {
         }
         foreach ($linked in Get-LinkedIssues -Repository $Repository -PullRequest $pullRequest) {
             if (!$seenIssues.Add($linked)) {
+                continue
+            }
+            $issueOwner = Get-LinkedIssueOwner `
+                -Repository $Repository `
+                -Issue $linked `
+                -ViaPullRequest $pullRequest `
+                -PullRequestOwners $pullRequestOwners
+            if (!$issueOwner -or $issueOwner.Title -ne $targetTitle) {
                 continue
             }
             $issue = Get-GitHubIssue -Repository $Repository -Number $linked
@@ -453,12 +690,13 @@ foreach ($item in $operations) {
         -Repository $Repository `
         -Item $item `
         -Milestones $milestones `
+        -PlanningTags $tags `
         -Push:$Push
 }
 if ($warnings.Count -eq 0) {
     Write-ReleaseStatus checked (
         "Reconciliation: $($operations.Count) assignment(s), $correct already correct; " +
-        'commits after the final shipped branch were not inspected.')
+        'commits not reachable from shipped tags were not inspected.')
 }
 
 Write-ReleaseStatus complete "Release assignment reconciliation completed ($mode)."

--- a/scripts/infra/publishing/reconcile-release-assignments.ps1
+++ b/scripts/infra/publishing/reconcile-release-assignments.ps1
@@ -93,12 +93,12 @@ function Get-ReleaseBranches([string] $Root, [string] $Version) {
     return [pscustomobject] @{ Selected = $selected; All = $all }
 }
 
-# Finds the latest shipped stable branch before the requested numeric line.
-function Get-PreviousStableBranch([object[]] $Branches, [string] $Version, [string[]] $Tags) {
+# Finds the latest shipped release branch before the requested numeric line.
+function Get-PreviousShippedBranch([object[]] $Branches, [string] $Version, [string[]] $Tags) {
     $target = ConvertTo-ReleaseMilestone $Version
     $candidates = $Branches |
-        Where-Object { !$_.Channel -and $_.NumericKey -lt $target.NumericKey } |
-        Sort-Object NumericKey -Descending
+        Where-Object { $_.NumericKey -lt $target.NumericKey } |
+        Sort-Object SortKey -Descending
     foreach ($candidate in $candidates) {
         if (Get-ShippedTag -Title $candidate.Title -Tags $Tags) {
             return $candidate
@@ -154,6 +154,56 @@ function Get-LinkedIssues([string] $Repository, [int] $PullRequest) {
     return @($numbers | Sort-Object)
 }
 
+# Plans one assignment and blocks forward moves out of earlier closed or shipped milestones.
+function Get-ReleaseAssignmentPlan(
+    [string] $Kind,
+    [int] $Number,
+    [object] $ViaPullRequest,
+    [string] $CurrentMilestone,
+    [string] $TargetMilestone,
+    [hashtable] $Milestones,
+    [string[]] $Tags
+) {
+    if ($CurrentMilestone -eq $TargetMilestone) {
+        return [pscustomobject] @{ Status = 'correct'; Operation = $null; Warning = $null }
+    }
+
+    $currentRelease = ConvertTo-ReleaseMilestone $CurrentMilestone
+    $targetRelease = ConvertTo-ReleaseMilestone $TargetMilestone
+    if ($currentRelease -and $targetRelease -and $currentRelease.SortKey -lt $targetRelease.SortKey) {
+        $currentState = if ($Milestones.ContainsKey($CurrentMilestone)) {
+            [string] $Milestones[$CurrentMilestone].state
+        } else {
+            ''
+        }
+        $currentTag = Get-ShippedTag -Title $currentRelease.Title -Tags $Tags
+        if ($currentState -eq 'closed' -or $currentTag) {
+            $via = if ($ViaPullRequest) { " via pull request #$ViaPullRequest" } else { '' }
+            $reason = if ($currentTag) { "shipped as $currentTag" } else { 'is closed' }
+            return [pscustomobject] @{
+                Status = 'blocked'
+                Operation = $null
+                Warning = (
+                    "Refusing to move $Kind #$Number$via from earlier milestone " +
+                    "$CurrentMilestone ($reason) to $TargetMilestone.")
+            }
+        }
+    }
+
+    return [pscustomobject] @{
+        Status = 'assign'
+        Warning = $null
+        Operation = [pscustomobject] @{
+            Kind = $Kind
+            Number = $Number
+            ViaPullRequest = $ViaPullRequest
+            FromMilestone = $CurrentMilestone
+            ToMilestone = $TargetMilestone
+            ToMilestoneNumber = [int] $Milestones[$TargetMilestone].number
+        }
+    }
+}
+
 # 1. Reconcile shipped commits, pull requests, and linked issues.
 Write-ReleaseStatus start "Release assignment reconciliation for $Version ($mode)."
 
@@ -162,13 +212,13 @@ $null = Invoke-Git -Root $root -Arguments @('fetch', 'origin', '--prune', '--tag
 $tags = Get-RemoteReleaseTags -Root $root
 $branchSet = Get-ReleaseBranches -Root $root -Version $Version
 $branches = @($branchSet.Selected)
-$previous = Get-PreviousStableBranch -Branches $branchSet.All -Version $Version -Tags $tags
+$previous = Get-PreviousShippedBranch -Branches $branchSet.All -Version $Version -Tags $tags
 $warnings = [System.Collections.Generic.List[string]]::new()
 $previousTag = if ($previous) { Get-ShippedTag -Title $previous.Title -Tags $tags } else { $null }
 if (!$previous) {
-    $warnings.Add("No previous stable release boundary exists for $Version.")
+    $warnings.Add("No previous shipped release boundary exists for $Version.")
 } elseif (!$previousTag) {
-    $warnings.Add("Previous stable release $($previous.Title) has no exact shipped tag.")
+    $warnings.Add("Previous shipped release $($previous.Title) has no exact shipped tag.")
 }
 
 # 1.2 Roll unshipped milestones forward and inspect each shipped tag range once.
@@ -212,17 +262,20 @@ foreach ($targetTitle in $targetTitles) {
         }
         $pull = Get-GitHubIssue -Repository $Repository -Number $pullRequest
         $current = [string] $pull.milestone.title
-        if ($current -eq $targetTitle) {
+        $pullPlan = Get-ReleaseAssignmentPlan `
+            -Kind 'pull-request' `
+            -Number $pullRequest `
+            -ViaPullRequest $null `
+            -CurrentMilestone $current `
+            -TargetMilestone $targetTitle `
+            -Milestones $milestones `
+            -Tags $tags
+        if ($pullPlan.Status -eq 'correct') {
             $correct++
+        } elseif ($pullPlan.Status -eq 'blocked') {
+            $warnings.Add($pullPlan.Warning)
         } else {
-            $operations.Add([pscustomobject] @{
-                Kind = 'pull-request'
-                Number = $pullRequest
-                ViaPullRequest = $null
-                FromMilestone = $current
-                ToMilestone = $targetTitle
-                ToMilestoneNumber = [int] $milestones[$targetTitle].number
-            })
+            $operations.Add($pullPlan.Operation)
         }
         foreach ($linked in Get-LinkedIssues -Repository $Repository -PullRequest $pullRequest) {
             if (!$seenIssues.Add($linked)) {
@@ -230,17 +283,20 @@ foreach ($targetTitle in $targetTitles) {
             }
             $issue = Get-GitHubIssue -Repository $Repository -Number $linked
             $linkedCurrent = [string] $issue.milestone.title
-            if ($linkedCurrent -eq $targetTitle) {
+            $issuePlan = Get-ReleaseAssignmentPlan `
+                -Kind 'issue' `
+                -Number $linked `
+                -ViaPullRequest $pullRequest `
+                -CurrentMilestone $linkedCurrent `
+                -TargetMilestone $targetTitle `
+                -Milestones $milestones `
+                -Tags $tags
+            if ($issuePlan.Status -eq 'correct') {
                 $correct++
+            } elseif ($issuePlan.Status -eq 'blocked') {
+                $warnings.Add($issuePlan.Warning)
             } else {
-                $operations.Add([pscustomobject] @{
-                    Kind = 'issue'
-                    Number = $linked
-                    ViaPullRequest = $pullRequest
-                    FromMilestone = $linkedCurrent
-                    ToMilestone = $targetTitle
-                    ToMilestoneNumber = [int] $milestones[$targetTitle].number
-                })
+                $operations.Add($issuePlan.Operation)
             }
         }
     }

--- a/scripts/infra/publishing/reconcile-release-assignments.ps1
+++ b/scripts/infra/publishing/reconcile-release-assignments.ps1
@@ -93,121 +93,70 @@ function Get-ReleaseBranches([string] $Root, [string] $Version) {
     return [pscustomobject] @{ Selected = $selected; All = $all }
 }
 
-# Reads the publication time for every published GitHub Release.
-function Get-GitHubPublishedReleaseMap([string] $Repository) {
-    $pages = Invoke-GitHubJsonWithRetry -Arguments @(
-        'api',
-        '--paginate',
-        '--slurp',
-        "repos/$Repository/releases?per_page=100"
-    )
-    $result = @{}
-    foreach ($release in Expand-GitHubPages $pages) {
-        $tag = [string] $release.tag_name
-        if (!$release.draft -and $release.published_at -and $tag) {
-            $result[$tag] = [datetimeoffset] $release.published_at
-        }
-    }
-    return $result
-}
-
-# Combines exact shipped tags with their publication chronology.
-function Get-ShippedReleases(
-    [object[]] $Branches,
-    [string[]] $Tags,
-    [hashtable] $PublishedReleases
-) {
+# Combines release identities with their exact shipped tags.
+function Get-ShippedReleases([object[]] $Branches, [string[]] $Tags) {
     $result = foreach ($branch in $Branches) {
         $tag = Get-ShippedTag -Title $branch.Title -Tags $Tags
         if ($tag) {
             [pscustomobject] @{
                 Title = $branch.Title
                 Tag = $tag
-                PublishedAt = if ($PublishedReleases.ContainsKey($tag)) {
-                    [datetimeoffset] $PublishedReleases[$tag]
-                } else {
-                    $null
-                }
+                NumericKey = $branch.NumericKey
+                SortKey = $branch.SortKey
             }
         }
     }
-    return @($result | Sort-Object `
-        @{ Expression = { $null -eq $_.PublishedAt }; Ascending = $true },
-        PublishedAt,
-        Tag)
+    return @($result | Sort-Object SortKey, Tag)
 }
 
-# Extracts every merged pull request through one first-parent release history.
-function Get-ReleasePullRequestsThrough([string] $Root, [string] $End) {
-    $output = (Invoke-Git -Root $Root -Arguments @(
-        'log',
-        '--format=%s',
-        '--first-parent',
-        $End
-    )).Output
-    $numbers = foreach ($subject in @($output -split "`r?`n")) {
-        $match = [regex]::Match($subject, '\(#(?<number>\d+)\)$')
-        if ($match.Success) {
-            [int] $match.Groups['number'].Value
-        }
-    }
-    return @($numbers | Sort-Object -Unique)
+# Refreshes remote release tags immediately before a write.
+function Get-CurrentRemoteReleaseTags([string] $Root) {
+    return Get-RemoteReleaseTags -Root $Root
 }
 
-# Selects pull requests first seen in one shipment across parallel release histories.
-function Get-FirstShippedPullRequests(
+# Finds the nearest branch commit shared with a semantically earlier shipped release.
+function Get-PreviousShippedBoundary(
     [string] $Root,
     [object[]] $Releases,
-    [string] $CurrentTag,
-    [datetimeoffset] $CurrentPublishedAt
+    [object] $CurrentRelease
 ) {
-    $previouslyShipped = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($release in @($Releases | Where-Object PublishedAt)) {
-        if ($release.PublishedAt -ge $CurrentPublishedAt) {
-            break
+    $end = (Invoke-Git -Root $Root -Arguments @(
+        'rev-parse',
+        "refs/tags/$($CurrentRelease.Tag)`^{commit}"
+    )).Output
+    $candidates = foreach ($release in $Releases) {
+        if ($release.SortKey -ge $CurrentRelease.SortKey) {
+            continue
         }
-        foreach ($pullRequest in Get-ReleasePullRequestsThrough `
-            -Root $Root `
-            -End "refs/tags/$($release.Tag)") {
-            $null = $previouslyShipped.Add($pullRequest)
+        $start = (Invoke-Git -Root $Root -Arguments @(
+            'merge-base',
+            "refs/tags/$($release.Tag)",
+            "refs/tags/$($CurrentRelease.Tag)"
+        )).Output
+        if (!$start) {
+            continue
         }
-    }
-    $firstShipped = @(
-        Get-ReleasePullRequestsThrough -Root $Root -End "refs/tags/$CurrentTag" |
-            Where-Object { !$previouslyShipped.Contains($_) }
-    )
-    $firstShippedSet = [System.Collections.Generic.HashSet[int]]::new()
-    foreach ($pullRequest in $firstShipped) {
-        $null = $firstShippedSet.Add($pullRequest)
-    }
-    $ambiguousReleases = foreach ($release in @($Releases | Where-Object {
-        !$_.PublishedAt -or
-        ($_.Tag -ne $CurrentTag -and $_.PublishedAt -eq $CurrentPublishedAt)
-    })) {
-        $claimsTargetPullRequest = $false
-        foreach ($pullRequest in Get-ReleasePullRequestsThrough `
-            -Root $Root `
-            -End "refs/tags/$($release.Tag)") {
-            if ($firstShippedSet.Contains($pullRequest)) {
-                $claimsTargetPullRequest = $true
-                break
-            }
-        }
-        if ($claimsTargetPullRequest) {
-            [pscustomobject] @{
-                Tag = $release.Tag
-                Reason = if ($release.PublishedAt) {
-                    "has the same published timestamp as $CurrentTag"
-                } else {
-                    'has no published GitHub Release timestamp'
-                }
-            }
+        $distance = (Invoke-Git -Root $Root -Arguments @(
+            'rev-list',
+            '--count',
+            '--first-parent',
+            "$start..$end"
+        )).Output
+        [pscustomobject] @{
+            Title = $release.Title
+            Tag = $release.Tag
+            Start = $start
+            End = $end
+            Distance = [long] $distance
+            SortKey = $release.SortKey
         }
     }
-    return [pscustomobject] @{
-        PullRequests = $firstShipped
-        Ambiguities = @($ambiguousReleases)
-    }
+    return $candidates |
+        Sort-Object `
+            @{ Expression = 'Distance'; Ascending = $true },
+            @{ Expression = 'SortKey'; Descending = $true },
+            @{ Expression = 'Tag'; Descending = $true } |
+        Select-Object -First 1
 }
 
 # Rolls each unshipped branch forward to the next branch that was shipped.
@@ -265,8 +214,7 @@ function Get-ReleaseAssignmentPlan(
     [string] $CurrentMilestone,
     [string] $TargetMilestone,
     [hashtable] $Milestones,
-    [string[]] $Tags,
-    [hashtable] $PublishedReleases
+    [string[]] $Tags
 ) {
     if ($CurrentMilestone -eq $TargetMilestone) {
         return [pscustomobject] @{ Status = 'correct'; Operation = $null; Warning = $null }
@@ -281,34 +229,10 @@ function Get-ReleaseAssignmentPlan(
             ''
         }
         $currentTag = Get-ShippedTag -Title $currentRelease.Title -Tags $Tags
-        if ($currentState -eq 'closed' -or $currentTag) {
-            $targetTag = Get-ShippedTag -Title $targetRelease.Title -Tags $Tags
-            $targetPublished = if ($targetTag -and $PublishedReleases.ContainsKey($targetTag)) {
-                [datetimeoffset] $PublishedReleases[$targetTag]
-            } else {
-                $null
-            }
-            $currentPublished = if ($currentTag -and $PublishedReleases.ContainsKey($currentTag)) {
-                [datetimeoffset] $PublishedReleases[$currentTag]
-            } else {
-                $null
-            }
-            $targetShippedEarlier = $targetPublished -and $currentPublished -and
-                $targetPublished -lt $currentPublished
-            if ($targetShippedEarlier) {
-                return [pscustomobject] @{
-                    Status = 'assign'
-                    Warning = $null
-                    Operation = [pscustomobject] @{
-                        Kind = $Kind
-                        Number = $Number
-                        ViaPullRequest = $ViaPullRequest
-                        FromMilestone = $CurrentMilestone
-                        ToMilestone = $TargetMilestone
-                        ToMilestoneNumber = [int] $Milestones[$TargetMilestone].number
-                    }
-                }
-            }
+        if (
+            $currentRelease.SortKey -lt $targetRelease.SortKey -and
+            ($currentState -eq 'closed' -or $currentTag)
+        ) {
             $via = if ($ViaPullRequest) { " via pull request #$ViaPullRequest" } else { '' }
             $reason = if ($currentTag) { "shipped as $currentTag" } else { 'is closed' }
             return [pscustomobject] @{
@@ -329,6 +253,11 @@ function Get-ReleaseAssignmentPlan(
             Number = $Number
             ViaPullRequest = $ViaPullRequest
             FromMilestone = $CurrentMilestone
+            FromMilestoneNumber = if ($Milestones.ContainsKey($CurrentMilestone)) {
+                [int] $Milestones[$CurrentMilestone].number
+            } else {
+                $null
+            }
             ToMilestone = $TargetMilestone
             ToMilestoneNumber = [int] $Milestones[$TargetMilestone].number
         }
@@ -337,15 +266,15 @@ function Get-ReleaseAssignmentPlan(
 
 # Revalidates a planned assignment immediately before a remote mutation.
 function Set-PlannedReleaseAssignment(
+    [string] $Root,
     [string] $Repository,
     [object] $Item,
     [hashtable] $Milestones,
-    [string[]] $Tags,
-    [hashtable] $PublishedReleases,
     [switch] $Push
 ) {
     if ($Push) {
         $live = Get-GitHubIssue -Repository $Repository -Number $Item.Number
+        $liveTags = Get-CurrentRemoteReleaseTags -Root $Root
         $liveMilestones = $Milestones.Clone()
         $liveMilestoneTitle = [string] $live.milestone.title
         if ($liveMilestoneTitle) {
@@ -358,8 +287,7 @@ function Set-PlannedReleaseAssignment(
             -CurrentMilestone $liveMilestoneTitle `
             -TargetMilestone $Item.ToMilestone `
             -Milestones $liveMilestones `
-            -Tags $Tags `
-            -PublishedReleases $PublishedReleases
+            -Tags $liveTags
         if ($livePlan.Status -eq 'correct') {
             Write-ReleaseStatus checked (
                 "$($Item.Kind) #$($Item.Number) is already assigned to $($Item.ToMilestone).")
@@ -379,6 +307,40 @@ function Set-PlannedReleaseAssignment(
         -MilestoneTitle $Item.ToMilestone `
         -Description $description `
         -Push:$Push
+
+    $sourceRelease = ConvertTo-ReleaseMilestone $Item.FromMilestone
+    $targetRelease = ConvertTo-ReleaseMilestone $Item.ToMilestone
+    if ($Push -and $sourceRelease -and $targetRelease -and $sourceRelease.SortKey -lt $targetRelease.SortKey) {
+        $postWriteMilestones = Get-GitHubMilestoneMap -Repository $Repository
+        $postWriteTags = Get-CurrentRemoteReleaseTags -Root $Root
+        $postWritePlan = Get-ReleaseAssignmentPlan `
+            -Kind $Item.Kind `
+            -Number $Item.Number `
+            -ViaPullRequest $Item.ViaPullRequest `
+            -CurrentMilestone $Item.FromMilestone `
+            -TargetMilestone $Item.ToMilestone `
+            -Milestones $postWriteMilestones `
+            -Tags $postWriteTags
+        if ($postWritePlan.Status -eq 'blocked') {
+            if (!$Item.FromMilestoneNumber) {
+                throw "$($postWritePlan.Warning) The assignment changed before it could be restored."
+            }
+            $postWriteItem = Get-GitHubIssue -Repository $Repository -Number $Item.Number
+            if ([string] $postWriteItem.milestone.title -ne $Item.ToMilestone) {
+                throw (
+                    "$($postWritePlan.Warning) The item changed again after mutation; " +
+                    'no automatic restoration was attempted.')
+            }
+            Set-GitHubItemMilestone `
+                -Repository $Repository `
+                -Number $Item.Number `
+                -MilestoneNumber $Item.FromMilestoneNumber `
+                -MilestoneTitle $Item.FromMilestone `
+                -Description "Restore $($Item.Kind) #$($Item.Number) to $($Item.FromMilestone)" `
+                -Push
+            throw "$($postWritePlan.Warning) The concurrent change was detected after mutation and the assignment was restored."
+        }
+    }
 }
 
 # 1. Reconcile shipped commits, pull requests, and linked issues.
@@ -390,11 +352,9 @@ $tags = Get-RemoteReleaseTags -Root $root
 $branchSet = Get-ReleaseBranches -Root $root -Version $Version
 $branches = @($branchSet.Selected)
 $warnings = [System.Collections.Generic.List[string]]::new()
-$publishedReleases = Get-GitHubPublishedReleaseMap -Repository $Repository
 $shippedReleases = @(Get-ShippedReleases `
     -Branches $branchSet.All `
-    -Tags $tags `
-    -PublishedReleases $publishedReleases)
+    -Tags $tags)
 
 # 1.2 Roll unshipped milestones forward and inspect each shipped tag range once.
 $effective = @(Get-EffectiveMilestoneTitles -Branches $branches -Tags $tags)
@@ -410,27 +370,27 @@ foreach ($targetTitle in $targetTitles) {
         $warnings.Add("Release milestone $targetTitle has no exact shipped tag.")
         continue
     }
-    $currentRelease = $shippedReleases |
-        Where-Object { $_.Tag -eq $currentTag -and $_.PublishedAt } |
-        Select-Object -First 1
+    $currentRelease = $shippedReleases | Where-Object Tag -eq $currentTag | Select-Object -First 1
     if (!$currentRelease) {
-        $warnings.Add("Release milestone $targetTitle has no published shipment chronology.")
+        $warnings.Add("Release milestone $targetTitle has no shipped release identity.")
         continue
     }
     if (!$milestones.ContainsKey($targetTitle)) {
         $warnings.Add("Milestone $targetTitle does not exist.")
         continue
     }
-    $shipmentPlan = Get-FirstShippedPullRequests `
+    $boundary = Get-PreviousShippedBoundary `
         -Root $root `
         -Releases $shippedReleases `
-        -CurrentTag $currentTag `
-        -CurrentPublishedAt $currentRelease.PublishedAt
-    foreach ($ambiguity in $shipmentPlan.Ambiguities) {
-        $warnings.Add(
-            "Shipped tag $($ambiguity.Tag) $($ambiguity.Reason) and overlaps $currentTag.")
+        -CurrentRelease $currentRelease
+    if (!$boundary) {
+        $warnings.Add("Release boundary before $targetTitle is missing.")
+        continue
     }
-    foreach ($pullRequest in $shipmentPlan.PullRequests) {
+    foreach ($pullRequest in Get-ReleasePullRequests `
+        -Root $root `
+        -Start $boundary.Start `
+        -End $boundary.End) {
         if (!$seenPullRequests.Add($pullRequest)) {
             continue
         }
@@ -443,8 +403,7 @@ foreach ($targetTitle in $targetTitles) {
             -CurrentMilestone $current `
             -TargetMilestone $targetTitle `
             -Milestones $milestones `
-            -Tags $tags `
-            -PublishedReleases $publishedReleases
+            -Tags $tags
         if ($pullPlan.Status -eq 'correct') {
             $correct++
         } elseif ($pullPlan.Status -eq 'blocked') {
@@ -465,8 +424,7 @@ foreach ($targetTitle in $targetTitles) {
                 -CurrentMilestone $linkedCurrent `
                 -TargetMilestone $targetTitle `
                 -Milestones $milestones `
-                -Tags $tags `
-                -PublishedReleases $publishedReleases
+                -Tags $tags
             if ($issuePlan.Status -eq 'correct') {
                 $correct++
             } elseif ($issuePlan.Status -eq 'blocked') {
@@ -491,11 +449,10 @@ if ($warnings.Count -gt 0) {
 }
 foreach ($item in $operations) {
     Set-PlannedReleaseAssignment `
+        -Root $root `
         -Repository $Repository `
         -Item $item `
         -Milestones $milestones `
-        -Tags $tags `
-        -PublishedReleases $publishedReleases `
         -Push:$Push
 }
 if ($warnings.Count -eq 0) {

--- a/scripts/infra/publishing/reconcile-release-assignments.ps1
+++ b/scripts/infra/publishing/reconcile-release-assignments.ps1
@@ -93,18 +93,121 @@ function Get-ReleaseBranches([string] $Root, [string] $Version) {
     return [pscustomobject] @{ Selected = $selected; All = $all }
 }
 
-# Finds the latest shipped release branch before the requested numeric line.
-function Get-PreviousShippedBranch([object[]] $Branches, [string] $Version, [string[]] $Tags) {
-    $target = ConvertTo-ReleaseMilestone $Version
-    $candidates = $Branches |
-        Where-Object { $_.NumericKey -lt $target.NumericKey } |
-        Sort-Object SortKey -Descending
-    foreach ($candidate in $candidates) {
-        if (Get-ShippedTag -Title $candidate.Title -Tags $Tags) {
-            return $candidate
+# Reads the publication time for every published GitHub Release.
+function Get-GitHubPublishedReleaseMap([string] $Repository) {
+    $pages = Invoke-GitHubJsonWithRetry -Arguments @(
+        'api',
+        '--paginate',
+        '--slurp',
+        "repos/$Repository/releases?per_page=100"
+    )
+    $result = @{}
+    foreach ($release in Expand-GitHubPages $pages) {
+        $tag = [string] $release.tag_name
+        if (!$release.draft -and $release.published_at -and $tag) {
+            $result[$tag] = [datetimeoffset] $release.published_at
         }
     }
-    return $null
+    return $result
+}
+
+# Combines exact shipped tags with their publication chronology.
+function Get-ShippedReleases(
+    [object[]] $Branches,
+    [string[]] $Tags,
+    [hashtable] $PublishedReleases
+) {
+    $result = foreach ($branch in $Branches) {
+        $tag = Get-ShippedTag -Title $branch.Title -Tags $Tags
+        if ($tag) {
+            [pscustomobject] @{
+                Title = $branch.Title
+                Tag = $tag
+                PublishedAt = if ($PublishedReleases.ContainsKey($tag)) {
+                    [datetimeoffset] $PublishedReleases[$tag]
+                } else {
+                    $null
+                }
+            }
+        }
+    }
+    return @($result | Sort-Object `
+        @{ Expression = { $null -eq $_.PublishedAt }; Ascending = $true },
+        PublishedAt,
+        Tag)
+}
+
+# Extracts every merged pull request through one first-parent release history.
+function Get-ReleasePullRequestsThrough([string] $Root, [string] $End) {
+    $output = (Invoke-Git -Root $Root -Arguments @(
+        'log',
+        '--format=%s',
+        '--first-parent',
+        $End
+    )).Output
+    $numbers = foreach ($subject in @($output -split "`r?`n")) {
+        $match = [regex]::Match($subject, '\(#(?<number>\d+)\)$')
+        if ($match.Success) {
+            [int] $match.Groups['number'].Value
+        }
+    }
+    return @($numbers | Sort-Object -Unique)
+}
+
+# Selects pull requests first seen in one shipment across parallel release histories.
+function Get-FirstShippedPullRequests(
+    [string] $Root,
+    [object[]] $Releases,
+    [string] $CurrentTag,
+    [datetimeoffset] $CurrentPublishedAt
+) {
+    $previouslyShipped = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($release in @($Releases | Where-Object PublishedAt)) {
+        if ($release.PublishedAt -ge $CurrentPublishedAt) {
+            break
+        }
+        foreach ($pullRequest in Get-ReleasePullRequestsThrough `
+            -Root $Root `
+            -End "refs/tags/$($release.Tag)") {
+            $null = $previouslyShipped.Add($pullRequest)
+        }
+    }
+    $firstShipped = @(
+        Get-ReleasePullRequestsThrough -Root $Root -End "refs/tags/$CurrentTag" |
+            Where-Object { !$previouslyShipped.Contains($_) }
+    )
+    $firstShippedSet = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($pullRequest in $firstShipped) {
+        $null = $firstShippedSet.Add($pullRequest)
+    }
+    $ambiguousReleases = foreach ($release in @($Releases | Where-Object {
+        !$_.PublishedAt -or
+        ($_.Tag -ne $CurrentTag -and $_.PublishedAt -eq $CurrentPublishedAt)
+    })) {
+        $claimsTargetPullRequest = $false
+        foreach ($pullRequest in Get-ReleasePullRequestsThrough `
+            -Root $Root `
+            -End "refs/tags/$($release.Tag)") {
+            if ($firstShippedSet.Contains($pullRequest)) {
+                $claimsTargetPullRequest = $true
+                break
+            }
+        }
+        if ($claimsTargetPullRequest) {
+            [pscustomobject] @{
+                Tag = $release.Tag
+                Reason = if ($release.PublishedAt) {
+                    "has the same published timestamp as $CurrentTag"
+                } else {
+                    'has no published GitHub Release timestamp'
+                }
+            }
+        }
+    }
+    return [pscustomobject] @{
+        PullRequests = $firstShipped
+        Ambiguities = @($ambiguousReleases)
+    }
 }
 
 # Rolls each unshipped branch forward to the next branch that was shipped.
@@ -162,7 +265,8 @@ function Get-ReleaseAssignmentPlan(
     [string] $CurrentMilestone,
     [string] $TargetMilestone,
     [hashtable] $Milestones,
-    [string[]] $Tags
+    [string[]] $Tags,
+    [hashtable] $PublishedReleases
 ) {
     if ($CurrentMilestone -eq $TargetMilestone) {
         return [pscustomobject] @{ Status = 'correct'; Operation = $null; Warning = $null }
@@ -170,7 +274,7 @@ function Get-ReleaseAssignmentPlan(
 
     $currentRelease = ConvertTo-ReleaseMilestone $CurrentMilestone
     $targetRelease = ConvertTo-ReleaseMilestone $TargetMilestone
-    if ($currentRelease -and $targetRelease -and $currentRelease.SortKey -lt $targetRelease.SortKey) {
+    if ($currentRelease -and $targetRelease) {
         $currentState = if ($Milestones.ContainsKey($CurrentMilestone)) {
             [string] $Milestones[$CurrentMilestone].state
         } else {
@@ -178,6 +282,33 @@ function Get-ReleaseAssignmentPlan(
         }
         $currentTag = Get-ShippedTag -Title $currentRelease.Title -Tags $Tags
         if ($currentState -eq 'closed' -or $currentTag) {
+            $targetTag = Get-ShippedTag -Title $targetRelease.Title -Tags $Tags
+            $targetPublished = if ($targetTag -and $PublishedReleases.ContainsKey($targetTag)) {
+                [datetimeoffset] $PublishedReleases[$targetTag]
+            } else {
+                $null
+            }
+            $currentPublished = if ($currentTag -and $PublishedReleases.ContainsKey($currentTag)) {
+                [datetimeoffset] $PublishedReleases[$currentTag]
+            } else {
+                $null
+            }
+            $targetShippedEarlier = $targetPublished -and $currentPublished -and
+                $targetPublished -lt $currentPublished
+            if ($targetShippedEarlier) {
+                return [pscustomobject] @{
+                    Status = 'assign'
+                    Warning = $null
+                    Operation = [pscustomobject] @{
+                        Kind = $Kind
+                        Number = $Number
+                        ViaPullRequest = $ViaPullRequest
+                        FromMilestone = $CurrentMilestone
+                        ToMilestone = $TargetMilestone
+                        ToMilestoneNumber = [int] $Milestones[$TargetMilestone].number
+                    }
+                }
+            }
             $via = if ($ViaPullRequest) { " via pull request #$ViaPullRequest" } else { '' }
             $reason = if ($currentTag) { "shipped as $currentTag" } else { 'is closed' }
             return [pscustomobject] @{
@@ -204,6 +335,52 @@ function Get-ReleaseAssignmentPlan(
     }
 }
 
+# Revalidates a planned assignment immediately before a remote mutation.
+function Set-PlannedReleaseAssignment(
+    [string] $Repository,
+    [object] $Item,
+    [hashtable] $Milestones,
+    [string[]] $Tags,
+    [hashtable] $PublishedReleases,
+    [switch] $Push
+) {
+    if ($Push) {
+        $live = Get-GitHubIssue -Repository $Repository -Number $Item.Number
+        $liveMilestones = $Milestones.Clone()
+        $liveMilestoneTitle = [string] $live.milestone.title
+        if ($liveMilestoneTitle) {
+            $liveMilestones[$liveMilestoneTitle] = $live.milestone
+        }
+        $livePlan = Get-ReleaseAssignmentPlan `
+            -Kind $Item.Kind `
+            -Number $Item.Number `
+            -ViaPullRequest $Item.ViaPullRequest `
+            -CurrentMilestone $liveMilestoneTitle `
+            -TargetMilestone $Item.ToMilestone `
+            -Milestones $liveMilestones `
+            -Tags $Tags `
+            -PublishedReleases $PublishedReleases
+        if ($livePlan.Status -eq 'correct') {
+            Write-ReleaseStatus checked (
+                "$($Item.Kind) #$($Item.Number) is already assigned to $($Item.ToMilestone).")
+            return
+        }
+        if ($livePlan.Status -eq 'blocked') {
+            throw $livePlan.Warning
+        }
+        $Item = $livePlan.Operation
+    }
+
+    $description = "Assign $($Item.Kind) #$($Item.Number) to $($Item.ToMilestone)"
+    Set-GitHubItemMilestone `
+        -Repository $Repository `
+        -Number $Item.Number `
+        -MilestoneNumber $Item.ToMilestoneNumber `
+        -MilestoneTitle $Item.ToMilestone `
+        -Description $description `
+        -Push:$Push
+}
+
 # 1. Reconcile shipped commits, pull requests, and linked issues.
 Write-ReleaseStatus start "Release assignment reconciliation for $Version ($mode)."
 
@@ -212,14 +389,12 @@ $null = Invoke-Git -Root $root -Arguments @('fetch', 'origin', '--prune', '--tag
 $tags = Get-RemoteReleaseTags -Root $root
 $branchSet = Get-ReleaseBranches -Root $root -Version $Version
 $branches = @($branchSet.Selected)
-$previous = Get-PreviousShippedBranch -Branches $branchSet.All -Version $Version -Tags $tags
 $warnings = [System.Collections.Generic.List[string]]::new()
-$previousTag = if ($previous) { Get-ShippedTag -Title $previous.Title -Tags $tags } else { $null }
-if (!$previous) {
-    $warnings.Add("No previous shipped release boundary exists for $Version.")
-} elseif (!$previousTag) {
-    $warnings.Add("Previous shipped release $($previous.Title) has no exact shipped tag.")
-}
+$publishedReleases = Get-GitHubPublishedReleaseMap -Repository $Repository
+$shippedReleases = @(Get-ShippedReleases `
+    -Branches $branchSet.All `
+    -Tags $tags `
+    -PublishedReleases $publishedReleases)
 
 # 1.2 Roll unshipped milestones forward and inspect each shipped tag range once.
 $effective = @(Get-EffectiveMilestoneTitles -Branches $branches -Tags $tags)
@@ -235,28 +410,27 @@ foreach ($targetTitle in $targetTitles) {
         $warnings.Add("Release milestone $targetTitle has no exact shipped tag.")
         continue
     }
+    $currentRelease = $shippedReleases |
+        Where-Object { $_.Tag -eq $currentTag -and $_.PublishedAt } |
+        Select-Object -First 1
+    if (!$currentRelease) {
+        $warnings.Add("Release milestone $targetTitle has no published shipment chronology.")
+        continue
+    }
     if (!$milestones.ContainsKey($targetTitle)) {
         $warnings.Add("Milestone $targetTitle does not exist.")
-        $previousTag = $currentTag
         continue
     }
-    if (!$previousTag) {
-        $warnings.Add("Release boundary before $targetTitle is missing.")
-        $previousTag = $currentTag
-        continue
+    $shipmentPlan = Get-FirstShippedPullRequests `
+        -Root $root `
+        -Releases $shippedReleases `
+        -CurrentTag $currentTag `
+        -CurrentPublishedAt $currentRelease.PublishedAt
+    foreach ($ambiguity in $shipmentPlan.Ambiguities) {
+        $warnings.Add(
+            "Shipped tag $($ambiguity.Tag) $($ambiguity.Reason) and overlaps $currentTag.")
     }
-    $start = (Invoke-Git -Root $root -Arguments @(
-        'merge-base',
-        "refs/tags/$previousTag",
-        "refs/tags/$currentTag"
-    )).Output
-    $end = (Invoke-Git -Root $root -Arguments @('rev-parse', "refs/tags/$currentTag`^{commit}")).Output
-    if (!$start -or !$end) {
-        $warnings.Add("Release boundaries from $previousTag to $currentTag are missing.")
-        $previousTag = $currentTag
-        continue
-    }
-    foreach ($pullRequest in Get-ReleasePullRequests -Root $root -Start $start -End $end) {
+    foreach ($pullRequest in $shipmentPlan.PullRequests) {
         if (!$seenPullRequests.Add($pullRequest)) {
             continue
         }
@@ -269,7 +443,8 @@ foreach ($targetTitle in $targetTitles) {
             -CurrentMilestone $current `
             -TargetMilestone $targetTitle `
             -Milestones $milestones `
-            -Tags $tags
+            -Tags $tags `
+            -PublishedReleases $publishedReleases
         if ($pullPlan.Status -eq 'correct') {
             $correct++
         } elseif ($pullPlan.Status -eq 'blocked') {
@@ -290,7 +465,8 @@ foreach ($targetTitle in $targetTitles) {
                 -CurrentMilestone $linkedCurrent `
                 -TargetMilestone $targetTitle `
                 -Milestones $milestones `
-                -Tags $tags
+                -Tags $tags `
+                -PublishedReleases $publishedReleases
             if ($issuePlan.Status -eq 'correct') {
                 $correct++
             } elseif ($issuePlan.Status -eq 'blocked') {
@@ -300,7 +476,6 @@ foreach ($targetTitle in $targetTitles) {
             }
         }
     }
-    $previousTag = $currentTag
 }
 
 foreach ($warning in $warnings) {
@@ -315,13 +490,12 @@ if ($warnings.Count -gt 0) {
     Write-ReleaseStatus blocked "Reconciliation has $($warnings.Count) warning(s); no mutation can be applied safely."
 }
 foreach ($item in $operations) {
-    $description = "Assign $($item.Kind) #$($item.Number) to $($item.ToMilestone)"
-    Set-GitHubItemMilestone `
+    Set-PlannedReleaseAssignment `
         -Repository $Repository `
-        -Number $item.Number `
-        -MilestoneNumber $item.ToMilestoneNumber `
-        -MilestoneTitle $item.ToMilestone `
-        -Description $description `
+        -Item $item `
+        -Milestones $milestones `
+        -Tags $tags `
+        -PublishedReleases $publishedReleases `
         -Push:$Push
 }
 if ($warnings.Count -eq 0) {

--- a/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
+++ b/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
@@ -108,11 +108,124 @@ $previousBranches = @(
     ConvertTo-ReleaseMilestone 'release/4.150.2'
     ConvertTo-ReleaseMilestone 'release/4.150.3'
 )
-$previousShipped = Get-PreviousStableBranch `
+$previousShipped = Get-PreviousShippedBranch `
     -Branches $previousBranches `
     -Version '4.151.0' `
     -Tags @('v4.150.2')
 Assert-Equal '4.150.2' $previousShipped.Title 'An unshipped stable branch became the previous release boundary.'
+
+$previewOnlyBranches = @(
+    ConvertTo-ReleaseMilestone 'release/4.151.2'
+    ConvertTo-ReleaseMilestone 'release/4.152.0-preview.1'
+    ConvertTo-ReleaseMilestone 'release/4.152.0-rc.1'
+    ConvertTo-ReleaseMilestone 'release/4.153.0-preview.1'
+    ConvertTo-ReleaseMilestone 'release/4.153.0-rc.1'
+    ConvertTo-ReleaseMilestone 'release/4.154.0-preview.1'
+)
+$previousPreviewOnly = Get-PreviousShippedBranch `
+    -Branches $previewOnlyBranches `
+    -Version '4.154.0' `
+    -Tags @(
+        'v4.151.2',
+        'v4.152.0-rc.1.26426.14',
+        'v4.153.0-preview.1.26454.6',
+        'v4.154.0-preview.1.26454.9'
+    )
+Assert-Equal '4.153.0-preview.1' $previousPreviewOnly.Title `
+    'A consecutive preview-only release line was skipped as the previous shipped boundary.'
+
+$hotfixBoundary = Get-PreviousShippedBranch `
+    -Branches @(
+        ConvertTo-ReleaseMilestone 'release/4.151.0-preview.1'
+        ConvertTo-ReleaseMilestone 'release/4.151.0'
+        ConvertTo-ReleaseMilestone 'release/4.151.1-preview.1'
+    ) `
+    -Version '4.151.1' `
+    -Tags @('v4.151.0-preview.1.1', 'v4.151.0')
+Assert-Equal '4.151.0' $hotfixBoundary.Title `
+    'Stable release ordering regressed when selecting a hotfix boundary.'
+
+$assignmentMilestones = @{
+    '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+    '4.154.0-preview.1' = [pscustomobject] @{ number = 75; state = 'closed' }
+}
+$assignmentTags = @(
+    'v4.153.0-preview.1.26454.6',
+    'v4.154.0-preview.1.26454.9'
+)
+$pullAssignment = Get-ReleaseAssignmentPlan `
+    -Kind 'pull-request' `
+    -Number 4826 `
+    -ViaPullRequest $null `
+    -CurrentMilestone '4.154.0-preview.1' `
+    -TargetMilestone '4.153.0-preview.1' `
+    -Milestones $assignmentMilestones `
+    -Tags $assignmentTags
+Assert-Equal 'assign' $pullAssignment.Status 'A pull request could not be repaired to its first shipped milestone.'
+Assert-Equal 74 $pullAssignment.Operation.ToMilestoneNumber 'A pull request repair targeted the wrong milestone.'
+
+$issueAssignment = Get-ReleaseAssignmentPlan `
+    -Kind 'issue' `
+    -Number 1234 `
+    -ViaPullRequest 4826 `
+    -CurrentMilestone '4.154.0-preview.1' `
+    -TargetMilestone '4.153.0-preview.1' `
+    -Milestones $assignmentMilestones `
+    -Tags $assignmentTags
+Assert-Equal 'assign' $issueAssignment.Status 'A linked issue could not be repaired to its first shipped milestone.'
+Assert-Equal 4826 $issueAssignment.Operation.ViaPullRequest 'A linked issue lost its source pull request.'
+
+$unshippedRollForward = Get-ReleaseAssignmentPlan `
+    -Kind 'pull-request' `
+    -Number 2000 `
+    -ViaPullRequest $null `
+    -CurrentMilestone '4.152.0-preview.1' `
+    -TargetMilestone '4.152.0-rc.1' `
+    -Milestones @{
+        '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+        '4.152.0-rc.1' = [pscustomobject] @{ number = 73; state = 'closed' }
+    } `
+    -Tags @('v4.152.0-rc.1.26426.14')
+Assert-Equal 'assign' $unshippedRollForward.Status `
+    'An unshipped preview could not roll forward to the next shipped milestone in its numeric line.'
+
+foreach ($unsafe in @(
+    Get-ReleaseAssignmentPlan `
+        -Kind 'pull-request' `
+        -Number 4826 `
+        -ViaPullRequest $null `
+        -CurrentMilestone '4.153.0-preview.1' `
+        -TargetMilestone '4.154.0-preview.1' `
+        -Milestones $assignmentMilestones `
+        -Tags $assignmentTags
+    Get-ReleaseAssignmentPlan `
+        -Kind 'issue' `
+        -Number 1234 `
+        -ViaPullRequest 4826 `
+        -CurrentMilestone '4.153.0-preview.1' `
+        -TargetMilestone '4.154.0-preview.1' `
+        -Milestones $assignmentMilestones `
+        -Tags $assignmentTags
+)) {
+    Assert-Equal 'blocked' $unsafe.Status `
+        'A forward move out of an earlier closed and shipped milestone was not blocked.'
+    Assert-True ($unsafe.Warning -match 'Refusing to move .* from earlier milestone') `
+        'A blocked assignment did not explain the safety invariant.'
+}
+
+$closedOnlyGuard = Get-ReleaseAssignmentPlan `
+    -Kind 'issue' `
+    -Number 4321 `
+    -ViaPullRequest 2000 `
+    -CurrentMilestone '4.152.0-preview.1' `
+    -TargetMilestone '4.153.0-preview.1' `
+    -Milestones @{
+        '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'closed' }
+        '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+    } `
+    -Tags @('v4.153.0-preview.1.26454.6')
+Assert-Equal 'blocked' $closedOnlyGuard.Status `
+    'A forward move out of an earlier closed milestone was not blocked without a shipped tag.'
 
 $schedule = [pscustomobject] @{
     branch_point = '2026-07-27T00:00:00Z'

--- a/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
+++ b/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
@@ -104,25 +104,25 @@ $greatestTag = Get-ShippedTag '4.152.0-preview.1' @(
 Assert-Equal 'v4.152.0-preview.1.26426.14' $greatestTag 'The greatest dnceng build tuple was not selected.'
 Assert-Equal 'v4.152.0' (Get-ShippedTag '4.152.0' @('v4.152.0')) 'A stable exact tag was not detected.'
 
-$topologyBranches = @(
-    ConvertTo-ReleaseMilestone 'release/4.152.0-preview.1'
-    ConvertTo-ReleaseMilestone 'release/4.153.0-preview.1'
-    ConvertTo-ReleaseMilestone 'release/4.153.0-rc.1'
-    ConvertTo-ReleaseMilestone 'release/4.154.0-preview.1'
-)
 $topologyTags = @(
     'v4.152.0-preview.1.1',
     'v4.153.0-preview.1.1',
     'v4.153.0-rc.1.1',
     'v4.154.0-preview.1.1'
 )
-$shippedTopology = @(Get-ShippedReleases -Branches $topologyBranches -Tags $topologyTags)
+$shippedTopology = @(Get-ShippedReleases -Tags $topologyTags)
 Assert-Equal @(
     '4.152.0-preview.1',
     '4.153.0-preview.1',
     '4.153.0-rc.1',
     '4.154.0-preview.1'
 ) @($shippedTopology.Title) 'Shipped releases were not ordered by release identity.'
+$sameMilestoneTags = @(Get-ShippedReleases -Tags @(
+    'v4.153.0-preview.1.1',
+    'v4.153.0-preview.1.2'
+))
+Assert-Equal 2 $sameMilestoneTags.Count `
+    'Multiple exact tags for one shipped milestone were not preserved as topology inputs.'
 
 $boundaryRoot = Join-Path $PSScriptRoot ".boundary-test-$([guid]::NewGuid().ToString('N'))"
 try {
@@ -130,6 +130,12 @@ try {
     & git -C $boundaryRoot init --quiet
     & git -C $boundaryRoot config user.name 'Release Boundary Tests'
     & git -C $boundaryRoot config user.email 'release-boundaries@example.invalid'
+    Assert-Equal @('4.153.0-preview.1', '4.153.0-rc.1') @(
+        (Get-ReleaseMilestones `
+            -Root $boundaryRoot `
+            -Version '4.153.0' `
+            -ShippedReleases $shippedTopology).Title
+    ) 'Shipped tag identities disappeared when their release branches were absent.'
     & git -C $boundaryRoot commit --quiet --allow-empty -m 'Previous release boundary'
     & git -C $boundaryRoot tag v4.152.0-preview.1.1
     & git -C $boundaryRoot commit --quiet --allow-empty -m 'Shared m153 line work (#4826)'
@@ -158,8 +164,8 @@ try {
         'A later numeric release became the boundary for an earlier release line.'
     Assert-Equal @(4826) @(Get-ReleasePullRequests `
         -Root $boundaryRoot `
-        -Start $m153PreviewBoundary.Start `
-        -End $m153PreviewBoundary.End) `
+        -Releases $shippedTopology `
+        -CurrentRelease $m153Preview) `
         'The m153 preview range did not begin at the previous release-line branch commit.'
 
     $m154Preview = $shippedTopology | Where-Object Title -eq '4.154.0-preview.1'
@@ -171,8 +177,8 @@ try {
         'A parallel m153 release did not preserve the shared m154 branch commit boundary.'
     Assert-Equal @(4945) @(Get-ReleasePullRequests `
         -Root $boundaryRoot `
-        -Start $m154Boundary.Start `
-        -End $m154Boundary.End) `
+        -Releases $shippedTopology `
+        -CurrentRelease $m154Preview) `
         'The m154 range included work from its parallel m153 release branch.'
 
     $m153Rc = $shippedTopology | Where-Object Title -eq '4.153.0-rc.1'
@@ -182,8 +188,8 @@ try {
         -CurrentRelease $m153Rc
     Assert-Equal @(5000) @(Get-ReleasePullRequests `
         -Root $boundaryRoot `
-        -Start $m153RcBoundary.Start `
-        -End $m153RcBoundary.End) `
+        -Releases $shippedTopology `
+        -CurrentRelease $m153Rc) `
         'A later m153 RC did not retain its own servicing-branch range.'
 } finally {
     if (Test-Path -LiteralPath $boundaryRoot) {
@@ -348,13 +354,47 @@ try {
     & git -C $gitRoot config user.name 'Release Milestone Tests'
     & git -C $gitRoot config user.email 'release-milestones@example.invalid'
     & git -C $gitRoot commit --quiet --allow-empty -m 'Boundary'
-    $start = (& git -C $gitRoot rev-parse HEAD).Trim()
+    $defaultBranch = (& git -C $gitRoot branch --show-current).Trim()
+    & git -C $gitRoot tag v1.0.0
     & git -C $gitRoot commit --quiet --allow-empty -m 'Merge feature (#42)'
+    & git -C $gitRoot branch nested-pr
+    & git -C $gitRoot switch --quiet nested-pr
+    & git -C $gitRoot commit --quiet --allow-empty -m 'Nested shipped change (#44)'
+    & git -C $gitRoot switch --quiet $defaultBranch
+    & git -C $gitRoot merge --quiet --no-ff nested-pr -m 'Merge pull request #43 from test/nested-pr'
     & git -C $gitRoot commit --quiet --allow-empty -m 'Commit without pull request'
     & git -C $gitRoot commit --quiet --allow-empty -m 'Revert "Feature (#4087)" (#4091)'
-    $end = (& git -C $gitRoot rev-parse HEAD).Trim()
-    Assert-Equal @(42, 4091) @(Get-ReleasePullRequests -Root $gitRoot -Start $start -End $end) `
-        'First-parent Git history did not yield trailing merged pull request numbers.'
+    & git -C $gitRoot tag v1.1.0
+    $releaseDag = @(Get-ShippedReleases -Tags @('v1.0.0', 'v1.1.0'))
+    $currentDagRelease = $releaseDag | Where-Object Title -eq '1.1.0'
+    Assert-Equal @(42, 43, 44, 4091) @(Get-ReleasePullRequests `
+        -Root $gitRoot `
+        -Releases $releaseDag `
+        -CurrentRelease $currentDagRelease) `
+        'Release membership did not include squash, merge, and nested DAG pull requests.'
+
+    & git -C $gitRoot commit --quiet --allow-empty -m 'Initial preview fix (#45)'
+    & git -C $gitRoot tag v1.2.0-preview.2.1
+    & git -C $gitRoot commit --quiet --allow-empty -m 'Relanded later preview fix (#45)'
+    & git -C $gitRoot tag v1.2.0-preview.10.1
+    & git -C $gitRoot commit --quiet --allow-empty -m 'Relanded stable fix (#45)'
+    & git -C $gitRoot tag v1.2.0
+    $previewDag = @(Get-ShippedReleases -Tags @(
+        'v1.0.0',
+        'v1.1.0',
+        'v1.2.0-preview.2.1',
+        'v1.2.0-preview.10.1',
+        'v1.2.0'
+    ))
+    Assert-Equal @(
+        '1.2.0-preview.2',
+        '1.2.0-preview.10',
+        '1.2.0'
+    ) @($previewDag | Where-Object NumericKey -eq $previewDag[-1].NumericKey | ForEach-Object Title) `
+        'Multi-digit preview iterations were not ordered semantically before stable.'
+    $previewOwners = Get-ReleasePullRequestOwners -Root $gitRoot -Releases $previewDag
+    Assert-Equal '1.2.0-preview.2' $previewOwners[45].Title `
+        'A later preview or stable reland overrode the first shipped preview owner.'
 } finally {
     if (Test-Path -LiteralPath $gitRoot) {
         Remove-Item -LiteralPath $gitRoot -Recurse -Force
@@ -367,15 +407,32 @@ $script:FakeMilestoneState = 'open'
 $script:FakeItemMilestone = '4.152.0-preview.1'
 $script:FakeLiveReleaseTags = @()
 $script:FakeLiveReleaseTagReads = 0
+$script:FakeTargetOwnsRelease = $true
+$script:FakeOwnershipKind = ''
 function Get-CurrentRemoteReleaseTags([string] $Root) {
     $script:FakeLiveReleaseTagReads++
-    if ($script:FakeGhScenario -eq 'post-write-shipment-race' -and $script:FakeLiveReleaseTagReads -gt 1) {
+    if (
+        $script:FakeGhScenario -in @('post-write-shipment-race', 'post-write-unassigned-race') -and
+        $script:FakeLiveReleaseTagReads -gt 1
+    ) {
         return @(
             'v4.152.0-preview.1.26426.14',
             'v4.153.0-preview.1.26454.6'
         )
     }
     return $script:FakeLiveReleaseTags
+}
+function Test-LiveReleaseAssignmentOwnership(
+    [string] $Root,
+    [string] $Repository,
+    [string[]] $Tags,
+    [string] $TargetMilestone,
+    [string] $Kind,
+    [int] $Number,
+    [object] $ViaPullRequest
+) {
+    $script:FakeOwnershipKind = $Kind
+    return $script:FakeTargetOwnsRelease
 }
 function global:gh {
     $command = $args -join ' '
@@ -452,6 +509,34 @@ function global:gh {
 '@
         }
     }
+    if ($script:FakeGhScenario -eq 'ownership-race') {
+        if ($command -match 'issues/6003 .*PATCH') {
+            throw 'Unsafe ownership-raced assignment reached PATCH.'
+        } elseif ($command -match 'issues/6003$') {
+            return '{"number":6003,"milestone":null}'
+        }
+    }
+    if ($script:FakeGhScenario -eq 'issue-ownership-race') {
+        if ($command -match 'issues/6005 .*PATCH') {
+            throw 'Unsafe issue ownership-raced assignment reached PATCH.'
+        } elseif ($command -match 'issues/6005$') {
+            return '{"number":6005,"milestone":null}'
+        }
+    }
+    if ($script:FakeGhScenario -eq 'post-write-unassigned-race') {
+        if ($command -match 'issues/6004 .*PATCH.*milestone=74') {
+            $script:FakeItemMilestone = '4.153.0-preview.1'
+            return '{"number":6004}'
+        } elseif ($command -match 'issues/6004 .*PATCH.*milestone=null') {
+            $script:FakeItemMilestone = ''
+            return '{"number":6004}'
+        } elseif ($command -match 'issues/6004$') {
+            if ($script:FakeItemMilestone) {
+                return '{"number":6004,"milestone":{"number":74,"title":"4.153.0-preview.1","state":"closed"}}'
+            }
+            return '{"number":6004,"milestone":null}'
+        }
+    }
     if ($command -match 'milestones\?state=all') {
         @'
 [[{"number":70,"title":"4.152.0-preview.1","state":"open"}]]
@@ -471,7 +556,28 @@ function global:gh {
 ]
 '@
     } elseif ($command -match 'graphql') {
-        '{"data":{"repository":{"pullRequest":{"closingIssuesReferences":{"nodes":[{"number":12}]}}}}}'
+        if ($command -match 'closedByPullRequestsReferences') {
+            return @'
+[
+  {"data":{"repository":{"issue":{"closedByPullRequestsReferences":{"nodes":[
+    {"number":77,"repository":{"nameWithOwner":"mono/SkiaSharp"}},
+    {"number":88,"repository":{"nameWithOwner":"mono/SkiaSharp"}},
+    {"number":99,"repository":{"nameWithOwner":"other/repository"}}
+  ]}}}}}
+]
+'@
+        }
+        @'
+[
+  {"data":{"repository":{"pullRequest":{"closingIssuesReferences":{"nodes":[
+    {"number":12,"repository":{"nameWithOwner":"mono/SkiaSharp"}},
+    {"number":410,"repository":{"nameWithOwner":"appium/appium-mac2-driver"}}
+  ]}}}}},
+  {"data":{"repository":{"pullRequest":{"closingIssuesReferences":{"nodes":[
+    {"number":13,"repository":{"nameWithOwner":"mono/SkiaSharp"}}
+  ]}}}}}
+]
+'@
     } elseif ($command -match 'pulls/77') {
         '{"body":"Fixes #34 and resolved: #56"}'
     } else {
@@ -483,8 +589,18 @@ $map = Get-GitHubMilestoneMap -Repository 'mono/SkiaSharp'
 Assert-Equal 70 $map['4.152.0-preview.1'].number 'The fake-gh milestone response was not parsed.'
 $openItems = Get-OpenMilestoneItems -Repository 'mono/SkiaSharp' -MilestoneNumber 70
 Assert-Equal @('issue', 'pull-request') @($openItems.Kind) 'Issues and pull requests were not distinguished.'
-Assert-Equal @(12, 34, 56) @(Get-LinkedIssues -Repository 'mono/SkiaSharp' -PullRequest 77) `
+Assert-Equal @(12, 13, 34, 56) @(Get-LinkedIssues -Repository 'mono/SkiaSharp' -PullRequest 77) `
     'GitHub references and closing keywords were not combined.'
+$linkedIssueOwner = Get-LinkedIssueOwner `
+    -Repository 'mono/SkiaSharp' `
+    -Issue 12 `
+    -ViaPullRequest 77 `
+    -PullRequestOwners @{
+        77 = [pscustomobject] @{ Title = '4.153.0-preview.1'; SortKey = '153'; Tag = 'm153' }
+        88 = [pscustomobject] @{ Title = '4.152.0-rc.1'; SortKey = '152'; Tag = 'm152' }
+    }
+Assert-Equal '4.152.0-rc.1' $linkedIssueOwner.Title `
+    'A linked issue did not select its lowest semantic owner across closing pull requests.'
 
 $callsBeforeDryRun = $script:FakeGhCalls.Count
 $dryRunOutput = @(
@@ -535,6 +651,7 @@ Assert-Throws {
         -Root 'fake-root' `
         -Repository 'mono/SkiaSharp' `
         -Item $racedOperation `
+        -PlanningTags $script:FakeLiveReleaseTags `
         -Milestones @{
             '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
             '4.154.0-preview.1' = [pscustomobject] @{ number = 75; state = 'closed' }
@@ -558,6 +675,7 @@ Assert-Throws {
         -Root 'fake-root' `
         -Repository 'mono/SkiaSharp' `
         -Item $closureRacedOperation `
+        -PlanningTags $script:FakeLiveReleaseTags `
         -Milestones @{
             '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
             '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
@@ -584,6 +702,7 @@ Assert-Throws {
         -Root 'fake-root' `
         -Repository 'mono/SkiaSharp' `
         -Item $shipmentRacedOperation `
+        -PlanningTags @('v4.153.0-preview.1.26454.6') `
         -Milestones @{
             '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
             '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
@@ -596,6 +715,7 @@ $script:FakeGhScenario = 'post-write-shipment-race'
 $script:FakeItemMilestone = '4.152.0-preview.1'
 $script:FakeLiveReleaseTagReads = 0
 $script:FakeLiveReleaseTags = @('v4.153.0-preview.1.26454.6')
+$script:FakeTargetOwnsRelease = $false
 $postWriteRacedOperation = [pscustomobject] @{
     Kind = 'pull-request'
     Number = 6002
@@ -610,15 +730,107 @@ Assert-Throws {
         -Root 'fake-root' `
         -Repository 'mono/SkiaSharp' `
         -Item $postWriteRacedOperation `
+        -PlanningTags $script:FakeLiveReleaseTags `
         -Milestones @{
             '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
             '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
         } `
         -Push
-} 'Refusing to move pull-request #6002.*concurrent change was detected after mutation.*restored' `
+} 'Release ownership changed during mutation.*assignment was restored' `
     'A source milestone shipped between revalidation and PATCH without restoring the assignment.'
 Assert-Equal '4.152.0-preview.1' $script:FakeItemMilestone `
     'A raced assignment was not restored to its newly shipped source milestone.'
+
+$script:FakeGhScenario = 'ownership-race'
+$script:FakeLiveReleaseTags = @(
+    'v4.152.0-preview.1.26426.14',
+    'v4.153.0-preview.1.26454.6'
+)
+$script:FakeTargetOwnsRelease = $false
+$ownershipRacedOperation = [pscustomobject] @{
+    Kind = 'pull-request'
+    Number = 6003
+    ViaPullRequest = $null
+    FromMilestone = ''
+    FromMilestoneNumber = $null
+    ToMilestone = '4.153.0-preview.1'
+    ToMilestoneNumber = 74
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
+        -Repository 'mono/SkiaSharp' `
+        -Item $ownershipRacedOperation `
+        -PlanningTags @('v4.153.0-preview.1.26454.6') `
+        -Milestones @{
+            '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+        } `
+        -Push
+} 'Release ownership changed after planning.*no longer owns pull request #6003' `
+    'A new predecessor tag did not invalidate an unassigned item before PATCH.'
+
+$script:FakeGhScenario = 'issue-ownership-race'
+$script:FakeOwnershipKind = ''
+$script:FakeLiveReleaseTags = @(
+    'v4.152.0-preview.1.26426.14',
+    'v4.153.0-preview.1.26454.6'
+)
+$script:FakeTargetOwnsRelease = $false
+$issueOwnershipRacedOperation = [pscustomobject] @{
+    Kind = 'issue'
+    Number = 6005
+    ViaPullRequest = 7000
+    FromMilestone = ''
+    FromMilestoneNumber = $null
+    ToMilestone = '4.153.0-preview.1'
+    ToMilestoneNumber = 74
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
+        -Repository 'mono/SkiaSharp' `
+        -Item $issueOwnershipRacedOperation `
+        -PlanningTags @('v4.153.0-preview.1.26454.6') `
+        -Milestones @{
+            '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+        } `
+        -Push
+} 'Release ownership changed after planning.*issue #6005 across its shipped closing pull requests' `
+    'A newly shipped earlier closing PR did not invalidate an issue assignment before PATCH.'
+Assert-Equal 'issue' $script:FakeOwnershipKind `
+    'Issue ownership revalidation used only the originally observed closing pull request.'
+
+$script:FakeGhScenario = 'post-write-unassigned-race'
+$script:FakeItemMilestone = ''
+$script:FakeLiveReleaseTagReads = 0
+$script:FakeLiveReleaseTags = @('v4.153.0-preview.1.26454.6')
+$script:FakeTargetOwnsRelease = $false
+$postWriteUnassignedOperation = [pscustomobject] @{
+    Kind = 'pull-request'
+    Number = 6004
+    ViaPullRequest = $null
+    FromMilestone = ''
+    FromMilestoneNumber = $null
+    ToMilestone = '4.153.0-preview.1'
+    ToMilestoneNumber = 74
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
+        -Repository 'mono/SkiaSharp' `
+        -Item $postWriteUnassignedOperation `
+        -PlanningTags $script:FakeLiveReleaseTags `
+        -Milestones @{
+            '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+        } `
+        -Push
+} 'Release ownership changed during mutation.*assignment was restored' `
+    'A new predecessor tag during PATCH did not restore an originally unassigned item.'
+Assert-Equal '' $script:FakeItemMilestone `
+    'A raced unassigned item was not restored to having no milestone.'
 
 $script:FakeGhScenario = 'new-item'
 Assert-Throws {

--- a/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
+++ b/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
@@ -104,36 +104,25 @@ $greatestTag = Get-ShippedTag '4.152.0-preview.1' @(
 Assert-Equal 'v4.152.0-preview.1.26426.14' $greatestTag 'The greatest dnceng build tuple was not selected.'
 Assert-Equal 'v4.152.0' (Get-ShippedTag '4.152.0' @('v4.152.0')) 'A stable exact tag was not detected.'
 
-$chronologyBranches = @(
+$topologyBranches = @(
     ConvertTo-ReleaseMilestone 'release/4.152.0-preview.1'
     ConvertTo-ReleaseMilestone 'release/4.153.0-preview.1'
     ConvertTo-ReleaseMilestone 'release/4.153.0-rc.1'
     ConvertTo-ReleaseMilestone 'release/4.154.0-preview.1'
 )
-$chronologyTags = @(
+$topologyTags = @(
     'v4.152.0-preview.1.1',
     'v4.153.0-preview.1.1',
     'v4.153.0-rc.1.1',
     'v4.154.0-preview.1.1'
 )
-$chronologyPublished = @{
-    'v4.153.0-preview.1.1' = [datetimeoffset] '2026-09-05T00:00:00Z'
-    'v4.154.0-preview.1.1' = [datetimeoffset] '2026-09-06T00:00:00Z'
-    'v4.153.0-rc.1.1' = [datetimeoffset] '2026-09-07T00:00:00Z'
-}
-$shippedChronology = @(Get-ShippedReleases `
-    -Branches $chronologyBranches `
-    -Tags $chronologyTags `
-    -PublishedReleases $chronologyPublished)
+$shippedTopology = @(Get-ShippedReleases -Branches $topologyBranches -Tags $topologyTags)
 Assert-Equal @(
+    '4.152.0-preview.1',
     '4.153.0-preview.1',
-    '4.154.0-preview.1',
-    '4.153.0-rc.1'
-) @($shippedChronology | Where-Object PublishedAt | ForEach-Object Title) `
-    'Shipped releases were not ordered by publication chronology.'
-Assert-Equal @('v4.152.0-preview.1.1') `
-    @($shippedChronology | Where-Object { !$_.PublishedAt } | ForEach-Object Tag) `
-    'A shipped release without publication chronology was silently omitted.'
+    '4.153.0-rc.1',
+    '4.154.0-preview.1'
+) @($shippedTopology.Title) 'Shipped releases were not ordered by release identity.'
 
 $boundaryRoot = Join-Path $PSScriptRoot ".boundary-test-$([guid]::NewGuid().ToString('N'))"
 try {
@@ -141,74 +130,61 @@ try {
     & git -C $boundaryRoot init --quiet
     & git -C $boundaryRoot config user.name 'Release Boundary Tests'
     & git -C $boundaryRoot config user.email 'release-boundaries@example.invalid'
-    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Shared boundary'
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Previous release boundary'
     & git -C $boundaryRoot tag v4.152.0-preview.1.1
-    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Ship m153 preview (#4826)'
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Shared m153 line work (#4826)'
+    $m153LinePoint = (& git -C $boundaryRoot rev-parse HEAD).Trim()
+    & git -C $boundaryRoot branch m153-servicing
+    & git -C $boundaryRoot branch m153-preview
+    & git -C $boundaryRoot switch --quiet m153-preview
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Create m153 preview release branch'
     & git -C $boundaryRoot tag v4.153.0-preview.1.1
-    & git -C $boundaryRoot branch later-m153-rc
-    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Ship m154 preview (#4945)'
-    & git -C $boundaryRoot tag v4.154.0-preview.1.1
-    & git -C $boundaryRoot switch --quiet later-m153-rc
-    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Backport already-shipped m154 change (#4945)'
-    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Ship later m153 RC (#5000)'
+    & git -C $boundaryRoot switch --quiet m153-servicing
+    & git -C $boundaryRoot branch m154-preview
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Later m153 servicing work (#5000)'
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Create later m153 RC release branch'
     & git -C $boundaryRoot tag v4.153.0-rc.1.1
+    & git -C $boundaryRoot switch --quiet m154-preview
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'm154-only work (#4945)'
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Create m154 preview release branch'
+    & git -C $boundaryRoot tag v4.154.0-preview.1.1
 
-    $m154Plan = Get-FirstShippedPullRequests `
+    $m153Preview = $shippedTopology | Where-Object Title -eq '4.153.0-preview.1'
+    $m153PreviewBoundary = Get-PreviousShippedBoundary `
         -Root $boundaryRoot `
-        -Releases $shippedChronology `
-        -CurrentTag 'v4.154.0-preview.1.1' `
-        -CurrentPublishedAt $chronologyPublished['v4.154.0-preview.1.1']
-    Assert-Equal @(4945) @($m154Plan.PullRequests) `
-        'A later shipment from an earlier numeric line changed the first-shipped m154 pull requests.'
-    Assert-Equal @() @($m154Plan.Ambiguities) `
-        'An unrelated undated release made a target shipment ambiguous.'
+        -Releases $shippedTopology `
+        -CurrentRelease $m153Preview
+    Assert-Equal 'v4.152.0-preview.1.1' $m153PreviewBoundary.Tag `
+        'A later numeric release became the boundary for an earlier release line.'
+    Assert-Equal @(4826) @(Get-ReleasePullRequests `
+        -Root $boundaryRoot `
+        -Start $m153PreviewBoundary.Start `
+        -End $m153PreviewBoundary.End) `
+        'The m153 preview range did not begin at the previous release-line branch commit.'
 
-    $laterM153Plan = Get-FirstShippedPullRequests `
+    $m154Preview = $shippedTopology | Where-Object Title -eq '4.154.0-preview.1'
+    $m154Boundary = Get-PreviousShippedBoundary `
         -Root $boundaryRoot `
-        -Releases $shippedChronology `
-        -CurrentTag 'v4.153.0-rc.1.1' `
-        -CurrentPublishedAt $chronologyPublished['v4.153.0-rc.1.1']
-    Assert-Equal @(5000) @($laterM153Plan.PullRequests) `
-        'A parallel release reclaimed a pull request first shipped from another numeric line.'
+        -Releases $shippedTopology `
+        -CurrentRelease $m154Preview
+    Assert-Equal $m153LinePoint $m154Boundary.Start `
+        'A parallel m153 release did not preserve the shared m154 branch commit boundary.'
+    Assert-Equal @(4945) @(Get-ReleasePullRequests `
+        -Root $boundaryRoot `
+        -Start $m154Boundary.Start `
+        -End $m154Boundary.End) `
+        'The m154 range included work from its parallel m153 release branch.'
 
-    $undatedOverlap = Get-FirstShippedPullRequests `
+    $m153Rc = $shippedTopology | Where-Object Title -eq '4.153.0-rc.1'
+    $m153RcBoundary = Get-PreviousShippedBoundary `
         -Root $boundaryRoot `
-        -Releases @(
-            [pscustomobject] @{
-                Title = '4.153.0-preview.1'
-                Tag = 'v4.153.0-preview.1.1'
-                PublishedAt = $null
-            }
-            [pscustomobject] @{
-                Title = '4.154.0-preview.1'
-                Tag = 'v4.154.0-preview.1.1'
-                PublishedAt = $chronologyPublished['v4.154.0-preview.1.1']
-            }
-        ) `
-        -CurrentTag 'v4.154.0-preview.1.1' `
-        -CurrentPublishedAt $chronologyPublished['v4.154.0-preview.1.1']
-    Assert-Equal @('v4.153.0-preview.1.1') @($undatedOverlap.Ambiguities.Tag) `
-        'An undated shipped release overlapping the target was not ambiguous.'
-
-    $sameTimestamp = [datetimeoffset] '2026-09-06T22:48:14Z'
-    $equalTimeOverlap = Get-FirstShippedPullRequests `
+        -Releases $shippedTopology `
+        -CurrentRelease $m153Rc
+    Assert-Equal @(5000) @(Get-ReleasePullRequests `
         -Root $boundaryRoot `
-        -Releases @(
-            [pscustomobject] @{
-                Title = '4.153.0-preview.1'
-                Tag = 'v4.153.0-preview.1.1'
-                PublishedAt = $sameTimestamp
-            }
-            [pscustomobject] @{
-                Title = '4.154.0-preview.1'
-                Tag = 'v4.154.0-preview.1.1'
-                PublishedAt = $sameTimestamp
-            }
-        ) `
-        -CurrentTag 'v4.154.0-preview.1.1' `
-        -CurrentPublishedAt $sameTimestamp
-    Assert-Equal @('v4.153.0-preview.1.1') @($equalTimeOverlap.Ambiguities.Tag) `
-        'Equal-time overlapping shipments were resolved by invocation order instead of blocked.'
+        -Start $m153RcBoundary.Start `
+        -End $m153RcBoundary.End) `
+        'A later m153 RC did not retain its own servicing-branch range.'
 } finally {
     if (Test-Path -LiteralPath $boundaryRoot) {
         Remove-Item -LiteralPath $boundaryRoot -Recurse -Force
@@ -224,11 +200,6 @@ $assignmentTags = @(
     'v4.154.0-preview.1.26454.9',
     'v4.153.0-rc.1.26455.1'
 )
-$assignmentPublished = @{
-    'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
-    'v4.154.0-preview.1.26454.9' = [datetimeoffset] '2026-09-06T22:48:14Z'
-    'v4.153.0-rc.1.26455.1' = [datetimeoffset] '2026-09-07T12:00:00Z'
-}
 $pullAssignment = Get-ReleaseAssignmentPlan `
     -Kind 'pull-request' `
     -Number 4826 `
@@ -236,8 +207,7 @@ $pullAssignment = Get-ReleaseAssignmentPlan `
     -CurrentMilestone '4.154.0-preview.1' `
     -TargetMilestone '4.153.0-preview.1' `
     -Milestones $assignmentMilestones `
-    -Tags $assignmentTags `
-    -PublishedReleases $assignmentPublished
+    -Tags $assignmentTags
 Assert-Equal 'assign' $pullAssignment.Status 'A pull request could not be repaired to its first shipped milestone.'
 Assert-Equal 74 $pullAssignment.Operation.ToMilestoneNumber 'A pull request repair targeted the wrong milestone.'
 
@@ -248,8 +218,7 @@ $issueAssignment = Get-ReleaseAssignmentPlan `
     -CurrentMilestone '4.154.0-preview.1' `
     -TargetMilestone '4.153.0-preview.1' `
     -Milestones $assignmentMilestones `
-    -Tags $assignmentTags `
-    -PublishedReleases $assignmentPublished
+    -Tags $assignmentTags
 Assert-Equal 'assign' $issueAssignment.Status 'A linked issue could not be repaired to its first shipped milestone.'
 Assert-Equal 4826 $issueAssignment.Operation.ViaPullRequest 'A linked issue lost its source pull request.'
 
@@ -263,10 +232,7 @@ $unshippedRollForward = Get-ReleaseAssignmentPlan `
         '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
         '4.152.0-rc.1' = [pscustomobject] @{ number = 73; state = 'closed' }
     } `
-    -Tags @('v4.152.0-rc.1.26426.14') `
-    -PublishedReleases @{
-        'v4.152.0-rc.1.26426.14' = [datetimeoffset] '2026-09-03T02:22:44Z'
-    }
+    -Tags @('v4.152.0-rc.1.26426.14')
 Assert-Equal 'assign' $unshippedRollForward.Status `
     'An unshipped preview could not roll forward to the next shipped milestone in its numeric line.'
 
@@ -278,8 +244,7 @@ foreach ($unsafe in @(
         -CurrentMilestone '4.153.0-preview.1' `
         -TargetMilestone '4.154.0-preview.1' `
         -Milestones $assignmentMilestones `
-        -Tags $assignmentTags `
-        -PublishedReleases $assignmentPublished
+        -Tags $assignmentTags
     Get-ReleaseAssignmentPlan `
         -Kind 'issue' `
         -Number 1234 `
@@ -287,8 +252,7 @@ foreach ($unsafe in @(
         -CurrentMilestone '4.153.0-preview.1' `
         -TargetMilestone '4.154.0-preview.1' `
         -Milestones $assignmentMilestones `
-        -Tags $assignmentTags `
-        -PublishedReleases $assignmentPublished
+        -Tags $assignmentTags
 )) {
     Assert-Equal 'blocked' $unsafe.Status `
         'A forward move out of an earlier closed and shipped milestone was not blocked.'
@@ -306,27 +270,9 @@ $closedOnlyGuard = Get-ReleaseAssignmentPlan `
         '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'closed' }
         '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
     } `
-    -Tags @('v4.153.0-preview.1.26454.6') `
-    -PublishedReleases @{
-        'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
-    }
+    -Tags @('v4.153.0-preview.1.26454.6')
 Assert-Equal 'blocked' $closedOnlyGuard.Status `
     'A forward move out of an earlier closed milestone was not blocked without a shipped tag.'
-
-$parallelLineGuard = Get-ReleaseAssignmentPlan `
-    -Kind 'pull-request' `
-    -Number 4945 `
-    -ViaPullRequest $null `
-    -CurrentMilestone '4.154.0-preview.1' `
-    -TargetMilestone '4.153.0-rc.1' `
-    -Milestones @{
-        '4.153.0-rc.1' = [pscustomobject] @{ number = 76; state = 'closed' }
-        '4.154.0-preview.1' = [pscustomobject] @{ number = 75; state = 'closed' }
-    } `
-    -Tags $assignmentTags `
-    -PublishedReleases $assignmentPublished
-Assert-Equal 'blocked' $parallelLineGuard.Status `
-    'A later shipment from an earlier numeric line stole an item from its first shipped milestone.'
 
 $schedule = [pscustomobject] @{
     branch_point = '2026-07-27T00:00:00Z'
@@ -419,6 +365,18 @@ $script:FakeGhCalls = [System.Collections.Generic.List[string]]::new()
 $script:FakeGhScenario = 'read'
 $script:FakeMilestoneState = 'open'
 $script:FakeItemMilestone = '4.152.0-preview.1'
+$script:FakeLiveReleaseTags = @()
+$script:FakeLiveReleaseTagReads = 0
+function Get-CurrentRemoteReleaseTags([string] $Root) {
+    $script:FakeLiveReleaseTagReads++
+    if ($script:FakeGhScenario -eq 'post-write-shipment-race' -and $script:FakeLiveReleaseTagReads -gt 1) {
+        return @(
+            'v4.152.0-preview.1.26426.14',
+            'v4.153.0-preview.1.26454.6'
+        )
+    }
+    return $script:FakeLiveReleaseTags
+}
 function global:gh {
     $command = $args -join ' '
     $script:FakeGhCalls.Add($command)
@@ -462,6 +420,36 @@ function global:gh {
             throw 'Unsafe closure-raced assignment reached PATCH.'
         } elseif ($command -match 'issues/6000$') {
             return '{"number":6000,"milestone":{"number":72,"title":"4.152.0-preview.1","state":"closed"}}'
+        }
+    }
+    if ($script:FakeGhScenario -eq 'shipment-race') {
+        if ($command -match 'issues/6001 .*PATCH') {
+            throw 'Unsafe shipment-raced assignment reached PATCH.'
+        } elseif ($command -match 'issues/6001$') {
+            return '{"number":6001,"milestone":{"number":72,"title":"4.152.0-preview.1","state":"open"}}'
+        }
+    }
+    if ($script:FakeGhScenario -eq 'post-write-shipment-race') {
+        if ($command -match 'issues/6002 .*PATCH.*milestone=74') {
+            $script:FakeItemMilestone = '4.153.0-preview.1'
+            return '{"number":6002}'
+        } elseif ($command -match 'issues/6002 .*PATCH.*milestone=72') {
+            $script:FakeItemMilestone = '4.152.0-preview.1'
+            return '{"number":6002}'
+        } elseif ($command -match 'issues/6002$') {
+            $milestoneNumber = if ($script:FakeItemMilestone -eq '4.152.0-preview.1') { 72 } else { 74 }
+            return [pscustomobject] @{
+                number = 6002
+                milestone = [pscustomobject] @{
+                    number = $milestoneNumber
+                    title = $script:FakeItemMilestone
+                    state = 'open'
+                }
+            } | ConvertTo-Json -Compress
+        } elseif ($command -match 'milestones\?state=all') {
+            return @'
+[[{"number":72,"title":"4.152.0-preview.1","state":"open"},{"number":74,"title":"4.153.0-preview.1","state":"closed"}]]
+'@
         }
     }
     if ($command -match 'milestones\?state=all') {
@@ -530,6 +518,10 @@ Assert-Equal '4.152.0-preview.2' $script:FakeItemMilestone 'The fake-gh apply pa
 Assert-Equal 'closed' $script:FakeMilestoneState 'The fake-gh apply path did not close the emptied milestone.'
 
 $script:FakeGhScenario = 'assignment-race'
+$script:FakeLiveReleaseTags = @(
+    'v4.153.0-preview.1.26454.6',
+    'v4.154.0-preview.1.26454.9'
+)
 $racedOperation = [pscustomobject] @{
     Kind = 'pull-request'
     Number = 4826
@@ -540,25 +532,19 @@ $racedOperation = [pscustomobject] @{
 }
 Assert-Throws {
     Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
         -Repository 'mono/SkiaSharp' `
         -Item $racedOperation `
         -Milestones @{
             '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
             '4.154.0-preview.1' = [pscustomobject] @{ number = 75; state = 'closed' }
         } `
-        -Tags @(
-            'v4.153.0-preview.1.26454.6',
-            'v4.154.0-preview.1.26454.9'
-        ) `
-        -PublishedReleases @{
-            'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
-            'v4.154.0-preview.1.26454.9' = [datetimeoffset] '2026-09-06T22:48:14Z'
-        } `
         -Push
 } 'Refusing to move pull-request #4826' `
     'A concurrent earlier shipped assignment was not revalidated before PATCH.'
 
 $script:FakeGhScenario = 'closure-race'
+$script:FakeLiveReleaseTags = @('v4.153.0-preview.1.26454.6')
 $closureRacedOperation = [pscustomobject] @{
     Kind = 'pull-request'
     Number = 6000
@@ -569,19 +555,70 @@ $closureRacedOperation = [pscustomobject] @{
 }
 Assert-Throws {
     Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
         -Repository 'mono/SkiaSharp' `
         -Item $closureRacedOperation `
         -Milestones @{
             '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
             '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
         } `
-        -Tags @('v4.153.0-preview.1.26454.6') `
-        -PublishedReleases @{
-            'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
-        } `
         -Push
 } 'Refusing to move pull-request #6000' `
     'A source milestone closed after planning was not revalidated before PATCH.'
+
+$script:FakeGhScenario = 'shipment-race'
+$script:FakeLiveReleaseTags = @(
+    'v4.152.0-preview.1.26426.14',
+    'v4.153.0-preview.1.26454.6'
+)
+$shipmentRacedOperation = [pscustomobject] @{
+    Kind = 'pull-request'
+    Number = 6001
+    ViaPullRequest = $null
+    FromMilestone = '4.152.0-preview.1'
+    ToMilestone = '4.153.0-preview.1'
+    ToMilestoneNumber = 74
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
+        -Repository 'mono/SkiaSharp' `
+        -Item $shipmentRacedOperation `
+        -Milestones @{
+            '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+        } `
+        -Push
+} 'Refusing to move pull-request #6001.*shipped as v4.152.0-preview.1.26426.14' `
+    'A source milestone shipped after planning was not revalidated before PATCH.'
+
+$script:FakeGhScenario = 'post-write-shipment-race'
+$script:FakeItemMilestone = '4.152.0-preview.1'
+$script:FakeLiveReleaseTagReads = 0
+$script:FakeLiveReleaseTags = @('v4.153.0-preview.1.26454.6')
+$postWriteRacedOperation = [pscustomobject] @{
+    Kind = 'pull-request'
+    Number = 6002
+    ViaPullRequest = $null
+    FromMilestone = '4.152.0-preview.1'
+    FromMilestoneNumber = 72
+    ToMilestone = '4.153.0-preview.1'
+    ToMilestoneNumber = 74
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Root 'fake-root' `
+        -Repository 'mono/SkiaSharp' `
+        -Item $postWriteRacedOperation `
+        -Milestones @{
+            '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+        } `
+        -Push
+} 'Refusing to move pull-request #6002.*concurrent change was detected after mutation.*restored' `
+    'A source milestone shipped between revalidation and PATCH without restoring the assignment.'
+Assert-Equal '4.152.0-preview.1' $script:FakeItemMilestone `
+    'A raced assignment was not restored to its newly shipped source milestone.'
 
 $script:FakeGhScenario = 'new-item'
 Assert-Throws {

--- a/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
+++ b/scripts/infra/publishing/tests/Test-ReleaseMilestones.ps1
@@ -104,46 +104,116 @@ $greatestTag = Get-ShippedTag '4.152.0-preview.1' @(
 Assert-Equal 'v4.152.0-preview.1.26426.14' $greatestTag 'The greatest dnceng build tuple was not selected.'
 Assert-Equal 'v4.152.0' (Get-ShippedTag '4.152.0' @('v4.152.0')) 'A stable exact tag was not detected.'
 
-$previousBranches = @(
-    ConvertTo-ReleaseMilestone 'release/4.150.2'
-    ConvertTo-ReleaseMilestone 'release/4.150.3'
-)
-$previousShipped = Get-PreviousShippedBranch `
-    -Branches $previousBranches `
-    -Version '4.151.0' `
-    -Tags @('v4.150.2')
-Assert-Equal '4.150.2' $previousShipped.Title 'An unshipped stable branch became the previous release boundary.'
-
-$previewOnlyBranches = @(
-    ConvertTo-ReleaseMilestone 'release/4.151.2'
+$chronologyBranches = @(
     ConvertTo-ReleaseMilestone 'release/4.152.0-preview.1'
-    ConvertTo-ReleaseMilestone 'release/4.152.0-rc.1'
     ConvertTo-ReleaseMilestone 'release/4.153.0-preview.1'
     ConvertTo-ReleaseMilestone 'release/4.153.0-rc.1'
     ConvertTo-ReleaseMilestone 'release/4.154.0-preview.1'
 )
-$previousPreviewOnly = Get-PreviousShippedBranch `
-    -Branches $previewOnlyBranches `
-    -Version '4.154.0' `
-    -Tags @(
-        'v4.151.2',
-        'v4.152.0-rc.1.26426.14',
-        'v4.153.0-preview.1.26454.6',
-        'v4.154.0-preview.1.26454.9'
-    )
-Assert-Equal '4.153.0-preview.1' $previousPreviewOnly.Title `
-    'A consecutive preview-only release line was skipped as the previous shipped boundary.'
+$chronologyTags = @(
+    'v4.152.0-preview.1.1',
+    'v4.153.0-preview.1.1',
+    'v4.153.0-rc.1.1',
+    'v4.154.0-preview.1.1'
+)
+$chronologyPublished = @{
+    'v4.153.0-preview.1.1' = [datetimeoffset] '2026-09-05T00:00:00Z'
+    'v4.154.0-preview.1.1' = [datetimeoffset] '2026-09-06T00:00:00Z'
+    'v4.153.0-rc.1.1' = [datetimeoffset] '2026-09-07T00:00:00Z'
+}
+$shippedChronology = @(Get-ShippedReleases `
+    -Branches $chronologyBranches `
+    -Tags $chronologyTags `
+    -PublishedReleases $chronologyPublished)
+Assert-Equal @(
+    '4.153.0-preview.1',
+    '4.154.0-preview.1',
+    '4.153.0-rc.1'
+) @($shippedChronology | Where-Object PublishedAt | ForEach-Object Title) `
+    'Shipped releases were not ordered by publication chronology.'
+Assert-Equal @('v4.152.0-preview.1.1') `
+    @($shippedChronology | Where-Object { !$_.PublishedAt } | ForEach-Object Tag) `
+    'A shipped release without publication chronology was silently omitted.'
 
-$hotfixBoundary = Get-PreviousShippedBranch `
-    -Branches @(
-        ConvertTo-ReleaseMilestone 'release/4.151.0-preview.1'
-        ConvertTo-ReleaseMilestone 'release/4.151.0'
-        ConvertTo-ReleaseMilestone 'release/4.151.1-preview.1'
-    ) `
-    -Version '4.151.1' `
-    -Tags @('v4.151.0-preview.1.1', 'v4.151.0')
-Assert-Equal '4.151.0' $hotfixBoundary.Title `
-    'Stable release ordering regressed when selecting a hotfix boundary.'
+$boundaryRoot = Join-Path $PSScriptRoot ".boundary-test-$([guid]::NewGuid().ToString('N'))"
+try {
+    $null = New-Item -ItemType Directory -Path $boundaryRoot
+    & git -C $boundaryRoot init --quiet
+    & git -C $boundaryRoot config user.name 'Release Boundary Tests'
+    & git -C $boundaryRoot config user.email 'release-boundaries@example.invalid'
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Shared boundary'
+    & git -C $boundaryRoot tag v4.152.0-preview.1.1
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Ship m153 preview (#4826)'
+    & git -C $boundaryRoot tag v4.153.0-preview.1.1
+    & git -C $boundaryRoot branch later-m153-rc
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Ship m154 preview (#4945)'
+    & git -C $boundaryRoot tag v4.154.0-preview.1.1
+    & git -C $boundaryRoot switch --quiet later-m153-rc
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Backport already-shipped m154 change (#4945)'
+    & git -C $boundaryRoot commit --quiet --allow-empty -m 'Ship later m153 RC (#5000)'
+    & git -C $boundaryRoot tag v4.153.0-rc.1.1
+
+    $m154Plan = Get-FirstShippedPullRequests `
+        -Root $boundaryRoot `
+        -Releases $shippedChronology `
+        -CurrentTag 'v4.154.0-preview.1.1' `
+        -CurrentPublishedAt $chronologyPublished['v4.154.0-preview.1.1']
+    Assert-Equal @(4945) @($m154Plan.PullRequests) `
+        'A later shipment from an earlier numeric line changed the first-shipped m154 pull requests.'
+    Assert-Equal @() @($m154Plan.Ambiguities) `
+        'An unrelated undated release made a target shipment ambiguous.'
+
+    $laterM153Plan = Get-FirstShippedPullRequests `
+        -Root $boundaryRoot `
+        -Releases $shippedChronology `
+        -CurrentTag 'v4.153.0-rc.1.1' `
+        -CurrentPublishedAt $chronologyPublished['v4.153.0-rc.1.1']
+    Assert-Equal @(5000) @($laterM153Plan.PullRequests) `
+        'A parallel release reclaimed a pull request first shipped from another numeric line.'
+
+    $undatedOverlap = Get-FirstShippedPullRequests `
+        -Root $boundaryRoot `
+        -Releases @(
+            [pscustomobject] @{
+                Title = '4.153.0-preview.1'
+                Tag = 'v4.153.0-preview.1.1'
+                PublishedAt = $null
+            }
+            [pscustomobject] @{
+                Title = '4.154.0-preview.1'
+                Tag = 'v4.154.0-preview.1.1'
+                PublishedAt = $chronologyPublished['v4.154.0-preview.1.1']
+            }
+        ) `
+        -CurrentTag 'v4.154.0-preview.1.1' `
+        -CurrentPublishedAt $chronologyPublished['v4.154.0-preview.1.1']
+    Assert-Equal @('v4.153.0-preview.1.1') @($undatedOverlap.Ambiguities.Tag) `
+        'An undated shipped release overlapping the target was not ambiguous.'
+
+    $sameTimestamp = [datetimeoffset] '2026-09-06T22:48:14Z'
+    $equalTimeOverlap = Get-FirstShippedPullRequests `
+        -Root $boundaryRoot `
+        -Releases @(
+            [pscustomobject] @{
+                Title = '4.153.0-preview.1'
+                Tag = 'v4.153.0-preview.1.1'
+                PublishedAt = $sameTimestamp
+            }
+            [pscustomobject] @{
+                Title = '4.154.0-preview.1'
+                Tag = 'v4.154.0-preview.1.1'
+                PublishedAt = $sameTimestamp
+            }
+        ) `
+        -CurrentTag 'v4.154.0-preview.1.1' `
+        -CurrentPublishedAt $sameTimestamp
+    Assert-Equal @('v4.153.0-preview.1.1') @($equalTimeOverlap.Ambiguities.Tag) `
+        'Equal-time overlapping shipments were resolved by invocation order instead of blocked.'
+} finally {
+    if (Test-Path -LiteralPath $boundaryRoot) {
+        Remove-Item -LiteralPath $boundaryRoot -Recurse -Force
+    }
+}
 
 $assignmentMilestones = @{
     '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
@@ -151,8 +221,14 @@ $assignmentMilestones = @{
 }
 $assignmentTags = @(
     'v4.153.0-preview.1.26454.6',
-    'v4.154.0-preview.1.26454.9'
+    'v4.154.0-preview.1.26454.9',
+    'v4.153.0-rc.1.26455.1'
 )
+$assignmentPublished = @{
+    'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
+    'v4.154.0-preview.1.26454.9' = [datetimeoffset] '2026-09-06T22:48:14Z'
+    'v4.153.0-rc.1.26455.1' = [datetimeoffset] '2026-09-07T12:00:00Z'
+}
 $pullAssignment = Get-ReleaseAssignmentPlan `
     -Kind 'pull-request' `
     -Number 4826 `
@@ -160,7 +236,8 @@ $pullAssignment = Get-ReleaseAssignmentPlan `
     -CurrentMilestone '4.154.0-preview.1' `
     -TargetMilestone '4.153.0-preview.1' `
     -Milestones $assignmentMilestones `
-    -Tags $assignmentTags
+    -Tags $assignmentTags `
+    -PublishedReleases $assignmentPublished
 Assert-Equal 'assign' $pullAssignment.Status 'A pull request could not be repaired to its first shipped milestone.'
 Assert-Equal 74 $pullAssignment.Operation.ToMilestoneNumber 'A pull request repair targeted the wrong milestone.'
 
@@ -171,7 +248,8 @@ $issueAssignment = Get-ReleaseAssignmentPlan `
     -CurrentMilestone '4.154.0-preview.1' `
     -TargetMilestone '4.153.0-preview.1' `
     -Milestones $assignmentMilestones `
-    -Tags $assignmentTags
+    -Tags $assignmentTags `
+    -PublishedReleases $assignmentPublished
 Assert-Equal 'assign' $issueAssignment.Status 'A linked issue could not be repaired to its first shipped milestone.'
 Assert-Equal 4826 $issueAssignment.Operation.ViaPullRequest 'A linked issue lost its source pull request.'
 
@@ -185,7 +263,10 @@ $unshippedRollForward = Get-ReleaseAssignmentPlan `
         '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
         '4.152.0-rc.1' = [pscustomobject] @{ number = 73; state = 'closed' }
     } `
-    -Tags @('v4.152.0-rc.1.26426.14')
+    -Tags @('v4.152.0-rc.1.26426.14') `
+    -PublishedReleases @{
+        'v4.152.0-rc.1.26426.14' = [datetimeoffset] '2026-09-03T02:22:44Z'
+    }
 Assert-Equal 'assign' $unshippedRollForward.Status `
     'An unshipped preview could not roll forward to the next shipped milestone in its numeric line.'
 
@@ -197,7 +278,8 @@ foreach ($unsafe in @(
         -CurrentMilestone '4.153.0-preview.1' `
         -TargetMilestone '4.154.0-preview.1' `
         -Milestones $assignmentMilestones `
-        -Tags $assignmentTags
+        -Tags $assignmentTags `
+        -PublishedReleases $assignmentPublished
     Get-ReleaseAssignmentPlan `
         -Kind 'issue' `
         -Number 1234 `
@@ -205,7 +287,8 @@ foreach ($unsafe in @(
         -CurrentMilestone '4.153.0-preview.1' `
         -TargetMilestone '4.154.0-preview.1' `
         -Milestones $assignmentMilestones `
-        -Tags $assignmentTags
+        -Tags $assignmentTags `
+        -PublishedReleases $assignmentPublished
 )) {
     Assert-Equal 'blocked' $unsafe.Status `
         'A forward move out of an earlier closed and shipped milestone was not blocked.'
@@ -223,9 +306,27 @@ $closedOnlyGuard = Get-ReleaseAssignmentPlan `
         '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'closed' }
         '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
     } `
-    -Tags @('v4.153.0-preview.1.26454.6')
+    -Tags @('v4.153.0-preview.1.26454.6') `
+    -PublishedReleases @{
+        'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
+    }
 Assert-Equal 'blocked' $closedOnlyGuard.Status `
     'A forward move out of an earlier closed milestone was not blocked without a shipped tag.'
+
+$parallelLineGuard = Get-ReleaseAssignmentPlan `
+    -Kind 'pull-request' `
+    -Number 4945 `
+    -ViaPullRequest $null `
+    -CurrentMilestone '4.154.0-preview.1' `
+    -TargetMilestone '4.153.0-rc.1' `
+    -Milestones @{
+        '4.153.0-rc.1' = [pscustomobject] @{ number = 76; state = 'closed' }
+        '4.154.0-preview.1' = [pscustomobject] @{ number = 75; state = 'closed' }
+    } `
+    -Tags $assignmentTags `
+    -PublishedReleases $assignmentPublished
+Assert-Equal 'blocked' $parallelLineGuard.Status `
+    'A later shipment from an earlier numeric line stole an item from its first shipped milestone.'
 
 $schedule = [pscustomobject] @{
     branch_point = '2026-07-27T00:00:00Z'
@@ -349,6 +450,20 @@ function global:gh {
     if ($script:FakeGhScenario -eq 'duplicate' -and $command -match 'milestones\?state=all') {
         return '[[{"number":1,"title":"duplicate"},{"number":2,"title":"duplicate"}]]'
     }
+    if ($script:FakeGhScenario -eq 'assignment-race') {
+        if ($command -match 'issues/4826 .*PATCH') {
+            throw 'Unsafe raced assignment reached PATCH.'
+        } elseif ($command -match 'issues/4826$') {
+            return '{"number":4826,"milestone":{"number":74,"title":"4.153.0-preview.1","state":"closed"}}'
+        }
+    }
+    if ($script:FakeGhScenario -eq 'closure-race') {
+        if ($command -match 'issues/6000 .*PATCH') {
+            throw 'Unsafe closure-raced assignment reached PATCH.'
+        } elseif ($command -match 'issues/6000$') {
+            return '{"number":6000,"milestone":{"number":72,"title":"4.152.0-preview.1","state":"closed"}}'
+        }
+    }
     if ($command -match 'milestones\?state=all') {
         @'
 [[{"number":70,"title":"4.152.0-preview.1","state":"open"}]]
@@ -413,6 +528,60 @@ try {
 }
 Assert-Equal '4.152.0-preview.2' $script:FakeItemMilestone 'The fake-gh apply path did not move open work.'
 Assert-Equal 'closed' $script:FakeMilestoneState 'The fake-gh apply path did not close the emptied milestone.'
+
+$script:FakeGhScenario = 'assignment-race'
+$racedOperation = [pscustomobject] @{
+    Kind = 'pull-request'
+    Number = 4826
+    ViaPullRequest = $null
+    FromMilestone = ''
+    ToMilestone = '4.154.0-preview.1'
+    ToMilestoneNumber = 75
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Repository 'mono/SkiaSharp' `
+        -Item $racedOperation `
+        -Milestones @{
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+            '4.154.0-preview.1' = [pscustomobject] @{ number = 75; state = 'closed' }
+        } `
+        -Tags @(
+            'v4.153.0-preview.1.26454.6',
+            'v4.154.0-preview.1.26454.9'
+        ) `
+        -PublishedReleases @{
+            'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
+            'v4.154.0-preview.1.26454.9' = [datetimeoffset] '2026-09-06T22:48:14Z'
+        } `
+        -Push
+} 'Refusing to move pull-request #4826' `
+    'A concurrent earlier shipped assignment was not revalidated before PATCH.'
+
+$script:FakeGhScenario = 'closure-race'
+$closureRacedOperation = [pscustomobject] @{
+    Kind = 'pull-request'
+    Number = 6000
+    ViaPullRequest = $null
+    FromMilestone = '4.152.0-preview.1'
+    ToMilestone = '4.153.0-preview.1'
+    ToMilestoneNumber = 74
+}
+Assert-Throws {
+    Set-PlannedReleaseAssignment `
+        -Repository 'mono/SkiaSharp' `
+        -Item $closureRacedOperation `
+        -Milestones @{
+            '4.152.0-preview.1' = [pscustomobject] @{ number = 72; state = 'open' }
+            '4.153.0-preview.1' = [pscustomobject] @{ number = 74; state = 'closed' }
+        } `
+        -Tags @('v4.153.0-preview.1.26454.6') `
+        -PublishedReleases @{
+            'v4.153.0-preview.1.26454.6' = [datetimeoffset] '2026-09-05T18:37:49Z'
+        } `
+        -Push
+} 'Refusing to move pull-request #6000' `
+    'A source milestone closed after planning was not revalidated before PATCH.'
 
 $script:FakeGhScenario = 'new-item'
 Assert-Throws {


### PR DESCRIPTION
## Description

Release assignment reconciliation previously chose only the latest shipped **stable** branch as the boundary before a numeric release line. Because 4.152 and 4.153 shipped prerelease tags without stable tags, the 4.154 reconciliation fell back to `v4.151.2`. Its range included 31 PRs already shipped in `4.153.0-preview.1` plus the m154 Skia bump, so run https://github.com/mono/SkiaSharp/actions/runs/34065404228 moved all 32 into `4.154.0-preview.1`. Run https://github.com/mono/SkiaSharp/actions/runs/33984759273 had previously assigned the 31 m153 PRs correctly.

This change makes “first shipped release” the lowest semantic shipped identity containing the work, independent of publication dates, workflow invocation order, or surviving release branches:

- discover shipped identities from immutable exact release tags;
- compute PR membership from the full reachable tag DAG minus every semantically earlier tag;
- union multiple exact tags for one milestone identity;
- recognize squash and merge commit subjects, including work merged below first-parent history;
- assign each PR to its lowest semantic shipped identity;
- assign each linked issue to the lowest semantic owner among all shipped local PRs that close it;
- retain repository identity when reading closing references so foreign issues are never treated as `mono/SkiaSharp` issues.

The semantic sort key parses preview/RC iterations numerically. Regression coverage includes `preview.2 < preview.10 < stable` and verifies that later relands cannot steal ownership. Within one numeric line, unshipped previews still roll forward to the next shipped preview/RC/stable milestone; stable and hotfix ordering remains intact.

The safety invariant blocks an assignment when an item is already in an earlier closed or shipped milestone. Before and after each PATCH, reconciliation refreshes tags and recomputes complete PR or linked-issue ownership. If a concurrent shipment invalidates the target after mutation, it restores the observed source milestone (including no milestone) unless another actor has already changed the item, then fails loudly. Any planning warning blocks `-Push`.

After merge, repairs remain separate maintainer actions: apply the reviewed 4.152 plan (19 assignments), clear the historically corrupted milestone on unrelated issue #410, then apply the 4.153 plan (31 PRs back to milestone 74). Re-run 4.152, 4.153, and 4.154 read-only to confirm convergence. No GitHub milestone assignments were mutated while developing this fix.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [x] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

None — release-maintenance tooling only; no public API or product behavior changes.

## Testing

- `Test-PublishingScripts.ps1`: 113 passed
- `Test-ReleaseMilestones.ps1`: 56 passed
- Full-DAG tests cover squash commits, merge commits, nested merged branches, duplicate exact tags, deleted historical branches, parallel release lines, multi-digit preview ordering, stable/hotfix ordering, and PR relands.
- Linked-issue tests cover multiple closing PRs across release lines, cross-repository references, pagination, and global earliest-owner selection.
- Safety tests cover changed assignments, pre/post-write tag races, ownership races, source closure, restoration to a prior milestone, and restoration to no milestone.
- Terra (`gpt-5.6-terra`) final review confirmed the root cause and ownership model; all findings resolved and merge-ready.
- Ordered live read-only reconciliation:
  - `4.152.0`: 19 assignments to `4.152.0-rc.1`, 71 already correct.
  - `4.153.0`: 31 assignments from `4.154.0-preview.1` to `4.153.0-preview.1`, 0 already correct.
  - `4.154.0`: 0 assignments, 1 already correct (#4945).

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later — not applicable
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated — not applicable
