### PR TITLE
[release] Order unreleased notes before releases

### DIFF
--- a/documentation/dev/release-notes-and-api-diffs.md
+++ b/documentation/dev/release-notes-and-api-diffs.md
@@ -718,6 +718,10 @@ not a HarfBuzzSharp release index. Both aggregates are assembled by
 timeline reads the Chrome schedule from the committed `releases/_sources/index.json`
 that `release-notes-index.py` wrote during Prepare.
 
+Within every minor line in both aggregates, an unreleased page always precedes all
+released pages, including when it has the same core as a released page or is the next
+servicing patch. Released pages then appear in descending semantic-version order.
+
 ##### Support tiers (the `support` block)
 
 Both `TOC.yml` and `index.md` are organised by a **support tier** so the navigation

--- a/documentation/docfx/releases/TOC.yml
+++ b/documentation/docfx/releases/TOC.yml
@@ -1,7 +1,7 @@
 - name: Overview
   href: index.md
 - name: Version 4.154.x
-  href: 4.154.0.md
+  href: 4.154.0-unreleased.md
   items:
     - name: Version 4.154.0 (Unreleased)
       href: 4.154.0-unreleased.md
@@ -13,7 +13,7 @@
     - name: Version 4.153.0
       href: 4.153.0.md
 - name: Version 4.152.x
-  href: 4.152.0.md
+  href: 4.152.1-unreleased.md
   items:
     - name: Version 4.152.1 (Unreleased)
       href: 4.152.1-unreleased.md
@@ -40,10 +40,10 @@
     - name: Version 4.150.0
       href: 4.150.0.md
 - name: Out of Support Versions
-  href: 4.148.0.md
+  href: 4.148.1-unreleased.md
   items:
     - name: Version 4.148.x
-      href: 4.148.0.md
+      href: 4.148.1-unreleased.md
       items:
         - name: Version 4.148.1 (Unreleased)
           href: 4.148.1-unreleased.md
@@ -52,7 +52,7 @@
     - name: Version 4.147.x
       href: 4.147.0.md
     - name: Version 3.119.x
-      href: 3.119.4.md
+      href: 3.119.5-unreleased.md
       items:
         - name: Version 3.119.5 (Unreleased)
           href: 3.119.5-unreleased.md

--- a/documentation/docfx/releases/index.md
+++ b/documentation/docfx/releases/index.md
@@ -63,8 +63,8 @@ The full Chrome release calendar is published at [Chromium's release schedule](h
 ## Supported versions
 
 - **Version 4.154.x** — Preview
-  - [Version 4.154.0](4.154.0.md)
   - [Version 4.154.0 (Unreleased)](4.154.0-unreleased.md)
+  - [Version 4.154.0](4.154.0.md)
 - **Version 4.153.x** — Preview
   - [Version 4.153.0](4.153.0.md)
 - **Version 4.152.x** — Preview

--- a/scripts/infra/docs/release-notes-render.py
+++ b/scripts/infra/docs/release-notes-render.py
@@ -475,6 +475,25 @@ def format_schedule_date(iso):
     return "{} {}".format(_MONTH_ABBR[int(month) - 1], int(day))
 
 
+def sort_navigation_entries(entries):
+    # type: (list[tuple[str, bool]]) -> list[tuple[str, bool]]
+    """Sort one minor line's pages: unreleased first, then semantic descending.
+
+    An unreleased head is the current page for its line, even when a stable page
+    has the same core or the head is the next servicing patch. Sorting by version
+    first retains semantic descending order inside each status partition.
+    """
+    by_version = sorted(entries, key=lambda entry: version_key(entry[0]), reverse=True)
+    return sorted(by_version, key=lambda entry: not entry[1])
+
+
+def navigation_href(entry):
+    # type: (tuple[str, bool]) -> str
+    """Return the release-notes path for a sorted navigation entry."""
+    version, is_unreleased = entry
+    return "{}{}.md".format(version, "-unreleased" if is_unreleased else "")
+
+
 def _toc_folded_section(title, groups, stable_groups, unreleased_groups):
     # type: (str, list[str], dict, dict) -> list[str]
     """Render a collapsed parent TOC node nesting its minor groups (spec §3.5).
@@ -489,21 +508,21 @@ def _toc_folded_section(title, groups, stable_groups, unreleased_groups):
     out = []  # type: list[str]
     if not groups:
         return out
-    head_members = stable_groups.get(groups[0]) or unreleased_groups.get(groups[0])
-    head = ("{}.md".format(head_members[0]) if groups[0] in stable_groups
-            else "{}-unreleased.md".format(head_members[0]))
+    head_entries = sort_navigation_entries(
+        [(v, True) for v in unreleased_groups.get(groups[0], [])] +
+        [(v, False) for v in stable_groups.get(groups[0], [])])
+    head = navigation_href(head_entries[0])
     out.append("- name: {}".format(title))
     out.append("  href: {}".format(head))
     out.append("  items:")
     for g in groups:
         stable = stable_groups.get(g, [])
         unreleased = unreleased_groups.get(g, [])
-        entries = [(v, True) for v in unreleased] + [(v, False) for v in stable]
+        entries = sort_navigation_entries(
+            [(v, True) for v in unreleased] + [(v, False) for v in stable])
         if not entries:
             continue
-        entries.sort(key=lambda t: version_key(t[0]), reverse=True)
-        g_header = ("{}.md".format(stable[0]) if stable
-                    else "{}-unreleased.md".format(unreleased[0]))
+        g_header = navigation_href(entries[0])
         out.append("    - name: Version {}.x".format(g))
         out.append("      href: {}".format(g_header))
         if len(entries) > 1:
@@ -558,13 +577,12 @@ def generate_toc(versions, next_versions):
     for g in supported:
         stable = stable_groups.get(g, [])
         unreleased = unreleased_groups.get(g, [])
-        header = "{}.md".format(stable[0]) if stable \
-            else "{}-unreleased.md".format(unreleased[0])
+        entries = sort_navigation_entries(
+            [(v, True) for v in unreleased] + [(v, False) for v in stable])
+        header = navigation_href(entries[0])
         lines.append("- name: Version {}.x".format(g))
         lines.append("  href: {}".format(header))
         lines.append("  items:")
-        entries = [(v, True) for v in unreleased] + [(v, False) for v in stable]
-        entries.sort(key=lambda t: version_key(t[0]), reverse=True)
         for v, is_unrel in entries:
             if is_unrel:
                 lines.append("    - name: Version {} (Unreleased)".format(v))
@@ -621,7 +639,7 @@ def generate_index(versions, next_versions, schedule_by_ms=None):
 
     def render_group(g, with_label):
         # type: (str, bool) -> list[str]
-        members = sorted(minor_map[g], key=lambda t: version_key(t[0]), reverse=True)
+        members = sort_navigation_entries(minor_map[g])
         label = channels.get(g)
         if with_label and label:
             out = ["- **Version {}.x** — {}".format(g, label)]
@@ -646,7 +664,7 @@ def generate_index(versions, next_versions, schedule_by_ms=None):
         Prefers the newest *released* page; falls back to the newest unreleased
         page when a line has shipped no stable page yet (spec §3.5).
         """
-        members = sorted(minor_map[g], key=lambda t: version_key(t[0]), reverse=True)
+        members = sort_navigation_entries(minor_map[g])
         released = [(v, u) for v, u in members if not u]
         v, is_unrel = released[0] if released else members[0]
         if is_unrel:

--- a/scripts/infra/docs/release_notes/tests/test_navigation_order.py
+++ b/scripts/infra/docs/release_notes/tests/test_navigation_order.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+_DOCS_DIR = Path(__file__).resolve().parents[2]
+
+
+def _load_renderer():
+    path = _DOCS_DIR / "release-notes-render.py"
+    spec = importlib.util.spec_from_file_location("_rn_navigation_tests", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseNotesNavigationOrderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.renderer = _load_renderer()
+
+    def setUp(self):
+        self.support = {
+            "stable": ["4.154"],
+            "preview": ["4.152"],
+            "supported": {"4.154", "4.152"},
+            "channels": {"4.154": "Stable", "4.152": "Preview"},
+        }
+        self.support_config = mock.patch.object(
+            self.renderer, "load_support_config", return_value=self.support)
+        self.support_config.start()
+        self.addCleanup(self.support_config.stop)
+        self.timeline = mock.patch.object(
+            self.renderer, "render_cadence_timeline", return_value=[])
+        self.timeline.start()
+        self.addCleanup(self.timeline.stop)
+
+    def test_navigation_orders_unreleased_before_releases_for_each_line(self):
+        versions = ["4.152.0", "4.154.0", "4.154.2", "4.154.1"]
+        next_versions = ["4.152.1", "4.154.0"]
+
+        toc = self.renderer.generate_toc(versions, next_versions)
+        index = self.renderer.generate_index(versions, next_versions)
+
+        expected_154 = [
+            "4.154.0-unreleased",
+            "4.154.2",
+            "4.154.1",
+            "4.154.0",
+        ]
+        expected_152 = ["4.152.1-unreleased", "4.152.0"]
+        for output in (toc, index):
+            positions = [output.index(
+                self._page_token(output, version)) for version in expected_154]
+            self.assertEqual(positions, sorted(positions))
+            positions = [output.index(
+                self._page_token(output, version)) for version in expected_152]
+            self.assertEqual(positions, sorted(positions))
+
+        self.assertIn("- **Version 4.154.x** — Stable", index)
+        self.assertIn("- **Version 4.152.x** — Preview", index)
+        self.assertIn("href: 4.154.0-unreleased.md", toc)
+        self.assertIn("href: 4.152.1-unreleased.md", toc)
+        self.assertEqual(
+            toc, self.renderer.generate_toc(
+                list(reversed(versions)), list(reversed(next_versions))))
+        self.assertEqual(
+            index, self.renderer.generate_index(
+                list(reversed(versions)), list(reversed(next_versions))))
+
+    def test_folded_toc_sections_use_the_same_order(self):
+        toc = self.renderer.generate_toc(
+            ["4.151.0", "2.88.0"], ["4.151.1", "2.88.0"])
+
+        for first, second in (
+                ("href: 4.151.1-unreleased.md", "href: 4.151.0.md"),
+                ("href: 2.88.0-unreleased.md", "href: 2.88.0.md")):
+            self.assertLess(toc.index(first), toc.index(second))
+
+    def test_navigation_without_unreleased_is_semver_descending_and_deterministic(self):
+        versions = ["4.154.0", "4.154.2", "4.154.1"]
+
+        toc = self.renderer.generate_toc(versions, [])
+        index = self.renderer.generate_index(versions, [])
+        self.assertLess(toc.index("4.154.2"), toc.index("4.154.1"))
+        self.assertLess(toc.index("4.154.1"), toc.index("4.154.0"))
+        self.assertLess(index.index("4.154.2"), index.index("4.154.1"))
+        self.assertLess(index.index("4.154.1"), index.index("4.154.0"))
+
+        self.assertEqual(toc, self.renderer.generate_toc(list(reversed(versions)), []))
+        self.assertEqual(index, self.renderer.generate_index(
+            list(reversed(versions)), []))
+
+    @staticmethod
+    def _page_token(output, version):
+        if "href:" in output:
+            return "href: {}.md".format(version)
+        if version.endswith("-unreleased"):
+            return "[Version {} (Unreleased)]({}.md)".format(
+                version.removesuffix("-unreleased"), version)
+        return "[Version {}]({}.md)".format(version, version)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The release landing page sorted mixed released and unreleased entries only by semantic version. Python's stable sort preserved the released-first input order for an equal core, placing `4.154.0-unreleased` after `4.154.0`.

The renderer now uses one deterministic navigation rule across the landing page and TOC: a live unreleased page is first in its minor line, followed by released pages in descending semantic-version order. This also makes each TOC minor-line link target that first page. Regenerated navigation outputs reflect the rule, including `4.154.0-unreleased` before `4.154.0` and `4.152.1-unreleased` before `4.152.0`.

**Related issues**

N/A

**Required skia PR**

None.

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [ ] Native dependency or Skia update (libpng, HarfBuzz, FreeType, zlib, milestone bump, …)
- [ ] Views & integrations (MAUI, Uno, WPF, WinUI, Blazor, …)
- [ ] Rendering output / visual behavior
- [ ] Performance
- [x] Tests
- [ ] Build, packaging, or CI
- [x] Documentation or samples

## Changes

None — no public API or runtime behavior changes. The deterministic release-notes navigation now places an unreleased page ahead of released pages in the same version line.

## Testing

- `python3 -m unittest scripts.infra.docs.release_notes.tests.test_navigation_order`
- `python3 -m unittest discover -s scripts/infra/docs/release_notes/tests -p 'test_*.py'`
- `.agents/skills/release-notes/scripts/render.sh`
- Confirmed the regenerated supported-version landing excerpt lists `4.154.0-unreleased` before `4.154.0` and `4.152.1-unreleased` before `4.152.0`; corresponding TOC entries and line links match.

## Checklist

- [x] Tests added or updated (if omitted, explain why above)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [ ] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later
- [ ] Native change? Companion `mono/skia` PR linked above and bindings regenerated