### PR TITLE
Exclude DocsMedia transport packages from SignCheck

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -6,6 +6,7 @@
 ;; build-input payloads; byte identity and signature absence are verified before SignCheck.
 _NativeAssets*.nupkg;;DO-NOT-SIGN, DO-NOT-UNPACK, non-shipping native transport package
 _NuGets*.nupkg;;DO-NOT-SIGN, DO-NOT-UNPACK, non-shipping managed transport package
+_DocsMedia*.nupkg;;DO-NOT-SIGN, DO-NOT-UNPACK, non-shipping documentation media transport package
 
 staticwebassets/DpiWatcher.js;SkiaSharp.Views.Blazor.;DO-NOT-SIGN, browser source distributed only through the signed NuGet
 staticwebassets/SKHtmlCanvas.js;SkiaSharp.Views.Blazor.;DO-NOT-SIGN, browser source distributed only through the signed NuGet


### PR DESCRIPTION
## Description

Exclude the intentionally nonshipping `_DocsMedia.0.0.0-branch.main.170.nupkg` transport package from SignCheck. Build 3073462 failed SignCheck with exactly one unsigned file because this package was missing from the repository's explicit transport-package exclusions. Transport packages intentionally remain unsigned and are not recursively unpacked for signing validation.

**Related issues**

None.

**Required skia PR**

None.

**Areas affected**

- [x] Build, packaging, or CI

## Changes

None - CI-only packaging policy change; no public API or observable product behavior changed.

## Testing

- `pwsh -NoLogo -NoProfile -File scripts/infra/package/tests/AssembleArcadeAssets.Tests.ps1`
- SignCheck itself is supplied by Arcade and runs in the post-build CI signing-validation stage; this repository has no focused SignCheck harness. The added exclusion uses the existing transport-package policy format.

## Checklist

- [x] Tests added or updated (not applicable - no repository-owned SignCheck test harness exists)
- [x] `Changes` above lists all public API and behavioral changes (or "None.")
- [x] New/changed public API? Filed a docs issue in [mono/SkiaSharp-API-docs](https://github.com/mono/SkiaSharp-API-docs/issues) so reference docs can be written later (not applicable - no public API change)
- [x] Native change? Companion `mono/skia` PR linked above and bindings regenerated (not applicable - no native change)
