### PR TITLE
[skia-sync] Merge upstream chrome/m152 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "8f5cc7a4c200ba8ecc5bc6263cf9f8bfe0ba6e6b"
+          "commitHash": "99bb2457f0147756de79349a8b48c751377a8852"
         }
       }
     },
@@ -323,7 +323,7 @@
         }
       },
       "chrome_milestone": 152,
-      "upstream_merge_commit": "0873ec164a06966b90ae0d43ef783cfb180084ae",
+      "upstream_merge_commit": "4ca59aa7629672a1edc686a06819f56333af45a6",
       "upstream_ref": "chrome/m152"
     }
   ]

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "99bb2457f0147756de79349a8b48c751377a8852"
+          "commitHash": "723c5a03a7d18de5fb1a041e6cae2f09c4cb3c7e"
         }
       }
     },


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m152. Targeting release branch `release/4.152.x` (mono/skia `release/4.152.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/358

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Updated the Skia submodule to mono/skia merge `99bb2457f0147756de79349a8b48c751377a8852` and reconciled `cgmanifest.json` to upstream `chrome/m152` commit `4ca59aa7629672a1edc686a06819f56333af45a6`.

This release-line sync preserves all M152 package and ABI versions. It adds no C API functions, generated bindings, managed wrappers, dependency changes, or test-source changes.

## Testing

- Linux x64 native source build: passed.
- `binding/SkiaSharp/SkiaSharp.csproj` managed build: passed.
- Binding regeneration: passed with no generated API changes.
- Canonical unfiltered `tests/SkiaSharp.Tests.Console.slnx`: passed. Core: 6,127 passed, 33 skipped; singleton initialization: 1 passed, 0 skipped; Vulkan: 23 passed, 2 skipped; Direct3D: 2 passed, 3 skipped.
- Linux-required GPU backends `ganesh-gl`, `ganesh-vulkan`, and `graphite-vulkan` initialized and executed. Platform-policy skips existed, but no required backend was skipped.

## Human review

Confirm the Skia PR first and preserve the required merge order so the parent gitlink can be updated to the merged mono/skia base commit. Validation ran on Linux x64; Windows, macOS, Android, Apple mobile, and browser targets were not executed locally and remain for CI.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-09-08T19:06:30Z_
