### PR TITLE
Bump to the next version (4.152.2) after release

### DIFF
--- a/scripts/VERSIONS.txt
+++ b/scripts/VERSIONS.txt
@@ -78,56 +78,56 @@ HarfBuzz                soname      0.61421.0
 # SkiaSharp.dll
 # SkiaSharp.dll
 SkiaSharp               assembly    4.152.0.0
-SkiaSharp               file        4.152.1.0
+SkiaSharp               file        4.152.2.0
 
 # HarfBuzzSharp package revision N reserves 100 values per Skia milestone.
 # The milestone adopting native X.Y.Z uses 0-99; later milestones add 100.
 # Native HarfBuzz upgrades reset N to 0 and establish a new base milestone.
 # HarfBuzzSharp.dll
 HarfBuzzSharp           assembly    1.0.0.0
-HarfBuzzSharp           file        14.2.1.201
+HarfBuzzSharp           file        14.2.1.202
 
 # nuget versions
 # SkiaSharp
-SkiaSharp                                       nuget       4.152.1
-SkiaSharp.NativeAssets.Linux                    nuget       4.152.1
-SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.1
-SkiaSharp.NativeAssets.NanoServer               nuget       4.152.1
-SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.1
-SkiaSharp.NativeAssets.Android                  nuget       4.152.1
-SkiaSharp.NativeAssets.iOS                      nuget       4.152.1
-SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.1
-SkiaSharp.NativeAssets.macOS                    nuget       4.152.1
-SkiaSharp.NativeAssets.Tizen                    nuget       4.152.1
-SkiaSharp.NativeAssets.tvOS                     nuget       4.152.1
-SkiaSharp.NativeAssets.Win32                    nuget       4.152.1
-SkiaSharp.NativeAssets.WinUI                    nuget       4.152.1
-SkiaSharp.Views                                 nuget       4.152.1
-SkiaSharp.Views.Desktop.Common                  nuget       4.152.1
-SkiaSharp.Views.Gtk3                            nuget       4.152.1
-SkiaSharp.Views.Gtk4                            nuget       4.152.1
-SkiaSharp.Views.WindowsForms                    nuget       4.152.1
-SkiaSharp.Views.WPF                             nuget       4.152.1
-SkiaSharp.Views.Uno.WinUI                       nuget       4.152.1
-SkiaSharp.Views.WinUI                           nuget       4.152.1
-SkiaSharp.Views.Maui.Core                       nuget       4.152.1
-SkiaSharp.Views.Maui.Controls                   nuget       4.152.1
-SkiaSharp.Views.Blazor                          nuget       4.152.1
-SkiaSharp.HarfBuzz                              nuget       4.152.1
-SkiaSharp.Skottie                               nuget       4.152.1
-SkiaSharp.SceneGraph                            nuget       4.152.1
-SkiaSharp.Resources                             nuget       4.152.1
-SkiaSharp.Vulkan.SharpVk                        nuget       4.152.1
-SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.1
-SkiaSharp.Direct3D.Vortice                      nuget       4.152.1
+SkiaSharp                                       nuget       4.152.2
+SkiaSharp.NativeAssets.Linux                    nuget       4.152.2
+SkiaSharp.NativeAssets.Linux.NoDependencies     nuget       4.152.2
+SkiaSharp.NativeAssets.NanoServer               nuget       4.152.2
+SkiaSharp.NativeAssets.WebAssembly              nuget       4.152.2
+SkiaSharp.NativeAssets.Android                  nuget       4.152.2
+SkiaSharp.NativeAssets.iOS                      nuget       4.152.2
+SkiaSharp.NativeAssets.MacCatalyst              nuget       4.152.2
+SkiaSharp.NativeAssets.macOS                    nuget       4.152.2
+SkiaSharp.NativeAssets.Tizen                    nuget       4.152.2
+SkiaSharp.NativeAssets.tvOS                     nuget       4.152.2
+SkiaSharp.NativeAssets.Win32                    nuget       4.152.2
+SkiaSharp.NativeAssets.WinUI                    nuget       4.152.2
+SkiaSharp.Views                                 nuget       4.152.2
+SkiaSharp.Views.Desktop.Common                  nuget       4.152.2
+SkiaSharp.Views.Gtk3                            nuget       4.152.2
+SkiaSharp.Views.Gtk4                            nuget       4.152.2
+SkiaSharp.Views.WindowsForms                    nuget       4.152.2
+SkiaSharp.Views.WPF                             nuget       4.152.2
+SkiaSharp.Views.Uno.WinUI                       nuget       4.152.2
+SkiaSharp.Views.WinUI                           nuget       4.152.2
+SkiaSharp.Views.Maui.Core                       nuget       4.152.2
+SkiaSharp.Views.Maui.Controls                   nuget       4.152.2
+SkiaSharp.Views.Blazor                          nuget       4.152.2
+SkiaSharp.HarfBuzz                              nuget       4.152.2
+SkiaSharp.Skottie                               nuget       4.152.2
+SkiaSharp.SceneGraph                            nuget       4.152.2
+SkiaSharp.Resources                             nuget       4.152.2
+SkiaSharp.Vulkan.SharpVk                        nuget       4.152.2
+SkiaSharp.Vulkan.Silk.NET                       nuget       4.152.2
+SkiaSharp.Direct3D.Vortice                      nuget       4.152.2
 # HarfBuzzSharp
-HarfBuzzSharp                                   nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.201
-HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.201
+HarfBuzzSharp                                   nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.Android              nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.iOS                  nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.Linux                nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.MacCatalyst          nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.macOS                nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.Tizen                nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.tvOS                 nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.WebAssembly          nuget       14.2.1.202
+HarfBuzzSharp.NativeAssets.Win32                nuget       14.2.1.202

--- a/scripts/azure-templates-variables.yml
+++ b/scripts/azure-templates-variables.yml
@@ -1,7 +1,7 @@
 variables:
   # NOTE: Update this value when bumping the SkiaSharp version. It must match
   # the SkiaSharp NuGet version in scripts/VERSIONS.txt.
-  SKIASHARP_VERSION: 4.152.1
+  SKIASHARP_VERSION: 4.152.2
   VERBOSITY: normal
   GIT_SHA: $(Build.SourceVersion)
   GIT_BRANCH_NAME: $(Build.SourceBranch)


### PR DESCRIPTION
## Description

Advance `release/4.152.x` after releasing `4.152.1` by returning it
to `preview.0` at SkiaSharp 4.152.2 and HarfBuzzSharp
14.2.1.202.

**Related issues**

N/A.

**Required skia PR**

None.

**Areas affected**

- [x] Build, packaging, or CI

## Changes

None - version metadata only.

## Testing

The release preparation script verified the version transformation.

## Checklist

- [x] Tests added or updated (not needed; version metadata only)
- [x] `Changes` above lists all public API and behavioral changes (None)
- [x] New/changed public API? N/A
- [x] Native change? N/A