### PR TITLE
[skia-sync] Merge upstream chrome/m153 bug fixes

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -308,7 +308,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/mono/skia.git",
-          "commitHash": "92dc1a61df70e9238e7efe435f40a4136e887df8"
+          "commitHash": "27f299657dc3318435a6d221bac900960e5355d3"
         }
       }
     },
@@ -323,7 +323,7 @@
         }
       },
       "chrome_milestone": 153,
-      "upstream_merge_commit": "4f574af2444846ceca4d277a8095c5d4229d175f",
+      "upstream_merge_commit": "fca11a08da7c1ed3777b40b31611961c85c63c43",
       "upstream_ref": "chrome/m153"
     }
   ]


### PR DESCRIPTION
## Description

Automated upstream bug-fix sync for m153. Targeting release branch `release/4.153.x` (mono/skia `release/4.153.x`).

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**Related issues**

N/A — automated upstream synchronization.

**Required skia PR**

Requires https://github.com/mono/skia/pull/360

**Areas affected**

- [ ] Managed API (`binding/`)
- [ ] Native / C API (`externals/skia/src/c`, `include/c`)
- [ ] Generated P/Invoke bindings
- [x] Native dependency or Skia update
- [ ] Views & integrations
- [ ] Rendering output / visual behavior
- [ ] Performance
- [ ] Tests
- [ ] Build, packaging, or CI
- [ ] Documentation or samples

## Changes

Updated the `externals/skia` gitlink from `92dc1a61df70e9238e7efe435f40a4136e887df8` to tested merge `27f299657dc3318435a6d221bac900960e5355d3`, and updated both Skia registrations in `cgmanifest.json` to the new fork and upstream SHAs. This is a same-milestone `release/4.153.x` bug-fix sync, so package, assembly, file, native ABI, and milestone versions remain unchanged.

All Skia binding configurations regenerate without differences and no new Skia native function needs a wrapper. The selected release base predates the main-line HarfBuzz generation-layout update; the unchanged HarfBuzz dependency produced only unrelated deferred output when checked with the newer staged helper, so no HarfBuzz source or binding change is included.

## Testing

- Version/dependency finalizer: passed; zero `DEPS` identity changes and no unrelated Component Governance version drift.
- Fork-patch audit: passed; 216 unchanged fork-delta files and no provisional dispositions.
- Linux x64 native source build: passed.
- `dotnet build binding/SkiaSharp/SkiaSharp.csproj`: passed with 0 errors.
- Full unfiltered `tests/SkiaSharp.Tests.Console.slnx` net10.0 run: passed.
- Core host: 6,127 passed, 33 platform-policy skips, 0 failed.
- Singleton host: 1 passed, 0 skipped, 0 failed.
- Vulkan host: 23 passed, 2 platform-policy skips, 0 failed.
- Direct3D host on Linux: 2 passed, 3 platform-policy skips, 0 failed.
- No backend required by Linux `GpuPolicy` was skipped.

## Human review

Confirm the cross-linked mono/skia merge is landed first, then repin this parent PR to the resulting release-branch commit. Linux x64 was validated locally; Windows/Direct3D, macOS/iOS/Metal, Android, Tizen, and WebAssembly remain for CI/cross-platform review. The staged regeneration helper’s directory-output assumption does not match this older release branch’s single-file generated layout; generated Skia outputs were nevertheless compared directly and were unchanged.


## Checklist

- [x] Tests added or updated when behavior required them, or the report explains why not
- [x] `Changes` above lists all public API and behavioral changes or states that none changed
- [x] Documentation follow-up filed, or no public API changed
- [x] Companion `mono/skia` PR linked above and bindings regenerated

_Last rendered by the sync workflow: 2026-09-11T19:09:46Z_
